### PR TITLE
have a specific method to check if a factory default value is overridden

### DIFF
--- a/lib/open_project/patches/factory_bot_evaluator.rb
+++ b/lib/open_project/patches/factory_bot_evaluator.rb
@@ -28,7 +28,9 @@
 
 module OpenProject::Patches
   module FactoryBotEvaluator
-    attr_reader :overrides
+    def overrides?(key)
+      @overrides.key?(key)
+    end
   end
 end
 

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -17,8 +17,8 @@ FactoryBot.define do
       # * it is not a date alert
       # * the values haven't been overridden (including setting them to nil).
       unless notification.reason_date_alert_due_date? || notification.reason_date_alert_start_date?
-        notification.journal ||= notification.resource.journals.last unless evaluator.overrides.key?(:journal)
-        notification.actor ||= notification.journal.try(:user) unless evaluator.overrides.key?(:actor)
+        notification.journal ||= notification.resource.journals.last unless evaluator.overrides?(:journal)
+        notification.actor ||= notification.journal.try(:user) unless evaluator.overrides?(:actor)
       end
     end
   end

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -73,8 +73,8 @@ FactoryBot.define do
       end
     end
 
-    callback(:after_stub) do |wp, arguments|
-      unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type) || wp.project.nil?
+    callback(:after_stub) do |wp, evaluator|
+      unless wp.type_id || evaluator.overrides?(:type) || wp.project.nil?
         wp.type = wp.project.types.first
       end
     end


### PR DESCRIPTION
Replaces the generic `override` getter for a specific `overrides?(key)` method that should suffice for the use cases we have with the factories.