### PR TITLE
Provide require$ and cachable resource services in base class

### DIFF
--- a/frontend/src/app/core/apiv3/api-v3.service.spec.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.spec.ts
@@ -26,7 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { States } from 'core-app/core/states/states.service';
@@ -35,8 +38,7 @@ describe('APIv3Service', () => {
   let service:ApiV3Service;
 
   beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+    void TestBed.configureTestingModule({
       providers: [
         States,
         PathHelperService,

--- a/frontend/src/app/core/apiv3/api-v3.service.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.ts
@@ -62,6 +62,7 @@ import { ApiV3NotificationsPaths } from 'core-app/core/apiv3/endpoints/notificat
 import { ApiV3ViewsPaths } from 'core-app/core/apiv3/endpoints/views/apiv3-views-paths';
 import { Apiv3BackupsPath } from 'core-app/core/apiv3/endpoints/backups/apiv3-backups-path';
 import { ApiV3DaysPaths } from 'core-app/core/apiv3/endpoints/days/api-v3-days-paths';
+import { Apiv3StoragesPaths } from 'core-app/core/apiv3/endpoints/storages/apiv3-storages-paths';
 
 @Injectable({ providedIn: 'root' })
 export class ApiV3Service {
@@ -79,6 +80,9 @@ export class ApiV3Service {
 
   // /api/v3/documents
   public readonly documents = this.apiV3CollectionEndpoint('documents');
+
+  // /api/v3/file_links
+  public readonly file_links = this.apiV3CollectionEndpoint('file_links');
 
   // /api/v3/notifications
   public readonly notifications = this.apiV3CustomEndpoint(ApiV3NotificationsPaths);
@@ -115,6 +119,9 @@ export class ApiV3Service {
 
   // /api/v3/news
   public readonly news = this.apiV3CustomEndpoint(ApiV3NewsPaths);
+
+  // /api/v3/storages
+  public readonly storages = this.apiV3CustomEndpoint(Apiv3StoragesPaths);
 
   // /api/v3/types
   public readonly types = this.apiV3CustomEndpoint(ApiV3TypesPaths);

--- a/frontend/src/app/core/apiv3/endpoints/storages/apiv3-storages-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/storages/apiv3-storages-paths.ts
@@ -26,34 +26,20 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
-import { forkJoin } from 'rxjs';
-import { IStorage } from 'core-app/core/state/storages/storage.model';
-import { StoragesStore } from 'core-app/core/state/storages/storages.store';
-import { insertCollectionIntoState } from 'core-app/core/state/collection-store';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { IHalResourceLink } from 'core-app/core/state/hal-resource';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ApiV3GettableResource,
+  ApiV3ResourceCollection,
+} from 'core-app/core/apiv3/paths/apiv3-resource';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { IStorage } from 'core-app/core/state/storages/storage.model';
 
-@Injectable()
-export class StoragesResourceService extends ResourceCollectionService<IStorage> {
-  updateCollection(key:string, storageLinks:IHalResourceLink[]):void {
-    forkJoin(
-      storageLinks.map((link) => this.http.get<IStorage>(link.href)),
-    ).subscribe((storages) => {
-      const storageCollection = { _embedded: { elements: storages } } as IHALCollection<IStorage>;
-      insertCollectionIntoState(this.store, storageCollection, key);
-    });
-  }
+export class Apiv3StoragesPaths
+  extends ApiV3ResourceCollection<IStorage, ApiV3GettableResource<IStorage>> {
+  // /api/v3/storages/files
+  public readonly files = this.subResource('files');
 
-  protected createStore():CollectionStore<IStorage> {
-    return new StoragesStore();
-  }
-
-  protected basePath():string {
-    return this.apiV3Service.storages.path;
+  constructor(protected apiRoot:ApiV3Service,
+    protected basePath:string) {
+    super(apiRoot, basePath, 'storages');
   }
 }

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -44,13 +44,9 @@ export class ConfigurationService {
   public constructor(
     readonly I18n:I18nService,
     readonly apiV3Service:ApiV3Service,
-    readonly weekdayService:WeekdayService,
   ) {
-    this.initialized = Promise
-      .all([
-        this.loadConfiguration(),
-        this.weekdayService.loadWeekdays().toPromise(),
-      ])
+    this.initialized = this
+      .loadConfiguration()
       .then(() => true)
       .catch(() => false);
   }

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -92,7 +92,7 @@ export class CurrentUserService {
 
           return { filters, pageSize: -1 };
         }),
-        switchMap((params) => this.capabilitiesService.require$(params)),
+        switchMap((params) => this.capabilitiesService.require(params)),
       );
   }
 

--- a/frontend/src/app/core/days/weekday.service.ts
+++ b/frontend/src/app/core/days/weekday.service.ts
@@ -59,7 +59,7 @@ export class WeekdayService {
    */
   public isNonWorkingDay(date:Date|number):boolean {
     const isoDayOfWeek = (typeof date === 'number') ? date : moment(date).isoWeekday();
-    return !!this.weekdays.find((wd) => wd.day === isoDayOfWeek && !wd.working);
+    return !!(this.weekdays || []).find((wd) => wd.day === isoDayOfWeek && !wd.working);
   }
 
   loadWeekdays():Observable<IWeekday[]> {

--- a/frontend/src/app/core/state/attachments/attachments.service.ts
+++ b/frontend/src/app/core/state/attachments/attachments.service.ts
@@ -61,20 +61,19 @@ import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @Injectable()
 export class AttachmentsResourceService extends ResourceCollectionService<IAttachment> {
-  constructor(
-    private readonly I18n:I18nService,
-    private readonly http:HttpClient,
-    private readonly apiV3Service:ApiV3Service,
-    private readonly fileUploadService:OpenProjectFileUploadService,
-    private readonly directFileUploadService:OpenProjectDirectFileUploadService,
-    private readonly configurationService:ConfigurationService,
-    private readonly toastService:ToastService,
-  ) {
-    super();
-  }
+  @InjectField() I18n:I18nService;
+
+  @InjectField() fileUploadService:OpenProjectFileUploadService;
+
+  @InjectField() directFileUploadService:OpenProjectDirectFileUploadService;
+
+  @InjectField() configurationService:ConfigurationService;
+
+  @InjectField() toastService:ToastService;
 
   /**
    * This method ensures that a specific collection is fetched, if not available.
@@ -245,5 +244,9 @@ export class AttachmentsResourceService extends ResourceCollectionService<IAttac
 
   protected createStore():CollectionStore<IAttachment> {
     return new AttachmentsStore();
+  }
+
+  protected basePath():string {
+    return this.apiV3Service.attachments.path;
   }
 }

--- a/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
@@ -220,7 +220,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require$(params)
+        .require(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });
@@ -234,7 +234,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require$(params)
+        .require(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });
@@ -244,7 +244,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require$(params)
+        .require(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(2);
         });
@@ -254,7 +254,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require$(params)
+        .require(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });

--- a/frontend/src/app/core/state/capabilities/capabilities.service.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.ts
@@ -5,8 +5,6 @@ import {
   switchMap,
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
@@ -17,23 +15,11 @@ import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @Injectable()
 export class CapabilitiesResourceService extends ResourceCollectionService<ICapability> {
-  constructor(
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-  ) {
-    super();
-  }
-
-  private get capabilitiesPath():string {
-    return this
-      .apiV3Service
-      .capabilities
-      .path;
-  }
+  @InjectField() toastService:ToastService;
 
   /**
    * Require the available capabilities for the given filter params
@@ -69,7 +55,7 @@ export class CapabilitiesResourceService extends ResourceCollectionService<ICapa
 
   public fetchCapabilities(params:ApiV3ListParameters):Observable<IHALCollection<ICapability>> {
     return this
-      .fetchCollection(this.http, this.capabilitiesPath, params)
+      .fetchCollection(params)
       .pipe(
         catchError((error) => {
           this.toastService.addError(error);
@@ -80,5 +66,12 @@ export class CapabilitiesResourceService extends ResourceCollectionService<ICapa
 
   protected createStore():CollectionStore<ICapability> {
     return new CapabilitiesStore();
+  }
+
+  protected basePath():string {
+    return this
+      .apiV3Service
+      .capabilities
+      .path;
   }
 }

--- a/frontend/src/app/core/state/collection-store.ts
+++ b/frontend/src/app/core/state/collection-store.ts
@@ -11,6 +11,7 @@ import {
 } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { IHalResourceLinks } from 'core-app/core/state/hal-resource';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { filter } from 'lodash';
 
 export interface CollectionResponse {
   ids:ID[];
@@ -63,14 +64,30 @@ export function collectionKey(params:ApiV3ListParameters):string {
 export function setCollectionLoading<T extends { id:ID }>(
   store:EntityStore<CollectionState<T>>,
   collectionUrl:string,
-  loading:boolean,
 ):void {
   store.update(({ loadingCollections }) => (
     {
       loadingCollections: {
         ...loadingCollections,
-        [collectionUrl]: loading,
+        [collectionUrl]: true,
       },
+    }
+  ));
+}
+
+/**
+ * Mark a collection key as no longer loading
+ *
+ * @param store An entity store for the collection
+ * @param collectionUrl The key to insert the collection at
+ */
+export function removeCollectionLoading<T extends { id:ID }>(
+  store:EntityStore<CollectionState<T>>,
+  collectionUrl:string,
+):void {
+  store.update(({ loadingCollections }) => (
+    {
+      loadingCollections: filter(loadingCollections, (_, key) => key !== collectionUrl),
     }
   ));
 }

--- a/frontend/src/app/core/state/days/day.service.ts
+++ b/frontend/src/app/core/state/days/day.service.ts
@@ -1,17 +1,20 @@
 import { Injectable } from '@angular/core';
 import {
+  finalize,
   map,
   tap,
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { HttpClient } from '@angular/common/http';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
+import {
+  ApiV3ListFilter,
+  ApiV3ListParameters,
+} from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import {
   collectionKey,
   extendCollectionElementsWithId,
   insertCollectionIntoState,
+  setCollectionLoading,
 } from 'core-app/core/state/collection-store';
 import { DayStore } from 'core-app/core/state/days/day.store';
 import { IDay } from 'core-app/core/state/days/day.model';
@@ -22,29 +25,47 @@ import {
 
 @Injectable()
 export class DayResourceService extends ResourceCollectionService<IDay> {
-  private get daysPath():string {
+  protected basePath():string {
     return this
       .apiV3Service
       .days
       .path;
   }
 
-  constructor(
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-  ) {
-    super();
+  isNonWorkingDay$(input:Date):Observable<boolean> {
+    const date = moment(input).format('YYYY-MM-DD');
+
+    return this
+      .requireNonWorkingYear$(input)
+      .pipe(
+        map((days) => days.findIndex((day:IDay) => !day.working && day.date === date) !== -1),
+      );
   }
 
-  fetchDays(params:ApiV3ListParameters):Observable<IHALCollection<IDay>> {
+  requireNonWorkingYear$(date:Date):Observable<IDay[]> {
+    const from = moment(date).startOf('year').format('YYYY-MM-DD');
+    const to = moment(date).endOf('year').format('YYYY-MM-DD');
+
+    const filters:ApiV3ListFilter[] = [
+      ['date', '<>d', [from, to]],
+      ['working', '=', ['f']],
+    ];
+
+    return this.require({ filters });
+  }
+
+  fetchCollection(params:ApiV3ListParameters):Observable<IHALCollection<IDay>> {
     const collectionURL = collectionKey(params);
+
+    setCollectionLoading(this.store, collectionURL, true);
 
     return this
       .http
-      .get<IHALCollection<IDay>>(this.daysPath + collectionURL)
+      .get<IHALCollection<IDay>>(this.basePath() + collectionURL)
       .pipe(
         map((collection) => extendCollectionElementsWithId(collection)),
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
+        finalize(() => setCollectionLoading(this.store, collectionURL, false)),
       );
   }
 

--- a/frontend/src/app/core/state/days/day.service.ts
+++ b/frontend/src/app/core/state/days/day.service.ts
@@ -14,6 +14,7 @@ import {
   collectionKey,
   extendCollectionElementsWithId,
   insertCollectionIntoState,
+  removeCollectionLoading,
   setCollectionLoading,
 } from 'core-app/core/state/collection-store';
 import { DayStore } from 'core-app/core/state/days/day.store';
@@ -57,7 +58,7 @@ export class DayResourceService extends ResourceCollectionService<IDay> {
   fetchCollection(params:ApiV3ListParameters):Observable<IHALCollection<IDay>> {
     const collectionURL = collectionKey(params);
 
-    setCollectionLoading(this.store, collectionURL, true);
+    setCollectionLoading(this.store, collectionURL);
 
     return this
       .http
@@ -65,7 +66,7 @@ export class DayResourceService extends ResourceCollectionService<IDay> {
       .pipe(
         map((collection) => extendCollectionElementsWithId(collection)),
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        finalize(() => setCollectionLoading(this.store, collectionURL, false)),
+        finalize(() => removeCollectionLoading(this.store, collectionURL)),
       );
   }
 

--- a/frontend/src/app/core/state/days/weekday.service.ts
+++ b/frontend/src/app/core/state/days/weekday.service.ts
@@ -8,9 +8,7 @@ import {
   EMPTY,
   Observable,
 } from 'rxjs';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { HttpClient } from '@angular/common/http';
 import {
   extendCollectionElementsWithId,
   insertCollectionIntoState,
@@ -24,21 +22,6 @@ import {
 
 @Injectable()
 export class WeekdayResourceService extends ResourceCollectionService<IWeekday> {
-  private get weekdaysPath():string {
-    return this
-      .apiV3Service
-      .days
-      .week
-      .path;
-  }
-
-  constructor(
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-  ) {
-    super();
-  }
-
   require():Observable<IWeekday[]> {
     return this
       .query
@@ -49,12 +32,12 @@ export class WeekdayResourceService extends ResourceCollectionService<IWeekday> 
       );
   }
 
-  private fetchWeekdays():Observable<IHALCollection<IWeekday>> {
+  protected fetchWeekdays():Observable<IHALCollection<IWeekday>> {
     const collectionURL = 'all'; // We load all weekdays
 
     return this
       .http
-      .get<IHALCollection<IWeekday>>(this.weekdaysPath)
+      .get<IHALCollection<IWeekday>>(this.basePath())
       .pipe(
         map((collection) => extendCollectionElementsWithId(collection)),
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
@@ -63,5 +46,13 @@ export class WeekdayResourceService extends ResourceCollectionService<IWeekday> 
 
   protected createStore():CollectionStore<IWeekday> {
     return new WeekdayStore();
+  }
+
+  protected basePath():string {
+    return this
+      .apiV3Service
+      .days
+      .week
+      .path;
   }
 }

--- a/frontend/src/app/core/state/file-links/file-links.service.ts
+++ b/frontend/src/app/core/state/file-links/file-links.service.ts
@@ -47,15 +47,11 @@ import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @Injectable()
 export class FileLinksResourceService extends ResourceCollectionService<IFileLink> {
-  constructor(
-    private readonly http:HttpClient,
-    private readonly toastService:ToastService,
-  ) {
-    super();
-  }
+  @InjectField() toastService:ToastService;
 
   updateCollectionsForWorkPackage(fileLinksSelfLink:string):void {
     this.http
@@ -106,5 +102,9 @@ export class FileLinksResourceService extends ResourceCollectionService<IFileLin
         }),
       )
       .subscribe(() => removeEntityFromCollectionAndState(this.store, fileLink.id, collectionKey));
+  }
+
+  protected basePath():string {
+    return this.apiV3Service.file_links.path;
   }
 }

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
@@ -2,15 +2,6 @@ import { Injectable } from '@angular/core';
 import { tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ID } from '@datorama/akita';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { HttpClient } from '@angular/common/http';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import {
-  collectionKey,
-  insertCollectionIntoState,
-} from 'core-app/core/state/collection-store';
 import {
   markNotificationsAsRead,
   notificationsMarkedRead,
@@ -26,36 +17,12 @@ import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
 export class InAppNotificationsResourceService extends ResourceCollectionService<INotification> {
-  private get notificationsPath():string {
-    return this
-      .apiV3Service
-      .notifications
-      .path;
-  }
-
-  constructor(
-    readonly actions$:ActionsService,
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-  ) {
-    super();
-  }
-
-  fetchNotifications(params:ApiV3ListParameters):Observable<IHALCollection<INotification>> {
-    const collectionURL = collectionKey(params);
-
-    return this
-      .http
-      .get<IHALCollection<INotification>>(this.notificationsPath + collectionURL)
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-      );
-  }
+  @InjectField() actions$:ActionsService;
 
   update(id:ID, inAppNotification:Partial<INotification>):void {
     this.store.update(id, inAppNotification);
@@ -87,5 +54,12 @@ export class InAppNotificationsResourceService extends ResourceCollectionService
 
   protected createStore():CollectionStore<INotification> {
     return new InAppNotificationsStore();
+  }
+
+  protected basePath():string {
+    return this
+      .apiV3Service
+      .notifications
+      .path;
   }
 }

--- a/frontend/src/app/core/state/principals/principals.service.ts
+++ b/frontend/src/app/core/state/principals/principals.service.ts
@@ -5,10 +5,8 @@ import {
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { applyTransaction } from '@datorama/akita';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { HttpClient } from '@angular/common/http';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import {
   collectionKey,
@@ -23,25 +21,14 @@ import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
 export class PrincipalsResourceService extends ResourceCollectionService<IPrincipal> {
-  private get principalsPath():string {
-    return this
-      .apiV3Service
-      .principals
-      .path;
-  }
+  @InjectField() actions$:ActionsService;
 
-  constructor(
-    readonly actions$:ActionsService,
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-  ) {
-    super();
-  }
+  @InjectField() toastService:ToastService;
 
   fetchUser(id:string|number):Observable<IUser> {
     return this.http
@@ -64,7 +51,7 @@ export class PrincipalsResourceService extends ResourceCollectionService<IPrinci
 
     return this
       .http
-      .get<IHALCollection<IPrincipal>>(this.principalsPath + collectionURL)
+      .get<IHALCollection<IPrincipal>>(this.basePath() + collectionURL)
       .pipe(
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
         catchError((error) => {
@@ -76,5 +63,12 @@ export class PrincipalsResourceService extends ResourceCollectionService<IPrinci
 
   protected createStore():CollectionStore<IPrincipal> {
     return new PrincipalsStore();
+  }
+
+  protected basePath():string {
+    return this
+      .apiV3Service
+      .principals
+      .path;
   }
 }

--- a/frontend/src/app/core/state/projects/projects.service.ts
+++ b/frontend/src/app/core/state/projects/projects.service.ts
@@ -27,20 +27,8 @@
 //++
 
 import { Injectable } from '@angular/core';
-import {
-  catchError,
-  tap,
-} from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import {
-  collectionKey,
-  insertCollectionIntoState,
-} from 'core-app/core/state/collection-store';
 import { IProject } from './project.model';
 import {
   CollectionStore,
@@ -50,36 +38,6 @@ import { ProjectsStore } from 'core-app/core/state/projects/projects.store';
 
 @Injectable()
 export class ProjectsResourceService extends ResourceCollectionService<IProject> {
-  private get projectsPath():string {
-    return this
-      .apiV3Service
-      .projects
-      .path;
-  }
-
-  constructor(
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-  ) {
-    super();
-  }
-
-  fetchProjects(params:ApiV3ListParameters):Observable<IHALCollection<IProject>> {
-    const collectionURL = collectionKey(params);
-
-    return this
-      .http
-      .get<IHALCollection<IProject>>(this.projectsPath + collectionURL)
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        catchError((error) => {
-          this.toastService.addError(error);
-          throw error;
-        }),
-      );
-  }
-
   update(link:string):Observable<IProject> {
     return this.http.get<IProject>(link)
       .pipe(
@@ -91,5 +49,12 @@ export class ProjectsResourceService extends ResourceCollectionService<IProject>
 
   protected createStore():CollectionStore<IProject> {
     return new ProjectsStore();
+  }
+
+  protected basePath():string {
+    return this
+      .apiV3Service
+      .projects
+      .path;
   }
 }

--- a/frontend/src/app/core/state/resource-collection.service.ts
+++ b/frontend/src/app/core/state/resource-collection.service.ts
@@ -45,6 +45,7 @@ import {
   CollectionResponse,
   CollectionState,
   insertCollectionIntoState,
+  removeCollectionLoading,
   setCollectionLoading,
 } from 'core-app/core/state/collection-store';
 import { omit } from 'lodash';
@@ -228,14 +229,14 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
   fetchCollection(params:ApiV3ListParameters|string):Observable<IHALCollection<T>> {
     const key = typeof params === 'string' ? params : collectionKey(params);
 
-    setCollectionLoading(this.store, key, true);
+    setCollectionLoading(this.store, key);
 
     return this
       .http
       .get<IHALCollection<T>>(this.basePath() + key)
       .pipe(
         tap((collection) => insertCollectionIntoState(this.store, collection, key)),
-        finalize(() => setCollectionLoading(this.store, key, false)),
+        finalize(() => removeCollectionLoading(this.store, key)),
         catchError((error:unknown) => {
           this.handleCollectionLoadingError(error as HttpErrorResponse, key);
           throw error;

--- a/frontend/src/app/core/state/storage-files/storage-files.service.ts
+++ b/frontend/src/app/core/state/storage-files/storage-files.service.ts
@@ -43,9 +43,6 @@ import { insertCollectionIntoState } from 'core-app/core/state/collection-store'
 
 @Injectable()
 export class StorageFilesResourceService extends ResourceCollectionService<IStorageFile> {
-  constructor(private readonly http:HttpClient) {
-    super();
-  }
 
   protected createStore():CollectionStore<IStorageFile> {
     return new StorageFilesStore();
@@ -68,5 +65,9 @@ export class StorageFilesResourceService extends ResourceCollectionService<IStor
 
   reset():void {
     this.store.reset();
+  }
+
+  protected basePath():string {
+    return this.apiV3Service.storages.files.path;
   }
 }

--- a/frontend/src/app/core/state/views/views.service.ts
+++ b/frontend/src/app/core/state/views/views.service.ts
@@ -1,70 +1,27 @@
 import { Injectable } from '@angular/core';
-import {
-  catchError,
-  tap,
-} from 'rxjs/operators';
-import { Observable } from 'rxjs';
-import {
-  applyTransaction,
-  ID,
-} from '@datorama/akita';
-import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { HttpClient } from '@angular/common/http';
-import {
-  collectionKey,
-  insertCollectionIntoState,
-} from 'core-app/core/state/collection-store';
-import {
-  EffectHandler,
-} from 'core-app/core/state/effects/effect-handler.decorator';
+import { EffectHandler } from 'core-app/core/state/effects/effect-handler.decorator';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { ViewsStore } from 'core-app/core/state/views/views.store';
-import { ViewsQuery } from 'core-app/core/state/views/views.query';
 import { IView } from 'core-app/core/state/views/view.model';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { addParamToHref } from 'core-app/shared/helpers/url-helpers';
 import {
   CollectionStore,
   ResourceCollectionService,
 } from 'core-app/core/state/resource-collection.service';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
 export class ViewsResourceService extends ResourceCollectionService<IView> {
-  private get viewsPath():string {
+  @InjectField() actions$:ActionsService;
+
+  protected createStore():CollectionStore<IView> {
+    return new ViewsStore();
+  }
+
+  protected basePath():string {
     return this
       .apiV3Service
       .views
       .path;
-  }
-
-  constructor(
-    readonly actions$:ActionsService,
-    private http:HttpClient,
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-  ) {
-    super();
-  }
-
-  fetchViews(params:ApiV3ListParameters):Observable<IHALCollection<IView>> {
-    const collectionURL = collectionKey(params);
-
-    return this
-      .http
-      .get<IHALCollection<IView>>(addParamToHref(this.viewsPath + collectionURL, { pageSize: '-1' }))
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        catchError((error) => {
-          this.toastService.addError(error);
-          throw error;
-        }),
-      );
-  }
-
-  protected createStore():CollectionStore<IView> {
-    return new ViewsStore();
   }
 }

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -265,7 +265,10 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       additionalOptions.initialView = 'dayGridWeek';
     }
 
-    void this.configuration.initialized
+    void Promise.all([
+      this.configuration.initialized,
+      this.weekdayService.loadWeekdays().toPromise(),
+    ])
       .then(() => {
         this.calendarOptions$.next(
           this.workPackagesCalendar.calendarOptions(additionalOptions),

--- a/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
@@ -46,8 +46,9 @@ export class IanBellService {
   }
 
   fetchUnread():Observable<number> {
-    return this.resourceService
-      .fetchNotifications({ filters: IAN_FACET_FILTERS.unread, pageSize: 0 })
+    return this
+      .resourceService
+      .fetchCollection({ filters: IAN_FACET_FILTERS.unread, pageSize: 0 })
       .pipe(
         map((result) => result.total),
         tap(

--- a/frontend/src/app/features/in-app-notifications/center/menu/state/ian-menu.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/state/ian-menu.service.ts
@@ -90,7 +90,7 @@ export class IanMenuService {
   }
 
   public reload():void {
-    this.ianResourceService.fetchNotifications(IAN_MENU_PROJECT_FILTERS)
+    this.ianResourceService.fetchCollection(IAN_MENU_PROJECT_FILTERS)
       .subscribe((data) => {
         const projectsFilter:ApiV3ListParameters = {
           pageSize: 100,
@@ -108,10 +108,10 @@ export class IanMenuService {
 
         // Only request if there are any groups
         if (data.groups && data.groups.length > 0) {
-          this.projectsResourceService.fetchProjects(projectsFilter).subscribe();
+          this.projectsResourceService.fetchCollection(projectsFilter).subscribe();
         }
       });
-    this.ianResourceService.fetchNotifications(IAN_MENU_REASON_FILTERS)
+    this.ianResourceService.fetchCollection(IAN_MENU_REASON_FILTERS)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       .subscribe((data) => this.store.update({ notificationsByReason: data.groups }));
   }

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -153,7 +153,7 @@ export class IanCenterService extends UntilDestroyedMixin {
     }),
     switchMap(() => this
       .resourceService
-      .fetchNotifications(this.params)
+      .fetchCollection(this.params)
       .pipe(
         switchMap(
           (results) => from(this.sideLoadInvolvedWorkPackages(results._embedded.elements))

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.store.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.store.ts
@@ -4,6 +4,8 @@ import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.i
 import { NOTIFICATIONS_MAX_SIZE } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { INotificationPageQueryParameters } from 'core-app/features/in-app-notifications/in-app-notifications.routes';
 
+export type InAppNotificationFacet = 'unread'|'all';
+
 export interface IanCenterState {
   params:{
     page:number;
@@ -17,8 +19,6 @@ export interface IanCenterState {
   /** Number of elements not showing after max values loaded */
   notLoaded:number;
 }
-
-export type InAppNotificationFacet = 'unread'|'all';
 
 export const IAN_FACET_FILTERS:Record<InAppNotificationFacet, ApiV3ListFilter[]> = {
   unread: [['readIAN', '=', false]],

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -416,7 +416,10 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   private initializeCalendar() {
-    void this.configuration.initialized
+    void Promise.all([
+      this.configuration.initialized,
+      this.weekdayService.loadWeekdays().toPromise(),
+    ])
       .then(() => {
         this.calendarOptions$.next(
           this.workPackagesCalendar.calendarOptions({

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
@@ -106,7 +106,7 @@ export class WpSingleViewService {
       .pipe(
         take(1),
         filter((loggedIn) => loggedIn),
-        switchMap(() => this.resourceService.fetchNotifications(this.params)),
+        switchMap(() => this.resourceService.fetchCollection(this.params)),
       )
       .subscribe();
   }

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -186,12 +186,10 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
       );
     }
 
-    this.viewsService.fetchViews(params)
+    this.viewsService.fetchResults(params)
       .pipe(this.untilDestroyed())
-      .subscribe((queryCollection) => {
-        queryCollection
-          ._embedded
-          .elements
+      .subscribe((views) => {
+        views
           .sort((a, b) => a._links.query.title.localeCompare(b._links.query.title))
           .forEach((view) => {
             let cat = 'private';


### PR DESCRIPTION
This PR clears up the interface of the base resource service to make it easier to provide cached collections in all the state-based resource services.

This removes a lot of duplication in resource services doing the same thing: Fetching a collection using a basePath + collection key, inserting that into the store, and returning it.