### PR TITLE
Remove attribute-help-text from spot, in favor of slot

### DIFF
--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-field-wrapper/dynamic-field-wrapper.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-field-wrapper/dynamic-field-wrapper.component.html
@@ -12,6 +12,13 @@
 >
   <ng-container #fieldComponent slot="input"></ng-container>
 
+  <attribute-help-text
+    slot="help-text"
+    class="spot-form-field--help-text"
+    [attribute]="to?.property"
+    [attributeScope]="to?.helpTextAttributeScope || dynamicFormComponent?.helpTextAttributeScope"
+  ></attribute-help-text>
+
   <formly-validation-message
     class="spot-form-field--error"
     [field]="field"
@@ -25,12 +32,16 @@
   [label]="to?.label"
   [hidden]="field?.hide"
   [required]="to?.required"
-  [helpTextAttribute]="to?.property"
-  [helpTextAttributeScope]="to?.helpTextAttributeScope || dynamicFormComponent?.helpTextAttributeScope"
   [showValidationErrorOn]="to?.showValidationErrorOn || dynamicFormComponent?.showValidationErrorsOn"
   [attr.data-qa-field-name]="to?.property"
 >
   <ng-container #fieldComponent slot="input"></ng-container>
+  <attribute-help-text
+    slot="help-text"
+    class="spot-form-field--help-text"
+    [attribute]="to?.property"
+    [attributeScope]="to?.helpTextAttributeScope || dynamicFormComponent?.helpTextAttributeScope"
+  ></attribute-help-text>
 
   <formly-validation-message
     class="spot-form-field--error"

--- a/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
@@ -21,11 +21,13 @@ import { DynamicFieldGroupWrapperComponent } from 'core-app/shared/components/dy
 import { FormattableControlModule } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.module';
 import { OPSharedModule } from 'core-app/shared/shared.module';
 import { UserInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/user-input/user-input.component';
+import { AttributeHelpTextModule } from 'core-app/shared/components/attribute-help-texts/attribute-help-text.module';
 
 @NgModule({
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AttributeHelpTextModule,
     FormlyModule.forRoot({
       types: [
         { name: 'booleanInput', component: BooleanInputComponent },

--- a/frontend/src/app/spot/components/form-field/form-field.component.html
+++ b/frontend/src/app/spot/components/form-field/form-field.component.html
@@ -11,11 +11,7 @@
 
       <span *ngIf="required" class="spot-form-field--label-indicator">*</span>
 
-      <attribute-help-text
-        class="spot-form-field--help-text"
-        [attribute]="helpTextAttribute"
-        [attributeScope]="helpTextAttributeScope"
-      ></attribute-help-text>
+      <ng-content select="[slot=help-text]"></ng-content>
     </div>
 
     <ng-container *ngIf="!noWrapLabel">

--- a/frontend/src/app/spot/components/form-field/form-field.component.ts
+++ b/frontend/src/app/spot/components/form-field/form-field.component.ts
@@ -28,10 +28,6 @@ export class SpotFormFieldComponent {
 
   @Input() control?:AbstractControl;
 
-  @Input() helpTextAttribute?:string;
-
-  @Input() helpTextAttributeScope?:string;
-
   @ContentChild(NgControl) ngControl:NgControl;
 
   internalID = `spot-form-field-${+new Date()}`;

--- a/frontend/src/app/spot/components/selector-field/selector-field.component.html
+++ b/frontend/src/app/spot/components/selector-field/selector-field.component.html
@@ -21,11 +21,7 @@
       >Invalid</span>
       {{ label }}
       <span *ngIf="required" class="spot-form-field--label-indicator">*</span>
-      <attribute-help-text
-        class="spot-form-field--help-text"
-        [attribute]="helpTextAttribute"
-        [attributeScope]="helpTextAttributeScope"
-      ></attribute-help-text>
+      <ng-content select="[slot=help-text]"></ng-content>
     </div>
   </label>
 

--- a/frontend/src/app/spot/components/selector-field/selector-field.component.ts
+++ b/frontend/src/app/spot/components/selector-field/selector-field.component.ts
@@ -36,10 +36,6 @@ export class SpotSelectorFieldComponent {
 
   @Input() control?:AbstractControl;
 
-  @Input() helpTextAttribute?:string;
-
-  @Input() helpTextAttributeScope?:string;
-
   @ContentChild(NgControl) ngControl:NgControl;
 
   internalID = `spot-selector-field-${+new Date()}`;

--- a/frontend/src/app/spot/spot.module.ts
+++ b/frontend/src/app/spot/spot.module.ts
@@ -27,7 +27,6 @@ import { AttributeHelpTextModule } from 'core-app/shared/components/attribute-he
     FormsModule,
     ReactiveFormsModule,
     CommonModule,
-    AttributeHelpTextModule,
   ],
 
   providers: [


### PR DESCRIPTION
Removing them from spot removes the tight coupling to other modules