### PR TITLE
Allow ldap_tls_options to be a setting

### DIFF
--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -163,7 +163,7 @@ class LdapAuthSource < AuthSource
 
     {
       method: tls_mode.to_sym,
-      tls_options: OpenProject::Configuration.ldap_tls_options.with_indifferent_access
+      tls_options: Setting.ldap_tls_options.with_indifferent_access
     }
   end
 

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -537,8 +537,9 @@ Settings::Definition.define do
       writable: false
 
   add :ldap_tls_options,
+      format: :hash,
       default: {},
-      writable: false
+      writable: true
 
   add :log_level,
       default: 'info',

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -515,11 +515,6 @@ Settings::Definition.define do
       default: nil,
       writable: false
 
-  add :ldap_auth_source_tls_options,
-      format: :string,
-      default: nil,
-      writable: false
-
   # Allow users to manually sync groups in a different way
   # than the provided job using their own cron
   add :ldap_groups_disable_sync_job,

--- a/spec/models/ldap_auth_source_spec.rb
+++ b/spec/models/ldap_auth_source_spec.rb
@@ -43,7 +43,7 @@ describe LdapAuthSource, type: :model do
   end
 
   describe 'overriding tls_options',
-           with_config: { ldap_tls_options: { ca_file: '/path/to/ca/file' } } do
+           with_settings: { ldap_tls_options: { ca_file: '/path/to/ca/file' } } do
     it 'sets the encryption options for start_tls' do
       ldap = LdapAuthSource.new tls_mode: :start_tls
       expect(ldap.send(:ldap_encryption)).to eq(method: :start_tls, tls_options: { 'ca_file' => '/path/to/ca/file' })


### PR DESCRIPTION
It is currently not writable, but would be useful to be in a multitenancy setting