### PR TITLE
Use datetime object for timestamps, not dates

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -45,7 +45,7 @@ class ActivitiesController < ApplicationController
                                         author: @author,
                                         scope: activity_scope)
 
-    events = @activity.events(@date_from, @date_to)
+    events = @activity.events(@date_from.to_datetime, @date_to.to_datetime)
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
Applying the fix found together with @cbliard for the case when a created_column is a `timestamp with time zone` column.

To reproduce, have a work package activity and modify the journals column:

`ALTER TABLE journals ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;`

https://community.openproject.org/wp/43771