### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * *' # Daily at 03:00
 
+permissions: {}
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -28,6 +29,9 @@ jobs:
         echo "::set-output name=crowdin_release_branch::release"
 
   crowdin:
+    permissions:
+      contents: write # for git push
+
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 60

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ on:
   push:
     tags:
       - v*
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   publish:
     # restrict this job to base repo for now

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -7,8 +7,17 @@ on:
   pull_request:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   deploy:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      deployments: write # to delete deployments
+      pull-requests: write # to remove labels
+      statuses: write # to create commit status
+
     if: github.repository == 'opf/openproject' && ( github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview') )
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.