### PR TITLE
Wrap project_autocompleter in a retry block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,6 +176,14 @@ RSpec/DescribeClass:
     - 'spec/features/**/*.rb'
     - 'modules/*/spec/features/**/*.rb'
 
+# dynamic finders cop clashes with capybara ID cop
+Rails/DynamicFindBy:
+  Enabled: true
+  Exclude:
+    - 'spec/features/**/*.rb'
+    - 'spec/support/**/*.rb'
+    - 'modules/*/spec/features/**/*.rb'
+
 # See RSpec/ExampleLength for why feature specs are excluded
 RSpec/MultipleExpectations:
   Max: 15

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -165,11 +165,13 @@ describe 'Projects autocomplete page', type: :feature, js: true do
   end
 
   it 'navigates to the first project upon hitting enter in the search bar' do
-    top_menu.toggle
-    top_menu.expect_open
+    retry_block do
+      top_menu.toggle unless top_menu.open?
+      top_menu.expect_open
 
-    # projects are displayed initially
-    top_menu.expect_result project.name
+      # projects are displayed initially
+      top_menu.expect_result project.name
+    end
 
     # Filter for projects
     top_menu.search '<strong'

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -35,19 +35,23 @@ module Components
       include ::Components::Autocompleter::AutocompleteHelpers
 
       def toggle
-        page.find('#projects-menu').click
+        page.find_by_id('projects-menu').click
+      end
+
+      def open?
+        page.has_selector?(autocompleter_selector)
       end
 
       def expect_current_project(name)
-        expect(page).to have_selector('#projects-menu', text: name)
+        page.find_by_id('projects-menu', text: name)
       end
 
       def expect_open
-        expect(page).to have_selector(autocompleter_selector)
+        page.find(autocompleter_selector)
       end
 
       def expect_closed
-        expect(page).to have_no_selector(autocompleter_selector)
+        page.raise_if_found(autocompleter_selector)
       end
 
       def search(query)
@@ -77,9 +81,9 @@ module Components
       def expect_result(name, disabled: false)
         within search_results do
           if disabled
-            expect(page).to have_selector(autocompleter_item_disabled_title_selector, text: name)
+            page.find(autocompleter_item_disabled_title_selector, text: name)
           else
-            expect(page).to have_selector(autocompleter_item_title_selector, text: name)
+            page.find(autocompleter_item_title_selector, text: name)
           end
         end
       end


### PR DESCRIPTION
To try and reduce the flickering, re-open the modal in case the first request fails - even though we don't know the reason for it failing yet