### PR TITLE
[Fix] Error on Mails::WatcherJob missing notification_settings

### DIFF
--- a/app/workers/mails/watcher_job.rb
+++ b/app/workers/mails/watcher_job.rb
@@ -61,6 +61,8 @@ class Mails::WatcherJob < Mails::DeliverJob
                .applicable(watcher.watchable.project)
                .first
 
+    return false if settings.nil?
+
     settings.watched
   end
 

--- a/spec/workers/mails/shared/watcher_job.rb
+++ b/spec/workers/mails/shared/watcher_job.rb
@@ -147,4 +147,11 @@ shared_examples "watcher job" do |action|
       [build_stubbed(:notification_setting, mentioned: true, involved: false, watched: false)]
     end
   end
+
+  it_behaves_like 'does not notify the watcher' do
+    # Regression test for notification settings being empty
+    let(:notification_settings) do
+      []
+    end
+  end
 end


### PR DESCRIPTION
Fixes [an error](https://appsignal.com/openproject-gmbh/sites/62b06dacd2a5e41321946fcf/exceptions/incidents/497?timestamp=2022-09-14T08%3A28%3A28Z) on the Mails::WatcherJob when the watcher user's `notification_settings` are empty.

Additionally we should investigate why the setting was deleted in the first place, as they all should have a default setting according to the [`Users::SetAttributesService`](https://github.com/opf/openproject/blob/3316b018e666e39bb0709d8675b88eec00e37971/app/services/users/set_attributes_service.rb#L55).