### PR TITLE
[#42923] Add job to reschedule on weekend days changes

### DIFF
--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -34,10 +34,11 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
 
     WorkPackage
       .where(ignore_non_working_days: false)
+      .order(created_at: :asc)
       .find_each do |work_package|
         next if dates_and_duration_match?(work_package)
 
-        WorkPackages::SetAttributesService
+        WorkPackages::UpdateService
           .new(user:, model: work_package, contract_class: EmptyContract)
           .call(duration: work_package.duration)
         work_package.save

--- a/modules/calendar/spec/features/calendar_dates_spec.rb
+++ b/modules/calendar/spec/features/calendar_dates_spec.rb
@@ -77,7 +77,7 @@ describe 'Calendar non working days', type: :feature, js: true do
 
   context 'with all days marked as weekend' do
     let!(:week_days) do
-      days = create(:week_days_with_saturday_and_sunday_as_weekend)
+      days = create(:week_with_saturday_and_sunday_as_weekend)
 
       WeekDay.update_all(working: false)
 

--- a/modules/calendar/spec/features/calendar_dates_spec.rb
+++ b/modules/calendar/spec/features/calendar_dates_spec.rb
@@ -77,7 +77,7 @@ describe 'Calendar non working days', type: :feature, js: true do
 
   context 'with all days marked as weekend' do
     let!(:week_days) do
-      days = create(:week_days)
+      days = create(:week_days_with_saturday_and_sunday_as_weekend)
 
       WeekDay.update_all(working: false)
 

--- a/modules/team_planner/spec/features/team_planner_dates_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_dates_spec.rb
@@ -73,7 +73,7 @@ describe 'Team planner working days', type: :feature, js: true do
 
   context 'with all days marked as weekend' do
     let!(:week_days) do
-      days = create(:week_days_with_saturday_and_sunday_as_weekend)
+      days = create(:week_with_saturday_and_sunday_as_weekend)
 
       WeekDay.update_all(working: false)
 

--- a/modules/team_planner/spec/features/team_planner_dates_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_dates_spec.rb
@@ -73,7 +73,7 @@ describe 'Team planner working days', type: :feature, js: true do
 
   context 'with all days marked as weekend' do
     let!(:week_days) do
-      days = create(:week_days)
+      days = create(:week_days_with_saturday_and_sunday_as_weekend)
 
       WeekDay.update_all(working: false)
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -600,7 +600,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days' do
       before do
-        create(:week_days) # sat and sun are weekends
+        create(:week_days_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 6
         work_package.start_date = "2022-08-22"
@@ -623,7 +623,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days and duration is too small' do
       before do
-        create(:week_days) # sat and sun are weekends
+        create(:week_days_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 1
         work_package.start_date = "2022-08-22"
@@ -646,7 +646,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days and duration is too big' do
       before do
-        create(:week_days) # sat and sun are weekends
+        create(:week_days_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 99
         work_package.start_date = "2022-08-22"

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -600,7 +600,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days' do
       before do
-        create(:week_days_with_saturday_and_sunday_as_weekend)
+        create(:week_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 6
         work_package.start_date = "2022-08-22"
@@ -623,7 +623,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days and duration is too small' do
       before do
-        create(:week_days_with_saturday_and_sunday_as_weekend)
+        create(:week_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 1
         work_package.start_date = "2022-08-22"
@@ -646,7 +646,7 @@ describe WorkPackages::BaseContract do
 
     context 'when setting duration and dates while covering non-working days and duration is too big' do
       before do
-        create(:week_days_with_saturday_and_sunday_as_weekend)
+        create(:week_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
         work_package.duration = 99
         work_package.start_date = "2022-08-22"

--- a/spec/factories/week_day_factory.rb
+++ b/spec/factories/week_day_factory.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
   end
 
   # Factory to create all 7 week days at once, Saturday and Sunday being weekend days
-  factory :week_days_with_saturday_and_sunday_as_weekend, aliases: [:week_days], class: 'Array' do
+  factory :week_with_saturday_and_sunday_as_weekend, aliases: [:week_days], class: 'Array' do
     # Skip the create callback to be able to use non-AR models. Otherwise FactoryBot will
     # try to call #save! on any created object.
     skip_create

--- a/spec/factories/week_day_factory.rb
+++ b/spec/factories/week_day_factory.rb
@@ -43,14 +43,30 @@ FactoryBot.define do
   end
 
   # Factory to create all 7 week days at once, Saturday and Sunday being weekend days
-  factory :week_with_saturday_and_sunday_as_weekend, aliases: [:week_days], class: 'Array' do
+  factory :week_with_saturday_and_sunday_as_weekend, aliases: [:week_days], parent: :week do
+    working_days { %w[monday tuesday wednesday thursday friday] }
+  end
+
+  # Factory to create all 7 week days at once
+  #
+  # use +working: ['monday', 'tuesday', ...]+ to define which days of the week
+  # will be working days. By default, all days are working days.
+  factory :week, class: 'Array' do
+    transient do
+      working_days { %w[monday tuesday wednesday thursday friday saturday sunday] }
+    end
+
     # Skip the create callback to be able to use non-AR models. Otherwise FactoryBot will
     # try to call #save! on any created object.
     skip_create
 
     initialize_with do
-      days = 1.upto(7).map { |day| create(:week_day, day:) }
-      new(days)
+      %w[monday tuesday wednesday thursday friday saturday sunday]
+        .map.with_index do |day_name, i|
+          day = i + 1
+          working = working_days.include?(day_name)
+          create(:week_day, day:, working:)
+        end
     end
   end
 end

--- a/spec/factories/week_day_factory.rb
+++ b/spec/factories/week_day_factory.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
   end
 
   # Factory to create all 7 week days at once, Saturday and Sunday being weekend days
-  factory :week_days, aliases: [:week_days_with_saturday_and_sunday_as_weekend], class: 'Array' do
+  factory :week_days_with_saturday_and_sunday_as_weekend, aliases: [:week_days], class: 'Array' do
     # Skip the create callback to be able to use non-AR models. Otherwise FactoryBot will
     # try to call #save! on any created object.
     skip_create

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -45,13 +45,13 @@ FactoryBot.define do
       # derive start date if due date and duration were provided
       next unless %i[due_date duration].all? { |field| __override_names__.include?(field) }
 
-      days.start_date(due_date&.to_date, duration)
+      due_date && duration && days.start_date(due_date.to_date, duration)
     end
     due_date do
       # derive due date if start date and duration were provided
       next unless %i[start_date duration].all? { |field| __override_names__.include?(field) }
 
-      days.due_date(start_date&.to_date, duration)
+      start_date && duration && days.due_date(start_date.to_date, duration)
     end
     duration { days.duration(start_date&.to_date, due_date&.to_date) }
 

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -43,14 +43,12 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     start_date do
       # derive start date if due date and duration were provided
-      next unless OpenProject::FeatureDecisions.work_packages_duration_field_active?
       next unless %i[due_date duration].all? { |field| __override_names__.include?(field) }
 
       days.start_date(due_date&.to_date, duration)
     end
     due_date do
       # derive due date if start date and duration were provided
-      next unless OpenProject::FeatureDecisions.work_packages_duration_field_active?
       next unless %i[start_date duration].all? { |field| __override_names__.include?(field) }
 
       days.due_date(start_date&.to_date, duration)

--- a/spec/lib/api/v3/days/day_collection_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_collection_representer_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe ::API::V3::Days::DayCollectionRepresenter do
-  let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+  let!(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
   let(:days) do
     [
       build(:day, date: Date.new(2022, 12, 27)),

--- a/spec/lib/api/v3/days/day_collection_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_collection_representer_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe ::API::V3::Days::DayCollectionRepresenter do
-  let!(:week_days) { create(:week_days) }
+  let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
   let(:days) do
     [
       build(:day, date: Date.new(2022, 12, 27)),

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -52,7 +52,7 @@ describe Day, type: :model do
     let(:non_working_dates) { [date_range.begin, date_range.begin + 1.day] }
 
     before do
-      create(:week_days_with_saturday_and_sunday_as_weekend)
+      create(:week_with_saturday_and_sunday_as_weekend)
       non_working_dates.each { |date| create(:non_working_day, date:) }
     end
 

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -52,7 +52,7 @@ describe Day, type: :model do
     let(:non_working_dates) { [date_range.begin, date_range.begin + 1.day] }
 
     before do
-      create(:week_days)
+      create(:week_days_with_saturday_and_sunday_as_weekend)
       non_working_dates.each { |date| create(:non_working_day, date:) }
     end
 

--- a/spec/models/queries/work_packages/filter/duration_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/duration_filter_spec.rb
@@ -48,6 +48,7 @@ describe Queries::WorkPackages::Filter::DurationFilter, type: :model do
     it_behaves_like 'non ar filter'
 
     describe '#where' do
+      # TODO: 0 duration should not happen in 12.x. Should we remove it?
       let!(:work_package_zero_duration) { create(:work_package, duration: 0) }
       let!(:work_package_no_duration) { create(:work_package, duration: nil) }
       let!(:work_package_with_duration) { create(:work_package, duration: 1) }

--- a/spec/requests/api/v3/days/day_spec.rb
+++ b/spec/requests/api/v3/days/day_spec.rb
@@ -38,7 +38,7 @@ describe ::API::V3::Days::DaysAPI,
   current_user { user }
 
   before do
-    create(:week_days)
+    create(:week_days_with_saturday_and_sunday_as_weekend)
     get api_v3_paths.path_for :days, filters:
   end
 

--- a/spec/requests/api/v3/days/day_spec.rb
+++ b/spec/requests/api/v3/days/day_spec.rb
@@ -38,7 +38,7 @@ describe ::API::V3::Days::DaysAPI,
   current_user { user }
 
   before do
-    create(:week_days_with_saturday_and_sunday_as_weekend)
+    create(:week_with_saturday_and_sunday_as_weekend)
     get api_v3_paths.path_for :days, filters:
   end
 

--- a/spec/requests/api/v3/days/week_spec.rb
+++ b/spec/requests/api/v3/days/week_spec.rb
@@ -38,7 +38,7 @@ describe ::API::V3::Days::WeekAPI,
   current_user { user }
 
   before do
-    create(:week_days_with_saturday_and_sunday_as_weekend)
+    create(:week_with_saturday_and_sunday_as_weekend)
     get api_v3_paths.days_week
   end
 

--- a/spec/requests/api/v3/days/week_spec.rb
+++ b/spec/requests/api/v3/days/week_spec.rb
@@ -38,7 +38,7 @@ describe ::API::V3::Days::WeekAPI,
   current_user { user }
 
   before do
-    create(:week_days)
+    create(:week_days_with_saturday_and_sunday_as_weekend)
     get api_v3_paths.days_week
   end
 

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1153,7 +1153,7 @@ describe WorkPackages::SetAttributesService,
         let(:call_attributes) { { ignore_non_working_days: false } }
 
         it_behaves_like 'service call' do
-          it "updates the start date to be on next working day, and due date to accomodate duration" do
+          it "updates the start date to be on next working day, and due date to accommodate duration" do
             expect { subject }
               .to change { work_package.slice(:start_date, :due_date, :duration) }
               .from(start_date: monday - 1.day, due_date: friday, duration: 6)

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1039,7 +1039,7 @@ describe WorkPackages::SetAttributesService,
     end
 
     context 'with non-working days' do
-      shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+      shared_let(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
       let(:monday) { Time.zone.today.beginning_of_week }
       let(:tuesday) { monday + 1.day }
       let(:wednesday) { monday + 2.days }
@@ -1648,7 +1648,7 @@ describe WorkPackages::SetAttributesService,
       let(:soonest_start) { saturday }
 
       before do
-        create(:week_days_with_saturday_and_sunday_as_weekend)
+        create(:week_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
       end
 

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1039,7 +1039,7 @@ describe WorkPackages::SetAttributesService,
     end
 
     context 'with non-working days' do
-      shared_let(:week_days) { create(:week_days) }
+      shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
       let(:monday) { Time.zone.today.beginning_of_week }
       let(:tuesday) { monday + 1.day }
       let(:wednesday) { monday + 2.days }
@@ -1648,7 +1648,7 @@ describe WorkPackages::SetAttributesService,
       let(:soonest_start) { saturday }
 
       before do
-        create(:week_days)
+        create(:week_days_with_saturday_and_sunday_as_weekend)
         work_package.ignore_non_working_days = false
       end
 

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -138,16 +138,19 @@ describe WorkPackages::SetScheduleService do
 
         expect(result.start_date)
           .to eql(start_date),
-              "Expected work package ##{wp.id} '#{wp.subject}' to have start date #{start_date}, got #{result.start_date}"
+              "Expected work package ##{wp.id} '#{wp.subject}' " \
+              "to have start date #{start_date.inspect}, got #{result.start_date.inspect}"
         expect(result.due_date)
           .to eql(due_date),
-              "Expected work package ##{wp.id} '#{wp.subject}' to have due date #{due_date}, got #{result.due_date}"
+              "Expected work package ##{wp.id} '#{wp.subject}' " \
+              "to have due date #{due_date.inspect}, got #{result.due_date.inspect}"
 
         duration = WorkPackages::Shared::AllDays.new.duration(start_date, due_date)
 
         expect(result.duration)
           .to eql(duration),
-              "Expected work package ##{wp.id} '#{wp.subject}' to have duration #{duration}, got #{result.duration}"
+              "Expected work package ##{wp.id} '#{wp.subject}' " \
+              "to have duration #{duration.inspect}, got #{result.duration.inspect}"
       end
     end
 

--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe WorkPackages::SetScheduleService, 'working days' do
   create_shared_association_defaults_for_work_package_factory
 
-  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+  shared_let(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
 
   let(:instance) do
     described_class.new(user:, work_package:)

--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe WorkPackages::SetScheduleService, 'working days' do
   create_shared_association_defaults_for_work_package_factory
 
-  shared_let(:week_days) { create(:week_days) }
+  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
 
   let(:instance) do
     described_class.new(user:, work_package:)

--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -1022,6 +1022,77 @@ describe WorkPackages::SetScheduleService, 'working days' do
       end
     end
 
+    def set_non_working_week_days(*days)
+      days.each do |day|
+        wday = %w[xxx monday tuesday wednesday thursday friday saturday sunday].index(day.downcase)
+        WeekDay.find_by!(day: wday).update(working: false)
+      end
+    end
+
+    context 'when moving forward due to days and predecessor due date now being non-working days' do
+      let_schedule(<<~CHART)
+        days         | MTWTFSS |
+        work_package | XX      |
+        follower1    |   X     | follows work_package
+        follower2    |    XX   | follows follower1
+      CHART
+
+      before do
+        # Tuesday, Thursday, and Friday are now non-working days. So work_package
+        # was starting on Monday and now is being shifted to Tuesday by the
+        # SetAttributesService.
+        #
+        # Below instructions reproduce the conditions in which such scheduling
+        # must happen.
+        set_non_working_week_days('tuesday', 'thursday', 'friday')
+        change_schedule([work_package], <<~CHART)
+          days         | MTWTFSS |
+          work_package | X.X     |
+        CHART
+      end
+
+      it 'reschedules all the followers keeping the delay and compacting the extra spaces' do
+        expect(subject.all_results).to match_schedule(<<~CHART)
+          days         | MTWTFSSm w    m |
+          work_package | X.X             |
+          follower1    |        X        |
+          follower2    |          X....X |
+        CHART
+      end
+    end
+
+    context 'when moving forward due to days and predecessor start date now being non-working days' do
+      let_schedule(<<~CHART)
+        days         | MTWTFSS |
+        work_package | XX      |
+        follower1    |   X     | follows work_package
+        follower2    |    XX   | follows follower1
+      CHART
+
+      before do
+        # Monday, Thursday, and Friday are now non-working days. So work_package
+        # was starting on Monday and now is being shifted to Tuesday by the
+        # SetAttributesService.
+        #
+        # Below instructions reproduce the conditions in which such scheduling
+        # must happen.
+        set_non_working_week_days('monday', 'thursday', 'friday')
+        change_schedule([work_package], <<~CHART)
+          days         | MTWTFSS |
+          work_package |  XX     |
+        CHART
+      end
+
+      it 'reschedules all the followers without crossing each other' do
+        expect(subject.all_results).to match_schedule(<<~CHART)
+          days         | MTWTFSS tw     tw |
+          work_package |  XX               |
+          follower1    |         X         |
+          follower2    |          X.....X  |
+        CHART
+      end
+    end
+
     context 'when moving backwards' do
       let_schedule(<<~CHART)
         days         | MTWTFSSm     sm     sm     |

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -29,7 +29,7 @@
 Date::DATE_FORMATS[:wday_date] = '%a %-d %b %Y' # Fri 5 Aug 2022
 
 RSpec.shared_context 'with weekend days Saturday and Sunday' do
-  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+  shared_let(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
 end
 
 RSpec.shared_context 'with non working days Christmas 2022 and new year 2023' do

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -29,7 +29,7 @@
 Date::DATE_FORMATS[:wday_date] = '%a %-d %b %Y' # Fri 5 Aug 2022
 
 RSpec.shared_context 'with weekend days Saturday and Sunday' do
-  shared_let(:week_days) { create(:week_days) }
+  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
 end
 
 RSpec.shared_context 'with non working days Christmas 2022 and new year 2023' do

--- a/spec/support/schedule_helpers/chart.rb
+++ b/spec/support/schedule_helpers/chart.rb
@@ -144,6 +144,11 @@ module ScheduleHelpers
       attributes[:duration] = duration
     end
 
+    def set_ignore_non_working_days(name, ignore_non_working_days)
+      attributes = work_package_attributes(name.to_sym)
+      attributes[:ignore_non_working_days] = ignore_non_working_days
+    end
+
     def add_follows_relation(predecessor:, follower:, delay:)
       predecessors_by_follower(follower) << predecessor
       delays_between[[predecessor, follower]] = delay

--- a/spec/support/schedule_helpers/chart_builder.rb
+++ b/spec/support/schedule_helpers/chart_builder.rb
@@ -114,6 +114,10 @@ module ScheduleHelpers
         )
       when /^duration (\d+)/
         chart.set_duration(name, $1.to_i)
+      when /^working days work week$/
+        chart.set_ignore_non_working_days(name, false)
+      when /^working days include weekends$/
+        chart.set_ignore_non_working_days(name, true)
       else
         raise "unable to parse property #{property.inspect} for line #{name.inspect}"
       end

--- a/spec/support/schedule_helpers/chart_representer.rb
+++ b/spec/support/schedule_helpers/chart_representer.rb
@@ -30,12 +30,12 @@ module ScheduleHelpers
   class ChartRepresenter
     LINE = "%<id>s | %<days>s |".freeze
 
-    def self.normalized_to_s(reference_chart, other_chart)
-      order = reference_chart.work_package_names
-      id_column_size = [reference_chart, other_chart].map(&:id_column_size).max
-      first_day = [reference_chart, other_chart].map(&:first_day).min
-      last_day = [reference_chart, other_chart].map(&:last_day).max
-      [reference_chart, other_chart]
+    def self.normalized_to_s(expected_chart, actual_chart)
+      order = expected_chart.work_package_names
+      id_column_size = [expected_chart, actual_chart].map(&:id_column_size).max
+      first_day = [expected_chart, actual_chart].map(&:first_day).min
+      last_day = [expected_chart, actual_chart].map(&:last_day).max
+      [expected_chart, actual_chart]
         .map { |chart| chart.with(order:, id_column_size:, first_day:, last_day:) }
         .map(&:to_s)
     end

--- a/spec/support_spec/schedule_helpers/chart_builder_spec.rb
+++ b/spec/support_spec/schedule_helpers/chart_builder_spec.rb
@@ -156,6 +156,26 @@ describe ScheduleHelpers::ChartBuilder do
         expect(chart.work_package_attributes(:main)).to include(duration: 3)
       end
     end
+
+    describe 'working days work week' do
+      it 'sets ignore_non_working_days to false for the work package' do
+        chart = builder.parse(<<~CHART)
+          days        | MTWTFSS |
+          main        |         | working days work week
+        CHART
+        expect(chart.work_package_attributes(:main)).to include(ignore_non_working_days: false)
+      end
+    end
+
+    describe 'working days include weekends' do
+      it 'sets ignore_non_working_days to true for the work package' do
+        chart = builder.parse(<<~CHART)
+          days        | MTWTFSS |
+          main        |         | working days include weekends
+        CHART
+        expect(chart.work_package_attributes(:main)).to include(ignore_non_working_days: true)
+      end
+    end
   end
 
   describe 'error handling' do

--- a/spec/support_spec/schedule_helpers/chart_representer_spec.rb
+++ b/spec/support_spec/schedule_helpers/chart_representer_spec.rb
@@ -39,7 +39,7 @@ describe ScheduleHelpers::ChartRepresenter do
   let(:sunday) { Date.new(2022, 6, 26) }
 
   describe '#normalized_to_s' do
-    let!(:week_days) { create(:week_days) }
+    let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
 
     context 'when both charts have different work packages items and/or order' do
       def to_first_columns(charts)

--- a/spec/support_spec/schedule_helpers/chart_representer_spec.rb
+++ b/spec/support_spec/schedule_helpers/chart_representer_spec.rb
@@ -39,7 +39,7 @@ describe ScheduleHelpers::ChartRepresenter do
   let(:sunday) { Date.new(2022, 6, 26) }
 
   describe '#normalized_to_s' do
-    let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+    let!(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
 
     context 'when both charts have different work packages items and/or order' do
       def to_first_columns(charts)

--- a/spec/support_spec/schedule_helpers/chart_spec.rb
+++ b/spec/support_spec/schedule_helpers/chart_spec.rb
@@ -157,7 +157,7 @@ describe ScheduleHelpers::Chart do
   end
 
   describe '#to_s' do
-    let!(:week_days) { create(:week_days) }
+    let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
 
     context 'with a chart built from ascii representation' do
       let(:chart) do

--- a/spec/support_spec/schedule_helpers/chart_spec.rb
+++ b/spec/support_spec/schedule_helpers/chart_spec.rb
@@ -157,7 +157,7 @@ describe ScheduleHelpers::Chart do
   end
 
   describe '#to_s' do
-    let!(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+    let!(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
 
     context 'with a chart built from ascii representation' do
       let(:chart) do

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   subject(:job) { described_class }
 
   shared_let(:user) { create(:user) }
-  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+  shared_let(:week_days) { create(:week_with_saturday_and_sunday_as_weekend) }
 
   def set_non_working_week_days(*days)
     days.each do |day|

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob,
-               with_flag: { work_packages_duration_field_active: true } do
+RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   subject(:job) { described_class }
 
   shared_let(:user) { create(:user) }

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 require 'rails_helper'
 
 RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
@@ -6,9 +34,11 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   shared_let(:user) { create(:user) }
   shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
 
-  def set_non_working_week_day(day)
-    wday = %w[xxx monday tuesday wednesday thursday friday saturday sunday].index(day.downcase)
-    WeekDay.find_by(day: wday).update(working: false)
+  def set_non_working_week_days(*days)
+    days.each do |day|
+      wday = %w[xxx monday tuesday wednesday thursday friday saturday sunday].index(day.downcase)
+      WeekDay.find_by!(day: wday).update(working: false)
+    end
   end
 
   context 'when a work package includes a date that is now a non-working day' do
@@ -18,7 +48,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     CHART
 
     before do
-      set_non_working_week_day('wednesday')
+      set_non_working_week_days('wednesday')
     end
 
     it 'moves the finish date to the corresponding number of now-excluded days to maintain duration [#31992]' do
@@ -37,7 +67,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     CHART
 
     before do
-      set_non_working_week_day('wednesday')
+      set_non_working_week_days('wednesday')
     end
 
     it 'does not move any dates' do
@@ -60,7 +90,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     CHART
 
     before do
-      set_non_working_week_day('wednesday')
+      set_non_working_week_days('wednesday')
     end
 
     it 'updates all impacted work packages' do
@@ -76,6 +106,32 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     end
   end
 
+  context 'when having multiple work packages following each other' do
+    let_schedule(<<~CHART, ignore_non_working_days: false)
+      days | MTWTFSS   |
+      wp1  |     X..XX | follows wp2
+      wp2  |    X      | follows wp3
+      wp3  | XXX       |
+    CHART
+
+    before do
+      set_non_working_week_days('tuesday', 'wednesday', 'friday')
+    end
+
+    it 'updates them only once' do
+      expect { job.perform_now(user_id: user.id) }
+        .to change { WorkPackage.pluck(:lock_version) }
+        .from([0, 0, 0])
+        .to([1, 1, 1])
+      expect(WorkPackage.all).to match_schedule(<<~CHART)
+        days | MTWTFSSmtwtfssmtwtfss  |
+        wp1  |               X..X...X |
+        wp2  |           X            |
+        wp3  | X..X...X               |
+      CHART
+    end
+  end
+
   context 'when a work package was scheduled to start on a date that is now a non-working day' do
     let_schedule(<<~CHART, ignore_non_working_days: false)
       days          | MTWTFSS |
@@ -83,7 +139,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     CHART
 
     before do
-      set_non_working_week_day('wednesday')
+      set_non_working_week_days('wednesday')
     end
 
     it 'moves the start date to the earliest working day in the future, ' \
@@ -104,7 +160,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     CHART
 
     before do
-      set_non_working_week_day('wednesday')
+      set_non_working_week_days('wednesday')
     end
 
     it 'moves the follower start date by consequence of the predecessor dates shift [#31992]' do

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -42,9 +42,13 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   end
 
   context 'when a work package includes a date that is now a non-working day' do
-    let_schedule(<<~CHART, ignore_non_working_days: false)
-      days          | MTWTFSS |
-      work_package  | XXXX    |
+    let_schedule(<<~CHART)
+      days                  | MTWTFSS |
+      work_package          | XXXX    |
+      work_package_on_start |   XX    |
+      work_package_on_due   | XXX     |
+      wp_start_only         |   [     |
+      wp_due_only           |   ]     |
     CHART
 
     before do
@@ -54,86 +58,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     it 'moves the finish date to the corresponding number of now-excluded days to maintain duration [#31992]' do
       job.perform_now(user_id: user.id)
       expect(WorkPackage.all).to match_schedule(<<~CHART)
-        days         | MTWTFSS |
-        work_package | XX.XX   |
-      CHART
-    end
-  end
-
-  context 'when a work package includes a date that is now a non-working day, but has working days include weekends' do
-    let_schedule(<<~CHART)
-      days          | MTWTFSS |
-      work_package  | XXXX    | working days include weekends
-    CHART
-
-    before do
-      set_non_working_week_days('wednesday')
-    end
-
-    it 'does not move any dates' do
-      job.perform_now(user_id: user.id)
-      expect(WorkPackage.all).to match_schedule(<<~CHART)
-        days         | MTWTFSS |
-        work_package | XXXX    | working days include weekends
-      CHART
-    end
-  end
-
-  context 'when having multiple work packages' do
-    let_schedule(<<~CHART, ignore_non_working_days: false)
-      days | MTWTFSS |
-      wp1  | XX      |
-      wp2  |  XX     |
-      wp3  |   XX    |
-      wp4  |    XX   |
-      wp5  | XXXXX   |
-    CHART
-
-    before do
-      set_non_working_week_days('wednesday')
-    end
-
-    it 'updates all impacted work packages' do
-      job.perform_now(user_id: user.id)
-      expect(WorkPackage.all).to match_schedule(<<~CHART)
-        days | MTWTFSS  |
-        wp1  | XX       |
-        wp2  |  X.X     |
-        wp3  |    XX    |
-        wp4  |    XX    |
-        wp5  | XX.XX..X |
-      CHART
-    end
-  end
-
-  context 'when having multiple work packages following each other' do
-    let_schedule(<<~CHART, ignore_non_working_days: false)
-      days | MTWTFSS   |
-      wp1  |     X..XX | follows wp2
-      wp2  |    X      | follows wp3
-      wp3  | XXX       |
-    CHART
-
-    before do
-      set_non_working_week_days('tuesday', 'wednesday', 'friday')
-    end
-
-    it 'updates them only once' do
-      expect { job.perform_now(user_id: user.id) }
-        .to change { WorkPackage.pluck(:lock_version) }
-        .from([0, 0, 0])
-        .to([1, 1, 1])
-      expect(WorkPackage.all).to match_schedule(<<~CHART)
-        days | MTWTFSSmtwtfssmtwtfss  |
-        wp1  |               X..X...X |
-        wp2  |           X            |
-        wp3  | X..X...X               |
+        days                  | MTWTFSS |
+        work_package          | XX.XX   |
+        work_package_on_start |    XX   |
+        work_package_on_due   | XX.X    |
+        wp_start_only         |    [    |
+        wp_due_only           |    ]    |
       CHART
     end
   end
 
   context 'when a work package was scheduled to start on a date that is now a non-working day' do
-    let_schedule(<<~CHART, ignore_non_working_days: false)
+    let_schedule(<<~CHART)
       days          | MTWTFSS |
       work_package  |   XX    |
     CHART
@@ -169,6 +105,93 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         days        | MTWTFSS |
         predecessor |  X.X    | working days work week
         follower    |     XXX | working days include weekends
+      CHART
+    end
+  end
+
+  context 'when a work package has working days include weekends, and includes a date that is now a non-working day' do
+    let_schedule(<<~CHART)
+      days          | MTWTFSS |
+      work_package  | XXXX    | working days include weekends
+    CHART
+
+    before do
+      set_non_working_week_days('wednesday')
+    end
+
+    it 'does not move any dates' do
+      job.perform_now(user_id: user.id)
+      expect(WorkPackage.all).to match_schedule(<<~CHART)
+        days         | MTWTFSS |
+        work_package | XXXX    | working days include weekends
+      CHART
+    end
+  end
+
+  context 'when a work package only has a duration' do
+    let_schedule(<<~CHART)
+      days          | MTWTFSS |
+      work_package  |         | duration 3 days
+    CHART
+
+    before do
+      set_non_working_week_days('wednesday')
+    end
+
+    it 'does not change anything' do
+      job.perform_now(user_id: user.id)
+      expect(work_package.duration).to eq(3)
+    end
+  end
+
+  context 'when having multiple work packages following each other' do
+    let_schedule(<<~CHART)
+      days | MTWTFSS   |
+      wp1  |     X..XX | follows wp2
+      wp2  |    X      | follows wp3
+      wp3  | XXX       |
+    CHART
+
+    before do
+      set_non_working_week_days('tuesday', 'wednesday', 'friday')
+    end
+
+    it 'updates them only once' do
+      expect { job.perform_now(user_id: user.id) }
+        .to change { WorkPackage.pluck(:lock_version) }
+        .from([0, 0, 0])
+        .to([1, 1, 1])
+      expect(WorkPackage.all).to match_schedule(<<~CHART)
+        days | MTWTFSSmtwtfssmtwtfss  |
+        wp1  |               X..X...X |
+        wp2  |           X            |
+        wp3  | X..X...X               |
+      CHART
+    end
+  end
+
+  context 'when having multiple work packages following each other and first one only has a due date' do
+    let_schedule(<<~CHART)
+      days | MTWTFSS   |
+      wp1  |     X..XX | follows wp2
+      wp2  |   XX      | follows wp3
+      wp3  |  ]       |
+    CHART
+
+    before do
+      set_non_working_week_days('tuesday', 'wednesday', 'friday')
+    end
+
+    it 'updates them only once' do
+      expect { job.perform_now(user_id: user.id) }
+        .to change { WorkPackage.pluck(:lock_version) }
+        .from([0, 0, 0])
+        .to([1, 1, 1])
+      expect(WorkPackage.all).to match_schedule(<<~CHART)
+        days | MTWTFSSm  t ssm  t ssm |
+        wp1  |               X..X...X |
+        wp2  |        X..X            |
+        wp3  |    ]                   |
       CHART
     end
   end

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob,
     expect(new_due_dates).to all(eq(Date.parse('Mon 2022-08-29')))
   end
 
-  xit 'updates followers if needed' do
+  it 'updates followers if needed' do
     work_package = create(:work_package,
                           ignore_non_working_days: false,
                           start_date: Date.parse('Mon 2022-08-22'),

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob,
+               with_flag: { work_packages_duration_field_active: true } do
+  subject(:job) { described_class }
+
+  shared_let(:user) { create(:user) }
+  shared_let(:week_days) { create(:week_days_with_saturday_and_sunday_as_weekend) }
+
+  def set_non_working_week_day(day)
+    wday = %w[xxx monday tuesday wednesday thursday friday saturday sunday].index(day.downcase)
+    WeekDay.find_by(day: wday).update(working: false)
+  end
+
+  it 'updates finish date of work packages after marking week days as non-working' do
+    work_package = create(:work_package,
+                          ignore_non_working_days: false,
+                          start_date: Date.parse('Mon 2022-08-22'),
+                          duration: 5)
+
+    expect do
+      set_non_working_week_day('wednesday')
+      job.perform_now(user_id: user.id)
+    end
+      .to change { work_package.reload.slice(:due_date) }
+      .from(due_date: Date.parse('Fri 2022-08-26'))
+      .to(due_date: Date.parse('Mon 2022-08-29'))
+  end
+
+  it 'does not change work packages ignoring non-working days' do
+    work_package = create(:work_package,
+                          ignore_non_working_days: true,
+                          start_date: Date.parse('Mon 2022-08-22'),
+                          duration: 5)
+
+    expect do
+      set_non_working_week_day('wednesday')
+      job.perform_now(user_id: user.id)
+    end
+      .not_to change { work_package.reload }
+  end
+
+  it 'updates multiple work packages' do
+    create_list(:work_package,
+                5,
+                ignore_non_working_days: false,
+                start_date: Date.parse('Mon 2022-08-22'),
+                duration: 5)
+
+    set_non_working_week_day('wednesday')
+    job.perform_now(user_id: user.id)
+
+    new_due_dates = WorkPackage.order(:id).pluck(:due_date)
+    expect(new_due_dates).to all(eq(Date.parse('Mon 2022-08-29')))
+  end
+
+  xit 'updates followers if needed' do
+    work_package = create(:work_package,
+                          ignore_non_working_days: false,
+                          start_date: Date.parse('Mon 2022-08-22'),
+                          duration: 5)
+    follower = create(:work_package,
+                      ignore_non_working_days: true,
+                      start_date: Date.parse('Sat 2022-08-27'),
+                      duration: 2)
+    create(:follows_relation, from: follower, to: work_package)
+
+    set_non_working_week_day('wednesday')
+    job.perform_now(user_id: user.id)
+
+    follower.reload
+    work_package.reload
+    expect(follower.start_date).not_to eq(Date.parse('Sat 2022-08-27'))
+    expect(follower.start_date).to eq(work_package.due_date + 1)
+    expect(follower.due_date).to eq(work_package.due_date + 2)
+  end
+end


### PR DESCRIPTION
When adding or removing weekend days, the duration stays the same, and dates changes. The rescheduling is done in an async job.

See [OP#42923](https://community.openproject.org/wp/42923)

## Todo

- [ ] Reschedule
  - [x] Exclude work packages including weekend days
  - [x] when adding non-working days
    - [x] All work packages which include working day becoming non-working days
    - [x] Update dependent work packages
    - [x] also start date only / finish date only work packages
  - [ ] when removing non-working days
    - [x] All work packages which include non working day becoming working days
    - [ ] Update dependent work packages
      - [ ] gap between 2 packages following each other must be preserved => will be done in #11249
        - for instance A follows B, 1 non working day between them. Gap is zero working days. When the non-working day is turned into a working day, then B must move one day back to preserve the zero gap. See [related comment](https://community.openproject.org/projects/openproject/work_packages/31992/activity#activity-155).
  - [x] Reschedule by start_date / due_date ascending order
    - [x] ~Add index on start_date~ adding an index would add a write cost to work_packages. Let's try without first. the background job is not time constrained.
- [x] Let Dmitrii know when he can start working on the journal entries ([#43640](https://community.openproject.org/work_packages/43640))