### PR TITLE
Bug/44318 switch field label extends into whitespace

### DIFF
--- a/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
@@ -14,7 +14,7 @@
 
   &--toggle-actions-container
     display: grid
-    grid-template-columns: auto 1fr
+    grid-template-columns: auto auto 1fr
     grid-column-gap: $spot-spacing-2
 
   &--dates-container


### PR DESCRIPTION
See [OP#44318](https://community.openproject.org/wp/44318)
Reduce the size of the toggle's surrounding label to adjust the clicking surface of the toggle to the expected size.
<img width="601" alt="image" src="https://user-images.githubusercontent.com/83396/194073600-3f3b9563-0b14-4e77-a431-1a8093f1b8d9.png">
