### PR TITLE
Allow setting timezone values in ENV

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -356,6 +356,8 @@ class Setting < ApplicationRecord
       Date.parse value
     when :datetime
       DateTime.parse value
+    when :timezone
+      ActiveSupport::TimeZone.lookup_timezone(value) || value
     else
       value
     end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -400,6 +400,8 @@ module Settings
         AR_BOOLEAN_TYPE.cast(value)
       when :symbol
         value.to_sym
+      when :timezone
+        ActiveSupport::TimeZone.lookup_timezone(value) || value
       else
         value
       end

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -922,7 +922,7 @@ Settings::Definition.define do
 
   add :user_default_timezone,
       default: nil,
-      format: :string,
+      format: :timezone,
       allowed: ActiveSupport::TimeZone.all + [nil]
 
   add :users_deletable_by_admins,

--- a/lib/core_extensions/time_zone.rb
+++ b/lib/core_extensions/time_zone.rb
@@ -26,9 +26,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'core_extensions/string'
-require 'core_extensions/time_with_zone'
-require 'core_extensions/time_zone'
+module CoreExtensions
+  module TimeZone # :nodoc:
+    def lookup_timezone(value)
+      all.detect { |tz| tz.name == value || tz.to_s == value || tz.tzinfo.canonical_identifier == value }
+    end
+  end
+end
 
-::String.prepend CoreExtensions::String
-::ActiveSupport::TimeWithZone.include CoreExtensions::TimeWithZone
+::ActiveSupport::TimeZone.extend ::CoreExtensions::TimeZone

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -163,6 +163,14 @@ describe Settings::Definition do
           .to eql Date.parse('2222-01-01')
       end
 
+      it 'overriding timezone configuration from ENV will cast the value' do
+        stub_const('ENV', { 'OPENPROJECT_USER__DEFAULT__TIMEZONE' => 'Europe/Berlin' })
+
+        value = all.detect { |d| d.name == 'user_default_timezone' }.value
+        expect(value).to be_a ::ActiveSupport::TimeZone
+        expect(value.name).to eq 'Berlin'
+      end
+
       it 'overriding configuration from ENV will set it to non writable' do
         stub_const('ENV', { 'OPENPROJECT_EDITION' => 'bim' })
 
@@ -973,6 +981,30 @@ describe Settings::Definition do
       it 'calls the proc as a default' do
         expect(instance.default)
           .to be false
+      end
+    end
+
+    context 'with a timezone' do
+      let(:instance) do
+        described_class.new 'timezone',
+                            format: :timezone,
+                            default: nil,
+                            allowed: ActiveSupport::TimeZone.all + [nil]
+      end
+
+      it 'accepts a TZ name' do
+        instance.value = 'Europe/Berlin'
+        expect(instance).to be_valid
+      end
+
+      it 'accepts a TZ full identifier' do
+        instance.value = '(GMT+01:00) Berlin'
+        expect(instance).to be_valid
+      end
+
+      it 'rejects a bogus value' do
+        instance.value = 'foobar'
+        expect(instance).not_to be_valid
       end
     end
   end


### PR DESCRIPTION
The allowed values for the :user_default_timezone setting did not allow ever setting it from ENV, as it only allows instances of TimeZones.

To reproduce, try running `OPENPROJECT_USER__DEFAULT__TIMEZONE="Asia/Tokyo" rails console`

https://community.openproject.org/wp/44737