### PR TITLE
Fix PATCH /api/v3/my_preferences endpoint

### DIFF
--- a/lib/api/v3/user_preferences/user_preferences_api.rb
+++ b/lib/api/v3/user_preferences/user_preferences_api.rb
@@ -37,6 +37,11 @@ module API
 
           patch do
             redirect api_v3_paths.user_preferences('me'), permanent: true
+            # HTTP 301: GET method unchanged, other methods may or may not be
+            # changed to GET depending on the user agent.
+            #
+            # HTTP 308: Method and body not changed
+            status 308
           end
         end
       end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -442,6 +442,10 @@ module API
             "#{user(id)}/preferences"
           end
 
+          def self.my_preferences
+            "#{root}/my_preferences"
+          end
+
           index :group
           show :group
 

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -174,4 +174,30 @@ describe 'API v3 UserPreferences resource', type: :request, content_type: :json 
       end
     end
   end
+
+  describe '/api/v3/my_preferences endpoint' do
+    let(:preference_path) { api_v3_paths.my_preferences }
+
+    describe '#GET' do
+      before do
+        get preference_path
+      end
+
+      it 'redirects to /api/v3/users/me/preferences' do
+        expect(subject.status).to eq(301) # Moved Permanently, it may change the method to GET
+        expect(response.get_header('Location')).to eq(api_v3_paths.user_preferences("me"))
+      end
+    end
+
+    describe '#PATCH' do
+      before do
+        patch preference_path
+      end
+
+      it 'redirects to /api/v3/users/me/preferences with 308 to keep the http method' do
+        expect(subject.status).to eq(308) # Method redirect, it keeps the same HTTP method.
+        expect(response.get_header('Location')).to eq(api_v3_paths.user_preferences("me"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/44845/github

This endpoint redirects to /api/v3/users/me/preferences. A 301 redirect may or may not change the PATCH method into a GET. A 308 removes the ambiguity and preserves the PATCH method on redirection.