### PR TITLE
Fix/typeahead order for work packages

### DIFF
--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -28,7 +28,8 @@
 
 class Queries::Columns::Base
   attr_reader :groupable,
-              :sortable
+              :sortable,
+              :displayable
 
   attr_accessor :name,
                 :sortable_join,
@@ -45,6 +46,7 @@ class Queries::Columns::Base
 
     %i(sortable
        sortable_join
+       displayable
        groupable
        summable
        summable_select
@@ -73,7 +75,15 @@ class Queries::Columns::Base
   end
 
   def sortable=(value)
-    @sortable =  name_or_value_or_false(value)
+    @sortable = name_or_value_or_false(value)
+  end
+
+  def displayable=(value)
+    @displayable = value.nil? ? true : value
+  end
+
+  def displayable?
+    displayable
   end
 
   # Returns true if the column is sortable, otherwise false

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -82,5 +82,7 @@ module Queries::WorkPackages
     column Columns::CustomFieldColumn
     column Columns::RelationToTypeColumn
     column Columns::RelationOfTypeColumn
+    column Columns::ManualSortingColumn
+    column Columns::TypeaheadColumn
   end
 end

--- a/app/models/queries/work_packages/columns/typeahead_column.rb
+++ b/app/models/queries/work_packages/columns/typeahead_column.rb
@@ -26,17 +26,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::WorkPackages::Columns::ManualSortingColumn < Queries::WorkPackages::Columns::WorkPackageColumn
-  include ::Queries::WorkPackages::Common::ManualSorting
-
-  def initialize
-    super :manual_sorting,
-          default_order: 'asc',
-          displayable: false,
-          sortable: "#{OrderedWorkPackage.table_name}.position NULLS LAST, #{WorkPackage.table_name}.id"
-  end
-
-  def sortable_join_statement(query)
-    ordered_work_packages_join(query)
+class Queries::WorkPackages::Columns::TypeaheadColumn < Queries::WorkPackages::Columns::WorkPackageColumn
+  def self.instances(_context = nil)
+    new :typeahead,
+        displayable: false,
+        # This is an ugly hack. When using the typeahead order, the work packages should always be ordered
+        # by their updated_at. But when asc is specified for typeahead, the updated_at property is to be used
+        # in desc order.
+        sortable: ->(table_name = WorkPackage.table_name) { "#{table_name}.updated_at DESC, #{table_name}.updated_at" }
   end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -84,7 +84,7 @@ class Query < ApplicationRecord
   def set_default_sort
     return if sort_criteria.any?
 
-    self.sort_criteria = [['id', 'asc']]
+    self.sort_criteria = [%w[id asc]]
   end
 
   def context
@@ -110,7 +110,7 @@ class Query < ApplicationRecord
   end
 
   def validate_columns
-    available_names = available_columns.map(&:name).map(&:to_sym)
+    available_names = displayable_columns.map(&:name).map(&:to_sym)
 
     (column_names - available_names).each do |name|
       errors.add :column_names,
@@ -190,11 +190,11 @@ class Query < ApplicationRecord
 
   def available_columns
     if @available_columns &&
-       (@available_columns_project == ((project && project.cache_key) || 0))
+       (@available_columns_project == (project&.cache_key || 0))
       return @available_columns
     end
 
-    @available_columns_project = (project && project.cache_key) || 0
+    @available_columns_project = project&.cache_key || 0
     @available_columns = ::Query.available_columns(project)
   end
 
@@ -205,12 +205,20 @@ class Query < ApplicationRecord
       .flatten
   end
 
+  def self.displayable_columns
+    available_columns.select(&:displayable?)
+  end
+
   def self.groupable_columns
     available_columns.select(&:groupable)
   end
 
   def self.sortable_columns
-    available_columns.select(&:sortable) + [manual_sorting_column]
+    available_columns.select(&:sortable)
+  end
+
+  def displayable_columns
+    available_columns.select(&:displayable?)
   end
 
   # Returns an array of columns that can be used to group the results
@@ -220,7 +228,7 @@ class Query < ApplicationRecord
 
   # Returns an array of columns that can be used to sort the results
   def sortable_columns
-    available_columns.select(&:sortable) + [manual_sorting_column]
+    available_columns.select(&:sortable)
   end
 
   # Returns a Hash of sql columns for sorting by column
@@ -249,7 +257,7 @@ class Query < ApplicationRecord
                   end
 
     # preserve the order
-    column_list.map { |name| available_columns.find { |col| col.name == name.to_sym } }.compact
+    column_list.map { |name| displayable_columns.find { |col| col.name == name.to_sym } }.compact
   end
 
   def column_names=(names)
@@ -428,7 +436,7 @@ class Query < ApplicationRecord
   end
 
   def valid_column_subset!
-    available_names = available_columns.map(&:name).map(&:to_sym)
+    available_names = displayable_columns.map(&:name).map(&:to_sym)
 
     self.column_names &= available_names
   end

--- a/app/models/query/highlighting.rb
+++ b/app/models/query/highlighting.rb
@@ -54,7 +54,7 @@ module Query::Highlighting
     end
 
     def available_highlighting_columns
-      @available_highlighting_columns ||= available_columns.select(&:highlightable?)
+      @available_highlighting_columns ||= displayable_columns.select(&:highlightable?)
     end
 
     def highlighted_columns

--- a/app/views/admin/settings/work_packages_settings/show.html.erb
+++ b/app/views/admin/settings/work_packages_settings/show.html.erb
@@ -69,7 +69,7 @@ See COPYRIGHT and LICENSE files for more details.
   </section>
   <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= t(:setting_column_options) %></legend>
     <%
-       column_choices = Query.new.available_columns.map { |column|
+       column_choices = Query.new.displayable_columns.map { |column|
          { caption: column.caption, value: column.name.to_s }
        }
     %>

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -977,7 +977,7 @@ Settings::Definition.define do
 
   add :work_package_list_default_columns,
       default: %w[id subject type status assigned_to priority],
-      allowed: -> { Query.new.available_columns.map(&:name).map(&:to_s) }
+      allowed: -> { Query.new.displayable_columns.map(&:name).map(&:to_s) }
 
   add :work_package_startdate_is_adddate,
       default: false

--- a/docs/api/apiv3/paths/work_package_available_relation_candidates.yml
+++ b/docs/api/apiv3/paths/work_package_available_relation_candidates.yml
@@ -18,7 +18,7 @@ get:
       type: integer
   - description: |-
       JSON specifying filter conditions.
-      Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/) endpoint.
+      Accepts the same filters as the [work packages](https://www.openproject.org/docs/api/endpoints/work_packages/) endpoint.
     example: '[{ "status_id": { "operator": "o", "values": null } }]'
     in: query
     name: filters
@@ -38,6 +38,16 @@ get:
     name: type
     required: false
     schema:
+      type: string
+  - description: |-
+      JSON specifying sort criteria.
+      Accepts the same sort criteria as the [work packages](https://www.openproject.org/docs/api/endpoints/work_packages/) endpoint.
+    example: '[["status", "asc"]]'
+    in: query
+    name: sortBy
+    required: false
+    schema:
+      default: '[["id", "asc"]]'
       type: string
   responses:
     '200':

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -173,7 +173,7 @@ module API
                                          required: false,
                                          writable: true,
                                          has_default: true,
-                                         values_callback: -> { represented.available_columns },
+                                         values_callback: -> { represented.displayable_columns },
                                          value_representer: ->(column) {
                                            Columns::QueryColumnsFactory.representer(column)
                                          },

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -32,7 +32,8 @@ module API
       class AvailableRelationCandidatesAPI < ::API::OpenProjectAPI
         helpers do
           def combined_params
-            { filters: filters_param, pageSize: params[:pageSize] }.with_indifferent_access
+            params
+              .merge({ filters: filters_param }.with_indifferent_access)
           end
 
           def filters_param

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -219,7 +219,7 @@ describe 'work package export', type: :feature do
 
     context 'with many columns' do
       before do
-        query.column_names = query.available_columns.map { |c| c.name.to_s } - ['bcf_thumbnail']
+        query.column_names = query.displayable_columns.map { |c| c.name.to_s } - ['bcf_thumbnail']
         query.save!
 
         # Despite attempts to provoke the error by having a lot of columns, the pdf

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -40,7 +40,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
       .and_return([])
 
     allow(query)
-      .to receive(:available_columns)
+      .to receive(:displayable_columns)
       .and_return([])
 
     allow(query)
@@ -346,7 +346,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
              Queries::WorkPackages::Columns::RelationToTypeColumn.new(type),
              Queries::WorkPackages::Columns::RelationOfTypeColumn.new(name: :label_relates_to, sym: :relation1)]
           end
-          let(:available_values_method) { :available_columns }
+          let(:available_values_method) { :displayable_columns }
 
           it_behaves_like 'has a collection of allowed values' do
             let(:expected_hrefs) do
@@ -390,7 +390,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
             [Queries::WorkPackages::Columns::PropertyColumn.new(:bogus1, highlightable: true),
              Queries::WorkPackages::Columns::PropertyColumn.new(:bogus2, highlightable: true)]
           end
-          let(:available_values_method) { :available_columns }
+          let(:available_values_method) { :displayable_columns }
 
           it_behaves_like 'has a collection of allowed values' do
             let(:expected_hrefs) do

--- a/spec/models/query/results_sort_intergration_spec.rb
+++ b/spec/models/query/results_sort_intergration_spec.rb
@@ -1,0 +1,520 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+describe ::Query::Results, 'sorting and grouping', with_mail: false do
+  create_shared_association_defaults_for_work_package_factory
+
+  let(:query) do
+    build_stubbed(:query,
+                  show_hierarchies: false,
+                  group_by:,
+                  sort_criteria: sort_by,
+                  project: project1,
+                  column_names: columns)
+  end
+
+  let(:query_results) do
+    described_class.new query
+  end
+  let(:project1) { create(:project) }
+  let(:user1) do
+    create(:user,
+           firstname: 'user',
+           lastname: '1',
+           member_in_project: project1,
+           member_with_permissions: [:view_work_packages])
+  end
+  let(:user_a) { create(:user, firstname: 'AAA', lastname: 'AAA') }
+  let(:user_m) { create(:user, firstname: 'mmm', lastname: 'mmm') }
+  let(:user_z) { create(:user, firstname: 'ZZZ', lastname: 'ZZZ') }
+
+  let(:work_package1) { create(:work_package, project: project1, id: 1) }
+  let(:work_package2) { create(:work_package, project: project1, id: 2) }
+  let(:work_package3) { create(:work_package, project: project1, id: 3) }
+  let(:sort_by) { [%w[id asc]] }
+  let(:columns) { %i(id subject) }
+  let(:group_by) { '' }
+
+  current_user { user1 }
+
+  context 'when grouping by assigned_to, having the author column selected' do
+    let(:group_by) { 'assigned_to' }
+    let(:columns) { %i(id subject author) }
+
+    before do
+      work_package1.assigned_to = user_m
+      work_package1.author = user_m
+
+      work_package1.save(validate: false)
+
+      work_package2.assigned_to = user_z
+      work_package2.author = user_a
+
+      work_package2.save(validate: false)
+
+      work_package3.assigned_to = user_m
+      work_package3.author = user_a
+
+      work_package3.save(validate: false)
+    end
+
+    it 'sorts case insensitive first by assigned_to (group by), then by sort criteria' do
+      # Would look like this in the table
+      #
+      # user_m
+      #   work_package 1
+      #   work_package 3
+      # user_z
+      #   work_package 2
+      expect(query_results.work_packages)
+        .to match [work_package1, work_package3, work_package2]
+    end
+  end
+
+  context 'when sorting by author, grouping by assigned_to' do
+    let(:group_by) { 'assigned_to' }
+    let(:sort_by) { [['author', 'asc']] }
+
+    before do
+      work_package1.assigned_to = user_m
+      work_package1.author = user_m
+
+      work_package1.save(validate: false)
+
+      work_package2.assigned_to = user_z
+      work_package2.author = user_a
+
+      work_package2.save(validate: false)
+
+      work_package3.assigned_to = user_m
+      work_package3.author = user_a
+
+      work_package3.save(validate: false)
+    end
+
+    it 'sorts case insensitive first by group by, then by assigned_to' do
+      # Would look like this in the table
+      #
+      # user_m
+      #   work_package 3
+      #   work_package 1
+      # user_z
+      #   work_package 2
+      expect(query_results.work_packages)
+        .to match [work_package3, work_package1, work_package2]
+
+      query.sort_criteria = [['author', 'desc']]
+
+      # Would look like this in the table
+      #
+      # user_m
+      #   work_package 1
+      #   work_package 3
+      # user_z
+      #   work_package 2
+      expect(query_results.work_packages)
+        .to match [work_package1, work_package3, work_package2]
+    end
+  end
+
+  context 'when sorting and grouping by priority' do
+    let(:prio_low) { create(:issue_priority, position: 1) }
+    let(:prio_high) { create(:issue_priority, position: 0) }
+    let(:group_by) { 'priority' }
+
+    before do
+      work_package1.priority = prio_low
+      work_package2.priority = prio_high
+
+      work_package1.save(validate: false)
+      work_package2.save(validate: false)
+    end
+
+    it 'respects the sorting (Regression #29689)' do
+      query.sort_criteria = [['priority', 'asc']]
+
+      expect(query_results.work_packages)
+        .to match [work_package1, work_package2]
+
+      query.sort_criteria = [['priority', 'desc']]
+
+      expect(query_results.work_packages)
+        .to match [work_package2, work_package1]
+    end
+  end
+
+  context 'when sorting by priority, grouping by project' do
+    let(:prio_low) { create(:issue_priority, position: 1) }
+    let(:prio_high) { create(:issue_priority, position: 0) }
+    let(:group_by) { 'project' }
+
+    before do
+      work_package1.priority = prio_low
+      work_package2.priority = prio_high
+
+      work_package1.save(validate: false)
+      work_package2.save(validate: false)
+    end
+
+    it 'properly selects project_id (Regression #31667)' do
+      query.sort_criteria = [['priority', 'asc']]
+
+      expect(query_results.work_packages)
+        .to match [work_package1, work_package2]
+
+      query.sort_criteria = [['priority', 'desc']]
+
+      expect(query_results.work_packages)
+        .to match [work_package2, work_package1]
+
+      group_count = query_results.work_package_count_by_group
+
+      expect(group_count).to eq({ project1 => 2 })
+    end
+  end
+
+  context 'when sorting by author and responsible, grouping by assigned_to' do
+    let(:group_by) { 'assigned_to' }
+    let(:sort_by) { [['author', 'asc'], ['responsible', 'desc']] }
+
+    before do
+      work_package1.assigned_to = user_m
+      work_package1.author = user_m
+      work_package1.responsible = user_a
+
+      work_package1.save(validate: false)
+
+      work_package2.assigned_to = user_z
+      work_package2.author = user_m
+      work_package3.responsible = user_m
+
+      work_package2.save(validate: false)
+
+      work_package3.assigned_to = user_m
+      work_package3.author = user_m
+      work_package3.responsible = user_z
+
+      work_package3.save(validate: false)
+    end
+
+    it 'sorts case insensitive first by group by, then by assigned_to (neutral as equal), then by responsible' do
+      # Would look like this in the table
+      #
+      # user_m
+      #   work_package 3
+      #   work_package 1
+      # user_z
+      #   work_package 2
+      expect(query_results.work_packages)
+        .to match [work_package3, work_package1, work_package2]
+
+      query.sort_criteria = [%w[author desc], %w[responsible asc]]
+
+      # Would look like this in the table
+      #
+      # user_m
+      #   work_package 1
+      #   work_package 3
+      # user_z
+      #   work_package 2
+      expect(query_results.work_packages)
+        .to match [work_package1, work_package3, work_package2]
+    end
+  end
+
+  context 'when sorting by project' do
+    let(:user1) { create(:admin) }
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+
+    let(:project1) { create(:project, name: 'Project A') }
+    let(:project2) { create(:project, name: 'Project b')  }
+    let(:project3) { create(:project, name: 'Project C')  }
+    let(:work_package1) { create(:work_package, project: project1) }
+    let(:work_package2) { create(:work_package, project: project2) }
+    let(:work_package3) { create(:work_package, project: project3) }
+
+    context 'when ascending' do
+      let(:sort_by) { [%w[project asc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [%w[project desc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by category' do
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+    let(:category1) { create(:category, project: project1, name: 'Category A') }
+    let(:category2) { create(:category, project: project1, name: 'Category b') }
+    let(:category3) { create(:category, project: project1, name: 'Category C') }
+    let(:work_package1) { create(:work_package, project: project1, category: category1) }
+    let(:work_package2) { create(:work_package, project: project1, category: category2) }
+    let(:work_package3) { create(:work_package, project: project1, category: category3) }
+
+    context 'when ascending' do
+      let(:sort_by) { [%w[category asc]] }
+
+      it 'sorts case insensitive' do
+        query_results.work_packages
+        [work_package1, work_package2, work_package3]
+
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [%w[category desc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by subject' do
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+    let(:work_package1) { create(:work_package, project: project1, subject: 'WorkPackage A') }
+    let(:work_package2) { create(:work_package, project: project1, subject: 'WorkPackage b') }
+    let(:work_package3) { create(:work_package, project: project1, subject: 'WorkPackage C') }
+
+    context 'when ascending' do
+      let(:sort_by) { [%w[subject asc]] }
+
+      it 'sorts case insensitive' do
+        query_results.work_packages
+        [work_package1, work_package2, work_package3]
+
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [%w[subject desc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by finish date' do
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+    let(:work_package1) { create(:work_package, project: project1, due_date: 3.days.ago) }
+    let(:work_package2) { create(:work_package, project: project1, due_date: 2.days.ago) }
+    let(:work_package3) { create(:work_package, project: project1, due_date: 1.day.ago) }
+
+    context 'when ascending' do
+      let(:sort_by) { [%w[due_date asc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [%w[due_date desc]] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by string custom field' do
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+
+    let(:work_package1) { create(:work_package, project: project1) }
+    let(:work_package2) { create(:work_package, project: project1) }
+    let(:work_package3) { create(:work_package, project: project1) }
+    let(:string_cf) { create(:string_wp_custom_field, is_filter: true) }
+    let!(:custom_value) do
+      create(:custom_value,
+             custom_field: string_cf,
+             customized: work_package1,
+             value: 'String A')
+    end
+    let!(:custom_value2) do
+      create(:custom_value,
+             custom_field: string_cf,
+             customized: work_package2,
+             value: 'String b')
+    end
+
+    let!(:custom_value3) do
+      create(:custom_value,
+             custom_field: string_cf,
+             customized: work_package3,
+             value: 'String C')
+    end
+
+    before do
+      work_package1.project.work_package_custom_fields << string_cf
+      work_package1.type.custom_fields << string_cf
+
+      work_package1.reload
+      project1.reload
+    end
+
+    context 'when ascending' do
+      let(:sort_by) { [["cf_#{string_cf.id}", 'asc']] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [["assigned_to", 'desc']] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by integer custom field' do
+    let(:query) do
+      build_stubbed(:query,
+                    show_hierarchies: false,
+                    project: nil,
+                    sort_criteria: sort_by)
+    end
+
+    let(:work_package1) { create(:work_package, project: project1) }
+    let(:work_package2) { create(:work_package, project: project1) }
+    let(:work_package3) { create(:work_package, project: project1) }
+    let(:int_cf) { create(:int_wp_custom_field, is_filter: true) }
+    let!(:custom_value) do
+      create(:custom_value,
+             custom_field: int_cf,
+             customized: work_package1,
+             value: 1)
+    end
+    let!(:custom_value2) do
+      create(:custom_value,
+             custom_field: int_cf,
+             customized: work_package2,
+             value: 2)
+    end
+
+    let!(:custom_value3) do
+      create(:custom_value,
+             custom_field: int_cf,
+             customized: work_package3,
+             value: 3)
+    end
+
+    before do
+      work_package1.project.work_package_custom_fields << int_cf
+      work_package1.type.custom_fields << int_cf
+
+      work_package1.reload
+      project1.reload
+    end
+
+    context 'when ascending' do
+      let(:sort_by) { [["cf_#{int_cf.id}", 'asc']] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package1, work_package2, work_package3]
+      end
+    end
+
+    context 'when descending' do
+      let(:sort_by) { [["cf_#{int_cf.id}", 'desc']] }
+
+      it 'sorts case insensitive' do
+        expect(query_results.work_packages)
+          .to match [work_package3, work_package2, work_package1]
+      end
+    end
+  end
+
+  context 'when sorting by typeahead' do
+    before do
+      work_package1.update_column(:updated_at, 5.days.ago)
+      work_package2.update_column(:updated_at, Time.current)
+      work_package3.update_column(:updated_at, 10.days.ago)
+    end
+
+    let(:sort_by) { [%w[typeahead asc]] }
+
+    current_user { user1 }
+
+    it 'sorts by updated_at desc' do
+      expect(query_results.work_packages)
+        .to match [work_package2, work_package1, work_package3]
+    end
+  end
+end

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -467,614 +467,141 @@ describe ::Query::Results, type: :model, with_mail: false do
     end
   end
 
-  describe 'sorting' do
-    let(:work_package1) { create(:work_package, project: project1, id: 1) }
-    let(:work_package2) { create(:work_package, project: project1, id: 2) }
-    let(:work_package3) { create(:work_package, project: project1, id: 3) }
-    let(:sort_by) { [['id', 'asc']] }
-    let(:columns) { %i(id subject) }
-    let(:group_by) { '' }
-
+  context 'when filtering by bool cf' do
     let(:query) do
-      build_stubbed :query,
+      build_stubbed(:query,
                     show_hierarchies: false,
                     group_by:,
                     sort_criteria: sort_by,
                     project: project1,
-                    column_names: columns
+                    column_names: columns)
     end
 
-    let(:query_results) do
-      described_class.new query
+    let(:bool_cf) { create(:bool_wp_custom_field, is_filter: true) }
+    let(:custom_value) do
+      create(:custom_value,
+             custom_field: bool_cf,
+             customized: work_package1,
+             value:)
+    end
+    let(:value) { 't' }
+    let(:filter_value) { 't' }
+    let(:activate_cf) do
+      work_package1.project.work_package_custom_fields << bool_cf
+      work_package1.type.custom_fields << bool_cf
+
+      work_package1.reload
+      project1.reload
+    end
+    let(:work_package1) { create(:work_package, project: project1) }
+    let(:work_package2) { create(:work_package, project: project1, id: 2) }
+    let(:work_package3) { create(:work_package, project: project1, id: 3) }
+    let(:sort_by) { [%w[id asc]] }
+    let(:columns) { %i(id subject) }
+    let(:group_by) { '' }
+
+    before do
+      allow(User).to receive(:current).and_return(user1)
+
+      custom_value
+
+      activate_cf
+
+      query.add_filter(:"cf_#{bool_cf.id}", '=', [filter_value])
     end
 
-    let(:user_a) { create(:user, firstname: 'AAA', lastname: 'AAA') }
-    let(:user_m) { create(:user, firstname: 'mmm', lastname: 'mmm') }
-    let(:user_z) { create(:user, firstname: 'ZZZ', lastname: 'ZZZ') }
-
-    context 'when grouping by assigned_to, having the author column selected' do
-      let(:group_by) { 'assigned_to' }
-      let(:columns) { %i(id subject author) }
-
-      before do
-        allow(User).to receive(:current).and_return(user1)
-
-        work_package1.assigned_to = user_m
-        work_package1.author = user_m
-
-        work_package1.save(validate: false)
-
-        work_package2.assigned_to = user_z
-        work_package2.author = user_a
-
-        work_package2.save(validate: false)
-
-        work_package3.assigned_to = user_m
-        work_package3.author = user_a
-
-        work_package3.save(validate: false)
-      end
-
-      it 'sorts case insensitive first by assigned_to (group by), then by sort criteria' do
-        # Would look like this in the table
-        #
-        # user_m
-        #   work_package 1
-        #   work_package 3
-        # user_z
-        #   work_package 2
-        expect(query_results.work_packages)
-          .to match [work_package1, work_package3, work_package2]
+    shared_examples_for 'is empty' do
+      it 'is empty' do
+        expect(query.results.work_packages)
+          .to be_empty
       end
     end
 
-    context 'when sorting by author, grouping by assigned_to' do
-      let(:group_by) { 'assigned_to' }
-      let(:sort_by) { [['author', 'asc']] }
-
-      before do
-        allow(User).to receive(:current).and_return(user1)
-
-        work_package1.assigned_to = user_m
-        work_package1.author = user_m
-
-        work_package1.save(validate: false)
-
-        work_package2.assigned_to = user_z
-        work_package2.author = user_a
-
-        work_package2.save(validate: false)
-
-        work_package3.assigned_to = user_m
-        work_package3.author = user_a
-
-        work_package3.save(validate: false)
-      end
-
-      it 'sorts case insensitive first by group by, then by assigned_to' do
-        # Would look like this in the table
-        #
-        # user_m
-        #   work_package 3
-        #   work_package 1
-        # user_z
-        #   work_package 2
-        expect(query_results.work_packages)
-          .to match [work_package3, work_package1, work_package2]
-
-        query.sort_criteria = [['author', 'desc']]
-
-        # Would look like this in the table
-        #
-        # user_m
-        #   work_package 1
-        #   work_package 3
-        # user_z
-        #   work_package 2
-        expect(query_results.work_packages)
-          .to match [work_package1, work_package3, work_package2]
+    shared_examples_for 'returns the wp' do
+      it 'returns the wp' do
+        expect(query.results.work_packages)
+          .to match_array(work_package1)
       end
     end
 
-    context 'when sorting and grouping by priority' do
-      let(:prio_low) { create :issue_priority, position: 1 }
-      let(:prio_high) { create :issue_priority, position: 0 }
-      let(:group_by) { 'priority' }
-
-      before do
-        allow(User).to receive(:current).and_return(user1)
-
-        work_package1.priority = prio_low
-        work_package2.priority = prio_high
-
-        work_package1.save(validate: false)
-        work_package2.save(validate: false)
-      end
-
-      it 'respects the sorting (Regression #29689)' do
-        query.sort_criteria = [['priority', 'asc']]
-
-        expect(query_results.work_packages)
-          .to match [work_package1, work_package2]
-
-        query.sort_criteria = [['priority', 'desc']]
-
-        expect(query_results.work_packages)
-          .to match [work_package2, work_package1]
-      end
+    context 'with the wp having true for the cf
+             and filtering for true' do
+      it_behaves_like 'returns the wp'
     end
 
-    context 'when sorting by priority, grouping by project' do
-      let(:prio_low) { create :issue_priority, position: 1 }
-      let(:prio_high) { create :issue_priority, position: 0 }
-      let(:group_by) { 'project' }
+    context 'with the wp having true for the cf
+             and filtering for false' do
+      let(:filter_value) { 'f' }
 
-      before do
-        allow(User).to receive(:current).and_return(user1)
-
-        work_package1.priority = prio_low
-        work_package2.priority = prio_high
-
-        work_package1.save(validate: false)
-        work_package2.save(validate: false)
-      end
-
-      it 'properly selects project_id (Regression #31667)' do
-        query.sort_criteria = [['priority', 'asc']]
-
-        expect(query_results.work_packages)
-          .to match [work_package1, work_package2]
-
-        query.sort_criteria = [['priority', 'desc']]
-
-        expect(query_results.work_packages)
-          .to match [work_package2, work_package1]
-
-        group_count = query_results.work_package_count_by_group
-
-        expect(group_count).to eq({ project1 => 2 })
-      end
+      it_behaves_like 'is empty'
     end
 
-    context 'when sorting by author and responsible, grouping by assigned_to' do
-      let(:group_by) { 'assigned_to' }
-      let(:sort_by) { [['author', 'asc'], ['responsible', 'desc']] }
+    context 'with the wp having false for the cf
+             and filtering for false' do
+      let(:value) { 'f' }
+      let(:filter_value) { 'f' }
 
-      before do
-        allow(User).to receive(:current).and_return(user1)
-
-        work_package1.assigned_to = user_m
-        work_package1.author = user_m
-        work_package1.responsible = user_a
-
-        work_package1.save(validate: false)
-
-        work_package2.assigned_to = user_z
-        work_package2.author = user_m
-        work_package3.responsible = user_m
-
-        work_package2.save(validate: false)
-
-        work_package3.assigned_to = user_m
-        work_package3.author = user_m
-        work_package3.responsible = user_z
-
-        work_package3.save(validate: false)
-      end
-
-      it 'sorts case insensitive first by group by, then by assigned_to (neutral as equal), then by responsible' do
-        # Would look like this in the table
-        #
-        # user_m
-        #   work_package 3
-        #   work_package 1
-        # user_z
-        #   work_package 2
-        expect(query_results.work_packages)
-          .to match [work_package3, work_package1, work_package2]
-
-        query.sort_criteria = [['author', 'desc'], ['responsible', 'asc']]
-
-        # Would look like this in the table
-        #
-        # user_m
-        #   work_package 1
-        #   work_package 3
-        # user_z
-        #   work_package 2
-        expect(query_results.work_packages)
-          .to match [work_package1, work_package3, work_package2]
-      end
+      it_behaves_like 'returns the wp'
     end
 
-    context 'when sorting by project' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
+    context 'with the wp having false for the cf
+             and filtering for true' do
+      let(:value) { 'f' }
 
-      let(:project1) { create :project, name: 'Project A' }
-      let(:project2) { create :project, name: 'Project b'  }
-      let(:project3) { create :project, name: 'Project C'  }
-      let(:work_package1) { create(:work_package, project: project1) }
-      let(:work_package2) { create(:work_package, project: project2) }
-      let(:work_package3) { create(:work_package, project: project3) }
-
-      before { login_as(user1) }
-
-      context 'when ascending' do
-        let(:sort_by) { [['project', 'asc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [['project', 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
+      it_behaves_like 'is empty'
     end
 
-    context 'when sorting by category' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
-      let(:category1) { create(:category, project: project1, name: 'Category A') }
-      let(:category2) { create(:category, project: project1, name: 'Category b') }
-      let(:category3) { create(:category, project: project1, name: 'Category C') }
-      let(:work_package1) { create(:work_package, project: project1, category: category1) }
-      let(:work_package2) { create(:work_package, project: project1, category: category2) }
-      let(:work_package3) { create(:work_package, project: project1, category: category3) }
+    context 'with the wp having no value for the cf
+             and filtering for true' do
+      let(:custom_value) { nil }
 
-      before { login_as(user1) }
-
-      context 'when ascending' do
-        let(:sort_by) { [['category', 'asc']] }
-
-        it 'sorts case insensitive' do
-          query_results.work_packages
-          [work_package1, work_package2, work_package3]
-
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [['category', 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
+      it_behaves_like 'is empty'
     end
 
-    context 'when sorting by subject' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
-      let(:work_package1) { create(:work_package, project: project1, subject: 'WorkPackage A') }
-      let(:work_package2) { create(:work_package, project: project1, subject: 'WorkPackage b') }
-      let(:work_package3) { create(:work_package, project: project1, subject: 'WorkPackage C') }
+    context 'with the wp having no value for the cf
+             and filtering for false' do
+      let(:custom_value) { nil }
+      let(:filter_value) { 'f' }
 
-      before { login_as(user1) }
-
-      context 'when ascending' do
-        let(:sort_by) { [['subject', 'asc']] }
-
-        it 'sorts case insensitive' do
-          query_results.work_packages
-          [work_package1, work_package2, work_package3]
-
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [['subject', 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
+      it_behaves_like 'returns the wp'
     end
 
-    context 'when sorting by finish date' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
-      let(:work_package1) { create(:work_package, project: project1, due_date: 3.days.ago) }
-      let(:work_package2) { create(:work_package, project: project1, due_date: 2.days.ago) }
-      let(:work_package3) { create(:work_package, project: project1, due_date: 1.day.ago) }
+    context 'with the wp having no value for the cf
+             and filtering for false
+             and the cf not being active for the type' do
+      let(:custom_value) { nil }
+      let(:filter_value) { 'f' }
 
-      before { login_as(user1) }
-
-      context 'when ascending' do
-        let(:sort_by) { [['due_date', 'asc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [['due_date', 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
-    end
-
-    context 'when sorting by string custom field' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
-
-      let(:work_package1) { create(:work_package, project: project1) }
-      let(:work_package2) { create(:work_package, project: project1) }
-      let(:work_package3) { create(:work_package, project: project1) }
-      let(:string_cf) { create(:string_wp_custom_field, is_filter: true) }
-      let!(:custom_value) do
-        create(:custom_value,
-               custom_field: string_cf,
-               customized: work_package1,
-               value: 'String A')
-      end
-      let!(:custom_value2) do
-        create(:custom_value,
-               custom_field: string_cf,
-               customized: work_package2,
-               value: 'String b')
-      end
-
-      let!(:custom_value3) do
-        create(:custom_value,
-               custom_field: string_cf,
-               customized: work_package3,
-               value: 'String C')
-      end
-
-      before do
-        work_package1.project.work_package_custom_fields << string_cf
-        work_package1.type.custom_fields << string_cf
-
-        work_package1.reload
-        project1.reload
-        login_as(user1)
-      end
-
-      context 'when ascending' do
-        let(:sort_by) { [["cf_#{string_cf.id}", 'asc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [["assigned_to", 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
-    end
-
-    context 'when sorting by integer custom field' do
-      let(:user1) { create(:admin) }
-      let(:query) do
-        build_stubbed :query,
-                      show_hierarchies: false,
-                      project: nil,
-                      sort_criteria: sort_by
-      end
-
-      let(:work_package1) { create(:work_package, project: project1) }
-      let(:work_package2) { create(:work_package, project: project1) }
-      let(:work_package3) { create(:work_package, project: project1) }
-      let(:int_cf) { create(:int_wp_custom_field, is_filter: true) }
-      let!(:custom_value) do
-        create(:custom_value,
-               custom_field: int_cf,
-               customized: work_package1,
-               value: 1)
-      end
-      let!(:custom_value2) do
-        create(:custom_value,
-               custom_field: int_cf,
-               customized: work_package2,
-               value: 2)
-      end
-
-      let!(:custom_value3) do
-        create(:custom_value,
-               custom_field: int_cf,
-               customized: work_package3,
-               value: 3)
-      end
-
-      before do
-        work_package1.project.work_package_custom_fields << int_cf
-        work_package1.type.custom_fields << int_cf
-
-        work_package1.reload
-        project1.reload
-        login_as(user1)
-      end
-
-      context 'when ascending' do
-        let(:sort_by) { [["cf_#{int_cf.id}", 'asc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package1, work_package2, work_package3]
-        end
-      end
-
-      context 'when descending' do
-        let(:sort_by) { [["cf_#{int_cf.id}", 'desc']] }
-
-        it 'sorts case insensitive' do
-          expect(query_results.work_packages)
-            .to match [work_package3, work_package2, work_package1]
-        end
-      end
-    end
-
-    context 'when filtering by bool cf' do
-      let(:bool_cf) { create(:bool_wp_custom_field, is_filter: true) }
-      let(:custom_value) do
-        create(:custom_value,
-               custom_field: bool_cf,
-               customized: work_package1,
-               value:)
-      end
-      let(:value) { 't' }
-      let(:filter_value) { 't' }
       let(:activate_cf) do
-        work_package1.project.work_package_custom_fields << bool_cf
         work_package1.type.custom_fields << bool_cf
 
         work_package1.reload
         project1.reload
       end
 
-      before do
-        allow(User).to receive(:current).and_return(user1)
+      it_behaves_like 'is empty'
+    end
 
-        custom_value
-
-        activate_cf
-
-        query.add_filter(:"cf_#{bool_cf.id}", '=', [filter_value])
+    context 'with the wp having no value for the cf
+             and filtering for false
+             and the cf not being active in the project
+             and the cf being for all' do
+      let(:custom_value) { nil }
+      let(:filter_value) { 'f' }
+      let(:bool_cf) do
+        create(:bool_wp_custom_field,
+               is_filter: true,
+               is_for_all: true)
       end
 
-      shared_examples_for 'is empty' do
-        it 'is empty' do
-          expect(query.results.work_packages)
-            .to be_empty
-        end
+      let(:activate_cf) do
+        work_package1.project.work_package_custom_fields << bool_cf
+
+        work_package1.reload
+        project1.reload
       end
 
-      shared_examples_for 'returns the wp' do
-        it 'returns the wp' do
-          expect(query.results.work_packages)
-            .to match_array(work_package1)
-        end
-      end
-
-      context 'with the wp having true for the cf
-               and filtering for true' do
-        it_behaves_like 'returns the wp'
-      end
-
-      context 'with the wp having true for the cf
-               and filtering for false' do
-        let(:filter_value) { 'f' }
-
-        it_behaves_like 'is empty'
-      end
-
-      context 'with the wp having false for the cf
-               and filtering for false' do
-        let(:value) { 'f' }
-        let(:filter_value) { 'f' }
-
-        it_behaves_like 'returns the wp'
-      end
-
-      context 'with the wp having false for the cf
-               and filtering for true' do
-        let(:value) { 'f' }
-
-        it_behaves_like 'is empty'
-      end
-
-      context 'with the wp having no value for the cf
-               and filtering for true' do
-        let(:custom_value) { nil }
-
-        it_behaves_like 'is empty'
-      end
-
-      context 'with the wp having no value for the cf
-               and filtering for false' do
-        let(:custom_value) { nil }
-        let(:filter_value) { 'f' }
-
-        it_behaves_like 'returns the wp'
-      end
-
-      context 'with the wp having no value for the cf
-               and filtering for false
-               and the cf not being active for the type' do
-        let(:custom_value) { nil }
-        let(:filter_value) { 'f' }
-
-        let(:activate_cf) do
-          work_package1.type.custom_fields << bool_cf
-
-          work_package1.reload
-          project1.reload
-        end
-
-        it_behaves_like 'is empty'
-      end
-
-      context 'with the wp having no value for the cf
-               and filtering for false
-               and the cf not being active in the project
-               and the cf being for all' do
-        let(:custom_value) { nil }
-        let(:filter_value) { 'f' }
-        let(:bool_cf) do
-          create(:bool_wp_custom_field,
-                 is_filter: true,
-                 is_for_all: true)
-        end
-
-        let(:activate_cf) do
-          work_package1.project.work_package_custom_fields << bool_cf
-
-          work_package1.reload
-          project1.reload
-        end
-
-        it_behaves_like 'is empty'
-      end
+      it_behaves_like 'is empty'
     end
   end
 end

--- a/spec/models/query/results_sums_integration_spec.rb
+++ b/spec/models/query/results_sums_integration_spec.rb
@@ -35,14 +35,14 @@ describe ::Query::Results, 'sums', type: :model do
       p.work_package_custom_fields << float_cf
     end
   end
-  let(:estimated_hours_column) { query.available_columns.detect { |c| c.name.to_s == 'estimated_hours' } }
-  let(:int_cf_column) { query.available_columns.detect { |c| c.name.to_s == "cf_#{int_cf.id}" } }
-  let(:float_cf_column) { query.available_columns.detect { |c| c.name.to_s == "cf_#{float_cf.id}" } }
-  let(:material_costs_column) { query.available_columns.detect { |c| c.name.to_s == "material_costs" } }
-  let(:labor_costs_column) { query.available_columns.detect { |c| c.name.to_s == "labor_costs" } }
-  let(:overall_costs_column) { query.available_columns.detect { |c| c.name.to_s == "overall_costs" } }
-  let(:remaining_hours_column) { query.available_columns.detect { |c| c.name.to_s == "remaining_hours" } }
-  let(:story_points_column) { query.available_columns.detect { |c| c.name.to_s == "story_points" } }
+  let(:estimated_hours_column) { query.displayable_columns.detect { |c| c.name.to_s == 'estimated_hours' } }
+  let(:int_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == "cf_#{int_cf.id}" } }
+  let(:float_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == "cf_#{float_cf.id}" } }
+  let(:material_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "material_costs" } }
+  let(:labor_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "labor_costs" } }
+  let(:overall_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "overall_costs" } }
+  let(:remaining_hours_column) { query.displayable_columns.detect { |c| c.name.to_s == "remaining_hours" } }
+  let(:story_points_column) { query.displayable_columns.detect { |c| c.name.to_s == "story_points" } }
   let(:other_project) do
     create(:project).tap do |p|
       p.work_package_custom_fields << int_cf

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -73,6 +73,15 @@ describe ::Query::SortCriteria, type: :model do
       end
     end
 
+    context 'with a sort_criteria for typeahead ASC' do
+      let(:sort_criteria) { [%w[typeahead asc]] }
+
+      it 'returns the custom order by id asc' do
+        expect(subject)
+          .to eq [['work_packages.updated_at DESC, work_packages.updated_at'], ['work_packages.id DESC']]
+      end
+    end
+
     context 'with sort_criteria with order handling and no order statement' do
       let(:sort_criteria) { [['start_date']] }
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -218,7 +218,7 @@ describe Query, type: :model do
   describe '#available_columns' do
     context 'with work_package_done_ratio NOT disabled' do
       it 'includes the done_ratio column' do
-        expect(query.available_columns.map(&:name)).to include :done_ratio
+        expect(query.displayable_columns.map(&:name)).to include :done_ratio
       end
     end
 
@@ -228,7 +228,7 @@ describe Query, type: :model do
       end
 
       it 'does not include the done_ratio column' do
-        expect(query.available_columns.map(&:name)).not_to include :done_ratio
+        expect(query.displayable_columns.map(&:name)).not_to include :done_ratio
       end
     end
 
@@ -238,7 +238,7 @@ describe Query, type: :model do
       it 'does not call the db twice' do
         query.project = project
 
-        query.available_columns
+        query.displayable_columns
 
         expect(project)
           .not_to receive(:all_work_package_custom_fields)
@@ -246,13 +246,13 @@ describe Query, type: :model do
         expect(project)
           .not_to receive(:types)
 
-        query.available_columns
+        query.displayable_columns
       end
 
       it 'does call the db if the project changes' do
         query.project = project
 
-        query.available_columns
+        query.displayable_columns
 
         query.project = project2
 
@@ -264,13 +264,13 @@ describe Query, type: :model do
           .to receive(:types)
           .and_return []
 
-        query.available_columns
+        query.displayable_columns
       end
 
       it 'does call the db if the project changes to nil' do
         query.project = project
 
-        query.available_columns
+        query.displayable_columns
 
         query.project = nil
 
@@ -282,7 +282,7 @@ describe Query, type: :model do
           .to receive(:all)
           .and_return []
 
-        query.available_columns
+        query.displayable_columns
       end
     end
 
@@ -309,18 +309,18 @@ describe Query, type: :model do
         end
 
         it 'includes the relation columns for project types' do
-          expect(query.available_columns.map(&:name)).to include :"relations_to_type_#{type_in_project.id}"
+          expect(query.displayable_columns.map(&:name)).to include :"relations_to_type_#{type_in_project.id}"
         end
 
         it 'does not include the relation columns for types not in project' do
-          expect(query.available_columns.map(&:name)).not_to include :"relations_to_type_#{type_not_in_project.id}"
+          expect(query.displayable_columns.map(&:name)).not_to include :"relations_to_type_#{type_not_in_project.id}"
         end
 
         context 'with the enterprise token disallowing relation columns' do
           let(:relation_columns_allowed) { false }
 
           it 'excludes the relation columns' do
-            expect(query.available_columns.map(&:name)).not_to include :"relations_to_type_#{type_in_project.id}"
+            expect(query.displayable_columns.map(&:name)).not_to include :"relations_to_type_#{type_in_project.id}"
           end
         end
       end
@@ -331,16 +331,16 @@ describe Query, type: :model do
         end
 
         it 'includes the relation columns for all types' do
-          expect(query.available_columns.map(&:name)).to include(:"relations_to_type_#{type_in_project.id}",
-                                                                 :"relations_to_type_#{type_not_in_project.id}")
+          expect(query.displayable_columns.map(&:name)).to include(:"relations_to_type_#{type_in_project.id}",
+                                                                   :"relations_to_type_#{type_not_in_project.id}")
         end
 
         context 'with the enterprise token disallowing relation columns' do
           let(:relation_columns_allowed) { false }
 
           it 'excludes the relation columns' do
-            expect(query.available_columns.map(&:name)).not_to include(:"relations_to_type_#{type_in_project.id}",
-                                                                       :"relations_to_type_#{type_not_in_project.id}")
+            expect(query.displayable_columns.map(&:name)).not_to include(:"relations_to_type_#{type_in_project.id}",
+                                                                         :"relations_to_type_#{type_not_in_project.id}")
           end
         end
       end
@@ -354,18 +354,35 @@ describe Query, type: :model do
       end
 
       it 'includes the relation columns for every relation type' do
-        expect(query.available_columns.map(&:name)).to include(:relations_of_type_relation1,
-                                                               :relations_of_type_relation2)
+        expect(query.displayable_columns.map(&:name)).to include(:relations_of_type_relation1,
+                                                                 :relations_of_type_relation2)
       end
 
       context 'with the enterprise token disallowing relation columns' do
         let(:relation_columns_allowed) { false }
 
         it 'excludes the relation columns' do
-          expect(query.available_columns.map(&:name)).not_to include(:relations_of_type_relation1,
-                                                                     :relations_of_type_relation2)
+          expect(query.displayable_columns.map(&:name)).not_to include(:relations_of_type_relation1,
+                                                                       :relations_of_type_relation2)
         end
       end
+    end
+  end
+
+  describe '.displayable_columns' do
+    it 'includes the id column' do
+      expect(query.displayable_columns.detect { |c| c.name == :id })
+        .not_to be_nil
+    end
+
+    it 'excludes the manual sorting column' do
+      expect(query.displayable_columns.detect { |c| c.name == :manual_sorting })
+        .to be_nil
+    end
+
+    it 'excludes the typeahead column' do
+      expect(query.displayable_columns.detect { |c| c.name == :typeahead })
+        .to be_nil
     end
   end
 

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -28,50 +28,50 @@
 
 require 'spec_helper'
 
-describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request do
-  let(:user) { create :admin }
+describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI do
+  shared_let(:user) { create(:admin) }
 
-  let(:project_1) { create :project }
+  shared_let(:project1) { create(:project) }
 
-  let!(:wp_1) { create :work_package, project: project_1, subject: "WP 1" }
+  # rubocop:disable Naming/VariableNumber
+  shared_let(:wp1) { create(:work_package, project: project1, subject: "WP 1") }
 
-  let!(:wp_1_1) do
-    create :work_package, parent: wp_1, project: project_1, subject: "WP 1.1"
+  shared_let(:wp1_1) do
+    create(:work_package, parent: wp1, project: project1, subject: "WP 1.1")
   end
 
-  let!(:wp_1_2) do
-    create :work_package, parent: wp_1, project: project_1, subject: "WP 1.2"
+  shared_let(:wp1_2) do
+    create(:work_package, parent: wp1, project: project1, subject: "WP 1.2")
   end
 
-  let!(:wp_1_2_1) do
-    create :work_package, parent: wp_1_2, project: project_1, subject: "WP 1.2.1"
+  shared_let(:wp1_2_1) do
+    create(:work_package, parent: wp1_2, project: project1, subject: "WP 1.2.1")
   end
 
-  let(:project_2) { create :project }
+  shared_let(:project2) { create(:project) }
 
-  let!(:wp_2) { create :work_package, project: project_2, subject: "WP 2" }
-  let!(:wp_2_1) { create :work_package, project: project_2, subject: "WP 2.1" }
-  let!(:wp_2_2) { create :work_package, project: project_2, subject: "WP 2.2" }
+  shared_let(:wp2) { create(:work_package, project: project2, subject: "WP 2") }
+  shared_let(:wp2_1) { create(:work_package, project: project2, subject: "WP 2.1") }
+  shared_let(:wp2_2) { create(:work_package, project: project2, subject: "WP 2.2") }
 
-  let!(:relation_wp_2_1_to_wp_2_2) do
-    create :relation, from: wp_2_1, to: wp_2_2, relation_type: "relates"
+  shared_let(:relation_wp2_1_to_wp2_2) do
+    create(:relation, from: wp2_1, to: wp2_2, relation_type: "relates")
   end
+  # rubocop:enable Naming/VariableNumber
 
-  let(:href) { "/api/v3/work_packages/#{wp_1.id}/available_relation_candidates?query=WP" }
+  let(:href) { "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=WP" }
   let(:request) { get href }
   let(:result) do
     request
     JSON.parse last_response.body
   end
-  let(:subjects) { work_packages.map { |e| e["subject"] } }
+  let(:subjects) { work_packages.pluck("subject") }
 
   def work_packages
     result["_embedded"]["elements"]
   end
 
-  before do
-    login_as user
-  end
+  current_user { user }
 
   context 'with no permissions' do
     let(:user) { create(:user) }
@@ -83,14 +83,14 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
 
   context "without cross project relations",
           with_settings: { cross_project_work_package_relations: false } do
-    describe "relation candidates for wp_1 (in hierarchy)" do
+    describe "relation candidates for wp1 (in hierarchy)" do
       it "returns an empty list" do # as relations to ancestors or descendents is not allowed
         expect(result["count"]).to eq 0
       end
     end
 
-    describe "relation candidates for wp_2" do
-      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP" }
+    describe "relation candidates for wp2" do
+      let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP" }
 
       it "returns WP 2.1 and 2.2" do
         expect(subjects).to match_array ["WP 2.1", "WP 2.2"]
@@ -98,7 +98,7 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
     end
 
     describe "case-insensitive matches" do
-      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=wp" }
+      let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=wp" }
 
       it "returns WP 2.1 and 2.2" do
         expect(subjects).to match_array ["WP 2.1", "WP 2.2"]
@@ -106,7 +106,7 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
     end
 
     describe "relation candidates for WP 2.2 (circular dependency check)" do
-      let(:href) { "/api/v3/work_packages/#{wp_2_2.id}/available_relation_candidates?query=WP" }
+      let(:href) { "/api/v3/work_packages/#{wp2_2.id}/available_relation_candidates?query=WP" }
 
       it "returns just WP 2, not WP 2.1" do
         expect(subjects).to match_array ["WP 2"]
@@ -116,29 +116,44 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
 
   context "with cross project relations",
           with_settings: { cross_project_work_package_relations: true } do
-    describe "relation candidates for wp_1 (in hierarchy)" do
-      let(:href) { "/api/v3/work_packages/#{wp_1.id}/available_relation_candidates?query=WP" }
+    describe "relation candidates for wp1 (in hierarchy)" do
+      let(:href) { "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=WP" }
 
       it "returns WP 2 and all WP 2.x" do
         expect(subjects).to match_array ["WP 2", "WP 2.1", "WP 2.2"]
       end
     end
 
-    describe "relation candidates for wp_2" do
-      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP&type=follows" }
+    describe "relation candidates for wp1 (in hierarchy) with typeahead sorting" do
+      let(:href) { "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=WP&sortBy=[[\"typeahead\", \"asc\"]]" }
+
+      before do
+        wp2_2.update_column(:updated_at, 10.days.ago)
+        wp2.update_column(:updated_at, 5.days.ago)
+      end
+
+      it "returns WP 2 and all WP 2.x sorted by updated_at DESC" do
+        expect(subjects).to match ["WP 2.1", "WP 2", "WP 2.2"]
+      end
+    end
+
+    describe "relation candidates for wp2" do
+      let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=follows" }
 
       it "returns WP 2.1 and 2.2, WP 1 and all WP 1.x" do
         expect(subjects).to match_array ["WP 1", "WP 1.1", "WP 1.2", "WP 1.2.1", "WP 2.1", "WP 2.2"]
       end
 
       describe 'with an already existing relationship from the work package' do
-        let!(:relation_wp_2_to_wp_2_2) do
-          create :relation, from: wp_2, to: wp_2_2, relation_type: "relates"
+        # rubocop:disable Naming/VariableNumber
+        shared_let(:relation_wp2_to_wp2_2) do
+          create(:relation, from: wp2, to: wp2_2, relation_type: "relates")
         end
 
-        let!(:relation_wp_1_1_to_wp_2) do
-          create :relation, from: wp_1_1, to: wp_2, relation_type: "relates"
+        shared_let(:relation_wp1_1_to_wp2) do
+          create(:relation, from: wp1_1, to: wp2, relation_type: "relates")
         end
+        # rubocop:enable Naming/VariableNumber
 
         context 'for a follows relationship' do
           it 'does not contain the work packages with which a relationship already exists but the parent' do
@@ -147,7 +162,7 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
         end
 
         context 'for a relates relationship' do
-          let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP&type=relates" }
+          let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=relates" }
 
           it 'does not contain the work packages with which a relationship already exists but the parent' do
             expect(subjects).to match_array ["WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1"]
@@ -157,8 +172,11 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI, type: :request
     end
 
     context 'when a project is archived' do
-      let(:project_1) { create :project, active: false }
-      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP" }
+      let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP" }
+
+      before do
+        project1.update_column(:active, false)
+      end
 
       it 'does not return work packages from that project' do
         expect(subjects).to match_array ["WP 2.1", "WP 2.2"]


### PR DESCRIPTION
Adds a sorting by typeahead to work package endpoints. Having `sortBy=[["typeahead"],["asc"]]` as a query prop will lead to having the work packages returned sorted by `updated_at DESC`.

It accepts `asc` while returning the work packages in descending order because from the client level, that is implementation specific. The client simply specifies to have the results in typeahead order. Having the abstraction allows to later on change the implementation.

Ideally, the client would not use the complicated `filters=[{"typeahead": { "operator": "**", "values" = ["the search string"]}]&sortBy=[["typeahead"],["asc"]]` but rather `typeahead="the search string"` which internally would apply both the filtering as well as the sorting. But this is outside of the scope of a patch level release.

There is no sugar coating it, this PR introduces a hack in that the `ORDER BY` statement for the typeahead column is hardcoded. Given the current structure of the work package query, which does not follow the query structure for other models, I could not find a way around it.

On the plus side, the hack of appending the ManualSortingColumn to the sortable columns only was replaced.

Does not fix https://community.openproject.org/wp/44197 on its own but enables the frontend to issue the required query props to do so.