### PR TITLE
Accept the datepicker range when two dates present, no duration

### DIFF
--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -474,8 +474,18 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
           this.ensureHoveredSelection(instance.calendarContainer);
         },
         onChange: (dates:Date[], _datestr, instance) => {
-          const { latestSelectedDateObj } = instance as { latestSelectedDateObj:Date };
           const activeField = this.currentlyActivatedDateField;
+
+          // When two values are passed from datepicker and we don't have duration set,
+          // just take the range provided by them
+          if (dates.length === 2 && !this.duration) {
+            this.setDatesAndDeriveDuration(dates[0], dates[1]);
+            this.toggleCurrentActivatedField();
+            return;
+          }
+
+          // Update with the same flow as entering a value
+          const { latestSelectedDateObj } = instance as { latestSelectedDateObj:Date };
           this.datepickerChanged$.next([activeField, latestSelectedDateObj]);
 
           // The duration field is special in how it handles focus transitions
@@ -518,6 +528,14 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
     const dates = [startDate, endDate];
     setDates(dates, this.datePickerInstance, enforceDate);
     this.onDataChange();
+  }
+
+  private setDatesAndDeriveDuration(newStart:Date, newEnd:Date) {
+    this.dates.start = this.timezoneService.formattedISODate(newStart);
+    this.dates.end = this.timezoneService.formattedISODate(newEnd);
+
+    // Derive duration
+    this.formUpdates$.next({ startDate: this.dates.start, dueDate: this.dates.end });
   }
 
   private handleSingleDateUpdate(activeField:DateFields, selectedDate:Date) {

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -819,7 +819,7 @@ describe 'Datepicker modal logic test cases (WP #43539)',
       }
     end
 
-    it 'sets due date to selected value, start to finish date, focus on finish' do
+    it 'sets due date to selected value, start to finish date, focus on start' do
       datepicker.expect_start_date ''
       datepicker.expect_due_date '2021-02-18'
       datepicker.expect_duration ''
@@ -834,7 +834,7 @@ describe 'Datepicker modal logic test cases (WP #43539)',
       datepicker.expect_due_date '2021-02-19'
       datepicker.expect_duration 2
 
-      datepicker.expect_due_highlighted
+      datepicker.expect_start_highlighted
 
       apply_and_expect_saved duration: 2,
                              start_date: Date.parse('2021-02-18'),
@@ -868,7 +868,7 @@ describe 'Datepicker modal logic test cases (WP #43539)',
       datepicker.expect_due_date '2021-02-18'
       datepicker.expect_duration 2
 
-      datepicker.expect_due_highlighted
+      datepicker.expect_start_highlighted
 
       apply_and_expect_saved duration: 2,
                              start_date: Date.parse('2021-02-17'),
@@ -902,7 +902,7 @@ describe 'Datepicker modal logic test cases (WP #43539)',
       datepicker.expect_due_date '2021-02-10'
       datepicker.expect_duration 4
 
-      # Focus is on finish date
+      # Focus is on start date
       datepicker.expect_due_highlighted
       datepicker.select_day 15
 


### PR DESCRIPTION
When no duration is set, simply accept the date range presented from datepicker as start - due date. Focused is toggled afterwards. This means that if we were in the duration field, focus will always be on start date.