### PR TITLE
Keep start_date, due_date, and duration in sync

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -347,7 +347,7 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def min_child_date
-    (work_package.children.map(&:start_date) + work_package.children.map(&:due_date)).compact.min
+    children_dates.min
   end
 
   def children_duration
@@ -362,7 +362,11 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def max_child_date
-    (work_package.children.map(&:start_date) + work_package.children.map(&:due_date)).compact.max
+    children_dates.max
+  end
+
+  def children_dates
+    @children_dates ||= work_package.children.pluck(:start_date, :due_date).flatten.compact
   end
 
   def parent_start_earlier_than_due?

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -74,11 +74,11 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   # fields are set. Matching is done in the order :duration, :due_date,
   # :start_date. The first one to match is returned.
   def derivable_attribute_by_others_presence
-    if attribute_not_set_in_params?(:duration) && both_present?(:start_date, :due_date)
+    if attribute_not_set_in_params?(:duration) && all_present?(:start_date, :due_date)
       :duration
-    elsif attribute_not_set_in_params?(:due_date) && both_present?(:start_date, :duration)
+    elsif attribute_not_set_in_params?(:due_date) && all_present?(:start_date, :duration)
       :due_date
-    elsif attribute_not_set_in_params?(:start_date) && both_present?(:due_date, :duration)
+    elsif attribute_not_set_in_params?(:start_date) && all_present?(:due_date, :duration)
       :start_date
     end
   end
@@ -109,7 +109,7 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def only_one_present?(*fields)
-    work_package.values_at(*fields).count(&:present?) == 1
+    work_package.values_at(*fields).one?(&:present?)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -104,7 +104,7 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     !params.has_key?(field)
   end
 
-  def both_present?(*fields)
+  def all_present?(*fields)
     work_package.values_at(*fields).all?(&:present?)
   end
 

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -73,32 +73,32 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     # if one is nil and one is set, which should trigger the computation of the
     # unchanged third one. Do it in the order :duration, :due_date, :start_date
     # and return the first one that matches.
-    if unchanged?(:duration) && both_set?(:start_date, :due_date)
+    if attribute_not_set_in_params?(:duration) && both_present?(:start_date, :due_date)
       :duration
-    elsif unchanged?(:due_date) && both_set?(:start_date, :duration)
+    elsif attribute_not_set_in_params?(:due_date) && both_present?(:start_date, :duration)
       :due_date
-    elsif unchanged?(:start_date) && both_set?(:due_date, :duration)
+    elsif attribute_not_set_in_params?(:start_date) && both_present?(:due_date, :duration)
       :start_date
-    elsif unchanged?(:duration) && only_one_is_nil?(:start_date, :due_date)
+    elsif attribute_not_set_in_params?(:duration) && only_one_present?(:start_date, :due_date)
       :duration
-    elsif unchanged?(:due_date) && only_one_is_nil?(:start_date, :duration)
+    elsif attribute_not_set_in_params?(:due_date) && only_one_present?(:start_date, :duration)
       :due_date
-    elsif unchanged?(:start_date) && only_one_is_nil?(:due_date, :duration)
+    elsif attribute_not_set_in_params?(:start_date) && only_one_present?(:due_date, :duration)
       :start_date
     end
   end
   # rubocop:enable Metrics/PerceivedComplexity, Lint/DuplicateBranch
 
-  def unchanged?(field)
-    !work_package.send("#{field}_changed?")
+  def attribute_not_set_in_params?(field)
+    !params.has_key?(field)
   end
 
-  def both_set?(*fields)
-    work_package.values_at(*fields).count(&:nil?) == 0
+  def both_present?(*fields)
+    work_package.values_at(*fields).all?(&:present?)
   end
 
-  def only_one_is_nil?(*fields)
-    work_package.values_at(*fields).count(&:nil?) == 1
+  def only_one_present?(*fields)
+    work_package.values_at(*fields).count(&:present?) == 1
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/services/work_packages/shared/all_days.rb
+++ b/app/services/work_packages/shared/all_days.rb
@@ -36,6 +36,13 @@ module WorkPackages
         (start_date..due_date).count
       end
 
+      def start_date(due_date, duration)
+        return nil unless due_date && duration
+        raise ArgumentError, 'duration must be strictly positive' if duration.is_a?(Integer) && duration <= 0
+
+        due_date - duration + 1
+      end
+
       def due_date(start_date, duration)
         return nil unless start_date && duration
         raise ArgumentError, 'duration must be strictly positive' if duration.is_a?(Integer) && duration <= 0

--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -37,6 +37,18 @@ module WorkPackages
         (start_date..due_date).count { working?(_1) }
       end
 
+      def start_date(due_date, duration)
+        return nil unless due_date && duration
+        raise ArgumentError, 'duration must be strictly positive' if duration.is_a?(Integer) && duration <= 0
+
+        start_date = due_date
+        until duration <= 1 && working?(start_date)
+          start_date -= 1
+          duration -= 1 if working?(start_date)
+        end
+        start_date
+      end
+
       def due_date(start_date, duration)
         return nil unless start_date && duration
         raise ArgumentError, 'duration must be strictly positive' if duration.is_a?(Integer) && duration <= 0

--- a/docs/api/apiv3/paths/work_package_form.yml
+++ b/docs/api/apiv3/paths/work_package_form.yml
@@ -55,4 +55,9 @@ post:
   - Work Packages
   description: ''
   operationId: Work_Package_Edit_Form
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "../components/schemas/work_package_model.yml"
   summary: Work Package Edit Form

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -86,7 +86,8 @@ describe 'Project templates', type: :feature, js: true do
       login_as current_user
     end
 
-    it 'can instantiate the project with the copy permission' do
+    it 'can instantiate the project with the copy permission',
+       with_flag: { work_packages_duration_field_active: true } do
       visit new_project_path
 
       name_field.set_value 'Foo bar'

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -37,7 +37,7 @@ describe 'date inplace editor',
          with_settings: { date_format: '%Y-%m-%d' },
          js: true, selenium: true do
   let(:project) { create :project_with_types, public: true }
-  let(:work_package) { create :work_package, project:, start_date: Date.parse('2016-01-02') }
+  let(:work_package) { create :work_package, project:, start_date: Date.parse('2016-01-02'), duration: nil }
   let(:user) { create :admin }
   let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
@@ -163,7 +163,7 @@ describe 'date inplace editor',
   end
 
   context 'with the start date empty' do
-    let(:work_package) { create :work_package, project:, start_date: nil }
+    let(:work_package) { create :work_package, project:, start_date: nil, duration: nil }
 
     it 'can set "today" as a date via the provided link' do
       start_date.activate!

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -925,15 +925,13 @@ describe WorkPackages::SetAttributesService,
         { initial: %i[start_date  due_date  duration], set: %i[start_date], nilled: %i[due_date], expected: { nilify: :duration } },
         { initial: %i[start_date                    ], set: %i[start_date], nilled: %i[due_date], expected: {} },
         { initial: %i[            due_date          ], set: %i[start_date], nilled: %i[due_date], expected: {} },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[                      duration], set: %i[start_date], nilled: %i[due_date], expected: { change: :due_date } },
+        { initial: %i[                      duration], set: %i[start_date], nilled: %i[due_date], expected: { nilify: :duration, same: :due_date } },
         { initial: %i[                              ], set: %i[start_date], nilled: %i[due_date], expected: {} },
 
         { initial: %i[start_date  due_date  duration], set: %i[due_date], nilled: %i[start_date], expected: { nilify: :duration } },
         { initial: %i[start_date                    ], set: %i[due_date], nilled: %i[start_date], expected: {} },
         { initial: %i[            due_date          ], set: %i[due_date], nilled: %i[start_date], expected: {} },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[                      duration], set: %i[due_date], nilled: %i[start_date], expected: { change: :start_date } },
+        { initial: %i[                      duration], set: %i[due_date], nilled: %i[start_date], expected: { nilify: :duration, same: :start_date } },
         { initial: %i[                              ], set: %i[due_date], nilled: %i[start_date], expected: {} },
 
         { initial: %i[start_date  due_date  duration], nilled: %i[start_date due_date], expected: {} },
@@ -950,15 +948,13 @@ describe WorkPackages::SetAttributesService,
 
         { initial: %i[start_date  due_date  duration], set: %i[start_date], nilled: %i[duration], expected: { nilify: :due_date } },
         { initial: %i[start_date                    ], set: %i[start_date], nilled: %i[duration], expected: {} },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[            due_date          ], set: %i[start_date], nilled: %i[duration], expected: { change: :duration } },
+        { initial: %i[            due_date          ], set: %i[start_date], nilled: %i[duration], expected: { nilify: :due_date, same: :duration } },
         { initial: %i[                      duration], set: %i[start_date], nilled: %i[duration], expected: {} },
         { initial: %i[                              ], set: %i[start_date], nilled: %i[duration], expected: {} },
 
         { initial: %i[start_date  due_date  duration], set: %i[duration], nilled: %i[start_date], expected: { nilify: :due_date } },
         { initial: %i[start_date                    ], set: %i[duration], nilled: %i[start_date], expected: {} },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[            due_date          ], set: %i[duration], nilled: %i[start_date], expected: { change: :start_date } },
+        { initial: %i[            due_date          ], set: %i[duration], nilled: %i[start_date], expected: { nilify: :due_date, same: :start_date } },
         { initial: %i[                      duration], set: %i[duration], nilled: %i[start_date], expected: {} },
         { initial: %i[                              ], set: %i[duration], nilled: %i[start_date], expected: {} },
 
@@ -975,15 +971,13 @@ describe WorkPackages::SetAttributesService,
         { initial: %i[                              ], set: %i[due_date duration], expected: { change: :start_date } },
 
         { initial: %i[start_date  due_date  duration], set: %i[due_date], nilled: %i[duration], expected: { nilify: :start_date } },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[start_date                    ], set: %i[due_date], nilled: %i[duration], expected: { change: :duration } },
+        { initial: %i[start_date                    ], set: %i[due_date], nilled: %i[duration], expected: { nilify: :start_date, same: :duration } },
         { initial: %i[            due_date          ], set: %i[due_date], nilled: %i[duration], expected: {} },
         { initial: %i[                      duration], set: %i[due_date], nilled: %i[duration], expected: {} },
         { initial: %i[                              ], set: %i[due_date], nilled: %i[duration], expected: {} },
 
         { initial: %i[start_date  due_date  duration], set: %i[duration], nilled: %i[due_date], expected: { nilify: :start_date } },
-        # TODO: is below scenario below ok? Problem is we can't detect that the user supplied nil as there is no change in the model
-        { initial: %i[start_date                    ], set: %i[duration], nilled: %i[due_date], expected: { change: :due_date } },
+        { initial: %i[start_date                    ], set: %i[duration], nilled: %i[due_date], expected: { nilify: :start_date, same: :due_date } },
         { initial: %i[            due_date          ], set: %i[duration], nilled: %i[due_date], expected: {} },
         { initial: %i[                      duration], set: %i[duration], nilled: %i[due_date], expected: {} },
         { initial: %i[                              ], set: %i[duration], nilled: %i[due_date], expected: {} },
@@ -1012,8 +1006,9 @@ describe WorkPackages::SetAttributesService,
         nilled = scenario[:nilled] || []
         expected = scenario[:expected]
         expected_change = expected[:change]
+        expected_same = expected[:same]
         expected_nilify = expected[:nilify]
-        unchanged = %i[start_date due_date duration] - set - nilled - expected.values
+        unchanged = %i[start_date due_date duration] - set - nilled - expected.values + [expected_same].compact
 
         context_description = []
         context_description << "with initial values for #{initial.inspect}" if initial.any?

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -79,6 +79,39 @@ RSpec.describe WorkPackages::Shared::AllDays do
     end
   end
 
+  describe '#start_date' do
+    it 'returns the start date for a due date and a duration' do
+      expect(subject.start_date(sunday_2022_07_31, 1)).to eq(sunday_2022_07_31)
+      expect(subject.start_date(sunday_2022_07_31 + 9.days, 10)).to eq(sunday_2022_07_31)
+    end
+
+    it 'raises an error if duration is 0 or negative' do
+      expect { subject.start_date(sunday_2022_07_31, 0) }
+        .to raise_error ArgumentError, 'duration must be strictly positive'
+      expect { subject.start_date(sunday_2022_07_31, -10) }
+        .to raise_error ArgumentError, 'duration must be strictly positive'
+    end
+
+    it 'returns nil if due_date is nil' do
+      expect(subject.start_date(nil, 1)).to be_nil
+    end
+
+    it 'returns nil if duration is nil' do
+      expect(subject.start_date(sunday_2022_07_31, nil)).to be_nil
+    end
+
+    context 'with weekend days (Saturday and Sunday)', :weekend_saturday_sunday do
+      include_examples 'start_date', due_date: sunday_2022_07_31, duration: 1, expected: sunday_2022_07_31
+      include_examples 'start_date', due_date: sunday_2022_07_31, duration: 5, expected: sunday_2022_07_31 - 4.days
+      include_examples 'start_date', due_date: sunday_2022_07_31, duration: 10, expected: sunday_2022_07_31 - 9.days
+    end
+
+    context 'with non working days (Christmas 2022-12-25 and new year\'s day 2023-01-01)', :christmas_2022_new_year_2023 do
+      include_examples 'start_date', due_date: Date.new(2022, 12, 31), duration: 365, expected: Date.new(2022, 1, 1)
+      include_examples 'start_date', due_date: Date.new(2023, 12, 31), duration: 365 * 2, expected: Date.new(2022, 1, 1)
+    end
+  end
+
   describe '#due_date' do
     it 'returns the due date for a start date and a duration' do
       expect(subject.due_date(sunday_2022_07_31, 1)).to eq(sunday_2022_07_31)

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -55,6 +55,12 @@ RSpec.shared_examples 'it returns duration' do |expected_duration, start_date, d
   end
 end
 
+RSpec.shared_examples 'start_date' do |due_date:, duration:, expected:|
+  it "start_date(#{due_date.to_fs(:wday_date)}, #{duration}) => #{expected.to_fs(:wday_date)}" do
+    expect(subject.start_date(due_date, duration)).to eq(expected)
+  end
+end
+
 RSpec.shared_examples 'due_date' do |start_date:, duration:, expected:|
   it "due_date(#{start_date.to_fs(:wday_date)}, #{duration}) => #{expected.to_fs(:wday_date)}" do
     expect(subject.due_date(start_date, duration)).to eq(expected)

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -56,11 +56,13 @@ module Components
         raise ArgumentError, "Invalid value #{value} for day, expected 1-31"
       end
 
-      container
-        .first('.flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)',
-               text: value,
-               exact_text: true)
-        .click
+      retry_block do
+        container
+          .first('.flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)',
+                 text: value,
+                 exact_text: true)
+          .click
+      end
     end
 
     ##


### PR DESCRIPTION
[See OP#43651](https://community.openproject.org/projects/openproject/work_packages/43651)

It makes sure that:
* when 2 fields are set, the third one is derived from them
* when 3 fields are set and one is unset, then one another is unset too.

This is needed to have the date picker query the work package edit form endpoint to update itself whenever the user enters new values.