### PR TITLE
Code maintenance/44704 harmonize bigint usage in database

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -320,7 +320,7 @@ module WorkPackages
     def validate_people_visible(attribute, id_attribute, list)
       id = model[id_attribute]
 
-      return if id.nil? || model.changed.exclude?(id_attribute)
+      return if id.nil? || id == 0 || model.changed.exclude?(id_attribute)
 
       unless principal_visible?(id, list)
         errors.add attribute,

--- a/app/models/concerns/inexistent_model.rb
+++ b/app/models/concerns/inexistent_model.rb
@@ -1,6 +1,6 @@
-#-- copyright
+# --copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2022 the OpenProject GmbH
+# Copyright (C) 2010-2022 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,12 +24,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class WorkPackage::InexistentWorkPackage < WorkPackage
-  include InexistentModel
+module InexistentModel
+  extend ActiveSupport::Concern
 
-  def does_not_exist
-    errors.add :base, :does_not_exist
+  included do
+    # Set an id so that e.g. change detection (dirty) on associations
+    # is picked up whenever such a model is assigned.
+    after_initialize do
+      self.id = 0
+    end
+
+    _validators.clear
   end
 end

--- a/app/models/priority/inexistent_priority.rb
+++ b/app/models/priority/inexistent_priority.rb
@@ -26,4 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Priority::InexistentPriority < IssuePriority; end
+class Priority::InexistentPriority < IssuePriority
+  include InexistentModel
+end

--- a/app/models/status/inexistent_status.rb
+++ b/app/models/status/inexistent_status.rb
@@ -26,4 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Status::InexistentStatus < Status; end
+class Status::InexistentStatus < Status
+  include InexistentModel
+end

--- a/app/models/type/inexistent_type.rb
+++ b/app/models/type/inexistent_type.rb
@@ -27,4 +27,5 @@
 #++
 
 class Type::InexistentType < Type
+  include InexistentModel
 end

--- a/app/models/users/inexistent_user.rb
+++ b/app/models/users/inexistent_user.rb
@@ -27,6 +27,8 @@
 #++
 
 class Users::InexistentUser < User
+  include InexistentModel
+
   def self.sti_name
     nil
   end

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -130,7 +130,7 @@ class BaseTypeService
 
     [
       name,
-      group['attributes'].map { |attr| attr['key'] }
+      group['attributes'].pluck('key')
     ]
   end
 
@@ -139,6 +139,11 @@ class BaseTypeService
     props = JSON.parse group['query']
 
     query = Query.new_default(name: "Embedded table: #{name}")
+
+    query.extend(OpenProject::ChangedBySystem)
+    query.change_by_system do
+      query.user = User.system
+    end
 
     ::API::V3::UpdateQueryFromV3ParamsService
       .new(query, user)

--- a/db/migrate/20221026132134_bigint_primary_and_foreign_keys.rb
+++ b/db/migrate/20221026132134_bigint_primary_and_foreign_keys.rb
@@ -1,0 +1,199 @@
+require_relative "./migration_utils/column"
+
+class BigintPrimaryAndForeignKeys < ActiveRecord::Migration[7.0]
+  KEY_CHANGES = {
+    Announcement => [:id],
+    Journal::AttachableJournal => %i[id journal_id attachment_id],
+    Journal::AttachmentJournal => %i[id container_id author_id],
+    Attachment => %i[id container_id author_id],
+    AttributeHelpText => [:id],
+    AuthSource => [:id],
+    Journal::BudgetJournal => %i[id project_id author_id],
+    Budget => %i[id project_id author_id],
+    Category => %i[id project_id assigned_to_id],
+    Change => %i[id changeset_id],
+    Journal::ChangesetJournal => %i[id repository_id user_id],
+    Changeset => %i[id repository_id user_id],
+    :changesets_work_packages => %i[changeset_id work_package_id],
+    Color => [:id],
+    Comment => %i[id commented_id author_id],
+    CostEntry => %i[id user_id project_id work_package_id cost_type_id rate_id],
+    CostQuery => %i[id user_id project_id],
+    CostType => [:id],
+    CustomAction => [:id],
+    :custom_actions_projects => %i[id project_id custom_action_id],
+    :custom_actions_roles => %i[id role_id custom_action_id],
+    :custom_actions_statuses => %i[id status_id custom_action_id],
+    :custom_actions_types => %i[id type_id custom_action_id],
+    CustomField => [:id],
+    :custom_fields_projects => %i[custom_field_id project_id],
+    :custom_fields_types => %i[custom_field_id type_id],
+    CustomOption => %i[id custom_field_id],
+    CustomStyle => [:id],
+    CustomValue => %i[id customized_id custom_field_id],
+    Journal::CustomizableJournal => %i[id journal_id custom_field_id],
+    Delayed::Job => [:id],
+    DesignColor => [:id],
+    Journal::DocumentJournal => %i[id project_id category_id],
+    Document => %i[id project_id category_id],
+    :done_statuses_for_project => %i[project_id status_id],
+    EnabledModule => %i[id project_id],
+    EnterpriseToken => [:id],
+    Enumeration => %i[id project_id parent_id color_id],
+    ExportCardConfiguration => [:id],
+    Forum => %i[id project_id last_message_id],
+    Grids::Widget => [:grid_id],
+    Grids::Grid => %i[user_id project_id],
+    GroupUser => %i[group_id user_id],
+    Journal => %i[id journable_id user_id],
+    LaborBudgetItem => %i[id budget_id user_id],
+    LdapGroups::Membership => %i[id user_id group_id],
+    LdapGroups::SynchronizedGroup => %i[id group_id auth_source_id],
+    MaterialBudgetItem => %i[id budget_id cost_type_id],
+    Journal::MeetingContentJournal => %i[id meeting_id author_id],
+    MeetingContent => %i[id meeting_id author_id],
+    Journal::MeetingJournal => %i[id project_id author_id],
+    MeetingParticipant => %i[id user_id meeting_id],
+    Meeting => %i[id author_id project_id],
+    MemberRole => %i[id member_id role_id inherited_from],
+    Member => %i[id user_id project_id],
+    MenuItem => %i[id parent_id navigatable_id],
+    Journal::MessageJournal => %i[id forum_id parent_id author_id],
+    Message => %i[id forum_id parent_id author_id last_reply_id],
+    News => %i[id project_id author_id],
+    Journal::NewsJournal => %i[id project_id author_id],
+    Doorkeeper::AccessGrant => %i[resource_owner_id application_id],
+    Doorkeeper::AccessToken => %i[resource_owner_id application_id],
+    Doorkeeper::Application => %i[owner_id client_credentials_user_id],
+    OrderedWorkPackage => %i[query_id work_package_id],
+    Project => %i[id parent_id],
+    :projects_types => %i[project_id type_id],
+    Query => %i[id project_id user_id],
+    Rate => %i[id project_id user_id cost_type_id],
+    Relation => [:id],
+    Repository => %i[id project_id],
+    RolePermission => %i[id role_id],
+    Role => [:id],
+    :sessions => %i[id user_id],
+    Setting => [:id],
+    Status => %i[id color_id],
+    TimeEntry => %i[id project_id user_id work_package_id activity_id rate_id],
+    Journal::TimeEntryJournal => %i[id project_id user_id work_package_id activity_id rate_id],
+    Token::Base => [:id],
+    ::TwoFactorAuthentication::Device => %i[id user_id],
+    Type => %i[id color_id],
+    UserPassword => %i[id user_id],
+    UserPreference => %i[id user_id],
+    User => %i[id auth_source_id],
+    VersionSetting => %i[id project_id version_id],
+    Version => %i[id project_id],
+    Watcher => %i[id watchable_id user_id],
+    Webhooks::Event => %i[id webhooks_webhook_id],
+    Webhooks::Log => %i[id webhooks_webhook_id],
+    Webhooks::Project => %i[id project_id webhooks_webhook_id],
+    Webhooks::Webhook => [:id],
+    Journal::WikiContentJournal => %i[id page_id author_id],
+    WikiContent => %i[id page_id author_id],
+    WikiPage => %i[id wiki_id parent_id],
+    WikiRedirect => %i[id wiki_id],
+    Wiki => %i[id project_id],
+    Journal::WorkPackageJournal => %i[id
+                                      type_id
+                                      project_id
+                                      category_id
+                                      status_id
+                                      assigned_to_id
+                                      priority_id
+                                      version_id
+                                      author_id
+                                      parent_id
+                                      responsible_id
+                                      budget_id],
+    WorkPackage => %i[id
+                      type_id
+                      project_id
+                      category_id
+                      status_id
+                      assigned_to_id
+                      priority_id
+                      version_id
+                      author_id
+                      parent_id
+                      responsible_id
+                      budget_id],
+    Workflow => %i[id type_id old_status_id new_status_id role_id]
+  }.freeze
+
+  DEFAULT_CHANGES = {
+    Journal::AttachmentJournal => [:author_id],
+    Attachment => [:author_id],
+    Category => [:project_id],
+    Comment => %i[commented_id author_id],
+    :custom_fields_projects => %i[custom_field_id project_id],
+    :custom_fields_types => %i[custom_field_id type_id],
+    CustomValue => %i[customized_id custom_field_id],
+    Journal::DocumentJournal => %i[project_id category_id],
+    Document => %i[project_id category_id],
+    Journal => [:user_id],
+    Member => [:user_id],
+    News => [:author_id],
+    Journal::NewsJournal => [:author_id],
+    :projects_types => %i[project_id type_id],
+    Query => [:user_id],
+    Repository => [:project_id],
+    UserPreference => [:user_id],
+    Version => [:project_id],
+    Watcher => [:watchable_id],
+    Journal::WorkPackageJournal => %i[type_id project_id status_id priority_id author_id],
+    WorkPackage => %i[type_id project_id status_id priority_id author_id],
+    Workflow => %i[type_id old_status_id new_status_id role_id]
+  }.freeze
+
+  def up
+    KEY_CHANGES.each do |klass, columns|
+      change_columns_type(klass, columns, :bigint)
+    end
+
+    DEFAULT_CHANGES.each do |klass, columns|
+      change_columns_default(klass, columns, from: 0, to: nil)
+    end
+  end
+
+  def down
+    KEY_CHANGES.each do |klass, columns|
+      change_columns_type(klass, columns, :integer)
+    end
+
+    DEFAULT_CHANGES.each do |klass, columns|
+      change_columns_default(klass, columns, from: nil, to: 0)
+    end
+  end
+
+  private
+
+  def change_columns_type(klass, columns, type)
+    for_each_klass_and_columns(klass, columns) do |table, column|
+      change_column_type(table, column, type)
+    end
+  end
+
+  def change_columns_default(klass, columns, from:, to:)
+    for_each_klass_and_columns(klass, columns) do |table, column|
+      change_column_default(table, column, from:, to:)
+    end
+  end
+
+  def change_column_type(table, column, type)
+    Migration::MigrationUtils::Column.new(connection, table, column).change_type! type
+  end
+
+  def for_each_klass_and_columns(klass, columns)
+    table = klass.respond_to?(:table_name) ? klass.table_name : klass
+
+    columns.each do |column|
+      yield table, column
+    end
+
+    klass.reset_column_information if klass.respond_to?(:reset_column_information)
+  end
+end

--- a/db/migrate/20221027151959_remove_plaintext_tokens.rb
+++ b/db/migrate/20221027151959_remove_plaintext_tokens.rb
@@ -1,0 +1,12 @@
+class RemovePlaintextTokens < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :plaintext_tokens do |t|
+      t.integer :user_id, default: 0, null: false
+      t.string :action, limit: 30, default: '', null: false
+      t.string :value, limit: 40, default: '', null: false
+      t.datetime :created_on, null: false
+
+      t.index :user_id, name: 'index_plaintext_tokens_on_user_id'
+    end
+  end
+end

--- a/db/migrate/migration_utils/column.rb
+++ b/db/migrate/migration_utils/column.rb
@@ -37,7 +37,7 @@ module Migration
         @name = name
         @ar_column = connection.columns(table.to_s).find { |col| col.name == name.to_s }
 
-        raise ArgumentError, "Column not found: #{field}" if ar_column.nil?
+        raise ArgumentError, "Column not found: #{name}" if ar_column.nil?
       end
 
       def change_type!(type)

--- a/modules/bim/spec/bcf/bcf_xml/issue_reader_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/issue_reader_spec.rb
@@ -153,7 +153,7 @@ describe ::OpenProject::Bim::BcfXml::IssueReader do
   context 'on updating import' do
     describe '#update_comment' do
       let(:work_package) { create(:work_package) }
-      let!(:bcf_issue) { create :bcf_issue_with_comment, work_package: }
+      let!(:bcf_issue) { create(:bcf_issue_with_comment, work_package:) }
 
       before do
         allow(subject).to receive(:issue).and_return(bcf_issue)

--- a/modules/boards/spec/factories/board_factory.rb
+++ b/modules/boards/spec/factories/board_factory.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
 
     callback(:after_build) do |board, evaluator| # this is also done after :create
       query = evaluator.query || begin
-        Query.new_default(name: 'List 1', public: true, project: board.project).tap do |q|
+        build(:public_query, name: 'List 1', project: board.project).tap do |q|
           q.sort_criteria = [[:manual_sorting, 'asc']]
           q.add_filter(:manual_sort, 'ow', [])
           q.save!
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     callback(:after_build) do |board, evaluator| # this is also done after :create
       evaluator.num_queries.times do |i|
-        query = Query.new_default(name: "List #{i + 1}", public: true, project: board.project).tap do |q|
+        query = build(:public_query, name: "List #{i + 1}", project: board.project).tap do |q|
           q.sort_criteria = [[:manual_sorting, 'asc']]
           q.add_filter(:manual_sort, 'ow', [])
           q.save!
@@ -78,7 +78,7 @@ FactoryBot.define do
 
     callback(:after_create) do |board, evaluator| # this is also done after :create
       evaluator.projects_columns.each do |project|
-        query = Query.new_default(name: project.name, project: board.project, public: true).tap do |q|
+        query = build(:public_query, name: project.name, project: board.project).tap do |q|
           q.sort_criteria = [[:manual_sorting, 'asc']]
           q.add_filter('only_subproject_id', '=', [project.id.to_s])
           q.save!

--- a/modules/my_page/spec/features/my/assigned_to_me_spec.rb
+++ b/modules/my_page/spec/features/my/assigned_to_me_spec.rb
@@ -160,17 +160,6 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
     project_field.set_value project.name
 
     embedded_table.expect_toast(
-      message: 'Type is not set to one of the allowed values.',
-      type: :error
-    )
-
-    # Set type
-    type_field = embedded_table.edit_field(nil, :type)
-    type_field.expect_active!
-    type_field.openSelectField
-    type_field.set_value type.name
-
-    embedded_table.expect_toast(
       message: 'Successful creation. Click here to open this work package in fullscreen view.'
     )
 

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -450,7 +450,8 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         work_package = create_work_package_with_entry(:cost_entry)
         create(:custom_value,
                custom_field: searchable_field,
-               value: "non-matching value")
+               value: "non-matching value",
+               customized: work_package)
         clear_cache
       end
 

--- a/modules/storages/app/models/storages/storage/inexistent_storage.rb
+++ b/modules/storages/app/models/storages/storage/inexistent_storage.rb
@@ -27,5 +27,5 @@
 #++
 
 class Storages::Storage::InexistentStorage < Storages::Storage
-  _validators.clear
+  include InexistentModel
 end

--- a/spec/factories/custom_value_factory.rb
+++ b/spec/factories/custom_value_factory.rb
@@ -36,11 +36,6 @@ FactoryBot.define do
       customized factory: :user
     end
 
-    factory :issue_custom_value do
-      custom_field factory: :issue_custom_field
-      customized factory: :work_package
-    end
-
     factory :work_package_custom_value do
       custom_field factory: :work_package_custom_field
       customized_type { 'WorkPackageCustomField' }

--- a/spec/factories/journal/work_package_journal_factory.rb
+++ b/spec/factories/journal/work_package_journal_factory.rb
@@ -29,5 +29,13 @@
 FactoryBot.define do
   factory :journal_work_package_journal, class: 'Journal::WorkPackageJournal' do
     ignore_non_working_days { false }
+    # The following properties are not actually valid.
+    # They were added when the default value (also 0) was removed and too many
+    # tests relied on this behaviour for it to be fixed right away.
+    type_id { 0 }
+    project_id { 0 }
+    status_id { 0 }
+    priority_id { 0 }
+    author_id { 0 }
   end
 end

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -74,7 +74,9 @@ FactoryBot.define do
     end
 
     callback(:after_stub) do |wp, arguments|
-      wp.type = wp.project.types.first unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type)
+      unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type) || wp.project.nil?
+        wp.type = wp.project.types.first
+      end
     end
   end
 end

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     old_status factory: :status
     new_status factory: :status
     role
+    type
 
     factory :workflow_with_default_status do
       old_status factory: :default_status

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -152,21 +152,12 @@ describe 'inline create work package', js: true do
     it_behaves_like 'inline create work package' do
       let(:callback) do
         -> {
-          # Set project
+          # Set project which will also select the type (first one in the selected project)
           project_field = wp_table.edit_field(nil, :project)
           project_field.expect_active!
 
           project_field.openSelectField
           project_field.set_value project.name
-
-          sleep 1
-
-          # Set type
-          type_field = wp_table.edit_field(nil, :type)
-          type_field.expect_active!
-
-          type_field.openSelectField
-          type_field.set_value type.name
         }
       end
     end

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe WorkPackagesHelper, type: :helper do
-  let(:stub_work_package) { build_stubbed(:work_package) }
+  let(:stub_work_package) { build_stubbed(:work_package, type: stub_type) }
   let(:stub_project) { build_stubbed(:project) }
   let(:stub_type) { build_stubbed(:type) }
   let(:stub_user) { build_stubbed(:user) }
@@ -42,16 +42,7 @@ describe WorkPackagesHelper, type: :helper do
     end
 
     describe 'without parameters' do
-      it 'returns a link to the work package with the id as the text' do
-        link_text = Regexp.new("^##{stub_work_package.id}$")
-        expect(helper.link_to_work_package(stub_work_package)).to have_selector(
-          "a[href='#{work_package_path(stub_work_package)}']", text: link_text
-        )
-      end
-
       it 'returns a link to the work package with type and id as the text if type is set' do
-        stub_work_package.type = stub_type
-
         link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id}$")
         expect(helper.link_to_work_package(stub_work_package)).to have_selector(
           "a[href='#{work_package_path(stub_work_package)}']", text: link_text
@@ -79,8 +70,6 @@ describe WorkPackagesHelper, type: :helper do
 
     describe 'with the all_link option provided' do
       it 'returns a link to the work package with the type, id, and subject as the text' do
-        stub_work_package.type = stub_type
-
         link_text = Regexp.new("^#{stub_type} ##{stub_work_package.id}: #{stub_work_package.subject}$")
         expect(helper.link_to_work_package(stub_work_package,
                                            all_link: true)).to have_selector(
@@ -113,8 +102,6 @@ describe WorkPackagesHelper, type: :helper do
 
     describe 'when omitting the type' do
       it 'omits the type' do
-        stub_work_package.type = stub_type
-
         link_text = Regexp.new("^##{stub_work_package.id}$")
         expect(helper.link_to_work_package(stub_work_package,
                                            type: false)).to have_selector("a[href='#{work_package_path(stub_work_package)}']",
@@ -139,9 +126,7 @@ describe WorkPackagesHelper, type: :helper do
     end
 
     describe 'when only wanting the id' do
-      it 'returns a link with the id as text only even if the work package has a type' do
-        stub_work_package.type = stub_type
-
+      it 'returns a link with the id as text only' do
         link_text = Regexp.new("^##{stub_work_package.id}$")
         expect(helper.link_to_work_package(stub_work_package,
                                            id_only: true)).to have_selector("a[href='#{work_package_path(stub_work_package)}']",
@@ -165,8 +150,6 @@ describe WorkPackagesHelper, type: :helper do
 
     describe 'with the status displayed' do
       it 'returns a link with the status name contained in the text' do
-        stub_work_package.type = stub_type
-
         link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id} #{stub_work_package.status}$")
         expect(helper.link_to_work_package(stub_work_package,
                                            status: true)).to have_selector("a[href='#{work_package_path(stub_work_package)}']",

--- a/spec/models/custom_value_spec.rb
+++ b/spec/models/custom_value_spec.rb
@@ -29,9 +29,11 @@
 require 'spec_helper'
 
 describe CustomValue do
+  shared_let(:version) { create(:version) }
+
   let(:format) { 'bool' }
   let(:custom_field) { create(:custom_field, field_format: format) }
-  let(:custom_value) { create(:custom_value, custom_field:, value:) }
+  let(:custom_value) { create(:custom_value, custom_field:, value:, customized: version) }
 
   describe '#typed_value' do
     subject { custom_value }

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -338,9 +338,9 @@ describe WorkPackage, type: :model do
         include_context 'for work package with custom value'
 
         let(:modified_custom_value) do
-          create :custom_value,
+          create(:work_package_custom_value,
                  value: 'true',
-                 custom_field:
+                 custom_field:)
         end
 
         before do
@@ -359,9 +359,9 @@ describe WorkPackage, type: :model do
         include_context 'for work package with custom value'
 
         let(:unmodified_custom_value) do
-          create :custom_value,
+          create(:work_package_custom_value,
                  value: 'false',
-                 custom_field:
+                 custom_field:)
         end
 
         before do

--- a/spec/services/users/replace_mentions_service_integration_spec.rb
+++ b/spec/services/users/replace_mentions_service_integration_spec.rb
@@ -350,7 +350,7 @@ describe Users::ReplaceMentionsService, 'integration' do
   end
 
   context 'for custom_value value' do
-    it_behaves_like 'rewritten mention', :custom_value, :value do
+    it_behaves_like 'rewritten mention', :principal_custom_value, :value do
       let(:additional_properties) { { custom_field: create(:text_wp_custom_field) } }
     end
   end
@@ -388,7 +388,11 @@ describe Users::ReplaceMentionsService, 'integration' do
   end
 
   context 'for news_journals description' do
-    it_behaves_like 'rewritten mention', :journal_news_journal, :description
+    shared_let(:author) { create(:user) }
+
+    it_behaves_like 'rewritten mention', :journal_news_journal, :description do
+      let(:additional_properties) { { author_id: author.id } }
+    end
   end
 
   context 'for project description' do

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -232,7 +232,7 @@ describe WorkPackages::SetAttributesService,
           subject
 
           expect(work_package.changed_by_system['author_id'])
-            .to eql [0, user.id]
+            .to eql [nil, user.id]
         end
       end
     end


### PR DESCRIPTION
Turns all primary keys into bigint that where still integers. In lockstep, foreign keys, that oftentimes are not treated as such on the database level yet are also turned into bigint.

This harmonizes the schema across instances stemming from MySql and also opens up a bigger value range.

Additionally, removes default values for foreign key columns (that are used as such but do not follow the constraints of one) as having a default value on a foreign key does not make sense.

It also removes a table that was left over from a previous migration.

While it would make sense to turn all foreign key columns into database constraints, this is outside of the scope of this PR since it might require dealing with corrupt data.

https://community.openproject.org/wp/44704 