### PR TITLE
Increase debounce for wp table filters update

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
@@ -56,7 +56,10 @@ export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit
 
   @Input() public showCloseFilter = false;
 
-  @Output() public filtersChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(componentDestroyed(this));
+  @Output() public filtersChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(
+    componentDestroyed(this),
+    500,
+  );
 
   public remainingFilters:any[] = [];
 


### PR DESCRIPTION
When making changes to wp table filters quickly, it was possible to get into a state where the filters are broken completely.

The 250ms default debounce on filter updates was too short for some fast typing users. Our HAL-based state management in the background causes a race condition here if the next update comes through too fast. Increasing the debounce to 500ms is a workaround that should fix this issue for most users.

This fix slows down filtering by a bit, but it's a lot easier than changing the full state management around work package tables away from HAL classes.

Closes https://community.openproject.org/work_packages/38313/activity