### PR TITLE
Fix flickering frontend test

### DIFF
--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15 as dev
+FROM node:16.15
 MAINTAINER operations@openproject.com
 
 ARG DEV_UID=1000

--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15
+FROM node:16.15 as dev
 MAINTAINER operations@openproject.com
 
 ARG DEV_UID=1000
@@ -7,6 +7,8 @@ ARG DEV_GID=1001
 ENV USER=node
 
 RUN apt-get update && apt-get install -y chromium
+
+ENV CHROME_BIN=/usr/bin/chromium
 
 RUN npm i -g npm
 

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.spec.ts
@@ -43,7 +43,7 @@ describe('WpTabsService', () => {
     });
     service = TestBed.inject(WorkPackageTabsService);
     (service as any).registeredTabs = [];
-    service.register(displayableTab, notDisplayableTab);
+    service.register({ ...displayableTab }, { ...notDisplayableTab });
   });
 
   describe('displayableTabs()', () => {


### PR DESCRIPTION
Shallow copy the registered tabs, so that modifying them in the test has no impact on subsequent tests.