### PR TITLE
simplify setting up feature flags

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -1,0 +1,40 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require_relative '../../lib_static/open_project/feature_decisions'
+
+# Add feature flags here via e.g.
+#
+#   OpenProject::FeatureDecisions.add :some_flag
+#
+# If the feature to be flag-guarded stems from a module, add an initializer
+# to that module's engine:
+#
+#   initializer 'the_engine.feature_decisions' do
+#     OpenProject::FeatureDecisions.add :some_flag
+#   end

--- a/docs/api/apiv3/components/schemas/configuration_model.yml
+++ b/docs/api/apiv3/components/schemas/configuration_model.yml
@@ -6,21 +6,17 @@ properties:
     type: integer
     description: The maximum allowed size of an attachment in Bytes
     readOnly: true
+  hostName:
+    type: string
+    description: The host name configured for the system
+    readOnly: true
   perPageOptions:
     type: array
     description: Page size steps to be offered in paginated list UI
     items:
       type: integer
-example:
-  _type: Configuration
-  _links:
-    self:
-      href: "/api/v3/configuration"
-    userPreferences:
-      href: "/api/v3/my_preferences"
-  maximumAttachmentFileSize: 5242880
-  hostName: 'example.com:8080'
-  perPageOptions:
-    - 1
-    - 10
-    - 100
+  activeFeatureFlags:
+    type: array
+    description: The list of all feature flags that are active
+    items:
+      type: string

--- a/docs/api/apiv3/paths/configuration.yml
+++ b/docs/api/apiv3/paths/configuration.yml
@@ -8,17 +8,21 @@ get:
           examples:
             response:
               value:
+                _type: Configuration
                 _links:
                   self:
                     href: "/api/v3/configuration"
                   userPreferences:
                     href: "/api/v3/my_preferences"
-                _type: Configuration
                 maximumAttachmentFileSize: 5242880
+                hostName: 'example.com:8080'
                 perPageOptions:
-                - 1
-                - 10
-                - 100
+                  - 1
+                  - 10
+                  - 100
+                activeFeatureFlags:
+                  - 'aFeatureFlag'
+                  - 'anotherFeatureFlag'
           schema:
             "$ref": "../components/schemas/configuration_model.yml"
       description: OK

--- a/docs/api/apiv3/tags/configuration.yml
+++ b/docs/api/apiv3/tags/configuration.yml
@@ -16,9 +16,10 @@ description: |-
 
   ## Local Properties
 
-  | Property                  | Description                                        | Type       | Condition                         | Supported operations |
-  | :-----------------------: | -------------------------------------------------- | ---------- | --------------------------------- | -------------------- |
-  | maximumAttachmentFileSize | The maximum allowed size of an attachment in Bytes | Integer    |                                   | READ                 |
-  | perPageOptions            | Page size steps to be offered in paginated list UI | Integer[]  |                                   | READ                 |
-  | hostName                  | The host name configured for the system            | String     |                                   | READ                 |
+  | Property                  | Description                                        | Type       | Condition         | Supported operations |
+  | :-----------------------: | -------------------------------------------------- | ---------- | ----------------- | -------------------- |
+  | maximumAttachmentFileSize | The maximum allowed size of an attachment in Bytes | Integer    |                   | READ                 |
+  | perPageOptions            | Page size steps to be offered in paginated list UI | Integer[]  |                   | READ                 |
+  | hostName                  | The host name configured for the system            | String     |                   | READ                 |
+  | activeFeatureFlags        | The list of all feature flags that are active      | String[]   |                   | READ                 |
 name: Configuration

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -79,6 +79,13 @@ module API
                  },
                  render_nil: true
 
+        property :active_feature_flags,
+                 getter: ->(*) {
+                   OpenProject::FeatureDecisions
+                     .active
+                     .map { |flag| flag.camelize(:lower) }
+                 }
+
         property :user_preferences,
                  embedded: true,
                  exec_context: :decorator,

--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -1,0 +1,86 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  ##
+  # This module is the container for temporary or permanent feature flags.
+  #
+  # New feature flags can automatically be added by calling
+  #
+  #   OpenProject::Application.initializer 'set flag' do
+  #     OpenProject::FeatureDecisions.add :the_name_of_the_flag
+  #   end
+  #
+  # This will set up:
+  # * the method `.the_name_of_the_flag_active?` for querying the state
+  #   of the flag. By default, it is false.
+  # * fetching the overwritten value from
+  #   * ENV variable (`OPENPROJECT_THE_NAME_OF_THE_FLAG_ACTIVE = 'true'`)
+  #   * configuration.yml file (`the_name_of_the_flag_active: true`)
+  #   * from the settings database table (`Setting.feature_the_name_of_the_flag_active = true)
+  # * including the flag in the `.active` array in case it is enabled
+  # * including the flag in the `.all`
+  #
+  # The setup should be carried out inside an initializer for the overwriting from ENV or configuration.yml
+  # to be picked up.
+  #
+  # A spec in which such a flag is to be enabled can do so via:
+  #
+  #   context 'some description', with_flag: { the_name_of_the_flag: true } do
+  #     ...
+  #   end
+  #
+  module FeatureDecisions
+    module_function
+
+    def add(flag_name)
+      all << flag_name
+      define_flag_methods(flag_name)
+      define_setting_definition(flag_name)
+    end
+
+    def active
+      all.filter { |flag_name| send("#{flag_name}_active?") }.map(&:to_s)
+    end
+
+    def all
+      @all ||= []
+    end
+
+    def define_flag_methods(flag_name)
+      define_singleton_method "#{flag_name}_active?" do
+        Setting.send("feature_#{flag_name}_active?")
+      end
+    end
+
+    def define_setting_definition(flag_name)
+      Settings::Definition.add :"feature_#{flag_name}_active",
+                               default: false
+    end
+  end
+end

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -29,19 +29,6 @@
 require 'spec_helper'
 
 describe Settings::Definition do
-  shared_context 'with clean definitions' do
-    let!(:definitions_before) { described_class.all.dup }
-
-    before do
-      described_class.send(:reset)
-    end
-
-    after do
-      described_class.send(:reset)
-      described_class.instance_variable_set(:@all, definitions_before)
-    end
-  end
-
   describe '.all' do
     subject(:all) { described_class.all }
 
@@ -71,7 +58,7 @@ describe Settings::Definition do
     end
 
     context 'when overriding from ENV' do
-      include_context 'with clean definitions'
+      include_context 'with clean setting definitions'
 
       def value_for(name)
         all.detect { |d| d.name == name }.value
@@ -375,7 +362,7 @@ describe Settings::Definition do
     end
 
     context 'when overriding from file' do
-      include_context 'with clean definitions'
+      include_context 'with clean setting definitions'
 
       let(:file_contents) do
         <<~YAML
@@ -505,7 +492,7 @@ describe Settings::Definition do
     end
 
     context 'when adding an additional setting' do
-      include_context 'with clean definitions'
+      include_context 'with clean setting definitions'
 
       it 'includes the setting' do
         all
@@ -551,7 +538,7 @@ describe Settings::Definition do
     end
 
     context 'when adding a setting late' do
-      include_context 'with clean definitions'
+      include_context 'with clean setting definitions'
       let(:key) { 'bogus' }
 
       before do
@@ -978,7 +965,7 @@ describe Settings::Definition do
   end
 
   describe '#on_change' do
-    include_context 'with clean definitions'
+    include_context 'with clean setting definitions'
 
     context 'for a definition with a callback' do
       let(:callback) { -> { 'foobar ' } }

--- a/spec/lib/api/v3/configuration/configuration_representer_spec.rb
+++ b/spec/lib/api/v3/configuration/configuration_representer_spec.rb
@@ -44,34 +44,34 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
     described_class.new(represented, current_user:, embed_links:)
   end
 
-  context 'generation' do
-    subject { representer.to_json }
+  subject { representer.to_json }
 
-    describe '_links' do
-      it_behaves_like 'has an untitled link' do
-        let(:link) { 'self' }
-        let(:href) { api_v3_paths.configuration }
+  describe '_links' do
+    it_behaves_like 'has an untitled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.configuration }
+    end
+
+    describe 'userPreferences' do
+      context 'if logged in' do
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'userPreferences' }
+          let(:href) { api_v3_paths.user_preferences(current_user.id) }
+        end
       end
 
-      context 'userPreferences' do
-        context 'if logged in' do
-          it_behaves_like 'has an untitled link' do
-            let(:link) { 'userPreferences' }
-            let(:href) { api_v3_paths.user_preferences(current_user.id) }
-          end
-        end
+      context 'if not logged in' do
+        let(:current_user) { build_stubbed(:anonymous) }
 
-        context 'if not logged in' do
-          let(:current_user) { build_stubbed(:anonymous) }
-
-          it_behaves_like 'has an untitled link' do
-            let(:link) { 'userPreferences' }
-            let(:href) { api_v3_paths.user_preferences(current_user.id) }
-          end
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'userPreferences' }
+          let(:href) { api_v3_paths.user_preferences(current_user.id) }
         end
       end
     end
+  end
 
+  describe 'properties' do
     it 'indicates its type' do
       expect(subject).to be_json_eql('Configuration'.to_json).at_path('_type')
     end
@@ -86,7 +86,7 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
       expect(subject).to be_json_eql([1, 50, 100].to_json).at_path('perPageOptions')
     end
 
-    context 'timeFormat' do
+    describe 'timeFormat' do
       context 'with time format', with_settings: { time_format: '%I:%M %p' } do
         it 'indicates the timeFormat' do
           expect(subject)
@@ -112,7 +112,7 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
       end
     end
 
-    context 'dateFormat' do
+    describe 'dateFormat' do
       context 'without a date format', with_settings: { date_format: '' } do
         it 'indicates the dateFormat' do
           expect(subject)
@@ -122,14 +122,6 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
       end
 
       context 'with date format (%Y-%m-%d)', with_settings: { date_format: '%Y-%m-%d' } do
-        it 'indicates the dateFormat' do
-          expect(subject)
-            .to be_json_eql('YYYY-MM-DD'.to_json)
-            .at_path('dateFormat')
-        end
-      end
-
-      context 'with date format (%d/%m/%Y)', with_settings: { date_format: '%Y-%m-%d' } do
         it 'indicates the dateFormat' do
           expect(subject)
             .to be_json_eql('YYYY-MM-DD'.to_json)
@@ -194,7 +186,7 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
       end
     end
 
-    context 'startOfWeek' do
+    describe 'startOfWeek' do
       context 'without a setting', with_settings: { start_of_week: '' } do
         it 'is null' do
           expect(subject)
@@ -212,23 +204,47 @@ describe ::API::V3::Configuration::ConfigurationRepresenter do
       end
     end
 
-    describe '_embedded' do
-      context 'userPreferences' do
-        context 'if embedding' do
-          let(:embed_links) { true }
+    describe 'activeFeatureFlags' do
+      context 'without any active flags' do
+        it 'is an empty array' do
+          expect(subject)
+            .to be_json_eql([].to_json)
+                  .at_path('activeFeatureFlags')
+        end
+      end
 
-          it 'embedds the user preferences' do
-            expect(subject)
-              .to be_json_eql('UserPreferences'.to_json)
-              .at_path('_embedded/userPreferences/_type')
-          end
+      context 'with active flags' do
+        before do
+          allow(OpenProject::FeatureDecisions)
+            .to receive(:active)
+                  .and_return(%w(the active_flags))
         end
 
-        context 'if not embedding' do
-          it 'embedds the user preferences' do
-            expect(subject)
-              .not_to have_json_path('_embedded/userPreferences/_type')
-          end
+        it 'is an array of strings of those flags' do
+          expect(subject)
+            .to be_json_eql(%w(the activeFlags).to_json)
+                  .at_path('activeFeatureFlags')
+        end
+      end
+    end
+  end
+
+  describe '_embedded' do
+    describe 'userPreferences' do
+      context 'if embedding' do
+        let(:embed_links) { true }
+
+        it 'embedds the user preferences' do
+          expect(subject)
+            .to be_json_eql('UserPreferences'.to_json)
+            .at_path('_embedded/userPreferences/_type')
+        end
+      end
+
+      context 'if not embedding' do
+        it 'embedds the user preferences' do
+          expect(subject)
+            .not_to have_json_path('_embedded/userPreferences/_type')
         end
       end
     end

--- a/spec/lib/open_project/feature_decisions_spec.rb
+++ b/spec/lib/open_project/feature_decisions_spec.rb
@@ -1,0 +1,97 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+require 'spec_helper'
+
+describe OpenProject::FeatureDecisions do
+  let(:flag_name) { :example_flag }
+
+  include_context 'with clean feature decisions'
+
+  shared_context 'when adding without env variable' do
+    before do
+      described_class.add flag_name
+    end
+  end
+
+  shared_context 'when adding with env variable set to true' do
+    before do
+      stub_const('ENV', 'OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE' => 'true')
+
+      described_class.add flag_name
+    end
+  end
+
+  include_context 'with clean setting definitions'
+
+  describe '`flag_name`_active?' do
+    context 'without an ENV variable' do
+      include_context 'when adding without env variable'
+
+      it 'is false by default' do
+        expect(described_class.send("#{flag_name}_active?"))
+          .to be false
+      end
+    end
+
+    context 'with an ENV variable (set to true)' do
+      include_context 'when adding with env variable set to true'
+
+      it 'is true' do
+        expect(described_class.send("#{flag_name}_active?"))
+          .to be true
+      end
+    end
+  end
+
+  describe 'active' do
+    context 'without any flags defined' do
+      it 'returns an empty array' do
+        expect(described_class.active)
+          .to eq []
+      end
+    end
+
+    context 'with a flag defined but not enabled' do
+      include_context 'when adding without env variable'
+
+      it 'returns an empty array' do
+        expect(described_class.active)
+          .to eq []
+      end
+    end
+
+    context 'with a flag defined that is enabled via env' do
+      include_context 'when adding with env variable set to true'
+
+      it 'returns an empty array' do
+        expect(described_class.active)
+          .to eq [flag_name.to_s]
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/configuration_resource_spec.rb
+++ b/spec/requests/api/v3/configuration_resource_spec.rb
@@ -36,17 +36,15 @@ describe 'API v3 Configuration resource', type: :request do
   let(:user) { create(:user) }
   let(:configuration_path) { api_v3_paths.configuration }
 
-  subject(:response) { last_response }
+  current_user { user }
 
-  before do
-    login_as(user)
+  subject(:response) do
+    get configuration_path
+
+    last_response
   end
 
   describe '#GET' do
-    before do
-      get configuration_path
-    end
-
     it 'returns 200 OK' do
       expect(subject.status).to eq(200)
     end
@@ -54,28 +52,50 @@ describe 'API v3 Configuration resource', type: :request do
     it 'returns the configuration', with_settings: { per_page_options: '3, 5, 8, 13' } do
       expect(subject.body)
         .to be_json_eql('Configuration'.to_json)
-        .at_path("_type")
+              .at_path("_type")
 
       expect(subject.body)
         .to be_json_eql([3, 5, 8, 13].to_json)
-        .at_path('perPageOptions')
+              .at_path('perPageOptions')
     end
 
     it 'embedds the current user preferences' do
       expect(subject.body)
         .to be_json_eql('UserPreferences'.to_json)
-        .at_path('_embedded/userPreferences/_type')
+              .at_path('_embedded/userPreferences/_type')
+    end
+
+    it 'does not embed the preferences' do
+      expect(subject.body)
+        .not_to have_json_path('_embedded/user_preferences')
+    end
+
+    context 'with feature flags' do
+      include_context 'with clean setting definitions'
+
+      before do
+        stub_const('ENV',
+                   'OPENPROJECT_FEATURE_AN_EXAMPLE_ACTIVE' => 'true',
+                   'OPENPROJECT_FEATURE_ANOTHER_EXAMPLE_ACTIVE' => 'true',
+                   'OPENPROJECT_FEATURE_INACTIVE_EXAMPLE_ACTIVE' => 'false')
+
+        OpenProject::FeatureDecisions.add :an_example
+        OpenProject::FeatureDecisions.add :another_example
+        OpenProject::FeatureDecisions.add :deactivated_example
+        OpenProject::FeatureDecisions.add :default_example
+      end
+
+      it 'lists the active feature flags' do
+        expect(subject.body)
+          .to be_json_eql(%w[anExample anotherExample].to_json)
+                .at_path('activeFeatureFlags')
+      end
     end
 
     context 'for a non logged in user' do
       it 'returns 200 OK' do
         expect(subject.status).to eq(200)
       end
-    end
-
-    it 'does not embed the preferences' do
-      expect(subject.body)
-        .not_to have_json_path('_embedded/user_preferences')
     end
   end
 end

--- a/spec/support/clean_feature_decisions.rb
+++ b/spec/support/clean_feature_decisions.rb
@@ -26,18 +26,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject
-  module FeatureDecisions
-    ##
-    # This module is the container for the temporary or permanent feature flags.
-    # Having a flag method instead of a plain Setting, enables
-    # incorporating more logic into flags, such as release date restrictions.
-    #
-    # For example:
-    #
-    #   def self.your_module_active?
-    #     release_date = Date.new(2022,01,01)
-    #     Setting.feature_your_module_active || Date.today > release_date
-    #   end
+RSpec.shared_context 'with clean feature decisions' do
+  let!(:decisions_before) { OpenProject::FeatureDecisions.all.dup }
+
+  before do
+    OpenProject::FeatureDecisions.instance_variable_set(:@all, [])
+  end
+
+  after do
+    OpenProject::FeatureDecisions.instance_variable_set(:@all, decisions_before)
   end
 end

--- a/spec/support/settings/clean_definitions.rb
+++ b/spec/support/settings/clean_definitions.rb
@@ -1,0 +1,40 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+RSpec.shared_context 'with clean setting definitions' do
+  let!(:definitions_before) { Settings::Definition.all.dup }
+
+  before do
+    Settings::Definition.send(:reset)
+  end
+
+  after do
+    Settings::Definition.send(:reset)
+    Settings::Definition.instance_variable_set(:@all, definitions_before)
+  end
+end

--- a/spec/support/shared/with_flag.rb
+++ b/spec/support/shared/with_flag.rb
@@ -29,7 +29,7 @@ module WithFlagMixin
 
   def with_flags(flags)
     flags.each do |k, value|
-      name = k.end_with?('?') ? k : "#{k}?"
+      name = "#{/(?:feature_)?(\w+?)(?:_active)?\??$/.match(k)[1]}_active?"
 
       raise "#{k} is not a valid flag" unless OpenProject::FeatureDecisions.respond_to?(name)
 


### PR DESCRIPTION
Defined feature flags are both set up to be picked up from ENV and configuration.yml as well as being listed in /api/v3/configuration endpoint.

Adding a feature flag is now quite trivial both from within the core as well as from a module.

https://community.openproject.org/wp/44817