### PR TITLE
Update storybook caddy command

### DIFF
--- a/docker/pullpreview-storybook/Dockerfile
+++ b/docker/pullpreview-storybook/Dockerfile
@@ -16,6 +16,6 @@ RUN mkdir -p /srv
 COPY --from=build /build/frontend/storybook-static /srv/storybook
 WORKDIR /srv/storybook
 CMD caddy file-server \
-  -root /srv/storybook \
-  -listen 0.0.0.0:8080
+  --root /srv/storybook \
+  --listen 0.0.0.0:8080
 


### PR DESCRIPTION
Caddy for storybook is failing in PullPreview instances because a new version of caddy has dropped and it does not recognize `-root` as a parameter, isntead needing `--root` with double dashes.