### PR TITLE
improve visiblity scope performance by EXIST

### DIFF
--- a/app/models/notifications/scopes/visible.rb
+++ b/app/models/notifications/scopes/visible.rb
@@ -36,9 +36,15 @@ module Notifications::Scopes
       # * the user has the permission to see the associated resource
       #
       # As currently only notifications for work packages exist, the implementation is work package specific.
+      # Using EXISTS as this performs better.
       def visible(user)
         recipient(user)
-          .where(resource_type: 'WorkPackage', resource_id: WorkPackage.visible(user).select(:id))
+          .where(resource_type: 'WorkPackage')
+          .where(WorkPackage
+                   .visible(user)
+                   .where("#{Notification.table_name}.resource_id = #{WorkPackage.table_name}.id")
+                   .arel
+                   .exists)
       end
     end
   end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -72,7 +72,12 @@ class WorkPackage < ApplicationRecord
   }
 
   scope :visible, ->(*args) {
-    where(project_id: Project.allowed_to(args.first || User.current, :view_work_packages))
+    # Using EXISTS as this performs better.
+    where(Project
+            .allowed_to(args.first || User.current, :view_work_packages)
+            .where("#{WorkPackage.table_name}.project_id = #{Project.table_name}.id")
+            .arel
+            .exists)
   }
 
   scope :in_status, ->(*args) do


### PR DESCRIPTION
Fetching the notifications, even if done so with a pageSize of 0, can, in cases where there are a medium or large size of unread notifications, perform poorly. As such a request is done regularly (every 10s for every user with an active tab) this can decrease the overall application performance.

The problem is caused by a non optimal database query. IN in combination with a subquery can lead to very poor performance if that subquery ends up being executed once for every candidate record. EXIST typically performs better and only rarely worse. Using a join would be even more stable but this is harder to do in the visible scopes which end up being used in a lot of queries combined of various scopes.

The problem scales by the number of work packages. 

Performance measurements on a client database for the original notification visibility check: 
```
SELECT COUNT(*) FROM "notifications" 
WHERE "notifications"."recipient_id" = 124 AND "notifications"."resource_type" = 'WorkPackage' 
AND "notifications"."resource_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."project_id" IN (SELECT DISTINCT "projects"."id" FROM "projects" LEFT OUTER JOIN "members" ON "projects"."id" = "members"."project_id" AND "members"."user_id" = 124 AND "projects"."active" = TRUE INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE INNER JOIN "role_permissions" ON "role_permissions"."permission" IN ('view_work_packages') INNER JOIN "roles" "permission_roles" ON "permission_roles"."id" = "role_permissions"."role_id" LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id" LEFT OUTER JOIN "roles" "assigned_roles" ON "assigned_roles"."id" = "permission_roles"."id" AND "projects"."active" = TRUE AND ("assigned_roles"."id" = "member_roles"."role_id" OR "projects"."public" = TRUE AND "assigned_roles"."builtin" = 1 AND "member_roles"."id" IS NULL) WHERE "assigned_roles"."id" IS NOT NULL))
```
revealed that it takes roughly 2.7s.

The altered statement
```
SELECT COUNT(*) FROM "notifications" 
WHERE "notifications"."recipient_id" = 124 AND "notifications"."resource_type" = 'WorkPackage' 
AND EXISTS (SELECT "work_packages".* FROM "work_packages" WHERE EXISTS (SELECT DISTINCT "projects".* FROM "projects" LEFT OUTER JOIN "members" ON "projects"."id" = "members"."project_id" AND "members"."user_id" = 124 AND "projects"."active" = TRUE INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE INNER JOIN "role_permissions" ON "role_permissions"."permission" IN ('view_work_packages') INNER JOIN "roles" "permission_roles" ON "permission_roles"."id" = "role_permissions"."role_id" LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id" LEFT OUTER JOIN "roles" "assigned_roles" ON "assigned_roles"."id" = "permission_roles"."id" AND "projects"."active" = TRUE AND ("assigned_roles"."id" = "member_roles"."role_id" OR "projects"."public" = TRUE AND "assigned_roles"."builtin" = 1 AND "member_roles"."id" IS NULL) 
																		WHERE "assigned_roles"."id" IS NOT NULL AND (work_packages.project_id = projects.id)) AND (notifications.resource_id = work_packages.id))
```

takes roughly 0.1s.

Both queries return the expected 648 results.

The execution plan of the original statement:

```
                                                                                                    QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=3393.12..3393.13 rows=1 width=8) (actual time=5429.557..5429.569 rows=1 loops=1)
   ->  Nested Loop Semi Join  (cost=1104.69..3392.70 rows=170 width=0) (actual time=9.131..5428.883 rows=648 loops=1)
         ->  Bitmap Heap Scan on notifications  (cost=8.84..1590.76 rows=570 width=8) (actual time=0.208..3.301 rows=648 loops=1)
               Recheck Cond: (recipient_id = 124)
               Filter: ((resource_type)::text = 'WorkPackage'::text)
               Heap Blocks: exact=518
               ->  Bitmap Index Scan on index_notifications_on_recipient_id  (cost=0.00..8.70 rows=571 width=0) (actual time=0.129..0.129 rows=648 loops=1)
                     Index Cond: (recipient_id = 124)
         ->  Hash Join  (cost=1095.84..1097.07 rows=1 width=4) (actual time=8.356..8.356 rows=1 loops=648)
               Hash Cond: (projects.id = work_packages.project_id)
               ->  Unique  (cost=1089.18..1089.51 rows=65 width=4) (actual time=8.312..8.331 rows=30 loops=648)
                     ->  Sort  (cost=1089.18..1089.35 rows=65 width=4) (actual time=8.312..8.319 rows=82 loops=648)
                           Sort Key: projects.id
                           Sort Method: quicksort  Memory: 37kB
                           ->  Merge Join  (cost=140.92..1087.23 rows=65 width=4) (actual time=0.560..8.254 rows=268 loops=648)
                                 Merge Cond: (role_permissions.role_id = permission_roles.id)
                                 ->  Nested Loop  (cost=140.62..1425.99 rows=97 width=12) (actual time=0.554..8.150 rows=268 loops=648)
                                       Join Filter: ((assigned_roles.id = member_roles.role_id) OR (projects.public AND (assigned_roles.builtin = 1) AND (member_roles.id IS NULL)))
                                       Rows Removed by Join Filter: 38484
                                       ->  Merge Join  (cost=84.19..86.07 rows=84 width=12) (actual time=0.413..0.504 rows=112 loops=648)
                                             Merge Cond: (role_permissions.role_id = assigned_roles.id)
                                             ->  Sort  (cost=76.95..77.26 rows=126 width=4) (actual time=0.360..0.373 rows=124 loops=648)
                                                   Sort Key: role_permissions.role_id
                                                   Sort Method: quicksort  Memory: 30kB
                                                   ->  Seq Scan on role_permissions  (cost=0.00..72.55 rows=126 width=4) (actual time=0.004..0.334 rows=126 loops=648)
                                                         Filter: ((permission)::text = 'view_work_packages'::text)
                                                         Rows Removed by Filter: 3198
                                             ->  Sort  (cost=7.24..7.54 rows=118 width=8) (actual time=0.051..0.064 rows=118 loops=648)
                                                   Sort Key: assigned_roles.id
                                                   Sort Method: quicksort  Memory: 30kB
                                                   ->  Seq Scan on roles assigned_roles  (cost=0.00..3.18 rows=118 width=8) (actual time=0.004..0.025 rows=118 loops=648)
                                                         Filter: (id IS NOT NULL)
                                       ->  Materialize  (cost=56.43..1140.34 rows=136 width=13) (actual time=0.000..0.027 rows=346 loops=72576)
                                             ->  Nested Loop Left Join  (cost=56.43..1139.66 rows=136 width=13) (actual time=0.367..0.902 rows=346 loops=1)
                                                   ->  Hash Right Join  (cost=56.14..347.40 rows=98 width=9) (actual time=0.358..0.496 rows=193 loops=1)
                                                         Hash Cond: (members.project_id = projects.id)
                                                         Join Filter: projects.active
                                                         ->  Bitmap Heap Scan on members  (cost=5.67..295.81 rows=178 width=8) (actual time=0.028..0.101 rows=157 loops=1)
                                                               Recheck Cond: (user_id = 124)
                                                               Heap Blocks: exact=71
                                                               ->  Bitmap Index Scan on index_members_on_user_id_and_project_id  (cost=0.00..5.62 rows=178 width=0) (actual time=0.020..0.021 rows=157 loops=1)
                                                                     Index Cond: (user_id = 124)
                                                         ->  Hash  (cost=49.25..49.25 rows=98 width=6) (actual time=0.320..0.323 rows=193 loops=1)
                                                               Buckets: 1024  Batches: 1  Memory Usage: 16kB
                                                               ->  Hash Join  (cost=32.40..49.25 rows=98 width=6) (actual time=0.160..0.289 rows=193 loops=1)
                                                                     Hash Cond: (enabled_modules.project_id = projects.id)
                                                                     ->  Bitmap Heap Scan on enabled_modules  (cost=7.27..23.09 rows=386 width=4) (actual time=0.025..0.081 rows=386 loops=1)
                                                                           Recheck Cond: ((name)::text = 'work_package_tracking'::text)
                                                                           Heap Blocks: exact=11
                                                                           ->  Bitmap Index Scan on index_enabled_modules_on_name  (cost=0.00..7.17 rows=386 width=0) (actual time=0.020..0.020 rows=386 loops=1)
                                                                                 Index Cond: ((name)::text = 'work_package_tracking'::text)
                                                                     ->  Hash  (cost=23.89..23.89 rows=99 width=6) (actual time=0.128..0.129 rows=196 loops=1)
                                                                           Buckets: 1024  Batches: 1  Memory Usage: 16kB
                                                                           ->  Seq Scan on projects  (cost=0.00..23.89 rows=99 width=6) (actual time=0.005..0.092 rows=196 loops=1)
                                                                                 Filter: (active AND active)
                                                                                 Rows Removed by Filter: 193
                                                   ->  Index Scan using index_member_roles_on_member_id on member_roles  (cost=0.29..8.06 rows=2 width=12) (actual time=0.001..0.002 rows=1 loops=193)
                                                         Index Cond: (member_id = members.id)
                                 ->  Index Only Scan using roles_pkey on roles permission_roles  (cost=0.14..17.90 rows=118 width=4) (actual time=0.004..0.043 rows=101 loops=648)
                                       Heap Fetches: 65448
               ->  Hash  (cost=6.65..6.65 rows=1 width=8) (actual time=0.012..0.012 rows=1 loops=648)
                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
                     ->  Index Scan using work_packages_pkey on work_packages  (cost=0.42..6.65 rows=1 width=8) (actual time=0.009..0.009 rows=1 loops=648)
                           Index Cond: (id = notifications.resource_id)
 Planning Time: 3.176 ms
 Execution Time: 5429.801 ms
(66 rows)
```

shows a looping for the visibility check over every notification's work package (loops=648).

The execution plan of the altered statement:

```
                                                                                                    QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=13173.54..13173.55 rows=1 width=8) (actual time=145.885..145.899 rows=1 loops=1)
   ->  Hash Semi Join  (cost=11588.83..13173.30 rows=95 width=0) (actual time=136.254..145.812 rows=648 loops=1)
         Hash Cond: (notifications.resource_id = work_packages.id)
         ->  Bitmap Heap Scan on notifications  (cost=8.84..1590.76 rows=570 width=8) (actual time=0.149..0.818 rows=648 loops=1)
               Recheck Cond: (recipient_id = 124)
               Filter: ((resource_type)::text = 'WorkPackage'::text)
               Heap Blocks: exact=518
               ->  Bitmap Index Scan on index_notifications_on_recipient_id  (cost=0.00..8.70 rows=571 width=0) (actual time=0.085..0.086 rows=648 loops=1)
                     Index Cond: (recipient_id = 124)
         ->  Hash  (cost=11275.87..11275.87 rows=24329 width=4) (actual time=135.944..135.956 rows=97175 loops=1)
               Buckets: 131072 (originally 32768)  Batches: 2 (originally 1)  Memory Usage: 3073kB
               ->  Hash Semi Join  (cost=1088.04..11275.87 rows=24329 width=4) (actual time=8.567..102.265 rows=97175 loops=1)
                     Hash Cond: (work_packages.project_id = projects.id)
                     ->  Seq Scan on work_packages  (cost=0.00..9534.98 rows=145598 width=8) (actual time=0.050..46.887 rows=145598 loops=1)
                     ->  Hash  (cost=1087.23..1087.23 rows=65 width=8) (actual time=8.506..8.517 rows=268 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 19kB
                           ->  Merge Join  (cost=140.92..1087.23 rows=65 width=8) (actual time=1.600..8.468 rows=268 loops=1)
                                 Merge Cond: (role_permissions.role_id = permission_roles.id)
                                 ->  Nested Loop  (cost=140.62..1425.99 rows=97 width=16) (actual time=1.589..8.368 rows=268 loops=1)
                                       Join Filter: ((assigned_roles.id = member_roles.role_id) OR (projects.public AND (assigned_roles.builtin = 1) AND (member_roles.id IS NULL)))
                                       Rows Removed by Join Filter: 38484
                                       ->  Merge Join  (cost=84.19..86.07 rows=84 width=12) (actual time=0.388..0.465 rows=112 loops=1)
                                             Merge Cond: (role_permissions.role_id = assigned_roles.id)
                                             ->  Sort  (cost=76.95..77.26 rows=126 width=4) (actual time=0.333..0.345 rows=124 loops=1)
                                                   Sort Key: role_permissions.role_id
                                                   Sort Method: quicksort  Memory: 30kB
                                                   ->  Seq Scan on role_permissions  (cost=0.00..72.55 rows=126 width=4) (actual time=0.006..0.306 rows=126 loops=1)
                                                         Filter: ((permission)::text = 'view_work_packages'::text)
                                                         Rows Removed by Filter: 3198
                                             ->  Sort  (cost=7.24..7.54 rows=118 width=8) (actual time=0.052..0.065 rows=118 loops=1)
                                                   Sort Key: assigned_roles.id
                                                   Sort Method: quicksort  Memory: 30kB
                                                   ->  Seq Scan on roles assigned_roles  (cost=0.00..3.18 rows=118 width=8) (actual time=0.006..0.026 rows=118 loops=1)
                                                         Filter: (id IS NOT NULL)
                                       ->  Materialize  (cost=56.43..1140.34 rows=136 width=17) (actual time=0.003..0.034 rows=346 loops=112)
                                             ->  Nested Loop Left Join  (cost=56.43..1139.66 rows=136 width=17) (actual time=0.374..0.922 rows=346 loops=1)
                                                   ->  Hash Right Join  (cost=56.14..347.40 rows=98 width=13) (actual time=0.368..0.507 rows=193 loops=1)
                                                         Hash Cond: (members.project_id = projects.id)
                                                         Join Filter: projects.active
                                                         ->  Bitmap Heap Scan on members  (cost=5.67..295.81 rows=178 width=8) (actual time=0.031..0.102 rows=157 loops=1)
                                                               Recheck Cond: (user_id = 124)
                                                               Heap Blocks: exact=71
                                                               ->  Bitmap Index Scan on index_members_on_user_id_and_project_id  (cost=0.00..5.62 rows=178 width=0) (actual time=0.023..0.023 rows=157 loops=1)
                                                                     Index Cond: (user_id = 124)
                                                         ->  Hash  (cost=49.25..49.25 rows=98 width=10) (actual time=0.327..0.330 rows=193 loops=1)
                                                               Buckets: 1024  Batches: 1  Memory Usage: 17kB
                                                               ->  Hash Join  (cost=32.40..49.25 rows=98 width=10) (actual time=0.164..0.293 rows=193 loops=1)
                                                                     Hash Cond: (enabled_modules.project_id = projects.id)
                                                                     ->  Bitmap Heap Scan on enabled_modules  (cost=7.27..23.09 rows=386 width=4) (actual time=0.027..0.082 rows=386 loops=1)
                                                                           Recheck Cond: ((name)::text = 'work_package_tracking'::text)
                                                                           Heap Blocks: exact=11
                                                                           ->  Bitmap Index Scan on index_enabled_modules_on_name  (cost=0.00..7.17 rows=386 width=0) (actual time=0.022..0.022 rows=386 loops=1)
                                                                                 Index Cond: ((name)::text = 'work_package_tracking'::text)
                                                                     ->  Hash  (cost=23.89..23.89 rows=99 width=6) (actual time=0.128..0.130 rows=196 loops=1)
                                                                           Buckets: 1024  Batches: 1  Memory Usage: 16kB
                                                                           ->  Seq Scan on projects  (cost=0.00..23.89 rows=99 width=6) (actual time=0.005..0.092 rows=196 loops=1)
                                                                                 Filter: (active AND active)
                                                                                 Rows Removed by Filter: 193
                                                   ->  Index Scan using index_member_roles_on_member_id on member_roles  (cost=0.29..8.06 rows=2 width=12) (actual time=0.001..0.002 rows=1 loops=193)
                                                         Index Cond: (member_id = members.id)
                                 ->  Index Only Scan using roles_pkey on roles permission_roles  (cost=0.14..17.90 rows=118 width=4) (actual time=0.007..0.041 rows=101 loops=1)
                                       Heap Fetches: 101
 Planning Time: 3.159 ms
 Execution Time: 146.466 ms
```
shows no such looping. It however shows a sequential scan on the work packages table which does not result in poor performance for this query. It is caused by the relatively large number of work packages that user is allowed to see (90000 of 140000).

It is also noteworthy, that the problem does not exist when checking for the work package visibility, which is a subpart of the query shown above. Here, both alternatives perform equally well (roughly 30ms).