### PR TITLE
avoid call to super removed in fb6d85d50b

### DIFF
--- a/modules/avatars/app/helpers/avatar_helper.rb
+++ b/modules/avatars/app/helpers/avatar_helper.rb
@@ -58,7 +58,7 @@ module AvatarHelper
     elsif avatar_manager.gravatar_enabled?
       build_gravatar_image_url user, options
     else
-      super
+      ''.html_safe
     end
   rescue StandardError => e
     Rails.logger.error "Failed to create avatar url for #{user}: #{e}"


### PR DESCRIPTION
fb6d85d50b removed the super method. Because of the `rescue`, the error never surfaced.