### PR TITLE
use Push change detection to avoid dom recreation

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { trackByProperty } from 'core-app/shared/helpers/angular/tracking-functions';
 import { ActivityPanelBaseController } from 'core-app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller';
@@ -34,6 +34,7 @@ import { ActivityPanelBaseController } from 'core-app/features/work-packages/com
 @Component({
   templateUrl: './activity-tab.html',
   selector: 'wp-activity-tab',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageActivityTabComponent extends ActivityPanelBaseController {
   public workPackage:WorkPackageResource;


### PR DESCRIPTION
When having a lot of activities for a single work package, the Angular change detection seems to be triggering a lot of DOM recreation leading to a hotspot in the `unsubscribe` function. This can be traced to the `activity-tab.component` which before this change did not make use of the OnPush strategy:

<img width="1748" alt="image" src="https://user-images.githubusercontent.com/617519/196491529-d0a3c377-6075-4f18-9271-227894c03171.png">

When applying the strategy, no functionality seems to be impeded but the hotspot vanishes:

<img width="1772" alt="image" src="https://user-images.githubusercontent.com/617519/196491761-ad105edd-a094-43cc-a5ed-5555bb1dd945.png">

To test this, create a work package with a large number of activites e.g. via the console:

```
wp = WorkPackage.find([some_id])
User.current = User.admin.first
200.times do { |i| AddWorkPackageNoteService.new(user: User.current, work_package: wp).call("Journal note update #{i}", send_notifications: false) }
```

Writing in the ck-editor e.g. when adding a new comment should improve noticeably.


https://community.openproject.org/wp/40373