### PR TITLE
Allow set_default to set setting only if empty and writable

### DIFF
--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -93,13 +93,22 @@ module DemoData
     end
 
     def seed_settings
-      welcome = demo_data_for('welcome')
-
-      if welcome.present?
-        Setting.welcome_title = welcome[:title]
-        Setting.welcome_text = welcome[:text]
-        Setting.welcome_on_homescreen = 1
+      seedable_welcome_settings
+        .select { |k,| Settings::Definition[k].writable? }
+        .each do |k, v|
+        Setting[k] = v
       end
+    end
+
+    def seedable_welcome_settings
+      welcome = demo_data_for('welcome')
+      return {} if welcome.blank?
+
+      {
+        welcome_title: welcome[:title],
+        welcome_text: welcome[:text],
+        welcome_on_homescreen: 1
+      }
     end
 
     def reset_project(key)


### PR DESCRIPTION
when setting something like `welcome_text` in a configuration or ENV, the seeding process will fails as it tries to `Setting.welcome_text = 'foo'`. There's no real helper to only set a value when it's empty, so I've added `set_default` to settings.

https://community.openproject.org/wp/44755