### PR TITLE
Add an admin flag for testing to ldap

### DIFF
--- a/spec/fixtures/ldap/users.ldif
+++ b/spec/fixtures/ldap/users.ldif
@@ -25,6 +25,16 @@ objectclass: organizationalUnit
 objectclass: top
 ou: attributetypes
 
+dn: m-oid=1.2.840.113556.1.4.220, ou=attributetypes, cn=microsoft, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.2.840.113556.1.4.220
+m-name: isAdmin
+m-equality: booleanMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.7
+m-singleValue: TRUE
+
 dn: m-oid=1.2.840.113556.1.4.221, ou=attributetypes, cn=microsoft, ou=schema
 objectclass: metaAttributeType
 objectclass: metaTop
@@ -60,6 +70,7 @@ m-supObjectClass: top
 m-typeObjectClass: AUXILIARY
 m-must: sAMAccountName
 m-may: memberOf
+m-may: isAdmin
 
 dn: cn=foo,ou=groups,dc=example,dc=com
 objectClass: groupOfNames
@@ -74,6 +85,29 @@ cn: bar
 member: uid=aa729,ou=people,dc=example,dc=com
 member: uid=bb459,ou=people,dc=example,dc=com
 member: uid=cc414,ou=people,dc=example,dc=com
+
+dn: cn=admins,ou=groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: admins
+member: uid=ldap_admin,ou=people,dc=example,dc=com
+
+dn: uid=ldap_admin,ou=people,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: simulatedMicrosoftSecurityPrincipal
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: LDAP Adminuser
+sn: Adminuser
+givenName: LDAP
+mail: ldapadmin@example.org
+uid: ldap_admin
+samAccountName: ldap_admin
+isAdmin: true
+memberOf: cn=admins,ou=groups,dc=example,dc=com
+# Password is "smada"
+userpassword:: e1NIQX1wR2xtWlgxVk9FZEhIYjMwSFplemVWTkZ4R009
 
 dn: uid=aa729,ou=people,dc=example,dc=com
 objectClass: inetOrgPerson

--- a/spec/models/ldap_auth_source_spec.rb
+++ b/spec/models/ldap_auth_source_spec.rb
@@ -159,10 +159,32 @@ describe LdapAuthSource, type: :model do
              attr_login: 'uid',
              attr_firstname: 'givenName',
              attr_lastname: 'sn',
-             attr_mail: 'mail'
+             attr_mail: 'mail',
+             attr_admin:
     end
 
     let(:filter_string) { nil }
+    let(:attr_admin) { nil }
+
+    describe 'attr_admin' do
+      context 'when set' do
+        let(:attr_admin) { 'isAdmin' }
+
+        it 'maps for the admin user in ldap', :aggregate_failures do
+          admin_attributes = ldap.find_user('ldap_admin')
+          expect(admin_attributes).to be_kind_of Hash
+          expect(admin_attributes[:firstname]).to eq 'LDAP'
+          expect(admin_attributes[:lastname]).to eq 'Adminuser'
+          expect(admin_attributes[:admin]).to eq true
+
+          admin_attributes = ldap.find_user('bb459')
+          expect(admin_attributes).to be_kind_of Hash
+          expect(admin_attributes[:firstname]).to eq 'Belle'
+          expect(admin_attributes[:lastname]).to eq 'Baldwin'
+          expect(admin_attributes[:admin]).to eq false
+        end
+      end
+    end
 
     describe '#authenticate' do
       context 'with a valid LDAP user' do


### PR DESCRIPTION
The test users.ldif didn't have a schema for a boolean admin flag. While testing how the flag behaves, I noticed this and wanted to add it