### PR TITLE
Remove custom display placeholder for formattable fields

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -653,6 +653,7 @@ en:
       default: '-'
       subject: 'Enter subject here'
       selection: 'Please select'
+      description: 'Description: Click to edit...'
       relation_description: 'Click to add description for this relation'
 
     project:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1004,7 +1004,6 @@ en:
       placeholders:
         default: "-"
         date: "Select date"
-        formattable: "%{name}: Click to edit..."
       query:
         column_names: "Columns"
         group_by: "Group results by"

--- a/docs/development/concepts/inline-editing/README.md
+++ b/docs/development/concepts/inline-editing/README.md
@@ -246,7 +246,7 @@ An example where this comes into play is the [`CustomText`](https://github.com/o
 
 - [`EditForm`](https://github.com/opf/openproject/blob/dev/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts) base class
 - [`EditFormComponent`](https://github.com/opf/openproject/blob/dev/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.component.ts#L28-L27) Angular `<edit-form>` component 
-- [`EditableAttributeFieldComponent`](https://github.com/opf/openproject/blob/dev/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts) Angular `<editable-attribute-field>` component for attributes within the edit form
+- [`EditableAttributeFieldComponent`](https://github.com/opf/openproject/blob/dev/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts) Angular `<op-editable-attribute-field>` component for attributes within the edit form
 - [`DisplayField`](https://github.com/opf/openproject/tree/dev/frontend/src/app/shared/components/fields/display) definitions containing all display fields and the service to instantiate them.
 - [`DisplayFieldRenderer`](https://github.com/opf/openproject/tree/dev/frontend/src/app/shared/components/fields/display/display-field-renderer.ts) to manually render display fields from JavaScript
 - [`DisplayFieldComponent`](https://github.com/opf/openproject/tree/dev/frontend/src/app/shared/components/fields/display/display-field.component.ts) an Angular component to render display fields
@@ -269,9 +269,9 @@ On the example of a work package, this following code snippet would create an ed
 
 ```html
 <edit-form *ngIf="workPackage" [resource]="workPackage">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                               fieldName="subject">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
 </edit-form>
 ```
 

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -51,15 +51,15 @@
              [inEditMode]="isNewResource(workPackage)"
              *ngIf="isNewResource(workPackage)">
     <div class="op-wp-single-card-content -new">
-      <editable-attribute-field [resource]="workPackage"
+      <op-editable-attribute-field [resource]="workPackage"
                                 [wrapperClasses]="'work-packages--type-selector'"
                                 [fieldName]="'type'"
                                 class="op-wp-single-card-content--type">
-      </editable-attribute-field>
-      <editable-attribute-field [resource]="workPackage"
+      </op-editable-attribute-field>
+      <op-editable-attribute-field [resource]="workPackage"
                                 fieldName="subject"
                                 class="op-wp-single-card-content--subject -bold">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
   </edit-form>
 

--- a/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.template.html
@@ -16,11 +16,11 @@
       <div *ngIf="!descriptor.multiple && descriptor.field"
            class="attributes-key-value--value-container">
 
-        <editable-attribute-field [ngClass]="{'wp-edit-formattable-field': descriptor.field!.isFormattable }"
+        <op-editable-attribute-field [ngClass]="{'wp-edit-formattable-field': descriptor.field!.isFormattable }"
                                   [resource]="workPackage"
                                   [isDropTarget]="descriptor.field!.isFormattable"
                                   [fieldName]="fieldName(descriptor.name)">
-        </editable-attribute-field>
+        </op-editable-attribute-field>
       </div>
     </ng-template>
   </div>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -45,7 +45,7 @@
 
     <div class="grid-content medium-3 collapse wp-relations-status-field">
       <edit-form *ngIf="relatedWorkPackage" [resource]="relatedWorkPackage">
-        <editable-attribute-field [resource]="relatedWorkPackage" fieldName="status"></editable-attribute-field>
+        <op-editable-attribute-field [resource]="relatedWorkPackage" fieldName="status"></op-editable-attribute-field>
       </edit-form>
     </div>
 

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
@@ -4,9 +4,9 @@
      data-selector="wp-single-view">
   <div class="wp-new--subject-wrapper"
        *ngIf="isNewResource">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                               [wrapperClasses]="'-no-label'"
-                              [fieldName]="'subject'"></editable-attribute-field>
+                              [fieldName]="'subject'"></op-editable-attribute-field>
   </div>
 
   <div class="wp-info-wrapper">
@@ -54,8 +54,8 @@
                                [attributeScope]="'WorkPackage'"></attribute-help-text>
         </div>
         <div class="attributes-key-value--value-container">
-          <editable-attribute-field [resource]="workPackage"
-                                    [fieldName]="descriptor.name"></editable-attribute-field>
+          <op-editable-attribute-field [resource]="workPackage"
+                                    [fieldName]="descriptor.name"></op-editable-attribute-field>
         </div>
       </div>
     </div>
@@ -85,11 +85,11 @@
 
   <div class="attributes-group description-group">
     <div class="single-attribute work-packages--details--description">
-      <editable-attribute-field [fieldName]="'description'"
+      <op-editable-attribute-field [fieldName]="'description'"
                                 [resource]="workPackage"
                                 [isDropTarget]="true"
                                 [wrapperClasses]="'-no-label'">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
   </div>
 

--- a/frontend/src/app/features/work-packages/components/wp-subject/wp-subject.html
+++ b/frontend/src/app/features/work-packages/components/wp-subject/wp-subject.html
@@ -3,15 +3,15 @@
      [ngClass]="'__overflowing_' + uniqueElementIdentifier"
      [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueElementIdentifier">
   <div class="work-packages--type-selector work-packages--subject-element">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                    [wrapperClasses]="'work-packages--type-selector work-packages--subject-element -no-label'"
                    [fieldName]="'type'">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
   </div>
   <div class="work-packages--details--subject work-packages--subject-element">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                    [wrapperClasses]="'work-packages--details--subject work-packages--subject-element -no-label'"
                    [fieldName]="'subject'">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
   </div>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-type-status/wp-type-status.html
+++ b/frontend/src/app/features/work-packages/components/wp-type-status/wp-type-status.html
@@ -1,16 +1,16 @@
 <div *ngIf="workPackage"
      class="wp-new-top-row">
   <div class="work-packages--status-selector wp-new-top-row--element">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                    [displayFieldOptions]="{ colorize: false }"
                    [wrapperClasses]="'wp-new-top-row--status -no-label'"
                    [fieldName]="'status'">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
   </div>
   <div class="work-packages--type-selector wp-new-top-row--element">
-    <editable-attribute-field [resource]="workPackage"
+    <op-editable-attribute-field [resource]="workPackage"
                    [wrapperClasses]="'wp-new-top-row--type -no-label'"
                    [fieldName]="'type'">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
   </div>
 </div>

--- a/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
@@ -23,7 +23,6 @@ export const readOnlyClassName = '-read-only';
 export const placeholderClassName = '-placeholder';
 export const displayClassName = 'inline-edit--display-field';
 export const editFieldContainerClass = 'inline-edit--container';
-export const cellEmptyPlaceholder = '-';
 
 export class DisplayFieldRenderer<T extends HalResource = HalResource> {
   @InjectField() displayFieldService:DisplayFieldService;
@@ -137,7 +136,7 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
 
   private getText(field:DisplayField):string {
     if (field.isEmpty()) {
-      return cellEmptyPlaceholder;
+      return field.placeholder;
     }
 
     return field.valueString;

--- a/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
@@ -37,16 +37,19 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
   /** We cache the previously used fields to avoid reinitialization */
   private fieldCache:{ [key:string]:DisplayField } = {};
 
-  constructor(public readonly injector:Injector,
+  constructor(
+    public readonly injector:Injector,
     public readonly container:'table'|'single-view'|'timeline',
-    public readonly options:{ [key:string]:any } = {}) {
+    public readonly options:{ [key:string]:unknown } = {},
+  ) {
   }
 
-  public render(resource:T,
+  public render(
+    resource:T,
     name:string,
     change:ResourceChangeset<T>|null,
-    placeholder?:string):HTMLSpanElement {
-    const [field, span] = this.renderFieldValue(resource, name, change, placeholder);
+  ):HTMLSpanElement {
+    const [field, span] = this.renderFieldValue(resource, name, change);
 
     if (field === null) {
       return span;
@@ -57,14 +60,16 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     return span;
   }
 
-  public renderFieldValue(resource:T,
+  public renderFieldValue(
+    resource:T,
     requestedAttribute:string,
     change:ResourceChangeset<T>|null,
-    placeholder?:string):[DisplayField|null, HTMLSpanElement] {
+  ):[DisplayField|null, HTMLSpanElement] {
     const span = document.createElement('span');
     const schema = this.schema(resource, change);
     const attributeName = this.attributeName(requestedAttribute, schema);
-    const fieldSchema = schema.ofProperty(attributeName);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const fieldSchema = schema.ofProperty(attributeName) as IFieldSchema;
 
     // If the resource does not have that field, return an empty
     // span (e.g., for the table).
@@ -73,7 +78,7 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     }
 
     const field = this.getField(resource, fieldSchema, attributeName, change);
-    field.render(span, this.getText(field, fieldSchema, placeholder), fieldSchema.options);
+    field.render(span, this.getText(field), fieldSchema.options);
 
     const { title } = field;
     if (title) {
@@ -84,13 +89,16 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     return [field, span];
   }
 
-  public getField(resource:T,
+  public getField(
+    resource:T,
     fieldSchema:IFieldSchema,
     attributeName:string,
-    change:ResourceChangeset<T>|null):DisplayField {
+    change:ResourceChangeset<T>|null,
+  ):DisplayField {
     let field = this.fieldCache[attributeName];
 
     if (!field) {
+      // eslint-disable-next-line no-multi-assign
       field = this.fieldCache[attributeName] = this.getFieldForCurrentContext(resource, attributeName, fieldSchema);
     }
 
@@ -127,10 +135,11 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     return this.displayFieldService.getField(resource, attributeName, fieldSchema, context);
   }
 
-  private getText(field:DisplayField, fieldSchema:IFieldSchema, placeholder?:string):string {
+  private getText(field:DisplayField):string {
     if (field.isEmpty()) {
-      return placeholder || this.getDefaultPlaceholder(fieldSchema);
+      return cellEmptyPlaceholder;
     }
+
     return field.valueString;
   }
 
@@ -158,13 +167,14 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     }
   }
 
-  private isAttributeEditable(schema:SchemaResource, fieldName:string) {
+  private isAttributeEditable(schema:SchemaResource, fieldName:string):boolean {
     // We need to handle start/due date cases like they were combined dates
     if (['startDate', 'dueDate', 'date'].includes(fieldName)) {
       fieldName = 'combinedDate';
     }
 
-    return schema.isAttributeEditable(fieldName);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    return schema.isAttributeEditable(fieldName) as boolean;
   }
 
   private getAriaLabel(field:DisplayField, schema:SchemaResource):string {
@@ -182,7 +192,8 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
       titleContent = labelContent;
     }
 
-    if (field.writable && schema.isAttributeEditable(field.name)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    if (field.writable && !!schema.isAttributeEditable(field.name)) {
       return this.I18n.t('js.inplace.button_edit', { attribute: `${field.displayName} ${titleContent}` });
     }
     return `${field.displayName} ${titleContent}`;
@@ -202,27 +213,25 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
    * @param schema
    * @param attribute
    */
-  private attributeName(attribute:string, schema:SchemaResource) {
+  private attributeName(attribute:string, schema:SchemaResource):string {
     if (schema.mappedName) {
-      return schema.mappedName(attribute);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      return schema.mappedName(attribute) as string;
     }
+
     return attribute;
   }
 
-  private getDefaultPlaceholder(fieldSchema:IFieldSchema):string {
-    if (fieldSchema.type === 'Formattable') {
-      return this.I18n.t('js.work_packages.placeholders.formattable', { name: fieldSchema.name });
-    }
-
-    return cellEmptyPlaceholder;
-  }
-
-  private schema(resource:T, change:ResourceChangeset<T>|null) {
+  private schema(resource:T, change:ResourceChangeset<T>|null):SchemaResource {
     if (change) {
       return change.schema;
-    } if (this.halEditing.typedState(resource).hasValue()) {
-      return this.halEditing.typedState(resource).value!.schema;
     }
+
+    if (this.halEditing.typedState(resource).hasValue()) {
+      const val = this.halEditing.typedState(resource).value as { schema:SchemaResource };
+      return val.schema;
+    }
+
     return this.schemaCache.of(resource);
   }
 }

--- a/frontend/src/app/shared/components/fields/display/field-types/formattable-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/formattable-display-field.module.ts
@@ -58,6 +58,14 @@ export class FormattableDisplayField extends DisplayField {
     DynamicBootstrapper.bootstrapOptionalEmbeddable(this.appRef, div);
   }
 
+  get placeholder():string {
+    if (this.name === 'description') {
+      return this.I18n.t('js.placeholders.description');
+    }
+
+    return super.placeholder;
+  }
+
   public get isFormattable():boolean {
     return true;
   }

--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -39,9 +39,7 @@ import {
   Optional,
   ViewChild,
 } from '@angular/core';
-import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { getPosition } from 'core-app/shared/helpers/set-click-position/set-click-position';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
@@ -56,9 +54,11 @@ import {
 import { States } from 'core-app/core/states/states.service';
 import { debugLog } from '../../../../helpers/debug_output';
 import { hasSelectionWithin } from '../../../../helpers/selection-helpers';
+import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
+import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 
 @Component({
-  selector: 'editable-attribute-field',
+  selector: 'op-editable-attribute-field',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './editable-attribute-field.component.html',
 })
@@ -69,15 +69,13 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
 
   @Input() public wrapperClasses?:string;
 
-  @Input() public displayFieldOptions:any = {};
-
-  @Input() public displayPlaceholder?:string;
+  @Input() public displayFieldOptions:{ [key:string]:unknown } = {};
 
   @Input() public isDropTarget?:boolean = false;
 
-  @ViewChild('displayContainer', { static: true }) readonly displayContainer:ElementRef;
+  @ViewChild('displayContainer', { static: true }) readonly displayContainer:ElementRef<HTMLElement>;
 
-  @ViewChild('editContainer', { static: true }) readonly editContainer:ElementRef;
+  @ViewChild('editContainer', { static: true }) readonly editContainer:ElementRef<HTMLElement>;
 
   public fieldRenderer:DisplayFieldRenderer;
 
@@ -92,7 +90,6 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   constructor(protected states:States,
     protected injector:Injector,
     protected elementRef:ElementRef,
-    protected ConfigurationService:ConfigurationService,
     protected opContextMenu:OPContextMenuService,
     protected halEditing:HalResourceEditingService,
     protected schemaCache:SchemaCacheService,
@@ -103,16 +100,16 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     super();
   }
 
-  public setActive(active = true) {
+  public setActive(active = true):void {
     this.active = active;
     if (!this.componentDestroyed) {
       this.cdRef.detectChanges();
     }
   }
 
-  public ngOnInit() {
+  public ngOnInit():void {
     this.fieldRenderer = new DisplayFieldRenderer(this.injector, 'single-view', this.displayFieldOptions);
-    this.$element = jQuery(this.elementRef.nativeElement);
+    this.$element = jQuery<HTMLElement>(this.elementRef.nativeElement);
 
     // Register on the form if we're in an editable context
     this.editForm?.register(this);
@@ -130,7 +127,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   }
 
   // Open the field when its closed and relay drag & drop events to it.
-  public startDragOverActivation(event:JQuery.TriggeredEvent) {
+  public startDragOverActivation(event:JQuery.TriggeredEvent):boolean {
     if (!this.isDropTarget || !this.isEditable || this.active) {
       return true;
     }
@@ -140,13 +137,13 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     return false;
   }
 
-  public render() {
-    const el = this.fieldRenderer.render(this.resource, this.fieldName, null, this.displayPlaceholder);
+  public render():void {
+    const el = this.fieldRenderer.render(this.resource, this.fieldName, null);
     this.displayContainer.nativeElement.innerHTML = '';
     this.displayContainer.nativeElement.appendChild(el);
   }
 
-  public deactivate(focus = false) {
+  public deactivate(focus = false):void {
     this.editContainer.nativeElement.innerHTML = '';
     this.editContainer.nativeElement.hidden = true;
     this.setActive(false);
@@ -157,10 +154,11 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   }
 
   public get isEditable():boolean {
-    return this.editForm && this.schema.isAttributeEditable(this.fieldName);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    return !!(this.editForm && this.schema.isAttributeEditable(this.fieldName));
   }
 
-  public activateIfEditable(event:MouseEvent|KeyboardEvent) {
+  public activateIfEditable(event:MouseEvent|KeyboardEvent):boolean {
     // Ignore selections
     if (hasSelectionWithin(event.target as HTMLElement)) {
       debugLog(`Not activating ${this.fieldName} because of active selection within`);
@@ -184,7 +182,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     return false;
   }
 
-  public activateOnForm(noWarnings = false) {
+  public activateOnForm(noWarnings = false):Promise<void|EditFieldHandler> {
     // Activate the field
     this.setActive(true);
 
@@ -193,7 +191,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       .catch(() => this.deactivate(true));
   }
 
-  public handleUserActivate(evt:MouseEvent|KeyboardEvent|null) {
+  public handleUserActivate(evt:MouseEvent|KeyboardEvent|null):boolean {
     let positionOffset = 0;
 
     if (evt?.type === 'click') {
@@ -201,7 +199,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       positionOffset = getPosition(evt);
     }
 
-    this.activateOnForm()
+    void this.activateOnForm()
       .then((handler) => {
         if (!handler) {
           return;
@@ -214,15 +212,17 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     return false;
   }
 
-  public reset() {
+  public reset():void {
     this.render();
     this.deactivate();
   }
 
   private get schema() {
     if (this.halEditing.typedState(this.resource).hasValue()) {
-      return this.halEditing.typedState(this.resource).value!.schema;
+      const val = this.halEditing.typedState(this.resource).value as { schema:SchemaResource };
+      return val.schema;
     }
+
     return this.schemaCache.of(this.resource);
   }
 }

--- a/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
@@ -15,8 +15,8 @@
 <div class="grid--widget-content -allow-inner-overflow">
   <edit-form *ngIf="(project$ | async) as project"
              [resource]="project">
-    <editable-attribute-field [resource]="project"
+    <op-editable-attribute-field [resource]="project"
                               fieldName="description">
-    </editable-attribute-field>
+    </op-editable-attribute-field>
   </edit-form>
 </div>

--- a/frontend/src/app/shared/components/grids/widgets/project-details/project-details.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-details/project-details.component.html
@@ -19,9 +19,9 @@
                                [attributeScope]="'Project'"></attribute-help-text>
         </div>
         <div class="attributes-map--value">
-          <editable-attribute-field [resource]="project"
+          <op-editable-attribute-field [resource]="project"
                                     [fieldName]="cf.key">
-          </editable-attribute-field>
+          </op-editable-attribute-field>
         </div>
       </ng-container>
     </div>

--- a/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
@@ -15,15 +15,15 @@
 <div class="grid--widget-content -allow-inner-overflow">
   <edit-form *ngIf="(project$ | async) as project" [resource]="project">
     <div class="project-status--container">
-      <editable-attribute-field [resource]="project"
+      <op-editable-attribute-field [resource]="project"
                                 fieldName="status"
                                 wrapperClasses="project-status--display-field">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
     <div class="project-status-explanation--container">
-      <editable-attribute-field [resource]="project"
+      <op-editable-attribute-field [resource]="project"
                                 fieldName="statusExplanation">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
   </edit-form>
 </div>

--- a/frontend/src/app/shared/components/time_entries/form/form.component.html
+++ b/frontend/src/app/shared/components/time_entries/form/form.component.html
@@ -10,10 +10,10 @@
            [textContent]="schema.user.name">
       </div>
       <div class="attributes-map--value">
-        <editable-attribute-field [resource]="entry"
+        <op-editable-attribute-field [resource]="entry"
                                   [wrapperClasses]="'-tiny'"
                                   [fieldName]="'user'">
-        </editable-attribute-field>
+        </op-editable-attribute-field>
       </div>
     </ng-container>
 
@@ -22,10 +22,10 @@
          [textContent]="schema.spentOn.name">
     </div>
     <div class="attributes-map--value">
-      <editable-attribute-field [resource]="entry"
+      <op-editable-attribute-field [resource]="entry"
                                 [wrapperClasses]="'-tiny'"
                                 [fieldName]="'spentOn'">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
 
     <div class="attributes-map--key"
@@ -33,10 +33,10 @@
          [textContent]="schema.hours.name">
     </div>
     <div class="attributes-map--value">
-      <editable-attribute-field [resource]="entry"
+      <op-editable-attribute-field [resource]="entry"
                                 [wrapperClasses]="'-tiny'"
                                 [fieldName]="'hours'">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
 
     <ng-container *ngIf="showWorkPackageField">
@@ -45,9 +45,9 @@
            [textContent]="schema.workPackage.name">
       </div>
       <div class="attributes-map--value">
-        <editable-attribute-field [resource]="entry"
+        <op-editable-attribute-field [resource]="entry"
                                   [fieldName]="'workPackage'">
-        </editable-attribute-field>
+        </op-editable-attribute-field>
       </div>
     </ng-container>
 
@@ -56,10 +56,10 @@
          [textContent]="schema.activity.name">
     </div>
     <div class="attributes-map--value">
-      <editable-attribute-field *ngIf="workPackageSelected"
+      <op-editable-attribute-field *ngIf="workPackageSelected"
                                 [resource]="entry"
                                 [fieldName]="'activity'">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
       <i *ngIf="!workPackageSelected"
          [textContent]="text.wpRequired">
       </i>
@@ -70,9 +70,9 @@
          [textContent]="schema.comment.name">
     </div>
     <div class="attributes-map--value">
-      <editable-attribute-field [resource]="entry"
+      <op-editable-attribute-field [resource]="entry"
                                 [fieldName]="'comment'">
-      </editable-attribute-field>
+      </op-editable-attribute-field>
     </div>
 
     <ng-container *ngFor="let cf of customFields">
@@ -81,9 +81,9 @@
            [textContent]="cf.label">
       </div>
       <div class="attributes-map--value">
-        <editable-attribute-field [resource]="entry"
+        <op-editable-attribute-field [resource]="entry"
                                   [fieldName]="cf.key">
-        </editable-attribute-field>
+        </op-editable-attribute-field>
       </div>
     </ng-container>
   </div>

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -147,7 +147,7 @@
     color: var(--inplace-edit--color--disabled)
     background: var(--inplace-edit--bg-color--disabled)
 
-editable-attribute-field
+op-editable-attribute-field
   width: 100%
 
   .-minimal &

--- a/spec/features/work_packages/details/markdown/description_editor_spec.rb
+++ b/spec/features/work_packages/details/markdown/description_editor_spec.rb
@@ -91,7 +91,7 @@ describe 'description inplace editor', js: true, selenium: true do
     let(:description_text) { '' }
 
     it 'renders a placeholder' do
-      field.expect_state_text 'Description: Click to edit...'
+      field.expect_state_text '-'
 
       field.activate!
       # An empty description is also allowed

--- a/spec/features/work_packages/details/markdown/description_editor_spec.rb
+++ b/spec/features/work_packages/details/markdown/description_editor_spec.rb
@@ -91,7 +91,7 @@ describe 'description inplace editor', js: true, selenium: true do
     let(:description_text) { '' }
 
     it 'renders a placeholder' do
-      field.expect_state_text '-'
+      field.expect_state_text 'Description: Click to edit...'
 
       field.activate!
       # An empty description is also allowed


### PR DESCRIPTION
All placeholders are reduced to show "-" when empty.

Drive-by feature for https://community.openproject.org/work_packages/40133