### PR TITLE
avoid multiple fetches of non working days

### DIFF
--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -130,7 +130,7 @@ module WorkPackages
       end
 
       def non_working_dates
-        @non_working_dates ||= Set.new(NonWorkingDay.pluck(:date))
+        @non_working_dates ||= RequestStore.fetch(:work_package_non_working_dates) { Set.new(NonWorkingDay.pluck(:date)) }
       end
     end
   end


### PR DESCRIPTION
Memoization does not suffice since multiple instance of `WorkingDays` can be created throughout a request leading to e.g.:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/617519/191538630-db8eee72-aa42-4c89-a0c6-97a563d73a40.png">
