### PR TITLE
[#43894] Fix SystemStackError with some deep work package trees

### DIFF
--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -93,6 +93,8 @@ class WorkPackages::ScheduleDependency
   end
 
   def descendants(work_package)
+    # Avoid using WorkPackage.with_ancestors to save database requests.
+    # All needed data is already loaded.
     @descendants ||= {}
     @descendants[work_package] ||= begin
       children = children_by_parent_id(work_package.id)
@@ -101,21 +103,32 @@ class WorkPackages::ScheduleDependency
     end
   end
 
+  # Get relations of type follows for which the given work package is a direct
+  # follower, or an indirect follower (through parent and/or children).
+  #
+  # Used by +Dependency#dependent_ids+ to get work packages that must be
+  # scheduled prior to the given work package.
   def follows_relations(work_package)
     @follows_relations ||= {}
-    @follows_relations[work_package] ||= begin
-      line = [work_package] + ancestors(work_package) + descendants(work_package)
-      @follows_relations_by_from_id ||= known_follows_relations.group_by(&:from_id)
-      @follows_relations_by_from_id
-        .fetch_values(*line.map(&:id)) { [] }
-        .flatten
-    end
+    @follows_relations[work_package] ||= all_direct_and_indirect_follows_relations_for(work_package)
   end
 
   private
 
   attr_accessor :known_follows_relations,
                 :moved_work_packages
+
+  def all_direct_and_indirect_follows_relations_for(work_package)
+    family = ancestors(work_package) + [work_package] + descendants(work_package)
+    follows_relations_by_follower_id
+      .fetch_values(*family.pluck(:id)) { [] }
+      .flatten
+      .uniq
+  end
+
+  def follows_relations_by_follower_id
+    @follows_relations_by_follower_id ||= known_follows_relations.group_by(&:from_id)
+  end
 
   def create_dependencies
     moving_work_packages.index_with { |work_package| Dependency.new(work_package, self) }
@@ -168,6 +181,7 @@ class WorkPackages::ScheduleDependency
     WorkPackage
       .with_ancestor(known_work_packages)
       .where.not(id: known_work_packages.map(&:id))
+      .distinct
   end
 
   # Load all the predecessors of follows relations that are not already loaded.


### PR DESCRIPTION
https://community.openproject.org/wp/43894

`WorkPackage.with_ancestors(known_work_packages)` returns the same work packages multiple time when two common ancestors are given as parameters. This lead to having `known_work_packages` with duplicates.

Later on, the computation of descendants would multiply the number of returned work packages, leading to having more arguments than available stack memory when calling `fetch_values(*family.pluck(:id))`.

On a hierarchy tree with 1239 loaded work packages, the number of arguments of the call was 267823. That's a bit too much.

The fix is deceptively easy: just call `#distinct` after `#with_ancestors`.