### PR TITLE
Remove readonly from type groups

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -41,6 +41,7 @@ module Type::Attributes
                 links
                 parent_id
                 parent
+                readonly
                 schedule_manually].freeze
 
   included do


### PR DESCRIPTION
This got added as an explicit API field, which is why it turns up here

Drive by fix for https://community.openproject.org/wp/43893