### PR TITLE
Set default active work package custom fields only if not provided

### DIFF
--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -47,7 +47,7 @@ module Projects
       set_default_public(attribute_keys.include?('public'))
       set_default_module_names(attribute_keys.include?('enabled_module_names'))
       set_default_types(attribute_keys.include?('types') || attribute_keys.include?('type_ids'))
-      set_default_active_work_package_custom_fields
+      set_default_active_work_package_custom_fields(attribute_keys.include?('work_package_custom_fields'))
     end
 
     def set_default_public(provided)
@@ -62,7 +62,9 @@ module Projects
       model.types = ::Type.default if !provided && model.types.empty?
     end
 
-    def set_default_active_work_package_custom_fields
+    def set_default_active_work_package_custom_fields(provided)
+      return if provided
+
       model.work_package_custom_fields = WorkPackageCustomField.joins(:types).where(types: { id: model.type_ids })
     end
 

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -744,6 +744,34 @@ describe Projects::CopyService, 'integration', type: :model do
           expect(cv.map(&:formatted_value)).to contain_exactly('A', 'B')
         end
       end
+
+      context 'with disabled work package custom field' do
+        it 'is still disabled in the copy' do
+          custom_field = create(:text_wp_custom_field)
+          create(:type_task,
+                 projects: [source],
+                 custom_fields: [custom_field])
+
+          expect(subject).to be_success
+
+          expect(source.work_package_custom_fields).to eq([])
+          expect(project_copy.work_package_custom_fields).to match_array(source.work_package_custom_fields)
+        end
+      end
+
+      context 'with enabled work package custom field' do
+        it 'is still enabled in the copy' do
+          custom_field = create(:text_wp_custom_field, projects: [source])
+          create(:type_task,
+                 projects: [source],
+                 custom_fields: [custom_field])
+
+          expect(subject).to be_success
+
+          expect(source.work_package_custom_fields).to eq([custom_field])
+          expect(project_copy.work_package_custom_fields).to match_array(source.work_package_custom_fields)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/43763

So that a project copy will have the same activated custom fields as its source project, instead of having the default active custom fields based on the types enabled on the projects (as introduced in [OP #41097](https://community.openproject.org/wp/41097)).