### PR TITLE
Fix/43909 project template rename checkbox labels under copy options

### DIFF
--- a/app/services/projects/copy/categories_dependent_service.rb
+++ b/app/services/projects/copy/categories_dependent_service.rb
@@ -29,7 +29,7 @@
 module Projects::Copy
   class CategoriesDependentService < Dependency
     def self.human_name
-      I18n.t(:label_work_package_category_plural)
+      I18n.t(:'projects.copy.work_package_categories')
     end
 
     def source_count

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -29,7 +29,7 @@
 module Projects::Copy
   class MembersDependentService < Dependency
     def self.human_name
-      I18n.t(:label_member_plural)
+      I18n.t(:'projects.copy.members')
     end
 
     def source_count

--- a/app/services/projects/copy/overview_dependent_service.rb
+++ b/app/services/projects/copy/overview_dependent_service.rb
@@ -29,7 +29,7 @@
 module Projects::Copy
   class OverviewDependentService < Dependency
     def self.human_name
-      I18n.t(:'overviews.label')
+      I18n.t(:'projects.copy.overviews')
     end
 
     protected

--- a/app/services/projects/copy/queries_dependent_service.rb
+++ b/app/services/projects/copy/queries_dependent_service.rb
@@ -29,7 +29,7 @@
 module Projects::Copy
   class QueriesDependentService < Dependency
     def self.human_name
-      I18n.t(:label_query_plural)
+      I18n.t(:'projects.copy.queries')
     end
 
     def source_count

--- a/app/services/projects/copy/wiki_page_attachments_dependent_service.rb
+++ b/app/services/projects/copy/wiki_page_attachments_dependent_service.rb
@@ -31,7 +31,7 @@ module Projects::Copy
     include ::Copy::Concerns::CopyAttachments
 
     def self.human_name
-      I18n.t(:label_wiki_page_attachments)
+      I18n.t(:'projects.copy.wiki_page_attachments')
     end
 
     def source_count

--- a/app/services/projects/copy/work_package_attachments_dependent_service.rb
+++ b/app/services/projects/copy/work_package_attachments_dependent_service.rb
@@ -31,7 +31,7 @@ module Projects::Copy
     include ::Copy::Concerns::CopyAttachments
 
     def self.human_name
-      I18n.t(:label_work_package_attachments)
+      I18n.t(:'projects.copy.work_package_attachments')
     end
 
     def source_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,15 @@ en:
       Enter one filename per line.
 
   projects:
+    copy:
+      # Contains custom strings for options when copying a project that cannot be found elsewhere.
+      members: 'Project members'
+      overviews: 'Project overview'
+      queries: 'Work packages: saved views'
+      wiki_page_attachments: 'Wiki pages: attachments'
+      work_package_attachments: 'Work packages: attachments'
+      work_package_categories: 'Work packages: categories'
+      work_package_file_links: 'Work packages: file links'
     delete:
       scheduled: "Deletion has been scheduled and is performed in the background. You will be notified of the result."
       schedule_failed: "Project cannot be deleted: %{errors}"
@@ -1999,7 +2008,6 @@ en:
   label_wiki_start: "Start page"
   label_work_package: "Work package"
   label_work_package_attachments: "Work package attachments"
-  label_work_package_file_link_plural: "Work package file links"
   label_work_package_category_new: "New category"
   label_work_package_category_plural: "Work package categories"
   label_work_package_hierarchy: "Work package hierarchy"

--- a/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
+++ b/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
@@ -29,7 +29,7 @@
 module Projects::Copy
   class FileLinksDependentService < ::Copy::Dependency
     def self.human_name
-      I18n.t(:label_work_package_file_link_plural)
+      I18n.t(:'projects.copy.work_package_file_links')
     end
 
     def source_count

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -124,7 +124,7 @@ describe 'Project templates', type: :feature, js: true do
       expect(page).to have_selector('[data-qa-field-name="sendNotifications"]')
 
       # And allows to deselect copying the members.
-      uncheck 'Members'
+      uncheck I18n.t(:'projects.copy.members')
 
       page.find('button:not([disabled])', text: 'Save').click
 


### PR DESCRIPTION
Provides custom labels for copy options so that the options are easier to understand. This follows the specification in https://community.openproject.org/wp/43909 with the exception of "Versions" which was specified to be renamed to "Backlogs versions". That renaming is currently discussed.

It also sorts the copy options based on their label which leads to the options for e.g. work packages being under each other.

<img width="511" alt="image" src="https://user-images.githubusercontent.com/617519/194064767-37baa4e0-7256-4b48-a5a8-58948422e471.png">
