### PR TITLE
Implementation/43640 journalling updates for work packages when non working days settings change

### DIFF
--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -121,7 +121,7 @@ module WorkPackages
 
         # WeekDay day of the week is stored as ISO, meaning Monday is 1 and Sunday is 7.
         # Ruby Date#wday value for Sunday is 0 and it goes until 6 Saturday.
-        # To accomodate both versions 0-6, 1-7, an array of 8 elements is created
+        # To accommodate both versions 0-6, 1-7, an array of 8 elements is created
         # where array[0] = array[7] = value for Sunday
         #
         # Since Setting.working_days can be empty, the initial array is

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -41,11 +41,13 @@ class WorkPackages::UpdateService < ::BaseServices::Update
 
   def update_related_work_packages(service_call)
     update_ancestors([service_call.result]).each do |ancestor_service_call|
-      service_call.merge!(ancestor_service_call)
+      ancestor_service_call.dependent_results.each do |ancestor_dependent_service_call|
+        service_call.add_dependent!(ancestor_dependent_service_call)
+      end
     end
 
     update_related(service_call.result).each do |related_service_call|
-      service_call.merge!(related_service_call)
+      service_call.add_dependent!(related_service_call)
     end
   end
 

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -36,10 +36,10 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
       updated_work_package_ids = []
 
       each_applicable_work_package(previous_working_days) do |work_package|
-        updated_work_package_ids += apply_change_to_work_package(user, work_package).map(&:id)
+        updated_work_package_ids.concat(apply_change_to_work_package(user, work_package).pluck(:id))
       end
       each_applicable_predecessor(updated_work_package_ids) do |work_package|
-        updated_work_package_ids += apply_change_to_predecessor(user, work_package).map(&:id)
+        updated_work_package_ids.concat(apply_change_to_predecessor(user, work_package).pluck(:id))
       end
 
       set_journal_notice(updated_work_package_ids, previous_working_days)

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -117,7 +117,7 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
 
   def working_day_change_message(day, working)
     I18n.t(:"working_days.journal_note.days.#{working ? :working : :non_working}",
-           day: I18n.t('date.day_names')[day])
+           day: WeekDay.find_by!(day:).name)
   end
 
   def for_each_work_package_in_scope(scope)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3112,6 +3112,11 @@ en:
     change_button: "Change working days"
     warning: >
       Changing which days of the week are considered working days can affect the start and finish days of all work packages in all projects in this instance.
+    journal_note:
+      changed: _**Working days** changed (%{changes})._
+      days:
+        working: "%{day} is now working"
+        non_working: "%{day} is now non-working"
   nothing_to_preview: "Nothing to preview"
 
   api_v3:

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -116,14 +116,11 @@ describe 'Working Days', type: :feature, js: true do
       follower              |                XXX  |
     CHART
 
-    [earliest_work_package,
-     second_work_package,
-     follower].each do |work_package|
-      expect(work_package.journals.count)
-        .to eq 2
-      expect(work_package.journals.last.notes)
-        .to include("Working days changed (Monday is now non-working, Friday is now non-working).")
-    end
+    # The updated work packages will have a journal entry informing about the change
+    wp_page = Pages::FullWorkPackage.new(earliest_work_package)
+    wp_page.visit!
+
+    wp_page.expect_comment(text: "Working days changed (Monday is now non-working, Friday is now non-working).")
   end
 
   it 'shows error when non working days are all unset' do

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -29,6 +29,8 @@
 require 'spec_helper'
 
 describe 'Working Days', type: :feature, js: true do
+  create_shared_association_defaults_for_work_package_factory
+
   shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }
   shared_let(:admin) { create :admin }
   let_schedule(<<~CHART)
@@ -117,12 +119,14 @@ describe 'Working Days', type: :feature, js: true do
     [earliest_work_package,
      second_work_package,
      follower].each do |work_package|
+      expect(work_package.journals.count)
+        .to eq 2
       expect(work_package.journals.last.notes)
-        .to include("Working days changed")
+        .to include("Working days changed (Monday is now non-working, Friday is now non-working).")
     end
   end
 
-  it 'shows error when non working days are set' do
+  it 'shows error when non working days are all unset' do
     uncheck 'Monday'
     uncheck 'Tuesday'
     uncheck 'Wednesday'

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -422,6 +422,11 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql(sibling2_attributes[:start_date])
       expect(sibling2_work_package.due_date)
         .to eql(sibling2_attributes[:due_date])
+
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -485,6 +490,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
       sibling2_work_package.reload
       expect(sibling2_work_package.done_ratio)
         .to eql(sibling2_attributes[:done_ratio])
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -546,6 +557,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
       child_work_package.reload
       expect(child_work_package.estimated_hours)
         .to eql(child_attributes[:estimated_hours].to_f)
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -571,6 +588,12 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to be_truthy
       expect(grandparent_work_package.reload.ignore_non_working_days)
         .to be_truthy
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         parent_work_package,
+                         grandparent_work_package])
     end
   end
 
@@ -768,6 +791,16 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql Time.zone.today + 32.days
       expect(following3_sibling_work_package.due_date)
         .to eql Time.zone.today + 36.days
+
+      # Returns changed work packages
+      expect(subject.all_results)
+        .to match_array([work_package,
+                         following_parent_work_package,
+                         following_work_package,
+                         following2_parent_work_package,
+                         following2_work_package,
+                         following3_parent_work_package,
+                         following3_work_package])
     end
     # rubocop:enable RSpec/ExampleLength
     # rubocop:enable RSpec/MultipleExpectations
@@ -816,6 +849,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
 
       expect(work_package.reload.slice(:start_date, :due_date).symbolize_keys)
         .to eq(expected_child_dates)
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         parent_work_package])
     end
   end
 
@@ -918,6 +955,11 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql work_package_attributes[:start_date]
       expect(new_parent_work_package.due_date)
         .to eql new_sibling_attributes[:due_date]
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         former_parent_work_package,
+                         new_parent_work_package])
     end
   end
 
@@ -995,6 +1037,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql new_parent_predecessor_attributes[:due_date] + 1.day
       expect(new_parent_work_package.due_date)
         .to eql new_parent_predecessor_attributes[:due_date] + 4.days
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         new_parent_work_package])
     end
   end
 
@@ -1064,6 +1110,10 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         .to eql sibling_attributes[:start_date]
       expect(parent_work_package.due_date)
         .to eql sibling_attributes[:due_date]
+
+      expect(subject.all_results.uniq)
+        .to match_array([work_package,
+                         parent_work_package])
     end
   end
 

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -551,4 +551,25 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       end
     end
   end
+
+  context 'when turning Sunday into a non working day' do
+    let_schedule(<<~CHART)
+      days          | MTWTFSSm |
+      work_package  |     X▓▓X |
+    CHART
+
+    before do
+      set_working_week_days('Sunday')
+    end
+
+    # Not interested in the scheduling changes in this spec
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [work_package]
+      end
+      let(:journal_notice) do
+        "**Working days** changed (Sunday is now working)."
+      end
+    end
+  end
 end

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
          wp_start_only,
          wp_due_only]
       end
-      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+      let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
     end
   end
 
@@ -123,7 +123,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       let(:changed_work_packages) do
         [work_package]
       end
-      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+      let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
     end
   end
 
@@ -149,7 +149,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       let(:changed_work_packages) do
         [work_package]
       end
-      let(:journal_notice) { "Working days changed (Saturday is now working)." }
+      let(:journal_notice) { "**Working days** changed (Saturday is now working)." }
     end
   end
 
@@ -177,7 +177,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       let(:changed_work_packages) do
         [predecessor, follower]
       end
-      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+      let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
     end
   end
 
@@ -208,7 +208,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       let(:unchanged_work_packages) do
         [predecessor]
       end
-      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+      let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
     end
   end
 
@@ -297,7 +297,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       let(:unchanged_work_packages) do
         [follower]
       end
-      let(:journal_notice) { "Working days changed (Wednesday is now working)." }
+      let(:journal_notice) { "**Working days** changed (Wednesday is now working)." }
     end
   end
 
@@ -406,7 +406,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         [wp1, wp2, wp3]
       end
       let(:journal_notice) do
-        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+        "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
       end
     end
   end
@@ -449,7 +449,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         [wp1, wp2, wp3]
       end
       let(:journal_notice) do
-        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+        "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
       end
     end
   end
@@ -487,7 +487,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         [wp2]
       end
       let(:journal_notice) do
-        "Working days changed (Tuesday is now working, Wednesday is now working, Friday is now working)."
+        "**Working days** changed (Tuesday is now working, Wednesday is now working, Friday is now working)."
       end
     end
   end
@@ -522,7 +522,32 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         [wp1, wp2, wp3]
       end
       let(:journal_notice) do
-        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+        "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+      end
+    end
+  end
+
+  context 'when having a non english default language', with_settings: { default_language: :fr } do
+    let_schedule(<<~CHART)
+      days          | fssMTWTFSS |
+      work_package  | X▓▓XX   ░░ |
+    CHART
+
+    before do
+      set_working_week_days('saturday')
+    end
+
+    # Not interested in the scheduling changes in this spec
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [work_package]
+      end
+      let(:journal_notice) do
+        I18n.with_locale(:fr) do
+          I18n.t(:'working_days.journal_note.changed',
+                 changes: I18n.t(:'working_days.journal_note.days.working',
+                                 day: I18n.t('date.day_names')[6]))
+        end
       end
     end
   end

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     end
   end
 
-  context 'when turning Sunday into a non working day' do
+  context 'when turning Sunday into a working day' do
     let_schedule(<<~CHART)
       days          | MTWTFSSm |
       work_package  |     X▓▓X |

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -39,6 +39,28 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   # This must run before any working days are changed, hence the `let!` form
   let!(:previous_working_days) { work_week }
 
+  shared_examples_for 'journal updates with note' do
+    let(:changed_work_packages) { [] }
+    let(:unchanged_work_packages) { [] }
+    let(:journal_notice) { raise 'need to specify note' }
+
+    it 'adds journal entries to changed work packages' do
+      job.perform_now(user_id: user.id, previous_working_days:)
+
+      changed_work_packages.each do |work_package|
+        expect(work_package.journals.count)
+          .to eq 2
+        expect(work_package.journals.last.notes)
+          .to include(journal_notice)
+      end
+
+      unchanged_work_packages.each do |work_package|
+        expect(work_package.journals.count)
+          .to eq 1
+      end
+    end
+  end
+
   context 'when a work package includes a date that is now a non-working day' do
     let_schedule(<<~CHART)
       days                  | MTWTFSS |
@@ -65,6 +87,17 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         wp_due_only           |   ░] ░░ |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [work_package,
+         work_package_on_start,
+         work_package_on_due,
+         wp_start_only,
+         wp_due_only]
+      end
+      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+    end
   end
 
   context 'when a work package was scheduled to start on a date that is now a non-working day' do
@@ -85,6 +118,13 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         work_package |   ░XX░░ |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [work_package]
+      end
+      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+    end
   end
 
   context 'when a work package includes a date that is no more a non-working day' do
@@ -103,6 +143,13 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         days          | fssMTWTFSS |
         work_package  | XX▓X     ░ |
       CHART
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [work_package]
+      end
+      let(:journal_notice) { "Working days changed (Saturday is now working)." }
     end
   end
 
@@ -125,6 +172,13 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         follower    |   ░ XXX | working days include weekends
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [predecessor, follower]
+      end
+      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
+    end
   end
 
   context 'when a follower has a predecessor with delay covering a day that is now a non-working day' do
@@ -145,6 +199,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         predecessor | XX░  ░░ |
         follower    |   ░ X░░ |
       CHART
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [follower]
+      end
+      let(:unchanged_work_packages) do
+        [predecessor]
+      end
+      let(:journal_notice) { "Working days changed (Wednesday is now non-working)." }
     end
   end
 
@@ -167,6 +231,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         follower    |   ░  ░░ |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:unchanged_work_packages) do
+        [predecessor, follower]
+      end
+    end
   end
 
   context 'when a follower has a predecessor with delay covering multiple days with different working changes' do
@@ -184,19 +254,25 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
 
     it 'correctly handles the changes' do
       job.perform_now(user_id: user.id, previous_working_days:)
-      expect(WorkPackage.all).to match_schedule(<<~CHART)
+      expect_schedule(WorkPackage.all, <<~CHART)
         days        | MTWTFSS |
         predecessor | X░   ░░ |
         follower    |  ░  X░░ |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:unchanged_work_packages) do
+        [predecessor, follower]
+      end
+    end
   end
 
   context 'when a follower has a predecessor with dates covering a day that is now a working day' do
     let_schedule(<<~CHART)
-      days        | MTWTFSS  |
-      predecessor |  X▓X ░░  | working days work week
-      follower    |   ░ XXX  | working days include weekends, follows predecessor
+      days        | MTWTFSS |
+      predecessor |  X▓X ░░ | working days work week
+      follower    |   ░ XXX | working days include weekends, follows predecessor
     CHART
     let(:work_week) { set_work_week('monday', 'tuesday', 'thursday', 'friday') }
 
@@ -206,6 +282,22 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
 
     it 'does not move the follower backwards' do
       job.perform_now(user_id: user.id, previous_working_days:)
+
+      expect_schedule(WorkPackage.all, <<~CHART)
+        days        | MTWTFSS |
+        predecessor |  XX  ░░ |
+        follower    |     XXX |
+      CHART
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [predecessor]
+      end
+      let(:unchanged_work_packages) do
+        [follower]
+      end
+      let(:journal_notice) { "Working days changed (Wednesday is now working)." }
     end
   end
 
@@ -229,6 +321,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         follower    |    XX░░ |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:unchanged_work_packages) do
+        [predecessor, follower]
+      end
+    end
   end
 
   context 'when a work package has working days include weekends, and includes a date that is now a non-working day' do
@@ -248,6 +346,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         work_package | XXXX ░░ | working days include weekends
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:unchanged_work_packages) do
+        [work_package]
+      end
+    end
   end
 
   context 'when a work package only has a duration' do
@@ -263,6 +367,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
     it 'does not change anything' do
       job.perform_now(user_id: user.id, previous_working_days:)
       expect(work_package.duration).to eq(3)
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:unchanged_work_packages) do
+        [work_package]
+      end
     end
   end
 
@@ -289,6 +399,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         wp2  |  ░░ ░░░ ░░X░░░ ░░ ░░░  |
         wp3  | X▓▓X▓▓▓X░░ ░░░ ░░ ░░░  |
       CHART
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [wp1, wp2, wp3]
+      end
+      let(:journal_notice) do
+        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+      end
     end
   end
 
@@ -324,6 +443,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         wp3  |  ░░ ░░░ ░░X |
       CHART
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [wp1, wp2, wp3]
+      end
+      let(:journal_notice) do
+        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+      end
+    end
   end
 
   context 'when having multiple work packages following each other, and having days becoming working days' do
@@ -350,6 +478,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       CHART
       expect(WorkPackage.pluck(:lock_version)).to all(be <= 1)
     end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [wp1, wp3]
+      end
+      let(:unchanged_work_packages) do
+        [wp2]
+      end
+      let(:journal_notice) do
+        "Working days changed (Tuesday is now working, Wednesday is now working, Friday is now working)."
+      end
+    end
   end
 
   context 'when having multiple work packages following each other and first one only has a due date' do
@@ -375,6 +515,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         wp2  |  ░░ ░░░X▓▓X░░░ ░░ ░░░  |
         wp3  |  ░░]░░░ ░░ ░░░ ░░ ░░░  |
       CHART
+    end
+
+    it_behaves_like 'journal updates with note' do
+      let(:changed_work_packages) do
+        [wp1, wp2, wp3]
+      end
+      let(:journal_notice) do
+        "Working days changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+      end
     end
   end
 end


### PR DESCRIPTION
Writes a message to all work packages changed during a working days changed background job run. 

It uses the simplified version of the message where the date changes (working/non-working) are simply enumerated, e.g. "**Working days** changed (Tuesday is now non-working, Wednesday is now working, Friday is now non-working)"

In order to gather the ids of all work packages that were rescheduled, the PR fixes the dependent_results returned by `WorkPackages::UpdateService` to actually include all changed work packages.

Since the ids of the work packages needed to be memorized anyway, this is used to avoid unnecessary loading and rescheduling of work packages involved in a follows relation if they were already changed.

https://community.openproject.org/wp/43640