### PR TITLE
Temporarily remove the files endpoint for storages from the public API specs

### DIFF
--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -353,8 +353,11 @@ paths:
     "$ref": "./paths/status.yml"
   "/api/v3/storages/{id}":
     "$ref": "./paths/storage.yml"
-  "/api/v3/storages/{id}/files":
-    "$ref": "./paths/storage_files.yml"
+# Temporarily removed for release 12.3 as the specification is not finished.
+# Also the implementation is not yet ready.
+# Discussion is tracked here: https://community.openproject.org/work_packages/43694  
+#  "/api/v3/storages/{id}/files":
+#    "$ref": "./paths/storage_files.yml"
   "/api/v3/time_entries":
     "$ref": "./paths/time_entries.yml"
   "/api/v3/time_entries/{id}/form":
@@ -554,8 +557,11 @@ components:
       "$ref": "./components/schemas/example_schema_model.yml"
     Execute_custom_action:
       "$ref": "./components/schemas/execute_custom_action.yml"
-    FileCollectionModel:
-      $ref: './components/schemas/file_collection_model.yml'
+# Temporarily removed for the 12.3 release as it is not yet 
+# implemented.
+# Discussion is tracked here: https://community.openproject.org/work_packages/43694
+#    FileCollectionModel:
+#      $ref: './components/schemas/file_collection_model.yml'
     FileLinkCollectionReadModel:
       $ref: './components/schemas/file_link_collection_read_model.yml'
     FileLinkCollectionWriteModel:


### PR DESCRIPTION
We are about to release 12.3 and the API spec for storage files is
unfinished and not implemented. With this PR I propose to temporarily
remove it to get shown to the public via swagger.

For 12.4 we can improve it and remove the comments.

https://community.openproject.org/work_packages/43694
