### PR TITLE
fix returning work packages altered indirectly by the WP::UpdateService

### DIFF
--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -41,11 +41,13 @@ class WorkPackages::UpdateService < ::BaseServices::Update
 
   def update_related_work_packages(service_call)
     update_ancestors([service_call.result]).each do |ancestor_service_call|
-      service_call.merge!(ancestor_service_call)
+      ancestor_service_call.dependent_results.each do |ancestor_dependent_service_call|
+        service_call.add_dependent!(ancestor_dependent_service_call)
+      end
     end
 
     update_related(service_call.result).each do |related_service_call|
-      service_call.merge!(related_service_call)
+      service_call.add_dependent!(related_service_call)
     end
   end
 

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -422,6 +422,11 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql(sibling2_attributes[:start_date])
       expect(sibling2_work_package.due_date)
         .to eql(sibling2_attributes[:due_date])
+
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -485,6 +490,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
       sibling2_work_package.reload
       expect(sibling2_work_package.done_ratio)
         .to eql(sibling2_attributes[:done_ratio])
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -546,6 +557,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
       child_work_package.reload
       expect(child_work_package.estimated_hours)
         .to eql(child_attributes[:estimated_hours].to_f)
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -571,6 +588,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to be_truthy
       expect(grandparent_work_package.reload.ignore_non_working_days)
         .to be_truthy
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -768,6 +791,16 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql Time.zone.today + 32.days
       expect(following3_sibling_work_package.due_date)
         .to eql Time.zone.today + 36.days
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         following_parent_work_package,
+                         following_work_package,
+                         following2_parent_work_package,
+                         following2_work_package,
+                         following3_parent_work_package,
+                         following3_work_package])
     end
     # rubocop:enable RSpec/ExampleLength
     # rubocop:enable RSpec/MultipleExpectations
@@ -816,6 +849,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
 
       expect(work_package.reload.slice(:start_date, :due_date).symbolize_keys)
         .to eq(expected_child_dates)
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         parent_work_package])
     end
   end
 
@@ -918,6 +955,11 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql work_package_attributes[:start_date]
       expect(new_parent_work_package.due_date)
         .to eql new_sibling_attributes[:due_date]
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         former_parent_work_package,
+                         new_parent_work_package])
     end
   end
 
@@ -995,6 +1037,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql new_parent_predecessor_attributes[:due_date] + 1.day
       expect(new_parent_work_package.due_date)
         .to eql new_parent_predecessor_attributes[:due_date] + 4.days
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         new_parent_work_package])
     end
   end
 
@@ -1064,6 +1110,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql sibling_attributes[:start_date]
       expect(parent_work_package.due_date)
         .to eql sibling_attributes[:due_date]
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         parent_work_package])
     end
   end
 


### PR DESCRIPTION
This includes e.g. followers, descendants and ancestors.

Ideally, the values returned would be unique but multiple services can have altered the same work package. Thus, a caller will need to call unique itself.

https://community.openproject.org/wp/43640