### PR TITLE
Fixes for mobile datepicker

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
@@ -43,7 +43,7 @@ describe('WpTabsService', () => {
     });
     service = TestBed.inject(WorkPackageTabsService);
     (service as any).registeredTabs = [];
-    service.register(displayableTab, notDisplayableTab);
+    service.register({ ...displayableTab }, { ...notDisplayableTab });
   });
 
   describe('displayableTabs()', () => {

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -43,6 +43,8 @@
           (ngModelChange)="startDateChanged$.next($event)"
           [disabled]="!isSchedulable"
           [showClearButton]="currentlyActivatedDateField === 'start'"
+          [pattern]="datePattern"
+          inputmode="numeric"
           (focusin)="setCurrentActivatedField('start')"
         ></spot-text-field>
         <button
@@ -69,6 +71,8 @@
           (ngModelChange)="endDateChanged$.next($event)"
           [disabled]="!isSchedulable"
           [showClearButton]="currentlyActivatedDateField === 'end'"
+          [pattern]="datePattern"
+          inputmode="numeric"
           (focusin)="setCurrentActivatedField('end')"
         ></spot-text-field>
         <button
@@ -94,6 +98,8 @@
           [ngClass]="{'op-datepicker-modal--date-field_current' : showFieldAsActive('duration')}"
           [ngModel]="durationFocused ? duration : displayedDuration"
           [showClearButton]="durationFocused"
+          pattern="\d*"
+          inputmode="numeric"
           (ngModelChange)="durationChanges$.next($event)"
           [disabled]="!isSchedulable"
           (focusin)="handleDurationFocusIn()"

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -105,6 +105,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
+        type="button"
         (click)="cancel()"
         class="op-datepicker-modal--action button button_no-margin spot-action-bar--action"
         data-qa-selector="op-datepicker-modal--action"

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -4,6 +4,10 @@
   [attr.id]="htmlId"
   #modalContainer
   data-indicator-name="modal"
+  tabindex="0"
+  cdkFocusInitial
+  cdkTrapFocus
+  [cdkTrapFocusAutoCapture]="true"
   (submit)="save($event)"
 >
   <op-datepicker-banner [scheduleManually]="scheduleManually"></op-datepicker-banner>

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -151,6 +151,8 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
 
   htmlId = '';
 
+  datePattern = '[0-9]{4}-[0-9]{2}-[0-9]{2}';
+
   dates:{ [key in DateKeys]:string|null } = {
     start: null,
     end: null,

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -46,7 +46,6 @@ import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.servi
 import { DatePicker } from 'core-app/shared/components/op-date-picker/datepicker';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
-import { BrowserDetector } from 'core-app/core/browser/browser-detector.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DayElement } from 'flatpickr/dist/types/instance';
@@ -77,8 +76,9 @@ import {
   validDate,
 } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
-import DateOption = flatpickr.Options.DateOption;
 import { FocusHelperService } from 'core-app/shared/directives/focus/focus-helper';
+import { DeviceService } from 'core-app/core/browser/device.service';
+import DateOption = flatpickr.Options.DateOption;
 
 export type DateKeys = 'start'|'end';
 export type DateFields = DateKeys|'duration';
@@ -118,7 +118,7 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
 
   @InjectField() dateModalRelations:DateModalRelationsService;
 
-  @InjectField() browserDetector:BrowserDetector;
+  @InjectField() deviceService:DeviceService;
 
   @InjectField() weekdayService:WeekdayService;
 
@@ -369,6 +369,10 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
 
   // eslint-disable-next-line class-methods-use-this
   reposition(element:JQuery<HTMLElement>, target:JQuery<HTMLElement>):void {
+    if (this.deviceService.isMobile) {
+      return;
+    }
+
     element.position({
       my: 'left top',
       at: 'left bottom',
@@ -457,7 +461,7 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
       [this.dates.start || '', this.dates.end || ''],
       {
         mode: 'range',
-        showMonths: this.browserDetector.isMobile ? 1 : 2,
+        showMonths: this.deviceService.isMobile ? 1 : 2,
         inline: true,
         onReady: (_date, _datestr, instance) => {
           this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.ts
@@ -464,6 +464,7 @@ export class MultiDateModalComponent extends OpModalComponent implements AfterVi
         showMonths: this.deviceService.isMobile ? 1 : 2,
         inline: true,
         onReady: (_date, _datestr, instance) => {
+          instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
           this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));
           this.ensureHoveredSelection(instance.calendarContainer);
         },

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
@@ -38,6 +38,8 @@
           [(ngModel)]="date"
           (ngModelChange)="dateChangedManually$.next()"
           [showClearButton]="true"
+          [pattern]="datePattern"
+          inputmode="numeric"
         ></spot-text-field>
         <button
           slot="action"

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
@@ -53,12 +53,14 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
+        type="button"
         (click)="cancel()"
         class="op-datepicker-modal--action button button_no-margin spot-action-bar--action"
         data-qa-selector="op-datepicker-modal--action"
         [textContent]="text.cancel"
       ></button>
       <button
+        type="submit"
         class="op-datepicker-modal--action button button_no-margin -highlight spot-action-bar--action"
         data-qa-selector="op-datepicker-modal--action"
         [textContent]="text.save"

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
@@ -5,6 +5,10 @@
   #modalContainer
   data-indicator-name="modal"
   (submit)="save($event)"
+  tabindex="0"
+  cdkFocusInitial
+  cdkTrapFocus
+  [cdkTrapFocusAutoCapture]="true"
 >
   <op-datepicker-banner [scheduleManually]="scheduleManually"></op-datepicker-banner>
 

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
@@ -268,7 +268,8 @@ export class SingleDateModalComponent extends OpModalComponent implements AfterV
         mode: 'single',
         showMonths: this.deviceService.isMobile ? 1 : 2,
         inline: true,
-        onReady: () => {
+        onReady: (_date, _datestr, instance) => {
+          instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
           this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));
         },
         onChange: (dates:Date[]) => {

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
@@ -114,6 +114,8 @@ export class SingleDateModalComponent extends OpModalComponent implements AfterV
 
   htmlId = '';
 
+  datePattern = '[0-9]{4}-[0-9]{2}-[0-9]{2}';
+
   date:string|null = null;
 
   dateChangedManually$ = new Subject<void>();

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.ts
@@ -71,6 +71,7 @@ import {
   setDates,
   validDate,
 } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 @Component({
   templateUrl: './single-date.modal.html',
@@ -93,7 +94,7 @@ export class SingleDateModalComponent extends OpModalComponent implements AfterV
 
   @InjectField() dateModalRelations:DateModalRelationsService;
 
-  @InjectField() browserDetector:BrowserDetector;
+  @InjectField() deviceService:DeviceService;
 
   @ViewChild('modalContainer') modalContainer:ElementRef<HTMLElement>;
 
@@ -245,6 +246,10 @@ export class SingleDateModalComponent extends OpModalComponent implements AfterV
 
   // eslint-disable-next-line class-methods-use-this
   reposition(element:JQuery<HTMLElement>, target:JQuery<HTMLElement>):void {
+    if (this.deviceService.isMobile) {
+      return;
+    }
+
     element.position({
       my: 'left top',
       at: 'left bottom',
@@ -261,7 +266,7 @@ export class SingleDateModalComponent extends OpModalComponent implements AfterV
       this.date || '',
       {
         mode: 'single',
-        showMonths: this.browserDetector.isMobile ? 1 : 2,
+        showMonths: this.deviceService.isMobile ? 1 : 2,
         inline: true,
         onReady: () => {
           this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));

--- a/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
@@ -4,6 +4,7 @@
   .op-datepicker-modal
     height: initial
     max-width: initial
+    margin-bottom: 0
 
     &--flatpickr-instance
       align-self: center

--- a/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
@@ -2,8 +2,8 @@
 
 @media screen and (max-width: 679px)
   .op-datepicker-modal
-    height: initial
-    max-width: initial
+    // Use same width as spot-modal mobile
+    width: calc(100vw - 2rem)
     margin-bottom: 0
 
     &--flatpickr-instance

--- a/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
@@ -5,6 +5,9 @@
     height: initial
     max-width: initial
 
+    &--flatpickr-instance
+      align-self: center
+
     &--dates-container
       grid-template-columns: 1fr 1fr
 

--- a/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker_mobile.modal.sass
@@ -3,7 +3,8 @@
 @media screen and (max-width: 679px)
   .op-datepicker-modal
     height: initial
-    max-width: 300px
+    max-width: initial
+
     &--dates-container
       grid-template-columns: 1fr 1fr
 

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -39,12 +39,15 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
 import { SingleDateModalComponent } from 'core-app/shared/components/datepicker/single-date-modal/single-date.modal';
 import { MultiDateModalComponent } from 'core-app/shared/components/datepicker/multi-date-modal/multi-date.modal';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 @Directive()
 export abstract class DatePickerEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
   @InjectField() readonly timezoneService:TimezoneService;
 
   @InjectField() opModalService:OpModalService;
+
+  @InjectField() deviceService:DeviceService;
 
   protected modal:SingleDateModalComponent|MultiDateModalComponent;
 
@@ -70,7 +73,12 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
     const component = this.change.schema.isMilestone ? SingleDateModalComponent : MultiDateModalComponent;
     this.modal = this
       .opModalService
-      .show<SingleDateModalComponent|MultiDateModalComponent>(component, this.injector, { changeset: this.change, fieldName: this.name }, true);
+      .show<SingleDateModalComponent|MultiDateModalComponent>(
+        component,
+        this.injector,
+        { changeset: this.change, fieldName: this.name },
+        !this.deviceService.isMobile,
+      );
 
     const { modal } = this;
 

--- a/frontend/src/app/spot/components/text-field/text-field.component.html
+++ b/frontend/src/app/spot/components/text-field/text-field.component.html
@@ -2,6 +2,8 @@
 <input
   class="spot-text-field--input"
   [attr.name]="name"
+  [attr.pattern]="pattern"
+  [attr.inputmode]="inputmode"
   [disabled]="disabled"
   [placeholder]="placeholder"
   [ngModel]="value"

--- a/frontend/src/app/spot/components/text-field/text-field.component.ts
+++ b/frontend/src/app/spot/components/text-field/text-field.component.ts
@@ -67,6 +67,10 @@ export class SpotTextFieldComponent implements ControlValueAccessor {
    */
   @Input() public value = '';
 
+  @Input() public pattern:string|undefined;
+
+  @Input() public inputmode:string = 'text';
+
   valueChanged(value:string):void {
     this.writeValue(value);
     this.onChange(value);

--- a/frontend/src/app/spot/components/text-field/text-field.component.ts
+++ b/frontend/src/app/spot/components/text-field/text-field.component.ts
@@ -67,9 +67,16 @@ export class SpotTextFieldComponent implements ControlValueAccessor {
    */
   @Input() public value = '';
 
+  /**
+   * The html input (Regexp) pattern to provide hints to keyboards what layout to use
+   * and to aid in validation.
+   */
   @Input() public pattern:string|undefined;
 
-  @Input() public inputmode:string = 'text';
+  /**
+   * The html inputmode to hint virtual keyboard layouts.
+   */
+  @Input() public inputmode:'text'|'decimal'|'numeric'|'tel'|'search'|'email'|'url' = 'text';
 
   valueChanged(value:string):void {
     this.writeValue(value);

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -67,6 +67,7 @@ $datepicker--border-radius: 5px
     .flatpickr-current-month
       @include spot-body-small(bold)
       justify-content: center
+      align-items: center
 
     .numInputWrapper
       position: relative


### PR DESCRIPTION
- [x] Fix closing the datepicker after "go-next" on duration field on mobile devices due to a wrong button type on cancel button
- [x] Treat mobile datepicker modal as other modals, being more or less fullscreen with a black background (and close button for the scope of this PR)
- [x] Add CDK focus trapping on the datepicker for good measure
- [x] The start date, finish date and duration fields open the numeric keyboard, not alpha-numeric one.

https://community.openproject.org/projects/openproject/work_packages/44144/activity?query_id=3510