### PR TITLE
Restore main wiki item on rendering wiki menu

### DIFF
--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -31,8 +31,9 @@ module Redmine::MenuManager::WikiMenuHelper
     return unless project.enabled_module_names.include? 'wiki'
 
     project_wiki = project.wiki
+    return if project_wiki.nil?
 
-    MenuItems::WikiMenuItem.main_items(project_wiki).each do |main_item|
+    wiki_main_items(project_wiki).each do |main_item|
       Redmine::MenuManager.loose :project_menu do |menu|
         push_wiki_main_menu(menu, main_item, project)
 
@@ -79,6 +80,16 @@ module Redmine::MenuManager::WikiMenuHelper
   end
 
   private
+
+  def wiki_main_items(wiki)
+    ##
+    # Ensure a main item exists if it got deleted somewhere
+    MenuItems::WikiMenuItem
+      .main_items(wiki)
+      .tap do |items|
+      wiki.create_menu_item_for_start_page if items.empty?
+    end
+  end
 
   def push_wiki_menu_partial(main_item, menu)
     menu.push :wiki_menu_partial,

--- a/spec/features/wiki/restore_main_item_spec.rb
+++ b/spec/features/wiki/restore_main_item_spec.rb
@@ -1,0 +1,65 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Wiki page - restoring main wiki item', type: :feature do
+  let(:project) { create(:project, enabled_module_names: %w[wiki]) }
+  let(:user) do
+    create :user,
+           member_in_project: project,
+           member_with_permissions: %i[view_wiki_pages
+                                       rename_wiki_pages]
+  end
+
+  before do
+    login_as(user)
+  end
+
+  it 'restores the main item on start' do
+    # For some reason, a customer had deleted their wiki start page
+    # even though it should be recreated on desctruction of the last item
+    # This spec ensure the wiki main item is rendered even if no menu item is saved.
+    visit project_path(project)
+
+    expect(page)
+      .to have_selector('.wiki-menu--main-item')
+
+    # Delete all items for some reason
+    MenuItems::WikiMenuItem.main_items(project.wiki).destroy_all
+
+    expect(MenuItems::WikiMenuItem.main_items(project.wiki).count).to eq 0
+
+    visit project_path(project)
+
+    expect(page)
+      .to have_selector('.wiki-menu--main-item')
+
+    expect(MenuItems::WikiMenuItem.main_items(project.wiki).count).to eq 1
+  end
+end


### PR DESCRIPTION
In case there is no wiki items, even if there should always be one, the wiki will be unaccessible.

To avoid this, we ensure the main wiki item is always created in case it is missing.

https://community.openproject.org/wp/43841