### PR TITLE
Autofocus on OTP input field

### DIFF
--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
@@ -10,7 +10,7 @@
     <div class="form--field -required -wide-label">
       <%= styled_label_tag 'backup_code', t('two_factor_authentication.backup_codes.singular') %>
       <div class="form--field-container">
-        <%= styled_text_field_tag 'backup_code', nil, required: true, autocomplete: 'off', size: 20, maxlength: 20, tabindex: 1, focus: true  %>
+        <%= styled_text_field_tag 'backup_code', nil, required: true, autocomplete: 'off', size: 20, maxlength: 20, tabindex: 1, autofocus: true  %>
       </div>
     </div>
       <input type="submit" name="login" value="<%=t(:button_submit)%>" class="button -highlight" tabindex="2" />

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
@@ -16,7 +16,7 @@
     <div class="form--field -wide-label">
       <%= styled_label_tag 'otp', t(:field_otp) %>
       <div class="form--field-container">
-        <%= styled_text_field_tag 'otp', nil, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, focus: true  %>
+        <%= styled_text_field_tag 'otp', nil, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, autofocus: true  %>
       </div>
     </div>
     <% if remember_2fa_enabled? %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
@@ -11,7 +11,7 @@
   <div class="form--field -required -wide-label">
     <%= styled_label_tag 'otp', t(:field_otp) %>
     <div class="form--field-container">
-      <%= styled_text_field_tag 'otp', nil, required: true, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, focus: true  %>
+      <%= styled_text_field_tag 'otp', nil, required: true, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, autofocus: true  %>
     </div>
   </div>
   <div>


### PR DESCRIPTION
While validating [OP #44327](https://community.openproject.org/wp/44327) I noticed that the OTP input field was not focused automatically. The property `focus: true` being used was the wrong one. The right one is `autofocus: true`.