### PR TITLE
Prevent dangling work packages when project gets `#destroy`ed without service call

### DIFF
--- a/app/services/concerns/with_reversible_state.rb
+++ b/app/services/concerns/with_reversible_state.rb
@@ -48,12 +48,6 @@ module WithReversibleState
     end
 
     ##
-    # Rollback changes made
-    def rollback
-      # Nothing to do by default
-    end
-
-    ##
     # Assign state to the service result
     def assign_state
       yield.tap do |call|

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -48,13 +48,6 @@ module Projects
       ]
     end
 
-    ##
-    # In case a rollback is needed,
-    # destroy the copied project again.
-    def rollback
-      state.project&.destroy
-    end
-
     protected
 
     ##

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -103,10 +103,6 @@ class ServiceResult
   end
 
   ##
-  # Rollback the state if possible
-  delegate :rollback!, to: :state
-
-  ##
   # Print messages to flash
   def apply_flash_message!(flash)
     if message

--- a/app/services/shared/service_state.rb
+++ b/app/services/shared/service_state.rb
@@ -48,17 +48,6 @@ module Shared
       service_chain << service
     end
 
-    # Roll back the context on all used services
-    def rollback!
-      return false if @rolled_back
-
-      service_chain.reverse_each do |service|
-        Rails.logger.debug { "[Service state] Rolling back execution of #{service}." }
-        service.rollback
-      end
-      @rolled_back = true
-    end
-
     # Remembered service calls this context was used against
     def service_chain
       @service_chain ||= []

--- a/db/migrate/20220831073113_work_package_project_foreign_key.rb
+++ b/db/migrate/20220831073113_work_package_project_foreign_key.rb
@@ -1,0 +1,28 @@
+class WorkPackageProjectForeignKey < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        cleanup_invalid_work_packages
+      end
+    end
+
+    add_foreign_key :work_packages, :projects
+  end
+
+  private
+
+  def cleanup_invalid_work_packages
+    WorkPackage
+      .where.not(project_id: Project.select(:id))
+      .find_each do |work_package|
+      WorkPackages::DeleteService
+        .new(user: User.system, model: work_package)
+        .call
+        .on_success { puts "Deleted stale work package #{work_package.inspect}" }
+        .on_failure { raise "Failed to delete stale work package #{work_package.inspect}" }
+    rescue ::ActiveRecord::RecordNotFound
+      # raised by #reload if work package no longer exists
+      # nothing to do, work package was already deleted (eg. by a parent)
+    end
+  end
+end

--- a/db/migrate/20220831073113_work_package_project_foreign_key.rb
+++ b/db/migrate/20220831073113_work_package_project_foreign_key.rb
@@ -18,8 +18,8 @@ class WorkPackageProjectForeignKey < ActiveRecord::Migration[7.0]
       WorkPackages::DeleteService
         .new(user: User.system, model: work_package)
         .call
-        .on_success { puts "Deleted stale work package #{work_package.inspect}" }
-        .on_failure { raise "Failed to delete stale work package #{work_package.inspect}" }
+        .on_success { Rails.logger.info "Deleted stale work package #{work_package.inspect}" }
+        .on_failure { Rails.logger.error "Failed to delete stale work package #{work_package.inspect}" }
     rescue ::ActiveRecord::RecordNotFound
       # raised by #reload if work package no longer exists
       # nothing to do, work package was already deleted (eg. by a parent)

--- a/spec/services/principals/replace_references_service_call_integration_spec.rb
+++ b/spec/services/principals/replace_references_service_call_integration_spec.rb
@@ -299,6 +299,11 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
     end
 
     context 'with WorkPackage' do
+      shared_let(:project) { create :project }
+      let(:attributes) do
+        { project_id: project.id }
+      end
+
       it_behaves_like 'rewritten record',
                       :work_package,
                       :assigned_to_id
@@ -311,8 +316,11 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
                       :journal_work_package_journal,
                       :assigned_to_id do
         let(:attributes) do
-          # ignore_non_working_days is non nullable. This part is not related to the test.
-          { ignore_non_working_days: false }
+          {
+            # ignore_non_working_days is non nullable. This part is not related to the test.
+            ignore_non_working_days: false,
+            project_id: project.id
+          }
         end
       end
 
@@ -320,8 +328,11 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
                       :journal_work_package_journal,
                       :responsible_id do
         let(:attributes) do
-          # ignore_non_working_days is non nullable. This part is not related to the test.
-          { ignore_non_working_days: false }
+          {
+            # ignore_non_working_days is non nullable. This part is not related to the test.
+            ignore_non_working_days: false,
+            project_id: project.id
+          }
         end
       end
     end


### PR DESCRIPTION
When destroying a project explicitly with `project.destroy`, associated work packages are no longer destroyed. There are some dangling work packages that I think are associated with the copy service.

We do have a `project.destroy` call there but as far as I could tell, that functionality (state rollback) is not or no longer in use. I couldn't find another path that would leave work packages dangling.

This PR adds a foreign key migration to ensure that work packages can no longer be dangling.

This prevents https://community.openproject.org/work_packages/43702 from occuring,  but does not fix the underyling cause, if it still exists.