### PR TITLE
avoid sending journal aggregated event if journal was updated

### DIFF
--- a/spec/models/work_package/openproject_notifications_spec.rb
+++ b/spec/models/work_package/openproject_notifications_spec.rb
@@ -61,23 +61,23 @@ describe WorkPackage, type: :model, with_settings: { journal_aggregation_time_mi
       end
 
       it "are triggered" do
-        expect(journal_ids).to include(work_package.journals.last.id)
+        expect(journal_ids).to match [work_package.journals.last.id]
       end
     end
 
     describe 'when after update' do
       before do
         work_package
-
+        perform_enqueued_jobs
         journal_ids.clear
 
-        work_package.update subject: 'the wind of change'
+        work_package.update(subject: 'the wind of change')
 
         perform_enqueued_jobs
       end
 
       it "are triggered" do
-        expect(journal_ids).to include(work_package.journals.last.id)
+        expect(journal_ids).to match [work_package.journals.last.id]
       end
     end
   end


### PR DESCRIPTION
Journals might get updated by a second change done to the journable within the aggregation time limit carried out by the same user.

In that case, the journal should not be considered `completed`.

https://community.openproject.org/wp/44158