### PR TITLE
increase feature flag robustness

### DIFF
--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -74,7 +74,7 @@ module OpenProject
 
     def define_flag_methods(flag_name)
       define_singleton_method "#{flag_name}_active?" do
-        Setting.send("feature_#{flag_name}_active?")
+        Setting.exists?("feature_#{flag_name}_active") && Setting.send("feature_#{flag_name}_active?")
       end
     end
 


### PR DESCRIPTION
Flags might be removed as happens within our test suite. 

To reproduce run:

```
rspec ./spec/lib/api/v3/configuration/configuration_representer_spec.rb spec/lib/open_project/feature_decisions_spec.rb spec/requests/api/v3/configuration_resource_spec.rb:73 --seed 45492
```