### PR TITLE
Keep duration when setting dates from soonest start date

### DIFF
--- a/app/services/work_packages/schedule_dependency/dependency.rb
+++ b/app/services/work_packages/schedule_dependency/dependency.rb
@@ -52,9 +52,10 @@ class WorkPackages::ScheduleDependency::Dependency
   end
 
   def soonest_start_date
-    follows_relations
-      .filter_map(&:successor_soonest_start)
-      .max
+    @soonest_start_date ||=
+      follows_relations
+        .filter_map(&:successor_soonest_start)
+        .max
   end
 
   def start_date

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -126,6 +126,9 @@ class WorkPackages::SetScheduleService
 
   # Calculates the dates of a work package based on its follows relations.
   #
+  # The start date of a work package is constrained by its direct and indirect
+  # predecessors, as it must start strictly after all predecessors finish.
+  #
   # The follows relations of ancestors are considered to be equal to own follows
   # relations as they inhibit moving a work package just the same. Only leaf
   # work packages are calculated like this.
@@ -139,42 +142,36 @@ class WorkPackages::SetScheduleService
   # work package moved to an earlier date:
   #   - following work packages do not move at all.
   def reschedule_by_predecessors(scheduled, dependency)
-    min_start_date = dependency.soonest_start_date
-    return unless min_start_date
+    return unless dependency.soonest_start_date
 
-    if !scheduled.start_date
-      schedule_on_missing_dates(scheduled, min_start_date)
-    elsif min_start_date > scheduled.start_date
-      reschedule_to_date(scheduled, min_start_date)
-    end
-  end
-
-  def reschedule_to_date(scheduled, date)
-    new_start_date = [scheduled.start_date, date].compact.max
-    # a new due date is set only if the moving work package already has one
-    if scheduled.due_date
-      new_due_date = [
-        WorkPackages::Shared::Days.for(scheduled).due_date(new_start_date, scheduled.duration),
-        new_start_date,
-        scheduled.due_date
-      ].compact.max
-    end
-
+    new_start_date = [scheduled.start_date, dependency.soonest_start_date].compact.max
+    new_due_date = determine_due_date(scheduled, new_start_date)
     set_dates(scheduled, new_start_date, new_due_date)
   end
 
-  def schedule_on_missing_dates(scheduled, min_start_date)
-    min_start_date = WorkPackages::Shared::Days.for(scheduled).soonest_working_day(min_start_date)
-    set_dates(scheduled,
-              min_start_date,
-              scheduled.due_date && scheduled.due_date < min_start_date ? min_start_date : scheduled.due_date)
+  def determine_due_date(work_package, start_date)
+    # due date is set only if the moving work package already has one or has a
+    # duration. If not, due date is nil (and duration will be nil too).
+    return unless work_package.due_date || work_package.duration
+
+    due_date =
+      if work_package.duration
+        days(work_package).due_date(start_date, work_package.duration)
+      else
+        work_package.due_date
+      end
+
+    # if due date is before start date, then start is used as due date.
+    [start_date, due_date].max
   end
 
   def set_dates(work_package, start_date, due_date)
     work_package.start_date = start_date
     work_package.due_date = due_date
-    work_package.duration = WorkPackages::Shared::Days
-                              .for(work_package)
-                              .duration(start_date, due_date)
+    work_package.duration = days(work_package).duration(start_date, due_date)
+  end
+
+  def days(work_package)
+    WorkPackages::Shared::Days.for(work_package)
   end
 end

--- a/spec/models/projects/exporter/exportable_project_context.rb
+++ b/spec/models/projects/exporter/exportable_project_context.rb
@@ -27,14 +27,14 @@
 #++
 
 shared_context 'with a project with an arrangement of custom fields' do
-  shared_let(:version_cf) { create(:version_project_custom_field) }
-  shared_let(:bool_cf) { create(:bool_project_custom_field) }
-  shared_let(:user_cf) { create(:user_project_custom_field) }
-  shared_let(:int_cf) { create(:int_project_custom_field) }
-  shared_let(:float_cf) { create(:float_project_custom_field) }
-  shared_let(:text_cf) { create(:text_project_custom_field) }
-  shared_let(:string_cf) { create(:string_project_custom_field) }
-  shared_let(:date_cf) { create(:date_project_custom_field) }
+  shared_let(:version_cf) { create(:version_project_custom_field, position: 1) }
+  shared_let(:bool_cf) { create(:bool_project_custom_field, position: 2) }
+  shared_let(:user_cf) { create(:user_project_custom_field, position: 3) }
+  shared_let(:int_cf) { create(:int_project_custom_field, position: 4) }
+  shared_let(:float_cf) { create(:float_project_custom_field, position: 5) }
+  shared_let(:text_cf) { create(:text_project_custom_field, position: 6) }
+  shared_let(:string_cf) { create(:string_project_custom_field, position: 7) }
+  shared_let(:date_cf) { create(:date_project_custom_field, position: 8) }
 
   shared_let(:system_version) { create(:version, sharing: 'system') }
 

--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -593,6 +593,31 @@ describe WorkPackages::SetScheduleService, 'working days' do
         end
       end
     end
+
+    context 'with successor having only duration' do
+      context 'when setting dates on predecessor' do
+        let_schedule(<<~CHART)
+          days              | MTWTFSS |
+          work_package      |         |
+          follower          |         | duration 3, follows work_package
+        CHART
+
+        before do
+          change_schedule([work_package], <<~CHART)
+            days          | MTWTFSS |
+            work_package  |   XX    |
+          CHART
+        end
+
+        it 'schedules successor to start after predecessor and keeps the duration (#44479)' do
+          expect(subject.all_results).to match_schedule(<<~CHART)
+            days          | MTWTFSS   |
+            work_package  |   XX      |
+            follower      |     X..XX |
+          CHART
+        end
+      end
+    end
   end
 
   context 'with a parent' do


### PR DESCRIPTION
Fixes https://community.openproject.org/wp/44479

This allowed to factorize common behavior of the `SetScheduleService` and make it even simpler.