### PR TITLE
Add includeSubprojects to query params for representation links

### DIFF
--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -55,6 +55,7 @@ module API
         def to_h(column_key: :columns)
           p = super
 
+          p[:includeSubprojects] = query.include_subprojects
           p[:showHierarchies] = query.show_hierarchies
           p[:showSums] = query.display_sums?
           p[:groupBy] = query.group_by if query.group_by?

--- a/spec/lib/api/v3/queries/queries_params_representer_spec.rb
+++ b/spec/lib/api/v3/queries/queries_params_representer_spec.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Queries::QueryParamsRepresenter do
+  let(:query) { build_stubbed(:query, **params) }
+  let(:instance) { described_class.new(query) }
+
+  describe '#to_h' do
+    subject { instance.to_h }
+
+    context 'with include_subprojects true' do
+      let(:params) { { include_subprojects: true } }
+
+      it 'transports that to the params (Regression #44248)' do
+        expect(subject[:includeSubprojects]).to be true
+      end
+    end
+
+    context 'with include_subprojects false' do
+      let(:params) { { include_subprojects: false } }
+
+      it 'transports that to the params' do
+        expect(subject.keys).to include :includeSubprojects
+        expect(subject[:includeSubprojects]).to be false
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/queries/query_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_rendering_spec.rb
@@ -121,6 +121,7 @@ describe ::API::V3::Queries::QueryRepresenter do
           offset: 1,
           showSums: false,
           showHierarchies: false,
+          includeSubprojects: true,
           pageSize: Setting.per_page_options_array.first,
           filters: []
         }
@@ -153,6 +154,7 @@ describe ::API::V3::Queries::QueryRepresenter do
             pageSize: Setting.per_page_options_array.first,
             showSums: false,
             showHierarchies: false,
+            includeSubprojects: true,
             filters: []
           }
           "#{api_v3_paths.work_packages}?#{non_empty_to_query(params)}"
@@ -341,6 +343,7 @@ describe ::API::V3::Queries::QueryRepresenter do
           filters: JSON::dump([{ subject: { operator: '~', values: ['bogus'] } }]),
           showSums: false,
           showHierarchies: false,
+          includeSubprojects: true,
           groupBy: 'author',
           sortBy: JSON::dump([%w[assignee asc], %w[type desc]])
         }
@@ -367,6 +370,7 @@ describe ::API::V3::Queries::QueryRepresenter do
           pageSize: 25,
           showSums: false,
           showHierarchies: false,
+          includeSubprojects: true,
           filters: []
         }
 


### PR DESCRIPTION
Fixes https://community.openproject.org/wp/44248

I'm not sure why we don't output the query#id in case we have it, since passing all params seems to be error prone.