### PR TITLE
Backport fixes for BIM developers setup scripts from dev branch

### DIFF
--- a/modules/bim/bin/setup_dev.sh
+++ b/modules/bim/bin/setup_dev.sh
@@ -14,7 +14,7 @@ fi
 
 # Specifics for BIM edition (Ubuntu)
 apt-get update -qq
-apt-get install -y dotnet-runtime-6.0
+apt-get install -y dotnet-runtime-6.0 wget unzip
 
 tmpdir=$(mktemp -d)
 cd $tmpdir

--- a/modules/bim/bin/setup_dev.sh
+++ b/modules/bim/bin/setup_dev.sh
@@ -12,11 +12,9 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-# Specifics for BIM edition
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-wget -q https://packages.microsoft.com/config/debian/9/prod.list -O /etc/apt/sources.list.d/microsoft-prod.list
+# Specifics for BIM edition (Ubuntu)
 apt-get update -qq
-apt-get install -y dotnet-runtime-3.1
+apt-get install -y dotnet-runtime-6.0
 
 tmpdir=$(mktemp -d)
 cd $tmpdir
@@ -31,11 +29,11 @@ wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b
 unzip -q IfcConvert-v0.6.0-517b819-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
-wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.0/xeokit-metadata-linux-x64.tar.gz
+wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
 tar -zxvf xeokit-metadata-linux-x64.tar.gz
 chmod +x xeokit-metadata-linux-x64/xeokit-metadata
-cp -r xeokit-metadata-linux-x64/ "/usr/lib/xeokit-metadata"
-rm -f /usr/local/bin/xeokit-metadatarm -f /usr/local/bin/xeokit-metadata
+cp -rT xeokit-metadata-linux-x64 "/usr/lib/xeokit-metadata"
+rm -f /usr/local/bin/xeokit-metadata
 ln -s /usr/lib/xeokit-metadata/xeokit-metadata /usr/local/bin/xeokit-metadata
 
 cd /
@@ -48,7 +46,7 @@ which COLLADA2GLTF
 echo "✔ COLLADA2GLTF is in your path."
 
 which xeokit-metadata
-echo "✔ xeokit-metadata is in your path. (without .NET yet, see below)"
+echo "✔ xeokit-metadata is in your path."
 
 echo "DONE - Now execute the following as your development user:
       $ # Install XKT converter


### PR DESCRIPTION
Original PR https://github.com/opf/openproject/pull/11385 got merged into dev 
branch. However, it would be great to have those fixes not sit around until 
12.4. 

- Update BIM development setup script to use .NET 6 and update xeokit-metadata
- Ensure wget and unzip are installed
