### PR TITLE
Better OmniAuth error message when trying to post to missing strategy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1342,6 +1342,7 @@ en:
   error_no_type_in_project: "No type is associated to this project. Please check the Project settings."
   error_omniauth_registration_timed_out: "The registration via an external authentication provider timed out. Please try again."
   error_omniauth_invalid_auth: "The authentication information returned from the identity provider was invalid. Please contact your administrator for further help."
+  error_omniauth_missing_strategy: "No strategy matched the request path, this is likely a configuration error."
   error_password_change_failed: 'An error occurred when trying to change the password.'
   error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
   error_scm_not_found: "The entry or revision was not found in the repository."

--- a/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
+++ b/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
@@ -29,6 +29,7 @@
 require 'spec_helper'
 
 describe Authentication::OmniauthAuthHashContract do
+  let(:strategy) { double('Strategy', name: 'saml') } # rubocop:disable RSpec/VerifiedDoubles
   let(:auth_hash) do
     OmniAuth::AuthHash.new(
       provider: 'google',
@@ -40,7 +41,7 @@ describe Authentication::OmniauthAuthHashContract do
     )
   end
 
-  let(:instance) { described_class.new(auth_hash) }
+  let(:instance) { described_class.new(strategy, auth_hash) }
 
   subject do
     instance.validate


### PR DESCRIPTION
When trying to POST to `/omniauth/<strategy>/callback` and we don't find it, we're stilling running through the omniauth_service trying to access the strategy. Provide a better error message in this case

Followup for 96dbb65f9e791ee8b7d4c614d7b5986cd004e832