### PR TITLE
Don't try to set datetime_type for nulldb

### DIFF
--- a/config/initializers/postgresql_timestamp.rb
+++ b/config/initializers/postgresql_timestamp.rb
@@ -1,2 +1,4 @@
 # Use timestampz to create new timestamp columns, so that we get WITH TIME ZONE support
-ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type = :timestamptz
+if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type = :timestamptz
+end


### PR DESCRIPTION
When using the application with a nulldb fallback (for compilation of assets or other reasons), the newly added initalizer to set the PostgreSQL datetime_type will cause an error.

https://community.openproject.org/wp/44635