### PR TITLE
Handle duration focusout after a timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,6 +165,11 @@ RSpec/ExampleLength:
     - 'spec/features/**/*.rb'
     - 'modules/*/spec/features/**/*.rb'
 
+# We have specs that have no expect(..) syntax,
+# but only helper classes that expect themselves
+RSpec/NoExpectationExample:
+  Enabled: false
+
 RSpec/DescribeClass:
   Enabled: true
   Exclude:

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -209,7 +209,6 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
     .durationChanges$
     .pipe(
       this.untilDestroyed(),
-      distinctUntilChanged(),
       debounceTime(500),
       map((value) => (value === '' ? null : parseInt(value, 10))),
       filter((val) => val !== this.duration),

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -388,7 +388,9 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
   }
 
   handleDurationFocusOut():void {
-    this.durationFocused = false;
+    setTimeout(() => {
+      this.durationFocused = false;
+    });
   }
 
   get displayedDuration():string {
@@ -553,9 +555,12 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
     // Focus moves to finish date
     this.setCurrentActivatedField('end');
 
-    // If duration has value, derive end date from start and duration
     if (this.duration) {
+      // If duration has value, derive end date from start and duration
       this.formUpdates$.next({ startDate: this.dates.start, duration: this.durationAsIso8601 });
+    } else if (this.dates.start && this.dates.end) {
+      // If start and due now have values, derive duration again
+      this.formUpdates$.next({ startDate: this.dates.start, dueDate: this.dates.end });
     }
   }
 

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -232,6 +232,74 @@ describe 'Datepicker modal logic test cases (WP #43539)',
     end
   end
 
+  describe 'when all values set, removing duration through icon (test case 6a)' do
+    let(:current_attributes) do
+      {
+        start_date: Date.parse('2021-02-09'),
+        due_date: Date.parse('2021-02-12'),
+        duration: 3
+      }
+    end
+
+    it 'also unsets the due date' do
+      datepicker.expect_start_date '2021-02-09'
+      datepicker.expect_due_date '2021-02-12'
+      datepicker.expect_duration 3
+
+      # The spec clears faster than the due date is filled, wait a bit
+      sleep 1
+      datepicker.clear_duration_with_icon
+
+      datepicker.expect_start_date '2021-02-09'
+      datepicker.expect_due_date ''
+      datepicker.expect_duration nil
+    end
+  end
+
+  describe 'when all values set, removing duration and setting it again' do
+    let(:current_attributes) do
+      {
+        start_date: Date.parse('2021-02-09'),
+        due_date: Date.parse('2021-02-12'),
+        duration: 3
+      }
+    end
+
+    it 'allows re-deriving duration' do
+      datepicker.expect_start_date '2021-02-09'
+      datepicker.expect_due_date '2021-02-12'
+      datepicker.expect_duration 3
+
+      # The spec clears faster than the due date is filled, wait a bit
+      sleep 1
+      datepicker.clear_duration_with_icon
+
+      datepicker.expect_start_date '2021-02-09'
+      datepicker.expect_due_date ''
+      datepicker.expect_duration nil
+
+      # Now select a date
+      datepicker.select_day 5
+
+      datepicker.expect_start_date '2021-02-05'
+      datepicker.expect_due_date '2021-02-09'
+      datepicker.expect_duration 3
+
+      # Clear again
+      sleep 1
+      datepicker.clear_duration_with_icon
+
+      datepicker.expect_start_date '2021-02-05'
+      datepicker.expect_due_date ''
+      datepicker.expect_duration nil
+
+      datepicker.select_day 8
+      datepicker.expect_start_date '2021-02-05'
+      datepicker.expect_due_date '2021-02-08'
+      datepicker.expect_duration 2
+    end
+  end
+
   describe 'when all values set, changing start date in calendar (test case 7)' do
     let(:current_attributes) do
       {

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -190,5 +190,13 @@ module Components
       # Focus a different field
       start_date_field.click
     end
+
+    def clear_duration_with_icon
+      duration_field.click
+
+      page
+        .find('[data-qa-selector="op-datepicker-modal--duration-field"] .spot-text-field--clear-button')
+        .click
+    end
   end
 end


### PR DESCRIPTION
Otherwise, the focusout event fires before the clear button click event was handled, which results in the field being set again.

This breaks the chain and causes ngModelChange not to trigger.

https://community.openproject.org/work_packages/44139