### PR TITLE
Fix default_url_options for capybara

### DIFF
--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -35,9 +35,9 @@ describe 'Omniauth authentication', type: :feature do
   def self.default_url_options
     host =
       if Capybara.app_host
-        Capybara.app_host.sub(/https?\/\//, "")
+        Capybara.app_host.sub(/https?\/\//, '')
       else
-        'http://www.example.com'
+        'www.example.com'
       end
 
     { host: }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,7 +5,21 @@ require 'capybara-screenshot/rspec'
 require 'rack_session_access/capybara'
 require 'action_dispatch'
 
-RSpec.configure do |_config|
+RSpec.shared_context 'with default_url_options set' do
+  before do
+    @original_host = default_url_options[:host]
+    @original_port = default_url_options[:port]
+    default_url_options[:host] = Capybara.server_host
+    default_url_options[:port] = Capybara.server_port
+  end
+
+  after do
+    default_url_options[:host] = @original_host # rubocop:disable RSpec/InstanceVariable
+    default_url_options[:port] = @original_port # rubocop:disable RSpec/InstanceVariable
+  end
+end
+
+RSpec.configure do |config|
   Capybara.default_max_wait_time = 4
   Capybara.javascript_driver = :chrome_en
 
@@ -23,6 +37,9 @@ RSpec.configure do |_config|
   else
     Capybara.server_host = ENV.fetch('CAPYBARA_APP_HOSTNAME', 'localhost')
   end
+
+  # Set the default options
+  config.include_context 'with default_url_options set', type: :feature
 end
 
 ##


### PR DESCRIPTION
Result of a debugging session with @cbliard to see why `visit root_url` would lead us to example.com