### PR TITLE
[Fix] Remove projects atom feed as it's not being used

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,10 +62,6 @@ class ProjectsController < ApplicationController
       format.any(*supported_export_formats) do
         export_list(request.format.symbol)
       end
-
-      format.atom do
-        atom_list
-      end
     end
   end
 

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -37,14 +37,14 @@ describe ProjectsController, type: :routing do
     end
 
     it do
-      expect(get('/projects.atom')).to route_to(
-        controller: 'projects', action: 'index', format: 'atom'
+      expect(get('/projects.csv')).to route_to(
+        controller: 'projects', action: 'index', format: 'csv'
       )
     end
 
     it do
-      expect(get('/projects.xml')).to route_to(
-        controller: 'projects', action: 'index', format: 'xml'
+      expect(get('/projects.xls')).to route_to(
+        controller: 'projects', action: 'index', format: 'xls'
       )
     end
   end


### PR DESCRIPTION
Driveby fix for [an error](https://appsignal.com/openproject-gmbh/sites/62b06dacd2a5e41321946fcf/exceptions/incidents/402?timestamp=2022-09-14T22%3A57%3A05Z) on the `ProjectsController#index` `atom` feed.

The atom format seems to be introduced [in this commit](https://github.com/opf/openproject/commit/eb4d7a1), however the commit and the associated PR has nothing to do with the atom format, so I assumed it was an accidental addition. cc:/ @oliverguenther 