### PR TITLE
Do not require faker gem by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -260,7 +260,7 @@ end
 group :development do
   gem 'listen', '~> 3.7.0' # Use for event-based reloaders
 
-  gem 'faker'
+  gem 'faker', require: false
   gem 'letter_opener'
 
   gem 'spring'

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -29,6 +29,8 @@
 namespace :sample_data do
   desc 'Create the given number of fake projects'
   task :projects, [:nr_of_projects] => :environment do |_task, args|
+    require 'faker'
+
     puts "Creating #{args[:nr_of_projects]} fake projects"
 
     args[:nr_of_projects].to_i.times do |i|


### PR DESCRIPTION
I noticed faker has some i18n translations to be loaded, but it's not widely used in our code base. Removing it does not save much, but letting it in does not add much either.