### PR TITLE
Fix template error when backlogs is not configured

### DIFF
--- a/modules/backlogs/app/views/shared/not_configured.html.erb
+++ b/modules/backlogs/app/views/shared/not_configured.html.erb
@@ -28,10 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div id="not_configured">
-    <%= t(:label_backlogs_unconfigured, {
-                :administration => t(:label_administration),
-                :plugins => t(:label_plugins),
-                :configure => t(:button_configure)
-            })
-    %>
+  <%= t(:label_backlogs_unconfigured,
+          administration: t(:label_administration),
+          plugins: t(:label_plugins),
+          configure: t(:button_configure))
+  %>
 </div>

--- a/modules/backlogs/spec/views/shared/not_configured_spec.rb
+++ b/modules/backlogs/spec/views/shared/not_configured_spec.rb
@@ -1,0 +1,35 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative '../../spec_helper'
+
+describe 'shared/not_configured', type: :view do
+  it 'renders without errors' do
+    render
+  end
+end


### PR DESCRIPTION
Reported by AppSignal on multitenancy-vips2
https://appsignal.com/openproject-gmbh/sites/62eba940d2a5e473be7feefd/exceptions/incidents/209

To produce view the "not configured" page, `Setting.plugin_openproject_backlogs` must have its `'story_types'` value blank or its `'task_type'` blank. As I was not sure about how to reproduce it, and why values were blank on multitenancy-vips2, I did not create a work package for it as qa would not know how to test it. Please advise if I should create one.