### PR TITLE
Set default workdays for email reminders to Monday-Friday

### DIFF
--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -33,6 +33,9 @@ class UserPreference < ApplicationRecord
 
   validates :user,
             presence: true
+
+  WORKDAYS_FROM_MONDAY_TO_FRIDAY = [1, 2, 3, 4, 5].freeze
+
   ##
   # Retrieve keys from settings, and allow accessing
   # as boolean with ? suffix
@@ -122,6 +125,10 @@ class UserPreference < ApplicationRecord
 
   def daily_reminders
     super.presence || { enabled: true, times: ["08:00:00+00:00"] }.with_indifferent_access
+  end
+
+  def workdays
+    super || WORKDAYS_FROM_MONDAY_TO_FRIDAY
   end
 
   def immediate_reminders

--- a/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
@@ -44,7 +44,7 @@ function createInitialState():IUserPreference {
       enabled: true,
       times: ['08:00'],
     },
-    workdays: [],
+    workdays: [1, 2, 3, 4, 5],
     immediateReminders: {
       mentioned: false,
     },

--- a/spec/features/notifications/settings/workdays_settings_spec.rb
+++ b/spec/features/notifications/settings/workdays_settings_spec.rb
@@ -14,7 +14,8 @@ describe "Workday notification settings", type: :feature, js: true do
         # Configure the reminders
         settings_page.visit!
 
-        settings_page.expect_non_workdays %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
+        settings_page.expect_workdays %w[Monday Tuesday Wednesday Thursday Friday]
+        settings_page.expect_non_workdays %w[Saturday Sunday]
 
         settings_page.set_workdays Monday: true,
                                    Tuesday: true,
@@ -36,11 +37,12 @@ describe "Workday notification settings", type: :feature, js: true do
         expect(pref.reload.workdays).to eq [1, 2, 5, 6, 7]
       end
 
-      it 'updates properly working days' do
+      it 'can unselect all working days' do
         # Configure the reminders
         settings_page.visit!
 
-        settings_page.expect_non_workdays %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
+        settings_page.expect_workdays %w[Monday Tuesday Wednesday Thursday Friday]
+        settings_page.expect_non_workdays %w[Saturday Sunday]
 
         settings_page.set_workdays Monday: false,
                                    Tuesday: false,
@@ -72,7 +74,8 @@ describe "Workday notification settings", type: :feature, js: true do
         settings_page.visit!
 
         # Expect Mo-Fr to be checked
-        settings_page.expect_non_workdays %w[Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Samstag]
+        settings_page.expect_workdays %w[Montag Dienstag Mittwoch Donnerstag Freitag]
+        settings_page.expect_non_workdays %w[Samstag Sonntag]
 
         settings_page.set_workdays Montag: true,
                                    Dienstag: true,

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -179,9 +179,44 @@ describe UserPreference do
         }
       end
 
-      it 'uses the defaults' do
+      it 'returns the stored value' do
         expect(subject.daily_reminders)
           .to eql(settings["daily_reminders"])
+      end
+    end
+  end
+
+  describe '#workdays' do
+    context 'without work days being stored' do
+      it 'uses the defaults' do
+        expect(subject.workdays)
+          .to eq([1, 2, 3, 4, 5])
+      end
+    end
+
+    context 'with work days being stored' do
+      let(:settings) do
+        {
+          "workdays" => [1, 2, 4, 5]
+        }
+      end
+
+      it 'returns the stored value' do
+        expect(subject.workdays)
+          .to eql([1, 2, 4, 5])
+      end
+    end
+
+    context 'with work days being stored and empty' do
+      let(:settings) do
+        {
+          "workdays" => []
+        }
+      end
+
+      it 'return empty array' do
+        expect(subject.workdays)
+          .to eql([])
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/projects/14/work_packages/44526

It partly reverts what has been done in PR #11133 and still fixes [OP #43158](https://community.openproject.org/wp/43158) bug while keeping the intended behavior of having Monday to Friday being the default workdays for email reminders.