### PR TITLE
inherit ignore_non_working_days up the ancestor chain

### DIFF
--- a/app/services/work_packages/update_ancestors/loader.rb
+++ b/app/services/work_packages/update_ancestors/loader.rb
@@ -1,0 +1,181 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+class WorkPackages::UpdateAncestors::Loader
+  def initialize(work_package, include_former_ancestors)
+    self.work_package = work_package
+    self.include_former_ancestors = include_former_ancestors
+  end
+
+  def select
+    ancestors.select do |ancestor|
+      yield ancestor, self
+    end
+  end
+
+  def descendants_of(queried_work_package)
+    @descendants ||= Hash.new do |hash, wp|
+      hash[wp] = replaced_related_of(wp, :descendants)
+    end
+
+    @descendants[queried_work_package]
+  end
+
+  def leaves_of(queried_work_package)
+    @leaves ||= Hash.new do |hash, wp|
+      hash[wp] = replaced_related_of(wp, :leaves) do |leaf|
+        # Mimic work package by implementing the closed? interface
+        leaf.send(:'closed?=', leaf.is_closed)
+      end
+    end
+
+    @leaves[queried_work_package]
+  end
+
+  def children_of(queried_work_package)
+    @children ||= Hash.new do |hash, wp|
+      hash[wp] = descendants_of(wp).select { |d| d.parent_id == wp.id }
+    end
+
+    @children[queried_work_package]
+  end
+
+  private
+
+  attr_accessor :work_package,
+                :include_former_ancestors
+
+  # Contains both the new as well as the former ancestors in ascending order from the leaves up (breadth first).
+  def ancestors
+    @ancestors ||= if include_former_ancestors
+                     former_ancestors.reverse.inject(current_ancestors) do |ancestors, former_ancestor|
+                       index = ancestors.index { |ancestor| ancestor.id == former_ancestor.parent_id }
+                       ancestors.insert(index || current_ancestors.length, former_ancestor)
+                       ancestors
+                     end
+                   else
+                     current_ancestors
+                   end
+  end
+
+  # Replace descendants/leaves by ancestors if they are the same.
+  # This can e.g. be the case in scenario of
+  # grandparent
+  #      |
+  #    parent
+  #      |
+  # work_package
+  #
+  # when grandparent used to be the direct parent of work_package (the work_package moved down the hierarchy).
+  # Then grandparent and parent are already in ancestors.
+  # Parent might be modified during the UpdateAncestorsService run,
+  # and the descendants of grandparent need to have the updated value.
+  def replaced_related_of(queried_work_package, relation_type)
+    related_of(queried_work_package, relation_type).map do |leaf|
+      if work_package.id == leaf.id
+        work_package
+      elsif (ancestor = ancestors.detect { |a| a.id == leaf.id })
+        ancestor
+      else
+        yield leaf if block_given?
+        leaf
+      end
+    end
+  end
+
+  def related_of(queried_work_package, relation_type)
+    scope = queried_work_package
+              .send(relation_type)
+              .where.not(id: queried_work_package.id)
+
+    if send("#{relation_type}_joins")
+      scope = scope.joins(send("#{relation_type}_joins"))
+    end
+
+    scope
+      .pluck(*send("selected_#{relation_type}_attributes"))
+      .map { |p| LoaderStruct.new(send("selected_#{relation_type}_attributes").zip(p).to_h) }
+  end
+
+  # Returns the current ancestors sorted by distance (called generations in the table)
+  # so the order is parent, grandparent, ..., root.
+  def current_ancestors
+    @current_ancestors ||= work_package.ancestors.includes(:status).where.not(id: former_ancestors.map(&:id)).to_a
+  end
+
+  # Returns the former ancestors sorted by distance (called generations in the table)
+  # so the order is former parent, former grandparent, ..., former root.
+  def former_ancestors
+    @former_ancestors ||= if previous_parent_id && include_former_ancestors
+                            parent = WorkPackage.find(previous_parent_id)
+
+                            [parent] + parent.ancestors
+                          else
+                            []
+                          end
+  end
+
+  def selected_descendants_attributes
+    # By having the id in here, we can avoid DISTINCT queries squashing duplicate values
+    %i(id estimated_hours parent_id schedule_manually ignore_non_working_days)
+  end
+
+  def descendants_joins
+    nil
+  end
+
+  def selected_leaves_attributes
+    %i(id done_ratio derived_estimated_hours estimated_hours is_closed)
+  end
+
+  def leaves_joins
+    :status
+  end
+
+  ##
+  # Get the previous parent ID
+  # This could either be +parent_id_was+ if parent was changed
+  # (when work_package was saved/destroyed)
+  # Or the set parent before saving
+  def previous_parent_id
+    if work_package.parent_id.nil? && work_package.parent_id_was
+      work_package.parent_id_was
+    else
+      previous_change_parent_id
+    end
+  end
+
+  def previous_change_parent_id
+    previous = work_package.previous_changes
+
+    previous_parent_changes = (previous[:parent_id] || previous[:parent])
+
+    previous_parent_changes ? previous_parent_changes.first : nil
+  end
+
+  class LoaderStruct < Hashie::Mash; end
+  LoaderStruct.disable_warnings
+end

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -57,50 +57,29 @@ class WorkPackages::UpdateAncestorsService
   private
 
   def update_current_and_former_ancestors(attributes)
-    to_update = get_current_ancestors
+    WorkPackages::UpdateAncestors::Loader
+      .new(work_package, (%i(parent_id parent) & attributes).any?)
+      .select do |ancestor, loader|
+        inherit_attributes(ancestor, loader, attributes)
 
-    if (%i(parent_id parent) & attributes).any?
-      to_update += get_former_ancestors
-      to_update.uniq!
-    end
-
-    to_update.select do |ancestor|
-      inherit_attributes(ancestor, attributes)
-
-      ancestor.changed?
-    end
+        ancestor.changed?
+      end
   end
 
-  def get_current_ancestors
-    work_package.ancestors.includes(:status)
-  end
-
-  def get_former_ancestors
-    return [] unless previous_parent_id
-
-    parent = WorkPackage.find(previous_parent_id)
-
-    [parent] + parent.ancestors
-  end
-
-  def inherit_attributes!(ancestor)
-    # pass :parent to force update of all inherited attributes
-    inherit_attributes(ancestor, %i(parent))
-  end
-
-  def inherit_attributes(ancestor, attributes)
+  def inherit_attributes(ancestor, loader, attributes)
     return unless attributes_justify_inheritance?(attributes)
 
     # Estimated hours need to be calculated before the done_ratio below.
     # The aggregation only depends on estimated hours.
-    derive_estimated_hours(ancestor) if inherit?(attributes, :estimated_hours)
+    derive_estimated_hours(ancestor, loader) if inherit?(attributes, :estimated_hours)
 
     # Progress (done_ratio or also: percentDone) depends on both
     # the completion of sub-WPs, as well as the estimated hours
     # as a weight factor. So changes in estimated hours also have
     # to trigger a recalculation of done_ratio.
-    #
-    inherit_done_ratio(ancestor) if inherit?(attributes, :done_ratio) || inherit?(attributes, :estimated_hours)
+    inherit_done_ratio(ancestor, loader) if inherit?(attributes, :done_ratio) || inherit?(attributes, :estimated_hours)
+
+    inherit_ignore_non_working_days(ancestor, loader) if inherit?(attributes, :ignore_non_working_days)
   end
 
   def inherit?(attributes, attribute)
@@ -113,21 +92,35 @@ class WorkPackages::UpdateAncestorsService
     end
   end
 
-  def inherit_done_ratio(ancestor)
+  def inherit_done_ratio(ancestor, loader)
     return if WorkPackage.done_ratio_disabled?
 
     return if WorkPackage.use_status_for_done_ratio? && ancestor.status && ancestor.status.default_done_ratio
 
     # done ratio = weighted average ratio of leaves
-    ratio = (aggregate_done_ratio(ancestor) || 0)
+    ancestor.done_ratio = (aggregate_done_ratio(ancestor, loader) || 0).round
+  end
 
-    ancestor.done_ratio = ratio.round
+  # Sets the ignore_non_working_days to true if any ancestor has its value set to true.
+  # If there is no value returned from the descendants, that means that the work package in
+  # question no longer has a descendant. But since we are in the service going up the ancestor chain,
+  # such a work package is the former parent. The property of such a work package is reset to `false`.
+  def inherit_ignore_non_working_days(work_package, loader)
+    return if work_package.schedule_manually
+
+    descendant_value = ignore_non_working_days_of_descendants(work_package, loader)
+
+    if descendant_value.nil?
+      descendant_value = work_package.ignore_non_working_days
+    end
+
+    work_package.ignore_non_working_days = descendant_value
   end
 
   ##
   # done ratio = weighted average ratio of leaves
-  def aggregate_done_ratio(work_package)
-    leaves = leaves_for_work_package(work_package)
+  def aggregate_done_ratio(work_package, loader)
+    leaves = loader.leaves_of(work_package)
 
     leaves_count = leaves.size
 
@@ -172,43 +165,10 @@ class WorkPackages::UpdateAncestorsService
     summands.sum
   end
 
-  def derive_estimated_hours(work_package)
-    descendants = descendants_for_work_package(work_package)
+  def derive_estimated_hours(work_package, loader)
+    descendants = loader.descendants_of(work_package)
 
     work_package.derived_estimated_hours = not_zero(all_estimated_hours(descendants).sum.to_f)
-  end
-
-  def descendants_for_work_package(work_package)
-    @descendants ||= Hash.new do |hash, wp|
-      hash[wp] = related_for_work_package(wp, :descendants)
-    end
-
-    @descendants[work_package]
-  end
-
-  def leaves_for_work_package(work_package)
-    @leaves ||= Hash.new do |hash, wp|
-      hash[wp] = related_for_work_package(wp, :leaves).each do |leaf|
-        # Mimic work package by implementing the closed? interface
-        leaf.send(:'closed?=', leaf.is_closed)
-      end
-    end
-
-    @leaves[work_package]
-  end
-
-  def related_for_work_package(work_package, relation_type)
-    scope = work_package
-            .send(relation_type)
-            .where.not(id: work_package.id)
-
-    if send("#{relation_type}_joins")
-      scope = scope.joins(send("#{relation_type}_joins"))
-    end
-
-    scope
-      .pluck(*send("selected_#{relation_type}_attributes"))
-      .map { |p| OpenStruct.new(send("selected_#{relation_type}_attributes").zip(p).to_h) }
   end
 
   def not_zero(value)
@@ -221,45 +181,17 @@ class WorkPackages::UpdateAncestorsService
       .reject { |hours| hours.to_f.zero? }
   end
 
-  ##
-  # Get the previous parent ID
-  # This could either be +parent_id_was+ if parent was changed
-  # (when work_package was saved/destroyed)
-  # Or the set parent before saving
-  def previous_parent_id
-    if work_package.parent_id.nil? && work_package.parent_id_was
-      work_package.parent_id_was
-    else
-      previous_change_parent_id
-    end
-  end
-
-  def previous_change_parent_id
-    previous = work_package.previous_changes
-
-    previous_parent_changes = (previous[:parent_id] || previous[:parent])
-
-    previous_parent_changes ? previous_parent_changes.first : nil
-  end
-
   def attributes_justify_inheritance?(attributes)
-    (%i(estimated_hours done_ratio parent parent_id status status_id) & attributes).any?
+    (%i(estimated_hours done_ratio parent parent_id status status_id ignore_non_working_days) & attributes).any?
   end
 
-  def selected_descendants_attributes
-    # By having the id in here, we can avoid DISTINCT queries squashing duplicate values
-    %i(id estimated_hours)
-  end
+  def ignore_non_working_days_of_descendants(ancestor, loader)
+    children = loader
+                 .children_of(ancestor)
+                 .reject(&:schedule_manually)
 
-  def descendants_joins
-    nil
-  end
-
-  def selected_leaves_attributes
-    %i(id done_ratio derived_estimated_hours estimated_hours is_closed)
-  end
-
-  def leaves_joins
-    :status
+    if children.any?
+      children.any?(&:ignore_non_working_days)
+    end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -132,6 +132,7 @@ module OpenProject::Backlogs
                Version]
 
     patch_with_namespace :API, :V3, :WorkPackages, :Schema, :SpecificWorkPackageSchema
+    patch_with_namespace :WorkPackages, :UpdateAncestors, :Loader
     patch_with_namespace :BasicData, :SettingSeeder
     patch_with_namespace :DemoData, :ProjectSeeder
     patch_with_namespace :WorkPackages, :UpdateAncestorsService

--- a/modules/backlogs/lib/open_project/backlogs/patches/update_ancestors_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/update_ancestors_service_patch.rb
@@ -36,14 +36,14 @@ module OpenProject::Backlogs::Patches::UpdateAncestorsServicePatch
 
     ##
     # Overrides method in original UpdateAncestorsService.
-    def inherit_attributes(ancestor, attributes)
+    def inherit_attributes(ancestor, loader, attributes)
       super
 
-      inherit_remaining_hours(ancestor) if inherit?(attributes, :remaining_hours)
+      inherit_remaining_hours(ancestor, loader) if inherit?(attributes, :remaining_hours)
     end
 
-    def inherit_remaining_hours(ancestor)
-      ancestor.remaining_hours = all_remaining_hours(leaves_for_work_package(ancestor)).sum.to_f
+    def inherit_remaining_hours(ancestor, loader)
+      ancestor.remaining_hours = all_remaining_hours(loader.leaves_of(ancestor)).sum.to_f
       ancestor.remaining_hours = nil if ancestor.remaining_hours == 0.0
     end
 
@@ -53,10 +53,6 @@ module OpenProject::Backlogs::Patches::UpdateAncestorsServicePatch
 
     def attributes_justify_inheritance?(attributes)
       super || attributes.include?(:remaining_hours)
-    end
-
-    def selected_leaves_attributes
-      super + [:remaining_hours]
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
@@ -1,0 +1,39 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+module OpenProject::Backlogs::Patches::WorkPackages::UpdateAncestors::LoaderPatch
+  def self.included(base)
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    private
+
+    def selected_leaves_attributes
+      super + [:remaining_hours]
+    end
+  end
+end

--- a/modules/backlogs/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
 
 describe WorkPackages::UpdateAncestorsService do
   let(:user) { create :user }

--- a/spec/services/work_packages/update_ancestors/loader_spec.rb
+++ b/spec/services/work_packages/update_ancestors/loader_spec.rb
@@ -1,0 +1,293 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+require 'spec_helper'
+
+describe WorkPackages::UpdateAncestors::Loader, type: :model do
+  shared_let(:grandgrandparent) do
+    create :work_package
+  end
+  shared_let(:grandparent_sibling) do
+    create :work_package,
+           parent: grandgrandparent
+  end
+  shared_let(:grandparent) do
+    create :work_package,
+           parent: grandgrandparent
+  end
+  shared_let(:parent) do
+    create :work_package,
+           parent: grandparent
+  end
+  shared_let(:sibling) do
+    create :work_package,
+           parent:
+  end
+  shared_let(:work_package) do
+    create :work_package,
+           parent:
+  end
+  shared_let(:child) do
+    create :work_package,
+           parent: work_package
+  end
+
+  let(:include_former_ancestors) { true }
+
+  let(:instance) do
+    described_class
+      .new(work_package, include_former_ancestors)
+  end
+
+  describe '#select' do
+    subject do
+      work_package.parent = new_parent
+      work_package.save!
+
+      instance
+    end
+
+    context 'when switching the hierarchy' do
+      let!(:new_grandgrandparent) do
+        create :work_package,
+               subject: 'new grandgrandparent'
+      end
+      let!(:new_grandparent) do
+        create :work_package,
+               parent: new_grandgrandparent,
+               subject: 'new grandparent'
+      end
+      let!(:new_parent) do
+        create :work_package,
+               subject: 'new parent',
+               parent: new_grandparent
+      end
+      let!(:new_sibling) do
+        create :work_package,
+               subject: 'new sibling',
+               parent: new_parent
+      end
+
+      it 'iterates over both current and former ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [new_parent, new_grandparent, new_grandgrandparent, parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when switching the hierarchy and not including the former ancestors' do
+      let!(:new_grandgrandparent) do
+        create :work_package,
+               subject: 'new grandgrandparent'
+      end
+      let!(:new_grandparent) do
+        create :work_package,
+               parent: new_grandgrandparent,
+               subject: 'new grandparent'
+      end
+      let!(:new_parent) do
+        create :work_package,
+               subject: 'new parent',
+               parent: new_grandparent
+      end
+      let!(:new_sibling) do
+        create :work_package,
+               subject: 'new sibling',
+               parent: new_parent
+      end
+
+      let(:include_former_ancestors) { false }
+
+      it 'iterates over the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [new_parent, new_grandparent, new_grandgrandparent]
+      end
+    end
+
+    context 'when removing the parent' do
+      let(:new_parent) { nil }
+
+      it 'iterates over the former ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when removing the parent and not including the former ancestors' do
+      let(:new_parent) { nil }
+      let(:include_former_ancestors) { false }
+
+      it 'loads nothing' do
+        expect(subject.select { |ancestor| ancestor })
+          .to be_empty
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy upwards' do
+      let(:new_parent) { grandgrandparent }
+
+      it 'iterates over the former ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy upwards and not loading former ancestors' do
+      let(:new_parent) { grandgrandparent }
+      let(:include_former_ancestors) { false }
+
+      it 'iterates over the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [grandgrandparent]
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy sideways' do
+      let(:new_parent) { sibling }
+
+      it 'iterates over the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [sibling, parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy sideways and not loading former ancestors' do
+      let(:new_parent) { sibling }
+      let(:include_former_ancestors) { false }
+
+      it 'iterates over the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [sibling, parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy sideways but to a different level' do
+      let(:new_parent) { grandparent_sibling }
+
+      it 'iterates over the former and the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [grandparent_sibling, parent, grandparent, grandgrandparent]
+      end
+    end
+
+    context 'when changing the parent within the same hierarchy sideways but to a different level and not loading ancestors' do
+      let(:new_parent) { grandparent_sibling }
+      let(:include_former_ancestors) { false }
+
+      it 'iterates over the former and the current ancestors' do
+        expect(subject.select { |ancestor| ancestor })
+          .to eql [grandparent_sibling, grandgrandparent]
+      end
+    end
+  end
+
+  describe '#descendants_of' do
+    def descendants_of_hash(hashed_work_package)
+      { "estimated_hours" => nil,
+        "id" => hashed_work_package.id,
+        "ignore_non_working_days" => false,
+        "parent_id" => hashed_work_package.parent_id,
+        "schedule_manually" => false }
+    end
+
+    context 'for the work_package' do
+      it 'is its child (as a hash)' do
+        expect(instance.descendants_of(work_package))
+          .to match_array([descendants_of_hash(child)])
+      end
+    end
+
+    context 'for the parent' do
+      it 'is the work package, its child (as a hash) and its sibling (as a hash)' do
+        expect(instance.descendants_of(parent))
+          .to match_array([descendants_of_hash(child),
+                           work_package,
+                           descendants_of_hash(sibling)])
+      end
+    end
+
+    context 'for the grandparent' do
+      it 'is the parent, the work package, its child (as a hash) and its sibling (as a hash)' do
+        expect(instance.descendants_of(grandparent))
+          .to match_array([parent,
+                           work_package,
+                           descendants_of_hash(child),
+                           descendants_of_hash(sibling)])
+      end
+    end
+
+    context 'for the grandgrandparent (the root)' do
+      it 'is the complete tree, partly as a hash and partly as the preloaded work packages' do
+        expect(instance.descendants_of(grandgrandparent))
+          .to match_array([descendants_of_hash(grandparent_sibling),
+                           grandparent,
+                           parent,
+                           work_package,
+                           descendants_of_hash(child),
+                           descendants_of_hash(sibling)])
+      end
+    end
+  end
+
+  describe '#children_of' do
+    def children_of_hash(hashed_work_package)
+      { "estimated_hours" => nil,
+        "id" => hashed_work_package.id,
+        "ignore_non_working_days" => false,
+        "parent_id" => hashed_work_package.parent_id,
+        "schedule_manually" => false }
+    end
+
+    context 'for the work_package' do
+      it 'is its child (as a hash)' do
+        expect(instance.children_of(work_package))
+          .to match_array([children_of_hash(child)])
+      end
+    end
+
+    context 'for the parent' do
+      it 'is the work package and its sibling (as a hash)' do
+        expect(instance.children_of(parent))
+          .to match_array([work_package,
+                           children_of_hash(sibling)])
+      end
+    end
+
+    context 'for the grandparent' do
+      it 'is the parent' do
+        expect(instance.children_of(grandparent))
+          .to match_array([parent])
+      end
+    end
+
+    context 'for the grandgrandparent' do
+      it 'is the grandparent and its sibling (as a hash)' do
+        expect(instance.children_of(grandgrandparent))
+          .to match_array([children_of_hash(grandparent_sibling),
+                           grandparent])
+      end
+    end
+  end
+end

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -549,6 +549,31 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
     end
   end
 
+  describe 'inheriting ignore_non_working_days' do
+    let(:attributes) { { ignore_non_working_days: true } }
+
+    before do
+      parent_work_package
+      grandparent_work_package
+      sibling1_work_package
+    end
+
+    it 'propagates the value up the ancestor chain' do
+      expect(subject)
+        .to be_success
+
+      # receives the provided value
+      expect(work_package.reload.ignore_non_working_days)
+        .to be_truthy
+
+      # parent and grandparent receive the value
+      expect(parent_work_package.reload.ignore_non_working_days)
+        .to be_truthy
+      expect(grandparent_work_package.reload.ignore_non_working_days)
+        .to be_truthy
+    end
+  end
+
   describe 'closing duplicates on closing status' do
     let(:status_closed) do
       create(:status,


### PR DESCRIPTION
Inherits the value of the `ignore_non_working_days` property of a work package up the ancestor chain.

* As soon as there is one child work package having `ignore_non_working_days` set to true, the parent work package will have its `ignore_non_working_days` value set to true as well. 
* The only exception to that are work packages having `schedule_manually` set to true. Those are not considered, both when being a child and their value would otherwise be propagated up, as well as when being the parent.

https://community.openproject.org/wp/43935