### PR TITLE
Fix clearing dates in datepicker

### DIFF
--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -197,11 +197,16 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
     )
     .subscribe(([field, update]) => {
       // When clearing the one date, clear the others as well
-      if (update === null) {
-        this.clearAllValues();
-      } else {
+      if (update !== null) {
         this.handleDatePickerChange(field, castArray(update));
       }
+
+      // Clear active field and duration
+      // when the active field was cleared
+      if (update === null && field !== 'duration') {
+        this.clearWithDuration(field);
+      }
+
 
       this.onDataChange();
       this.cdRef.detectChanges();
@@ -436,10 +441,9 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
     return null;
   }
 
-  private clearAllValues() {
+  private clearWithDuration(field:DateKeys) {
     this.duration = null;
-    this.dates.start = null;
-    this.dates.end = null;
+    this.dates[field] = null;
     this.enforceManualChangesToDatepicker();
   }
 

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -207,7 +207,6 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
         this.clearWithDuration(field);
       }
 
-
       this.onDataChange();
       this.cdRef.detectChanges();
     });

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -553,6 +553,60 @@ describe 'Datepicker modal logic test cases (WP #43539)',
     end
   end
 
+  describe 'When all values set, clear the start date (Scenario 21a)' do
+    let(:current_attributes) do
+      {
+        start_date: Date.parse('2021-02-20'),
+        due_date: Date.parse('2021-02-21'),
+        duration: 1,
+        ignore_non_working_days: true
+      }
+    end
+
+    it 'also removes duration, but keeps finish date' do
+      datepicker.expect_start_date '2021-02-20'
+      datepicker.expect_due_date '2021-02-21'
+      datepicker.expect_duration 1
+      datepicker.expect_ignore_non_working_days true
+
+      datepicker.set_start_date ''
+      datepicker.expect_duration ''
+      datepicker.expect_due_date '2021-02-21'
+
+      apply_and_expect_saved duration: nil,
+                             start_date: nil,
+                             due_date: Date.parse('2021-02-21'),
+                             ignore_non_working_days: true
+    end
+  end
+
+  describe 'When all values set, clear the due date (Scenario 21a)' do
+    let(:current_attributes) do
+      {
+        start_date: Date.parse('2021-02-20'),
+        due_date: Date.parse('2021-02-21'),
+        duration: 1,
+        ignore_non_working_days: true
+      }
+    end
+
+    it 'also removes duration, but keeps start date' do
+      datepicker.expect_start_date '2021-02-20'
+      datepicker.expect_due_date '2021-02-21'
+      datepicker.expect_duration 1
+      datepicker.expect_ignore_non_working_days true
+
+      datepicker.set_due_date ''
+      datepicker.expect_duration ''
+      datepicker.expect_start_date '2021-02-20'
+
+      apply_and_expect_saved duration: nil,
+                             start_date: Date.parse('2021-02-20'),
+                             due_date: nil,
+                             ignore_non_working_days: true
+    end
+  end
+
   describe 'when all values set and duration highlighted, selecting date in datepicker' do
     let(:current_attributes) do
       {

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -85,16 +85,16 @@ module Components
       focus_start_date
       fill_in 'startDate', with: value, fill_options: { clear: :backspace }
 
-      # Focus a different field
-      due_date_field.click
+      # Wait for the value to be applied
+      sleep 1
     end
 
     def set_due_date(value)
       focus_due_date
       fill_in 'endDate', with: value, fill_options: { clear: :backspace }
 
-      # Focus a different field
-      start_date_field.click
+      # Wait for the value to be applied
+      sleep 1
     end
 
     def expect_start_highlighted


### PR DESCRIPTION
Expected: Clear the field + duration
Previous behavior: Clears all values

Fixes in https://community.openproject.org/projects/openproject/work_packages/41341/activity?query_id=3470
- [x] Clearing the finish date clears duration (as expected), but also start date; it should only remove finish date and duration, and conserve start date.
Note that clearing duration correctly removes the finish date but conserves start date, as illustrated in the screencapture.