### PR TITLE
Make expect_schedule behave like match_schedule

### DIFF
--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -246,6 +246,9 @@ describe WorkPackages::SetScheduleService, 'working days' do
           expect_schedule(subject.all_results, <<~CHART)
                           | MTWTFSS       |
             work_package  | XXXXX..X      |
+          CHART
+          expect_schedule([follower], <<~CHART)
+                          | MTWTFSS       |
             follower      |          XXX  |
           CHART
         end
@@ -386,6 +389,9 @@ describe WorkPackages::SetScheduleService, 'working days' do
           expect_schedule(subject.all_results, <<~CHART)
             days          | MTWTFSS |
             work_package  |         |
+          CHART
+          expect_schedule([follower], <<~CHART)
+            days          | MTWTFSS |
             follower      |   XXX   |
           CHART
         end
@@ -409,6 +415,9 @@ describe WorkPackages::SetScheduleService, 'working days' do
           expect_schedule(subject.all_results, <<~CHART)
             days          | MTWTFSS |
             work_package  |         |
+          CHART
+          expect_schedule([follower], <<~CHART)
+            days          | MTWTFSS |
             follower      |     ]   |
           CHART
         end

--- a/spec/support/schedule_helpers/example_methods.rb
+++ b/spec/support/schedule_helpers/example_methods.rb
@@ -33,11 +33,11 @@ module ScheduleHelpers
     # For instance:
     #
     #   create_schedule(<<~CHART)
-    #     days       | MTWTFSS   |
-    #     main       | XX        |
-    #     follower   |   XXX     | follows main
-    #     start_only |  [        |
-    #     due_only   |    ]      |
+    #     days       | MTWTFSS |
+    #     main       | XX      |
+    #     follower   |   XXX   | follows main
+    #     start_only |  [      |
+    #     due_only   |    ]    |
     #   CHART
     #
     # is equivalent to:
@@ -87,37 +87,29 @@ module ScheduleHelpers
 
     # Expect the given work packages to match a visual chart representation.
     #
+    # It uses +match_schedule+ internally.
+    #
     # For instance:
     #
     #   it 'is scheduled' do
     #     expect_schedule(work_packages, <<~CHART)
-    #       days     | MTWTFSS   |
-    #       main     | XX        |
-    #       follower |   XXX     |
+    #       days     | MTWTFSS |
+    #       main     | XX      |
+    #       follower |   XXX   |
     #     CHART
     #   end
     #
     # is equivalent to:
     #
     #   it 'is scheduled' do
-    #     main = work_packages.find { _1.id == main.id } || main
-    #     expect(main.start_date).to eq(next_monday)
-    #     expect(main.due_date).to eq(next_monday + 1.day)
-    #     follower = work_packages.find { _1.id == follower.id } || follower
-    #     expect(follower.start_date).to eq(next_monday + 2.days)
-    #     expect(follower.due_date).to eq(next_monday + 4.days)
+    #     expect(work_packages).to match_schedule(<<~CHART)
+    #       days     | MTWTFSS |
+    #       main     | XX      |
+    #       follower |   XXX   |
+    #     CHART
     #   end
     def expect_schedule(work_packages, chart)
-      by_id = work_packages.index_by(&:id)
-      chart = Chart.for(chart)
-      chart.work_packages_attributes.each do |attributes|
-        name = attributes[:name]
-        raise ArgumentError, "unable to find WorkPackage :#{name}" unless respond_to?(name)
-
-        work_package = send(name)
-        work_package = by_id[work_package.id] if by_id.has_key?(work_package.id)
-        expect(work_package).to have_attributes(attributes.slice(:subject, :start_date, :due_date))
-      end
+      expect(work_packages).to match_schedule(chart)
     end
   end
 end

--- a/spec/support_spec/schedule_helpers/example_methods_spec.rb
+++ b/spec/support_spec/schedule_helpers/example_methods_spec.rb
@@ -179,45 +179,14 @@ describe ScheduleHelpers::ExampleMethods do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
-    it 'raises an error if no work package exists for a given name' do
-      expect do
-        expect_schedule([main], <<~CHART)
-                  | MTWTFSS |
-          unknown | XX      |
-        CHART
-      end.to raise_error(ArgumentError, "unable to find WorkPackage :unknown")
-    end
-
-    it 'checks against the given work packages rather than the ones from the let! definitions' do
-      expect do
-        expect_schedule([], <<~CHART)
-                | MTWTFSS |
-          main  | XX      |
-        CHART
-      end.not_to raise_error
-    end
-
-    it 'uses the work package from the let! definitions if it is not given as parameter' do
-      a_modified_instance_of_main = WorkPackage.find(main.id)
-      a_modified_instance_of_main.due_date += 2.days
+    it 'raises an error if a work package name in the chart cannot be found in the given work packages' do
       expect do
         expect_schedule([main], <<~CHART)
                 | MTWTFSS |
           main  | XX      |
+          other |   XXXX  |
         CHART
-      end.not_to raise_error
-      expect do
-        expect_schedule([a_modified_instance_of_main], <<~CHART)
-                | MTWTFSS |
-          main  | XXXX    |
-        CHART
-      end.not_to raise_error
-      expect do
-        expect_schedule([], <<~CHART)
-                | MTWTFSS |
-          main  | XX      |
-        CHART
-      end.not_to raise_error
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
 end


### PR DESCRIPTION
Using `expect_schedule(work_packages, chart)` should behave like using `expect(work_packages).to match_schedule(chart)`.