### PR TITLE
Require fileutils in the bulk_run_spec

### DIFF
--- a/script/bulk_run_rspec
+++ b/script/bulk_run_rspec
@@ -10,6 +10,7 @@
 # rubocop:disable Rails
 require 'ostruct'
 require 'pathname'
+require 'fileutils'
 
 RAILS_ROOT = Pathname.new File.expand_path('../', __dir__)
 RSPEC_EXAMPLE_STATUS_PERSISTENCE_FILE_PATH = RAILS_ROOT.join('tmp/spec_examples.txt')


### PR DESCRIPTION
Whenever I re-run the `script/bulk_run_spec` I get an error regarding `FileUtils` missing.

<img width="806" alt="image" src="https://user-images.githubusercontent.com/83396/187395055-831db7d2-1195-4c0c-9f2b-4db88153666e.png">
