### PR TITLE
[Fix] BIM XML wp exporter error regarding missing view point snapshot

### DIFF
--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
@@ -223,7 +223,7 @@ module OpenProject::Bim::BcfXml
       issue.viewpoints.find_each do |vp|
         xml.Viewpoints "Guid" => vp.uuid do
           xml.Viewpoint "#{vp.uuid}.bcfv"
-          xml.Snapshot "#{vp.uuid}#{vp.snapshot.extension}"
+          xml.Snapshot "#{vp.uuid}#{vp.snapshot.extension}" if vp.snapshot
         end
       end
     end

--- a/modules/bim/spec/factories/bcf_issue_factory.rb
+++ b/modules/bim/spec/factories/bcf_issue_factory.rb
@@ -111,15 +111,19 @@ FactoryBot.define do
     labels { [] }
     sequence(:index)
 
+    transient do
+      vp_snapshot { nil }
+    end
+
     factory :bcf_issue_with_viewpoint do
-      after(:create) do |issue|
-        create(:bcf_viewpoint, issue:)
+      after(:create) do |issue, evaluator|
+        create(:bcf_viewpoint, issue:, snapshot: evaluator.vp_snapshot)
       end
     end
 
     factory :bcf_issue_with_comment do
-      after(:create) do |issue|
-        viewpoint = create(:bcf_viewpoint, issue:)
+      after(:create) do |issue, evaluator|
+        viewpoint = create(:bcf_viewpoint, issue:, snapshot: evaluator.vp_snapshot)
         create(:bcf_comment, issue:, viewpoint:)
       end
     end


### PR DESCRIPTION
Driveby fix for [an error](https://appsignal.com/openproject-gmbh/sites/62eba940d2a5e473be7feefd/exceptions/incidents/723?timestamp=2022-09-26T10%3A40%3A00Z) on the BIM work package xml exporter.