### PR TITLE
[#44286] Support mobile view - vertical alignment of weekly checkboxes

### DIFF
--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -427,6 +427,12 @@ fieldset.form--fieldset
   &.-vertical
     display: block
 
+  &.-horizontal
+    flex-wrap: wrap
+    &> *
+      flex-basis: calc((50rem - 100%) * 999)
+      flex-grow: 1
+
   .form--field.-visible-overflow &
     overflow: visible
 

--- a/frontend/src/global_styles/content/_toast.sass
+++ b/frontend/src/global_styles/content/_toast.sass
@@ -42,9 +42,9 @@ $nm-color-success-border: #35c53f
 $nm-color-success-icon: #35c53f
 $nm-color-success-background: #d8fdd1
 
-$nm-color-warning-border: #b5b078
-$nm-color-warning-icon: #333
-$nm-color-warning-background: #f4f4aa
+$nm-color-warning-border: #ef9e56
+$nm-color-warning-icon: #ef9e56
+$nm-color-warning-background: #ffe6c6
 
 $nm-color-info-icon: #333
 
@@ -71,7 +71,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   color: $nm-color-success-icon
 
 %nm-icon-warning
-  @include icon-mixin-attention
+  @include icon-mixin-warning
   color: $nm-color-warning-icon
 
 %nm-icon-info


### PR DESCRIPTION
See [OP#44286](https://community.openproject.org/work_packages/44286)

Following a discussion with @psatyal, I included the updated warning toast style. This is a global change, meaning all warning toasts across the site are affected.

![Sep-27-2022 15-15-43](https://user-images.githubusercontent.com/83396/192536710-13c57e4f-50f0-43cb-8127-7a65da6ff6c2.gif)
