### PR TITLE
Fix/rendering date alert notifications

### DIFF
--- a/app/models/queries/notifications/filters/reason_filter.rb
+++ b/app/models/queries/notifications/filters/reason_filter.rb
@@ -27,7 +27,11 @@
 #++
 
 class Queries::Notifications::Filters::ReasonFilter < Queries::Notifications::Filters::NotificationFilter
-  REASONS = Notification.reasons.except(:date_alert_start_date, :date_alert_due_date).merge(date_alert: [10, 11])
+  REASONS = Notification
+              .reasons
+              .except(:date_alert_start_date, :date_alert_due_date)
+              .merge(dateAlert: [Notification::REASONS[:date_alert_start_date],
+                                 Notification::REASONS[:date_alert_due_date]])
 
   def allowed_values
     REASONS.keys.map { |reason| [reason, reason] }

--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
@@ -96,7 +96,7 @@ export class IanMenuComponent implements OnInit {
       key: 'dateAlert',
       title: this.I18n.t('js.notifications.menu.date_alert'),
       icon: 'date-alert',
-      ...getUiLinkForFilters({ filter: 'reason', name: 'date_alert' }),
+      ...getUiLinkForFilters({ filter: 'reason', name: 'dateAlert' }),
     },
   ];
 

--- a/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
+++ b/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
@@ -32,20 +32,22 @@ module API
       class NotificationEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
         class << self
           def wrap(notifications)
-            API::V3::Activities::ActivityEagerLoadingWrapper.wrap(notifications.map(&:journal))
-            set_resource(notifications)
-
-            super
+            notifications
+              .includes(API::V3::Notifications::NotificationRepresenter.to_eager_load)
+              .to_a
+              .tap { |loaded_notifications| set_resource(loaded_notifications) }
           end
 
           private
 
-          # Copy the resource over from the journal.
-          # Those two should always be the same.
-          # The journable will be loaded within the ActivityEagerLoadingWrapper.
+          # The resource cannot be loaded by rails eager loading means (include)
+          # because it is a polymorphic association. That being as it is, currently only
+          # work packages are assigned.
           def set_resource(notifications)
-            notifications.select { |n| n.journal.present? }.each do |notification|
-              notification.resource = notification.journal.journable
+            work_packages_by_id = WorkPackage.where(id: notifications.pluck(:resource_id).uniq).index_by(&:id)
+
+            notifications.each do |notification|
+              notification.resource = work_packages_by_id[notification.resource_id]
             end
           end
         end

--- a/lib/api/v3/notifications/notification_representer.rb
+++ b/lib/api/v3/notifications/notification_representer.rb
@@ -91,7 +91,7 @@ module API
           'Notification'
         end
 
-        self.to_eager_load = %i[project actor]
+        self.to_eager_load = %i[project actor journal]
       end
     end
   end

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -45,7 +45,6 @@ module API
             def notification_scope
               ::Notification
                 .visible(current_user)
-                .includes(NotificationRepresenter.to_eager_load)
                 .where
                 .not(read_ian: nil)
             end

--- a/lib/open_project/patches/factory_bot_evaluator.rb
+++ b/lib/open_project/patches/factory_bot_evaluator.rb
@@ -1,0 +1,37 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module OpenProject::Patches
+  module FactoryBotEvaluator
+    attr_reader :overrides
+  end
+end
+
+if defined?(FactoryBot::Evaluator)
+  FactoryBot::Evaluator.prepend OpenProject::Patches::FactoryBotEvaluator
+end

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -6,14 +6,20 @@ FactoryBot.define do
     mail_alert_sent { false }
     reason { :mentioned }
     recipient factory: :user
-    project { association :project }
+    project
     resource { association :work_package, project: }
-    actor { nil }
-    journal { nil }
+    # journal and actor are not listed by intend.
+    # They will be set in the after_build callback.
+    # But not listing them allows to identify if they have been provided, even if nil has been provided.
 
-    callback(:after_build) do |notification, _|
-      notification.journal ||= notification.resource.journals.last
-      notification.actor ||= notification.journal.try(:user)
+    callback(:after_build) do |notification, evaluator|
+      # Default the journal and the actor associations but only if:
+      # * it is not a date alert
+      # * the values haven't been overridden (including setting them to nil).
+      unless notification.reason_date_alert_due_date? || notification.reason_date_alert_start_date?
+        notification.journal ||= notification.resource.journals.last unless evaluator.overrides.key?(:journal)
+        notification.actor ||= notification.journal.try(:user) unless evaluator.overrides.key?(:actor)
+      end
     end
   end
 end

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -196,8 +196,6 @@ describe "Notification center", js: true, with_settings: { journal_aggregation_t
                recipient:,
                resource: starting_soon_work_package,
                project: project1,
-               actor: nil,
-               journal: nil,
                read_ian: false)
       end
       let(:due_date_notification) do
@@ -206,8 +204,6 @@ describe "Notification center", js: true, with_settings: { journal_aggregation_t
                recipient:,
                resource: ending_soon_work_package,
                project: project1,
-               actor: nil,
-               journal: nil,
                read_ian: false)
       end
       let(:overdue_date_notification) do
@@ -216,8 +212,6 @@ describe "Notification center", js: true, with_settings: { journal_aggregation_t
                recipient:,
                resource: overdue_work_package,
                project: project1,
-               actor: nil,
-               journal: nil,
                read_ian: false)
       end
 

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -50,9 +50,7 @@ describe ::API::V3::Notifications::NotificationsAPI,
            recipient:,
            reason: :date_alert_start_date,
            resource: work_package,
-           project: work_package.project,
-           journal: nil,
-           actor: nil)
+           project: work_package.project)
   end
 
   let(:filters) { nil }
@@ -250,9 +248,7 @@ describe ::API::V3::Notifications::NotificationsAPI,
                recipient:,
                reason: :date_alert_due_date,
                resource: work_package,
-               project: work_package.project,
-               journal: nil,
-               actor: nil)
+               project: work_package.project)
       end
 
       let(:send_request) do
@@ -337,7 +333,7 @@ describe ::API::V3::Notifications::NotificationsAPI,
     it_behaves_like 'API V3 collection response', 0, 0, 'Notification'
   end
 
-  describe 'as an anyonymous user' do
+  describe 'as an anonymous user' do
     let(:current_user) { User.anonymous }
 
     it 'returns a 403 response' do


### PR DESCRIPTION
Fixes:
* Responding to `/api/v3/notifications` in case date alert notifications are to be returned. This failed since date alerts do not have a journal attached but the eager loading wrapper relied on that.
* eager loading the notifications in above case since that was still optimized back when the `details` were still to be included. Now, journal, resource, actor and project are probably eager loaded again so that no n+1 query occurs.
* the notification factory in case of a date alert. For those, journal and actor are no longer automatically assigned. 