### PR TITLE
Allow choosing "Based on user's language" for first_day_of_week and start_of_week

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -150,8 +150,22 @@ class Setting < ApplicationRecord
   validates :value,
             numericality: {
               only_integer: true,
-              if: Proc.new { |setting| setting.format == :integer }
+              if: ->(setting) { setting.non_null_integer_format? }
             }
+  validates :value,
+            numericality: {
+              only_integer: true,
+              allow_nil: true,
+              if: ->(setting) { setting.nullable_integer_format? }
+            }
+
+  def nullable_integer_format?
+    format == :integer && definition.default.nil?
+  end
+
+  def non_null_integer_format?
+    format == :integer && !definition.default.nil?
+  end
 
   def value
     self.class.deserialize(name, read_attribute(:value))

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -179,6 +179,47 @@ describe Setting, type: :model do
       expect { described_class.smtp_openssl_verify_mode = 'none' }
         .to raise_error NoMethodError
     end
+
+    context 'for a integer setting with non-nil default value', :settings_reset do
+      before do
+        Settings::Definition.add(
+          'my_setting',
+          format: :integer,
+          default: 42
+        )
+      end
+
+      it 'does not save it when set to nil' do
+        expect(described_class.my_setting).to eq(42)
+        described_class.my_setting = nil
+        expect(described_class.my_setting).not_to be_nil
+        expect(described_class.my_setting).to eq(42)
+      end
+    end
+
+    context 'for a integer setting with nil default value', :settings_reset do
+      before do
+        Settings::Definition.add(
+          'my_setting',
+          format: :integer,
+          default: nil
+        )
+      end
+
+      it 'saves it when set to nil' do
+        described_class.my_setting = 42
+        expect(described_class.my_setting).to eq(42)
+        described_class.my_setting = nil
+        expect(described_class.my_setting).to be_nil
+      end
+
+      it 'saves it as nil when set to empty string' do
+        described_class.my_setting = 42
+        expect(described_class.my_setting).to eq(42)
+        described_class.my_setting = ''
+        expect(described_class.my_setting).to be_nil
+      end
+    end
   end
 
   describe '.[setting]_writable?' do


### PR DESCRIPTION
https://community.openproject.org/wp/44833

It was not working because the numericality check was too strict and did not allow `nil`. This PR allows `nil` for a setting if the default value of the setting is `nil`.