### PR TITLE
Fix/copying attachments on s3

### DIFF
--- a/app/services/copy/concerns/copy_attachments.rb
+++ b/app/services/copy/concerns/copy_attachments.rb
@@ -6,20 +6,27 @@ module Copy
       def copy_attachments(container_type, from_id:, to_id:)
         Attachment
           .where(container_type:, container_id: from_id)
-          .find_each do |old_attachment|
-          copied = old_attachment.dup
-          old_attachment.file.copy_to(copied)
+          .find_each do |source|
 
-          copied.author = user
-          copied.container_type = old_attachment.container_type
-          copied.container_id = to_id
+          copy = Attachment
+                   .new(attachment_copy_attributes(source, to_id))
+          source.file.copy_to(copy)
 
-          unless copied.save
-            Rails.logger.error { "Attachments ##{old_attachment.id} could not be copied: #{copied.errors.full_messages} " }
+          unless copy.save
+            Rails.logger.error { "Attachments ##{source.id} could not be copy: #{copy.errors.full_messages} " }
           end
         rescue StandardError => e
-          Rails.logger.error { "Failed to copy attachments from ##{from_container_id} to ##{to_container_id}: #{e}" }
+          Rails.logger.error { "Failed to copy attachments from ##{from_id} to ##{to_id}: #{e}" }
         end
+      end
+
+      def attachment_copy_attributes(source, to_id)
+        source
+          .dup
+          .attributes
+          .except('file')
+          .merge('author_id' => user.id,
+                 'container_id' => to_id)
       end
     end
   end

--- a/app/uploaders/fog_file_uploader.rb
+++ b/app/uploaders/fog_file_uploader.rb
@@ -40,7 +40,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
   after :store, :delete_old_tmp_file
 
   def copy_to(attachment)
-    attachment.remote_file_url = remote_file.url
+    attachment.file = local_file
   end
 
   def store_dir


### PR DESCRIPTION
For reasons I did not follow up on, the old approach of using `remote_file_url = ...` no longer works.

My attempt to use [Fog's copy_to functionality](https://github.com/carrierwaveuploader/carrierwave/blob/1.x-stable/lib/carrierwave/storage/fog.rb#L431-L434) failed between setting the file (`attachment.file = file.copy_to(....)`), when it is present on S3, and saving the attachment (when the file is gone). This approach would have avoided having to download the attachment from S3 to the local server only to upload it again. But it would only have been possible after the attachment had been saved as the attachment's id is part of the path.

This approach works even with the drawback outlined above.

https://community.openproject.org/wp/43005 