### PR TITLE
Fix font loading in storybook

### DIFF
--- a/frontend/.storybook/SpotTheme.js
+++ b/frontend/.storybook/SpotTheme.js
@@ -5,6 +5,6 @@ export default create({
 
   brandTitle: 'SPOT - Single Point Of Truth',
   brandUrl: '/',
-  brandImage: 'https://www.openproject.org/docs/development/design-system/logo_openproject_spot.png',
+  brandImage: '/assets/logo_openproject_spot.png',
   brandTarget: '_self',
 });

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -22,6 +22,12 @@ module.exports = {
     // modernInlineRender: true,
   },
   staticDirs: [
-    { from: '../src/stories/assets', to: '/assets' },
+    // Copy local static assets
+    { from: '../src/stories/assets/', to: '/assets' },
+    
+    // Copy font files to specific locations so the normal core SASS 
+    // will load the files correctly without having to use variables
+    { from: '../src/assets/fonts/openproject_icon/', to: '/assets/frontend/' },
+    { from: '../src/assets/fonts/lato/', to: '/assets/frontend/' },
   ],
 };

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   stories: [
     "../src/**/*.stories.mdx",
@@ -23,11 +25,35 @@ module.exports = {
   },
   staticDirs: [
     // Copy local static assets
-    { from: '../src/stories/assets/', to: '/assets' },
+    '../src/stories/assets/logo_openproject.png',
+    '../src/stories/assets/logo_openproject_spot.png',
     
     // Copy font files to specific locations so the normal core SASS 
     // will load the files correctly without having to use variables
-    { from: '../src/assets/fonts/openproject_icon/', to: '/assets/frontend/' },
-    { from: '../src/assets/fonts/lato/', to: '/assets/frontend/' },
-  ],
+    '../src/assets/fonts/openproject_icon/openproject-icon-font.ttf',
+    '../src/assets/fonts/openproject_icon/openproject-icon-font.svg',
+    '../src/assets/fonts/openproject_icon/openproject-icon-font.eot',
+    '../src/assets/fonts/openproject_icon/openproject-icon-font.woff',
+    '../src/assets/fonts/openproject_icon/openproject-icon-font.woff2',
+
+    '../src/assets/fonts/lato/Lato-Regular.woff',
+    '../src/assets/fonts/lato/Lato-Regular.woff2',
+
+    '../src/assets/fonts/lato/Lato-Bold.woff',
+    '../src/assets/fonts/lato/Lato-Bold.woff2',
+
+    '../src/assets/fonts/lato/Lato-Light.woff',
+    '../src/assets/fonts/lato/Lato-Light.woff2',
+
+    '../src/assets/fonts/lato/Lato-Italic.woff',
+    '../src/assets/fonts/lato/Lato-Italic.woff2',
+
+    '../src/assets/fonts/lato/Lato-BoldItalic.woff',
+    '../src/assets/fonts/lato/Lato-BoldItalic.woff2',
+
+    '../src/assets/fonts/lato/Lato-LightItalic.woff',
+    '../src/assets/fonts/lato/Lato-LightItalic.woff2',
+  ].map((from) => ({
+    from, to: path.join('/assets/frontend/', path.basename(from)),
+  })),
 };


### PR DESCRIPTION
Both Lato and the icon font were not loading correctly since the CSS expects them to be available under a certain URL. This URL is available in the core app, but not storybook. This commit makes sure the assets load correctly in Storybook, giving us pretty icons and the right font.