### PR TITLE
remove unused Project#users_by_role method

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -258,17 +258,6 @@ class Project < ApplicationRecord
     @assignable_versions ||= shared_versions.references(:project).with_status_open.order_by_semver_name.to_a
   end
 
-  # Returns a hash of project users grouped by role
-  def users_by_role
-    members.includes(:principal, :roles).inject({}) do |h, m|
-      m.roles.each do |r|
-        h[r] ||= []
-        h[r] << m.principal
-      end
-      h
-    end
-  end
-
   # Returns an AR scope of all custom fields enabled for project's work packages
   # (explicitly associated custom fields and custom fields enabled for all projects)
   def all_work_package_custom_fields

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -34,14 +34,6 @@ describe Project, type: :model do
     User.current = nil
   end
 
-  it 'userses by role' do
-    users_by_role = Project.find(1).users_by_role
-    assert_kind_of Hash, users_by_role
-    role = Role.find(1)
-    assert_kind_of Array, users_by_role[role]
-    assert users_by_role[role].include?(User.find(2))
-  end
-
   it 'rolleds up types' do
     parent = Project.find(1)
     parent.types = ::Type.find([1, 2])


### PR DESCRIPTION
This method is not used anywhere in the application any more. 

The last reference was apparently removed in 08391c7807.