### PR TITLE
Derive inline create permissions from capabilities

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -142,14 +142,16 @@ Rails.application.reloader.to_prepare do
                      contract_actions: { work_packages: %i[read] }
 
       wpt.permission :add_work_packages,
-                     {}
+                     {},
+                     contract_actions: { work_packages: %i[create] }
 
       wpt.permission :edit_work_packages,
                      {
                        'work_packages/bulk': %i[edit update]
                      },
                      require: :member,
-                     dependencies: :view_work_packages
+                     dependencies: :view_work_packages,
+                     contract_actions: { work_packages: %i[update] }
 
       wpt.permission :move_work_packages,
                      { 'work_packages/moves': %i[new create] },

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -75,7 +75,7 @@ export class CurrentUserService {
   /**
    * Returns the set of capabilities for the given context and/or actions
    */
-  public capabilities$(actions:string[] = [], projectContext:string|null = null):Observable<ICapability[]> {
+  public capabilities$(actions:string[] = [], projectContext:string|null):Observable<ICapability[]> {
     return this
       .principalFilter$()
       .pipe(
@@ -100,7 +100,7 @@ export class CurrentUserService {
    * Returns an Observable<boolean> indicating whether the current user has the required capabilities
    * in the provided context.
    */
-  public hasCapabilities$(action:string|string[], projectContext = 'global'):Observable<boolean> {
+  public hasCapabilities$(action:string|string[], projectContext:string|null):Observable<boolean> {
     const actions = _.castArray(action);
     return this
       .capabilities$(actions, projectContext)
@@ -117,7 +117,7 @@ export class CurrentUserService {
    * Returns an Observable<boolean> indicating whether the current user
    * has any of the required capabilities in the provided context.
    */
-  public hasAnyCapabilityOf$(actions:string|string[], projectContext = 'global'):Observable<boolean> {
+  public hasAnyCapabilityOf$(actions:string|string[], projectContext:string|null):Observable<boolean> {
     const actionsToFilter = _.castArray(actions);
     return this
       .capabilities$(actionsToFilter, projectContext)

--- a/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
@@ -263,10 +263,10 @@ describe('Capabilities service', () => {
     });
 
     it('Should filter by context and all actions', () => {
-      currentUser.hasCapabilities$('asdf/asdf').subscribe((hasCaps) => {
+      currentUser.hasCapabilities$('asdf/asdf', 'global').subscribe((hasCaps) => {
         expect(hasCaps).toEqual(false);
       });
-      currentUser.hasCapabilities$('placeholder_users/read').subscribe((hasCaps) => {
+      currentUser.hasCapabilities$('placeholder_users/read', 'global').subscribe((hasCaps) => {
         expect(hasCaps).toEqual(true);
       });
       currentUser.hasCapabilities$(['memberships/update', 'memberships/read'], '6').subscribe((hasCaps) => {

--- a/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
@@ -42,7 +42,8 @@ import { Observable } from 'rxjs';
 
 @Injectable()
 export class BoardInlineCreateService extends WorkPackageInlineCreateService {
-  constructor(readonly injector:Injector,
+  constructor(
+    readonly injector:Injector,
     protected readonly querySpace:IsolatedQuerySpace,
     protected readonly halResourceService:HalResourceService,
   ) {

--- a/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
@@ -26,7 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import {
+  Injectable,
+  Injector,
+} from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
@@ -35,15 +38,14 @@ import { HalResourceService } from 'core-app/features/hal/services/hal-resource.
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { BoardInlineAddAutocompleterComponent } from 'core-app/features/boards/board/inline-add/board-inline-add-autocompleter.component';
 import { GonService } from 'core-app/core/gon/gon.service';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class BoardInlineCreateService extends WorkPackageInlineCreateService {
   constructor(readonly injector:Injector,
     protected readonly querySpace:IsolatedQuerySpace,
     protected readonly halResourceService:HalResourceService,
-    protected readonly pathHelperService:PathHelperService,
-    protected readonly Gon:GonService,
-    protected readonly wpRelationsHierarchyService:WorkPackageRelationsHierarchyService) {
+  ) {
     super(injector);
   }
 
@@ -57,12 +59,22 @@ export class BoardInlineCreateService extends WorkPackageInlineCreateService {
    */
   public referenceTarget:WorkPackageResource|null = null;
 
-  public get canAdd() {
-    return this.authorisationService.can('work_packages', 'createWorkPackage');
+  public get canAdd():Observable<boolean> {
+    return this
+      .currentUser
+      .hasCapabilities$(
+        ['work_packages/create'],
+        this.currentProject.id || 'global',
+      );
   }
 
-  public get canReference() {
-    return this.authorisationService.can('work_packages', 'editWorkPackage');
+  public get canReference():Observable<boolean> {
+    return this
+      .currentUser
+      .hasCapabilities$(
+        ['work_packages/update'],
+        this.currentProject.id || 'global',
+      );
   }
 
   /**

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -36,9 +36,11 @@ import { CausedUpdatesService } from 'core-app/features/boards/board/caused-upda
 import { BoardListMenuComponent } from 'core-app/features/boards/board/board-list/board-list-menu.component';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { WorkPackageCardDragAndDropService } from 'core-app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service';
-import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { BoardFiltersService } from 'core-app/features/boards/board/board-filter/board-filters.service';
-import { StateService, TransitionService } from '@uirouter/core';
+import {
+  StateService,
+  TransitionService,
+} from '@uirouter/core';
 import { WorkPackageViewFocusService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import { BoardListCrossSelectionService } from 'core-app/features/boards/board/board-list/board-list-cross-selection.service';
@@ -46,7 +48,6 @@ import {
   debounceTime,
   filter,
   map,
-  retry,
   take,
 } from 'rxjs/operators';
 import { ChangeItem } from 'core-app/shared/components/fields/changeset/changeset';
@@ -57,7 +58,10 @@ import { ApiV3Filter } from 'core-app/shared/helpers/api-v3/api-v3-filter-builde
 import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { HalEvent, HalEventsService } from 'core-app/features/hal/services/hal-events.service';
+import {
+  HalEvent,
+  HalEventsService,
+} from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 
 export interface DisabledButtonPlaceholder {
@@ -180,13 +184,15 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
     // If this query space changes its focused or selected
     // work packages, update the board cross selection
-    this.wpViewSelectionService
+    this
+      .wpViewSelectionService
       .updates$()
       .pipe(
         debounceTime(100),
         this.untilDestroyed(),
-      ).subscribe((selectionState) => {
-        const selected = Object.keys(_.pickBy(selectionState.selected, (selected, _) => selected === true));
+      )
+      .subscribe((selectionState) => {
+        const selected = Object.keys(_.pickBy(selectionState.selected, (option, _) => option === true));
 
         const focused = this.wpViewFocusService.focusedWorkPackage;
 
@@ -224,6 +230,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       .pipe(
         this.untilDestroyed(),
       )
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       .subscribe(async (query) => {
         this.query = query;
         this.canDragOutOf = !!this.query.updateOrderedWorkPackages;
@@ -322,7 +329,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     this.loadQuery(visibly);
   }
 
-  private async loadActionAttribute(query:QueryResource) {
+  private async loadActionAttribute(query:QueryResource):Promise<void> {
     if (!this.board.isAction) {
       this.actionResource = undefined;
       this.headerComponent = undefined;
@@ -341,18 +348,21 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     }
 
     // Load the resource
-    actionService.getLoadedActionValue(query).then(async (resource) => {
-      this.actionResource = resource;
-      this.headerComponent = actionService.headerComponent();
-      this.buttonPlaceholder = actionService.disabledAddButtonPlaceholder(resource);
-      this.actionResourceClass = this.boardListActionColorClass(resource);
-      this.canDragInto = actionService.dragIntoAllowed(query, resource);
+    // eslint-disable-next-line consistent-return
+    return actionService
+      .getLoadedActionValue(query)
+      .then(async (resource) => {
+        this.actionResource = resource;
+        this.headerComponent = actionService.headerComponent();
+        this.buttonPlaceholder = actionService.disabledAddButtonPlaceholder(resource);
+        this.actionResourceClass = this.boardListActionColorClass(resource);
+        this.canDragInto = actionService.dragIntoAllowed(query, resource);
 
-      const canWriteAttribute = await actionService.canAddToQuery(query);
-      const canAdd = await this.canAdd;
-      this.showAddButton = this.canDragInto && canAdd && canWriteAttribute;
-      this.cdRef.detectChanges();
-    });
+        const canWriteAttribute = await actionService.canAddToQuery(query);
+        const canAdd = await this.canAdd;
+        this.showAddButton = this.canDragInto && canAdd && canWriteAttribute;
+        this.cdRef.detectChanges();
+      });
   }
 
   /**
@@ -409,7 +419,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
         },
         (error) => {
           const userIsNotAllowedToSeeSubprojectError = 'urn:openproject-org:api:v3:errors:InvalidQuery';
-          if(error.errorIdentifier === userIsNotAllowedToSeeSubprojectError) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          if (error.errorIdentifier === userIsNotAllowedToSeeSubprojectError) {
             this.visibilityChange.emit(false);
           }
           this.loadingError = this.halNotification.retrieveErrorMessage(error);
@@ -462,7 +473,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
           return !!current && (current === to || current === from);
         }),
-      ).subscribe((event) => {
+      )
+      .subscribe(() => {
         this.updateQuery(true);
       });
   }

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
@@ -54,7 +54,7 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
     .currentUserService
     .hasCapabilities$(
       'boards/create',
-      this.currentProject.id || undefined,
+      this.currentProject.id || null,
     )
     .pipe(this.untilDestroyed());
 

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
@@ -29,7 +29,7 @@ export class CalendarSidemenuComponent extends UntilDestroyedMixin {
     .currentUserService
     .hasCapabilities$(
       'calendars/create',
-      this.currentProjectService.id || undefined,
+      this.currentProjectService.id || null,
     )
     .pipe(this.untilDestroyed());
 

--- a/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.ts
+++ b/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.ts
@@ -43,7 +43,7 @@ export class InviteUserButtonComponent {
       .currentUserService
       .hasCapabilities$(
         'memberships/create',
-        this.projectId || undefined,
+        this.projectId || null,
       );
   }
 

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
@@ -67,7 +67,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
   public canInviteByEmail$ = combineLatest(
     this.items$,
     this.input$,
-    this.currentUserService.hasCapabilities$('users/create'),
+    this.currentUserService.hasCapabilities$('users/create', 'global'),
   ).pipe(
     map(([elements, input, canCreateUsers]) => canCreateUsers
       && this.type === PrincipalType.User
@@ -79,7 +79,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
   public canCreateNewPlaceholder$ = combineLatest([
     this.items$,
     this.input$,
-    this.currentUserService.hasCapabilities$('placeholder_users/create'),
+    this.currentUserService.hasCapabilities$('placeholder_users/create', 'global'),
   ])
     .pipe(
       map(([elements, input, hasCapability]) => {

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
@@ -110,7 +110,7 @@ export class ProjectSelectionComponent implements OnInit {
 
     this
       .currentUserService
-      .capabilities$(['memberships/create'])
+      .capabilities$(['memberships/create'], null)
       .pipe(
         map((capabilities) => capabilities.filter((c) => c._links.action.href.endsWith('/memberships/create'))),
       )

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
@@ -31,7 +31,7 @@ export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
     .currentUserService
     .hasCapabilities$(
       'team_planners/create',
-      this.currentProjectService.id || undefined,
+      this.currentProjectService.id || null,
     )
     .pipe(
       map((val) => val && !this.bannersService.eeShowBanners),

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
@@ -41,6 +41,7 @@ import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
+import { combineLatest } from 'rxjs';
 
 export type CardViewOrientation = 'horizontal'|'vertical';
 
@@ -102,11 +103,6 @@ export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements
     },
   };
 
-  /** Inline create / reference properties */
-  public canAdd = false;
-
-  public canReference = false;
-
   public inReference = false;
 
   public referenceClass = this.wpInlineCreate.referenceComponentClass;
@@ -143,15 +139,6 @@ export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements
 
   ngOnInit() {
     this.registerCreationCallback();
-
-    // Update permission on model updates
-    this.authorisationService
-      .observeUntil(componentDestroyed(this))
-      .subscribe(() => {
-        this.canAdd = this.wpInlineCreate.canAdd;
-        this.canReference = this.wpInlineCreate.canReference;
-        this.cdRef.detectChanges();
-      });
 
     // Observe changes to the work packages in this view
     this.halEvents

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
@@ -22,7 +22,11 @@ import { StateService } from '@uirouter/core';
 import { States } from 'core-app/core/states/states.service';
 import { WorkPackageViewOrderService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { filter, map, withLatestFrom } from 'rxjs/operators';
+import {
+  filter,
+  map,
+  withLatestFrom,
+} from 'rxjs/operators';
 import { CausedUpdatesService } from 'core-app/features/boards/board/caused-updates/caused-updates.service';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import { CardViewHandlerRegistry } from 'core-app/features/work-packages/components/wp-card-view/event-handler/card-view-handler-registry';
@@ -35,13 +39,11 @@ import {
   WorkPackageViewOutputs,
 } from 'core-app/features/work-packages/routing/wp-view-base/event-handling/event-handler-registry';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
-import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { QueryColumn } from 'core-app/features/work-packages/components/wp-query/query-column';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
-import { combineLatest } from 'rxjs';
 
 export type CardViewOrientation = 'horizontal'|'vertical';
 

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
@@ -31,19 +31,16 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   HostListener,
   Injector,
   Input,
-  EventEmitter,
   OnInit,
   Output,
 } from '@angular/core';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { WorkPackageViewFocusService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
-import {
-  filter,
-  shareReplay,
-} from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -56,7 +53,6 @@ import { WorkPackageViewColumnsService } from 'core-app/features/work-packages/r
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
 import { EditForm } from 'core-app/shared/components/fields/edit/edit-form/edit-form';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
-import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import {
   inlineCreateCancelClassName,

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
@@ -26,19 +26,30 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector, OnDestroy } from '@angular/core';
+import {
+  Injectable,
+  Injector,
+  OnDestroy,
+} from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Subject } from 'rxjs';
+import {
+  Observable,
+  of,
+  Subject,
+} from 'rxjs';
 import { ComponentType } from '@angular/cdk/portal';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 @Injectable()
 export class WorkPackageInlineCreateService implements OnDestroy {
   @InjectField() I18n!:I18nService;
 
-  @InjectField() protected readonly authorisationService:AuthorisationService;
+  @InjectField() protected readonly currentUser:CurrentUserService;
+
+  @InjectField() protected readonly currentProject:CurrentProjectService;
 
   constructor(readonly injector:Injector) {
   }
@@ -61,17 +72,28 @@ export class WorkPackageInlineCreateService implements OnDestroy {
     create: this.I18n.t('js.label_create_work_package'),
   };
 
-  public get canAdd() {
-    return this.canCreateWorkPackages || this.authorisationService.can('work_package', 'addChild');
+  public get canAdd():Observable<boolean> {
+    return this.canCreateWorkPackages();
   }
 
-  public get canReference() {
-    return false;
+  public get canReference():Observable<boolean> {
+    return of(false);
   }
 
-  public get canCreateWorkPackages() {
-    return this.authorisationService.can('work_packages', 'createWorkPackage')
-      && this.authorisationService.can('work_packages', 'editWorkPackage');
+  /**
+   * Observable capability check for work_packages/create and /edit.
+   * Edit is included as inline create saves quickly, preventing further edits for users
+   * that don't also have edit permisison.
+   *
+   * @protected
+   */
+  protected canCreateWorkPackages(projectId:string|null = this.currentProject.id):Observable<boolean> {
+    return this
+      .currentUser
+      .hasCapabilities$(
+        ['work_packages/create', 'work_packages/update'],
+        projectId || 'global',
+      );
   }
 
   /** Allow callbacks to happen on newly created inline work packages */
@@ -83,7 +105,7 @@ export class WorkPackageInlineCreateService implements OnDestroy {
   /**
    * Ensure hierarchical injected versions of this service correctly unregister
    */
-  ngOnDestroy() {
+  ngOnDestroy():void {
     this.newInlineWorkPackageCreated.complete();
     this.newInlineWorkPackageReferenced.complete();
   }

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
@@ -92,7 +92,7 @@ export class WorkPackageInlineCreateService implements OnDestroy {
       .currentUser
       .hasCapabilities$(
         ['work_packages/create', 'work_packages/update'],
-        projectId || 'global',
+        projectId || null,
       );
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
@@ -33,6 +33,11 @@ import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/
 import { WpRelationInlineCreateServiceInterface } from 'core-app/features/work-packages/components/wp-relations/embedded/wp-relation-inline-create.service.interface';
 import { WpRelationInlineAddExistingComponent } from 'core-app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
 @Injectable()
 export class WpChildrenInlineCreateService extends WorkPackageInlineCreateService implements WpRelationInlineCreateServiceInterface {
@@ -71,16 +76,21 @@ export class WpChildrenInlineCreateService extends WorkPackageInlineCreateServic
    */
   public referenceTarget:WorkPackageResource|null = null;
 
-  public get canAdd() {
-    return !!(this.referenceTarget && this.canCreateWorkPackages && this.canAddChild);
+  public get canAdd():Observable<boolean> {
+    if (!(this.referenceTarget && this.canAddChild)) {
+      return of(false);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return this.canCreateWorkPackages(idFromLink(this.referenceTarget.project.href));
   }
 
-  public get canReference() {
-    return !!(this.referenceTarget && this.canAddChild);
+  public get canReference():Observable<boolean> {
+    return of(!!this.referenceTarget && this.canAddChild);
   }
 
-  public get canAddChild() {
-    return this.schema && !this.schema.isMilestone && this.referenceTarget!.changeParent;
+  public get canAddChild():boolean {
+    return !!(this.schema && !this.schema.isMilestone && this.referenceTarget!.changeParent);
   }
 
   /**

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
@@ -90,7 +90,7 @@ export class WpChildrenInlineCreateService extends WorkPackageInlineCreateServic
   }
 
   public get canAddChild():boolean {
-    return !!(this.schema && !this.schema.isMilestone && this.referenceTarget!.changeParent);
+    return !!(this.schema && !this.schema.isMilestone && this.referenceTarget?.changeParent);
   }
 
   /**

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
@@ -33,6 +33,11 @@ import { WpRelationInlineAddExistingComponent } from 'core-app/features/work-pac
 import { WorkPackageRelationsService } from 'core-app/features/work-packages/components/wp-relations/wp-relations.service';
 import { WpRelationInlineCreateServiceInterface } from 'core-app/features/work-packages/components/wp-relations/embedded/wp-relation-inline-create.service.interface';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
 @Injectable()
 export class WpRelationInlineCreateService extends WorkPackageInlineCreateService implements WpRelationInlineCreateServiceInterface, OnDestroy {
@@ -77,12 +82,17 @@ export class WpRelationInlineCreateService extends WorkPackageInlineCreateServic
    */
   public referenceTarget:WorkPackageResource|null = null;
 
-  public get canAdd() {
-    return !!(this.referenceTarget && this.canCreateWorkPackages && this.referenceTarget.addRelation);
+  public get canAdd():Observable<boolean> {
+    if (!this.referenceTarget?.addRelation) {
+      return of(false);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return this.canCreateWorkPackages(idFromLink(this.referenceTarget.project.href));
   }
 
-  public get canReference() {
-    return !!this.canAdd;
+  public get canReference():Observable<boolean> {
+    return this.canAdd;
   }
 
   /**

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -71,7 +71,7 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin {
 
   public textFieldFocused = false;
 
-  public canCreateNewProjects$ = this.currentUserService.hasCapabilities$('projects/create');
+  public canCreateNewProjects$ = this.currentUserService.hasCapabilities$('projects/create', 'global');
 
   public projects$ = combineLatest([
     this.searchableProjectListService.allProjects$,

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -93,15 +93,17 @@ describe 'Projects autocomplete page', type: :feature, js: true do
   end
 
   it 'allows to filter and select projects' do
-    top_menu.toggle
-    top_menu.expect_open
+    retry_block do
+      top_menu.toggle unless top_menu.open?
+      top_menu.expect_open
 
-    # projects are displayed initially
-    top_menu.expect_result project.name
-    # public project is displayed as it is public
-    top_menu.expect_result public_project.name
-    # only projects the user is member in are displayed
-    top_menu.expect_no_result non_member_project.name
+      # projects are displayed initially
+      top_menu.expect_result project.name
+      # public project is displayed as it is public
+      top_menu.expect_result public_project.name
+      # only projects the user is member in are displayed
+      top_menu.expect_no_result non_member_project.name
+    end
 
     # Filter for projects
     top_menu.search '<strong'

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -105,7 +105,8 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     to_copy_work_package_page.save!
 
     expect(page).to have_selector('.op-toast--content',
-                                  text: I18n.t('js.notice_successful_create'))
+                                  text: I18n.t('js.notice_successful_create'),
+                                  wait: 20)
 
     copied_work_package = WorkPackage.order(created_at: 'desc').first
 
@@ -156,10 +157,9 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     to_copy_work_package_page.expect_fully_loaded
 
     to_copy_work_package_page.update_attributes Description: 'Copied WP Description'
-    to_copy_work_package_page.save!
 
-    expect(page).to have_selector('.op-toast--content',
-                                  text: I18n.t('js.notice_successful_create'))
+    to_copy_work_package_page.save!
+    find('.op-toast--content', text: I18n.t('js.notice_successful_create'), wait: 20)
 
     copied_work_package = WorkPackage.order(created_at: 'desc').first
 

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -58,8 +58,12 @@ module Components
 
       def open!
         SeleniumHubWaiter.wait
-        scroll_to_and_click trigger
-        expect_open
+        retry_block do
+          next if open?
+
+          scroll_to_and_click trigger
+          expect_open
+        end
       end
 
       def set_display_sums(enable: true)
@@ -82,7 +86,11 @@ module Components
       end
 
       def expect_open
-        expect(page).to have_selector(selector, wait: 40)
+        raise "Expected modal to be open" unless open?
+      end
+
+      def open?
+        page.has_selector?('.wp-table--configuration-modal', wait: 1)
       end
 
       def expect_closed

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -27,6 +27,9 @@ module Components
     end
 
     def set_markdown(text)
+      # wait for element to be loaded
+      editor_element
+
       textarea = container.find('.op-ckeditor-source-element', visible: :all)
       page.execute_script(
         'jQuery(arguments[0]).trigger("op:ckeditor:setData", arguments[1])',


### PR DESCRIPTION
Adds new capabilities to derive whether adding or editing work packages is allowed. Uses theses capabilities to show the add and link existing buttons in inline-create forms.

https://community.openproject.org/wp/43834