### PR TITLE
rely on contract for duration & non working days writability

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -120,7 +120,6 @@ module API
           schema :duration,
                  type: 'Duration',
                  required: false,
-                 writable: false,
                  show_if: ->(*) { !represented.milestone? && OpenProject::FeatureDecisions.work_packages_duration_field_active? }
 
           schema :schedule_manually,
@@ -131,7 +130,6 @@ module API
           schema :ignore_non_working_days,
                  type: 'Boolean',
                  required: false,
-                 writable: false,
                  show_if: ->(*) { OpenProject::FeatureDecisions.work_packages_duration_field_active? }
 
           schema :start_date,

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -307,7 +307,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:type) { 'Duration' }
         let(:name) { I18n.t('activerecord.attributes.work_package.duration') }
         let(:required) { false }
-        let(:writable) { false }
+        let(:writable) { true }
       end
 
       context 'when the work package is a milestone' do
@@ -342,7 +342,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:type) { 'Boolean' }
         let(:name) { I18n.t('activerecord.attributes.work_package.ignore_non_working_days') }
         let(:required) { false }
-        let(:writable) { false }
+        let(:writable) { true }
       end
 
       context 'when the feature flag is off', with_flag: { work_packages_duration_field_active: false } do


### PR DESCRIPTION
After the change, both fields are marked as writable in the work package schema. The frontend will then behave accordingly e.g. allowing to click on the duration field in the work package list.

/cc @HDinger this might be needed for #11151 to work as well.