### PR TITLE
Import HttpClient module only once

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {
   Injector,
   NgModule,
 } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { States } from 'core-app/core/states/states.service';
@@ -168,6 +169,9 @@ export function initializeServices(injector:Injector) {
 
     // Angular Forms
     ReactiveFormsModule,
+
+    // Angular Http Client
+    HttpClientModule,
 
     // Augmenting Module
     OpenprojectAugmentingModule,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -32,6 +32,10 @@ import {
   Injector,
   NgModule,
 } from '@angular/core';
+import {
+  HTTP_INTERCEPTORS,
+  HttpClientModule,
+} from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { States } from 'core-app/core/states/states.service';
@@ -88,7 +92,6 @@ import { OpenProjectBackupService } from './core/backup/op-backup.service';
 import { OpenProjectDirectFileUploadService } from './core/file-upload/op-direct-file-upload.service';
 import { OpenProjectStateModule } from 'core-app/core/state/openproject-state.module';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 
 export function initializeServices(injector:Injector) {
@@ -168,6 +171,9 @@ export function initializeServices(injector:Injector) {
 
     // Angular Forms
     ReactiveFormsModule,
+
+    // Angular Http Client
+    HttpClientModule,
 
     // Augmenting Module
     OpenprojectAugmentingModule,

--- a/frontend/src/app/core/apiv3/endpoints/work_packages/work-package-cache.spec.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/work-package-cache.spec.ts
@@ -45,6 +45,7 @@ import { OpenProjectDirectFileUploadService } from 'core-app/core/file-upload/op
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('WorkPackageCache', () => {
   let injector:Injector;
@@ -57,6 +58,7 @@ describe('WorkPackageCache', () => {
     TestBed.configureTestingModule({
       imports: [
         OpenprojectHalModule,
+        HttpClientTestingModule,
       ],
       providers: [
         States,

--- a/frontend/src/app/features/hal/openproject-hal.module.ts
+++ b/frontend/src/app/features/hal/openproject-hal.module.ts
@@ -31,7 +31,6 @@ import {
   ErrorHandler,
   NgModule,
 } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { HalAwareErrorHandler } from 'core-app/features/hal/services/hal-aware-error-handler';
 import { initializeHalResourceConfig } from 'core-app/features/hal/services/hal-resource.config';
@@ -41,7 +40,6 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
 @NgModule({
   imports: [
     CommonModule,
-    HttpClientModule,
   ],
   providers: [
     { provide: ErrorHandler, useClass: HalAwareErrorHandler },

--- a/frontend/src/app/features/hal/resources/hal-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/hal-resource.spec.ts
@@ -35,6 +35,7 @@ import { of } from 'rxjs';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
 import { HalLink, HalLinkInterface } from 'core-app/features/hal/hal-link/hal-link';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import Spy = jasmine.Spy;
 
 describe('HalResource', () => {
@@ -52,6 +53,7 @@ describe('HalResource', () => {
     TestBed.configureTestingModule({
       imports: [
         OpenprojectHalModule,
+        HttpClientTestingModule,
       ],
       providers: [
         HalResourceService,

--- a/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
@@ -50,6 +50,7 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('WorkPackage', () => {
   let halResourceService:HalResourceService;
@@ -73,6 +74,7 @@ describe('WorkPackage', () => {
     TestBed.configureTestingModule({
       imports: [
         OpenprojectHalModule,
+        HttpClientTestingModule,
       ],
       providers: [
         HalResourceService,

--- a/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormlyModule } from '@ngx-formly/core';
 import { NgOptionHighlightModule } from '@ng-select/ng-option-highlight';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TextInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/text-input/text-input.component';
 import { IntegerInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/integer-input/integer-input.component';
@@ -49,7 +48,6 @@ import { UserInputComponent } from 'core-app/shared/components/dynamic-forms/com
         },
       ],
     }),
-    HttpClientModule,
     OPSharedModule,
 
     // Input dependencies

--- a/frontend/src/app/shared/components/toaster/toast.service.spec.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.spec.ts
@@ -28,6 +28,7 @@
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
@@ -40,6 +41,7 @@ describe('ToastService', () => {
     TestBed.configureTestingModule({
       imports: [
         OpenprojectHalModule,
+        HttpClientTestingModule,
       ],
       providers: [
         { provide: ConfigurationService, useValue: { autoHidePopups: () => true } },


### PR DESCRIPTION
The reimport caused our http interceptor to not be set for the second httpclient module. That in turn caused missing CSRF headers on at least one call, which resulted in a 422 and a subsequent refresh of the session and the accompanying logout.

Closes https://community.openproject.org/work_packages/44161/activity

Co-authored-by: Oliver Günther <mail@oliverguenther.de>