### PR TITLE
Move cached capabilities back to currentUserService

### DIFF
--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
@@ -47,7 +47,6 @@ import {
   Subject,
 } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 @Component({
   selector: 'op-ifc-viewer',
@@ -91,7 +90,6 @@ export class IFCViewerComponent implements OnInit, OnDestroy, AfterViewInit {
     private ifcViewerService:IFCViewerService,
     private currentUserService:CurrentUserService,
     private currentProjectService:CurrentProjectService,
-    private capabilitiesService:CapabilitiesResourceService,
   ) {
   }
 
@@ -104,7 +102,7 @@ export class IFCViewerComponent implements OnInit, OnDestroy, AfterViewInit {
     // as it needs all view children ready and rendered
     combineLatest([
       this
-        .capabilitiesService
+        .currentUserService
         .hasCapabilities$(
           [
             'ifc_models/create',

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
@@ -7,10 +7,7 @@ import {
 import { Observable } from 'rxjs';
 import { BoardService } from 'core-app/features/boards/board/board.service';
 import { Board } from 'core-app/features/boards/board/board';
-import {
-  map,
-  skip,
-} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -20,7 +17,6 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { NewBoardModalComponent } from 'core-app/features/boards/new-board-modal/new-board-modal.component';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { IOpSidemenuItem } from 'core-app/shared/components/sidemenu/sidemenu.component';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 export const boardsMenuSelector = 'boards-menu';
 
@@ -55,7 +51,7 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
     );
 
   canCreateBoards$ = this
-    .capabilitiesService
+    .currentUserService
     .hasCapabilities$(
       'boards/create',
       this.currentProject.id || undefined,
@@ -73,7 +69,6 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
     private readonly currentProject:CurrentProjectService,
     private readonly mainMenuService:MainMenuNavigationService,
     readonly currentUserService:CurrentUserService,
-    readonly capabilitiesService:CapabilitiesResourceService,
     readonly I18n:I18nService,
     private readonly opModalService:OpModalService,
     private readonly injector:Injector,

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
@@ -1,16 +1,15 @@
 import {
-  Component,
   ChangeDetectionStrategy,
-  Input,
+  Component,
   ElementRef,
   HostBinding,
+  Input,
 } from '@angular/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 export const opCalendarSidemenuSelector = 'op-calendar-sidemenu';
 
@@ -27,7 +26,7 @@ export class CalendarSidemenuComponent extends UntilDestroyedMixin {
   @Input() projectId:string|undefined;
 
   canCreateCalendar$ = this
-    .capabilitiesService
+    .currentUserService
     .hasCapabilities$(
       'calendars/create',
       this.currentProjectService.id || undefined,
@@ -52,7 +51,6 @@ export class CalendarSidemenuComponent extends UntilDestroyedMixin {
     readonly elementRef:ElementRef,
     readonly currentUserService:CurrentUserService,
     readonly currentProjectService:CurrentProjectService,
-    readonly capabilitiesService:CapabilitiesResourceService,
     readonly I18n:I18nService,
   ) {
     super();

--- a/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.ts
+++ b/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.ts
@@ -8,7 +8,6 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { OpInviteUserModalService } from 'core-app/features/invite-user-modal/invite-user-modal.service';
 import { OpAutocompleterComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 @Component({
   selector: 'op-invite-user-button',
@@ -34,7 +33,6 @@ export class InviteUserButtonComponent {
     readonly opInviteUserModalService:OpInviteUserModalService,
     readonly currentProjectService:CurrentProjectService,
     readonly currentUserService:CurrentUserService,
-    readonly capabilitiesService:CapabilitiesResourceService,
     readonly autocompleter:OpAutocompleterComponent,
   ) {
   }
@@ -42,7 +40,7 @@ export class InviteUserButtonComponent {
   public ngOnInit():void {
     this.projectId = this.projectId || this.currentProjectService.id;
     this.canInviteUsersToProject$ = this
-      .capabilitiesService
+      .currentUserService
       .hasCapabilities$(
         'memberships/create',
         this.projectId || undefined,

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
@@ -67,7 +67,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
   public canInviteByEmail$ = combineLatest(
     this.items$,
     this.input$,
-    this.capabilitiesService.hasCapabilities$('users/create'),
+    this.currentUserService.hasCapabilities$('users/create'),
   ).pipe(
     map(([elements, input, canCreateUsers]) => canCreateUsers
       && this.type === PrincipalType.User
@@ -79,9 +79,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
   public canCreateNewPlaceholder$ = combineLatest([
     this.items$,
     this.input$,
-    this
-      .capabilitiesService
-      .hasCapabilities$('placeholder_users/create'),
+    this.currentUserService.hasCapabilities$('placeholder_users/create'),
   ])
     .pipe(
       map(([elements, input, hasCapability]) => {

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-allowed.validator.ts
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-allowed.validator.ts
@@ -9,12 +9,13 @@ import {
   take,
 } from 'rxjs/operators';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 
-export const ProjectAllowedValidator = (capabilitiesService:CapabilitiesResourceService) => (control:AbstractControl):Observable<null|{ lackingPermission:boolean }> => {
-  const href = control.value?.href || control.value?.$links?.self.href;
-  const id = href ? idFromLink(href) : control.value;
-  return capabilitiesService
+export const ProjectAllowedValidator = (currentUser:CurrentUserService) => (control:AbstractControl):Observable<null|{ lackingPermission:boolean }> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const href = (control.value?.href || control.value?.$links?.self.href) as string;
+  const id = (href ? idFromLink(href) : control.value) as string;
+  return currentUser
     .hasCapabilities$(
       'memberships/create',
       id,

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
@@ -1,12 +1,12 @@
 import {
   ChangeDetectionStrategy,
-  Component,
-  OnInit,
-  Input,
-  EventEmitter,
-  Output,
-  ElementRef,
   ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -22,14 +22,10 @@ import { cloneHalResource } from 'core-app/features/hal/helpers/hal-resource-bui
 import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 import { PrincipalType } from '../invite-user.component';
 import { ProjectAllowedValidator } from './project-allowed.validator';
-import {
-  map,
-  switchMap,
-} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { IProjectAutocompleteItem } from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocomplete-item';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
 
 @Component({
@@ -80,7 +76,7 @@ export class ProjectSelectionComponent implements OnInit {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     type: new FormControl(PrincipalType.User, [Validators.required]),
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    project: new FormControl(null, [Validators.required], ProjectAllowedValidator(this.capabilitiesService)),
+    project: new FormControl(null, [Validators.required], ProjectAllowedValidator(this.currentUserService)),
   });
 
   get typeControl():AbstractControl {
@@ -99,7 +95,6 @@ export class ProjectSelectionComponent implements OnInit {
     readonly bannersService:BannersService,
     readonly apiV3Service:ApiV3Service,
     readonly currentUserService:CurrentUserService,
-    readonly capabilitiesService:CapabilitiesResourceService,
     readonly cdRef:ChangeDetectorRef,
   ) {}
 
@@ -113,10 +108,9 @@ export class ProjectSelectionComponent implements OnInit {
     this.setPlaceholderOption();
 
     this
-      .capabilitiesService
-      .userActionFilter$('memberships/create')
+      .currentUserService
+      .capabilities$(['memberships/create'])
       .pipe(
-        switchMap((params) => this.capabilitiesService.require$(params)),
         map((capabilities) => capabilities.filter((c) => c._links.action.href.endsWith('/memberships/create'))),
       )
       .subscribe((projectInviteCapabilities) => {

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
@@ -12,7 +12,6 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { map } from 'rxjs/operators';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 export const opTeamPlannerSidemenuSelector = 'op-team-planner-sidemenu';
 
@@ -29,7 +28,7 @@ export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
   @Input() projectId:string|undefined;
 
   canAddTeamPlanner$ = this
-    .capabilitiesService
+    .currentUserService
     .hasCapabilities$(
       'team_planners/create',
       this.currentProjectService.id || undefined,
@@ -54,7 +53,6 @@ export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
   constructor(
     readonly elementRef:ElementRef,
     readonly currentUserService:CurrentUserService,
-    readonly capabilitiesService:CapabilitiesResourceService,
     readonly currentProjectService:CurrentProjectService,
     readonly bannersService:BannersService,
     readonly I18n:I18nService,

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
@@ -26,9 +26,19 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { combineLatest, Observable } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+} from '@angular/core';
+import {
+  combineLatest,
+  Observable,
+} from 'rxjs';
+import {
+  catchError,
+  map,
+} from 'rxjs/operators';
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -40,7 +50,6 @@ import { ProjectsResourceService } from 'core-app/core/state/projects/projects.s
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 @Component({
   selector: 'op-files-tab',
@@ -67,7 +76,6 @@ export class WorkPackageFilesTabComponent implements OnInit {
     private readonly i18n:I18nService,
     private readonly hook:HookService,
     private readonly currentUserService:CurrentUserService,
-    private readonly capabilitiesService:CapabilitiesResourceService,
     private readonly projectsResourceService:ProjectsResourceService,
     private readonly storagesResourceService:StoragesResourceService,
     private readonly apiV3:ApiV3Service,
@@ -81,7 +89,7 @@ export class WorkPackageFilesTabComponent implements OnInit {
     }
 
     const canViewFileLinks = this
-      .capabilitiesService
+      .currentUserService
       .hasCapabilities$('file_links/view', project.id);
 
     this.storages$ = this

--- a/frontend/src/app/shared/components/file-links/file-link-list/file-link-list.component.ts
+++ b/frontend/src/app/shared/components/file-links/file-link-list/file-link-list.component.ts
@@ -32,7 +32,10 @@ import {
   Input,
   OnInit,
 } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+} from 'rxjs';
 import { CookieService } from 'ngx-cookie-service';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -52,10 +55,7 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { StorageActionButton } from 'core-app/shared/components/file-links/storage-information/storage-action-button';
-import {
-  StorageInformationBox,
-} from 'core-app/shared/components/file-links/storage-information/storage-information-box';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
+import { StorageInformationBox } from 'core-app/shared/components/file-links/storage-information/storage-information-box';
 
 @Component({
   selector: 'op-file-link-list',
@@ -108,7 +108,6 @@ export class FileLinkListComponent extends UntilDestroyedMixin implements OnInit
     private readonly fileLinkResourceService:FileLinksResourceService,
     private readonly currentUserService:CurrentUserService,
     private readonly cookieService:CookieService,
-    private readonly capabilitiesService:CapabilitiesResourceService,
   ) {
     super();
   }
@@ -134,7 +133,7 @@ export class FileLinkListComponent extends UntilDestroyedMixin implements OnInit
       });
 
     this.allowEditing$ = this
-      .capabilitiesService
+      .currentUserService
       .hasCapabilities$('file_links/manage', (this.resource.project as unknown&{ id:string }).id);
   }
 

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -38,11 +38,11 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import { combineLatest } from 'rxjs';
 import {
   debounceTime,
-  map,
   filter,
-  take,
+  map,
   mergeMap,
   shareReplay,
+  take,
 } from 'rxjs/operators';
 import { IProject } from 'core-app/core/state/projects/project.model';
 import { insertInList } from 'core-app/shared/components/project-include/insert-in-list';
@@ -51,7 +51,6 @@ import { SearchableProjectListService } from 'core-app/shared/components/searcha
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { IProjectData } from 'core-app/shared/components/searchable-project-list/project-data';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 export const headerProjectSelectSelector = 'op-header-project-select';
 
@@ -72,7 +71,7 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin {
 
   public textFieldFocused = false;
 
-  public canCreateNewProjects$ = this.capabilitiesService.hasCapabilities$('projects/create');
+  public canCreateNewProjects$ = this.currentUserService.hasCapabilities$('projects/create');
 
   public projects$ = combineLatest([
     this.searchableProjectListService.allProjects$,
@@ -147,7 +146,6 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin {
     protected currentProject:CurrentProjectService,
     readonly searchableProjectListService:SearchableProjectListService,
     readonly currentUserService:CurrentUserService,
-    readonly capabilitiesService:CapabilitiesResourceService,
   ) {
     super();
 


### PR DESCRIPTION
Moves the updated capabilities check that are only relevant to the current user back to the CurrentUserService, as this makes it clearer who the capabilities belong to.

Loading, caching, storing is remaining in the CapabilitiesResourceService