### PR TITLE
Make datepicker today links input dates in new fashion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,6 +165,11 @@ RSpec/ExampleLength:
     - 'spec/features/**/*.rb'
     - 'modules/*/spec/features/**/*.rb'
 
+# We have specs that have no expect(..) syntax,
+# but only helper classes that expect themselves
+RSpec/NoExpectationExample:
+  Enabled: false
+
 RSpec/DescribeClass:
   Enabled: true
   Exclude:

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -346,15 +346,10 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
   }
 
   setToday(key:DateKeys):void {
-    const today = parseDate(new Date());
-    this.dates[key] = this.timezoneService.formattedISODate(today);
+    this.datepickerChanged$.next([key, new Date()]);
 
-    if (today instanceof Date) {
-      this.enforceManualChangesToDatepicker(today);
-      this.toggleCurrentActivatedField();
-    } else {
-      this.enforceManualChangesToDatepicker();
-    }
+    const nextActive = key === 'start' ? 'end' : 'start';
+    this.setCurrentActivatedField(nextActive);
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -527,6 +527,9 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
 
       // Active is on start or end, the other was missing
       this.deriveOtherField(activeField);
+
+      // Set the selected date on the datepicker
+      this.enforceManualChangesToDatepicker(selectedDate);
     }
   }
 

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -686,7 +686,7 @@ describe 'Datepicker modal logic test cases (WP #43539)',
     end
   end
 
-  context 'when setting ignore NWD to true for a milesotone' do
+  context 'when setting ignore NWD to true for a milestone' do
     let(:date_attribute) { :date }
     let(:work_package) { milestone_wp }
     let(:current_attributes) do
@@ -711,6 +711,41 @@ describe 'Datepicker modal logic test cases (WP #43539)',
       apply_and_expect_saved start_date: Date.parse('2022-06-19'),
                              due_date: Date.parse('2022-06-19'),
                              ignore_non_working_days: true
+    end
+  end
+
+  context 'when setting start and due date through today links' do
+    let(:current_attributes) do
+      {
+        start_date: nil,
+        due_date: nil,
+        duration: nil,
+        ignore_non_working_days: true
+      }
+    end
+
+    it 'allows to persist that value (Regression #44140)' do
+      datepicker.expect_start_date ''
+      datepicker.expect_due_date ''
+      datepicker.expect_duration ''
+
+      today = Time.zone.today
+      today_str = today.iso8601
+
+      # Setting start will set active to due
+      datepicker.set_today 'start'
+      datepicker.expect_start_date today_str
+      datepicker.expect_due_highlighted
+
+      datepicker.set_today 'due'
+      datepicker.expect_due_date today_str
+      datepicker.expect_start_highlighted
+
+      datepicker.expect_duration 1
+
+      apply_and_expect_saved start_date: today,
+                             due_date: today,
+                             duration: 1
     end
   end
 end

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -61,6 +61,10 @@ describe 'date inplace editor',
     start_date.datepicker.expect_month 'January'
     start_date.datepicker.select_day '25'
 
+    start_date.datepicker.expect_start_date '2016-01-02'
+    start_date.datepicker.expect_due_date '2016-01-25'
+    start_date.datepicker.expect_duration 24
+
     start_date.save!
     start_date.expect_inactive!
     start_date.expect_state_text '2016-01-02 - 2016-01-25'
@@ -74,6 +78,10 @@ describe 'date inplace editor',
     start_date.datepicker.expect_month 'January'
     start_date.datepicker.select_day '1'
 
+    start_date.datepicker.expect_start_date '2016-01-01'
+    start_date.datepicker.expect_due_date '2016-01-02'
+    start_date.datepicker.expect_duration 2
+
     start_date.save!
     start_date.expect_inactive!
     start_date.expect_state_text '2016-01-01 - 2016-01-02'
@@ -83,7 +91,13 @@ describe 'date inplace editor',
     start_date.activate!
     start_date.expect_active!
 
-    start_date.click_today
+    start_date.datepicker.expect_start_date '2016-01-02'
+    start_date.datepicker.expect_year work_package.start_date.year
+    start_date.datepicker.expect_month work_package.start_date.strftime("%B")
+    start_date.datepicker.expect_day work_package.start_date.day
+
+    start_date.datepicker.set_today :start
+    start_date.datepicker.expect_start_date Time.zone.today.iso8601
 
     start_date.datepicker.expect_year Time.zone.today.year
     start_date.datepicker.expect_month Time.zone.today.strftime("%B")
@@ -110,6 +124,10 @@ describe 'date inplace editor',
       start_date.datepicker.expect_month 'January'
       start_date.datepicker.select_day '1'
 
+      start_date.datepicker.expect_start_date '2016-01-01'
+      start_date.datepicker.expect_due_date '2016-01-24'
+      start_date.datepicker.expect_duration 24
+
       start_date.save!
       start_date.expect_inactive!
       start_date.expect_state_text '2016-01-01 - 2016-01-24'
@@ -123,8 +141,13 @@ describe 'date inplace editor',
       start_date.datepicker.expect_month 'January'
       start_date.datepicker.select_day '3'
 
+      start_date.datepicker.expect_start_date '2016-01-03'
+
       # Since the focus shifts automatically, we can directly click again to modify the end date
       start_date.datepicker.select_day '21'
+
+      start_date.datepicker.expect_due_date '2016-01-21'
+      start_date.datepicker.expect_duration 19
 
       start_date.save!
       start_date.expect_inactive!
@@ -169,7 +192,10 @@ describe 'date inplace editor',
       start_date.activate!
       start_date.expect_active!
 
-      start_date.click_today
+      # Wait for the datepicker to be loaded
+      sleep 1
+      start_date.datepicker.set_today :start
+      start_date.datepicker.expect_start_date Time.zone.today.iso8601
 
       start_date.datepicker.expect_year Time.zone.today.year
       start_date.datepicker.expect_month Time.zone.today.strftime("%B")

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -94,8 +94,9 @@ module Components
     ##
     # Expect the selected year
     def expect_year(value)
-      field = flatpickr_container.first('.cur-year')
-      expect(field.value.to_i).to eq(value.to_i)
+      expect(flatpickr_container).to have_selector('.cur-year') do |field|
+        field.value.to_i == value.to_i
+      end
     end
 
     ##

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -135,6 +135,20 @@ module Components
       due_date_field.click
     end
 
+    def set_today(date)
+      key =
+        case date.to_s
+        when 'due'
+          'end'
+        else
+          date
+        end
+
+      page.within("[data-qa-selector='datepicker-#{key}-date']") do
+        find('a', text: 'Today').click
+      end
+    end
+
     def set_duration(value)
       focus_duration
       fill_in 'duration', with: value, fill_options: { clear: :backspace }

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -130,12 +130,6 @@ class DateEditField < EditField
     end
   end
 
-  def click_today(which: :start)
-    within_modal do
-      find("[data-qa-selector='datepicker-#{which}-date'] .form--field-extra-actions a", text: 'Today').click
-    end
-  end
-
   def set_value(value)
     if value.is_a?(Array)
       datepicker.clear!


### PR DESCRIPTION
The today links were kept at the old behavior, only setting the internal dates. We now have an rxjs pipeline to cause updates to trigger necessary form posts and other derived values.

It was simply not used there.

https://community.openproject.org/work_packages/44140