### PR TITLE
Feature/43636 update work package table view for duration

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
@@ -47,9 +47,10 @@ import { WorkPackageCommentFieldComponent } from 'core-app/features/work-package
 import { ProjectEditFieldComponent } from './field-types/project-edit-field.component';
 import { HoursDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
 import { UserEditFieldComponent } from './field-types/user-edit-field.component';
+import { DaysDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent';
 
 export function initializeCoreEditFields(editFieldService:EditFieldService, selectAutocompleterRegisterService:SelectAutocompleterRegisterService) {
-  return () => {
+  return ():void => {
     editFieldService.defaultFieldType = 'text';
     editFieldService
       .addFieldType(TextEditFieldComponent, 'text', ['String'])
@@ -81,6 +82,9 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
       .addSpecificFieldType('WorkPackage', CombinedDateEditFieldComponent,
         'date',
         ['combinedDate', 'startDate', 'dueDate', 'date'])
+      .addSpecificFieldType('WorkPackage', DaysDurationEditFieldComponent,
+        'duration',
+        ['duration'])
       .addSpecificFieldType('Project', ProjectStatusEditFieldComponent, 'status', ['status'])
       .addSpecificFieldType('TimeEntry', PlainFormattableEditFieldComponent, 'comment', ['comment'])
       .addSpecificFieldType('TimeEntry', TimeEntryWorkPackageEditFieldComponent, 'workPackage', ['WorkPackage'])

--- a/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
@@ -26,86 +26,40 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
-import { OpModalService } from 'core-app/shared/components/modal/modal.service';
-import { take } from 'rxjs/operators';
-import { DateEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.component';
-import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { DatePickerModalComponent } from 'core-app/shared/components/datepicker/datepicker.modal';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { DatePickerEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/date-picker-edit-field.component';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 
 @Component({
   template: `
     <input [value]="dates"
-           (click)="handleClick()"
+           (click)="showDatePickerModal()"
            class="op-input"
            type="text" />
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CombinedDateEditFieldComponent extends DateEditFieldComponent implements OnInit, OnDestroy {
-  @InjectField() readonly timezoneService:TimezoneService;
-
-  @InjectField() opModalService:OpModalService;
-
+export class CombinedDateEditFieldComponent extends DatePickerEditFieldComponent {
   dates = '';
 
   text_no_start_date = this.I18n.t('js.label_no_start_date');
 
   text_no_due_date = this.I18n.t('js.label_no_due_date');
 
-  private modal:OpModalComponent;
+  public showDatePickerModal():void {
+    super.showDatePickerModal();
 
-  ngOnInit() {
-    super.ngOnInit();
-
-    this.handler
-      .$onUserActivate
-      .pipe(
-        this.untilDestroyed(),
-      )
-      .subscribe(() => {
-        this.showDatePickerModal();
-      });
-  }
-
-  ngOnDestroy() {
-    super.ngOnDestroy();
-    this.modal?.closeMe();
-  }
-
-  public handleClick() {
-    this.showDatePickerModal();
-  }
-
-  private showDatePickerModal():void {
-    const modal = this.modal = this
-      .opModalService
-      .show(DatePickerModalComponent, this.injector, { changeset: this.change, fieldName: this.name }, true);
-
-    setTimeout(() => {
-      const modalElement = jQuery(modal.elementRef.nativeElement).find('.op-datepicker-modal');
-      const field = jQuery(this.elementRef.nativeElement);
-      modal.reposition(modalElement, field);
-    });
-
-    modal
+    this
+      .modal
       .onDataUpdated
       .subscribe((dates:string) => {
         this.dates = dates;
         this.cdRef.detectChanges();
       });
-
-    modal
-      .closingEvent
-      .pipe(take(1))
-      .subscribe(() => {
-        this.handler.handleUserSubmit();
-      });
   }
 
-  // Overwrite super in order to set the inital dates.
-  protected initialize() {
+  // Overwrite super in order to set the initial dates.
+  protected initialize():void {
     super.initialize();
 
     // this breaks the preceived abstraction of the edit fields. But the date picker
@@ -114,10 +68,10 @@ export class CombinedDateEditFieldComponent extends DateEditFieldComponent imple
   }
 
   protected get currentStartDate():string {
-    return this.resource.startDate || this.text_no_start_date;
+    return ((this.resource && (this.resource as WorkPackageResource).startDate) || this.text_no_start_date) as string;
   }
 
   protected get currentDueDate():string {
-    return this.resource.dueDate || this.text_no_due_date;
+    return ((this.resource && (this.resource as WorkPackageResource).dueDate) || this.text_no_due_date) as string;
   }
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -1,0 +1,87 @@
+/*
+ *  OpenProject is an open source project management software.
+ *  Copyright (C) 2010-2022 the OpenProject GmbH
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License version 3.
+ *
+ *  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ *  Copyright (C) 2006-2013 Jean-Philippe Lang
+ *  Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  See COPYRIGHT and LICENSE files for more details.
+ */
+
+import {
+  Directive,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
+import { take } from 'rxjs/operators';
+import { DatePickerModalComponent } from 'core-app/shared/components/datepicker/datepicker.modal';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
+
+@Directive()
+export abstract class DatePickerEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
+  @InjectField() readonly timezoneService:TimezoneService;
+
+  @InjectField() opModalService:OpModalService;
+
+  protected modal:DatePickerModalComponent;
+
+  ngOnInit():void {
+    super.ngOnInit();
+
+    this.handler
+      .$onUserActivate
+      .pipe(
+        this.untilDestroyed(),
+      )
+      .subscribe(() => {
+        this.showDatePickerModal();
+      });
+  }
+
+  ngOnDestroy():void {
+    super.ngOnDestroy();
+    this.modal?.closeMe();
+  }
+
+  public showDatePickerModal():void {
+    this.modal = this
+      .opModalService
+      .show(DatePickerModalComponent, this.injector, { changeset: this.change, fieldName: this.name }, true);
+
+    const { modal } = this;
+
+    setTimeout(() => {
+      const modalElement = jQuery(modal.elementRef.nativeElement).find('.op-datepicker-modal');
+      const field = jQuery(this.elementRef.nativeElement);
+      modal.reposition(modalElement, field);
+    });
+
+    modal
+      .closingEvent
+      .pipe(take(1))
+      .subscribe(() => {
+        void this.handler.handleUserSubmit();
+      });
+  }
+}

--- a/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent.ts
@@ -1,0 +1,101 @@
+/*
+ *  OpenProject is an open source project management software.
+ *  Copyright (C) 2010-2022 the OpenProject GmbH
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License version 3.
+ *
+ *  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ *  Copyright (C) 2006-2013 Jean-Philippe Lang
+ *  Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  See COPYRIGHT and LICENSE files for more details.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
+import { take } from 'rxjs/operators';
+import { DatePickerModalComponent } from 'core-app/shared/components/datepicker/datepicker.modal';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
+
+@Component({
+  template: `
+    <input type="number"
+           class="inline-edit--field op-input"
+           [ngModel]="formattedValue"
+           [disabled]="true"
+           [id]="handler.htmlId" />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DaysDurationEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
+  @InjectField() readonly timezoneService:TimezoneService;
+
+  @InjectField() opModalService:OpModalService;
+
+  private modal:DatePickerModalComponent;
+
+  public get formattedValue():number {
+    return Number(moment.duration(this.value).asDays().toFixed(0));
+  }
+
+  ngOnInit():void {
+    super.ngOnInit();
+
+    this.handler
+      .$onUserActivate
+      .pipe(
+        this.untilDestroyed(),
+      )
+      .subscribe(() => {
+        this.showDatePickerModal();
+      });
+  }
+
+  ngOnDestroy():void {
+    super.ngOnDestroy();
+    this.modal?.closeMe();
+  }
+
+  public showDatePickerModal():void {
+    this.modal = this
+      .opModalService
+      .show(DatePickerModalComponent, this.injector, { changeset: this.change, fieldName: this.name }, true);
+
+    const { modal } = this;
+
+    setTimeout(() => {
+      const modalElement = jQuery(modal.elementRef.nativeElement).find('.op-datepicker-modal');
+      const field = jQuery(this.elementRef.nativeElement);
+      modal.reposition(modalElement, field);
+    });
+
+    modal
+      .closingEvent
+      .pipe(take(1))
+      .subscribe(() => {
+        void this.handler.handleUserSubmit();
+      });
+  }
+}

--- a/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent.ts
@@ -29,73 +29,21 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnDestroy,
-  OnInit,
 } from '@angular/core';
-import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
-import { OpModalService } from 'core-app/shared/components/modal/modal.service';
-import { take } from 'rxjs/operators';
-import { DatePickerModalComponent } from 'core-app/shared/components/datepicker/datepicker.modal';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
-import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
+import { DatePickerEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/date-picker-edit-field.component';
 
 @Component({
   template: `
     <input type="number"
            class="inline-edit--field op-input"
            [ngModel]="formattedValue"
-           [disabled]="true"
+           disabled="disabled"
            [id]="handler.htmlId" />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DaysDurationEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
-  @InjectField() readonly timezoneService:TimezoneService;
-
-  @InjectField() opModalService:OpModalService;
-
-  private modal:DatePickerModalComponent;
-
+export class DaysDurationEditFieldComponent extends DatePickerEditFieldComponent {
   public get formattedValue():number {
     return Number(moment.duration(this.value).asDays().toFixed(0));
-  }
-
-  ngOnInit():void {
-    super.ngOnInit();
-
-    this.handler
-      .$onUserActivate
-      .pipe(
-        this.untilDestroyed(),
-      )
-      .subscribe(() => {
-        this.showDatePickerModal();
-      });
-  }
-
-  ngOnDestroy():void {
-    super.ngOnDestroy();
-    this.modal?.closeMe();
-  }
-
-  public showDatePickerModal():void {
-    this.modal = this
-      .opModalService
-      .show(DatePickerModalComponent, this.injector, { changeset: this.change, fieldName: this.name }, true);
-
-    const { modal } = this;
-
-    setTimeout(() => {
-      const modalElement = jQuery(modal.elementRef.nativeElement).find('.op-datepicker-modal');
-      const field = jQuery(this.elementRef.nativeElement);
-      modal.reposition(modalElement, field);
-    });
-
-    modal
-      .closingEvent
-      .pipe(take(1))
-      .subscribe(() => {
-        void this.handler.handleUserSubmit();
-      });
   }
 }

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -62,6 +62,7 @@ import { EditFieldControlsModule } from 'core-app/shared/components/fields/edit/
 import { ProjectEditFieldComponent } from './edit/field-types/project-edit-field.component';
 import { HoursDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
 import { UserEditFieldComponent } from './edit/field-types/user-edit-field.component';
+import { DaysDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/days-duration-edit-field.compontent';
 
 @NgModule({
   imports: [
@@ -103,6 +104,7 @@ import { UserEditFieldComponent } from './edit/field-types/user-edit-field.compo
   declarations: [
     EditFormPortalComponent,
     HoursDurationEditFieldComponent,
+    DaysDurationEditFieldComponent,
     FloatEditFieldComponent,
     PlainFormattableEditFieldComponent,
     MultiSelectEditFieldComponent,


### PR DESCRIPTION
Enables clicking on the duration field in the wp table to open the date picker modal. 

Since that modal does not have the duration field in it, modification is still not possible. This should be possible once #11151 is merged.

The field is set to disabled since modification should not be possible in that field directly. I would opt for doing the same to the start and finish date in the wp table.

https://community.openproject.org/wp/43636

### Todos

* [ ] add feature specs
* [x] reduce duplication. 

 