### PR TITLE
[44406] After moving a work package card on the calendar, update dates based on its duration

### DIFF
--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -420,7 +420,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
   updateDates(resizeInfo:EventResizeDoneArg|EventDropArg|EventReceiveArg, dragged?:boolean):ResourceChangeset<WorkPackageResource> {
     const workPackage = resizeInfo.event.extendedProps.workPackage as WorkPackageResource;
     const changeset = this.halEditing.edit(workPackage);
-    if (!workPackage.ignoreNonWorkingDays && dragged) {
+    if (!workPackage.ignoreNonWorkingDays && workPackage.duration && dragged) {
       changeset.setValue('duration', workPackage.duration);
     } else {
       const due = moment(resizeInfo.event.endStr)

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -52,6 +52,7 @@ import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { WorkPackageViewContextMenu } from 'core-app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
+import { WeekdayService } from 'core-app/core/days/weekday.service';
 
 export interface CalendarViewEvent {
   el:HTMLElement;
@@ -98,6 +99,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     readonly wpTableSelection:WorkPackageViewSelectionService,
     readonly contextMenuService:OPContextMenuService,
     readonly calendarService:OpCalendarService,
+    readonly weekdayService:WeekdayService,
   ) {
     super();
   }
@@ -415,16 +417,18 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     );
   }
 
-  updateDates(resizeInfo:EventResizeDoneArg|EventDropArg|EventReceiveArg):ResourceChangeset<WorkPackageResource> {
+  updateDates(resizeInfo:EventResizeDoneArg|EventDropArg|EventReceiveArg, dragged?:boolean):ResourceChangeset<WorkPackageResource> {
     const workPackage = resizeInfo.event.extendedProps.workPackage as WorkPackageResource;
-
     const changeset = this.halEditing.edit(workPackage);
+    if (!workPackage.ignoreNonWorkingDays && dragged) {
+      changeset.setValue('duration', workPackage.duration);
+    } else {
+      const due = moment(resizeInfo.event.endStr)
+        .subtract(1, 'day')
+        .format('YYYY-MM-DD');
+      changeset.setValue('dueDate', due);
+    }
     changeset.setValue('startDate', resizeInfo.event.startStr);
-    const due = moment(resizeInfo.event.endStr)
-      .subtract(1, 'day')
-      .format('YYYY-MM-DD');
-    changeset.setValue('dueDate', due);
-
     return changeset;
   }
 }

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -216,7 +216,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
           resizeInfo?.revert();
           return;
         }
-        void this.updateEvent(resizeInfo);
+        void this.updateEvent(resizeInfo, false);
       },
       eventDrop: (dropInfo:EventDropArg) => {
         const start = moment(dropInfo.event.startStr).toDate();
@@ -226,7 +226,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
           dropInfo?.revert();
           return;
         }
-        void this.updateEvent(dropInfo);
+        void this.updateEvent(dropInfo, true);
       },
       eventResizeStart: (resizeInfo:EventResizeDoneArg) => {
         const wp = resizeInfo.event.extendedProps.workPackage as WorkPackageResource;
@@ -325,8 +325,8 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     });
   }
 
-  private async updateEvent(info:EventResizeDoneArg|EventDropArg):Promise<void> {
-    const changeset = this.workPackagesCalendar.updateDates(info);
+  private async updateEvent(info:EventResizeDoneArg|EventDropArg, dragged:boolean):Promise<void> {
+    const changeset = this.workPackagesCalendar.updateDates(info, dragged);
 
     try {
       const result = await this.halEditing.save(changeset);

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -506,7 +506,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
                 resizeInfo?.revert();
                 return;
               }
-              void this.updateEvent(resizeInfo);
+              void this.updateEvent(resizeInfo, false);
             },
             eventResizeStart: (resizeInfo:EventResizeDoneArg) => {
               const wp = resizeInfo.event.extendedProps.workPackage as WorkPackageResource;
@@ -539,18 +539,17 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
                 dropInfo?.revert();
                 return;
               }
-              void this.updateEvent(dropInfo);
+              void this.updateEvent(dropInfo, true);
             },
             eventReceive: async (dropInfo:EventReceiveArg) => {
-              const due = moment(dropInfo.event.endStr).subtract(1, 'day').toDate();
               const start = moment(dropInfo.event.startStr).toDate();
               const wp = dropInfo.event.extendedProps.workPackage as WorkPackageResource;
-              if (!wp.ignoreNonWorkingDays && (this.weekdayService.isNonWorkingDay(start) || this.weekdayService.isNonWorkingDay(due))) {
+              if (!wp.ignoreNonWorkingDays && (this.weekdayService.isNonWorkingDay(start))) {
                 this.toastService.addError(this.text.cannot_drag_to_non_working_day);
                 dropInfo?.revert();
                 return;
               }
-              await this.updateEvent(dropInfo);
+              await this.updateEvent(dropInfo, true);
               this.actions$.dispatch(teamPlannerEventAdded({ workPackage: wp.id as string }));
             },
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -837,8 +836,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     return id !== globalDraggingId;
   }
 
-  private async updateEvent(info:EventResizeDoneArg|EventDropArg|EventReceiveArg):Promise<void> {
-    const changeset = this.workPackagesCalendar.updateDates(info);
+  private async updateEvent(info:EventResizeDoneArg|EventDropArg|EventReceiveArg, dragged:boolean):Promise<void> {
+    const changeset = this.workPackagesCalendar.updateDates(info, dragged);
     const resource = info.event.getResources()[0];
     if (resource) {
       changeset.setValue('assignee', { href: resource.id });


### PR DESCRIPTION
If a week-days-only WP card is moving and spanning non-working days, the end-date should be updated based on its duration.

https://community.openproject.org/work_packages/44406/activity