### PR TITLE
[chore] fix loading skeleton in file picker

### DIFF
--- a/frontend/src/app/shared/components/file-links/file-picker-modal/file-picker-modal.html
+++ b/frontend/src/app/shared/components/file-links/file-picker-modal/file-picker-modal.html
@@ -17,9 +17,9 @@
   <div class="spot-divider"></div>
 
   <div class="spot-modal--body spot-container">
-    <ng-container *ngIf="(loading$ | async) === false; else loadingTemplate">
-      <spot-breadcrumbs [content]="breadcrumbs"></spot-breadcrumbs>
+    <spot-breadcrumbs [content]="breadcrumbs"></spot-breadcrumbs>
 
+    <ng-container *ngIf="(loading$ | async) === false; else loadingTemplate">
       <ul
         class="spot-list spot-list_compact op-file-list"
         data-qa-selector="op-files-picker-modal--file-list"
@@ -35,7 +35,7 @@
     </ng-container>
 
     <ng-template #loadingTemplate>
-      <op-loading-file-list></op-loading-file-list>
+      <op-loading-file-list class="spot-list"></op-loading-file-list>
     </ng-template>
   </div>
 

--- a/frontend/src/app/shared/components/file-links/loading-file-list/loading-file-list.html
+++ b/frontend/src/app/shared/components/file-links/loading-file-list/loading-file-list.html
@@ -1,11 +1,11 @@
-<op-content-loader viewBox="0 0 1080 200">
-  <svg:rect x="0" y="20" width="100%" height="32" rx="1" />
+<op-content-loader viewBox="0 0 960 186">
+  <svg:rect x="0" y="4" width="100%" height="32" rx="1" />
 
-  <svg:rect x="0" y="56" width="100%" height="32" rx="1" />
+  <svg:rect x="0" y="40" width="100%" height="32" rx="1" />
 
-  <svg:rect x="0" y="92" width="100%" height="32" rx="1" />
+  <svg:rect x="0" y="76" width="100%" height="32" rx="1" />
 
-  <svg:rect x="0" y="128" width="100%" height="32" rx="1" />
+  <svg:rect x="0" y="112" width="100%" height="32" rx="1" />
 
-  <svg:rect x="0" y="164" width="100%" height="32" rx="1" />
+  <svg:rect x="0" y="148" width="100%" height="32" rx="1" />
 </op-content-loader>

--- a/frontend/src/app/shared/components/file-links/storage-file-list-item/storage-file-list-item.html
+++ b/frontend/src/app/shared/components/file-links/storage-file-list-item/storage-file-list-item.html
@@ -47,7 +47,7 @@
 
     <button
       *ngIf="content.isDirectory"
-      class="spot-link"
+      class="spot-link op-file-list--item-button"
       data-qa-selector="op-files-picker-modal--list-item-caret"
       (click)="content.enterDirectory()"
     >

--- a/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
@@ -76,6 +76,13 @@
       &-icon
         margin-right: $spot-spacing-0_25
 
+    & &-button
+      display: flex
+
+      &:hover,
+      &:focus
+        text-decoration: none
+
   & &--item &--item-floating-actions
     padding-right: 0
 


### PR DESCRIPTION
- excluded breadcrumbs from being replaced by loading skeleton
- added cancellation to data load, if breadcrumbs action is triggered while loading
- resized skeleton correctly