### PR TITLE
Add background job to trigger date alerts notifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,7 @@ class User < Principal
          :newest,
          :notified_globally,
          :watcher_recipients,
+         :with_time_zone,
          :having_reminder_mail_to_send
 
   def self.create_blocked_scope(scope, blocked)

--- a/app/models/users/scopes/with_time_zone.rb
+++ b/app/models/users/scopes/with_time_zone.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Find a user account by matching case-insensitive.
+module Users::Scopes
+  module WithTimeZone
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def with_time_zone(time_zones)
+        return User.none if time_zones.empty?
+
+        where_clause = <<~SQL.squish
+          COALESCE(
+            NULLIF(user_preferences.settings->>'time_zone', ''),
+            #{user_default_time_zone.to_sql}
+          ) IN (?)
+        SQL
+        User
+          .left_joins(:preference)
+          .where(where_clause, time_zones)
+      end
+
+      def user_default_time_zone
+        Arel::Nodes::build_quoted(Setting.user_default_timezone.presence || 'Etc/UTC')
+      end
+    end
+  end
+end

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -47,17 +47,18 @@ class Watcher < ApplicationRecord
   protected
 
   def validate_active_user
-    # TODO add informative error message
     return if user.blank?
 
-    errors.add :user_id, :invalid if user.locked?
+    errors.add :user_id, :locked if user.locked?
   end
 
   def validate_user_allowed_to_watch
-    # TODO add informative error message
     return if user.blank? || watchable.blank?
+    # No need to add a missing permission error on top of the user locked error
+    # created by validate_active_user.
+    return if user.locked?
 
-    errors.add :user_id, :invalid unless watchable.possible_watcher?(user)
+    errors.add :user_id, :not_allowed_to_view unless watchable.possible_watcher?(user)
   end
 
   class << self

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -124,6 +124,7 @@ class WorkPackage < ApplicationRecord
          :for_scheduling,
          :include_derived_dates,
          :include_spent_time,
+         :involving_user,
          :left_join_self_and_descendants,
          :relatable
 

--- a/app/models/work_packages/scopes/involving_user.rb
+++ b/app/models/work_packages/scopes/involving_user.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+
+module WorkPackages::Scopes
+  module InvolvingUser
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Fetches all work packages for which a user is assigned to, responsible
+      # for, or watcher, via a group or themself
+      #
+      # @param user User the user involved in work packages.
+      def involving_user(user)
+        WorkPackage.left_joins(:watchers)
+          .where(watchers: { user: })
+          .or(WorkPackage.where(assigned_to: user))
+          .or(WorkPackage.where(assigned_to: group_having(user)))
+          .or(WorkPackage.where(responsible: user))
+          .or(WorkPackage.where(responsible: group_having(user)))
+      end
+
+      private
+
+      def group_having(user)
+        GroupUser.select(:group_id).where(user_id: user.id)
+      end
+    end
+  end
+end

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -44,7 +44,7 @@ module Notifications
     end
 
     def send_start_date_alert_notifications(user)
-      work_package_with_involved(user)
+      WorkPackage.with_status_open.involving_user(user)
         .where(start_date: Date.current + 1.day)
         .each do |work_package|
           create_service = Notifications::CreateService.new(user:)
@@ -56,14 +56,6 @@ module Notifications
             read_ian: false
           )
         end
-    end
-
-    def work_package_with_involved(user)
-      work_packages = WorkPackage
-        .joins(:status)
-        .where(statuses: { is_closed: false })
-      work_packages.where(assigned_to: user)
-        .or(work_packages.where(responsible: user))
     end
 
     def time_zones_covering_1am_local_time

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -1,0 +1,105 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Notifications
+  class CreateDateAlertsNotificationsJob < Cron::CronJob
+    # runs every quarter of an hour, so 00:00, 00:15,..., 15:30, 15:45, 16:00, ...
+    self.cron_expression = '*/15 * * * *'
+
+    def perform
+      users_with_1am_local_time.each do |user|
+        work_package_with_involved(user)
+          .where(start_date: Date.current + 1.day)
+          .each do |work_package|
+            create_service = Notifications::CreateService.new(user:)
+            create_service.call(
+              recipient_id: user.id,
+              project_id: work_package.project_id,
+              resource: work_package,
+              reason: :date_alert_start_date,
+              read_ian: false
+            )
+          end
+      end
+    end
+
+    def users_with_1am_local_time
+      time_zones = time_zones_covering_1am_local_time
+
+      return User.none if time_zones.empty?
+
+      User
+        .joins(:preference)
+        .where("user_preferences.settings->>'time_zone' IN (?)", time_zones)
+    end
+
+    def work_package_with_involved(user)
+      WorkPackage.where(assigned_to: user)
+    end
+
+    def time_zones_covering_1am_local_time
+      UserPreferences::UpdateContract
+        .assignable_time_zones
+        .select { |time_zone| executing_at_1am_for_timezone?(time_zone) }
+        .map { |time_zone| time_zone.tzinfo.canonical_zone.name }
+    end
+
+    def executing_at_1am_for_timezone?(time_zone)
+      times_from_scheduled_to_execution.any? { |time| is_1am?(time, time_zone) }
+    end
+
+    def is_1am?(time, time_zone)
+      local_time = time.in_time_zone(time_zone)
+      local_time.strftime('%H:%M') == '01:00'
+    end
+
+    # Returns times from scheduled execution time to current time in 15 minutes
+    # steps.
+    #
+    # As scheduled execution time can be different from current time by more
+    # than 15 minutes when workers are busy, all times at 15 minutes interval
+    # between scheduled time and current time need to be considered to match
+    # with 1:00am in a time zone.
+    def times_from_scheduled_to_execution
+      @times_from_scheduled_to_execution ||= begin
+        time = scheduled_time
+        times = []
+        begin
+          times << time
+          time += 15.minutes
+        end while time < Time.current
+        times
+      end
+    end
+
+    def scheduled_time
+      @scheduled_time ||=
+        self.class.delayed_job.run_at.then { |t| t.change(min: t.min / 15 * 15) }
+    end
+  end
+end

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -45,12 +45,23 @@ module Notifications
 
     def send_date_alert_notifications(user)
       alertables = AlertableWorkPackages.new(user)
-      alertables.alertable_for_start.each do |work_package|
-        create_date_alert_notification(user, work_package, :date_alert_start_date)
+      create_date_alert_notifications(user, alertables.alertable_for_start, :date_alert_start_date)
+      create_date_alert_notifications(user, alertables.alertable_for_due, :date_alert_due_date)
+    end
+
+    def create_date_alert_notifications(user, work_packages, reason)
+      mark_previous_notifications_as_read(user, work_packages, reason)
+      work_packages.find_each do |work_package|
+        create_date_alert_notification(user, work_package, reason)
       end
-      alertables.alertable_for_due.each do |work_package|
-        create_date_alert_notification(user, work_package, :date_alert_due_date)
-      end
+    end
+
+    def mark_previous_notifications_as_read(user, work_packages, reason)
+      Notification
+        .where(recipient: user,
+               reason:,
+               resource: work_packages)
+        .update_all(read_ian: true, updated_at: Time.current)
     end
 
     def create_date_alert_notification(user, work_package, reason)

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -59,10 +59,11 @@ module Notifications
     end
 
     def work_package_with_involved(user)
-      WorkPackage
+      work_packages = WorkPackage
         .joins(:status)
         .where(statuses: { is_closed: false })
-        .where(assigned_to: user)
+      work_packages.where(assigned_to: user)
+        .or(work_packages.where(responsible: user))
     end
 
     def time_zones_covering_1am_local_time

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -38,46 +38,29 @@ module Notifications
 
       Time.use_zone(time_zones.first) do
         User.with_time_zone(time_zones).find_each do |user|
-          send_start_date_alert_notifications(user)
-          send_due_date_alert_notifications(user)
+          send_date_alert_notifications(user)
         end
       end
     end
 
-    def send_start_date_alert_notifications(user)
-      start_date_alert = user.notification_settings.first.start_date
-      return if start_date_alert.nil?
-
-      WorkPackage.with_status_open.involving_user(user)
-        .where(start_date: Date.current + start_date_alert.days)
-        .each do |work_package|
-          create_service = Notifications::CreateService.new(user:)
-          create_service.call(
-            recipient_id: user.id,
-            project_id: work_package.project_id,
-            resource: work_package,
-            reason: :date_alert_start_date,
-            read_ian: false
-          )
-        end
+    def send_date_alert_notifications(user)
+      alertables = AlertableWorkPackages.new(user)
+      alertables.alertable_for_start.each do |work_package|
+        create_date_alert_notification(user, work_package, :date_alert_start_date)
+      end
+      alertables.alertable_for_due.each do |work_package|
+        create_date_alert_notification(user, work_package, :date_alert_due_date)
+      end
     end
 
-    def send_due_date_alert_notifications(user)
-      due_date_alert = user.notification_settings.first.due_date
-      return if due_date_alert.nil?
-
-      WorkPackage.with_status_open.involving_user(user)
-        .where(due_date: Date.current + due_date_alert.days)
-        .each do |work_package|
-          create_service = Notifications::CreateService.new(user:)
-          create_service.call(
-            recipient_id: user.id,
-            project_id: work_package.project_id,
-            resource: work_package,
-            reason: :date_alert_due_date,
-            read_ian: false
-          )
-        end
+    def create_date_alert_notification(user, work_package, reason)
+      create_service = Notifications::CreateService.new(user:)
+      create_service.call(
+        recipient_id: user.id,
+        project_id: work_package.project_id,
+        resource: work_package,
+        reason:
+      )
     end
 
     def time_zones_covering_1am_local_time

--- a/app/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages.rb
@@ -1,0 +1,124 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class Notifications::CreateDateAlertsNotificationsJob::AlertableWorkPackages
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def alertable_for_start
+    find_alertables
+      .filter_map { |row| row["id"] if row["start_alert"] }
+      .then { |ids| WorkPackage.where(id: ids) }
+  end
+
+  def alertable_for_due
+    find_alertables
+      .filter_map { |row| row["id"] if row["due_alert"] }
+      .then { |ids| WorkPackage.where(id: ids) }
+  end
+
+  private
+
+  def find_alertables
+    @find_alertables ||= ActiveRecord::Base.connection.execute(query).to_a
+  end
+
+  def query
+    alertables = alertable_work_packages(user)
+      .select(:id,
+              :project_id,
+              "work_packages.start_date - #{today} AS start_delta",
+              "work_packages.due_date - #{today} AS due_delta",
+              "#{today} - work_packages.due_date AS overdue_delta")
+      .where("work_packages.start_date - #{today} BETWEEN 0 AND 7 " \
+             "OR work_packages.due_date - #{today} BETWEEN 0 and 7 " \
+             "OR #{today} - work_packages.due_date > 0")
+
+    <<~SQL.squish
+      WITH
+      alertable_work_packages (id, project_id, start_delta, due_delta, overdue_delta) AS (
+        #{alertables.to_sql}
+      ),
+      project_ids AS (
+        SELECT distinct project_id
+        FROM alertable_work_packages
+      ),
+      project_notification_settings (project_id, start_delta, due_delta, overdue_step) AS (
+        SELECT DISTINCT ON (project_ids.project_id)
+          project_ids.project_id,
+          notification_settings.start_date,
+          notification_settings.due_date,
+          notification_settings.overdue
+        FROM project_ids
+          LEFT OUTER JOIN notification_settings ON (
+            notification_settings.project_id = project_ids.project_id
+            OR notification_settings.project_id IS NULL
+          )
+        WHERE notification_settings.user_id = #{user.id}
+        ORDER BY project_ids.project_id, notification_settings.project_id NULLS LAST
+      ),
+      notifiable_work_packages (id, start_alert, due_alert) AS (
+        SELECT
+            alertable_work_packages.id,
+            pns.start_delta = alertable_work_packages.start_delta AS start_alert,
+            (
+              (pns.due_delta = alertable_work_packages.due_delta)
+              OR (alertable_work_packages.overdue_delta > 0)
+            ) AS due_alert
+        FROM alertable_work_packages
+          LEFT OUTER JOIN project_notification_settings AS pns USING (project_id)
+        WHERE pns.start_delta = alertable_work_packages.start_delta
+          OR pns.due_delta = alertable_work_packages.due_delta
+          OR (
+            (alertable_work_packages.overdue_delta > 0)
+            AND (MOD(alertable_work_packages.overdue_delta - 1, pns.overdue_step) = 0)
+          )
+      )
+      SELECT id, start_alert, due_alert
+      FROM notifiable_work_packages
+    SQL
+  end
+
+  def alertable_work_packages(user)
+    relation = WorkPackage.with_status_open.involving_user(user)
+    # `relation.to_sql` was producing SQL with weird select clauses that could
+    # not be used in a CTE, while doing `relation.pluck(:something)` was producing
+    # nice formatted sql. Reading `#pluck` source code revealed the existence
+    # of `#join_dependency` and how to use it to have a nicely formatted sql
+    # query.
+    join_dependency = relation.construct_join_dependency([:status], Arel::Nodes::OuterJoin)
+    relation.joins(join_dependency)
+  end
+
+  def today
+    @today ||= Arel::Nodes::build_quoted(Date.current).to_sql
+  end
+end

--- a/app/workers/notifications/workflow_job.rb
+++ b/app/workers/notifications/workflow_job.rb
@@ -27,16 +27,27 @@
 #++
 
 # Governs the workflow of how journals are passed through:
-#   1) The notifications for any event (e.g. journal creation) is to be created as fast as possible
-#      so that it becomes visible as an in app notification. If the resource passed in is indeed a journal,
-#      it might get replaced later on (by a subsequent journal). This will lead to notifications being removed.
-#      In case the notification has a mentioned-reason, the mail is to be sent right away. This accepts the possibility
-#      of the journal being deleted later on.
-#   2) After the journal aggregation time has passed direct mails are scheduled.
-# This order has to be kept to ensure that the notifications are created before email sending is attempted. If it weren't
-# guaranteed, with the notifications created in one job and the mails send in another, the mail sending job might get executed
-# without any notifications being created which would result in no emails being sent at all. An alternative would be to
-# decouple notification creation and mail sending from another. But then, in app notifications being read could not prevent
+#
+#   1) The notifications for any event (e.g. journal creation) is to be created
+#      as fast as possible so that it becomes visible as an in app notification.
+#      If the resource passed in is indeed a journal, it might get replaced
+#      later on (by a subsequent journal). This will lead to notifications being
+#      removed. In case the notification has a mentioned-reason, the mail is to
+#      be sent right away. This accepts the possibility of the journal being
+#      deleted later on.
+#
+#   2) After the journal aggregation time has passed, direct mails are
+#      scheduled.
+#
+# This order has to be kept to ensure that the notifications are created before
+# email sending is attempted.
+#
+# If it wasn't guaranteed, with the notifications created in one job and the
+# mails send in another, the mail sending job might get executed without any
+# notifications being created which would result in no emails being sent at all.
+#
+# An alternative would be to decouple notification creation and mail sending
+# from another. But then, in app notifications being read could not prevent
 # mails being sent out.
 class Notifications::WorkflowJob < ApplicationJob
   include ::StateMachineJob

--- a/config/initializers/cronjobs.rb
+++ b/config/initializers/cronjobs.rb
@@ -8,6 +8,7 @@ OpenProject::Application.configure do |application|
                               ::OAuth::CleanupJob,
                               ::PaperTrailAudits::CleanupJob,
                               ::Attachments::CleanupUncontaineredJob,
+                              ::Notifications::CreateDateAlertsNotificationsJob,
                               ::Notifications::ScheduleReminderMailsJob,
                               ::Ldap::SynchronizationJob
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -821,6 +821,11 @@ en:
               email_alerts_global: 'The email notification settings can only be set globally.'
               format: "%{message}"
               wrong_date: 'Wrong value for Start date, Due date, or Overdue.'
+        watcher:
+          attributes:
+            user_id:
+              not_allowed_to_view: "is not allowed to view this resource."
+              locked: "is locked."
         wiki_page:
           attributes:
             slug:

--- a/docs/api/apiv3/components/schemas/notification_settings_model.yml
+++ b/docs/api/apiv3/components/schemas/notification_settings_model.yml
@@ -55,7 +55,7 @@ items:
       description: |-
         Sets a startDate notification for work packages. It is null when no notification is set,
         otherwise it holds an ISO8601 formatted duration string with the possible values listed below.
-        The possible values are: same day, 1 day before, 3 days before, 1 week before.
+        The possible values are: none, same day, 1 day before, 3 days before, 1 week before.
       enum:
         - ""
         - PT0S
@@ -65,7 +65,7 @@ items:
     dueDate:
       type: string
       description: |-
-        Sets a startDate notification for work packages. It is null when no notification is set,
+        Sets a dueDate notification for work packages. It is null when no notification is set,
         otherwise it holds an ISO8601 formatted duration string with the possible values listed below.
         The possible values are: none, same day, 1 day before, 3 days before, 1 week before.
       enum:

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -32,6 +32,8 @@ namespace 'openproject:cron' do
     # Does nothing by default
   end
 
+  # This task will be automatically called when running jobs:work or jobs:workoff
+  # making sure cron jobs are scheduled. See lib/tasks/delayed_job.rake.
   desc 'Ensure the cron-like background jobs are actively scheduled'
   task schedule: [:environment] do
     ::Cron::CronJob.schedule_registered_jobs!

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     callback(:after_build) do |user, evaluator|
-      evaluator.preferences.each do |key, val|
+      evaluator.preferences&.each do |key, val|
         user.pref[key] = val
       end
     end

--- a/spec/models/users/scopes/with_time_zone_spec.rb
+++ b/spec/models/users/scopes/with_time_zone_spec.rb
@@ -1,0 +1,126 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Users::Scopes::WithTimeZone do
+  shared_let(:user_besancon) do
+    create(
+      :user,
+      firstname: 'Besançon',
+      preferences: { time_zone: 'Europe/Paris' }
+    )
+  end
+  shared_let(:user_kathmandu) do
+    create(
+      :user,
+      firstname: 'Kathmandu',
+      preferences: { time_zone: 'Asia/Kathmandu' }
+    )
+  end
+  shared_let(:user_new_york) do
+    create(
+      :user,
+      firstname: 'New York',
+      preferences: { time_zone: 'America/New_York' }
+    )
+  end
+  shared_let(:user_paris) do
+    create(
+      :user,
+      firstname: 'Paris',
+      preferences: { time_zone: 'Europe/Paris' }
+    )
+  end
+  shared_let(:user_without_preferences) do
+    create(
+      :user,
+      firstname: 'no preference',
+      preferences: nil
+    )
+  end
+  shared_let(:user_without_time_zone) do
+    create(
+      :user,
+      firstname: 'no preference',
+      preferences: {}
+    )
+  end
+  shared_let(:user_with_empty_time_zone) do
+    create(
+      :user,
+      firstname: 'no preference',
+      preferences: { time_zone: '' }
+    )
+  end
+
+  describe '.with_time_zone' do
+    it 'returns user having set a time zone in their preference matching the specified time zone(s)' do
+      expect(User.with_time_zone('Europe/Paris'))
+        .to contain_exactly(user_paris, user_besancon)
+
+      expect(User.with_time_zone([]))
+        .to eq([])
+
+      expect(User.with_time_zone(['America/New_York', 'Asia/Kathmandu']))
+        .to contain_exactly(user_new_york, user_kathmandu)
+    end
+
+    context 'when users have no preferences' do
+      it 'uses the default time zone returned by Setting.user_default_timezone',
+         with_settings: { user_default_timezone: "Europe/Berlin" } do
+        expect(User.with_time_zone("Europe/Berlin"))
+          .to include(user_without_preferences)
+      end
+    end
+
+    context 'when users have preferences without time zone set' do
+      it 'uses the default time zone returned by Setting.user_default_timezone',
+         with_settings: { user_default_timezone: "Europe/Berlin" } do
+        expect(User.with_time_zone("Europe/Berlin"))
+          .to include(user_without_time_zone)
+      end
+    end
+
+    context 'when users have preferences with time zone set to empty string' do
+      it 'uses the default time zone returned by Setting.user_default_timezone',
+         with_settings: { user_default_timezone: "Europe/Berlin" } do
+        expect(User.with_time_zone("Europe/Berlin"))
+          .to include(user_with_empty_time_zone)
+      end
+    end
+
+    context 'when users have no time zone and default user time zone is not set' do
+      it 'assumes Etc/UTC as default time zone',
+         with_settings: { user_default_timezone: nil } do
+        expect(User.with_time_zone("Etc/UTC"))
+          .to contain_exactly(user_without_preferences, user_without_time_zone, user_with_empty_time_zone)
+      end
+    end
+  end
+end

--- a/spec/models/work_package/work_package_visibility_spec.rb
+++ b/spec/models/work_package/work_package_visibility_spec.rb
@@ -41,10 +41,10 @@ describe 'WorkPackage-Visibility', type: :model do
   describe 'of public projects' do
     subject { create(:work_package, project: public_project) }
 
-    it 'is viewable by anonymous, with the view_work_packages permissison' do
+    it 'is viewable by anonymous, with the view_work_packages permission' do
       # it is not really clear, where these kind of "preconditions" belong to: This setting
       # is a default in Redmine::DefaultData::Loader - but this not loaded in the tests: here we
-      # just make sure, that the workpackage is visible, when this permission is set
+      # just make sure, that the work package is visible, when this permission is set
       Role.anonymous.add_permission! :view_work_packages
       expect(WorkPackage.visible(anonymous)).to match_array [subject]
     end
@@ -61,7 +61,7 @@ describe 'WorkPackage-Visibility', type: :model do
       expect(WorkPackage.visible(anonymous)).to match_array []
     end
 
-    it 'is visible for members of the project, with the view_work_packages permissison' do
+    it 'is visible for members of the project, with the view_work_packages permission' do
       create(:member,
              user:,
              project: private_project,
@@ -82,11 +82,11 @@ describe 'WorkPackage-Visibility', type: :model do
       expect(WorkPackage.visible(user).pluck(:id)).to match_array [subject.id]
     end
 
-    it 'is not visible for non-members of the project without the view_work_packages permissison' do
+    it 'is not visible for non-members of the project without the view_work_packages permission' do
       expect(WorkPackage.visible(user)).to match_array []
     end
 
-    it 'is not visible for members of the project, without the view_work_packages permissison' do
+    it 'is not visible for members of the project, without the view_work_packages permission' do
       no_permission = create(:role, permissions: [:no_permission])
       create(:member,
              user:,

--- a/spec/models/work_packages/scopes/involving_user_spec.rb
+++ b/spec/models/work_packages/scopes/involving_user_spec.rb
@@ -1,0 +1,91 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe WorkPackages::Scopes::InvolvingUser do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:user) do
+    create(
+      :user,
+      # project_with_types is from create_shared_association_defaults_for_work_package_factory helper
+      member_in_project: project_with_types,
+      member_with_permissions: %i[view_work_packages]
+    )
+  end
+
+  it 'returns work packages for which a user is assigned to' do
+    _work_package_blank = create(:work_package)
+    work_package_assigned1 = create(:work_package, assigned_to: user)
+    work_package_assigned2 = create(:work_package, assigned_to: user)
+
+    expect(WorkPackage.involving_user(user))
+      .to contain_exactly(work_package_assigned1, work_package_assigned2)
+  end
+
+  it 'returns work packages for which a user is accountable / responsible' do
+    _work_package_blank = create(:work_package)
+    work_package_responsible1 = create(:work_package, responsible: user)
+    work_package_responsible2 = create(:work_package, responsible: user)
+
+    expect(WorkPackage.involving_user(user))
+      .to contain_exactly(work_package_responsible1, work_package_responsible2)
+  end
+
+  it 'returns work packages for which a user is a watcher' do
+    _work_package_blank = create(:work_package)
+    work_package_watched1 = create(:work_package)
+    create(:watcher, watchable: work_package_watched1, user:)
+    work_package_watched2 = create(:work_package)
+    create(:watcher, watchable: work_package_watched2, user:)
+
+    expect(WorkPackage.involving_user(user))
+      .to contain_exactly(work_package_watched1, work_package_watched2)
+  end
+
+  context 'when user is part of a group' do
+    shared_let(:group) { create(:group, members: [user]) }
+
+    it 'returns work packages for which the group is assigned to' do
+      _work_package_blank = create(:work_package)
+      work_package_assigned = create(:work_package, assigned_to: group)
+
+      expect(WorkPackage.involving_user(user))
+        .to contain_exactly(work_package_assigned)
+    end
+
+    it 'returns work packages for which the group is accountable / responsible' do
+      _work_package_blank = create(:work_package)
+      work_package_responsible = create(:work_package, responsible: group)
+
+      expect(WorkPackage.involving_user(user))
+        .to contain_exactly(work_package_responsible)
+    end
+  end
+end

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -33,7 +33,7 @@ describe 'API v3 Watcher resource', type: :request, content_type: :json do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 
-  let(:project) { create(:project, identifier: 'test_project', public: false) }
+  shared_let(:project) { create(:project, identifier: 'test_project', public: false) }
   let(:current_user) do
     create :user, member_in_project: project, member_through_role: role
   end
@@ -173,7 +173,21 @@ describe 'API v3 Watcher resource', type: :request, content_type: :json do
       let(:new_watcher) { create(:user) }
 
       it_behaves_like 'constraint violation' do
-        let(:message) { 'User is invalid' }
+        let(:message) { 'User is not allowed to view this resource.' }
+      end
+    end
+
+    context 'when the target user is locked' do
+      let(:new_watcher) do
+        user = create(:user,
+                      member_in_project: project,
+                      member_through_role: view_work_packages_role)
+        user.locked!
+        user
+      end
+
+      it_behaves_like 'constraint violation' do
+        let(:message) { 'User is locked.' }
       end
     end
 

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -72,30 +72,24 @@ module Components
     # Create an image fixture with the optional caption
     def drag_attachment(image_fixture, caption = 'Some caption')
       in_editor do |_container, editable|
-        sleep 1
-
         # Click the latest figure, if any
-        images = editable.all('figure.image')
+        # Do not wait more than 1 second to check if there is an image
+        images = editable.all('figure.image', wait: 1)
         if images.count > 0
           images.last.click
-        end
 
-        # Click the "move below figure" button if selected
-        selected = page.all('.ck-widget_selected .ck-widget__type-around__button_after')
-        if selected.count > 0
-          selected.first.click
+          # Click the "move below figure" button
+          selected = page.all('.ck-widget_selected .ck-widget__type-around__button_after')
+          selected.first&.click
         end
 
         editable.base.send_keys(:enter, 'some text', :enter, :enter)
-
-        sleep 1
 
         attachments.drag_and_drop_file(editable, image_fixture, :bottom)
 
         expect(page)
             .to have_selector('img[src^="/api/v3/attachments/"]', count: images.length + 1, wait: 10)
 
-        sleep 1
         expect(page).to have_no_selector('op-toasters-upload-progress', wait: 5)
 
         # Get the image uploaded last. As there is no way to distinguish between

--- a/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
@@ -1,0 +1,386 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'rails_helper'
+
+def relative_days(nb_days)
+  case nb_days
+  when 1 then 'tomorrow'
+  when 0 then 'today'
+  when -1 then 'yesterday'
+  else nb_days > 0 ? "in #{nb_days} days" : "#{-nb_days} days ago"
+  end
+end
+
+RSpec.describe Notifications::CreateDateAlertsNotificationsJob::AlertableWorkPackages do
+  subject { described_class.new(user) }
+
+  shared_let(:today) { Date.current }
+  shared_let(:yesterday) { today - 1.day }
+  shared_let(:in_1_day) { today + 1.day }
+
+  shared_let(:role) { create(:existing_role, permissions: [:view_work_packages]) }
+  shared_let(:user) { create(:user, firstname: 'main') }
+  shared_let(:other_user) { create(:user, firstname: 'other') }
+  shared_let(:project) { create(:project, name: 'main', members: { user => role }) }
+  shared_let(:other_project) { create(:project, name: 'other', members: { user => role }) }
+
+  shared_let(:status_open) { create(:status, name: "open", is_closed: false) }
+  shared_let(:status_closed) { create(:status, name: "closed", is_closed: true) }
+
+  shared_let(:alertable_work_packages) do
+    create_list(:work_package, 3, project:, author: user)
+  end
+
+  let(:global_notification_settings) { user.notification_settings.first }
+
+  def make_alertable_work_package(attributes = {})
+    assignee = attributes.slice(:responsible, :responsible_id).any? ? nil : user
+    attributes = attributes.reverse_merge(
+      start_date: in_1_day,
+      assigned_to: assignee
+    )
+    wp = alertable_work_packages.shift
+    wp.update!(attributes)
+    wp
+  end
+
+  ### open / closed work package
+
+  it 'returns open work packages' do
+    open_work_package = make_alertable_work_package(status: status_open)
+    expect(subject.alertable_for_start).to include(open_work_package)
+  end
+
+  it 'does not return closed work packages' do
+    make_alertable_work_package(status: status_closed)
+    expect(subject.alertable_for_start).to be_empty
+  end
+
+  ### user involved
+
+  it 'returns work packages the user is assigned to' do
+    assigned_work_package = make_alertable_work_package(assigned_to: user)
+    expect(subject.alertable_for_start).to include(assigned_work_package)
+  end
+
+  it 'returns work packages the user is responsible / accountable for' do
+    accountable_work_package = make_alertable_work_package(responsible: user)
+    expect(subject.alertable_for_start).to include(accountable_work_package)
+  end
+
+  it 'returns work packages the user is watching' do
+    watched_work_package = make_alertable_work_package(assigned_to: nil)
+    create(:watcher, watchable: watched_work_package, user:)
+    expect(subject.alertable_for_start).to include(watched_work_package)
+  end
+
+  it 'does not return work packages the user is author of' do
+    make_alertable_work_package(author: user, assigned_to: nil)
+    expect(subject.alertable_for_start).to be_empty
+  end
+
+  it 'does not return work packages other users are involved into' do
+    make_alertable_work_package(assigned_to: other_user)
+    expect(subject.alertable_for_start).to be_empty
+  end
+
+  ### default notification settings
+
+  context 'with default global notification settings' do
+    it 'returns work packages starting in 1 day for a user' do
+      wp_start_in_1_day = make_alertable_work_package(start_date: in_1_day, due_date: nil)
+      expect(subject.alertable_for_start).to include(wp_start_in_1_day)
+    end
+
+    it 'returns work packages due in 1 day for a user' do
+      wp_due_in_1_day = make_alertable_work_package(start_date: nil, due_date: in_1_day)
+      expect(subject.alertable_for_due).to include(wp_due_in_1_day)
+    end
+
+    it 'does not return overdue work packages for a user' do
+      make_alertable_work_package(start_date: nil, due_date: yesterday)
+      expect(subject.alertable_for_due).to be_empty
+    end
+  end
+
+  ### start_date specs
+
+  shared_examples 'alertable if start date' do |days_from_now:|
+    date = Date.current + days_from_now.days
+
+    it "returns work packages with start date being #{relative_days(days_from_now)}" do
+      work_package = make_alertable_work_package(start_date: date, due_date: nil)
+      expect(subject.alertable_for_start).to include(work_package)
+    end
+  end
+
+  shared_examples 'not alertable if start date' do |days_from_now:|
+    date = Date.current + days_from_now.days
+
+    it "does not return work packages with start date being #{relative_days(days_from_now)}" do
+      make_alertable_work_package(start_date: date, due_date: nil)
+      expect(subject.alertable_for_start).to be_empty
+    end
+  end
+
+  context 'with notification settings start_date not set' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if start date', days_from_now: 0
+    include_examples 'not alertable if start date', days_from_now: 1
+    include_examples 'not alertable if start date', days_from_now: 3
+    include_examples 'not alertable if start date', days_from_now: 42
+  end
+
+  context 'with notification settings start_date set to same day' do
+    before do
+      global_notification_settings.update(start_date: 0, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'alertable if start date', days_from_now: 0
+    include_examples 'not alertable if start date', days_from_now: 1
+    include_examples 'not alertable if start date', days_from_now: 3
+    include_examples 'not alertable if start date', days_from_now: 7
+  end
+
+  context 'with notification settings start_date set to 1 day' do
+    before do
+      global_notification_settings.update(start_date: 1, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if start date', days_from_now: 0
+    include_examples 'alertable if start date', days_from_now: 1
+    include_examples 'not alertable if start date', days_from_now: 3
+    include_examples 'not alertable if start date', days_from_now: 7
+  end
+
+  context 'with notification settings start_date set to 3 days' do
+    before do
+      global_notification_settings.update(start_date: 3, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if start date', days_from_now: 0
+    include_examples 'not alertable if start date', days_from_now: 1
+    include_examples 'alertable if start date', days_from_now: 3
+    include_examples 'not alertable if start date', days_from_now: 7
+  end
+
+  context 'with notification settings start_date set to 7 days' do
+    before do
+      global_notification_settings.update(start_date: 7, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if start date', days_from_now: 0
+    include_examples 'not alertable if start date', days_from_now: 1
+    include_examples 'not alertable if start date', days_from_now: 3
+    include_examples 'alertable if start date', days_from_now: 7
+  end
+
+  ### due_date specs
+
+  shared_examples 'alertable if due date' do |days_from_now:|
+    date = Date.current + days_from_now.days
+
+    it "returns work packages with due date being #{relative_days(days_from_now)}" do
+      work_package = make_alertable_work_package(start_date: nil, due_date: date)
+      expect(subject.alertable_for_due).to include(work_package)
+    end
+  end
+
+  shared_examples 'not alertable if due date' do |days_from_now:|
+    date = Date.current + days_from_now.days
+
+    it "does not return work packages with due date being #{relative_days(days_from_now)}" do
+      make_alertable_work_package(start_date: nil, due_date: date)
+      expect(subject.alertable_for_due).to be_empty
+    end
+  end
+
+  context 'with notification settings due_date not set' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if due date', days_from_now: 0
+    include_examples 'not alertable if due date', days_from_now: 1
+    include_examples 'not alertable if due date', days_from_now: 3
+    include_examples 'not alertable if due date', days_from_now: 42
+  end
+
+  context 'with notification settings due_date set to same day' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: 0, overdue: nil)
+    end
+
+    include_examples 'alertable if due date', days_from_now: 0
+    include_examples 'not alertable if due date', days_from_now: 1
+    include_examples 'not alertable if due date', days_from_now: 3
+    include_examples 'not alertable if due date', days_from_now: 7
+  end
+
+  context 'with notification settings due_date set to 1 day' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: 1, overdue: nil)
+    end
+
+    include_examples 'not alertable if due date', days_from_now: 0
+    include_examples 'alertable if due date', days_from_now: 1
+    include_examples 'not alertable if due date', days_from_now: 3
+    include_examples 'not alertable if due date', days_from_now: 7
+  end
+
+  context 'with notification settings due_date set to 3 days' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: 3, overdue: nil)
+    end
+
+    include_examples 'not alertable if due date', days_from_now: 0
+    include_examples 'not alertable if due date', days_from_now: 1
+    include_examples 'alertable if due date', days_from_now: 3
+    include_examples 'not alertable if due date', days_from_now: 7
+  end
+
+  context 'with notification settings due_date set to 7 days' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: 7, overdue: nil)
+    end
+
+    include_examples 'not alertable if due date', days_from_now: 0
+    include_examples 'not alertable if due date', days_from_now: 1
+    include_examples 'not alertable if due date', days_from_now: 3
+    include_examples 'alertable if due date', days_from_now: 7
+  end
+
+  ### overdue specs
+
+  shared_examples 'alertable if due' do |days_ago:|
+    date = Date.current - days_ago.days
+
+    it "returns work packages due #{relative_days(-days_ago)}" do
+      work_package = make_alertable_work_package(start_date: nil, due_date: date)
+      expect(subject.alertable_for_due).to include(work_package)
+    end
+  end
+
+  shared_examples 'not alertable if due' do |days_ago:|
+    date = Date.current - days_ago.days
+
+    it "does not return work packages due #{relative_days(-days_ago)}" do
+      make_alertable_work_package(start_date: nil, due_date: date)
+      expect(subject.alertable_for_due).to be_empty
+    end
+  end
+
+  context 'with notification settings overdue not set' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: nil)
+    end
+
+    include_examples 'not alertable if due', days_ago: 0
+    include_examples 'not alertable if due', days_ago: 1
+    include_examples 'not alertable if due', days_ago: 2
+    include_examples 'not alertable if due', days_ago: 3
+    include_examples 'not alertable if due', days_ago: 42
+  end
+
+  context 'with notification settings overdue set to every day' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: 1)
+    end
+
+    include_examples 'not alertable if due', days_ago: 0
+    include_examples 'alertable if due', days_ago: 1
+    include_examples 'alertable if due', days_ago: 2
+    include_examples 'alertable if due', days_ago: 10
+  end
+
+  context 'with notification settings overdue set to every 3 days' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: 3)
+    end
+
+    include_examples 'not alertable if due', days_ago: 0
+    include_examples 'alertable if due', days_ago: 1
+    include_examples 'not alertable if due', days_ago: 2
+    include_examples 'not alertable if due', days_ago: 3
+    include_examples 'alertable if due', days_ago: 4
+    include_examples 'alertable if due', days_ago: 7
+  end
+
+  context 'with notification settings overdue set to every 7 days' do
+    before do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: 7)
+    end
+
+    include_examples 'not alertable if due', days_ago: 0
+    include_examples 'alertable if due', days_ago: 1
+    include_examples 'not alertable if due', days_ago: 2
+    include_examples 'not alertable if due', days_ago: 3
+    include_examples 'not alertable if due', days_ago: 4
+    include_examples 'not alertable if due', days_ago: 7
+    include_examples 'alertable if due', days_ago: 8
+    include_examples 'alertable if due', days_ago: 15
+  end
+
+  ### project-specific notification settings specs
+
+  context 'with project notification settings overriding global notification settings' do
+    shared_let(:project_notification_settings) { user.notification_settings.create(project:) }
+
+    it 'uses the project settings' do
+      global_notification_settings.update(start_date: nil, due_date: nil, overdue: nil)
+      project_notification_settings.update(start_date: 1, due_date: 1, overdue: 1)
+
+      wp_start_and_due_in_1_day =
+        make_alertable_work_package(start_date: in_1_day, due_date: in_1_day, project:)
+      wp_overdue =
+        make_alertable_work_package(start_date: nil, due_date: yesterday, project:)
+      wp_start_and_due_in_1_day_other_project =
+        make_alertable_work_package(start_date: in_1_day, due_date: in_1_day, project: other_project)
+
+      expect(subject.alertable_for_start).to include(wp_start_and_due_in_1_day)
+      expect(subject.alertable_for_due).to include(wp_start_and_due_in_1_day, wp_overdue)
+
+      expect(subject.alertable_for_start).not_to include(wp_start_and_due_in_1_day_other_project)
+      expect(subject.alertable_for_due).not_to include(wp_start_and_due_in_1_day_other_project)
+    end
+
+    it 'does not use global settings if project settings are nil' do
+      global_notification_settings.update(start_date: 1, due_date: 1)
+      project_notification_settings.update(start_date: nil, due_date: nil)
+
+      make_alertable_work_package(start_date: in_1_day, due_date: in_1_day, project:)
+
+      expect(subject.alertable_for_start).to be_empty
+      expect(subject.alertable_for_due).to be_empty
+    end
+  end
+end

--- a/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
@@ -332,6 +332,8 @@ RSpec.describe Notifications::CreateDateAlertsNotificationsJob::AlertableWorkPac
     include_examples 'not alertable if due', days_ago: 2
     include_examples 'not alertable if due', days_ago: 3
     include_examples 'alertable if due', days_ago: 4
+    include_examples 'not alertable if due', days_ago: 5
+    include_examples 'not alertable if due', days_ago: 6
     include_examples 'alertable if due', days_ago: 7
   end
 
@@ -347,6 +349,7 @@ RSpec.describe Notifications::CreateDateAlertsNotificationsJob::AlertableWorkPac
     include_examples 'not alertable if due', days_ago: 4
     include_examples 'not alertable if due', days_ago: 7
     include_examples 'alertable if due', days_ago: 8
+    include_examples 'not alertable if due', days_ago: 12
     include_examples 'alertable if due', days_ago: 15
   end
 

--- a/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
@@ -1,0 +1,159 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Notifications::CreateDateAlertsNotificationsJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  create_shared_association_defaults_for_work_package_factory
+
+  subject { scheduled_job.invoke_job }
+
+  let(:scheduled_job) do
+    described_class.ensure_scheduled!
+
+    Delayed::Job.first
+  end
+
+  let(:today) { Date.current }
+  let(:in_1_day) { today + 1.day }
+
+  let(:user_paris) do
+    create(
+      :user,
+      firstname: 'Europe/Paris',
+      preferences: { time_zone: 'Europe/Paris' }
+    )
+  end
+  let(:user_kathmandu) do
+    create(
+      :user,
+      firstname: 'Asia/Kathmandu',
+      preferences: { time_zone: 'Asia/Kathmandu' }
+    )
+  end
+
+  before do
+    # We need to access the job as stored in the database to get at the run_at time persisted there
+    allow(ActiveJob::Base)
+      .to receive(:queue_adapter)
+            .and_return(ActiveJob::QueueAdapters::DelayedJobAdapter.new)
+  end
+
+  define :have_a_start_date_alert_notification_for do |work_package|
+    match do |user|
+      Notification
+        .reason_date_alert_start_date
+        .recipient(user)
+        .exists?(resource: work_package)
+    end
+
+    failure_message do |user|
+      "expected user #{inspect_keys(user, :id, :firstname)} " \
+        "to have a start date alert notification for work package " \
+        "#{inspect_keys(work_package, :id, :start_date, :due_date)}"
+    end
+
+    failure_message_when_negated do |user|
+      "expected user #{inspect_keys(user, :id, :firstname)} " \
+        "to NOT have a start date alert notification for work package " \
+        "#{inspect_keys(work_package, :id, :start_date, :due_date)}"
+    end
+
+    def inspect_keys(object, *keys)
+      formatted_pairs = object
+        .slice(*keys)
+        .map { |k, v| "#{k}: #{v.is_a?(Date) ? v.to_s : v.inspect}" }
+        .join(', ')
+      "#<#{formatted_pairs}>"
+    end
+  end
+
+  def set_run_at(run_at)
+    scheduled_job.update_column(:run_at, run_at)
+  end
+
+  describe '#perform' do
+    let(:timezone_paris) { ActiveSupport::TimeZone[user_paris.preference.time_zone] }
+
+    context 'when scheduled and executed at 01:00 am Paris local time' do
+      it 'creates a start date alert notification for a user in the same time zone' do
+        set_run_at(timezone_paris.now.change(hour: 1, min: 0))
+        travel_to(timezone_paris.now.change(hour: 1, min: 0))
+        work_package = create(:work_package,
+                              start_date: in_1_day,
+                              assigned_to: user_paris)
+
+        scheduled_job.invoke_job
+
+        expect(user_paris).to have_a_start_date_alert_notification_for(work_package)
+      end
+
+      it 'does not create a start date alert notification for a user in another time zone' do
+        set_run_at(timezone_paris.now.change(hour: 1, min: 0))
+        travel_to(timezone_paris.now.change(hour: 1, min: 0))
+        work_package = create(:work_package,
+                              start_date: in_1_day,
+                              assigned_to: user_kathmandu)
+
+        scheduled_job.invoke_job
+
+        expect(user_kathmandu).not_to have_a_start_date_alert_notification_for(work_package)
+      end
+    end
+
+    context 'when running at 01:14 am Paris local time' do
+      it 'creates a start date alert notification for a user in the same time zone' do
+        set_run_at(timezone_paris.now.change(hour: 1, min: 14))
+        travel_to(timezone_paris.now.change(hour: 1, min: 14))
+        work_package = create(:work_package,
+                              start_date: in_1_day,
+                              assigned_to: user_paris)
+
+        scheduled_job.invoke_job
+
+        expect(user_paris).to have_a_start_date_alert_notification_for(work_package)
+      end
+    end
+
+    context 'when running at 01:15 am Paris local time' do
+      it 'does not create a start date alert notification for a user in the same time zone' do
+        set_run_at(timezone_paris.now.change(hour: 1, min: 15))
+        travel_to(timezone_paris.now.change(hour: 1, min: 15))
+        work_package = create(:work_package,
+                              start_date: in_1_day,
+                              assigned_to: user_paris)
+
+        scheduled_job.invoke_job
+
+        expect(user_paris).not_to have_a_start_date_alert_notification_for(work_package)
+      end
+    end
+  end
+end

--- a/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
@@ -377,5 +377,18 @@ describe Notifications::CreateDateAlertsNotificationsJob, type: :job do
         expect(user_paris).not_to have_a_start_date_alert_notification_for(work_package)
       end
     end
+
+    context 'when scheduled at 01:00 am Paris local time and executed at 01:37 am' do
+      it 'creates a start date alert notification for a user in the same time zone' do
+        work_package = alertable_work_package
+
+        set_scheduled_time(timezone_paris.now.change(hour: 1, min: 0))
+        travel_to(timezone_paris.now.change(hour: 1, min: 37))
+
+        scheduled_job.invoke_job
+
+        expect(user_paris).to have_a_start_date_alert_notification_for(work_package)
+      end
+    end
   end
 end


### PR DESCRIPTION
[OP #43674](https://community.openproject.org/wp/43674)

* [x] Date alerts notifications must be triggered at 1 am local time. 
  * The job thus has to run every 15 min to cover all time zones, and focus on users for whom it is 1 am in their time zone. See `Notifications::ScheduleReminderMailsJob` for something similar.
* [x] Users without time zone preference use `Settings.user_default_timezone`
* [x] When `Settings.user_default_timezone` is unset, use UTC

* [x] Create date alerts notifications depending on the notification settings.
  * [x] Use user specific notification settings for work packages with a `project_id` matching. 
  * [x] Use user global notification settings (with `project_id: nil`) for other work packages. 
  * Note: `Notifications::CreateFromModelService` probably cannot be adapted but might serve as a blueprint.

* [x] Date alert notification is created when:
  * [x] work packages is open
  * [x] user is involved (assignee, accountable, or watcher)
  - For a `date_alert_start_date` notification:
    * [x] user notification settings start date is set
    * [x] work package start date is x days from today where x is given by user notification settings start date 
  - For a `date_alert_due_date` notification:
    * either
      * [x] user notification settings due date is set
      * [x] work package due date is x days from today where x is given by user notification settings due date 
    * or
      * [x] user notification settings overdue is set
      * [x] work package due date is n*x days after today where x is given by user notification settings overdue

* [x] Work package is attached as the `resource` of the notification
* [x] Mark previous date alerts notifications as seen whenever a new notification is created for the same date alert (same work package, same reason, and same user)