### PR TITLE
Add the Enterprise Edition guard on date alerts creation

### DIFF
--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -30,23 +30,24 @@ class Authorization::EnterpriseService
   attr_accessor :token
 
   GUARDED_ACTIONS = %i(
-    define_custom_style
-    multiselect_custom_fields
-    edit_attribute_groups
-    work_package_query_relation_columns
-    attribute_help_texts
-    two_factor_authentication
-    ldap_groups
-    custom_fields_in_projects_list
-    custom_actions
-    conditional_highlighting
-    readonly_work_packages
     attachment_filters
+    attribute_help_texts
     board_view
+    conditional_highlighting
+    custom_actions
+    custom_fields_in_projects_list
+    date_alerts
+    define_custom_style
+    edit_attribute_groups
     grid_widget_wp_graph
-    placeholder_users
-    team_planner_view
+    ldap_groups
+    multiselect_custom_fields
     openid_providers
+    placeholder_users
+    readonly_work_packages
+    team_planner_view
+    two_factor_authentication
+    work_package_query_relation_columns
   ).freeze
 
   def initialize(token)

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -33,6 +33,8 @@ module Notifications
     self.cron_expression = '*/15 * * * *'
 
     def perform
+      return unless EnterpriseToken.allows_to?(:date_alerts)
+
       time_zones = time_zones_covering_1am_local_time
       return if time_zones.empty?
 

--- a/spec/support/shared/with_ee.rb
+++ b/spec/support/shared/with_ee.rb
@@ -26,13 +26,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+def assert_valid_ee_action(action, example)
+  valid_ee_actions = Authorization::EnterpriseService::GUARDED_ACTIONS
+  return if valid_ee_actions.include?(action)
+
+  spell_checker = DidYouMean::SpellChecker.new(dictionary: valid_ee_actions)
+  suggestions = spell_checker.correct(action).map(&:inspect).join(' ')
+  did_you_mean = " Did you mean #{suggestions} instead?" if suggestions.present?
+
+  raise "Invalid Enterprise action #{action.inspect} at #{example.location}.#{did_you_mean}"
+end
+
+def ee_actions(example)
+  return [] unless example.respond_to?(:metadata) && example.metadata[:with_ee]
+
+  actions = example.metadata[:with_ee]
+  actions.each { |action| assert_valid_ee_action(action, example) }
+end
+
 def aggregate_parent_array(example, acc)
   # We have to manually check parent groups for with_ee:,
   # since they are being ignored otherwise
   example.example_group.module_parents.each do |parent|
-    if parent.respond_to?(:metadata) && parent.metadata[:with_ee]
-      acc.merge(parent.metadata[:with_ee])
-    end
+    acc.merge(ee_actions(parent))
   end
 
   acc
@@ -40,7 +56,7 @@ end
 
 RSpec.configure do |config|
   config.before do |example|
-    allowed = example.metadata[:with_ee]
+    allowed = ee_actions(example)
     if allowed.present?
       allowed = aggregate_parent_array(example, allowed.to_set)
 

--- a/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe Notifications::CreateDateAlertsNotificationsJob, type: :job do
+describe Notifications::CreateDateAlertsNotificationsJob, type: :job, with_ee: %i[date_alerts] do
   include ActiveSupport::Testing::TimeHelpers
 
   shared_let(:project) { create(:project, name: 'main') }
@@ -237,6 +237,18 @@ describe Notifications::CreateDateAlertsNotificationsJob, type: :job do
         expect(user_paris).not_to have_a_due_date_alert_notification_for(work_package)
         expect(user_berlin).not_to have_a_start_date_alert_notification_for(work_package)
         expect(user_berlin).to have_a_due_date_alert_notification_for(work_package)
+      end
+    end
+
+    context 'without enterprise token', with_ee: false do
+      it 'does not create any date alerts' do
+        work_package = alertable_work_package
+        set_scheduled_time(timezone_paris.now.change(hour: 1, min: 0))
+        travel_to(timezone_paris.now.change(hour: 1, min: 4)) do
+          scheduled_job.invoke_job
+
+          expect(user_paris).not_to have_a_start_date_alert_notification_for(work_package)
+        end
       end
     end
 


### PR DESCRIPTION
https://community.openproject.org/wp/44414

I also sorted the guarded actions alphabetically, and added a check so that specifying an invalid `with_ee:` value will make the test fail.