### PR TITLE
Remove break-all from all paragraphs

### DIFF
--- a/frontend/src/global_styles/content/user-content/_typography.sass
+++ b/frontend/src/global_styles/content/user-content/_typography.sass
@@ -43,7 +43,7 @@
   margin: 0
   line-height: 1.6em
   color: inherit
-  word-break: break-all
+  overflow-wrap: break-word
 
 .op-uc-blockquote
   display: block

--- a/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
@@ -30,9 +30,6 @@
   display: block
   margin: 12px 0 0 0
 
-  li, p
-    word-wrap: break-word
-
   &.wiki
     ul
       padding-left: 18px


### PR DESCRIPTION
Replaces https://github.com/opf/openproject/pull/11172/commits/1821e2289978ec1e46f11b3a274cdea36ded4dd2 in favor of `overflow-wrap: break-word`