### PR TITLE
bail on altering working days before last change is processed

### DIFF
--- a/app/contracts/settings/working_days_params_contract.rb
+++ b/app/contracts/settings/working_days_params_contract.rb
@@ -31,12 +31,19 @@ module Settings
     include RequiresAdminGuard
 
     validate :working_days_are_present
+    validate :unique_job
 
     protected
 
     def working_days_are_present
       if working_days.empty?
         errors.add :base, :working_days_are_missing
+      end
+    end
+
+    def unique_job
+      if WorkPackages::ApplyWorkingDaysChangeJob.scheduled?
+        errors.add :base, :previous_working_day_changes_unprocessed
       end
     end
 

--- a/app/workers/concerns/scheduled_job.rb
+++ b/app/workers/concerns/scheduled_job.rb
@@ -1,0 +1,43 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+module ScheduledJob
+  extend ActiveSupport::Concern
+
+  class_methods do
+    ##
+    # Is there a job scheduled?
+    def scheduled?
+      delayed_job_query.exists?
+    end
+
+    private
+
+    def delayed_job_query
+      Delayed::Job.where('handler LIKE ?', "%job_class: #{name}%")
+    end
+  end
+end

--- a/app/workers/cron/cron_job.rb
+++ b/app/workers/cron/cron_job.rb
@@ -33,6 +33,8 @@ module Cron
     # List of registered jobs, requires eager load in dev(!)
     class_attribute :registered_jobs, default: []
 
+    include ScheduledJob
+
     class << self
       ##
       # Register new job class(es)
@@ -66,18 +68,8 @@ module Cron
         delayed_job&.destroy
       end
 
-      ##
-      # Is there a job scheduled?
-      def scheduled?
-        delayed_job_query.exists?
-      end
-
       def delayed_job
         delayed_job_query.first
-      end
-
-      def delayed_job_query
-        Delayed::Job.where('handler LIKE ?', "%job_class: #{name}%")
       end
     end
   end

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -28,6 +28,7 @@
 
 class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
   queue_with_priority :above_normal
+  include ::ScheduledJob
 
   def perform(user_id:, previous_working_days:)
     user = User.find(user_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -800,6 +800,7 @@ en:
           attributes:
             base:
               working_days_are_missing: 'At least one working day needs to be specified.'
+              previous_working_day_changes_unprocessed: 'The previous changes to the working days configuration have not been applied yet.'
         time_entry:
           attributes:
             hours:

--- a/spec/contracts/settings/working_days_params_contract_spec.rb
+++ b/spec/contracts/settings/working_days_params_contract_spec.rb
@@ -37,6 +37,13 @@ describe Settings::WorkingDaysParamsContract do
   let(:contract) do
     described_class.new(setting, current_user, params:)
   end
+  let(:apply_job_scheduled) { false }
+
+  before do
+    allow(WorkPackages::ApplyWorkingDaysChangeJob)
+      .to receive(:scheduled?)
+            .and_return(apply_job_scheduled)
+  end
 
   it_behaves_like 'contract is valid for active admins and invalid for regular users'
 
@@ -44,5 +51,12 @@ describe Settings::WorkingDaysParamsContract do
     let(:params) { { working_days: [] } }
 
     include_examples 'contract is invalid', base: :working_days_are_missing
+  end
+
+  context 'with an ApplyWorkingDaysChangeJob already existing' do
+    let(:params) { { working_days: [1, 2, 3] } }
+    let(:apply_job_scheduled) { true }
+
+    include_examples 'contract is invalid', base: :previous_working_day_changes_unprocessed
   end
 end

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -377,4 +377,26 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       CHART
     end
   end
+
+  describe '.scheduled?' do
+    context 'with a job already scheduled in the DB' do
+      before do
+        ActiveJob::QueueAdapters::DelayedJobAdapter
+          .new
+          .enqueue(described_class.new(user_id: 5, previous_working_days: [1, 2]))
+      end
+
+      it 'is true' do
+        expect(described_class)
+          .to be_scheduled
+      end
+    end
+
+    context 'without a job already scheduled in the DB' do
+      it 'is false' do
+        expect(described_class)
+          .not_to be_scheduled
+      end
+    end
+  end
 end


### PR DESCRIPTION
Checks for the existence of a `WorkPackages::ApplyWorkingDaysChangeJob` in the database and presents an error message in case one is found.

https://community.openproject.org/wp/44220