### PR TITLE
Extract rendering of search form into helper

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -81,7 +81,6 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
       <%= call_hook :view_layouts_base_top_menu %>
       <div class="op-app-header--end">
-        <%= render_top_menu_search %>
         <%= render_top_menu_right %>
       </div>
     </header>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -81,7 +81,7 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
       <%= call_hook :view_layouts_base_top_menu %>
       <div class="op-app-header--end">
-        <%= render partial: 'search/mini_form' %>
+        <%= render_top_menu_search %>
         <%= render_top_menu_right %>
       </div>
     </header>

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -45,6 +45,10 @@ module Redmine::MenuManager::TopMenuHelper
     end
   end
 
+  def render_top_menu_search
+    render partial: 'search/mini_form'
+  end
+
   def render_top_menu_right
     content_tag :ul, class: 'op-app-menu' do
       [render_module_top_menu_node,

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -33,10 +33,14 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_top_menu_left
     content_tag :ul, class: 'op-app-menu op-app-menu_drop-left' do
-      [render_main_top_menu_nodes,
-       render_projects_top_menu_node,
-       render_quick_add_menu].join.html_safe
+      safe_join top_menu_left_menu_items
     end
+  end
+
+  def top_menu_left_menu_items
+    [render_main_top_menu_nodes,
+     render_projects_top_menu_node,
+     render_quick_add_menu]
   end
 
   def render_top_menu_center
@@ -50,12 +54,23 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_top_menu_right
-    content_tag :ul, class: 'op-app-menu' do
-      [render_module_top_menu_node,
-       render_notification_top_menu_node,
-       render_help_top_menu_node,
-       render_user_top_menu_node].join.html_safe
+    capture do
+      concat render_top_menu_search
+      concat top_menu_right_node
     end
+  end
+
+  def top_menu_right_node
+    content_tag(:ul, class: 'op-app-menu') do
+      safe_join top_menu_right_menu_items
+    end
+  end
+
+  def top_menu_right_menu_items
+    [render_module_top_menu_node,
+     render_notification_top_menu_node,
+     render_help_top_menu_node,
+     render_user_top_menu_node]
   end
 
   private

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -98,9 +98,9 @@ module Redmine::MenuManager::TopMenuHelper
     link = link_to url,
                    class: 'op-app-menu--item-action',
                    title: I18n.t(:label_login) do
-      concat('<span class="op-app-menu--item-title hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
-      concat('<i class="op-app-menu--item-dropdown-indicator button--dropdown-indicator hidden-for-mobile"></i>'.html_safe)
-      concat('<i class="icon2 icon-user hidden-for-desktop"></i>'.html_safe)
+      concat content_tag(:span, I18n.t(:label_login), class: 'op-app-menu--item-title hidden-for-mobile')
+      concat content_tag(:i, '', class: 'op-app-menu--item-dropdown-indicator button--dropdown-indicator hidden-for-mobile')
+      concat content_tag(:i, '', class: 'icon2 icon-user hidden-for-desktop')
     end
 
     render_menu_dropdown(link, menu_item_class: '') do
@@ -112,8 +112,8 @@ module Redmine::MenuManager::TopMenuHelper
     link = link_to signin_path,
                    class: 'op-app-menu--item-action login',
                    title: I18n.t(:label_login) do
-      concat('<span class="op-app-menu--item-title hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
-      concat('<i class="icon2 icon-user hidden-for-desktop"></i>'.html_safe)
+      concat content_tag(:span, I18n.t(:label_login), class: 'op-app-menu--item-title hidden-for-mobile')
+      concat content_tag(:i, '', class: 'icon2 icon-user hidden-for-desktop')
     end
 
     content_tag :li, class: "" do


### PR DESCRIPTION
The position of menus need to be overridden for souvap, which is why it's being moved into the helper to be easily extensible.

The second commit 5aa996d removes manual calls to .html_safe in favor of rails helpers

https://community.openproject.org/projects/openproject/work_packages/44768