### PR TITLE
Add date alerts to reasons

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -591,6 +591,11 @@ en:
         processed: 'processed'
         prioritized: 'prioritized'
         dateAlert: 'Date alert'
+      date_alerts:
+        work_package_is: 'Work package is'
+        overdue_since: 'Overdue since %{difference_in_days}'
+        property_is: '%{property} is in %{difference_in_days}'
+        property_was: '%{property} was %{difference_in_days} ago'
       facets:
         unread: 'Unread'
         unread_title: 'Show unread'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -590,6 +590,7 @@ en:
         commented: 'commented'
         processed: 'processed'
         prioritized: 'prioritized'
+        dateAlert: 'Date alert'
       facets:
         unread: 'Unread'
         unread_title: 'Show unread'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -592,7 +592,7 @@ en:
         prioritized: 'prioritized'
         dateAlert: 'Date alert'
       date_alerts:
-        work_package_is: 'Work package is'
+        milestone_date: 'Milestone date'
         overdue: 'Overdue'
         overdue_since: 'since %{difference_in_days}'
         property_is: 'is in %{difference_in_days}'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -597,6 +597,7 @@ en:
         overdue_since: 'since %{difference_in_days}'
         property_is: 'is in %{difference_in_days}'
         property_was: 'was %{difference_in_days} ago'
+        property_is_deleted: 'is deleted'
       facets:
         unread: 'Unread'
         unread_title: 'Show unread'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -595,6 +595,7 @@ en:
         milestone_date: 'Milestone date'
         overdue: 'Overdue'
         overdue_since: 'since %{difference_in_days}'
+        property_today: 'is today'
         property_is: 'is in %{difference_in_days}'
         property_was: 'was %{difference_in_days} ago'
         property_is_deleted: 'is deleted'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -593,9 +593,10 @@ en:
         dateAlert: 'Date alert'
       date_alerts:
         work_package_is: 'Work package is'
-        overdue_since: 'Overdue since %{difference_in_days}'
-        property_is: '%{property} is in %{difference_in_days}'
-        property_was: '%{property} was %{difference_in_days} ago'
+        overdue: 'Overdue'
+        overdue_since: 'since %{difference_in_days}'
+        property_is: 'is in %{difference_in_days}'
+        property_was: 'was %{difference_in_days} ago'
       facets:
         unread: 'Unread'
         unread_title: 'Show unread'

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -92,6 +92,9 @@ module.exports = {
         // destructuring doesn't always look better, only when object/array destructuring
         "prefer-destructuring": "off",
 
+        // Sometimes, arrow functions implicit return looks better below, so allow both
+        "implicit-arrow-linebreak": "off",
+
         // No void at all collides with `@typescript-eslint/no-floating-promises` which wants us to handle each promise.
         // Until we do that, `void` is a good way to explicitly mark unhandled promises. 
         "no-void": ["error", { allowAsStatement: true }],

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
@@ -12,6 +12,8 @@ export interface IInAppNotificationHalResourceLinks extends IHalResourceLinks {
   resource:IHalResourceLink;
   activity:IHalResourceLink;
 }
+export interface IInAppNotificationHalResourceEmbedded {
+}
 
 export interface INotification {
   id:ID;
@@ -28,4 +30,5 @@ export interface INotification {
   expanded:boolean;
 
   _links:IInAppNotificationHalResourceLinks;
+  _embedded:IInAppNotificationHalResourceEmbedded;
 }

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
@@ -17,7 +17,7 @@ export type IInAppNotificationDetailsAttribute = 'startDate'|'dueDate'|'date';
 
 export interface IInAppNotificationDetailsResource {
   property:IInAppNotificationDetailsAttribute;
-  value:string;
+  value:string|null;
 
   _links:{
     self:IHalResourceLink;

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notification.model.ts
@@ -12,7 +12,21 @@ export interface IInAppNotificationHalResourceLinks extends IHalResourceLinks {
   resource:IHalResourceLink;
   activity:IHalResourceLink;
 }
+
+export type IInAppNotificationDetailsAttribute = 'startDate'|'dueDate'|'date';
+
+export interface IInAppNotificationDetailsResource {
+  property:IInAppNotificationDetailsAttribute;
+  value:string;
+
+  _links:{
+    self:IHalResourceLink;
+    schema:IHalResourceLink;
+  };
+}
+
 export interface IInAppNotificationHalResourceEmbedded {
+  details:IInAppNotificationDetailsResource[];
 }
 
 export interface INotification {

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -6,6 +6,7 @@ import {
   debounceTime,
   defaultIfEmpty,
   distinctUntilChanged,
+  filter,
   map,
   mapTo,
   pluck,
@@ -80,6 +81,15 @@ export class IanCenterService extends UntilDestroyedMixin {
   paramsChanges$ = this.query.select(['params', 'activeFacet']);
 
   activeCollection$ = this.query.select('activeCollection');
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  activeReason$:Observable<string|undefined> = this.uiRouterGlobals.params$!.pipe(
+    this.untilDestroyed(),
+    distinctUntilChanged(),
+    filter((params) => params.filter === 'reason'),
+    map((params) => params.name as string),
+    shareReplay(1),
+  );
 
   loading$:Observable<boolean> = this.query.selectLoading();
 

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -83,11 +83,10 @@ export class IanCenterService extends UntilDestroyedMixin {
   activeCollection$ = this.query.select('activeCollection');
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  activeReason$:Observable<string|undefined> = this.uiRouterGlobals.params$!.pipe(
+  activeReason$:Observable<string|null> = this.uiRouterGlobals.params$!.pipe(
     this.untilDestroyed(),
     distinctUntilChanged(),
-    filter((params) => params.filter === 'reason'),
-    map((params) => params.name as string),
+    map((params) => params.filter === 'reason' ? (params.name as string) : null),
     shareReplay(1),
   );
 

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -6,7 +6,6 @@ import {
   debounceTime,
   defaultIfEmpty,
   distinctUntilChanged,
-  filter,
   map,
   mapTo,
   pluck,
@@ -86,7 +85,13 @@ export class IanCenterService extends UntilDestroyedMixin {
   activeReason$:Observable<string|null> = this.uiRouterGlobals.params$!.pipe(
     this.untilDestroyed(),
     distinctUntilChanged(),
-    map((params) => params.filter === 'reason' ? (params.name as string) : null),
+    map((params) => {
+      if (params.filter === 'reason') {
+        return params.name as string;
+      }
+
+      return null;
+    }),
     shareReplay(1),
   );
 

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
@@ -1,27 +1,21 @@
-<div class="op-ian-actors">
-  <div
-    class="op-ian-actors--date"
-    [title]="fixedTime"
-    [textContent]="relativeTime$ | async"
-  ></div>
-  <div>
-    <ng-container *ngFor="let actor of actors | slice:0:3; let last = last">
-          <span *ngIf="last && actors.length > 1 && actors.length < 4">
-            {{ text.and }}
-          </span>
-      <op-principal
-        class="op-ian-item--actors"
-        [principal]="actor"
-        [hideName]="false"
-        [hideAvatar]="true"
-        [link]="!isMobile()"
-      ></op-principal>
-      <span *ngIf="!last && actors.length > 2" [textContent]="', '"></span>
-    </ng-container>
-    <span
-      *ngIf="actors.length > 3"
-    >
-    {{ text_for_additional_authors(actors.length - 3) }}
-  </span>
-  </div>
+<div
+  class="op-ian-actors--date"
+  [title]="fixedTime"
+  [textContent]="relativeTime$ | async"
+></div>
+<div>
+  <ng-container *ngFor="let actor of actors | slice:0:3; let last = last">
+      <span *ngIf="last && actors.length > 1 && actors.length < 4">
+        {{ text.and }}
+      </span>
+    <op-principal
+      class="op-ian-item--actors"
+      [principal]="actor"
+      [hideName]="false"
+      [hideAvatar]="true"
+      [link]="!deviceService.isMobile"
+    ></op-principal>
+    <span *ngIf="!last && actors.length > 2" [textContent]="', '"></span>
+  </ng-container>
+  <span *ngIf="actors.length > 3" [textContent]="text_for_additional_authors(actors.length - 3) "></span>
 </div>

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
@@ -1,0 +1,27 @@
+<div class="op-ian-actors">
+  <div
+    class="op-ian-actors--date"
+    [title]="fixedTime"
+    [textContent]="relativeTime$ | async"
+  ></div>
+  <div>
+    <ng-container *ngFor="let actor of actors | slice:0:3; let last = last">
+          <span *ngIf="last && actors.length > 1 && actors.length < 4">
+            {{ text.and }}
+          </span>
+      <op-principal
+        class="op-ian-item--actors"
+        [principal]="actor"
+        [hideName]="false"
+        [hideAvatar]="true"
+        [link]="!isMobile()"
+      ></op-principal>
+      <span *ngIf="!last && actors.length > 2" [textContent]="', '"></span>
+    </ng-container>
+    <span
+      *ngIf="actors.length > 3"
+    >
+    {{ text_for_additional_authors(actors.length - 3) }}
+  </span>
+  </div>
+</div>

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
@@ -3,7 +3,7 @@
 .op-ian-actors
   display: grid
   grid-template-columns: auto 1fr
-  grid-column-gap: 5px
+  grid-column-gap: $spot-spacing-0_25
   align-items: center
   color: var(--gray-dark)
 

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
@@ -1,0 +1,16 @@
+@import "src/assets/sass/helpers"
+
+.op-ian-actors
+  display: grid
+  grid-template-columns: auto 1fr
+  grid-column-gap: 5px
+  align-items: center
+  color: var(--gray-dark)
+
+  &--line
+    vertical-align: baseline
+
+  &--date
+    @include text-shortener
+    max-width: 100%
+    line-height: 16px

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -70,9 +70,9 @@ export class InAppNotificationActorsLineComponent implements OnInit {
   text_for_additional_authors(number:number):string {
     if (number === 1) {
       return this.text.and_other_singular;
-    } else {
-      return this.text.and_other_plural(number);
     }
+
+    return this.text.and_other_plural(number);
   }
 
   private buildTime() {

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  HostBinding,
   Input,
   OnInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { PrincipalLike } from 'core-app/shared/components/principal/principal-types';
@@ -23,8 +25,11 @@ import { DeviceService } from 'core-app/core/browser/device.service';
   templateUrl: './in-app-notification-actors-line.component.html',
   styleUrls: ['./in-app-notification-actors-line.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
 })
 export class InAppNotificationActorsLineComponent implements OnInit {
+  @HostBinding('class.op-ian-actors') className = true;
+
   @Input() aggregatedNotifications:INotification[];
 
   @Input() notification:INotification;
@@ -52,9 +57,9 @@ export class InAppNotificationActorsLineComponent implements OnInit {
   };
 
   constructor(
+    readonly deviceService:DeviceService,
     private I18n:I18nService,
     private timezoneService:TimezoneService,
-    private deviceService:DeviceService,
   ) { }
 
   ngOnInit():void {
@@ -62,18 +67,12 @@ export class InAppNotificationActorsLineComponent implements OnInit {
     this.buildTime();
   }
 
-  isMobile():boolean {
-    return this.deviceService.isMobile;
-  }
-
   text_for_additional_authors(number:number):string {
-    let hint:string;
     if (number === 1) {
-      hint = this.text.and_other_singular;
+      return this.text.and_other_singular;
     } else {
-      hint = this.text.and_other_plural(number);
+      return this.text.and_other_plural(number);
     }
-    return hint;
   }
 
   private buildTime() {

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -1,0 +1,109 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
+import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
+import { PrincipalLike } from 'core-app/shared/components/principal/principal-types';
+import {
+  Observable,
+  timer,
+} from 'rxjs';
+import {
+  distinctUntilChanged,
+  map,
+} from 'rxjs/operators';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { DeviceService } from 'core-app/core/browser/device.service';
+
+@Component({
+  selector: 'op-in-app-notification-actors-line',
+  templateUrl: './in-app-notification-actors-line.component.html',
+  styleUrls: ['./in-app-notification-actors-line.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InAppNotificationActorsLineComponent implements OnInit {
+  @Input() aggregatedNotifications:INotification[];
+
+  @Input() notification:INotification;
+
+  // The actor, if any
+  actors:PrincipalLike[] = [];
+
+  // Fixed notification time
+  fixedTime:string;
+
+  // Format relative elapsed time (n seconds/minutes/hours ago)
+  // at an interval for auto updating
+  relativeTime$:Observable<string>;
+
+  text = {
+    and: this.I18n.t('js.notifications.center.label_actor_and'),
+    and_other_singular: this.I18n.t('js.notifications.center.and_more_users.one'),
+    and_other_plural: (count:number):string => this.I18n.t('js.notifications.center.and_more_users.other',
+      { count }),
+    loading: this.I18n.t('js.ajax.loading'),
+    placeholder: this.I18n.t('js.placeholders.default'),
+    mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
+    updated_by_at: (age:string):string => this.I18n.t('js.notifications.center.text_update_date',
+      { date: age }),
+  };
+
+  constructor(
+    private I18n:I18nService,
+    private timezoneService:TimezoneService,
+    private deviceService:DeviceService,
+  ) { }
+
+  ngOnInit():void {
+    this.buildActors();
+    this.buildTime();
+  }
+
+  isMobile():boolean {
+    return this.deviceService.isMobile;
+  }
+
+  text_for_additional_authors(number:number):string {
+    let hint:string;
+    if (number === 1) {
+      hint = this.text.and_other_singular;
+    } else {
+      hint = this.text.and_other_plural(number);
+    }
+    return hint;
+  }
+
+  private buildTime() {
+    this.fixedTime = this.timezoneService.formattedDatetime(this.notification.createdAt);
+    this.relativeTime$ = timer(0, 10000)
+      .pipe(
+        map(() => this.text.updated_by_at(
+          this.timezoneService.formattedRelativeDateTime(this.notification.createdAt),
+        )),
+        distinctUntilChanged(),
+      );
+  }
+
+  private buildActors() {
+    const actors = this
+      .aggregatedNotifications
+      .map((notification) => {
+        const { actor } = notification._links;
+
+        if (!actor) {
+          return null;
+        }
+
+        return {
+          href: actor.href,
+          name: actor.title,
+        };
+      })
+      .filter((actor) => actor !== null) as PrincipalLike[];
+
+    this.actors = _.uniqBy(actors, (item) => item.href);
+  }
+}

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
@@ -1,0 +1,1 @@
+<p>in-app-notification-date-alert works!</p>

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
@@ -1,12 +1,7 @@
-<div
-  class="op-ian-date-alert"
-  [ngClass]="{ 'op-ian-date-alert_overdue': isOverdue }"
->
-  <span
-    class="op-ian-date-alert--property"
-    [textContent]="propertyText"></span>
-  &ngsp;
-  <span
-    class="op-ian-date-alert--days"
-    [textContent]="alertText"></span>
-</div>
+<span
+  class="op-ian-date-alert--property"
+  [textContent]="propertyText"></span>
+&ngsp;
+<span
+  class="op-ian-date-alert--days"
+  [textContent]="alertText"></span>

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
@@ -1,7 +1,12 @@
 <div
   class="op-ian-date-alert"
+  [ngClass]="{ 'op-ian-date-alert_overdue': isOverdue }"
 >
   <span
-    [ngClass]="{ 'op-ian-date-alert_overdue': isOverdue }"
+    class="op-ian-date-alert--property"
+    [textContent]="propertyText"></span>
+  &ngsp;
+  <span
+    class="op-ian-date-alert--days"
     [textContent]="alertText"></span>
 </div>

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.html
@@ -1,1 +1,7 @@
-<p>in-app-notification-date-alert works!</p>
+<div
+  class="op-ian-date-alert"
+>
+  <span
+    [ngClass]="{ 'op-ian-date-alert_overdue': isOverdue }"
+    [textContent]="alertText"></span>
+</div>

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
@@ -1,0 +1,3 @@
+.op-ian-date-alert
+  &_overdue
+    color: var(--warn)

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
@@ -1,3 +1,8 @@
 .op-ian-date-alert
+  color: var(--gray-dark)
+
   &_overdue
     color: var(--warn)
+
+  &--property
+    font-weight: bold

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -19,9 +19,6 @@ import { Moment } from 'moment';
   styleUrls: ['./in-app-notification-date-alert.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: {
-    class: 'op-ian-date-alert'
-  }
 })
 export class InAppNotificationDateAlertComponent implements OnInit {
   @Input() aggregatedNotifications:INotification[];

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -48,7 +48,7 @@ export class InAppNotificationDateAlertComponent implements OnInit {
       this.I18n.t('js.notifications.date_alerts.property_was', { difference_in_days }),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
     dueDate: this.I18n.t('js.work_packages.properties.dueDate'),
-    date: this.I18n.t('js.work_packages.properties.date'),
+    date: this.I18n.t('js.notifications.date_alerts.milestone_date'),
   };
 
   constructor(

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -33,17 +33,19 @@ export class InAppNotificationDateAlertComponent implements OnInit {
 
   isOverdue:boolean;
 
-  private propertyText:string;
+  propertyText:string;
 
   private daysDiff:string;
 
   text = {
     work_package_is: this.I18n.t('js.notifications.date_alerts.work_package_is'),
-    overdue_since: (difference_in_days:string) => this.I18n.t('js.notifications.date_alerts.overdue_since', { difference_in_days }),
-    property_is: (property:string, difference_in_days:string) =>
-      this.I18n.t('js.notifications.date_alerts.property_is', { property, difference_in_days }),
-    property_was: (property:string, difference_in_days:string) =>
-      this.I18n.t('js.notifications.date_alerts.property_was', { property, difference_in_days }),
+    overdue: this.I18n.t('js.notifications.date_alerts.overdue'),
+    overdue_since: (difference_in_days:string):string =>
+      this.I18n.t('js.notifications.date_alerts.overdue_since', { difference_in_days }),
+    property_is: (difference_in_days:string):string =>
+      this.I18n.t('js.notifications.date_alerts.property_is', { difference_in_days }),
+    property_was: (difference_in_days:string):string =>
+      this.I18n.t('js.notifications.date_alerts.property_was', { difference_in_days }),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
     dueDate: this.I18n.t('js.work_packages.properties.dueDate'),
     date: this.I18n.t('js.work_packages.properties.date'),
@@ -61,7 +63,7 @@ export class InAppNotificationDateAlertComponent implements OnInit {
     this.dateIsPast = dateValue.isBefore();
     this.isOverdue = this.dateIsPast && ['date', 'dueDate'].includes(property);
     this.daysDiff = this.dateDiff(dateValue);
-    this.propertyText = this.text[property] || property;
+    this.propertyText = this.isOverdue ? this.text.overdue : this.text[property];
     this.alertText = this.buildAlertText();
   }
 
@@ -71,10 +73,10 @@ export class InAppNotificationDateAlertComponent implements OnInit {
     }
 
     if (this.dateIsPast) {
-      return this.text.property_was(this.propertyText, this.daysDiff);
+      return this.text.property_was(this.daysDiff);
     }
 
-    return this.text.property_is(this.propertyText, this.daysDiff);
+    return this.text.property_is(this.daysDiff);
   }
 
   private dateDiff(reference:Moment):string {

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -46,6 +46,7 @@ export class InAppNotificationDateAlertComponent implements OnInit {
       this.I18n.t('js.notifications.date_alerts.property_is', { difference_in_days }),
     property_was: (difference_in_days:string):string =>
       this.I18n.t('js.notifications.date_alerts.property_was', { difference_in_days }),
+    property_deleted: this.I18n.t('js.notifications.date_alerts.property_is_deleted'),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
     dueDate: this.I18n.t('js.work_packages.properties.dueDate'),
     date: this.I18n.t('js.notifications.date_alerts.milestone_date'),
@@ -62,7 +63,17 @@ export class InAppNotificationDateAlertComponent implements OnInit {
 
     const detail = interestingAlert._embedded.details[0];
     const property = detail.property;
-    const dateValue = this.timezoneService.parseISODate(detail.value);
+
+    if (!detail.value) {
+      this.propertyText = this.text[property];
+      this.alertText = this.text.property_deleted;
+    } else {
+      this.deriveDueDate(detail.value, property);
+    }
+  }
+
+  private deriveDueDate(value:string, property:'startDate'|'dueDate'|'date') {
+    const dateValue = this.timezoneService.parseISODate(value);
     this.dateIsPast = dateValue.isBefore();
     this.isOverdue = this.dateIsPast && ['date', 'dueDate'].includes(property);
     this.daysDiff = this.dateDiff(dateValue);

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  HostBinding,
   Input,
   OnInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -16,17 +18,23 @@ import { Moment } from 'moment';
   templateUrl: './in-app-notification-date-alert.component.html',
   styleUrls: ['./in-app-notification-date-alert.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'op-ian-date-alert'
+  }
 })
 export class InAppNotificationDateAlertComponent implements OnInit {
   @Input() aggregatedNotifications:INotification[];
 
   @Input() workPackage:WorkPackageResource;
 
+  @HostBinding('class.op-ian-date-alert') className = true;
+
+  @HostBinding('class.op-ian-date-alert_overdue') isOverdue:boolean;
+
   alertText:string;
 
   dateIsPast:boolean;
-
-  isOverdue:boolean;
 
   propertyText:string;
 

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -1,0 +1,69 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+} from '@angular/core';
+import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
+import { PrincipalLike } from 'core-app/shared/components/principal/principal-types';
+import { Observable } from 'rxjs';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { DeviceService } from 'core-app/core/browser/device.service';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
+
+@Component({
+  selector: 'op-in-app-notification-date-alert',
+  templateUrl: './in-app-notification-date-alert.component.html',
+  styleUrls: ['./in-app-notification-date-alert.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class InAppNotificationDateAlertComponent implements OnInit {
+  @Input() aggregatedNotifications:INotification[];
+
+  @Input() notification:INotification;
+
+  @Input() workPackage:WorkPackageResource;
+
+  text = {
+    and: this.I18n.t('js.notifications.center.label_actor_and'),
+    and_other_singular: this.I18n.t('js.notifications.center.and_more_users.one'),
+    and_other_plural: (count:number):string => this.I18n.t('js.notifications.center.and_more_users.other',
+      { count }),
+    loading: this.I18n.t('js.ajax.loading'),
+    placeholder: this.I18n.t('js.placeholders.default'),
+    mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
+    updated_by_at: (age:string):string => this.I18n.t('js.notifications.center.text_update_date',
+      { date: age }),
+  };
+
+  constructor(
+    private I18n:I18nService,
+    private timezoneService:TimezoneService,
+    private deviceService:DeviceService,
+    private schemaCache:SchemaCacheService,
+  ) { }
+
+  ngOnInit():void {
+    this.buildAlertText();
+  }
+
+  private buildAlertText() {
+    if (this.isOverdue) {
+      return;
+    }
+
+    if (this.isMilestone) {
+
+    }
+  }
+
+  private get isOverdue():boolean {
+    return false;
+  }
+
+  private get isMilestone():boolean {
+    return this.schemaCache.of(this.workPackage).isMilestone as boolean;
+  }
+}

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -87,15 +87,15 @@
     <div
       class="op-ian-item--bottom-line"
     >
-      <ng-container *ngIf="(showDateAlert$ | async) as showDateAlert">
+      <ng-container *ngIf="{ showDateAlert: (showDateAlert$ | async) } as context">
         <op-in-app-notification-date-alert
-          *ngIf="showDateAlert"
+          *ngIf="context.showDateAlert"
           [workPackage]="workPackage"
           [notification]="notification"
           [aggregatedNotifications]="aggregatedNotifications"
         ></op-in-app-notification-date-alert>
         <op-in-app-notification-actors-line
-          *ngIf="!showDateAlert"
+          *ngIf="!context.showDateAlert"
           [notification]="notification"
           [aggregatedNotifications]="aggregatedNotifications"
         ></op-in-app-notification-actors-line>

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -91,7 +91,6 @@
         <op-in-app-notification-date-alert
           *ngIf="context.showDateAlert"
           [workPackage]="workPackage"
-          [notification]="notification"
           [aggregatedNotifications]="aggregatedNotifications"
         ></op-in-app-notification-date-alert>
         <op-in-app-notification-actors-line

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -87,10 +87,19 @@
     <div
       class="op-ian-item--bottom-line"
     >
-      <op-in-app-notification-actors-line
-        [notification]="notification"
-        [aggregatedNotifications]="aggregatedNotifications"
-      ></op-in-app-notification-actors-line>
+      <ng-container *ngIf="(showDateAlert$ | async) as showDateAlert">
+        <op-in-app-notification-date-alert
+          *ngIf="showDateAlert"
+          [workPackage]="workPackage"
+          [notification]="notification"
+          [aggregatedNotifications]="aggregatedNotifications"
+        ></op-in-app-notification-date-alert>
+        <op-in-app-notification-actors-line
+          *ngIf="!showDateAlert"
+          [notification]="notification"
+          [aggregatedNotifications]="aggregatedNotifications"
+        ></op-in-app-notification-actors-line>
+      </ng-container>
     </div>
   </ng-container>
   <ng-template #workPackageLoading>

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -87,31 +87,10 @@
     <div
       class="op-ian-item--bottom-line"
     >
-      <div
-        class="op-ian-item--date"
-        [title]="fixedTime"
-        [textContent]="relativeTime$ | async"
-      ></div>
-      <div>
-        <ng-container *ngFor ="let actor of actors | slice:0:3; let last = last">
-          <span *ngIf="last && actors.length > 1 && actors.length < 4">
-            {{ text.and }}
-          </span>
-          <op-principal
-            class="op-ian-item--actors"
-            [principal]="actor"
-            [hideName]="false"
-            [hideAvatar]="true"
-            [link]="!isMobile()"
-          ></op-principal>
-          <span *ngIf="!last && actors.length > 2" [textContent]="', '"></span>
-        </ng-container>
-        <span
-          *ngIf="actors.length > 3"
-        >
-          {{ text_for_additional_authors(actors.length - 3) }}
-        </span>
-      </div>
+      <op-in-app-notification-actors-line
+        [notification]="notification"
+        [aggregatedNotifications]="aggregatedNotifications"
+      ></op-in-app-notification-actors-line>
     </div>
   </ng-container>
   <ng-template #workPackageLoading>

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -66,11 +66,6 @@ $subject-font-size: 14px
 
   &--bottom-line
     grid-area: footer
-    display: grid
-    grid-template-columns: auto 1fr
-    grid-column-gap: 5px
-    align-items: center
-    color: var(--gray-dark)
 
   &--work-package-subject
     @include text-shortener
@@ -103,11 +98,6 @@ $subject-font-size: 14px
     color: var(--gray-dark)
     max-width: 100%
 
-  &--date
-    @include text-shortener
-    max-width: 100%
-    line-height: 16px
-
   &--status
     grid-area: status
     margin-right: 5px
@@ -137,7 +127,3 @@ $subject-font-size: 14px
     grid-template-columns: max-content auto minmax(20px, max-content)
     grid-template-areas: "loadingIndicator count buttons"
     grid-column-gap: 5px
-
-  &--actors
-    vertical-align: baseline
-  

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -7,13 +7,18 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import {
+  defaultIfEmpty,
   map,
+  shareReplay,
   startWith,
   tap,
 } from 'rxjs/operators';
@@ -41,15 +46,17 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   workPackage$:Observable<WorkPackageResource>|null = null;
 
-  dateAlertFiltered$:Observable<boolean> = this
+  showDateAlert$:Observable<boolean> = this
     .storeService
     .activeReason$
     .pipe(
       map((reason) => reason === 'date_alert'),
-      startWith(false),
+      map((dateAlertFiltered) => {
+        const dateAlerts = this.aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
+        return dateAlertFiltered || dateAlerts.length === this.aggregatedNotifications.length;
+      }),
+      shareReplay(1),
     );
-
-  showDateAlert$:Observable<boolean>;
 
   loading$ = this.storeService.query.selectLoading();
 
@@ -79,7 +86,6 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   ngOnInit():void {
     this.buildTranslatedReason();
-    this.buildDateAlert();
     this.buildProject();
     this.loadWorkPackage();
   }
@@ -152,16 +158,5 @@ export class InAppNotificationEntryComponent implements OnInit {
         showUrl: this.pathHelper.projectPath(idFromLink(project.href)),
       };
     }
-  }
-
-  private buildDateAlert() {
-    this.showDateAlert$ = this
-      .dateAlertFiltered$
-      .pipe(
-        map((dateAlertFiltered) => {
-          const dateAlerts = this.aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
-          return dateAlertFiltered || dateAlerts.length === this.aggregatedNotifications.length;
-        }),
-      );
   }
 }

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -7,20 +7,14 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import {
-  Observable,
-  of,
-} from 'rxjs';
+import { Observable } from 'rxjs';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import {
-  defaultIfEmpty,
   map,
   shareReplay,
-  startWith,
-  tap,
 } from 'rxjs/operators';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { take } from 'rxjs/internal/operators/take';

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -45,7 +45,6 @@ export class InAppNotificationEntryComponent implements OnInit {
     .storeService
     .activeReason$
     .pipe(
-      tap((x) => console.warn(x)),
       map((reason) => reason === 'date_alert'),
       startWith(false),
     );

--- a/frontend/src/app/features/in-app-notifications/in-app-notifications.module.ts
+++ b/frontend/src/app/features/in-app-notifications/in-app-notifications.module.ts
@@ -20,6 +20,7 @@ import { MarkAllAsReadButtonComponent } from './center/toolbar/mark-all-as-read/
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
 import { EmptyStateComponent } from './center/empty-state/empty-state.component';
 import { IanBellService } from 'core-app/features/in-app-notifications/bell/state/ian-bell.service';
+import { InAppNotificationActorsLineComponent } from './entry/actors-line/in-app-notification-actors-line.component';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import { IanBellService } from 'core-app/features/in-app-notifications/bell/stat
     MarkAllAsReadButtonComponent,
     IanMenuComponent,
     EmptyStateComponent,
+    InAppNotificationActorsLineComponent,
   ],
   imports: [
     OPSharedModule,

--- a/frontend/src/app/features/in-app-notifications/in-app-notifications.module.ts
+++ b/frontend/src/app/features/in-app-notifications/in-app-notifications.module.ts
@@ -21,6 +21,7 @@ import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-co
 import { EmptyStateComponent } from './center/empty-state/empty-state.component';
 import { IanBellService } from 'core-app/features/in-app-notifications/bell/state/ian-bell.service';
 import { InAppNotificationActorsLineComponent } from './entry/actors-line/in-app-notification-actors-line.component';
+import { InAppNotificationDateAlertComponent } from './entry/date-alert/in-app-notification-date-alert.component';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { InAppNotificationActorsLineComponent } from './entry/actors-line/in-app
     IanMenuComponent,
     EmptyStateComponent,
     InAppNotificationActorsLineComponent,
+    InAppNotificationDateAlertComponent,
   ],
   imports: [
     OPSharedModule,

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -47,6 +47,7 @@ module API
                 .visible(current_user)
                 .where
                 .not(read_ian: nil)
+                .order(id: :desc)
             end
 
             def bulk_update_status(attributes)

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe "Notification center date alerts", js: true, with_settings: { journal_aggregation_time_minutes: 0 } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) { project_with_types }
+  shared_let(:role) { create :role, permissions: %i[view_work_packages edit_work_packages work_package_assigned] }
+  shared_let(:membership) { create :member, principal: user, project: project_with_types, roles: [role] }
+  shared_let(:milestone_type) { create :type_milestone }
+
+  shared_let(:milestone_wp_past) { create :work_package, project:, type: milestone_type, due_date: 2.days.ago }
+  shared_let(:milestone_wp_future) { create :work_package, project:, type: milestone_type, due_date: 1.day.from_now }
+
+  shared_let(:wp_start_past) { create :work_package, project:, start_date: 1.day.ago }
+  shared_let(:wp_start_future) { create :work_package, project:, start_date: 2.days.from_now }
+
+  shared_let(:wp_due_past) { create :work_package, project:, due_date: 3.days.ago }
+  shared_let(:wp_due_future) { create :work_package, project:, due_date: 3.days.from_now }
+
+  shared_let(:wp_double_notification) { create :work_package, project:, due_date: 1.days.from_now }
+
+  shared_let(:notification_milestone_past) do
+    create :notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: milestone_wp_past,
+           project:
+  end
+
+  shared_let(:notification_milestone_future) do
+    create :notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: milestone_wp_future,
+           project:
+  end
+
+  shared_let(:notification_wp_start_past) do
+    create :notification,
+           reason: :date_alert_start_date,
+           recipient: user,
+           resource: wp_start_past,
+           project:
+  end
+
+  shared_let(:notification_wp_start_future) do
+    create :notification,
+           reason: :date_alert_start_date,
+           recipient: user,
+           resource: wp_start_future,
+           project:
+  end
+
+  shared_let(:notification_wp_due_past) do
+    create :notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: wp_due_past,
+           project:
+  end
+
+  shared_let(:notification_wp_due_future) do
+    create :notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: wp_due_future,
+           project:
+  end
+
+  shared_let(:notification_wp_double_date_alert) do
+    create :notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: wp_double_notification,
+           project:
+  end
+
+  shared_let(:notification_wp_double_mention) do
+    create :notification,
+           reason: :mentioned,
+           recipient: user,
+           resource: wp_double_notification,
+           project:
+  end
+
+  let(:center) { ::Pages::Notifications::Center.new }
+  let(:side_menu) { ::Components::Notifications::Sidemenu.new }
+
+  before do
+    login_as user
+    visit notifications_center_path
+  end
+
+  it 'shows the date alerts according to specification' do
+    center.expect_item(notification_wp_start_past, 'Start date was 1 day ago')
+    center.expect_item(notification_wp_start_future, 'Start date is in 2 days')
+
+    center.expect_item(notification_wp_due_past, 'Overdue since 3 days')
+    center.expect_item(notification_wp_due_future, 'Finish date is in 3 days')
+
+    center.expect_item(notification_milestone_past, 'Overdue since 2 days')
+    center.expect_item(notification_milestone_future, 'Finish date is in 1 day')
+
+    # Doesn't show the date alert for the mention, not the alert
+    center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)
+    center.expect_no_item(notification_wp_double_date_alert)
+
+    # When switch to date alerts, it shows the alert, no longer the mention
+    side_menu.click_item 'Date alert'
+    center.expect_item(notification_wp_double_date_alert, 'Finish date is in 1 day')
+    center.expect_no_item(notification_wp_double_mention)
+  end
+end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -109,5 +109,12 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
     side_menu.click_item 'Date alert'
     center.expect_item(notification_wp_double_date_alert, 'Finish date is in 1 day')
     center.expect_no_item(notification_wp_double_mention)
+
+    # When a work package is updated to a different date
+    wp_double_notification.update_column(:due_date, 5.days.from_now)
+    page.driver.refresh
+
+    center.expect_item(notification_wp_double_date_alert, 'Finish date is in 5 days')
+    center.expect_no_item(notification_wp_double_mention)
   end
 end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -25,6 +25,8 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
 
   shared_let(:wp_unset_date) { create(:work_package, subject: 'Unset date', project:, due_date: nil) }
 
+  shared_let(:wp_due_today) { create(:work_package, subject: 'Due today', project:, due_date: Time.zone.today) }
+
   shared_let(:wp_double_alert) do
     create(:work_package, subject: 'Double alert', project:, start_date: 1.day.ago, due_date: 1.day.from_now)
   end
@@ -117,6 +119,14 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
            project:)
   end
 
+  shared_let(:notification_wp_due_today) do
+    create(:notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: wp_due_today,
+           project:)
+  end
+
   let(:center) { ::Pages::Notifications::Center.new }
   let(:side_menu) { ::Components::Notifications::Sidemenu.new }
 
@@ -136,6 +146,8 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
     center.expect_item(notification_milestone_future, 'Milestone date is in 1 day')
 
     center.expect_item(notification_wp_unset_date, 'Finish date is deleted')
+
+    center.expect_item(notification_wp_due_today, 'Finish date is today')
 
     # Doesn't show the date alert for the mention, not the alert
     center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -23,6 +23,8 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
 
   shared_let(:wp_double_notification) { create(:work_package, subject: 'Alert + Mention', project:, due_date: 1.day.from_now) }
 
+  shared_let(:wp_unset_date) { create(:work_package, subject: 'Unset date', project:, due_date: nil) }
+
   shared_let(:wp_double_alert) do
     create(:work_package, subject: 'Double alert', project:, start_date: 1.day.ago, due_date: 1.day.from_now)
   end
@@ -107,6 +109,14 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
     [start, due]
   end
 
+  shared_let(:notification_wp_unset_date) do
+    create(:notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: wp_unset_date,
+           project:)
+  end
+
   let(:center) { ::Pages::Notifications::Center.new }
   let(:side_menu) { ::Components::Notifications::Sidemenu.new }
 
@@ -124,6 +134,8 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
 
     center.expect_item(notification_milestone_past, 'Overdue since 2 days')
     center.expect_item(notification_milestone_future, 'Milestone date is in 1 day')
+
+    center.expect_item(notification_wp_unset_date, 'Finish date is deleted')
 
     # Doesn't show the date alert for the mention, not the alert
     center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -4,83 +4,107 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:project) { project_with_types }
-  shared_let(:role) { create :role, permissions: %i[view_work_packages edit_work_packages work_package_assigned] }
-  shared_let(:membership) { create :member, principal: user, project: project_with_types, roles: [role] }
-  shared_let(:milestone_type) { create :type_milestone }
+  shared_let(:role) { create(:role, permissions: %i[view_work_packages edit_work_packages work_package_assigned]) }
+  shared_let(:membership) { create(:member, principal: user, project: project_with_types, roles: [role]) }
+  shared_let(:milestone_type) { create(:type_milestone) }
 
-  shared_let(:milestone_wp_past) { create :work_package, project:, type: milestone_type, due_date: 2.days.ago }
-  shared_let(:milestone_wp_future) { create :work_package, project:, type: milestone_type, due_date: 1.day.from_now }
+  shared_let(:milestone_wp_past) do
+    create(:work_package, subject: 'Milestone WP past', project:, type: milestone_type, due_date: 2.days.ago)
+  end
+  shared_let(:milestone_wp_future) do
+    create(:work_package, subject: 'Milestone WP future', project:, type: milestone_type, due_date: 1.day.from_now)
+  end
 
-  shared_let(:wp_start_past) { create :work_package, project:, start_date: 1.day.ago }
-  shared_let(:wp_start_future) { create :work_package, project:, start_date: 2.days.from_now }
+  shared_let(:wp_start_past) { create(:work_package, subject: 'WP start past', project:, start_date: 1.day.ago) }
+  shared_let(:wp_start_future) { create(:work_package, subject: 'WP start future', project:, start_date: 2.days.from_now) }
 
-  shared_let(:wp_due_past) { create :work_package, project:, due_date: 3.days.ago }
-  shared_let(:wp_due_future) { create :work_package, project:, due_date: 3.days.from_now }
+  shared_let(:wp_due_past) { create(:work_package, subject: 'WP due past', project:, due_date: 3.days.ago) }
+  shared_let(:wp_due_future) { create(:work_package, subject: 'WP due future', project:, due_date: 3.days.from_now) }
 
-  shared_let(:wp_double_notification) { create :work_package, project:, due_date: 1.days.from_now }
+  shared_let(:wp_double_notification) { create(:work_package, subject: 'Alert + Mention', project:, due_date: 1.day.from_now) }
+
+  shared_let(:wp_double_alert) do
+    create(:work_package, subject: 'Double alert', project:, start_date: 1.day.ago, due_date: 1.day.from_now)
+  end
 
   shared_let(:notification_milestone_past) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: milestone_wp_past,
-           project:
+           project:)
   end
 
   shared_let(:notification_milestone_future) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: milestone_wp_future,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_start_past) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_start_date,
            recipient: user,
            resource: wp_start_past,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_start_future) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_start_date,
            recipient: user,
            resource: wp_start_future,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_due_past) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: wp_due_past,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_due_future) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: wp_due_future,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_double_date_alert) do
-    create :notification,
+    create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: wp_double_notification,
-           project:
+           project:)
   end
 
   shared_let(:notification_wp_double_mention) do
-    create :notification,
+    create(:notification,
            reason: :mentioned,
            recipient: user,
            resource: wp_double_notification,
-           project:
+           project:)
+  end
+
+  shared_let(:notification_wp_double_alerts) do
+    due = create(:notification,
+                 reason: :date_alert_due_date,
+                 recipient: user,
+                 resource: wp_double_alert,
+                 project:)
+
+    start = create(:notification,
+                   reason: :date_alert_start_date,
+                   recipient: user,
+                   resource: wp_double_alert,
+                   project:)
+
+    [start, due]
   end
 
   let(:center) { ::Pages::Notifications::Center.new }
@@ -109,6 +133,15 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
     side_menu.click_item 'Date alert'
     center.expect_item(notification_wp_double_date_alert, 'Finish date is in 1 day')
     center.expect_no_item(notification_wp_double_mention)
+
+    # Ensure that start is created later than due for implicit ID sorting
+    double_alert_start, double_alert_due = notification_wp_double_alerts
+    expect(double_alert_start.id).to be > double_alert_due.id
+
+    # We see that start is actually the newest ID, hence shown as the primary notification
+    # but the date alert still shows the finish date
+    center.expect_item(double_alert_start, 'Finish date is in 1 day')
+    center.expect_no_item(double_alert_due)
 
     # When a work package is updated to a different date
     wp_double_notification.update_column(:due_date, 5.days.from_now)

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -123,7 +123,7 @@ describe "Notification center date alerts", js: true, with_settings: { journal_a
     center.expect_item(notification_wp_due_future, 'Finish date is in 3 days')
 
     center.expect_item(notification_milestone_past, 'Overdue since 2 days')
-    center.expect_item(notification_milestone_future, 'Finish date is in 1 day')
+    center.expect_item(notification_milestone_future, 'Milestone date is in 1 day')
 
     # Doesn't show the date alert for the mention, not the alert
     center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -63,9 +63,9 @@ module Pages
         page.within("[data-qa-selector='op-ian-notification-item-#{notification.id}']", &)
       end
 
-      def expect_item(notification, subject: notification.subject)
+      def expect_item(notification, expected_text = notification.subject)
         within_item(notification) do
-          expect(page).to have_text subject, normalize_ws: true
+          expect(page).to have_text expected_text, normalize_ws: true
         end
       end
 
@@ -97,7 +97,7 @@ module Pages
           raise(ArgumentError, "Expected work package") unless work_package.is_a?(WorkPackage)
 
           expect_item notification,
-                      subject: "#{work_package.type.name.upcase} #{work_package.subject}"
+                      "#{work_package.type.name.upcase} #{work_package.subject}"
         end
       end
 


### PR DESCRIPTION
- [x]   The _reason_ provided for a date alert notification (comparable to &quot;mentioned&quot; or &quot;watched&quot;) will be &quot;Date alert&quot;.
- [x]   When the user is inside the sidebar element &quot;Date alert&quot; the 3rd line of information always display the related info with the date alert in the style specified in the visuals. As the {time} is relative, this will change accordingly with the current date:
    - [x]   &quot;Start date is {time}&quot; (&quot;Start date was {time}&quot; in case of past)
    - [x]   &quot;Finish date is {time}&quot;
    - [x]   Once the finish date is in the past, the work package is considered overdue: &quot;Overdue since {time}&quot;
    - [x]   {time} is the relative difference between the current date and the set date in question
- [x]   In case the user is in any of the other sidebar elements (eg. Inbox) there are two possibilities:
    - [x]   There is only one notification for the work package and it is a date alert: in this case the 3rd line will follow the same logic specified above.
    - [x]   There is one date alert but also other notifications concerning that work package: the date alert isn&#39;t immediately visible, we will display the normal information &quot;X days ago by Name Surname&quot;.
- [x]   In case start and finish date are on the same day and the configuration is also configured equally for both start and finish date, only display the finish date information as that one is more important.
- [x]   In the specific case of MILESTONES as they only have a single date, the finish date of the configuration will govern whether to create a notification.
    - [x]   Display text that is specific to milestones: &quot;Milestone date is {time}&quot;.
    - [x]   Overdue should the same for milestone-typed WPs as for any other type.
- [x]   The information needs to reflect changes done to the work package after the notification is created.
    - [x]   E.g. User is notified about the work package starting in 2 days. Another user moves the work package a week into the future. Then the notification card needs to say that it is starting in 9 days.
- [x] When a notification is emitted and the work package's due/start date is unset in the meantime, the frontend receives a detail of `null` and shows "is deleted" matching the activity text.


https://community.openproject.org/wp/43683

