### PR TITLE
[43762][43775] Gantt chart header is not updated correctly

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -69,10 +69,6 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
   }
 
   private renderLabels(vp:TimelineViewParameters):void {
-    if (this.activeZoomLevel === vp.settings.zoomLevel) {
-      return;
-    }
-
     this.gridContainer.empty();
 
     switch (vp.settings.zoomLevel) {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/header/wp-timeline-header.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/header/wp-timeline-header.directive.ts
@@ -69,25 +69,28 @@ export class WorkPackageTimelineHeaderController implements OnInit {
     this.renderLabels(vp);
   }
 
-  private renderLabels(vp:TimelineViewParameters) {
-    if (this.activeZoomLevel === vp.settings.zoomLevel) {
-      return;
-    }
-
+  private renderLabels(vp:TimelineViewParameters):void {
     this.innerHeader.empty();
     this.innerHeader.attr('data-current-zoom-level', this.wpTimelineService.zoomLevel);
 
     switch (vp.settings.zoomLevel) {
       case 'days':
-        return this.renderLabelsDays(vp);
+        this.renderLabelsDays(vp);
+        break;
       case 'weeks':
-        return this.renderLabelsWeeks(vp);
+        this.renderLabelsWeeks(vp);
+        break;
       case 'months':
-        return this.renderLabelsMonths(vp);
+        this.renderLabelsMonths(vp);
+        break;
       case 'quarters':
-        return this.renderLabelsQuarters(vp);
+        this.renderLabelsQuarters(vp);
+        break;
       case 'years':
-        return this.renderLabelsYears(vp);
+        this.renderLabelsYears(vp);
+        break;
+      default:
+        return;
     }
 
     this.activeZoomLevel = vp.settings.zoomLevel;


### PR DESCRIPTION
Always update gantt cells and header to have correct data displayed when collapsing groups. Previously, only the bars would change its position, but since the header remained, the bars where shown at the wrong time.


Fixes 
https://community.openproject.org/projects/openproject/work_packages/43775/activity
as well as 
https://community.openproject.org/projects/openproject/work_packages/43762/activity