### PR TITLE
Move fsevent to the optional depencencies as it is not required on mac

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50931,12 +50931,14 @@
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "chownr": {
@@ -56410,7 +56412,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -56419,6 +56420,9 @@
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -64731,7 +64735,6 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -64740,6 +64743,9 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          },
+          "optionalDependencies": {
+            "fsevents": "^1.2.7"
           }
         },
         "fill-range": {
@@ -65098,7 +65104,6 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -65107,6 +65112,9 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          },
+          "optionalDependencies": {
+            "fsevents": "^1.2.7"
           }
         },
         "cliui": {


### PR DESCRIPTION
While running `bin/setup_dev` I am getting the following error on mac os:

```
Installing node_modules ... 
npm WARN prepare removing existing node_modules/ before installation
npm ERR! fsevents not accessible from chokidar
```

Moving `fsevents` to the optional dependencies solves the issue.