### PR TITLE
Add CostEntry#logged_by in fashion of time entries

### DIFF
--- a/db/migrate/20221018160449_add_logged_by_to_cost_entries.rb
+++ b/db/migrate/20221018160449_add_logged_by_to_cost_entries.rb
@@ -1,0 +1,15 @@
+class AddLoggedByToCostEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :cost_entries, :logged_by, foreign_key: { to_table: :users }, index: true
+
+    reversible do |dir|
+      dir.up do
+        CostEntry
+          .where.not(user_id: User.select(:id))
+          .update_all(user_id: DeletedUser.first.id)
+
+        CostEntry.update_all('logged_by_id = user_id')
+      end
+    end
+  end
+end

--- a/modules/costs/app/models/cost_entry.rb
+++ b/modules/costs/app/models/cost_entry.rb
@@ -30,6 +30,7 @@ class CostEntry < ApplicationRecord
   belongs_to :project
   belongs_to :work_package
   belongs_to :user
+  belongs_to :logged_by, class_name: 'User'
   include ::Costs::DeletedUserFallback
   belongs_to :cost_type
   belongs_to :budget
@@ -37,7 +38,7 @@ class CostEntry < ApplicationRecord
 
   include ActiveModel::ForbiddenAttributesProtection
 
-  validates_presence_of :work_package_id, :project_id, :user_id, :cost_type_id, :units, :spent_on
+  validates_presence_of :work_package_id, :project_id, :user_id, :logged_by_id, :cost_type_id, :units, :spent_on
   validates_numericality_of :units, allow_nil: false, message: :invalid
   validates_length_of :comments, maximum: 255, allow_nil: true
 
@@ -53,7 +54,12 @@ class CostEntry < ApplicationRecord
   include Entry::SplashedDates
 
   def after_initialize
-    if new_record? && cost_type.nil? && default_cost_type = CostType.default
+    return unless new_record?
+
+    # This belongs in a SetAttributesService, but cost_entries are not yet created as such
+    self.logged_by = User.current
+
+    if cost_type.nil? && default_cost_type = CostType.default
       self.cost_type_id = default_cost_type.id
     end
   end

--- a/modules/costs/spec/models/cost_entry_spec.rb
+++ b/modules/costs/spec/models/cost_entry_spec.rb
@@ -361,6 +361,19 @@ describe CostEntry, type: :model do
       end
     end
 
+    describe '#logged_by' do
+      it 'validates' do
+        cost_entry.logged_by = nil
+        expect(cost_entry).not_to be_valid
+        expect(cost_entry.errors[:logged_by_id]).to be_present
+      end
+
+      it 'sets logged_by from current user' do
+        entry = User.execute_as(user2) { described_class.new logged_by: user }
+        expect(entry.logged_by).to eq(user2)
+      end
+    end
+
     describe '#editable_by?' do
       describe "WHEN the user has the edit_cost_entries permission
                 WHEN the cost entry is not created by the user" do

--- a/modules/reporting/app/models/cost_query/sql_statement.rb
+++ b/modules/reporting/app/models/cost_query/sql_statement.rb
@@ -111,7 +111,7 @@ class CostQuery::SqlStatement < Report::SqlStatement
   #
   # @param [CostQuery::SqlStatement] query The statement to adjust
   def self.unify_cost_entries(query)
-    query.select :units, :cost_type_id, activity_id: -1, logged_by_id: -1
+    query.select :units, :cost_type_id, :logged_by_id, activity_id: -1
     query.select cost_type: "cost_types.name"
     query.join CostType
   end


### PR DESCRIPTION
This adds logged_by and sets it identical to how time entries migrated.

Unfortunately, cost entries don't have base services yet and so we set it in

an after_initialize hook

https://community.openproject.org/work_packages/44352