### PR TITLE
accept `false` value overriding definition

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -230,9 +230,10 @@ module Settings
         envs = ['default', Rails.env]
         envs.delete('default') if Rails.env.test? # The test setup should govern the configuration
         envs.each do |env|
-          next unless file_config.dig(env, definition.name)
+          next unless (env_config = file_config[env])
+          next unless env_config.has_key?(definition.name)
 
-          definition.override_value(file_config.dig(env, definition.name))
+          definition.override_value(env_config[definition.name])
         end
       end
 

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -383,6 +383,7 @@ describe Settings::Definition do
             default:
               edition: 'bim'
               sendmail_location: 'default_location'
+              direct_uploads: false
             test:
               smtp_address: 'test address'
               sendmail_location: 'test location'
@@ -446,6 +447,11 @@ describe Settings::Definition do
       it 'correctly parses date objects' do
         expect(all.detect { |d| d.name == 'consent_time' }.value)
           .to eql DateTime.parse("2222-01-01")
+      end
+
+      it 'correctly overrides a default by a false value' do
+        expect(all.detect { |d| d.name == 'direct_uploads' }.value)
+          .to be false
       end
 
       context 'when Rails environment is test' do


### PR DESCRIPTION
`false` values were not accepted as`file_config.dig(env, definition.name)` returns `false` for those, exiting the block before the value was set.   

https://community.openproject.org/projects/openproject/work_packages/44492