### PR TITLE
speedup journal deletion

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -46,8 +46,8 @@ class Journal < ApplicationRecord
   belongs_to :journable, polymorphic: true
   belongs_to :data, polymorphic: true, dependent: :destroy
 
-  has_many :attachable_journals, class_name: 'Journal::AttachableJournal', dependent: :destroy
-  has_many :customizable_journals, class_name: 'Journal::CustomizableJournal', dependent: :destroy
+  has_many :attachable_journals, class_name: 'Journal::AttachableJournal', dependent: :delete_all
+  has_many :customizable_journals, class_name: 'Journal::CustomizableJournal', dependent: :delete_all
 
   has_many :notifications, dependent: :destroy
 


### PR DESCRIPTION
Avoiding instantiation of:
* `attachable_journals`
* `customizable_journals`

should considerably speed up the deletion of journals. The number of those journals can be quite large as one record is created for every custom_field/attachment.

The two classes don't have any associations themselves so using `delete_all` should not lead to callbacks being missed.