### PR TITLE
[Fix] Create rake task to fix missing notification settings

### DIFF
--- a/app/contracts/users/create_contract.rb
+++ b/app/contracts/users/create_contract.rb
@@ -41,12 +41,19 @@ module Users
     validate :authentication_defined
     validate :type_is_user
     validate :user_limit_not_exceeded
+    validate :notification_settings_present
 
     private
 
     def user_limit_not_exceeded
       if OpenProject::Enterprise.user_limit_reached?
         errors.add :base, :user_limit_reached
+      end
+    end
+
+    def notification_settings_present
+      if model.notification_settings.empty?
+        errors.add :notification_settings, :blank
       end
     end
 

--- a/lib/tasks/fix_missing_notification_settings.rake
+++ b/lib/tasks/fix_missing_notification_settings.rake
@@ -1,0 +1,44 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+namespace :migrations do
+  desc "Fix the missing notification settings"
+  task fix_missing_notification_settings: :environment do
+    ActiveRecord::Base.connection.execute <<~SQL.squish
+      INSERT INTO
+        notification_settings
+        (user_id, watched, involved, mentioned)
+      SELECT
+        u.id, true, true, true
+      FROM
+        users u
+      WHERE type = 'User'
+      AND NOT EXISTS (SELECT * FROM notification_settings ns WHERE ns.user_id = u.id)
+    SQL
+  end
+end

--- a/lib/tasks/fix_missing_notification_settings.rake
+++ b/lib/tasks/fix_missing_notification_settings.rake
@@ -32,9 +32,9 @@ namespace :migrations do
     ActiveRecord::Base.connection.execute <<~SQL.squish
       INSERT INTO
         notification_settings
-        (user_id, watched, involved, mentioned)
+        (user_id)
       SELECT
-        u.id, true, true, true
+        u.id
       FROM
         users u
       WHERE type = 'User'

--- a/spec/contracts/users/create_contract_spec.rb
+++ b/spec/contracts/users/create_contract_spec.rb
@@ -43,7 +43,8 @@ describe Users::CreateContract do
         login: user_login,
         mail: user_mail,
         password: user_password,
-        password_confirmation: user_password_confirmation
+        password_confirmation: user_password_confirmation,
+        notification_settings: [NotificationSetting.new]
       }
     end
 


### PR DESCRIPTION
Follow up on [this comment](https://github.com/opf/openproject/pull/11355#issuecomment-1259402005) from #11355.
Since this code might need to be ran multiple times in the future, I decided to create a rake task instead of a migration.