### PR TITLE
Connect working days administration page and background job

### DIFF
--- a/app/services/settings/update_service.rb
+++ b/app/services/settings/update_service.rb
@@ -49,6 +49,11 @@ class Settings::UpdateService < ::BaseServices::BaseContracted
       Setting[name] = derive_value(value)
     end
 
+    if params.has_key?(:working_days)
+      WorkPackages::ApplyWorkingDaysChangeJob
+        .perform_later(user_id: user.id)
+    end
+
     call
   end
 

--- a/app/services/settings/update_service.rb
+++ b/app/services/settings/update_service.rb
@@ -46,18 +46,31 @@ class Settings::UpdateService < ::BaseServices::BaseContracted
 
   def after_validate(params, call)
     params.each do |name, value|
-      Setting[name] = derive_value(value)
-    end
-
-    if params.has_key?(:working_days)
-      WorkPackages::ApplyWorkingDaysChangeJob
-        .perform_later(user_id: user.id)
+      set_setting_value(name, value)
     end
 
     call
   end
 
+  def after_perform(call)
+    super.tap do
+      params.each_key do |name|
+        run_on_change_callback(name)
+      end
+    end
+  end
+
   private
+
+  def set_setting_value(name, value)
+    Setting[name] = derive_value(value)
+  end
+
+  def run_on_change_callback(name)
+    if (definition = Settings::Definition[name]) && definition.on_change
+      definition.on_change.call
+    end
+  end
 
   def derive_value(value)
     case value

--- a/app/services/settings/update_service.rb
+++ b/app/services/settings/update_service.rb
@@ -46,6 +46,7 @@ class Settings::UpdateService < ::BaseServices::BaseContracted
 
   def after_validate(params, call)
     params.each do |name, value|
+      remember_previous_value(name)
       set_setting_value(name, value)
     end
 
@@ -62,13 +63,21 @@ class Settings::UpdateService < ::BaseServices::BaseContracted
 
   private
 
+  def remember_previous_value(name)
+    previous_values[name] = Setting[name]
+  end
+
   def set_setting_value(name, value)
     Setting[name] = derive_value(value)
   end
 
+  def previous_values
+    @previous_values ||= {}
+  end
+
   def run_on_change_callback(name)
     if (definition = Settings::Definition[name]) && definition.on_change
-      definition.on_change.call
+      definition.on_change.call(previous_values[name])
     end
   end
 

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -33,7 +33,8 @@ module Settings
 
     attr_accessor :name,
                   :format,
-                  :env_alias
+                  :env_alias,
+                  :on_change
 
     attr_writer :value,
                 :allowed
@@ -43,7 +44,8 @@ module Settings
                    format: nil,
                    writable: true,
                    allowed: nil,
-                   env_alias: nil)
+                   env_alias: nil,
+                   on_change: nil)
       self.name = name.to_s
       @default = default.is_a?(Hash) ? default.deep_stringify_keys : default
       @default.freeze
@@ -52,6 +54,7 @@ module Settings
       self.writable = writable
       self.allowed = allowed
       self.env_alias = env_alias
+      self.on_change = on_change
     end
 
     def default
@@ -131,12 +134,14 @@ module Settings
       # @param [nil] env_alias Alternative for the default env name to also look up. E.g. with the alias set to
       #  `OPENPROJECT_2FA` for a definition with the name `two_factor_authentication`, the value is fetched
       #  from the ENV OPENPROJECT_2FA as well.
+      # @param [nil] on_change A callback lambda to be triggered whenever the setting is stored to the database.
       def add(name,
               default:,
               format: nil,
               writable: true,
               allowed: nil,
-              env_alias: nil)
+              env_alias: nil,
+              on_change: nil)
         return if @by_name.present? && @by_name[name.to_s].present?
 
         @by_name = nil
@@ -146,7 +151,8 @@ module Settings
                          default:,
                          writable:,
                          allowed:,
-                         env_alias:)
+                         env_alias:,
+                         on_change:)
 
         override_value(definition)
 

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -989,7 +989,8 @@ Settings::Definition.define do
   add :working_days,
       format: :array,
       allowed: Array(1..7),
-      default: Array(1..5) # Sat, Sun being non-working days
+      default: Array(1..5), # Sat, Sun being non-working days
+      on_change: -> { WorkPackages::ApplyWorkingDaysChangeJob.perform_later(user_id: User.current.id) }
 
   add :youtube_channel,
       default: 'https://www.youtube.com/c/OpenProjectCommunity',

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -990,7 +990,9 @@ Settings::Definition.define do
       format: :array,
       allowed: Array(1..7),
       default: Array(1..5), # Sat, Sun being non-working days
-      on_change: -> { WorkPackages::ApplyWorkingDaysChangeJob.perform_later(user_id: User.current.id) }
+      on_change: ->(previous_working_days) do
+        WorkPackages::ApplyWorkingDaysChangeJob.perform_later(user_id: User.current.id, previous_working_days:)
+      end
 
   add :youtube_channel,
       default: 'https://www.youtube.com/c/OpenProjectCommunity',

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -970,4 +970,34 @@ describe Settings::Definition do
       end
     end
   end
+
+  describe '#on_change' do
+    include_context 'with clean definitions'
+
+    context 'for a definition with a callback' do
+      let(:callback) { -> { 'foobar ' } }
+
+      it 'includes the callback' do
+        described_class.add 'bogus',
+                            default: 1,
+                            format: :integer,
+                            on_change: callback
+
+        expect(described_class['bogus'].on_change)
+          .to eq callback
+      end
+    end
+
+    context 'for a definition without a callback' do
+      it 'includes the callback' do
+        described_class.add 'bogus',
+                            default: 1,
+                            format: :integer,
+                            on_change: nil
+
+        expect(described_class['bogus'].on_change)
+          .to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/settings/update_service_spec.rb
+++ b/spec/services/settings/update_service_spec.rb
@@ -27,77 +27,46 @@
 require 'spec_helper'
 
 describe Settings::UpdateService do
-  let(:user) { build_stubbed(:user) }
-  let(:contract_success) { true }
-  let(:contract_errors) { instance_double(ActiveModel::Error) }
-  let(:contract_options) { {} }
   let(:instance) do
     described_class.new(user:, contract_options:)
   end
-  let!(:contract) do
-    contract_instance = instance_double(Settings::UpdateContract)
-
-    allow(Settings::UpdateContract)
-      .to receive(:new)
-            .and_return(contract_instance)
-
-    allow(contract_instance)
-      .to receive(:validate)
-            .and_return(contract_success)
-    allow(contract_instance)
-      .to receive(:errors)
-            .and_return(contract_errors)
-
-    contract_instance
+  let(:user) { build_stubbed(:user) }
+  let(:contract_options) { {} }
+  let(:contract) do
+    instance_double(Settings::UpdateContract,
+                    validate: contract_success,
+                    errors: instance_double(ActiveModel::Error))
   end
-  let!(:params_contract) do
-    contract_instance = instance_double(ParamsContract)
-
-    allow(ParamsContract)
-      .to receive(:new)
-            .and_return(contract_instance)
-
-    allow(contract_instance)
-      .to receive(:valid?)
-            .and_return(params_contract_success)
-    allow(contract_instance)
-      .to receive(:errors)
-            .and_return(params_contract_errors)
-
-    contract_instance
-  end
-  let(:params_contract_success) { true }
-  let(:params_contract_errors) { instance_double(ActiveModel::Error) }
-  let!(:setting) do
-    allow(Setting)
-      .to receive(:[]=)
-            .with(setting_name, setting_value)
-  end
-  let!(:definition) do
-    instance_double(Settings::Definition).tap do |definition_instance|
-      allow(Settings::Definition)
-        .to receive(:[])
-              .and_call_original
-
-      allow(Settings::Definition)
-        .to receive(:[])
-              .with(setting_name)
-              .and_return(definition_instance)
-
-      allow(definition_instance)
-        .to receive(:on_change)
-              .and_return(definition_on_change)
-    end
+  let(:contract_success) { true }
+  let(:setting_definition) do
+    instance_double(Settings::Definition,
+                    on_change: definition_on_change)
   end
   let(:definition_on_change) do
-    instance_double(Proc).tap do |proc|
-      allow(proc)
-        .to receive(:call)
-    end
+    instance_double(Proc,
+                    call: nil)
   end
-  let(:setting_name) { :setting_name }
-  let(:setting_value) { 'setting_value' }
+  let(:setting_name) { :a_setting_name }
+  let(:setting_value) { 'a_setting_value' }
   let(:params) { { setting_name => setting_value } }
+
+  before do
+    # stub a setting definition
+    allow(Settings::Definition)
+      .to receive(:[])
+            .and_call_original
+    allow(Settings::Definition)
+      .to receive(:[])
+            .with(setting_name)
+            .and_return(setting_definition)
+    allow(Setting)
+      .to receive(:[]=)
+
+    # stub contract
+    allow(Settings::UpdateContract)
+      .to receive(:new)
+          .and_return(contract)
+  end
 
   describe '#call' do
     shared_examples_for 'successful call' do
@@ -106,11 +75,12 @@ describe Settings::UpdateService do
           .to be_success
       end
 
-      it 'sets the value' do
+      it 'sets the setting value' do
         instance.call(params)
 
         expect(Setting)
           .to have_received(:[]=)
+              .with(setting_name, setting_value)
       end
 
       it 'calls the on_change handler' do
@@ -127,41 +97,54 @@ describe Settings::UpdateService do
           .not_to be_success
       end
 
+      it 'does not set the setting value' do
+        instance.call(params)
+
+        expect(Setting)
+          .not_to have_received(:[]=)
+      end
+
       it 'does not call the on_change handler' do
         instance.call(params)
 
         expect(definition_on_change)
           .not_to have_received(:call)
       end
-
-      it 'does not set the value' do
-        instance.call(params)
-
-        expect(Setting)
-          .not_to have_received(:[]=)
-      end
     end
 
-    it_behaves_like 'successful call'
+    include_examples 'successful call'
 
     context 'when the contract is not successfully validated' do
       let(:contract_success) { false }
 
-      it_behaves_like 'unsuccessful call'
+      include_examples 'unsuccessful call'
     end
 
-    context 'with a provided params_contract that is successfully validated' do
+    context 'with a provided params_contract' do
       let(:contract_options) { { params_contract: ParamsContract } }
-      let(:params_contract_success) { true }
+      let(:params_contract) do
+        instance_double(ParamsContract,
+                        valid?: params_contract_success,
+                        errors: instance_double(ActiveModel::Error))
+      end
 
-      it_behaves_like 'successful call'
-    end
+      before do
+        allow(ParamsContract)
+        .to receive(:new)
+            .and_return(params_contract)
+      end
 
-    context 'with a provided params_contract that fails validation' do
-      let(:contract_options) { { params_contract: ParamsContract } }
-      let(:params_contract_success) { false }
+      context 'with a provided params_contract that is successfully validated' do
+        let(:params_contract_success) { true }
 
-      it_behaves_like 'unsuccessful call'
+        include_examples 'successful call'
+      end
+
+      context 'with a provided params_contract that fails validation' do
+        let(:params_contract_success) { false }
+
+        include_examples 'unsuccessful call'
+      end
     end
   end
 end

--- a/spec/services/settings/update_service_spec.rb
+++ b/spec/services/settings/update_service_spec.rb
@@ -47,8 +47,9 @@ describe Settings::UpdateService do
                     call: nil)
   end
   let(:setting_name) { :a_setting_name }
-  let(:setting_value) { 'a_setting_value' }
-  let(:params) { { setting_name => setting_value } }
+  let(:new_setting_value) { 'a_new_setting_value' }
+  let(:previous_setting_value) { 'the_previous_setting_value' }
+  let(:params) { { setting_name => new_setting_value } }
 
   before do
     # stub a setting definition
@@ -59,6 +60,12 @@ describe Settings::UpdateService do
       .to receive(:[])
             .with(setting_name)
             .and_return(setting_definition)
+    allow(Setting)
+      .to receive(:[])
+          .and_call_original
+    allow(Setting)
+      .to receive(:[]).with(setting_name)
+          .and_return(previous_setting_value)
     allow(Setting)
       .to receive(:[]=)
 
@@ -80,14 +87,14 @@ describe Settings::UpdateService do
 
         expect(Setting)
           .to have_received(:[]=)
-              .with(setting_name, setting_value)
+              .with(setting_name, new_setting_value)
       end
 
       it 'calls the on_change handler' do
         instance.call(params)
 
         expect(definition_on_change)
-          .to have_received(:call)
+          .to have_received(:call).with(previous_setting_value)
       end
     end
 

--- a/spec/services/settings/update_service_spec.rb
+++ b/spec/services/settings/update_service_spec.rb
@@ -1,0 +1,167 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+require 'spec_helper'
+
+describe Settings::UpdateService do
+  let(:user) { build_stubbed(:user) }
+  let(:contract_success) { true }
+  let(:contract_errors) { instance_double(ActiveModel::Error) }
+  let(:contract_options) { {} }
+  let(:instance) do
+    described_class.new(user:, contract_options:)
+  end
+  let!(:contract) do
+    contract_instance = instance_double(Settings::UpdateContract)
+
+    allow(Settings::UpdateContract)
+      .to receive(:new)
+            .and_return(contract_instance)
+
+    allow(contract_instance)
+      .to receive(:validate)
+            .and_return(contract_success)
+    allow(contract_instance)
+      .to receive(:errors)
+            .and_return(contract_errors)
+
+    contract_instance
+  end
+  let!(:params_contract) do
+    contract_instance = instance_double(ParamsContract)
+
+    allow(ParamsContract)
+      .to receive(:new)
+            .and_return(contract_instance)
+
+    allow(contract_instance)
+      .to receive(:valid?)
+            .and_return(params_contract_success)
+    allow(contract_instance)
+      .to receive(:errors)
+            .and_return(params_contract_errors)
+
+    contract_instance
+  end
+  let(:params_contract_success) { true }
+  let(:params_contract_errors) { instance_double(ActiveModel::Error) }
+  let!(:setting) do
+    allow(Setting)
+      .to receive(:[]=)
+            .with(setting_name, setting_value)
+  end
+  let!(:definition) do
+    instance_double(Settings::Definition).tap do |definition_instance|
+      allow(Settings::Definition)
+        .to receive(:[])
+              .and_call_original
+
+      allow(Settings::Definition)
+        .to receive(:[])
+              .with(setting_name)
+              .and_return(definition_instance)
+
+      allow(definition_instance)
+        .to receive(:on_change)
+              .and_return(definition_on_change)
+    end
+  end
+  let(:definition_on_change) do
+    instance_double(Proc).tap do |proc|
+      allow(proc)
+        .to receive(:call)
+    end
+  end
+  let(:setting_name) { :setting_name }
+  let(:setting_value) { 'setting_value' }
+  let(:params) { { setting_name => setting_value } }
+
+  describe '#call' do
+    shared_examples_for 'successful call' do
+      it 'is successful' do
+        expect(instance.call(params))
+          .to be_success
+      end
+
+      it 'sets the value' do
+        instance.call(params)
+
+        expect(Setting)
+          .to have_received(:[]=)
+      end
+
+      it 'calls the on_change handler' do
+        instance.call(params)
+
+        expect(definition_on_change)
+          .to have_received(:call)
+      end
+    end
+
+    shared_examples_for 'unsuccessful call' do
+      it 'is not successful' do
+        expect(instance.call(params))
+          .not_to be_success
+      end
+
+      it 'does not call the on_change handler' do
+        instance.call(params)
+
+        expect(definition_on_change)
+          .not_to have_received(:call)
+      end
+
+      it 'does not set the value' do
+        instance.call(params)
+
+        expect(Setting)
+          .not_to have_received(:[]=)
+      end
+    end
+
+    it_behaves_like 'successful call'
+
+    context 'when the contract is not successfully validated' do
+      let(:contract_success) { false }
+
+      it_behaves_like 'unsuccessful call'
+    end
+
+    context 'with a provided params_contract that is successfully validated' do
+      let(:contract_options) { { params_contract: ParamsContract } }
+      let(:params_contract_success) { true }
+
+      it_behaves_like 'successful call'
+    end
+
+    context 'with a provided params_contract that fails validation' do
+      let(:contract_options) { { params_contract: ParamsContract } }
+      let(:params_contract_success) { false }
+
+      it_behaves_like 'unsuccessful call'
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/44214

### TODO

* [x] Trigger `WorkPackages::ApplyWorkingDaysChangeJob` whenever the `working_days` Setting is altered.
* [x] Avoid having `working_days` Setting specific code in the `Settings::UpdateService`
  * A `on_change` callback parameter is introduced that gets called by the `Settings::UpdateService` whenever the setting is altered. That way, every definition can define an `on_change` parameter.
* [x] Add a spec for `Settings::UpdateService`