### PR TITLE
Add meaningful HTML titles

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2910,7 +2910,6 @@ en:
       noneSelection: "(none)"
       outline: "Initial outline expansion"
       parent: "Show subprojects of"
-      work_package_filters: "Filter work packages"
       work_package_responsible: "Show work packages with accountable"
       work_package_assignee: "Show work packages with assignee"
       types: "Show types"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -99,6 +99,10 @@ en:
     button_open_fullscreen: "Open fullscreen view"
     button_show_cards: "Show card view"
     button_show_list: "Show list view"
+    button_show_table: "Show table view"
+    button_show_gantt: "Show gantt view"
+    button_show_fullscreen: "Show fullscreen view"
+    button_more_actions: "More actions"
     button_quote: "Quote"
     button_save: "Save"
     button_settings: "Settings"
@@ -586,7 +590,9 @@ en:
         prioritized: 'prioritized'
       facets:
         unread: 'Unread'
+        unread_title: 'Show unread'
         all: 'All'
+        all_title: 'Show all'
       center:
         and_more_users:
           one: 'and 1 other'
@@ -947,6 +953,8 @@ en:
       message_work_package_read_only: "Work package is locked in this status. No attribute other than status can be altered."
       message_work_package_status_blocked: "Work package status is not writable due to closed status and closed version being assigned."
       placeholder_filter_by_text: "Subject, description, comments, ..."
+      filters:
+        title: 'Filter work packages'
       inline_create:
         title: 'Click here to add a new work package to this list'
       create:

--- a/frontend/src/app/features/in-app-notifications/center/toolbar/facet/activate-facet-button.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/toolbar/facet/activate-facet-button.component.html
@@ -2,6 +2,7 @@
   <button
     type="button"
     class="button form--field-inline-button"
+    [title]="text.facet_titles[facet]"
     [class.-active]="facet === (activeFacet$ | async)"
     (click)="activateFacet(facet)"
   >

--- a/frontend/src/app/features/in-app-notifications/center/toolbar/facet/activate-facet-button.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/toolbar/facet/activate-facet-button.component.ts
@@ -17,6 +17,10 @@ export class ActivateFacetButtonComponent {
       unread: this.I18n.t('js.notifications.facets.unread'),
       all: this.I18n.t('js.notifications.facets.all'),
     },
+    facet_titles: {
+      unread: this.I18n.t('js.notifications.facets.unread_title'),
+      all: this.I18n.t('js.notifications.facets.all_title'),
+    },
   };
 
   availableFacets = Object.keys(IAN_FACET_FILTERS);

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -55,6 +55,7 @@
           *ngIf="!notification.readIAN"
           data-qa-selector="mark-as-read-button"
           class="op-ian-item--button icon-mark-read"
+          [title]="text.mark_as_read"
           (click)="markAsRead($event, aggregatedNotifications)"
           tabindex="0"
         >

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -68,6 +68,7 @@ export class InAppNotificationEntryComponent implements OnInit {
       { count }),
     loading: this.I18n.t('js.ajax.loading'),
     placeholder: this.I18n.t('js.placeholders.default'),
+    mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
     updated_by_at: (age:string):string => this.I18n.t('js.notifications.center.text_update_date',
       { date: age }),
   };

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -9,6 +9,7 @@
       #addExistingToggle
       class="button op-team-planner--add-existing-toggle"
       [ngClass]="{'-active': (showAddExistingPane | async)}"
+      [title]="text.add_existing_title"
       data-qa-selector="op-team-planner--add-existing-toggle"
       (click)="toggleAddExistingPane()">
       <op-icon icon-classes="icon-add button--icon"></op-icon>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -281,6 +281,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
 
   text = {
     add_existing: this.I18n.t('js.team_planner.add_existing'),
+    add_existing_title: this.I18n.t('js.team_planner.add_existing_title'),
     assignee: this.I18n.t('js.label_assignee'),
     add_assignee: this.I18n.t('js.team_planner.add_assignee'),
     remove_assignee: this.I18n.t('js.team_planner.remove_assignee'),

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -13,9 +13,10 @@
     class="button -alt-highlight"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
+    [title]="createButton.title"
     data-qa-selector="team-planner--create-button"
   >
     <span class="spot-icon spot-icon_add"></span>
-    <span [textContent]="createButton.title"></span>
+    <span [textContent]="createButton.text"></span>
   </button>
 </div>

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
@@ -38,12 +38,9 @@ export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
       map((val) => val && !this.bannersService.eeShowBanners),
     );
 
-  text = {
-    create_new_team_planner: this.I18n.t('js.team_planner.title'),
-  };
-
   createButton = {
-    title: this.text.create_new_team_planner,
+    text: this.I18n.t('js.team_planner.create_label'),
+    title: this.I18n.t('js.team_planner.create_title'),
     uiSref: 'team_planner.page.show',
     uiParams: {
       query_id: null,

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.component.ts
@@ -58,6 +58,7 @@ export class WorkPackageCreateButtonComponent extends UntilDestroyedMixin implem
   transitionUnregisterFn:Function;
 
   text = {
+    title: this.I18n.t('js.work_packages.create.title'),
     createWithDropdown: this.I18n.t('js.work_packages.create.button'),
     createButton: this.I18n.t('js.label_work_package'),
     explanation: this.I18n.t('js.label_create_work_package'),

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -1,11 +1,14 @@
 <div class="wp-create-button">
-  <button class="button -alt-highlight add-work-package"
-          [disabled]="disabled"
-          [attr.aria-label]="text.explanation"
-          opTypesCreateDropdown
-          [projectIdentifier]="projectIdentifier"
-          [stateName]="stateName$ | async"
-          [dropdownActive]="allowed">
+  <button
+    class="button -alt-highlight add-work-package"
+    [disabled]="disabled"
+    [attr.aria-label]="text.explanation"
+    opTypesCreateDropdown
+    [projectIdentifier]="projectIdentifier"
+    [stateName]="stateName$ | async"
+    [dropdownActive]="allowed"
+    [title]="text.title"
+  >
     <op-icon icon-classes="button--icon icon-add"></op-icon>
     <span class="button--text"
           [textContent]="text.createWithDropdown"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
@@ -49,6 +49,8 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
 
   public iconClass = 'icon-filter';
 
+  public title = this.I18n.t('js.work_packages.filters.title');
+
   constructor(
     readonly I18n:I18nService,
     protected cdRef:ChangeDetectorRef,

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -2,7 +2,7 @@
   class="button"
   [attr.id]="buttonId"
   [attr.accesskey]="accessKey"
-  [attr.title]="label"
+  [attr.title]="title"
   [attr.aria-label]="label"
   [disabled]="disabled"
   (click)="performAction($event)"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.html
@@ -1,5 +1,5 @@
 <button id="work-packages-settings-button"
-        title="{{ text.button_settings }}"
+        [title]="text.more_actions"
         class="button last work-packages-settings-button toolbar-icon"
         opSettingsContextMenu
         opSettingsContextMenu-query="query"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.ts
@@ -41,7 +41,7 @@ export class WorkPackageSettingsButtonComponent {
   @Input() hideTableOptions = false;
 
   public text = {
-    button_settings: this.I18n.t('js.button_settings'),
+    more_actions: this.I18n.t('js.button_more_actions'),
   };
 
   constructor(readonly I18n:I18nService) {

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
@@ -28,7 +28,7 @@ export class WpTabsComponent implements OnInit {
   text = {
     details: {
       close: this.I18n.t('js.button_close_details'),
-      goToFullScreen: this.I18n.t('js.work_packages.message_successful_show_in_fullscreen'),
+      goToFullScreen: this.I18n.t('js.button_show_fullscreen'),
     },
   };
 

--- a/frontend/src/app/shared/components/icon/icon.component.ts
+++ b/frontend/src/app/shared/components/icon/icon.component.ts
@@ -33,7 +33,7 @@ import { Component, Input } from '@angular/core';
   host: { class: 'op-icon--wrapper' },
   template: `
       <i [ngClass]="iconClasses"
-         [title]="iconTitle"
+         [attr.title]="iconTitle || undefined"
          aria-hidden="true"></i>
       <span
         class="hidden-for-sighted"

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -71,6 +71,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
         {
           // Card View
           linkText: this.I18n.t('js.views.card'),
+          title: this.I18n.t('js.button_show_cards'),
           icon: 'icon-view-card',
           onClick: (evt:any) => {
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayCardRepresentation);
@@ -89,6 +90,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
         {
           // List View
           linkText: this.I18n.t('js.views.list'),
+          title: this.I18n.t('js.button_show_table'),
           icon: 'icon-view-list',
           onClick: (evt:any) => {
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
@@ -106,6 +108,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
         {
           // List View with enabled Gantt
           linkText: this.I18n.t('js.views.timeline'),
+          title: this.I18n.t('js.button_show_gantt'),
           icon: 'icon-view-timeline',
           onClick: (evt:any) => {
             if (!this.wpTableTimeline.isVisible) {

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
@@ -15,6 +15,7 @@
           [attr.href]="item.href"
           [attr.aria-disabled]="item.disabled"
           [attr.aria-label]="item.ariaLabel || item.linkText"
+          [attr.title]="item.title || undefined"
           (click)="handleClick(item, $event)"
         >
           <op-icon *ngIf="item.icon" icon-classes="icon-action-menu {{ item.icon }}"></op-icon>
@@ -30,6 +31,7 @@
           [class.inactive]="item.disabled"
           [attr.aria-disabled]="item.disabled"
           [attr.aria-label]="item.ariaLabel || item.linkText"
+          [attr.title]="item.title || undefined"
           (click)="handleClick(item, $event)"
         >
           <op-icon *ngIf="item.icon" icon-classes="icon-action-menu {{ item.icon }}"></op-icon>

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
@@ -16,6 +16,7 @@ export interface OpContextMenuItem {
   class?:string;
   ariaLabel?:string;
   linkText?:string;
+  title?:string;
   divider?:boolean;
   onClick?:($event:JQuery.TriggeredEvent|MouseEvent) => boolean;
 }

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -10,6 +10,7 @@
     type="button"
     class="button"
     (click)="toggleOpen()"
+    [title]="text.toggle_title"
     data-qa-selector="project-include-button"
   >
     {{ text.toggle_title }}

--- a/lib/redmine/menu_manager/top_menu/projects_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/projects_menu.rb
@@ -37,7 +37,7 @@ module Redmine::MenuManager::TopMenu::ProjectsMenu
   private
 
   def render_projects_dropdown
-    content_tag(:li, class: 'op-app-menu--item') do
+    content_tag(:li, class: 'op-app-menu--item', title: I18n.t(:label_project_view_all)) do
       angular_component_tag('op-header-project-select')
     end
   end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -53,7 +53,7 @@ module Redmine::MenuManager::TopMenuHelper
   def render_notification_top_menu_node
     return ''.html_safe unless User.current.logged?
 
-    content_tag('li', class: 'op-app-menu--item') do
+    content_tag('li', class: 'op-app-menu--item', title: I18n.t('mail.notification.center')) do
       tag('op-in-app-notification-bell')
     end
   end

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -3,7 +3,9 @@ en:
   js:
     team_planner:
       add_existing: 'Add existing'
-      title: 'Team planner'
+      add_existing_title: 'Add existing work packages'
+      create_label: 'Team planner'
+      create_title: 'Create new team planner'
       unsaved_title: 'Unnamed team planner'
       no_data: 'Add assignees to set up your team planner.'
       add_assignee: 'Add assignee'

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -44,7 +44,7 @@ describe 'Team planner', type: :feature, js: true do
     end
 
     expect(page).to have_content 'There is currently nothing to display.'
-    click_on 'Create'
+    click_on 'Create', match: :first
 
     team_planner.expect_title
 

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Query menu items', js: true do
     it 'can be added', js: true, selenium: true do
       visit_index_page(query)
 
-      click_on 'Settings'
+      click_on 'More actions'
       click_on I18n.t('js.toolbar.settings.visibility_settings')
       check 'Favored'
       click_on 'Save'

--- a/spec/features/work_packages/select/select_query_spec.rb
+++ b/spec/features/work_packages/select/select_query_spec.rb
@@ -85,10 +85,8 @@ describe 'Query selection', type: :feature do
       filters.open
       filters.expect_filter_by 'Assignee', 'is', ['me']
       filters.expect_filter_by 'Progress (%)', '>=', ['10'], 'percentageDone'
-    end
 
-    it 'shows filter count within toggle button', js: true do
-      expect(find_button('Activate Filter')).to have_text /2$/
+      expect(page).to have_selector('[data-qa-selector="wp-filter-button"] .badge', text: '2')
     end
   end
 


### PR DESCRIPTION
Top menu

- [x] Project select: "View all projects" (em.yml: root -> label_project_view_all)
- [x] Notification center icon: "To notification center" (em.yml: root -> mail -> notification -> center)

Notification center

- [x] Unread toggle: "Unread" (js-en.yml: root -> js -> notifications -> facets -> unread)
- [x] All toggle: "Show all" (en.yml: root -> timelines -> outlines -> all)

Notification card

- [x] Mark as read button: "Mark as read" (js-en.yml: root -> js -> notifications -> center -> mark_as_read)

Work packages

- [x] Create button: "New work package" (js-en.yml: root -> js -> work_packages -> create -> title)
- [x] Include projects: "Include projects" (js-en.yml: root -> js -> include_projects -> toggle_title)
- [x] Filter: "Filter work packages" (en.yml: root -> timelines -> filter -> work_package_filters)
- [x] Table: "Show table view" (new)
- [x] Card: "Show card view" (update js-en.yml: root -> js -> button_show_cards)
- [x] Gantt: "Show Gantt view" (new)
- [x] i icon: "Open details view" (js-en.yml: root -> js -> button_open_details)
- [x] Fullscreen icon: "Open fullscreen view" (js-en.yml: root -> js -> button_open_fullscreen)
- [x] three-dot more icon: "More actions" (update en.yml: root -> more_actions)

Work package details/fullscreen view

- [x] Back button: "Back to list view" (js-en.yml: root -> js -> button_back_to_list_view) [**Kept at Back for now**]

Team planner

- [x]  Team planner button: "Create new team planner" (en.yml: root -> team_planner -> label_create_new_team_planner)
- [x]  Add existing: "Add existing work packages" (new, full version of "add existing")
- [x] Include projects: "Include projects" (js-en.yml: root -> js -> include_projects -> toggle_title)
- [x] three-dot more icon: "More actions" (update en.yml: root -> more_actions)


https://community.openproject.org/projects/openproject/work_packages/43299/activity