### PR TITLE
[43638] Update team planner and calendar for duration and non-working days

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -314,9 +314,15 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
   }
 
   private handleDateClicked(info:DateSelectArg) {
+    const startDay = new Date(info.start).getDate();
+    const endDay = new Date(info.end).getDate();
+    const duration = endDay - startDay;
+    const nonWorkingDays = duration !== 1 ? false : this.weekdayService.isNonWorkingDay(info.start);
+
     const defaults = {
       startDate: info.startStr,
       dueDate: this.workPackagesCalendar.getEndDateFromTimestamp(info.endStr),
+      ignoreNonWorkingDays: nonWorkingDays,
     };
 
     void this.$state.go(

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -780,7 +780,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
           href: resourceHref,
         },
       },
-      nonWorkingDays,
+      ignoreNonWorkingDays: nonWorkingDays,
     };
 
     void this.$state.go(

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -898,7 +898,24 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       )
       .subscribe(([assignable, principals]) => {
         const api = this.ucCalendar.getApi();
+        if (!wp.ignoreNonWorkingDays) {
+          let currentStartDate = this.ucCalendar.getApi().view.currentStart;
+          const currentEndDate = moment(this.ucCalendar.getApi().view.currentEnd).add('1', 'day').toDate();
+          const nonWorkingDays = new Array<{ start:Date, end:Date }>();
 
+          while (currentStartDate.toString() !== currentEndDate.toString()) {
+            if (this.weekdayService.isNonWorkingDay(currentStartDate)) {
+              nonWorkingDays.push({
+                start: currentStartDate,
+                end: currentStartDate,
+              });
+            }
+            currentStartDate = moment(currentStartDate).add('1', 'day').toDate();
+          }
+          nonWorkingDays.forEach((day) => {
+            api.addEvent({ ...day }, 'background');
+          });
+        }
         const eventBase = {
           start: moment().subtract('1', 'month').toDate(),
           end: moment().add('1', 'month').toDate(),

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -494,6 +494,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
             editable: true,
             droppable: true,
             eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
+            eventResizeStart: (resizeInfo:EventResizeDoneArg) => this.addBackgroundEvents(resizeInfo.event),
+            eventResizeStop: () => this.removeBackGroundEvents(),
             eventDragStart: (dragInfo:EventDragStartArg) => {
               if (dragInfo.event.source?.id === 'skeleton') {
                 return;

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -771,7 +771,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     'document:teamPlannerSelectDate',
     ['$event.detail.start', '$event.detail.end', '$event.detail.assignee'],
   )
-  openNewSplitCreate(start:string, end:string, resourceHref:string):void {
+  openNewSplitCreate(start:string, end:string, resourceHref:string, nonWorkingDays:boolean):void {
     const defaults = {
       startDate: start,
       dueDate: end,
@@ -780,6 +780,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
           href: resourceHref,
         },
       },
+      nonWorkingDays,
     };
 
     void this.$state.go(


### PR DESCRIPTION
On team planner, 

while creating new cards by clicking/selecting dates:
  - When clicking on a single date that is a non-working day
  - [x] the work package will be scheduled for that day  (done before)
  - [x] "Include non-working days" will be enabled in the date picker
  - Selecting a range of days that includes a non-working day
  - [x] the work package will be scheduled on the selected days excluding non-working days  (done before)
  - [x] "Include non-working days" will not be enabled in the date picker
  - Clicking a day or selecting a range of days that does not include non-working days
  - [x] The work package will be scheduled on the selected days (done before)
  - [x] "Include non-working days" will not be enabled in the date picker
- [x] Automatically scheduled work packages whose dates are derived should be blocked from dragging (as is the case currently on the GANTT view for parent work packages) (done before)
while dragging or resizing an existing work package
- [x] Moving a work package (where the "include non-working days checkbox is NOT selected) to a start date that is a non-working day is blocked visually (similar to the permission-based blocking)

https://community.openproject.org/projects/openproject/work_packages/43638/activity