### PR TITLE
Make demo projects aware of non-working days

### DIFF
--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -146,7 +146,11 @@ module DemoData
     end
 
     def set_time_tracking_attributes!(wp_attr, attributes)
-      wp_attr.merge!(TimeTrackingAttributes.for(attributes))
+      wp_attr.merge!(time_tracking_attributes(attributes))
+    end
+
+    def time_tracking_attributes(attributes)
+      TimeTrackingAttributes.for(attributes)
     end
 
     def set_backlogs_attributes!(wp_attr, attributes)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -146,13 +146,7 @@ module DemoData
     end
 
     def set_time_tracking_attributes!(wp_attr, attributes)
-      start_date = calculate_start_date(attributes[:start])
-
-      wp_attr[:start_date] = start_date
-      wp_attr[:due_date] = calculate_due_date(start_date, attributes[:duration])
-      wp_attr[:ignore_non_working_days] = calculate_ignore_non_working_days(wp_attr)
-      wp_attr[:duration] = calculate_duration(wp_attr)
-      wp_attr[:estimated_hours] = attributes[:estimated_hours].to_i if attributes[:estimated_hours]
+      wp_attr.merge!(TimeTrackingAttributes.for(attributes))
     end
 
     def set_backlogs_attributes!(wp_attr, attributes)
@@ -201,30 +195,63 @@ module DemoData
       Relation.create!(from:, to:, relation_type: type)
     end
 
-    def calculate_start_date(days_ahead)
-      Time.zone.today.monday + (days_ahead || 0).days
-    end
+    class TimeTrackingAttributes
+      def self.for(attributes)
+        new(attributes).work_package_attributes
+      end
 
-    # Returns the due date based on the starting date and the duration.
-    def calculate_due_date(date, duration)
-      WorkPackages::Shared::AllDays.new.due_date(date, duration)
-    end
+      def work_package_attributes
+        {
+          start_date:,
+          due_date:,
+          duration:,
+          ignore_non_working_days:,
+          estimated_hours:
+        }
+      end
 
-    def calculate_ignore_non_working_days(work_package_attributes)
-      work_package_attributes
-        .values_at(:start_date, :due_date)
-        .compact
-        .any? { |date| working_days.non_working?(date) }
-    end
+      private
 
-    def calculate_duration(work_package_attributes)
-      start_date, due_date, ignore_non_working_days = work_package_attributes.values_at(:start_date, :due_date, :ignore_non_working_days)
-      days = WorkPackages::Shared::Days.for_ignore_non_working_days(ignore_non_working_days)
-      days.duration(start_date, due_date)
-    end
+      attr_reader :attributes
 
-    def working_days
-      @working_days ||= WorkPackages::Shared::WorkingDays.new
+      def initialize(attributes)
+        @attributes = attributes
+      end
+
+      def start_date
+        days_ahead = attributes[:start] || 0
+        Time.zone.today.monday + days_ahead.days
+      end
+
+      def due_date
+        all_days.due_date(start_date, attributes[:duration])
+      end
+
+      def duration
+        days.duration(start_date, due_date)
+      end
+
+      def ignore_non_working_days
+        [start_date, due_date]
+          .compact
+          .any? { |date| working_days.non_working?(date) }
+      end
+
+      def estimated_hours
+        attributes[:estimated_hours]&.to_i
+      end
+
+      def all_days
+        @all_days ||= WorkPackages::Shared::AllDays.new
+      end
+
+      def working_days
+        @working_days ||= WorkPackages::Shared::WorkingDays.new
+      end
+
+      def days
+        ignore_non_working_days ? all_days : working_days
+      end
     end
   end
 end

--- a/app/services/work_packages/shared/days.rb
+++ b/app/services/work_packages/shared/days.rb
@@ -31,11 +31,7 @@ module WorkPackages
     class Days
       # Returns the right day computation instance for the given instance.
       def self.for(work_package)
-        for_ignore_non_working_days(work_package.ignore_non_working_days)
-      end
-
-      def self.for_ignore_non_working_days(ignore_non_working_days)
-        ignore_non_working_days ? AllDays.new : WorkingDays.new
+        work_package.ignore_non_working_days ? AllDays.new : WorkingDays.new
       end
     end
   end

--- a/app/services/work_packages/shared/days.rb
+++ b/app/services/work_packages/shared/days.rb
@@ -31,7 +31,11 @@ module WorkPackages
     class Days
       # Returns the right day computation instance for the given instance.
       def self.for(work_package)
-        work_package.ignore_non_working_days ? AllDays.new : WorkingDays.new
+        for_ignore_non_working_days(work_package.ignore_non_working_days)
+      end
+
+      def self.for_ignore_non_working_days(ignore_non_working_days)
+        ignore_non_working_days ? AllDays.new : WorkingDays.new
       end
     end
   end

--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -82,6 +82,10 @@ module WorkPackages
         working_week_day?(date) && working_specific_date?(date)
       end
 
+      def non_working?(date)
+        !working?(date)
+      end
+
       private
 
       def assert_strictly_positive_duration(duration)

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -384,8 +384,8 @@ en:
               - subject: New website
                 status: :default_status_specified
                 type: :default_type_epic
-                start: 26
-                duration: 1
+                start: 0
+                duration: 29
                 children:
                   - subject: Newsletter registration form
                     status: :default_status_in_progress
@@ -403,14 +403,14 @@ en:
                     version: Sprint 1
                     position: 2
                     story_points: 3
-                    start: 26
+                    start: 28
                     duration: 1
                     children:
                       - subject: Create wireframes for new landing page
                         status: :default_status_in_progress
                         type: :default_type_task
                         version: Sprint 1
-                        start: 26
+                        start: 28
                         duration: 1
               - subject: Contact form
                 status: :default_status_specified

--- a/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
@@ -7,17 +7,16 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
     def create_or_update_work_package(attributes)
       uuid = attributes[:bcf_issue_uuid]
       if uuid
-
-        start_date = calculate_start_date(attributes[:start])
-        due_date = calculate_due_date(start_date, attributes[:duration])
+        time_tracking_attributes = time_tracking_attributes(attributes)
 
         work_package = find_bcf_issue(uuid)
-
         work_package.update_columns(created_at: Time.now,
                                     author_id: user.id,
                                     assigned_to_id: find_assignee_id(attributes[:assigned_to]),
-                                    start_date:,
-                                    due_date:)
+                                    start_date: time_tracking_attributes[:start_date],
+                                    due_date: time_tracking_attributes[:due_date],
+                                    duration: time_tracking_attributes[:duration],
+                                    ignore_non_working_days: time_tracking_attributes[:ignore_non_working_days])
 
         update_parent(work_package, attributes)
       else

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -1,0 +1,219 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe ::DemoData::WorkPackageSeeder do
+  shared_let(:work_week) { week_with_saturday_and_sunday_as_weekend }
+  shared_let(:seeding) do
+    [
+      # Color records needed by StatusSeeder and TypeSeeder
+      BasicData::ColorSeeder,
+      BasicData::ColorSchemeSeeder,
+
+      # Status records needed by WorkPackageSeeder
+      StandardSeeder::BasicData::StatusSeeder,
+
+      # Type records needed by WorkPackageSeeder
+      StandardSeeder::BasicData::TypeSeeder,
+
+      # IssuePriority records needed by WorkPackageSeeder
+      StandardSeeder::BasicData::PrioritySeeder,
+
+      # User admin needed by WorkPackageSeeder
+      AdminUserSeeder
+    ].each { |seeder| seeder.new.seed! }
+  end
+  let(:project) { create(:project) }
+  let(:new_project_role) { Role.find_by(name: I18n.t(:default_role_project_admin)) }
+  let(:closed_status) { Status.find_by(name: I18n.t(:default_status_closed)) }
+  let(:work_packages_data) { [] }
+
+  def work_package_data(**attributes)
+    {
+      start: 0,
+      subject: "Some subject",
+      status: "default_status_new",
+      type: "default_type_task"
+    }.merge(attributes)
+  end
+
+  before do
+    work_package_seeder = described_class.new(project, "dummy-project")
+    allow(work_package_seeder)
+      .to receive(:project_data_for).with('dummy-project', 'work_packages')
+          .and_return(work_packages_data)
+    work_package_seeder.seed!
+  end
+
+  # available for debugging purposes, to see what real world data looks like
+  def real_work_package_data
+    seeder.send(:translate_with_base_url, "seeders.standard.demo_data.projects.demo-project.work_packages")
+  end
+
+  context 'with work package data with start: 0' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: 0)
+      ]
+    end
+
+    it 'start on the Monday of the current week' do
+      current_week_monday = Date.current.monday
+      expect(WorkPackage.first.start_date).to eq(current_week_monday)
+    end
+  end
+
+  context 'with work package data with start: n' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: 2),
+        work_package_data(start: 42)
+      ]
+    end
+
+    it 'will start n days after the Monday of the current week' do
+      current_week_monday = Date.current.monday
+      expect(WorkPackage.first.start_date).to eq(current_week_monday + 2.days)
+      expect(WorkPackage.second.start_date).to eq(current_week_monday + 42.days)
+    end
+  end
+
+  context 'with work package data with start: -n' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: -3),
+        work_package_data(start: -17)
+      ]
+    end
+
+    it 'will start n days before the Monday of the current week' do
+      current_week_monday = Date.current.monday
+      expect(WorkPackage.first.start_date).to eq(current_week_monday - 3.days)
+      expect(WorkPackage.second.start_date).to eq(current_week_monday - 17.days)
+    end
+  end
+
+  context 'with work package data with duration' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: 0, duration: 1), # from Monday to Saturday
+        work_package_data(start: 0, duration: 6), # from Monday to Saturday
+        work_package_data(start: 0, duration: 15) # from Monday to next next Monday
+      ]
+    end
+
+    it 'will have finish date calculated being start + duration - 1' do
+      current_week_monday = Date.current.monday
+      expect(WorkPackage.first.due_date).to eq(current_week_monday)
+      expect(WorkPackage.second.due_date).to eq(current_week_monday + 5.days)
+      expect(WorkPackage.third.due_date).to eq(current_week_monday + 14.days)
+    end
+  end
+
+  context 'with work package data without duration' do
+    let(:work_packages_data) do
+      [
+        work_package_data(duration: nil)
+      ]
+    end
+
+    it 'will have no duration' do
+      expect(WorkPackage.first.duration).to be_nil
+    end
+
+    it 'will have no finish date' do
+      expect(WorkPackage.first.due_date).to be_nil
+    end
+  end
+
+  context 'when both start date and due date are on a working day' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: 1, duration: 10) # from Tuesday to next Thursday
+      ]
+    end
+
+    it 'will have ignore_non_working_day set to true' do
+      expect(WorkPackage.first.ignore_non_working_days).to be(false)
+    end
+
+    it 'will have finish date calculated from duration based on real days' do
+      work_package = WorkPackage.first
+      expect(work_package.due_date).to eq(work_package.start_date + 9.days)
+      expect(work_package.due_date.wday).to eq(4)
+    end
+
+    it 'will have duration adjusted to count only working days' do
+      expect(WorkPackage.first.duration).to eq(8)
+    end
+  end
+
+  context 'when either start date or finish date is on a non-working day' do
+    let(:work_packages_data) do
+      [
+        work_package_data(start: -1, duration: 3), # start date non working: from Sunday to Tuesday
+        work_package_data(start: 0, duration: 7) # finish date non working: from Monday to Sunday
+      ]
+    end
+
+    it 'will have ignore_non_working_day set to true' do
+      expect(WorkPackage.first.ignore_non_working_days).to be(true)
+      expect(WorkPackage.second.ignore_non_working_days).to be(true)
+    end
+
+    it 'will have duration being the same as defined' do
+      expect(WorkPackage.first.duration).to eq(3)
+      expect(WorkPackage.second.duration).to eq(7)
+    end
+  end
+
+  context 'with work package data with estimated_hours' do
+    let(:work_packages_data) do
+      [
+        work_package_data(estimated_hours: 3)
+      ]
+    end
+
+    it 'sets estimated_hours to the given value' do
+      expect(WorkPackage.first.estimated_hours).to eq(3)
+    end
+  end
+
+  context 'with work package data without estimated_hours' do
+    let(:work_packages_data) do
+      [
+        work_package_data(estimated_hours: nil)
+      ]
+    end
+
+    it 'does not set estimated_hours' do
+      expect(WorkPackage.first.estimated_hours).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/44316

Work package has `ignore_non_working_days` set to `true` if start date or due date is on a non-working day.

Duration is computed correctly regarding non-working days and `ignore_non_working_days` flag.

Setting `done_ratio` was dead code and removed.