### PR TITLE
[#44541] Unify the strings used for user involvement

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -582,8 +582,8 @@ en:
       no_unread: "No unread notifications"
       reasons:
         mentioned: 'mentioned'
-        watched: 'watched'
-        assigned: 'assigned'
+        watched: 'watcher'
+        assigned: 'assignee'
         responsible: 'accountable'
         created: 'created'
         scheduled: 'scheduled'
@@ -621,7 +621,7 @@ en:
         by_reason: 'Involvement'
         inbox: 'Inbox'
         mentioned: 'Mentioned'
-        watching: 'Watching'
+        watched: 'Watcher'
       settings:
         change_notification_settings: 'To view and change your notification settings, <a target="_blank" href="%{url}">click here</a>'
         title: "Notification settings"

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -77,7 +77,7 @@ export class InAppNotificationCenterComponent implements OnInit {
     },
     {
       key: 'watched',
-      title: this.I18n.t('js.notifications.menu.watching'),
+      title: this.I18n.t('js.notifications.menu.watched'),
     },
   ];
 

--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
@@ -88,7 +88,7 @@ export class IanMenuComponent implements OnInit {
     },
     {
       key: 'watched',
-      title: this.I18n.t('js.notifications.menu.watching'),
+      title: this.I18n.t('js.notifications.menu.watched'),
       icon: 'watching',
       ...getUiLinkForFilters({ filter: 'reason', name: 'watched' }),
     },

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -40,7 +40,7 @@
         class="op-ian-item--reason"
         *ngFor="let item of translatedReasons | keyvalue; let first = first; let last = last"
       >
-        {{ item.key }}<ng-container *ngIf="!last && first !== last">, </ng-container>
+        {{ item.key }}<ng-container *ngIf="!last">, </ng-container>
       </span>
       </div>
 

--- a/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
@@ -76,7 +76,7 @@ describe "Notification center sidemenu", type: :feature, js: true do
       side_menu.expect_item_with_no_count 'Assignee'
       side_menu.expect_item_with_no_count 'Mentioned'
       side_menu.expect_item_with_no_count 'Accountable'
-      side_menu.expect_item_with_no_count 'Watching'
+      side_menu.expect_item_with_no_count 'Watcher'
     end
   end
 
@@ -88,7 +88,7 @@ describe "Notification center sidemenu", type: :feature, js: true do
     side_menu.expect_item_with_count 'Assignee', 1
     side_menu.expect_item_with_count 'Mentioned', 1
     side_menu.expect_item_with_count 'Accountable', 1
-    side_menu.expect_item_with_count 'Watching', 1
+    side_menu.expect_item_with_count 'Watcher', 1
 
     # Expect project filters
     side_menu.expect_item_with_count project.name, 1
@@ -103,7 +103,7 @@ describe "Notification center sidemenu", type: :feature, js: true do
     side_menu.expect_item_with_count 'Assignee', 1
     side_menu.expect_item_with_count 'Mentioned', 1
     side_menu.expect_item_with_count 'Accountable', 1
-    side_menu.expect_item_with_no_count 'Watching'
+    side_menu.expect_item_with_no_count 'Watcher'
 
     # ... and show only those projects with a notification
     side_menu.expect_item_not_visible project.name
@@ -111,9 +111,9 @@ describe "Notification center sidemenu", type: :feature, js: true do
     side_menu.expect_item_with_count "... #{project3.name}", 2
 
     # Empty filter sets have a separate message
-    side_menu.click_item 'Watching'
+    side_menu.click_item 'Watcher'
     side_menu.finished_loading
-    expect(page).to have_text "Looks like you're all caught up for Watching filter"
+    expect(page).to have_text "Looks like you're all caught up for Watcher filter"
 
     # Marking all as read
     side_menu.click_item 'Inbox'
@@ -123,7 +123,7 @@ describe "Notification center sidemenu", type: :feature, js: true do
     side_menu.expect_item_with_no_count 'Assignee'
     side_menu.expect_item_with_no_count 'Mentioned'
     side_menu.expect_item_with_no_count 'Accountable'
-    side_menu.expect_item_with_no_count 'Watching'
+    side_menu.expect_item_with_no_count 'Watcher'
 
     side_menu.expect_item_not_visible project.name
     side_menu.expect_item_not_visible project2.name
@@ -134,8 +134,8 @@ describe "Notification center sidemenu", type: :feature, js: true do
     # All notifications are shown
     center.expect_work_package_item notification, notification2, notification3, notification4
 
-    # Filter for "Watching"
-    side_menu.click_item 'Watching'
+    # Filter for "Watcher"
+    side_menu.click_item 'Watcher'
     side_menu.finished_loading
     center.expect_work_package_item notification
     center.expect_no_item notification2, notification3, notification4


### PR DESCRIPTION
https://community.openproject.org/work_packages/44541

Changes:
- Notification centre side menu
<img width="230" alt="image" src="https://user-images.githubusercontent.com/83396/197751448-ac45d890-f646-4ca7-ba1b-f76234aa97ae.png">

- Notification centre side menu all notifications are read
    - Mentioned
    <img width="960" alt="image" src="https://user-images.githubusercontent.com/83396/197752988-06048d0e-5b3e-40d4-812b-8bfc29192264.png">

    - Assignee
    <img width="959" alt="image" src="https://user-images.githubusercontent.com/83396/197753058-bb6fbecd-27e6-4e74-89bd-0b584faa974e.png">

    - Accountable
    <img width="972" alt="image" src="https://user-images.githubusercontent.com/83396/197753110-52d9b088-a77c-4557-b510-ef937bf4d406.png">

    - Watcher
    <img width="957" alt="image" src="https://user-images.githubusercontent.com/83396/197753163-5e63cf67-3edb-4766-aae7-741dbc127dba.png">

- Notification cards (first row)
<img width="608" alt="image" src="https://user-images.githubusercontent.com/83396/197751477-758886c6-1ea6-4284-9721-4267392882f2.png">

- Notification settings for general "Participating"
<img width="211" alt="image" src="https://user-images.githubusercontent.com/83396/197751539-2ce13c9a-d918-4dbf-9353-35c43ba2cef2.png">

- Notification settings for project-specific "Participating"
<img width="254" alt="image" src="https://user-images.githubusercontent.com/83396/197751604-78ccd1d7-8108-4375-a537-6ace98cec24d.png">
