### PR TITLE
Fix flickering test and deprecation warning

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -140,7 +140,7 @@ class AccountController < ApplicationController
   end
 
   def allow_registration?
-    allow = Setting.self_registration? && !OpenProject::Configuration.disable_password_login?
+    allow = Setting::SelfRegistration.enabled? && !OpenProject::Configuration.disable_password_login?
 
     invited = session[:invitation_token].present?
     get = request.get? && allow
@@ -163,7 +163,7 @@ class AccountController < ApplicationController
       handle_expired_token token
     elsif token.user.invited?
       activate_by_invite_token token
-    elsif Setting.self_registration?
+    elsif Setting::SelfRegistration.enabled?
       activate_self_registered token
     else
       invalid_token_and_redirect

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -70,7 +70,7 @@ module Accounts::CurrentUser
     if session[:user_id]
       # existing session
       User.active.find_by(id: session[:user_id])
-    elsif cookies[OpenProject::Configuration['autologin_cookie_name']] && Setting.autologin?
+    elsif cookies[OpenProject::Configuration['autologin_cookie_name']] && Setting::Autologin.enabled?
       # auto-login feature starts a new session
       user = User.try_to_autologin(cookies[OpenProject::Configuration['autologin_cookie_name']])
       session[:user_id] = user.id if user

--- a/app/controllers/concerns/accounts/user_login.rb
+++ b/app/controllers/concerns/accounts/user_login.rb
@@ -4,7 +4,7 @@ module Accounts::UserLogin
 
   def login_user!(user)
     # generate a key and set cookie if autologin
-    if Setting.autologin? && (params[:autologin] || session.delete(:autologin_requested))
+    if Setting::Autologin.enabled? && (params[:autologin] || session.delete(:autologin_requested))
       set_autologin_cookie(user)
     end
 

--- a/app/controllers/concerns/accounts/user_password_change.rb
+++ b/app/controllers/concerns/accounts/user_password_change.rb
@@ -71,7 +71,7 @@ module Accounts::UserPasswordChange
     end
 
     flash_error_message(log_reason: 'invalid credentials', flash_now:) do
-      if Setting.brute_force_block_after_failed_logins?
+      if Setting.brute_force_block_after_failed_logins.to_i > 0
         :notice_account_invalid_credentials_or_blocked
       else
         :notice_account_invalid_credentials

--- a/app/models/setting/autologin.rb
+++ b/app/models/setting/autologin.rb
@@ -27,63 +27,9 @@
 #++
 
 class Setting
-  ##
-  # Shorthand to common setting aliases to avoid checking values
-  module SelfRegistration
-    VALUES = {
-      disabled: 0,
-      activation_by_email: 1,
-      manual_activation: 2,
-      automatic_activation: 3
-    }.freeze
-    KEYS = VALUES.invert.merge(VALUES.invert.transform_keys(&:to_s)).freeze
-
-    def self.values
-      VALUES
-    end
-
-    def self.value(key:)
-      VALUES[key]
-    end
-
-    def self.key(value:)
-      KEYS[value]
-    end
-
-    def self.disabled
-      value key: :disabled
-    end
-
-    def self.disabled?
-      key(value: Setting.self_registration) == :disabled
-    end
-
+  module Autologin
     def self.enabled?
-      !disabled?
-    end
-
-    def self.by_email
-      value key: :activation_by_email
-    end
-
-    def self.by_email?
-      key(value: Setting.self_registration) == :activation_by_email
-    end
-
-    def self.manual
-      value key: :manual_activation
-    end
-
-    def self.manual?
-      key(value: Setting.self_registration) == :manual_activation
-    end
-
-    def self.automatic
-      value key: :automatic_activation
-    end
-
-    def self.automatic?
-      key(value: Setting.self_registration) == :automatic_activation
+      Setting.autologin.presence != 0
     end
   end
 end

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -39,10 +39,10 @@ See COPYRIGHT and LICENSE files for more details.
           <%= styled_text_field_tag 'username', nil, id: 'username-pulldown', tabindex: 1, autocapitalize: 'none' %>
         </div>
         <div class="form--field-extra-actions">
-          <% if Setting.autologin? %>
+          <% if Setting::Autologin.enabled? %>
             <label class="form--label-with-check-box">
               <%= styled_check_box_tag 'autologin', 1, false, id: 'autologin-pulldown' %> <%= t(:label_stay_logged_in) %></label>
-          <% elsif Setting.self_registration? %>
+          <% elsif Setting::SelfRegistration.enabled? %>
             <%# show here if autologin is disabled, otherwise below lost_password link %>
               <%= link_to t(:label_register),
                 account_register_path,
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% if Setting.lost_password? %>
             <%= link_to t(:label_password_lost), {controller: '/account', action: 'lost_password'} %>
           <% end %>
-          <% if Setting.autologin? && Setting.self_registration? %>
+          <% if Setting::Autologin.enabled? && Setting::SelfRegistration.enabled? %>
             <%# show here if autologin is enabled, otherwise below login field %>
             <%= '<br>'.html_safe if Setting.lost_password? %>
             <%= link_to t(:label_register),

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
   </div>
 
-  <% if Setting.autologin? %>
+  <% if Setting::Autologin.enabled? %>
     <div class="form--field -no-label">
       <div class="form--field-container">
         <label class="form--label-with-check-box">
@@ -66,7 +66,7 @@ See COPYRIGHT and LICENSE files for more details.
         <%= link_to t(:label_password_lost), { controller: '/account', action: 'lost_password' } %>
         <br>
       <% end %>
-      <% if Setting.self_registration? %>
+      <% if Setting::SelfRegistration.enabled? %>
         <%= link_to t(:label_register),
           '',
           title: t(:label_register),

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -189,12 +189,11 @@ describe AccountController,
         expect(response).to redirect_to my_page_path
       end
 
-      context 'with an auth source' do
+      context 'with an auth source',
+              with_settings: { self_registration: Setting::SelfRegistration.disabled } do
         let(:auth_source) { create :ldap_auth_source }
 
         it 'creates the user on the fly' do
-          allow(Setting).to receive(:self_registration).and_return('0')
-          allow(Setting).to receive(:self_registration?).and_return(false)
           allow(AuthSource).to receive(:authenticate).and_return(login: 'foo',
                                                                  firstname: 'Foo',
                                                                  lastname: 'Smith',
@@ -405,7 +404,8 @@ describe AccountController,
       end
     end
 
-    context 'with an auth source' do
+    context 'with an auth source',
+            with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       let(:auth_source) { create :ldap_auth_source }
 
       let(:user_attributes) do
@@ -421,8 +421,6 @@ describe AccountController,
       let(:authenticate) { true }
 
       before do
-        allow(Setting).to receive(:self_registration).and_return('0')
-        allow(Setting).to receive(:self_registration?).and_return(false)
         allow(AuthSource).to receive(:authenticate).and_return(authenticate ? user_attributes : nil)
 
         # required so that the register view can be rendered
@@ -550,11 +548,8 @@ describe AccountController,
   end
 
   context 'GET #register' do
-    context 'with self registration on' do
-      before do
-        allow(Setting).to receive(:self_registration).and_return('3')
-      end
-
+    context 'with self registration on',
+            with_settings: { self_registration: Setting::SelfRegistration.automatic } do
       context 'and password login enabled' do
         before do
           get :register
@@ -579,22 +574,20 @@ describe AccountController,
       end
     end
 
-    context 'with self registration off' do
+    context 'with self registration off',
+            with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       before do
-        allow(Setting).to receive(:self_registration).and_return('0')
-        allow(Setting).to receive(:self_registration?).and_return(false)
         get :register
       end
 
       it_behaves_like 'registration disabled'
     end
 
-    context 'with self registration off but an ongoing invitation activation' do
+    context 'with self registration off but an ongoing invitation activation',
+            with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       let(:token) { create :invitation_token }
 
       before do
-        allow(Setting).to receive(:self_registration).and_return('0')
-        allow(Setting).to receive(:self_registration?).and_return(false)
         session[:invitation_token] = token.value
 
         get :register
@@ -610,10 +603,10 @@ describe AccountController,
 
   # See integration/account_test.rb for the full test
   context 'POST #register' do
-    context 'with self registration on automatic' do
+    context 'with self registration on automatic',
+            with_settings: { self_registration: Setting::SelfRegistration.automatic } do
       before do
         allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
-        allow(Setting).to receive(:self_registration).and_return('3')
       end
 
       context 'with password login enabled' do
@@ -718,11 +711,8 @@ describe AccountController,
       end
     end
 
-    context 'with self registration by email' do
-      before do
-        allow(Setting).to receive(:self_registration).and_return('1')
-      end
-
+    context 'with self registration by email',
+            with_settings: { self_registration: Setting::SelfRegistration.by_email } do
       context 'with password login enabled' do
         before do
           Token::Invitation.delete_all
@@ -769,7 +759,8 @@ describe AccountController,
       end
     end
 
-    context 'with manual activation' do
+    context 'with manual activation',
+            with_settings: { self_registration: Setting::SelfRegistration.manual } do
       let(:user_hash) do
         { login: 'register',
           password: 'adminADMIN!',
@@ -777,10 +768,6 @@ describe AccountController,
           firstname: 'John',
           lastname: 'Doe',
           mail: 'register@example.com' }
-      end
-
-      before do
-        allow(Setting).to receive(:self_registration).and_return('2')
       end
 
       context 'without back_url' do
@@ -834,10 +821,9 @@ describe AccountController,
       end
     end
 
-    context 'with self registration off' do
+    context 'with self registration off',
+            with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       before do
-        allow(Setting).to receive(:self_registration).and_return('0')
-        allow(Setting).to receive(:self_registration?).and_return(false)
         post :register,
              params: {
                user: {
@@ -854,10 +840,9 @@ describe AccountController,
       it_behaves_like 'registration disabled'
     end
 
-    context 'with on-the-fly registration' do
+    context 'with on-the-fly registration',
+            with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       before do
-        allow(Setting).to receive(:self_registration).and_return('0')
-        allow(Setting).to receive(:self_registration?).and_return(false)
         allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false)
         allow(AuthSource).to receive(:authenticate).and_return(login: 'foo',
                                                                lastname: 'Smith',

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -468,7 +468,7 @@ describe AccountController,
       end
 
       context 'with a locked account',
-              with_settings: { brute_force_block_after_failed_logins?: false } do
+              with_settings: { brute_force_block_after_failed_logins: 0 } do
         before do
           user.lock
           user.save!

--- a/spec/features/auth/consent_auth_stage_spec.rb
+++ b/spec/features/auth/consent_auth_stage_spec.rb
@@ -74,7 +74,7 @@ describe 'Authentication Stages', type: :feature do
 
     it 'keeps the autologin request (Regression #33696)',
        with_settings: { autologin: '1' } do
-      expect(Setting.autologin?).to be true
+      expect(Setting::Autologin.enabled?).to be true
 
       login_with user.login, user_password, autologin: true
       expect(page).to have_no_selector('.account-consent')
@@ -211,7 +211,7 @@ describe 'Authentication Stages', type: :feature do
 
     it 'keeps the autologin request (Regression #33696)',
        with_settings: { autologin: '1' } do
-      expect(Setting.autologin?).to be true
+      expect(Setting::Autologin.enabled?).to be true
 
       login_with user.login, user_password, autologin: true
 

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -138,12 +138,6 @@ describe 'Login', type: :feature do
         page.driver.browser.set_cookie(OpenProject::Configuration['session_cookie_name'])
       end
 
-      before do
-        allow(Setting)
-          .to receive(:autologin?)
-          .and_return(true)
-      end
-
       it 'logs in the user automatically if enabled' do
         login_with(user.login, user_password, autologin: true)
 
@@ -155,9 +149,7 @@ describe 'Login', type: :feature do
 
         fake_browser_closed
         # faking having changed the autologin setting
-        allow(Setting)
-          .to receive(:autologin?)
-          .and_return(false)
+        with_settings(autologin: 0)
         visit my_page_path
 
         # expect not being logged in automatically

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -175,7 +175,7 @@ describe 'Omniauth authentication', type: :feature do
   context 'register on the fly',
           with_settings: {
             self_registration?: true,
-            self_registration: '3',
+            self_registration: Setting::SelfRegistration.automatic,
             available_languages: [:en]
           } do
     let(:user) do
@@ -218,8 +218,7 @@ describe 'Omniauth authentication', type: :feature do
 
   context 'registration by email',
           with_settings: {
-            self_registration?: true,
-            self_registration: Setting::SelfRegistration.by_email.to_s
+            self_registration: Setting::SelfRegistration.by_email
           } do
     shared_examples 'registration with registration by email' do
       it 'shows a note explaining that the account has to be activated' do


### PR DESCRIPTION
In some examples of `spec/controllers/account_controller_spec.rb`, `Setting.self_registration?` was not mocked. If such example is run first, it would fail.

Almost same for `spec/features/auth/login_spec.rb` and `Settings.autologin?` as calling `Settings.autologin` for the first time would define method `Settings.autologin?`, and remove the mock used in the test.

Fix it by using with `with_settings` helper.

Fix deprecation warnings seen when using `Setting.xxx?` when the setting xxx is not a boolean.
