### PR TITLE
Hide hover state of flatpickr when mouse exits container

### DIFF
--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -60,6 +60,7 @@ import {
 } from 'rxjs/operators';
 import { activeFieldContainerClassName } from 'core-app/shared/components/fields/edit/edit-form/edit-form';
 import {
+  fromEvent,
   merge,
   Observable,
   Subject,
@@ -456,8 +457,9 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
         mode: 'range',
         showMonths: this.browserDetector.isMobile ? 1 : 2,
         inline: true,
-        onReady: () => {
+        onReady: (_date, _datestr, instance) => {
           this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));
+          this.ensureHoveredSelection(instance.calendarContainer);
         },
         onChange: (dates:Date[]) => {
           const activeField = this.currentlyActivatedDateField;
@@ -728,5 +730,28 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
         }),
         map((date) => [key, date]),
       );
+  }
+
+  /**
+   * When hovering selections in the range datepicker, the range usually
+   * stays active no matter where the cursor is.
+   *
+   * We want to hide any hovered selection preview when we leave the datepicker.
+   * @param calendarContainer
+   * @private
+   */
+  private ensureHoveredSelection(calendarContainer:HTMLDivElement) {
+    fromEvent(calendarContainer, 'mouseenter')
+      .pipe(
+        this.untilDestroyed(),
+      )
+      .subscribe(() => calendarContainer.classList.remove('flatpickr-container-suppress-hover'));
+
+    fromEvent(calendarContainer, 'mouseleave')
+      .pipe(
+        this.untilDestroyed(),
+        filter(() => !(!!this.dates.start && !!this.dates.end)),
+      )
+      .subscribe(() => calendarContainer.classList.add('flatpickr-container-suppress-hover'));
   }
 }

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -173,3 +173,12 @@ $datepicker--border-radius: 5px
 
           &.today
             color: $spot-color-basic-gray-4
+
+.flatpickr-calendar.flatpickr-container-suppress-hover
+  .flatpickr-day
+    &.inRange,
+    &.startRange:not(.selected),
+    &.endRange:not(.selected)
+      background: transparent !important
+      border-color: transparent !important
+      color: black !important


### PR DESCRIPTION
https://community.openproject.org/wp/41341

> For example, when a user removes the start date, initially, the finish date is conserved (correctly) and gets rounded corners or all sides (correctly). On hover, a "preview" is provided (correctly). 
> But if the user choses to just save the date picker as is, with just the finish date date, moving the mouse across the calendar to the save button creates a new "preview" of a start date too in the mini calendar, even when the user has scrolled past the calendar and is trying to save the current state. This could lead to confusion.