### PR TITLE
Added docs for Breadcrumbs

### DIFF
--- a/frontend/src/stories/Breadcrumbs.stories.mdx
+++ b/frontend/src/stories/Breadcrumbs.stories.mdx
@@ -6,7 +6,7 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs';
 
 > Example: A 3-level breadcrumb, root with icon
 
-Breadcrumbs provide important semantic context to information being presented on the screen by allowing users to identify where they are in a hierarchical structural.
+Breadcrumbs provide important semantic context to information being presented on the screen by allowing users to identify where they are in a hierarchical structure.
 
 Breadcrumbs allow users to:
 
@@ -26,16 +26,14 @@ The last level is always the current level; this is never clickable. All other l
 Because the length of the breadcrumb can vary significantly (depending on the title of each level and the available space), it can condense to fit the available space:
 
 - The breadcrumb can show four (4) levels in full, space permitting, before going to "collapsed" mode.
-- If the available space in the parent container does afford sufficient width to display the four levels in full, their names are truncated with ellipses ("Root ▶ First level ▶ Second le... ▶ Third le... ▶ Fourth level").
-    - *The middle levels (excluding first and last) are truncated first. (??)*
-    - *If space is still tight, root and current level are also truncated. (??)*
+- If the available space in the parent container not does afford sufficient width to display the four levels in full, the middle levels are truncated with ellipses ("Root ▶ Second le... ▶ Third le... ▶ Fourth level"). 
 
 > *Example: A 5-level breadcrumb, collapsed*
 
 There are special rules on mobile:
 
-- The root level shows only an icon (no text)
-- The direct parent (...) is displays as non-shrinkable ellipses that are clickable
+- The root level shows only an icon and ellipses ("...", fully truncated).
+- The direct parent (...) is displayed as non-shrinkable ellipses that are clickable
 - Further parents (between the direct parent and the root) are not displayed
 - The current level maybe be truncated with ellipses ("Icon ▶ ... ▶Current le...) if needed.
 
@@ -52,7 +50,7 @@ The icon is almost always only used for the first item, although the component d
 
 The text for each level is always a link, except for:
 
-- root level
+- current level
 - collapsed levels between the direct parent and root in collapsed mode
 
 ## Margins and Spacing

--- a/frontend/src/stories/Breadcrumbs.stories.mdx
+++ b/frontend/src/stories/Breadcrumbs.stories.mdx
@@ -1,0 +1,61 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+
+<Meta title="Patterns/Breadcrumbs" />
+
+# Breadcrumbs
+
+> Example: A 3-level breadcrumb, root with icon
+
+Breadcrumbs provide important semantic context to information being presented on the screen by allowing users to identify where they are in a hierarchical structural.
+
+Breadcrumbs allow users to:
+
+- identify their current location (in a folder structure or hierarchy of work packages)
+- navigate up to the parent(s)
+
+## Structure and Options
+
+Breadcrumbs consist of a series of "levels" presented horizontally, separated by a right arrow (▶). Each level is a child of the level preceding it, except the first level, which is the root.
+
+> Example: A 4-level breadcrumb, root with icon
+
+## Behaviour
+
+The last level is always the current level; this is never clickable. All other levels (the parents) are links, and clicking on them will take users to that level.
+
+Because the length of the breadcrumb can vary significantly (depending on the title of each level and the available space), it can condense to fit the available space:
+
+- The breadcrumb can show four (4) levels in full, space permitting, before going to "collapsed" mode.
+- If the available space in the parent container does afford sufficient width to display the four levels in full, their names are truncated with ellipses ("Root ▶ First level ▶ Second le... ▶ Third le... ▶ Fourth level").
+    - *The middle levels (excluding first and last) are truncated first. (??)*
+    - *If space is still tight, root and current level are also truncated. (??)*
+
+> *Example: A 5-level breadcrumb, collapsed*
+
+There are special rules on mobile:
+
+- The root level shows only an icon (no text)
+- The direct parent (...) is displays as non-shrinkable ellipses that are clickable
+- Further parents (between the direct parent and the root) are not displayed
+- The current level maybe be truncated with ellipses ("Icon ▶ ... ▶Current le...) if needed.
+
+> Example: A 4-level breadcrumb, mobile
+
+## Options
+
+Each level can consist of:
+
+- an icon
+- a text
+
+The icon is almost always only used for the first item, although the component does allow it to be present at any level.
+
+The text for each level is always a link, except for:
+
+- root level
+- collapsed levels between the direct parent and root in collapsed mode
+
+## Margins and Spacing
+
+
+The breadcrumb component does not inherently have margins or padding. There is a 0.25 rem spacing between each level and a right arrow (that is, 0.25 to the left and right of every right arrow).


### PR DESCRIPTION
Hi @Kharonus,

Could you please review the text of the docs and see if the rules concerning shrinking/truncating are correct? 

I had some doubts about this bit from your notes:

>* the crumbs do shrink to fit into the max-width, if the full width would exceed it
>  * the root crumb and the current layer crumb are not shrinked
>  * the parent and the grand parent are shrinked with textoverflow: ellipsis (i.e. ... at the end of the still visible letters)
>  * the ... crumb, indicating that there are collapsed crumbs, is not shrinkable

Cheers
Parimal