### PR TITLE
Add action slot for inputs below it, don't impose padding on it

### DIFF
--- a/frontend/src/app/features/invite-user-modal/principal/principal.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal.component.html
@@ -71,7 +71,7 @@
       ></op-ium-role-search>
       <p
         class="spot-form-field--description"
-        slot="help-text"
+        slot="action"
         [innerHtml]="text.role.description()"
       ></p>
 
@@ -98,7 +98,7 @@
 
       <p 
         class="spot-form-field--description" 
-        slot="help-text"
+        slot="action"
         [innerHtml]="text.message.description()">
       </p>
     </spot-form-field>

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
@@ -20,7 +20,7 @@
       ></op-project-autocompleter>
 
       <div
-        slot="help-text"
+        slot="action"
         *ngIf="projectControl.errors?.lackingPermission"
       >
         {{ text.project.lackingPermissionInfo }}

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -42,9 +42,9 @@
           (focusin)="setCurrentActivatedField('start')"
         ></spot-text-field>
         <button
-          slot="help-text"
+          slot="action"
           type="button"
-          class="spot-link"
+          class="spot-link op-datepicker-modal--today-link"
           [ngClass]="{ 'op-datepicker-modal--hidden-link': !showTodayLink() }"
           (click)="setToday('start')"
           [textContent]="text.today">
@@ -68,9 +68,9 @@
           (focusin)="setCurrentActivatedField('end')"
         ></spot-text-field>
         <button
-          slot="help-text"
+          slot="action"
           type="button"
-          class="spot-link"
+          class="spot-link op-datepicker-modal--today-link"
           [ngClass]="{ 'op-datepicker-modal--hidden-link': !showTodayLink() }"
           (click)="setToday('end')"
           [textContent]="text.today">

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -44,7 +44,7 @@
         <button
           slot="action"
           type="button"
-          class="spot-link op-datepicker-modal--today-link"
+          class="spot-link"
           [ngClass]="{ 'op-datepicker-modal--hidden-link': !showTodayLink() }"
           (click)="setToday('start')"
           [textContent]="text.today">
@@ -70,7 +70,7 @@
         <button
           slot="action"
           type="button"
-          class="spot-link op-datepicker-modal--today-link"
+          class="spot-link"
           [ngClass]="{ 'op-datepicker-modal--hidden-link': !showTodayLink() }"
           (click)="setToday('end')"
           [textContent]="text.today">

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
@@ -23,32 +23,27 @@
     </div>
 
     <div class="op-datepicker-modal--dates-container">
-      <div class="form--field op-datepicker-modal--date-form">
-        <label class="form--label"
-               [textContent]="text.date">
-        </label>
-        <div class="form--field-container">
-          <div class="form--text-field-container op-datepicker-modal--date-container">
-            <spot-text-field
-              name="date"
-              class="op-datepicker-modal--date-field"
-              [ngClass]="{ 'op-datepicker-modal--date-field_current': this.dateModalScheduling.isSchedulable }"
-              [(ngModel)]="date"
-              (ngModelChange)="dateChangedManually$.next()"
-              [showClearButton]="true"
-            ></spot-text-field>
-          </div>
-        </div>
-        <div class="form--field-extra-actions">
-          <button
-            type="button"
-            class="spot-link"
-            [ngClass]="{ 'op-datepicker-modal--hidden-link': !dateModalScheduling.isSchedulable }"
-            (click)="setToday()"
-            [textContent]="text.today">
-          </button>
-        </div>
-      </div>
+      <spot-form-field
+        [label]="text.date"
+        >
+        <spot-text-field
+          slot="input"
+          name="date"
+          class="op-datepicker-modal--date-field"
+          [ngClass]="{ 'op-datepicker-modal--date-field_current': this.dateModalScheduling.isSchedulable }"
+          [(ngModel)]="date"
+          (ngModelChange)="dateChangedManually$.next()"
+          [showClearButton]="true"
+        ></spot-text-field>
+        <button
+          slot="action"
+          type="button"
+          class="spot-link"
+          [ngClass]="{ 'op-datepicker-modal--hidden-link': !dateModalScheduling.isSchedulable }"
+          (click)="setToday()"
+          [textContent]="text.today">
+        </button>
+      </spot-form-field>
     </div>
 
     <input id="flatpickr-input"

--- a/frontend/src/app/spot/components/form-field/form-field.component.html
+++ b/frontend/src/app/spot/components/form-field/form-field.component.html
@@ -35,8 +35,10 @@
     <ng-content select="[slot=errors]"></ng-content>
   </div>
 
-  <div class="spot-form-field--help-text">
-    <ng-content select="[slot=help-text]"></ng-content>
+  <div
+    class="spot-form-field--action"
+  >
+    <ng-content select="[slot=action]"></ng-content>
   </div>
 </ng-container>
 

--- a/frontend/src/app/spot/styles/sass/components/form-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/form-field.sass
@@ -28,6 +28,9 @@
   &--help-text
     padding-left: $spot-spacing-0-25
 
+  &--action
+    @include spot-body-small
+
   &--input
     margin-bottom: $spot-spacing-0_25
 

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -181,7 +181,7 @@ module Components
       def expect_help_displayed(message)
         within_modal do
           expect(page)
-            .to have_selector('.spot-form-field--help-text', text: message)
+            .to have_text(message)
         end
       end
     end


### PR DESCRIPTION
The padding was meant for the attribute-help-text icon and accidentally got moved into the text below the input, causing it to be non-aligned.

https://community.openproject.org/projects/openproject/work_packages/44147/activity?query_id=3510#activity-19