### PR TITLE
[#43677] Replace the date_alertin the Notification::REASONS

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -10,7 +10,8 @@ class Notification < ApplicationRecord
     prioritized: 7,
     scheduled: 8,
     responsible: 9,
-    date_alert: 10
+    date_alert_start_date: 10,
+    date_alert_due_date: 11
   }.freeze
 
   enum reason: REASONS,


### PR DESCRIPTION
https://community.openproject.org/work_packages/43677
- [X] Replace the date_alert with date_alert_start_date and date_alert_due_date in the Notification::REASONS