### PR TITLE
[#43637] Update gantt chart for duration and non-working days

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -63,7 +63,8 @@ module.exports = {
         ],
 
         // Sometimes we need to shush the TypeScript compiler
-        "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
+        "no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
 
         // Who cares about line length
         "max-len": "off",

--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
@@ -79,8 +79,7 @@ export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponen
   }
 
   // Disable show viewpoint functionality
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  showViewpoint(workPackage:WorkPackageResource, index:number):void {
+  showViewpoint(_workPackage:WorkPackageResource, _index:number):void {
 
   }
 

--- a/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
@@ -120,8 +120,7 @@ export class WorkPackagesCalendarPageComponent extends PartitionedQuerySpacePage
     this.currentPartition = state.data?.partition || '-split';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected staticQueryName(query:QueryResource):string {
+  protected staticQueryName(_query:QueryResource):string {
     return this.text.unsaved_title;
   }
 

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
@@ -124,13 +124,13 @@ export class InAppNotificationCenterPageComponent extends UntilDestroyedMixin im
   }
 
   // For shared template compliance
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-  updateTitleName(val:string):void {
+  // eslint-disable-next-line class-methods-use-this
+  updateTitleName(_val:string):void {
   }
 
   // For shared template compliance
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-  changeChangesFromTitle(val:string):void {
+  // eslint-disable-next-line class-methods-use-this
+  changeChangesFromTitle(_val:string):void {
   }
 
   private setInitialHtmlTitle():void {

--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -119,8 +119,7 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
     this.currentPartition = state.data?.partition || '-split';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected staticQueryName(query:QueryResource):string {
+  protected staticQueryName(_query:QueryResource):string {
     return this.text.unsaved_title;
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -315,6 +315,16 @@ export class TimelineCellRenderer {
     return newDuration;
   }
 
+  isCursorOnInvalidDay(ev:MouseEvent, renderInfo:RenderInfo):boolean {
+    const workPackage = renderInfo.workPackage;
+    if (workPackage.ignoreNonWorkingDays) {
+      return false;
+    };
+
+    const [currentDate, _] = this.cursorDateAndDayOffset(ev, renderInfo);
+    return this.weekdayService.isNonWorkingDay(currentDate.toDate());
+  }
+
   getMarginLeftOfLeftSide(renderInfo:RenderInfo):number {
     const projection = renderInfo.change.projectedResource;
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -11,24 +11,7 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
-import {
-  classNameBarLabel,
-  classNameLeftHandle,
-  classNameRightHandle,
-  MouseDirection,
-} from './wp-timeline-cell-mouse-handler';
-import {
-  classNameFarRightLabel,
-  classNameHideOnHover,
-  classNameHoverStyle,
-  classNameLeftHoverLabel,
-  classNameLeftLabel,
-  classNameRightContainer,
-  classNameRightHoverLabel,
-  classNameRightLabel,
-  classNameShowOnHover,
-  WorkPackageCellLabels,
-} from './wp-timeline-cell';
+import { WorkPackageCellLabels } from './wp-timeline-cell';
 import {
   calculatePositionValueForDayCount,
   calculatePositionValueForDayCountingPx,
@@ -48,6 +31,20 @@ export interface CellDateMovement {
 }
 
 export type LabelPosition = 'left'|'right'|'farRight';
+export type MouseDirection = 'left'|'right'|'both'|'create'|'dragright';
+
+export const classNameLeftLabel = 'labelLeft';
+export const classNameRightContainer = 'containerRight';
+export const classNameRightLabel = 'labelRight';
+export const classNameLeftHoverLabel = 'labelHoverLeft';
+export const classNameRightHoverLabel = 'labelHoverRight';
+export const classNameHoverStyle = '-label-style';
+export const classNameFarRightLabel = 'labelFarRight';
+export const classNameShowOnHover = 'show-on-hover';
+export const classNameHideOnHover = 'hide-on-hover';
+export const classNameLeftHandle = 'leftHandle';
+export const classNameRightHandle = 'rightHandle';
+export const classNameBarLabel = 'bar-label';
 
 class TimezoneService {
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -46,13 +46,8 @@ export const classNameLeftHandle = 'leftHandle';
 export const classNameRightHandle = 'rightHandle';
 export const classNameBarLabel = 'bar-label';
 
-class TimezoneService {
-}
-
 export class TimelineCellRenderer {
   @InjectField() wpTableTimeline:WorkPackageViewTimelineService;
-
-  @InjectField() TimezoneService:TimezoneService;
 
   @InjectField() weekdayService:WeekdayService;
 
@@ -81,7 +76,7 @@ export class TimelineCellRenderer {
     return 'bar';
   }
 
-  public canMoveDates(wp:WorkPackageResource) {
+  public canMoveDates(wp:WorkPackageResource):boolean {
     const schema = this.schemaCache.of(wp);
     return schema.startDate.writable && schema.dueDate.writable && schema.isAttributeEditable('startDate');
   }

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -95,15 +95,16 @@ export class TimelineCellRenderer {
 
   public displayPlaceholderUnderCursor(ev:MouseEvent, renderInfo:RenderInfo):HTMLElement {
     const days = Math.floor(ev.offsetX / renderInfo.viewParams.pixelPerDay);
+    const wpDuration = Number(moment.duration(renderInfo.workPackage.duration).asDays().toFixed(0));
+    const width = wpDuration * renderInfo.viewParams.pixelPerDay || 30;
 
     const placeholder = document.createElement('div');
     placeholder.style.pointerEvents = 'none';
     placeholder.style.position = 'absolute';
     placeholder.style.height = '1em';
-    placeholder.style.width = '30px';
+    placeholder.style.width = `${width}px`;
     placeholder.style.zIndex = '9999';
     placeholder.style.left = `${days * renderInfo.viewParams.pixelPerDay}px`;
-
     this.applyTypeColor(renderInfo, placeholder);
 
     return placeholder;
@@ -202,7 +203,10 @@ export class TimelineCellRenderer {
 
     if (dateForCreate) {
       projection.startDate = dateForCreate;
-      projection.dueDate = dateForCreate;
+      projection.dueDate = moment(dateForCreate)
+        .add(renderInfo.workPackage.duration || "P1D")
+        .add(-1, 'days')
+        .format('YYYY-MM-DD');
       direction = 'dragright';
     }
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -305,7 +305,7 @@ export class TimelineCellRenderer {
     for (newDuration; newDuration < duration; newDuration++) {
       const currentDate = date.clone().add(newDuration, 'days');
 
-      // Break out of the loop when we reach end of the visible table
+      // Stop adding duration when we reach end of the visible table
       if (currentDate > dateDisplayEnd) {
         break;
       }

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -11,7 +11,7 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
-import { WorkPackageCellLabels } from './wp-timeline-cell';
+import { WorkPackageCellLabels } from './wp-timeline-cell-labels';
 import {
   calculatePositionValueForDayCount,
   calculatePositionValueForDayCountingPx,

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -71,7 +71,7 @@ export class TimelineCellRenderer {
 
   public fieldRenderer:DisplayFieldRenderer = new DisplayFieldRenderer(this.injector, 'timeline');
 
-  protected cursorType:string;
+  protected mouseDownCursorType:string;
 
   constructor(readonly injector:Injector,
     readonly workPackageTimeline:WorkPackageTimelineTableController) {
@@ -190,21 +190,21 @@ export class TimelineCellRenderer {
     if (jQuery(ev.target!).hasClass(classNameLeftHandle)) {
       // only left
       direction = 'left';
-      this.cursorType = 'col-resize'
+      this.mouseDownCursorType = 'col-resize'
       if (projection.startDate === null) {
         projection.startDate = projection.dueDate;
       }
     } else if (jQuery(ev.target!).hasClass(classNameRightHandle) || dateForCreate) {
       // only right
       direction = 'right';
-      this.cursorType = 'col-resize';
+      this.mouseDownCursorType = 'col-resize';
     } else {
       // both
       direction = 'both';
-      this.cursorType = 'ew-resize';
+      this.mouseDownCursorType = 'ew-resize';
     }
 
-    this.workPackageTimeline.forceCursor(this.cursorType);
+    this.workPackageTimeline.forceCursor(this.mouseDownCursorType);
 
     if (dateForCreate) {
       const [dateUnderCursor, _] = this.cursorDateAndDayOffset(ev, renderInfo);
@@ -222,8 +222,8 @@ export class TimelineCellRenderer {
 
   public onMouseDownEnd(labels:WorkPackageCellLabels, change:WorkPackageChangeset) {
     // Reset the cursor set by onMouseDown
-    this.cursorType = '';
-    this.workPackageTimeline.forceCursor(this.cursorType);
+    this.mouseDownCursorType = '';
+    this.workPackageTimeline.forceCursor(this.mouseDownCursorType);
     this.updateLabels(false, labels, change);
   }
 
@@ -528,7 +528,7 @@ export class TimelineCellRenderer {
       this.workPackageTimeline.forceCursor('not-allowed');
     } else {
       // Restore the previous cursor set by onMouseDown
-      this.workPackageTimeline.forceCursor(this.cursorType);
+      this.workPackageTimeline.forceCursor(this.mouseDownCursorType);
     }
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -71,7 +71,7 @@ export class TimelineCellRenderer {
 
   public fieldRenderer:DisplayFieldRenderer = new DisplayFieldRenderer(this.injector, 'timeline');
 
-  protected dateDisplaysOnMouseMove:{ left?:HTMLElement; right?:HTMLElement } = {};
+  protected cursorType:string;
 
   constructor(readonly injector:Injector,
     readonly workPackageTimeline:WorkPackageTimelineTableController) {
@@ -190,19 +190,21 @@ export class TimelineCellRenderer {
     if (jQuery(ev.target!).hasClass(classNameLeftHandle)) {
       // only left
       direction = 'left';
-      this.workPackageTimeline.forceCursor('col-resize');
+      this.cursorType = 'col-resize'
       if (projection.startDate === null) {
         projection.startDate = projection.dueDate;
       }
     } else if (jQuery(ev.target!).hasClass(classNameRightHandle) || dateForCreate) {
       // only right
       direction = 'right';
-      this.workPackageTimeline.forceCursor('col-resize');
+      this.cursorType = 'col-resize';
     } else {
       // both
       direction = 'both';
-      this.workPackageTimeline.forceCursor('ew-resize');
+      this.cursorType = 'ew-resize';
     }
+
+    this.workPackageTimeline.forceCursor(this.cursorType);
 
     if (dateForCreate) {
       const [dateUnderCursor, _] = this.cursorDateAndDayOffset(ev, renderInfo);
@@ -219,6 +221,9 @@ export class TimelineCellRenderer {
   }
 
   public onMouseDownEnd(labels:WorkPackageCellLabels, change:WorkPackageChangeset) {
+    // Reset the cursor set by onMouseDown
+    this.cursorType = '';
+    this.workPackageTimeline.forceCursor(this.cursorType);
     this.updateLabels(false, labels, change);
   }
 
@@ -522,7 +527,8 @@ export class TimelineCellRenderer {
     if (invalidDates) {
       this.workPackageTimeline.forceCursor('not-allowed');
     } else {
-      this.workPackageTimeline.forceCursor('');
+      // Restore the previous cursor set by onMouseDown
+      this.workPackageTimeline.forceCursor(this.cursorType);
     }
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -10,7 +10,12 @@ import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decora
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
-import { classNameBarLabel, classNameLeftHandle, classNameRightHandle } from './wp-timeline-cell-mouse-handler';
+import {
+  classNameBarLabel,
+  classNameLeftHandle,
+  classNameRightHandle,
+  MouseDirection
+} from './wp-timeline-cell-mouse-handler';
 import {
   classNameFarRightLabel,
   classNameHideOnHover,
@@ -125,7 +130,7 @@ export class TimelineCellRenderer {
   public onDaysMoved(change:WorkPackageChangeset,
     dayUnderCursor:Moment,
     delta:number,
-    direction:'left'|'right'|'both'|'create'|'dragright'):CellDateMovement {
+    direction:MouseDirection):CellDateMovement {
     const initialStartDate = change.pristineResource.startDate;
     const initialDueDate = change.pristineResource.dueDate;
 
@@ -166,8 +171,7 @@ export class TimelineCellRenderer {
   public onMouseDown(ev:MouseEvent,
     dateForCreate:string|null,
     renderInfo:RenderInfo,
-    labels:WorkPackageCellLabels,
-    elem:HTMLElement):'left'|'right'|'both'|'dragright'|'create' {
+    labels:WorkPackageCellLabels):MouseDirection {
     // check for active selection mode
     if (renderInfo.viewParams.activeSelectionMode) {
       renderInfo.viewParams.activeSelectionMode(renderInfo.workPackage);
@@ -176,7 +180,7 @@ export class TimelineCellRenderer {
     }
 
     const projection = renderInfo.change.projectedResource;
-    let direction:'left'|'right'|'both'|'dragright';
+    let direction:Exclude<MouseDirection, 'create'>;
 
     // Update the cursor and maybe set start/due values
     if (jQuery(ev.target!).hasClass(classNameLeftHandle)) {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -15,7 +15,7 @@ import {
   classNameBarLabel,
   classNameLeftHandle,
   classNameRightHandle,
-  MouseDirection
+  MouseDirection,
 } from './wp-timeline-cell-mouse-handler';
 import {
   classNameFarRightLabel,
@@ -190,7 +190,7 @@ export class TimelineCellRenderer {
     if (jQuery(ev.target!).hasClass(classNameLeftHandle)) {
       // only left
       direction = 'left';
-      this.mouseDownCursorType = 'col-resize'
+      this.mouseDownCursorType = 'col-resize';
       if (projection.startDate === null) {
         projection.startDate = projection.dueDate;
       }
@@ -207,7 +207,7 @@ export class TimelineCellRenderer {
     this.workPackageTimeline.forceCursor(this.mouseDownCursorType);
 
     if (dateForCreate) {
-      const [dateUnderCursor, _] = this.cursorDateAndDayOffset(ev, renderInfo);
+      const [dateUnderCursor, ] = this.cursorDateAndDayOffset(ev, renderInfo);
       const duration = this.displayDurationForDate(renderInfo, dateUnderCursor) - 1;
 
       projection.startDate = dateForCreate;
@@ -270,7 +270,7 @@ export class TimelineCellRenderer {
     return true;
   }
 
-  public cursorDateAndDayOffset(ev:MouseEvent, renderInfo: RenderInfo):[Moment, number] {
+  public cursorDateAndDayOffset(ev:MouseEvent, renderInfo:RenderInfo):[Moment, number] {
     const dayOffset = Math.floor(ev.offsetX / renderInfo.viewParams.pixelPerDay);
     const dateUnderCursor = renderInfo.viewParams.dateDisplayStart.clone().add(dayOffset, 'days');
     return [dateUnderCursor, dayOffset];
@@ -296,15 +296,15 @@ export class TimelineCellRenderer {
    * @return {number} the NonWorkingDays adjusted duration
    */
 
-  protected displayDurationForDate(renderInfo: RenderInfo, date:Moment):number {
-    const workPackage = renderInfo.workPackage;
-    let duration = Number(moment.duration(workPackage.duration || "P1D").asDays().toFixed(0));
+  protected displayDurationForDate(renderInfo:RenderInfo, date:Moment):number {
+    const { workPackage } = renderInfo;
+    let duration = Number(moment.duration(workPackage.duration || 'P1D').asDays().toFixed(0));
 
     if (workPackage.ignoreNonWorkingDays) {
       return duration;
     }
 
-    const dateDisplayEnd = renderInfo.viewParams.dateDisplayEnd;
+    const { dateDisplayEnd } = renderInfo.viewParams;
     let newDuration = 0;
 
     for (newDuration; newDuration < duration; newDuration++) {
@@ -315,7 +315,9 @@ export class TimelineCellRenderer {
         break;
       }
       // Extend the duration if the currentDate is non-working
-      this.weekdayService.isNonWorkingDay(currentDate.toDate()) && duration++;
+      if (this.weekdayService.isNonWorkingDay(currentDate.toDate())) {
+        duration += 1;
+      }
     }
     return newDuration;
   }
@@ -459,11 +461,11 @@ export class TimelineCellRenderer {
   cursorOrDatesAreNonWorking(evOrDates:MouseEvent|Moment[], renderInfo:RenderInfo):boolean {
     if (renderInfo.workPackage.ignoreNonWorkingDays) {
       return false;
-    };
+    }
 
-    const dates = (evOrDates instanceof MouseEvent) ?
-      [this.cursorDateAndDayOffset(evOrDates, renderInfo)[0]] :
-      evOrDates;
+    const dates = (evOrDates instanceof MouseEvent)
+      ? [this.cursorDateAndDayOffset(evOrDates, renderInfo)[0]]
+      : evOrDates;
 
     return dates.some((date) => this.weekdayService.isNonWorkingDay(date.toDate()));
   }
@@ -522,7 +524,7 @@ export class TimelineCellRenderer {
     // Check for non-working days and display a not-allowed cursor
     // when the startDate, dueDate are non-working days
     const { startDate, dueDate } = renderInfo.change.projectedResource;
-    const invalidDates = this.cursorOrDatesAreNonWorking([moment(startDate), moment(dueDate)], renderInfo)
+    const invalidDates = this.cursorOrDatesAreNonWorking([moment(startDate), moment(dueDate)], renderInfo);
 
     if (invalidDates) {
       this.workPackageTimeline.forceCursor('not-allowed');

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -207,7 +207,7 @@ export class TimelineCellRenderer {
     this.workPackageTimeline.forceCursor(this.mouseDownCursorType);
 
     if (dateForCreate) {
-      const [dateUnderCursor, ] = this.cursorDateAndDayOffset(ev, renderInfo);
+      const dateUnderCursor = this.cursorDateAndDayOffset(ev, renderInfo)[0];
       const duration = this.displayDurationForDate(renderInfo, dateUnderCursor) - 1;
 
       projection.startDate = dateForCreate;

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -7,8 +7,6 @@ import {
   timelineElementCssClass,
 } from '../wp-timeline';
 
-import { MouseDirection } from './wp-timeline-cell-mouse-handler';
-import { CellDateMovement, LabelPosition, TimelineCellRenderer } from './timeline-cell-renderer';
 import {
   classNameFarRightLabel,
   classNameHideOnHover,
@@ -19,8 +17,12 @@ import {
   classNameRightHoverLabel,
   classNameRightLabel,
   classNameShowOnHover,
-  WorkPackageCellLabels,
-} from './wp-timeline-cell';
+  CellDateMovement,
+  LabelPosition,
+  TimelineCellRenderer,
+  MouseDirection,
+} from './timeline-cell-renderer';
+import { WorkPackageCellLabels } from './wp-timeline-cell';
 import Moment = moment.Moment;
 
 export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -6,6 +6,8 @@ import {
   RenderInfo,
   timelineElementCssClass,
 } from '../wp-timeline';
+
+import { MouseDirection } from './wp-timeline-cell-mouse-handler';
 import { CellDateMovement, LabelPosition, TimelineCellRenderer } from './timeline-cell-renderer';
 import {
   classNameFarRightLabel,
@@ -76,7 +78,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
   public onDaysMoved(change:WorkPackageChangeset,
     dayUnderCursor:Moment,
     delta:number,
-    direction:'left' | 'right' | 'both' | 'create' | 'dragright') {
+    _direction:MouseDirection):CellDateMovement {
     const initialDate = change.pristineResource.date;
     const dates:CellDateMovement = {};
 
@@ -90,8 +92,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
   public onMouseDown(ev:MouseEvent,
     dateForCreate:string | null,
     renderInfo:RenderInfo,
-    labels:WorkPackageCellLabels,
-    elem:HTMLElement):'left' | 'right' | 'both' | 'create' | 'dragright' {
+    labels:WorkPackageCellLabels):MouseDirection {
     // check for active selection mode
     if (renderInfo.viewParams.activeSelectionMode) {
       renderInfo.viewParams.activeSelectionMode(renderInfo.workPackage);

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -22,7 +22,7 @@ import {
   TimelineCellRenderer,
   MouseDirection,
 } from './timeline-cell-renderer';
-import { WorkPackageCellLabels } from './wp-timeline-cell';
+import { WorkPackageCellLabels } from './wp-timeline-cell-labels';
 import Moment = moment.Moment;
 
 export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-labels.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-labels.ts
@@ -1,0 +1,38 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2022 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+export class WorkPackageCellLabels {
+  constructor(public readonly center:HTMLDivElement|null,
+    public readonly left:HTMLDivElement,
+    public readonly leftHover:HTMLDivElement|null,
+    public readonly right:HTMLDivElement,
+    public readonly rightHover:HTMLDivElement|null,
+    public readonly farRight:HTMLDivElement,
+    public readonly withAlternativeLabels?:boolean) {
+  }
+}

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -171,8 +171,7 @@ export function registerWorkPackageMouseHandler(this:void,
       bar.style.pointerEvents = 'none';
       ev.preventDefault();
 
-      const offsetDayStart = Math.floor(ev.offsetX / renderInfo.viewParams.pixelPerDay);
-      const clickStart = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayStart, 'days');
+      const [clickStart, offsetDayStart] = renderer.cursorDateAndDayOffset(ev, renderInfo);
       const dateForCreate = clickStart.format('YYYY-MM-DD');
       const mouseDownType = renderer.onMouseDown(ev, dateForCreate, renderInfo, labels);
       renderer.update(bar, labels, renderInfo);

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -40,17 +40,10 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 import { take } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { WorkPackageCellLabels } from './wp-timeline-cell';
-import { TimelineCellRenderer } from './timeline-cell-renderer';
+import { MouseDirection, TimelineCellRenderer } from './timeline-cell-renderer';
 import { RenderInfo } from '../wp-timeline';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
 import Moment = moment.Moment;
-
-export const classNameBar = 'bar';
-export const classNameLeftHandle = 'leftHandle';
-export const classNameRightHandle = 'rightHandle';
-export const classNameBarLabel = 'bar-label';
-
-export type MouseDirection = 'left'|'right'|'both'|'create'|'dragright';
 
 export function registerWorkPackageMouseHandler(this:void,
   injector:Injector,

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -186,16 +186,16 @@ export function registerWorkPackageMouseHandler(this:void,
       const dateForCreate = clickStart.format('YYYY-MM-DD');
       const mouseDownType = renderer.onMouseDown(ev, dateForCreate, renderInfo, labels);
       renderer.update(bar, labels, renderInfo);
+
       if (mouseDownType === 'create') {
         deactivate(false);
-        ev.preventDefault();
         return;
       }
 
       jBody.on('mousemove.emptytimelinecell', mouseMoveOnEmptyCellFn(offsetDayStart, mouseDownType));
       jBody.on('mouseup.emptytimelinecell', () => deactivate(false));
 
-      cell.onmouseup = (ev) => {
+      cell.onmouseup = () => {
         deactivate(false);
       };
 

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -174,13 +174,13 @@ export function registerWorkPackageMouseHandler(this:void,
     cell.onmousedown = (ev) => {
       placeholderForEmptyCell.remove();
 
+      ev.preventDefault();
+
       if (renderer.cursorOrDatesAreNonWorking(ev, renderInfo)) {
-        ev.preventDefault();
         return;
       }
 
       bar.style.pointerEvents = 'none';
-      ev.preventDefault();
 
       const [clickStart, offsetDayStart] = renderer.cursorDateAndDayOffset(ev, renderInfo);
       const dateForCreate = clickStart.format('YYYY-MM-DD');

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -39,7 +39,7 @@ import { WorkPackageNotificationService } from 'core-app/features/work-packages/
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { take } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { WorkPackageCellLabels } from './wp-timeline-cell';
+import { WorkPackageCellLabels } from './wp-timeline-cell-labels';
 import { MouseDirection, TimelineCellRenderer } from './timeline-cell-renderer';
 import { RenderInfo } from '../wp-timeline';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -230,7 +230,7 @@ export function registerWorkPackageMouseHandler(this:void,
     mouseDownStartDay = null;
 
     // Cancel changes if the startDate or dueDate are not allowed
-    const { startDate, dueDate } = renderInfo.change.projectedResource
+    const { startDate, dueDate } = renderInfo.change.projectedResource;
     const invalidDates = renderer.cursorOrDatesAreNonWorking([moment(startDate), moment(dueDate)], renderInfo);
 
     if (cancelled || renderInfo.change.isEmpty() || invalidDates) {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -195,6 +195,7 @@ export function registerWorkPackageMouseHandler(this:void,
 
   function mouseMoveOnEmptyCellFn(offsetDayStart:number, mouseDownType:MouseDirection) {
     return (ev:JQuery.MouseMoveEvent) => {
+      placeholderForEmptyCell.remove();
       const relativePosition = Math.abs(cell.getBoundingClientRect().x - ev.clientX);
       const offsetDayCurrent = Math.floor(relativePosition / renderInfo.viewParams.pixelPerDay);
       const dayUnderCursor = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayCurrent, 'days');

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -148,11 +148,10 @@ export function registerWorkPackageMouseHandler(this:void,
     }
 
     // placeholder logic
-    placeholderForEmptyCell && placeholderForEmptyCell.remove();
+    placeholderForEmptyCell?.remove();
     placeholderForEmptyCell = renderer.displayPlaceholderUnderCursor(ev, renderInfo);
 
-    const isEditable =
-      (wp.isLeaf || wp.scheduleManually)
+    const isEditable = (wp.isLeaf || wp.scheduleManually)
       && renderer.canMoveDates(wp)
       && !renderer.cursorOrDatesAreNonWorking(ev, renderInfo);
 
@@ -232,8 +231,7 @@ export function registerWorkPackageMouseHandler(this:void,
 
     // Cancel changes if the startDate or dueDate are not allowed
     const { startDate, dueDate } = renderInfo.change.projectedResource
-    const invalidDates =
-      renderer.cursorOrDatesAreNonWorking([moment(startDate), moment(dueDate)], renderInfo)
+    const invalidDates = renderer.cursorOrDatesAreNonWorking([moment(startDate), moment(dueDate)], renderInfo);
 
     if (cancelled || renderInfo.change.isEmpty() || invalidDates) {
       cancelChange();

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell.ts
@@ -41,16 +41,6 @@ import { TimelineCellRenderer } from './timeline-cell-renderer';
 import { RenderInfo } from '../wp-timeline';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
 
-export const classNameLeftLabel = 'labelLeft';
-export const classNameRightContainer = 'containerRight';
-export const classNameRightLabel = 'labelRight';
-export const classNameLeftHoverLabel = 'labelHoverLeft';
-export const classNameRightHoverLabel = 'labelHoverRight';
-export const classNameHoverStyle = '-label-style';
-export const classNameFarRightLabel = 'labelFarRight';
-export const classNameShowOnHover = 'show-on-hover';
-export const classNameHideOnHover = 'hide-on-hover';
-
 export class WorkPackageCellLabels {
   constructor(public readonly center:HTMLDivElement|null,
     public readonly left:HTMLDivElement,

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/wp-timeline-cell.ts
@@ -38,19 +38,9 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { registerWorkPackageMouseHandler } from './wp-timeline-cell-mouse-handler';
 import { TimelineMilestoneCellRenderer } from './timeline-milestone-cell-renderer';
 import { TimelineCellRenderer } from './timeline-cell-renderer';
+import { WorkPackageCellLabels } from './wp-timeline-cell-labels';
 import { RenderInfo } from '../wp-timeline';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
-
-export class WorkPackageCellLabels {
-  constructor(public readonly center:HTMLDivElement|null,
-    public readonly left:HTMLDivElement,
-    public readonly leftHover:HTMLDivElement|null,
-    public readonly right:HTMLDivElement,
-    public readonly rightHover:HTMLDivElement|null,
-    public readonly farRight:HTMLDivElement,
-    public readonly withAlternativeLabels?:boolean) {
-  }
-}
 
 export class WorkPackageTimelineCell {
   @InjectField() halEditing:HalResourceEditingService;

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -78,7 +78,7 @@ export class WorkPackageTabsService {
           ...tab,
           counter: tab.count
             ? (injector:Injector) => tab.count!(workPackage, injector || this.injector) // eslint-disable-line @typescript-eslint/no-non-null-assertion
-            : (_:Injector) => from([0]), // eslint-disable-line @typescript-eslint/no-unused-vars
+            : (_:Injector) => from([0]),
         }),
       );
   }

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -219,10 +219,8 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
     this.value = value;
   }
 
-  // eslint-disable-next-line no-unused-vars
   onChange = (_:IProjectAutocompleterData|IProjectAutocompleterData[]|null):void => {};
 
-  // eslint-disable-next-line no-unused-vars
   onTouched = (_:IProjectAutocompleterData|IProjectAutocompleterData[]|null):void => {};
 
   registerOnChange(fn:(_:IProjectAutocompleterData|IProjectAutocompleterData[]|null) => void):void {

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -202,10 +202,8 @@ export class UserAutocompleterComponent extends UntilDestroyedMixin implements O
     this.value = value;
   }
 
-  // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
   onChange = (_:IUserAutocompleteItem|IUserAutocompleteItem[]|null):void => {};
 
-  // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
   onTouched = (_:IUserAutocompleteItem|IUserAutocompleteItem[]|null):void => {};
 
   registerOnChange(fn:(_:IUserAutocompleteItem|IUserAutocompleteItem[]|null) => void):void {

--- a/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.ts
+++ b/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.ts
@@ -76,10 +76,8 @@ export class WpDestroyModalComponent extends OpModalComponent implements OnInit 
     label_confirm_children_deletion: this.I18n.t('js.modals.destroy_work_package.confirm_deletion_children'),
     title: '',
     text: '',
-    // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-    childCount: (wp:WorkPackageResource):string => '',
-    // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-    hasChildren: (wp:WorkPackageResource):string => '',
+    childCount: (_wp:WorkPackageResource):string => '',
+    hasChildren: (_wp:WorkPackageResource):string => '',
     deletesChildren: '',
   };
 

--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
@@ -67,8 +67,7 @@ export class ScrollableTabsComponent implements AfterViewInit, OnChanges {
     this.updateScrollableArea();
   }
 
-  // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-  ngOnChanges(changes:SimpleChanges):void {
+  ngOnChanges(_changes:SimpleChanges):void {
     if (this.pane) {
       this.updateScrollableArea();
     }

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -32,19 +32,43 @@ RSpec.describe 'Work package timeline date formatting',
                with_settings: { date_format: '%Y-%m-%d' },
                js: true,
                selenium: true do
-  shared_let(:type) { create(:type_bug) }
+
+  shared_let(:type) { create(:type_bug, color: create(:color_green)) }
   shared_let(:project) { create(:project, types: [type]) }
+
+  shared_let(:start_date) { Date.parse('2020-12-31') }
+  shared_let(:due_date) { Date.parse('2021-01-01') }
+  shared_let(:duration) { due_date - start_date + 1 }
 
   shared_let(:work_package) do
     create :work_package,
            project:,
            type:,
-           start_date: Date.parse('2020-12-31'),
-           due_date: Date.parse('2021-01-01'),
+           start_date:,
+           due_date:,
+           duration:,
            subject: 'My subject'
   end
 
+  shared_let(:work_package_with_non_working_days) do
+    create :work_package,
+           project:,
+           type:,
+           duration: 5,
+           subject: 'My Subject 2'
+  end
+
+  shared_let(:work_package_without_non_workign_days) do
+    create :work_package,
+           project:,
+           type:,
+           duration: 5,
+           ignore_non_working_days: true,
+           subject: 'Work Package ignoring non working days'
+  end
+
   let(:week_days) { nil }
+
   let(:wp_timeline) { Pages::WorkPackagesTimeline.new(project) }
   let!(:query_tl) do
     query = build(:query, user: current_user, project:)
@@ -135,6 +159,154 @@ RSpec.describe 'Work package timeline date formatting',
       expect_date_week work_package.due_date.iso8601, '01'
       # First sunday in january is in second week
       expect_date_week '2021-01-03', '02'
+    end
+  end
+
+  describe 'setting dates', with_flag: { work_packages_duration_field_active: true } do
+    let(:current_user) { create :admin }
+    let(:week_days) { create :week_days }
+    let(:row) { wp_timeline.timeline_row work_package_with_non_working_days.id }
+
+    shared_examples "sets dates, duration and displays bar" do
+      it 'sets dates, duration and duration bar' do
+        subject
+
+        row.expect_bar(duration: expected_bar_duration)
+        row.expect_labels left: nil,
+                          right: nil,
+                          farRight: expected_label
+
+        row.expect_hovered_labels left: expected_start_date.iso8601,
+                                  right: expected_due_date.iso8601
+
+        target_wp.reload.tap do |wp|
+          expect(wp.start_date).to eq(expected_start_date)
+          expect(wp.due_date).to eq(expected_due_date)
+          expect(wp.duration).to eq(expected_duration)
+        end
+      end
+    end
+
+    context 'with an existing duration only' do
+      before do
+        # Reset dates on each run
+        work_package_with_non_working_days.update({ start_date: nil, due_date: nil, duration: 5 })
+      end
+
+      it 'displays the hover bar correctly' do
+        # Expect no hover bar when hovering over a non working day
+        row.hover_bar(offset_days: -1)
+        row.expect_no_hovered_bar
+
+        # Expect timeline bar when clicking on a non working day
+        row.click_bar(offset_days: -1)
+        row.expect_no_bar
+
+        # Expect hovered bar size to equal duration
+        row.hover_bar
+        row.expect_hovered_bar(duration: work_package_with_non_working_days.duration)
+
+        # Expect hovered bar size to equal duration + non working days
+        # when the hovered bar passes through non working days
+        row.hover_bar(offset_days: 1)
+        row.expect_hovered_bar(duration: work_package_with_non_working_days.duration + 2)
+      end
+
+      describe 'set the start, due date while preserving duration' do
+        subject { row.click_bar }
+
+        it_behaves_like 'sets dates, duration and displays bar' do
+          let(:target_wp) { work_package_with_non_working_days }
+          let(:expected_bar_duration) { work_package_with_non_working_days.duration }
+          let(:expected_start_date) { Date.parse('2021-01-04') }
+          let(:expected_due_date) { Date.parse('2021-01-08') }
+          let(:expected_duration) { 5 }
+          let(:expected_label) { work_package_with_non_working_days.subject }
+        end
+      end
+
+      describe 'set the start, due date while preserving duration over the weekend' do
+        subject { row.click_bar(offset_days: 1) }
+
+        it_behaves_like 'sets dates, duration and displays bar' do
+          let(:target_wp) { work_package_with_non_working_days }
+          let(:expected_bar_duration) { work_package_with_non_working_days.duration + 2 }
+          let(:expected_start_date) { Date.parse('2021-01-05') }
+          let(:expected_due_date) { Date.parse('2021-01-11') }
+          let(:expected_duration) { 5 }
+          let(:expected_label) { work_package_with_non_working_days.subject }
+        end
+      end
+
+      describe 'sets the start, due dates while preserving duration on a drag and drop create' do
+        subject { row.drag_and_drop(days: 5) }
+
+        it_behaves_like 'sets dates, duration and displays bar' do
+          let(:target_wp) { work_package_with_non_working_days }
+          let(:expected_bar_duration) { work_package_with_non_working_days.duration }
+          let(:expected_start_date) { Date.parse('2021-01-04') }
+          let(:expected_due_date) { Date.parse('2021-01-08') }
+          let(:expected_duration) { 5 }
+          let(:expected_label) { work_package_with_non_working_days.subject }
+        end
+      end
+
+      describe 'sets the start, due dates while preserving duration on a drag and drop create over the weekend' do
+        subject { row.drag_and_drop(offset_days: 1, days: 7) }
+
+        it_behaves_like 'sets dates, duration and displays bar' do
+          let(:target_wp) { work_package_with_non_working_days }
+          let(:expected_bar_duration) { work_package_with_non_working_days.duration + 2 }
+          let(:expected_start_date) { Date.parse('2021-01-05') }
+          let(:expected_due_date) { Date.parse('2021-01-11') }
+          let(:expected_duration) { 5 }
+          let(:expected_label) { work_package_with_non_working_days.subject }
+        end
+      end
+
+      describe 'sets the start, due dates and duration on a drag and drop create over the weekend' do
+        subject { row.drag_and_drop(offset_days: 1, days: 8) }
+
+        it_behaves_like 'sets dates, duration and displays bar' do
+          let(:target_wp) { work_package_with_non_working_days }
+          let(:expected_bar_duration) { work_package_with_non_working_days.duration + 3 }
+          let(:expected_start_date) { Date.parse('2021-01-05') }
+          let(:expected_due_date) { Date.parse('2021-01-12') }
+          let(:expected_duration) { 6 }
+          let(:expected_label) { work_package_with_non_working_days.subject }
+        end
+      end
+
+      it 'cancels when the drag starts or finishes on a weekend' do
+        # Finish on the weekend
+        row.drag_and_drop(offset_days: 1, days: 5)
+
+        row.expect_no_bar
+        expect { work_package_with_non_working_days.reload }.not_to change { work_package_with_non_working_days }
+
+        # Start on the weekend
+        row.drag_and_drop(offset_days: -1, days: 5)
+
+        row.expect_no_bar
+        expect { work_package_with_non_working_days.reload }.not_to change { work_package_with_non_working_days }
+      end
+
+      context 'when ignore_non_working_days if true' do
+        let(:row) { wp_timeline.timeline_row work_package_without_non_workign_days.id }
+
+        describe 'sets the start, due dates and duration on a drag and drop create over the weekend' do
+          subject { row.drag_and_drop(offset_days: 1, days: 8) }
+
+          it_behaves_like 'sets dates, duration and displays bar' do
+            let(:target_wp) { work_package_without_non_workign_days }
+            let(:expected_bar_duration) { work_package_without_non_workign_days.duration + 3 }
+            let(:expected_start_date) { Date.parse('2021-01-05') }
+            let(:expected_due_date) { Date.parse('2021-01-12') }
+            let(:expected_duration) { 8 }
+            let(:expected_label) { work_package_without_non_workign_days.subject }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe 'Work package timeline date formatting',
                with_settings: { date_format: '%Y-%m-%d' },
                js: true,
                selenium: true do
-
   shared_let(:type) { create(:type_bug, color: create(:color_green)) }
   shared_let(:project) { create(:project, types: [type]) }
-
   shared_let(:start_date) { Date.parse('2020-12-31') }
   shared_let(:due_date) { Date.parse('2021-01-01') }
   shared_let(:duration) { due_date - start_date + 1 }
@@ -68,7 +66,6 @@ RSpec.describe 'Work package timeline date formatting',
   end
 
   let(:week_days) { nil }
-
   let(:wp_timeline) { Pages::WorkPackagesTimeline.new(project) }
   let!(:query_tl) do
     query = build(:query, user: current_user, project:)

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe 'Work package timeline date formatting',
     end
   end
 
-  describe 'setting dates', with_flag: { work_packages_duration_field_active: true } do
+  describe 'setting dates' do
     let(:current_user) { create :admin }
     let(:week_days) { create :week_days }
     let(:row) { wp_timeline.timeline_row work_package_with_non_working_days.id }

--- a/spec/support/components/timelines/timeline_row.rb
+++ b/spec/support/components/timelines/timeline_row.rb
@@ -71,6 +71,46 @@ module Components
           end
         end
       end
+
+      def hover_bar(offset_days: 0)
+        container.hover
+        offset_x = offset_days * 30
+        page.driver.browser.action.move_to(@container.native, offset_x).perform
+      end
+
+      def click_bar(offset_days: 0)
+        hover_bar(offset_days:)
+        page.driver.browser.action.click.perform
+      end
+
+      def expect_hovered_bar(duration: 1)
+        expected_length = duration * 30
+        expect(container).to have_selector('div[class^="__hl_background_"', style: { width: "#{expected_length}px" })
+      end
+
+      def expect_bar(duration: 1)
+        loading_indicator_saveguard
+        expected_length = duration * 30
+        expect(container).to have_selector('.timeline-element', style: { width: "#{expected_length}px" })
+      end
+
+      def expect_no_hovered_bar
+        expect(container).not_to have_selector('div[class^="__hl_background_"')
+      end
+
+      def expect_no_bar
+        loading_indicator_saveguard
+        expect(container).not_to have_selector('.timeline-element')
+      end
+
+      def drag_and_drop(offset_days: 0, days: 1)
+        container.hover
+        offset_x_start = offset_days * 30
+        start_dragging(container, offset_x: offset_x_start)
+        offset_x = ((days - 1) * 30) + offset_x_start
+        drag_element_to(container, offset_x:)
+        drag_release
+      end
     end
   end
 end

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -26,14 +26,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-def start_dragging(from)
+def start_dragging(from, offset_x: nil, offset_y: nil)
   scroll_to_element(from)
   page
     .driver
     .browser
     .action
-    .move_to(from.native)
-    .click_and_hold(from.native)
+    .move_to(from.native, offset_x, offset_y)
+    .click_and_hold
     .perform
 end
 


### PR DESCRIPTION
See [OP#43637](https://community.openproject.org/work_packages/43637)

- [x] Hover duration over Gantt chart for work packages without a start date
- [x] Set due date from duration when start date is set via the Gantt chart click
- [x] Set due date via Gantt chart click and drag with existing duration
- [x] Factor in the non-working days when calculating duration
- [x] Block clicking on a non-working day when ignore_non_working_days is false