### PR TITLE
Bug/43832 reorder values alphabetically does not work reliably

### DIFF
--- a/app/models/custom_option.rb
+++ b/app/models/custom_option.rb
@@ -30,8 +30,6 @@
 # A custom option is a possible value for a given custom field
 # which is restricted to a set of specific values.
 class CustomOption < ApplicationRecord
-  acts_as_list
-
   belongs_to :custom_field, touch: true
 
   validates :value, presence: true, length: { maximum: 255 }

--- a/spec/features/custom_fields/reorder_options_spec.rb
+++ b/spec/features/custom_fields/reorder_options_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
+def get_possible_values(amount)
+  (1..amount).to_a.map { |x| "PREFIX #{x}" }
+end
+
+def get_shuffled_possible_values(amount)
+  get_possible_values(amount).shuffle(random: Random.new(2))
+end
+
+def get_possible_values_reordered(amount)
+  get_possible_values(amount).sort
+end
+
 describe 'Reordering custom options of a list custom field', js: true do
   let(:user) { create :admin }
   let(:cf_page) { Pages::CustomFields.new }
@@ -9,7 +21,7 @@ describe 'Reordering custom options of a list custom field', js: true do
     create(
       :list_wp_custom_field,
       name: "Platform",
-      possible_values: %w[Playstation Xbox Nintendo PC Switch Mobile Dreamcast]
+      possible_values: get_shuffled_possible_values(200)
     )
   end
 
@@ -19,7 +31,7 @@ describe 'Reordering custom options of a list custom field', js: true do
 
   it 'reorders the items alphabetically when pressed' do
     expect(custom_field.custom_options.order(:position).pluck(:value))
-      .to eq %w[Playstation Xbox Nintendo PC Switch Mobile Dreamcast]
+      .to eq get_shuffled_possible_values(200)
 
     cf_page.visit!
     click_link custom_field.name
@@ -28,6 +40,6 @@ describe 'Reordering custom options of a list custom field', js: true do
     cf_page.accept_alert_dialog!
     expect(page).to have_selector('.flash.notice', text: I18n.t(:notice_successful_update))
     expect(custom_field.custom_options.order(:position).pluck(:value))
-      .to eq %w[Dreamcast Mobile Nintendo PC Playstation Switch Xbox]
+      .to eq get_possible_values_reordered(200)
   end
 end


### PR DESCRIPTION
Rebase of #11342 to have the fix on release/12.3

/cc @srkunze

https://community.openproject.org/wp/43832