### PR TITLE
Document how to deal with migrations run locally

### DIFF
--- a/docs/development/running-tests/README.md
+++ b/docs/development/running-tests/README.md
@@ -115,6 +115,14 @@ Possible reasons are:
   * To help diagnose why a system test is failing:
     * Browser screenshots are created for failing system tests involving a browser. You can find them in the job log output.
     * Try running with `OPENPROJECT_TESTING_NO_HEADLESS=1` to view what the browser is doing. Use `OPENPROJECT_TESTING_AUTO_DEVTOOLS=1` to have DevTools opened so that you can use `debugger` statements in the js code.
+* Migration executed locally
+  * While developing on another branch, you may run migrations and forget to roll them back when switching branches. This can lead to different test results: a migration modifying a database column default value can impact system behavior and change test results.
+  * To find if this is your case, run `rails db:migrate:status` to list migration status. Look for `up    <migration-id>  ********** NO FILE **********` patterns. If you have some, try looking up the commit associated with this migration and check if it explains behavior difference.
+  * To look up commits referencing the migration, use the `<migration-id>` from previous command and run `git log -p --all -- '**/*<migration-id>*'`. For instance `git log -p --all -- '**/*20220816065025*'`.
+  * If you find a commit and want to roll the associated migration back:
+    * Checkout the commit: `git switch --detach <commit-sha>`
+    * Roll the migration back: `rails db:migrate:down VERSION=<migration-id>`
+    * Switch back to where you left: `git switch -`
 
 
 


### PR DESCRIPTION
From a [discussion with Oliver](https://matrix.to/#/!nBswTuuAGGsFHRrmMC:openproject.org/$sVysYVt81HGLRZGQu9y-9i67-XXM2NU4PLXRDLLMp_w?via=openproject.org) while I had different test results between my machine and CI because of a migration that changed the default value of `ignore_non_working_days` on my machine but not on the CI.