### PR TITLE
[#42923] Move followers to a later date when delay covers days changing from working to non-working

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -99,6 +99,9 @@ class Relation < ApplicationRecord
   scope :of_work_package,
         ->(work_package) { where(from: work_package).or(where(to: work_package)) }
 
+  scope :follows_with_delay,
+        -> { follows.where("delay > 0") }
+
   validates :delay, numericality: { allow_nil: true }
 
   validates :to, uniqueness: { scope: :from }

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -131,8 +131,10 @@ class Relation < ApplicationRecord
   end
 
   def successor_soonest_start
-    if relation_type == TYPE_FOLLOWS && (to.start_date || to.due_date)
-      (to.due_date || to.start_date) + 1 + (delay || 0)
+    if follows? && (to.start_date || to.due_date)
+      days = WorkPackages::Shared::Days.for(from)
+      relation_start_date = (to.due_date || to.start_date) + 1.day
+      days.soonest_working_day(relation_start_date, delay:)
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -120,7 +120,8 @@ class WorkPackage < ApplicationRecord
     where(author_id: author.id)
   }
 
-  scopes :for_scheduling,
+  scopes :covering_days_of_week,
+         :for_scheduling,
          :include_derived_dates,
          :include_spent_time,
          :left_join_self_and_descendants,

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -38,7 +38,7 @@ module WorkPackage::SchedulingRules
   # will not violate the precedes relations (max(finish date, start date) + relation delay)
   # of this work package or its ancestors
   # e.g.
-  # AP(due_date: 2017/07/24)-precedes(delay: 1)-A
+  # AP(due_date: 2017/07/25)-precedes(delay: 0)-A
   #                                             |
   #                                           parent
   #                                             |
@@ -49,17 +49,16 @@ module WorkPackage::SchedulingRules
   # CP(due_date: 2017/07/25)-precedes(delay: 2)-C
   #
   # Then soonest_start for:
-  #   C is 2017/07/27
-  #   B is 2017/07/25
-  #   A is 2017/07/25
+  #   C is 2017/07/28
+  #   B is 2017/07/26
+  #   A is 2017/07/26
   def soonest_start
-    # eager load `to` to avoid n+1 on successor_soonest_start
+    # eager load `to` and `from` to avoid n+1 on successor_soonest_start
     @soonest_start ||=
       Relation
         .follows_non_manual_ancestors(self)
-        .includes(:to)
-        .map(&:successor_soonest_start)
-        .compact
+        .includes(:to, :from)
+        .filter_map(&:successor_soonest_start)
         .max
   end
 end

--- a/app/models/work_packages/scopes/covering_days_of_week.rb
+++ b/app/models/work_packages/scopes/covering_days_of_week.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages::Scopes::CoveringDaysOfWeek
+  extend ActiveSupport::Concern
+  using CoreExtensions::SquishSql
+
+  class_methods do
+    # Fetches all work packages that cover specific days of the week.
+    #
+    # The period considered is from the work package start date to the due date.
+    #
+    # @param days_of_week number[] An array of the ISO days of the week to
+    #   consider. 1 is Monday, 7 is Sunday.
+    def covering_days_of_week(days_of_week)
+      days_of_week = Array(days_of_week)
+      return none if days_of_week.empty?
+
+      where("id IN (#{query(days_of_week)})")
+    end
+
+    private
+
+    def query(days_of_week)
+      sql = <<~SQL.squish
+        -- select work packages dates with their followers dates
+        WITH work_packages_with_dates AS (
+          SELECT work_packages.id,
+            work_packages.start_date AS work_package_start_date,
+            work_packages.due_date AS work_package_due_date
+          FROM work_packages
+          WHERE work_packages.ignore_non_working_days = false
+            AND (
+              work_packages.start_date IS NOT NULL
+              OR work_packages.due_date IS NOT NULL
+            )
+          ORDER BY work_packages.id
+        ),
+        -- coalesce non-existing dates of work package to get period start/end
+        work_packages_periods AS (
+          SELECT id,
+            LEAST(work_package_start_date, work_package_due_date) AS start_date,
+            GREATEST(work_package_start_date, work_package_due_date) AS end_date
+          FROM work_packages_with_dates
+        ),
+        -- expand period into days of the week. Limit to 7 days (more would be useless).
+        work_packages_days_of_week AS (
+          SELECT id,
+            extract(
+              isodow
+              from generate_series(
+                  work_packages_periods.start_date,
+                  LEAST(
+                    work_packages_periods.start_date + 6,
+                    work_packages_periods.end_date
+                  ),
+                  '1 day'
+                )
+            ) AS dow
+            FROM work_packages_periods
+        )
+        -- select id of work packages covering the given days
+        SELECT DISTINCT id
+        FROM work_packages_days_of_week
+        WHERE dow IN (:days_of_week)
+      SQL
+
+      sanitize_sql([sql, { days_of_week: }])
+    end
+  end
+end

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -28,6 +28,7 @@
 
 module Groups
   class AddUsersService < ::BaseServices::BaseContracted
+    using CoreExtensions::SquishSql
     include Groups::Concerns::MembershipManipulation
 
     def initialize(group, current_user:, contract_class: AdminOnlyContract)
@@ -49,7 +50,7 @@ module Groups
     end
 
     def add_to_user_and_projects_cte
-      <<~SQL
+      <<~SQL.squish
         -- select existing users from given IDs
         WITH found_users AS (
           SELECT id as user_id FROM #{User.table_name} WHERE id IN (:user_ids)

--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -151,8 +151,8 @@ class WorkPackages::ScheduleDependency
     # preload unmoving predecessors, as they influence the computation of Relation#successor_soonest_start
     known_work_packages.concat(fetch_unmoving_predecessors)
 
-    # rehydrate the predecessors of follows relations
-    rehydrate_predecessors_of_follows_relations
+    # rehydrate the predecessors and followers of follows relations
+    rehydrate_follows_relations
   end
 
   # Returns all the descendants of moved and moving work packages that are not
@@ -184,9 +184,13 @@ class WorkPackages::ScheduleDependency
     self.known_follows_relations = Relation.follows.where(from_id: known_work_packages.map(&:id))
   end
 
-  # rehydrate the #to member of the preloaded follows relations, to
-  # prevent triggering additional database requests.
-  def rehydrate_predecessors_of_follows_relations
-    known_follows_relations.each { |relation| relation.to = work_package_by_id(relation.to_id) }
+  # rehydrate the #to and #from members of the preloaded follows relations, to
+  # prevent triggering additional database requests when computing soonest
+  # start.
+  def rehydrate_follows_relations
+    known_follows_relations.each do |relation|
+      relation.from = work_package_by_id(relation.from_id)
+      relation.to = work_package_by_id(relation.to_id)
+    end
   end
 end

--- a/app/services/work_packages/schedule_dependency/dependency.rb
+++ b/app/services/work_packages/schedule_dependency/dependency.rb
@@ -52,10 +52,9 @@ class WorkPackages::ScheduleDependency::Dependency
   end
 
   def soonest_start_date
-    soonest_start = follows_relations
+    follows_relations
       .filter_map(&:successor_soonest_start)
       .max
-    WorkPackages::Shared::Days.for(work_package).soonest_working_day(soonest_start)
   end
 
   def start_date

--- a/app/services/work_packages/shared/all_days.rb
+++ b/app/services/work_packages/shared/all_days.rb
@@ -50,8 +50,9 @@ module WorkPackages
         start_date + duration - 1
       end
 
-      def soonest_working_day(date)
-        date
+      def soonest_working_day(date, delay: nil)
+        delay ||= 0
+        date + delay.days if date
       end
 
       def working?(_date)

--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -61,12 +61,20 @@ module WorkPackages
         due_date
       end
 
-      def soonest_working_day(date)
+      def soonest_working_day(date, delay: nil)
         return unless date
+
+        delay ||= 0
+
+        while delay > 0
+          delay -= 1 if working?(date)
+          date += 1
+        end
 
         until working?(date)
           date += 1
         end
+
         date
       end
 

--- a/lib/core_extensions/squish_sql.rb
+++ b/lib/core_extensions/squish_sql.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Refinement to also remove SQL comments when using +String#squish+.
+#
+# To use it, add +using CoreExtensions::SquishSql+. Refinements are scoped.
+# See https://docs.ruby-lang.org/en/3.1/syntax/refinements_rdoc.html
+module CoreExtensions::SquishSql
+  refine String do
+    # Like +squish+ from ActiveSupport, and also removes single line sql
+    # comments.
+    #
+    #   <<~SQL.squish
+    #     -- select existing users from given IDs
+    #     SELECT id AS user_id
+    #     FROM users
+    #     WHERE id IN (:user_ids)
+    #   SQL
+    #   => "SELECT id as user_id FROM users WHERE id IN (:user_ids)"
+    def squish
+      dup.squish!
+    end
+
+    # Performs a destructive squish. See String#squish.
+    def squish!
+      gsub!(/[[:space:]]*--[^\r\n]*$/, " ")
+      super
+    end
+  end
+end

--- a/spec/lib/core_extensions/squish_sql_spec.rb
+++ b/spec/lib/core_extensions/squish_sql_spec.rb
@@ -1,0 +1,47 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe CoreExtensions::SquishSql do
+  using described_class
+
+  it 'removes single line SQL comments' do
+    sql = <<~SQL.squish
+      -- select existing users from given IDs
+      --
+      -- another comment
+      SELECT id as user_id
+        -- this comment is removed too
+      FROM users
+      WHERE id IN (:user_ids)
+    SQL
+
+    expect(sql).to eq("SELECT id as user_id FROM users WHERE id IN (:user_ids)")
+  end
+end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -103,7 +103,7 @@ describe Day, type: :model do
     end
 
     context 'when the week day is working' do
-      shared_let(:working_days) { reset_working_week_days('saturday') }
+      shared_let(:working_days) { set_work_week('saturday') }
 
       it 'is true' do
         expect(subject.working).to be_truthy

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -28,6 +28,8 @@
 require 'spec_helper'
 
 describe Relation, type: :model do
+  create_shared_association_defaults_for_work_package_factory
+
   let(:from) { create(:work_package) }
   let(:to) { create(:work_package) }
   let(:type) { 'relates' }
@@ -124,6 +126,122 @@ describe Relation, type: :model do
       it 'is falsey' do
         expect(relation)
           .not_to be_follows
+      end
+    end
+  end
+
+  describe '#successor_soonest_start' do
+    context 'with a follows relation' do
+      let_schedule(<<~CHART)
+        days     | MTWTFSS |
+        main     | ]       |
+        follower |         | follows main
+      CHART
+
+      it 'returns predecessor due_date + 1' do
+        relation = schedule.follows_relation(from: 'follower', to: 'main')
+        expect(relation.successor_soonest_start).to eq(schedule.tuesday)
+      end
+    end
+
+    context 'with a follows relation with predecessor having only start date' do
+      let_schedule(<<~CHART)
+        days     | MTWTFSS |
+        main     | [       |
+        follower |         | follows main
+      CHART
+
+      it 'returns predecessor start_date + 1' do
+        relation = schedule.follows_relation(from: 'follower', to: 'main')
+        expect(relation.successor_soonest_start).to eq(schedule.tuesday)
+      end
+    end
+
+    context 'with a non-follows relation' do
+      let_schedule(<<~CHART)
+        days    | MTWTFSS |
+        main    | X       |
+        related |         |
+      CHART
+      let(:relation) { create(:relation, from: main, to: related) }
+
+      it 'returns nil' do
+        expect(relation.successor_soonest_start).to be_nil
+      end
+    end
+
+    context 'with a follows relation with a delay' do
+      let_schedule(<<~CHART)
+        days       | MTWTFSS |
+        main       | X       |
+        follower_a |         | follows main with delay 0
+        follower_b |         | follows main with delay 1
+        follower_c |         | follows main with delay 3
+      CHART
+
+      it 'returns predecessor due_date + delay + 1' do
+        relation_a = schedule.follows_relation(from: 'follower_a', to: 'main')
+        expect(relation_a.successor_soonest_start).to eq(schedule.tuesday)
+
+        relation_b = schedule.follows_relation(from: 'follower_b', to: 'main')
+        expect(relation_b.successor_soonest_start).to eq(schedule.wednesday)
+
+        relation_c = schedule.follows_relation(from: 'follower_c', to: 'main')
+        expect(relation_c.successor_soonest_start).to eq(schedule.friday)
+      end
+    end
+
+    context 'with a follows relation with a delay and with non-working days in the delay period' do
+      let_schedule(<<~CHART)
+        days            | MTWTFSSmtw |
+        main            | X░ ░ ░░ ░  |
+        follower_delay0 |  ░ ░ ░░ ░  | follows main with delay 0
+        follower_delay1 |  ░ ░ ░░ ░  | follows main with delay 1
+        follower_delay2 |  ░ ░ ░░ ░  | follows main with delay 2
+        follower_delay3 |  ░ ░ ░░ ░  | follows main with delay 3
+      CHART
+
+      it 'returns a date such as the number of working days between both work package is equal to the delay' do
+        set_work_week('monday', 'wednesday', 'friday')
+
+        relation_delay0 = schedule.follows_relation(from: 'follower_delay0', to: 'main')
+        expect(relation_delay0.successor_soonest_start).to eq(schedule.wednesday)
+
+        relation_delay1 = schedule.follows_relation(from: 'follower_delay1', to: 'main')
+        expect(relation_delay1.successor_soonest_start).to eq(schedule.friday)
+
+        relation_delay2 = schedule.follows_relation(from: 'follower_delay2', to: 'main')
+        expect(relation_delay2.successor_soonest_start).to eq(schedule.monday + 7.days)
+
+        relation_delay3 = schedule.follows_relation(from: 'follower_delay3', to: 'main')
+        expect(relation_delay3.successor_soonest_start).to eq(schedule.wednesday + 7.days)
+      end
+    end
+
+    context 'with a follows relation with a delay, non-working days, and follower ignoring non-working days' do
+      let_schedule(<<~CHART)
+        days            | MTWTFSSmtw |
+        main            | X░ ░ ░░ ░  |
+        follower_delay0 |  ░ ░ ░░ ░  | follows main with delay 0, working days include weekends
+        follower_delay1 |  ░ ░ ░░ ░  | follows main with delay 1, working days include weekends
+        follower_delay2 |  ░ ░ ░░ ░  | follows main with delay 2, working days include weekends
+        follower_delay3 |  ░ ░ ░░ ░  | follows main with delay 3, working days include weekends
+      CHART
+
+      it 'returns predecessor due_date + delay + 1 (like without non-working days)' do
+        set_work_week('monday', 'wednesday', 'friday')
+
+        relation_delay0 = schedule.follows_relation(from: 'follower_delay0', to: 'main')
+        expect(relation_delay0.successor_soonest_start).to eq(schedule.tuesday)
+
+        relation_delay1 = schedule.follows_relation(from: 'follower_delay1', to: 'main')
+        expect(relation_delay1.successor_soonest_start).to eq(schedule.wednesday)
+
+        relation_delay2 = schedule.follows_relation(from: 'follower_delay2', to: 'main')
+        expect(relation_delay2.successor_soonest_start).to eq(schedule.thursday)
+
+        relation_delay3 = schedule.follows_relation(from: 'follower_delay3', to: 'main')
+        expect(relation_delay3.successor_soonest_start).to eq(schedule.friday)
       end
     end
   end

--- a/spec/models/work_packages/scopes/covering_days_of_week_spec.rb
+++ b/spec/models/work_packages/scopes/covering_days_of_week_spec.rb
@@ -1,0 +1,129 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'rails_helper'
+
+RSpec.describe WorkPackages::Scopes::CoveringDaysOfWeek do
+  create_shared_association_defaults_for_work_package_factory
+
+  it 'returns work packages having start date or due date being in the given days of week' do
+    schedule =
+      create_schedule(<<~CHART)
+        days         | MTWTFSS |
+        covered1     | XX      |
+        covered2     |  XX     |
+        covered3     |  X      |
+        covered4     |  [      |
+        covered5     |  ]      |
+        not_covered1 | X       |
+        not_covered2 |   X     |
+        not_covered3 |    XX   |
+        not_covered4 |         |
+      CHART
+
+    expect(WorkPackage.covering_days_of_week(2))
+      .to contain_exactly(
+        schedule.work_package("covered1"),
+        schedule.work_package("covered2"),
+        schedule.work_package("covered3"),
+        schedule.work_package("covered4"),
+        schedule.work_package("covered5")
+      )
+  end
+
+  it 'returns work packages having days between start date and due date being in the given days of week' do
+    schedule =
+      create_schedule(<<~CHART)
+        days         | MTWTFSS |
+        covered1     | XXXX    |
+        covered2     |  XXX    |
+        not_covered1 |    XX   |
+        not_covered2 | X       |
+      CHART
+
+    expect(WorkPackage.covering_days_of_week([2, 3]))
+      .to contain_exactly(
+        schedule.work_package("covered1"),
+        schedule.work_package("covered2")
+      )
+  end
+
+  context 'if work package ignores non working days' do
+    it 'does not returns it' do
+      create_schedule(<<~CHART)
+        days         | MTWTFSS |
+        not_covered  | XXXXXXX | working days include weekends
+      CHART
+
+      expect(WorkPackage.covering_days_of_week(3))
+        .to eq([])
+    end
+  end
+
+  it 'does not return work packages having follows relation covering the given days of week' do
+    create_schedule(<<~CHART)
+      days         | MTWTFSS |
+      not_covered1 | X       |
+      follower1    |     X   | follows not_covered1
+      not_covered2 | X       |
+      follower2    |   X     | follows not_covered2
+    CHART
+
+    expect(WorkPackage.covering_days_of_week([2, 4]))
+      .to eq([])
+  end
+
+  it 'does not return work packages having follows relation with delay covering the given days of week' do
+    create_schedule(<<~CHART)
+      days         | MTWTFSS |
+      not_covered1 | X       |
+      follower1    |     X   | follows not_covered1 with delay 3
+      not_covered2 | X       |
+      follower2    |   X     | follows not_covered2 with delay 1
+    CHART
+
+    expect(WorkPackage.covering_days_of_week([2, 4]))
+      .to eq([])
+  end
+
+  it 'accepts a single day of week or an array of days' do
+    schedule =
+      create_schedule(<<~CHART)
+        days          | MTWTFSS |
+        covered       |  X      |
+        not_covered   | X       |
+      CHART
+
+    expect(WorkPackage.covering_days_of_week(2))
+      .to eq([schedule.work_package("covered")])
+    expect(WorkPackage.covering_days_of_week([2]))
+      .to eq([schedule.work_package("covered")])
+    expect(WorkPackage.covering_days_of_week([2, 3]))
+      .to eq([schedule.work_package("covered")])
+  end
+end

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -142,15 +142,32 @@ RSpec.describe WorkPackages::Shared::AllDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
+    context 'with delay' do
+      it 'returns the soonest working day from the given day, after a configurable delay of working days' do
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: nil)).to eq(sunday_2022_07_31)
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: 0)).to eq(sunday_2022_07_31)
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: 1)).to eq(Date.new(2022, 8, 1))
+      end
+    end
+
     context 'with weekend days (Saturday and Sunday)', :weekend_saturday_sunday do
       it 'returns the given day' do
         expect(subject.soonest_working_day(sunday_2022_07_31)).to eq(sunday_2022_07_31)
+      end
+
+      context 'with delay' do
+        include_examples 'soonest working day with delay', date: Date.new(2022, 1, 1), delay: 30, expected: Date.new(2022, 1, 31)
       end
     end
 
     context 'with some non working days (Christmas 2022-12-25 and new year\'s day 2023-01-01)', :christmas_2022_new_year_2023 do
       it 'returns the given day' do
         expect(subject.soonest_working_day(Date.new(2022, 12, 25))).to eq(Date.new(2022, 12, 25))
+      end
+
+      context 'with delay' do
+        include_examples 'soonest working day with delay', date: Date.new(2022, 12, 24), delay: 7,
+                                                           expected: Date.new(2022, 12, 31)
       end
     end
   end

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -81,3 +81,9 @@ RSpec.shared_examples 'soonest working day' do |date:, expected:|
     expect(subject.soonest_working_day(date)).to eq(expected)
   end
 end
+
+RSpec.shared_examples 'soonest working day with delay' do |date:, delay:, expected:|
+  it "soonest_working_day(#{date.to_fs(:wday_date)}, delay: #{delay.inspect}) => #{expected.to_fs(:wday_date)}" do
+    expect(subject.soonest_working_day(date, delay:)).to eq(expected)
+  end
+end

--- a/spec/services/work_packages/shared/working_days_spec.rb
+++ b/spec/services/work_packages/shared/working_days_spec.rb
@@ -188,17 +188,49 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
+    context 'with delay' do
+      it 'returns the soonest working day from the given day, after a configurable delay of working days' do
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: nil)).to eq(sunday_2022_07_31)
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: 0)).to eq(sunday_2022_07_31)
+        expect(subject.soonest_working_day(sunday_2022_07_31, delay: 1)).to eq(monday_2022_08_01)
+      end
+
+      it 'works with big delay value like 100_000' do
+        # First implementation was recursive and failed with SystemStackError: stack level too deep
+        expect { subject.soonest_working_day(sunday_2022_07_31, delay: 100_000) }
+          .not_to raise_error
+      end
+    end
+
     context 'with weekend days (Saturday and Sunday)', :weekend_saturday_sunday do
       include_examples 'soonest working day', date: friday_2022_07_29, expected: friday_2022_07_29
       include_examples 'soonest working day', date: saturday_2022_07_30, expected: monday_2022_08_01
       include_examples 'soonest working day', date: sunday_2022_07_31, expected: monday_2022_08_01
       include_examples 'soonest working day', date: monday_2022_08_01, expected: monday_2022_08_01
+
+      context 'with delay' do
+        include_examples 'soonest working day with delay', date: friday_2022_07_29, delay: 0, expected: friday_2022_07_29
+        include_examples 'soonest working day with delay', date: saturday_2022_07_30, delay: 0, expected: monday_2022_08_01
+        include_examples 'soonest working day with delay', date: sunday_2022_07_31, delay: 0, expected: monday_2022_08_01
+        include_examples 'soonest working day with delay', date: monday_2022_08_01, delay: 0, expected: monday_2022_08_01
+
+        include_examples 'soonest working day with delay', date: friday_2022_07_29, delay: 1, expected: monday_2022_08_01
+        include_examples 'soonest working day with delay', date: saturday_2022_07_30, delay: 1, expected: Date.new(2022, 8, 2)
+        include_examples 'soonest working day with delay', date: sunday_2022_07_31, delay: 1, expected: Date.new(2022, 8, 2)
+        include_examples 'soonest working day with delay', date: monday_2022_08_01, delay: 1, expected: Date.new(2022, 8, 2)
+
+        include_examples 'soonest working day with delay', date: friday_2022_07_29, delay: 8, expected: Date.new(2022, 8, 10)
+      end
     end
 
     context 'with some non working days (Christmas 2022-12-25 and new year\'s day 2023-01-01)', :christmas_2022_new_year_2023 do
       include_examples 'soonest working day', date: Date.new(2022, 12, 25), expected: Date.new(2022, 12, 26)
       include_examples 'soonest working day', date: Date.new(2022, 12, 31), expected: Date.new(2022, 12, 31)
       include_examples 'soonest working day', date: Date.new(2023, 1, 1), expected: Date.new(2023, 1, 2)
+
+      context 'with delay' do
+        include_examples 'soonest working day with delay', date: Date.new(2022, 12, 24), delay: 7, expected: Date.new(2023, 1, 2)
+      end
     end
 
     context 'with no working days', :no_working_days do

--- a/spec/support/schedule_helpers/chart.rb
+++ b/spec/support/schedule_helpers/chart.rb
@@ -64,7 +64,7 @@ module ScheduleHelpers
     end
 
     def initialize
-      self.monday = next_monday
+      self.monday = Date.current.next_occurring(:monday)
       self.id_column_size = FIRST_CELL_TEXT.length
     end
 
@@ -228,12 +228,6 @@ module ScheduleHelpers
       else
         WorkPackages::Shared::WorkingDays.new
       end
-    end
-
-    def next_monday
-      date = Time.zone.today
-      date += 1.day while date.wday != 1
-      date
     end
 
     def predecessors_by_followers

--- a/spec/support/schedule_helpers/chart_builder.rb
+++ b/spec/support/schedule_helpers/chart_builder.rb
@@ -119,7 +119,19 @@ module ScheduleHelpers
       when /^working days include weekends$/
         chart.set_ignore_non_working_days(name, true)
       else
-        raise "unable to parse property #{property.inspect} for line #{name.inspect}"
+        spell_checker = DidYouMean::SpellChecker.new(
+          dictionary: [
+            "follows :wp",
+            "follows :wp with delay :int",
+            "child of :wp",
+            "duration :int",
+            "working days work week",
+            "working days include weekends"
+          ]
+        )
+        suggestions = spell_checker.correct(property).map(&:inspect).join(' ')
+        did_you_mean = " Did you mean #{suggestions} instead?" if suggestions.present?
+        raise "unable to parse property #{property.inspect} for line #{name.inspect}.#{did_you_mean}"
       end
     end
 

--- a/spec/support/schedule_helpers/example_methods.rb
+++ b/spec/support/schedule_helpers/example_methods.rb
@@ -28,6 +28,31 @@
 
 module ScheduleHelpers
   module ExampleMethods
+    # Create work packages and relations from a visual chart representation.
+    #
+    # For instance:
+    #
+    #   create_schedule(<<~CHART)
+    #     days       | MTWTFSS   |
+    #     main       | XX        |
+    #     follower   |   XXX     | follows main
+    #     start_only |  [        |
+    #     due_only   |    ]      |
+    #   CHART
+    #
+    # is equivalent to:
+    #
+    #   create(:work_package, subject: 'main', start_date: next_monday, due_date: next_monday + 1.day)
+    #   create(:work_package, subject: 'follower', start_date: next_monday + 2.days, due_date: next_monday + 4.days) }
+    #   create(:work_package, subject: 'start_only', start_date: next_monday + 1.day) }
+    #   create(:work_package, subject: 'due_only', due_date: next_monday + 3.days) }
+    #   create(:follows_relation, from: follower, to: main, delay: 0) }
+    #
+    def create_schedule(chart_representation)
+      chart = Chart.for(chart_representation)
+      ScheduleBuilder.from_chart(chart, self)
+    end
+
     # Change the given work packages according to the given chart representation.
     # Work packages are changed without being saved.
     #

--- a/spec/support/schedule_helpers/schedule.rb
+++ b/spec/support/schedule_helpers/schedule.rb
@@ -44,6 +44,14 @@ module ScheduleHelpers
       @follows_relations[from:, to:]
     end
 
+    def monday
+      Date.current.next_occurring(:monday)
+    end
+
+    %i[tuesday wednesday thursday friday saturday sunday].each do |day_name|
+      define_method(day_name) { monday.next_occurring(day_name) }
+    end
+
     private
 
     def normalize_name(name)

--- a/spec/support/schedule_helpers/schedule.rb
+++ b/spec/support/schedule_helpers/schedule.rb
@@ -26,46 +26,34 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
-
-describe ScheduleHelpers::LetSchedule do
-  create_shared_association_defaults_for_work_package_factory
-
-  describe 'let_schedule' do
-    let_schedule(<<~CHART)
-      days      | MTWTFSS |
-      main      | XX      |
-      follower  |   XXX   | follows main with delay 2
-      child     |         | child of main
-    CHART
-
-    it 'creates let calls for each work package' do
-      expect([main, follower, child]).to all(be_an_instance_of(WorkPackage))
-      expect([main, follower, child]).to all(be_persisted)
-      expect(main).to have_attributes(
-        subject: 'main',
-        start_date: schedule.monday,
-        due_date: schedule.tuesday
-      )
-      expect(follower).to have_attributes(
-        subject: 'follower',
-        start_date: schedule.wednesday,
-        due_date: schedule.friday
-      )
-      expect(child).to have_attributes(
-        subject: 'child',
-        start_date: nil,
-        due_date: nil
-      )
+module ScheduleHelpers
+  class Schedule
+    def initialize(work_packages, follows_relations)
+      @work_packages = work_packages
+      @follows_relations = follows_relations
     end
 
-    it 'creates follows relations between work packages' do
-      expect(follower.follows_relations.count).to eq(1)
-      expect(follower.follows_relations.first.to).to eq(main)
+    def work_package(name)
+      name = normalize_name(name)
+      @work_packages[name]
     end
 
-    it 'creates parent / child relations' do
-      expect(child.parent).to eq(main)
+    def follows_relation(from:, to:)
+      from = normalize_name(from)
+      to = normalize_name(to)
+      @follows_relations[from:, to:]
+    end
+
+    private
+
+    def normalize_name(name)
+      symbolic_name = name.to_sym
+      return symbolic_name if @work_packages.has_key?(symbolic_name)
+
+      spell_checker = DidYouMean::SpellChecker.new(dictionary: @work_packages.keys.map(&:to_s))
+      suggestions = spell_checker.correct(name).map(&:inspect).join(' ')
+      did_you_mean = " Did you mean #{suggestions} instead?" if suggestions.present?
+      raise "No work package with name #{name.inspect} in schedule.#{did_you_mean}"
     end
   end
 end

--- a/spec/support/schedule_helpers/schedule_builder.rb
+++ b/spec/support/schedule_helpers/schedule_builder.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ScheduleHelpers
+  class ScheduleBuilder
+    def self.from_chart(chart, rspec_example)
+      creator = new(chart, rspec_example)
+      chart.work_package_names.each do |name|
+        creator.create_work_package(name)
+        creator.create_follows_relations(name)
+      end
+      Schedule.new(creator.work_packages, creator.follows_relations)
+    end
+
+    attr_reader :chart, :work_packages, :follows_relations
+
+    def initialize(chart, rspec_example)
+      @chart = chart
+      @rspec_example = rspec_example
+      @work_packages = {}
+      @follows_relations = {}
+    end
+
+    def create_work_package(name)
+      work_packages[name] ||= begin
+        attributes = chart
+          .work_package_attributes(name)
+          .excluding(:name)
+          .merge(parent: parent_of(name))
+        @rspec_example.create(:work_package, attributes)
+      end
+    end
+
+    def create_follows_relations(follower)
+      chart.predecessors_by_follower(follower).each do |predecessor|
+        follows_relations[from: follower, to: predecessor] =
+          @rspec_example.create(:follows_relation,
+                                from: create_work_package(follower),
+                                to: create_work_package(predecessor),
+                                delay: chart.delay_between(predecessor:, follower:))
+      end
+    end
+
+    def parent_of(name)
+      if chart.parent(name)
+        create_work_package(chart.parent(name))
+      end
+    end
+  end
+end

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -58,7 +58,7 @@ def set_week_days(*days, working: true)
   end
 end
 
-def reset_working_week_days(*days)
+def set_work_week(*days)
   week_days = get_week_days(*days)
   Setting.working_days = week_days
 end

--- a/spec/support_spec/schedule_helpers/example_methods_spec.rb
+++ b/spec/support_spec/schedule_helpers/example_methods_spec.rb
@@ -29,18 +29,120 @@
 require 'spec_helper'
 
 describe ScheduleHelpers::ExampleMethods do
-  include ActiveSupport::Testing::TimeHelpers
-
   create_shared_association_defaults_for_work_package_factory
 
-  let(:fake_today) { Date.new(2022, 6, 16) } # Thursday 16 June 2022
-  let(:monday) { Date.new(2022, 6, 20) } # Monday 20 June
-  let(:tuesday) { Date.new(2022, 6, 21) }
-  let(:wednesday) { Date.new(2022, 6, 22) }
-  let(:thursday) { Date.new(2022, 6, 23) }
-  let(:friday) { Date.new(2022, 6, 24) }
-  let(:saturday) { Date.new(2022, 6, 25) }
-  let(:sunday) { Date.new(2022, 6, 26) }
+  describe 'create_schedule' do
+    let(:monday) { Date.current.next_occurring(:monday) }
+    let(:tuesday) { monday + 1.day }
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'creates work packages from the given chart' do
+      schedule = create_schedule(<<~CHART)
+        days       | MTWTFSS |
+        main       | XX      |
+        start_only | [       |
+        due_only   |  ]      |
+        no_dates   |         |
+      CHART
+
+      expect(WorkPackage.count).to eq(4)
+      expect(schedule.work_package("main")).to have_attributes(
+        subject: "main",
+        start_date: monday,
+        due_date: tuesday,
+        duration: 2
+      )
+      expect(schedule.work_package("start_only")).to have_attributes(
+        subject: "start_only",
+        start_date: monday,
+        due_date: nil,
+        duration: nil
+      )
+      expect(schedule.work_package("due_only")).to have_attributes(
+        subject: "due_only",
+        start_date: nil,
+        due_date: tuesday,
+        duration: nil
+      )
+      expect(schedule.work_package("no_dates")).to have_attributes(
+        subject: "no_dates",
+        start_date: nil,
+        due_date: nil,
+        duration: nil
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'creates parent/child relations from the given chart' do
+      schedule = create_schedule(<<~CHART)
+        days      | MTWTFSS |
+        main      |         |
+        child     |         | child of main
+      CHART
+      expect(schedule.work_package("main")).to have_attributes(
+        children: [schedule.work_package("child")]
+      )
+      expect(schedule.work_package("child")).to have_attributes(
+        parent: schedule.work_package("main")
+      )
+    end
+
+    it 'creates follows relations from the given chart' do
+      schedule = create_schedule(<<~CHART)
+        days        | MTWTFSS |
+        predecessor | XX      |
+        follower    |     X   | follows predecessor with delay 2
+      CHART
+      expect(Relation.count).to eq(1)
+      expect(schedule.follows_relation(from: "follower", to: "predecessor")).to be_an_instance_of(Relation)
+      expect(schedule.follows_relation(from: "follower", to: "predecessor")).to have_attributes(
+        relation_type: "follows",
+        delay: 2,
+        from: schedule.work_package("follower"),
+        to: schedule.work_package("predecessor")
+      )
+    end
+  end
+
+  describe 'change_schedule' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:fake_today) { Date.new(2022, 6, 16) } # Thursday 16 June 2022
+    let(:monday) { Date.new(2022, 6, 20) } # Monday 20 June
+    let(:tuesday) { Date.new(2022, 6, 21) }
+    let(:thursday) { Date.new(2022, 6, 23) }
+    let(:friday) { Date.new(2022, 6, 24) }
+
+    before do
+      travel_to(fake_today)
+    end
+
+    it 'applies dates changes to a group of work packages from a visual chart representation' do
+      main = build_stubbed(:work_package, subject: 'main')
+      second = build_stubbed(:work_package, subject: 'second')
+      change_schedule([main, second], <<~CHART)
+        days   | MTWTFSS |
+        main   | XX      |
+        second |    XX   |
+      CHART
+      expect(main.start_date).to eq(monday)
+      expect(main.due_date).to eq(tuesday)
+      expect(second.start_date).to eq(thursday)
+      expect(second.due_date).to eq(friday)
+    end
+
+    it 'does not save changes' do
+      main = create(:work_package, subject: 'main')
+      expect(main.persisted?).to be(true)
+      expect(main.has_changes_to_save?).to be(false)
+      change_schedule([main], <<~CHART)
+        days   | MTWTFSS |
+        main   | XX      |
+      CHART
+      expect(main.has_changes_to_save?).to be(true)
+      expect(main.changes).to eq('start_date' => [nil, monday], 'due_date' => [nil, tuesday])
+    end
+  end
 
   describe 'expect_schedule' do
     let_schedule(<<~CHART)
@@ -116,38 +218,6 @@ describe ScheduleHelpers::ExampleMethods do
           main  | XX      |
         CHART
       end.not_to raise_error
-    end
-  end
-
-  describe 'change_schedule' do
-    before do
-      travel_to(fake_today)
-    end
-
-    it 'applies dates changes to a group of work packages from a visual chart representation' do
-      main = build_stubbed(:work_package, subject: 'main')
-      second = build_stubbed(:work_package, subject: 'second')
-      change_schedule([main, second], <<~CHART)
-        days   | MTWTFSS |
-        main   | XX      |
-        second |    XX   |
-      CHART
-      expect(main.start_date).to eq(monday)
-      expect(main.due_date).to eq(tuesday)
-      expect(second.start_date).to eq(thursday)
-      expect(second.due_date).to eq(friday)
-    end
-
-    it 'does not save changes' do
-      main = create(:work_package, subject: 'main')
-      expect(main.persisted?).to be(true)
-      expect(main.has_changes_to_save?).to be(false)
-      change_schedule([main], <<~CHART)
-        days   | MTWTFSS |
-        main   | XX      |
-      CHART
-      expect(main.has_changes_to_save?).to be(true)
-      expect(main.changes).to eq('start_date' => [nil, monday], 'due_date' => [nil, tuesday])
     end
   end
 end


### PR DESCRIPTION
It is part of  [OP#42923](https://community.openproject.org/wp/42923) and a continuation of the initial PR #11205 Add job to reschedule on weekend days changes 

~~The special case to handle is about keeping the same ~gap~ distance between work packages following each other when some working days are added. In this case, the reschedule service has to know what were the working days before they changed, and they must be passed down from the `ApplyWorkingDaysChangeJob` to the `SetScheduleService`.~~

EDIT 2022-09-19: it changed since [OP#44053 Disregard distance (not lag) between related work packages when scheduling FS-related work packages](https://community.openproject.org/wp/44053). The only reason a follower would move forward now is to have a violation of follows/precede relation: having a follower starting before its predecessor ends is forbidden. A follower can never move backwards (unless moved by user).

So the below comment from Parimal is no longer relevant

From [Parimal related comment](https://community.openproject.org/projects/openproject/work_packages/31992/activity#activity-155)
> Let's look at how two WPs with a preceeding/following relationship behave today when the date of the former changes (taking non-working days out of the question completely).
> 
> Imagine that the gap between A and B (where B is following A) is 4 days. When you move A back 2 days, the start date of B also moves backwards by two days. However, when you move A forward 2 days, the start date of B does not change; instead, the gap is reduced to 2 days.
> 
> This behaviour might be odd, but the Duration/Non-working days feature do not intend to change it.
> 
> In light of this, let's introduce non-workings days back into the equation. In your scenario, wp2 and wp1 had a gap of 0 working days. When Wednesday is added as working day and we don't affect the dates of wp2, the gap increases to 1 day. Since this increase in gap gap is not manually set (this can be done by manually moving wp2 into the future), the change of Wednesday as a working day should not automatically do this.
> 
> Instead, the start date of wp2 should move back by one day to Wednesday, and the finish date to Thursday (conserving duration, naturally).
> 
> Same behaviour for that second case; if Wednesday is added as a working day, the 4 day gap is retained and wp2 now starts on Wednesday next week (and ends on Thursday).
> 

There is still a case to handle: follower work packages with a follows relation with a delay (also known as lag) will have to move forward if that delay is covering a day changing from working to non-working.

I prefer having this second part in a separate pull request so it can be paused or cancelled any time while still having the first part reviewed, validated and merged.