### PR TITLE
add constraint to work package start/due date

### DIFF
--- a/db/migrate/20220926124435_constrain_work_package_dates.rb
+++ b/db/migrate/20220926124435_constrain_work_package_dates.rb
@@ -1,0 +1,18 @@
+class ConstrainWorkPackageDates < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        WorkPackage.where("start_date > due_date").in_batches.each_record do |work_package|
+          User.execute_as(User.system) do
+            work_package.start_date = work_package.due_date
+            work_package.duration = 1
+            work_package.journal_notes = '_Resetting the start date automatically to fix inconsistent dates._'
+            work_package.save!(validate: false)
+          end
+        end
+      end
+    end
+
+    add_check_constraint :work_packages, 'due_date >= start_date', name: 'work_packages_due_larger_start_date'
+  end
+end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -276,12 +276,9 @@ describe WorkPackages::SetAttributesService,
 
   context 'with the actual contract' do
     let(:invalid_wp) do
-      wp = create(:work_package)
-      wp.start_date = Time.zone.today + 5.days
-      wp.due_date = Time.zone.today
-      wp.save!(validate: false)
-
-      wp
+      build(:work_package, subject: '').tap do |wp|
+        wp.save!(validate: false)
+      end
     end
     let(:user) { build_stubbed(:admin) }
     let(:instance) do
@@ -290,9 +287,9 @@ describe WorkPackages::SetAttributesService,
                           contract_class:)
     end
 
-    context 'with a current invalid start date' do
+    context 'with a currently invalid subject' do
       let(:call_attributes) { attributes }
-      let(:attributes) { { start_date: Time.zone.today - 5.days } }
+      let(:attributes) { { subject: 'ABC' } }
       let(:contract_valid) { true }
 
       subject { instance.call(call_attributes) }


### PR DESCRIPTION
Add a constraint on the work packages table to ensure that start_date <= due_date.

Work packages which are invalid are updated so that their start date is set to their due date. This does not bubble up which leads to new inconsistencies. But those will be fixed automatically whenever a work package chain is rescheduled.

https://community.openproject.org/wp/44243  