### PR TITLE
Hide cancel button and empty action bars on mobile

### DIFF
--- a/app/views/projects/_project_export_modal.html.erb
+++ b/app/views/projects/_project_export_modal.html.erb
@@ -46,10 +46,10 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     </ul>
   </div>
-  <div class="spot-action-bar">
+  <div class="spot-action-bar hidden-for-mobile">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         dynamic-content-modal-close-button
         title=<%= t(:button_cancel) %>
       ><%= t(:button_cancel) %></button>

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
@@ -48,7 +48,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         data-qa-selector="confirmation-modal--cancel"
         (click)="closeMe($event)"
         [textContent]="text.button_cancel"

--- a/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
+++ b/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
@@ -13,7 +13,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         [textContent]="text.cancelButton"
         (click)="closeMe($event)"
       ></button>

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
@@ -25,7 +25,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-      class="button button_no-margin spot-action-bar--action"
+      class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
       [textContent]="text.cancelButton"
       (click)="closeMe($event)"
       >

--- a/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-modal/multi-date.modal.html
@@ -117,7 +117,7 @@
       <button
         type="button"
         (click)="cancel()"
-        class="op-datepicker-modal--action button button_no-margin spot-action-bar--action"
+        class="op-datepicker-modal--action spot-modal--cancel-button button button_no-margin spot-action-bar--action"
         data-qa-selector="op-datepicker-modal--action"
         [textContent]="text.cancel"
       ></button>

--- a/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-modal/single-date.modal.html
@@ -61,7 +61,7 @@
       <button
         type="button"
         (click)="cancel()"
-        class="op-datepicker-modal--action button button_no-margin spot-action-bar--action"
+        class="op-datepicker-modal--action spot-modal--cancel-button button button_no-margin spot-action-bar--action"
         data-qa-selector="op-datepicker-modal--action"
         [textContent]="text.cancel"
       ></button>

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
@@ -37,11 +37,11 @@
     </ul>
   </div>
 
-  <div class="spot-action-bar">
+  <div class="spot-action-bar hidden-for-mobile">
     <div class="spot-action-bar--right">
       <button
         type="button"
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         (click)="closeMe()"
         >
         {{ text.cancel_button }}

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.html
@@ -20,7 +20,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         [textContent]="text.cancelButton"
         (click)="closeMe($event)"
       ></button>

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
@@ -27,7 +27,7 @@
     <div class="spot-action-bar--right">
       <button
         type="button"
-        class="button spot-action-bar--action"
+        class="button spot-modal--cancel-button spot-action-bar--action"
         data-qa-selector="confirmation-modal--cancel"
         (click)="closeMe($event)"
       >

--- a/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
+++ b/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
@@ -22,11 +22,11 @@
       </li>
     </ul>
   </div>
-  <div class="spot-action-bar">
+  <div class="spot-action-bar hidden-for-mobile">
     <div class="spot-action-bar--right">
       <button
         type="button"
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         (click)="closeMe()"
         >
         {{ text.cancelButton }}

--- a/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
+++ b/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
@@ -31,7 +31,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         [textContent]="additionalText.cancel_button"
         (click)="closeMe()"
         >

--- a/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
+++ b/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
@@ -44,7 +44,7 @@
     <div class="spot-action-bar--right">
       <button
         type="button"
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         [textContent]="text.button_cancel"
         (click)="closeMe($event)"
       ></button>

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
@@ -16,7 +16,7 @@
 
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
-      <button class="button button_no-margin spot-action-bar--action"
+      <button class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
               [textContent]="text.button_cancel"
               [disabled]="isBusy"
               (click)="closeMe($event)">

--- a/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
+++ b/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
@@ -62,7 +62,7 @@
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
       <button
-        class="button button_no-margin spot-action-bar--action"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         [textContent]="text.cancel"
         (click)="closeMe($event)"
       ></button>

--- a/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
+++ b/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
@@ -28,7 +28,7 @@
       </button>
     </div>
     <div class="spot-action-bar--right">
-      <button class="button button_no-margin spot-action-bar--action"
+      <button class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
               *ngIf="saveAllowed"
               (click)="closeMe($event)"
               [textContent]="text.cancel"

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -66,3 +66,7 @@
 
     &:focus
       outline-style: none
+
+  &--cancel-button
+    @media (max-width: 680px)
+      display: none

--- a/frontend/src/global_styles/content/_modal.lsg
+++ b/frontend/src/global_styles/content/_modal.lsg
@@ -50,6 +50,10 @@
   </div>
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
+        <button
+          type="button"
+          class="spot-modal--cancel-button button button_no-margin spot-action-bar--action"
+        >Cancel</button>
       <button name="button" type="submit" class="button button_no-margin spot-action-bar--action">Close</button>
     </div>
   </div>
@@ -72,7 +76,7 @@
   </div>
   <div class="spot-action-bar">
     <div class="spot-action-bar--right">
-      <button name="button" type="submit" class="button button_no-margin spot-action-bar--action">Cancel</button>
+      <button name="button" type="button" class="button button_no-margin spot-action-bar--action">Cancel</button>
       <button name="button" type="submit" class="button button_no-margin -danger spot-action-bar--action">Continue</button>
     </div>
   </div>


### PR DESCRIPTION
I was looking into a programatic way to hide the action bar through spot, but `:empty` unfortunately doesn't work with hidden items. We'd have to remove the cancel button from DOM for it to work, and that moves the logic elsewhere. So, `hidden-for-mobile`will have to do 

https://community.openproject.org/work_packages/44398