### PR TITLE
Destroy invalid journals

### DIFF
--- a/db/migrate/20220818074150_fix_invalid_journals.rb
+++ b/db/migrate/20220818074150_fix_invalid_journals.rb
@@ -1,0 +1,31 @@
+class FixInvalidJournals < ActiveRecord::Migration[7.0]
+  def up
+    get_broken_journals.each do |journable_type, relation|
+      next unless relation.any?
+
+      # rubocop:disable Rails/Output
+      puts "Cleaning up broken journals on #{journable_type}"
+      # rubocop:enable Rails/Output
+      relation.destroy_all
+    end
+  end
+
+  def down
+    # nothing to do
+  end
+
+  def get_broken_journals
+    Journal
+      .pluck('DISTINCT(journable_type)')
+      .compact
+      .to_h do |journable_type|
+      journal_class = journable_type.constantize.journal_class
+
+      relation = Journal
+        .where(journable_type:)
+        .where.not(data_type: journal_class.to_s)
+
+      [journable_type, relation]
+    end
+  end
+end


### PR DESCRIPTION
While working on the db/migrate/20220818074159_fix_deleted_data_journals.rb migration, we noticed a few customers reporting errors with that migration.

It turned out every journal affected by it had a `journable_type` reference that did not match it's data_type. For example, `journable_type: 'WorkPackage', data_type: 'Journal::MeetingContentJournal'`. While not being able to explain them, they are never functional so we should be able to destroy them.

Destroying them in a migration before the above runs will avoid errors in that run.

https://community.openproject.org/projects/openproject/work_packages/44132/activity?query_id=3498