### PR TITLE
[chore] use selenium hub version major tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
 
   # https://vitobotta.com/2019/09/04/rails-parallel-system-tests-selenium-docker/
   selenium-hub:
-    image: selenium/hub:4.0
+    image: selenium/hub:4
     container_name: selenium-hub
     hostname: selenium-hub
     environment:
@@ -200,7 +200,7 @@ services:
       - "4442-4444:4442-4444"
 
   chrome:
-    image: selenium/node-chrome:4.0
+    image: selenium/node-chrome:4
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"
@@ -220,7 +220,7 @@ services:
       NODE_MAX_SESSION: "${CI_JOBS:-4}"
 
   firefox:
-    image: selenium/node-firefox:4.0
+    image: selenium/node-firefox:4
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"
@@ -240,7 +240,7 @@ services:
       NODE_MAX_SESSION: "${CI_JOBS:-4}"
 
   opera:
-    image: selenium/node-opera:4.0
+    image: selenium/node-opera:4
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"


### PR DESCRIPTION
- we used to use 4.0, while 4.5 was already released, bundling newer version of the browsers