### PR TITLE
Include Capybara::RSpecMatchers to speed up Capybara negative assertion matchers

### DIFF
--- a/modules/bim/spec/support/components/xeokit_model_tree.rb
+++ b/modules/bim/spec/support/components/xeokit_model_tree.rb
@@ -29,9 +29,8 @@
 module Components
   class XeokitModelTree
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
-
-    def initialize; end
 
     def sidebar_shows_viewer_menu(visible)
       selector = '.xeokit-tab'

--- a/modules/reporting/spec/features/support/components/cost_reports_base_table.rb
+++ b/modules/reporting/spec/features/support/components/cost_reports_base_table.rb
@@ -29,6 +29,7 @@
 module Components
   class CostReportsBaseTable
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     attr_reader :time_logging_modal

--- a/modules/storages/spec/support/components/file_picker_dialog.rb
+++ b/modules/storages/spec/support/components/file_picker_dialog.rb
@@ -29,6 +29,7 @@
 module Components
   class FilePickerDialog
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     def container

--- a/modules/team_planner/spec/support/components/add_existing_pane.rb
+++ b/modules/team_planner/spec/support/components/add_existing_pane.rb
@@ -29,9 +29,8 @@
 module Components
   class AddExistingPane
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
-
-    def initialize; end
 
     def selector
       "[data-qa-selector='add-existing-pane']"

--- a/spec/features/categories/categories_page.rb
+++ b/spec/features/categories/categories_page.rb
@@ -29,6 +29,7 @@
 class CategoriesPage
   include Rails.application.routes.url_helpers
   include Capybara::DSL
+  include Capybara::RSpecMatchers
 
   def initialize(project = nil)
     @project = project

--- a/spec/features/custom_fields/custom_fields_page.rb
+++ b/spec/features/custom_fields/custom_fields_page.rb
@@ -29,6 +29,7 @@
 class CustomFieldsPage
   include Rails.application.routes.url_helpers
   include Capybara::DSL
+  include Capybara::RSpecMatchers
 
   def visit_new(type = 'WorkPackageCustomField')
     visit new_custom_field_path type:

--- a/spec/features/repositories/repository_settings_page.rb
+++ b/spec/features/repositories/repository_settings_page.rb
@@ -29,6 +29,7 @@
 class RepositorySettingsPage
   include Rails.application.routes.url_helpers
   include Capybara::DSL
+  include Capybara::RSpecMatchers
 
   def initialize(project)
     @project = project

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -29,6 +29,7 @@
 module Components
   class AttributeHelpTextModal
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     attr_reader :help_text, :context

--- a/spec/features/support/components/danger_zone.rb
+++ b/spec/features/support/components/danger_zone.rb
@@ -28,6 +28,7 @@
 
 class DangerZone
   include Capybara::DSL
+  include Capybara::RSpecMatchers
 
   attr_reader :page
 

--- a/spec/features/support/components/time_logging_modal.rb
+++ b/spec/features/support/components/time_logging_modal.rb
@@ -29,6 +29,7 @@
 module Components
   class TimeLoggingModal
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     attr_reader :activity_field,

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -29,6 +29,7 @@
 class WorkPackagesPage
   include Rails.application.routes.url_helpers
   include Capybara::DSL
+  include Capybara::RSpecMatchers
   include RSpec::Matchers
 
   def initialize(project = nil)

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -30,9 +30,8 @@ module Components
   module Admin
     class TypeConfigurationForm
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
-
-      def initialize; end
 
       def add_button_dropdown
         page.find '.form-configuration--add-group', text: 'Group'

--- a/spec/support/components/attachments/attachments.rb
+++ b/spec/support/components/attachments/attachments.rb
@@ -3,8 +3,7 @@
 module Components
   class Attachments
     include Capybara::DSL
-
-    def initialize; end
+    include Capybara::RSpecMatchers
 
     ##
     # Drag and Drop the file loaded from path on to the (native) target element

--- a/spec/support/components/common/modal.rb
+++ b/spec/support/components/common/modal.rb
@@ -30,9 +30,8 @@ module Components
   module Common
     class Modal
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
-
-      def initialize; end
 
       def expect_title(text)
         within_modal do

--- a/spec/support/components/common/sidemenu.rb
+++ b/spec/support/components/common/sidemenu.rb
@@ -30,9 +30,8 @@ module Components
   module Notifications
     class Sidemenu
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
-
-      def initialize; end
 
       def expect_open
         expect(page).to have_selector('[data-qa-selector="op-sidemenu"]')

--- a/spec/support/components/confirmation_dialog.rb
+++ b/spec/support/components/confirmation_dialog.rb
@@ -29,6 +29,7 @@
 module Components
   class ConfirmationDialog
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     def container

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -1,6 +1,7 @@
 module Components
   class Datepicker
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
     attr_reader :context_selector
 

--- a/spec/support/components/global_search.rb
+++ b/spec/support/components/global_search.rb
@@ -1,9 +1,8 @@
 module Components
   class GlobalSearch
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
-
-    def initialize; end
 
     def container
       page.find('.top-menu-search--input')

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -2,6 +2,7 @@ module Components
   module Grids
     class GridArea
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_accessor :area_selector

--- a/spec/support/components/html_title.rb
+++ b/spec/support/components/html_title.rb
@@ -29,6 +29,7 @@
 module Components
   class HtmlTitle
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     attr_reader :project

--- a/spec/support/components/menu/dropdown.rb
+++ b/spec/support/components/menu/dropdown.rb
@@ -29,9 +29,8 @@
 module Components
   class Dropdown
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
-
-    def initialize; end
 
     def toggle
       trigger_element.click

--- a/spec/support/components/password_confirmation_dialog.rb
+++ b/spec/support/components/password_confirmation_dialog.rb
@@ -29,6 +29,7 @@
 module Components
   class PasswordConfirmationDialog
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     def confirm_flow_with(password, should_fail: false)

--- a/spec/support/components/project_include_component.rb
+++ b/spec/support/components/project_include_component.rb
@@ -29,9 +29,8 @@
 module Components
   class ProjectIncludeComponent
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
-
-    def initialize; end
 
     def clear_tooltips
       # Just hover anything else

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -31,6 +31,7 @@ module Components
   module Projects
     class TopMenu
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
       include ::Components::Autocompleter::AutocompleteHelpers
 

--- a/spec/support/components/table_pagination.rb
+++ b/spec/support/components/table_pagination.rb
@@ -29,6 +29,7 @@
 module Components
   class TablePagination
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     def expect_range(from, to, total)

--- a/spec/support/components/timelines/configuration_modal.rb
+++ b/spec/support/components/timelines/configuration_modal.rb
@@ -30,6 +30,7 @@ module Components
   module Timelines
     class ConfigurationModal
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_reader :settings_menu

--- a/spec/support/components/timelines/timeline_row.rb
+++ b/spec/support/components/timelines/timeline_row.rb
@@ -30,6 +30,7 @@ module Components
   module Timelines
     class TimelineRow
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_reader :container

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class Activities
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_reader :work_package

--- a/spec/support/components/work_packages/columns.rb
+++ b/spec/support/components/work_packages/columns.rb
@@ -32,6 +32,7 @@ module Components
   module WorkPackages
     class Columns
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 

--- a/spec/support/components/work_packages/context_menu.rb
+++ b/spec/support/components/work_packages/context_menu.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class ContextMenu
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def open_for(work_package, card_view: false)

--- a/spec/support/components/work_packages/destroy_modal.rb
+++ b/spec/support/components/work_packages/destroy_modal.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class DestroyModal
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def container

--- a/spec/support/components/work_packages/display_representation.rb
+++ b/spec/support/components/work_packages/display_representation.rb
@@ -30,9 +30,8 @@ module Components
   module WorkPackages
     class DisplayRepresentation
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
-
-      def initialize; end
 
       def switch_to_card_layout
         expect_button 'Card'

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -33,6 +33,7 @@ module Components
   module WorkPackages
     class Filters
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
       include SeleniumWorkarounds
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class GroupBy
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def enable_via_header(name)

--- a/spec/support/components/work_packages/hierarchies.rb
+++ b/spec/support/components/work_packages/hierarchies.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class Hierarchies
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_reader :context_menu

--- a/spec/support/components/work_packages/query_menu.rb
+++ b/spec/support/components/work_packages/query_menu.rb
@@ -31,6 +31,7 @@ module Components
   module WorkPackages
     class QueryMenu
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
       include ::Components::Autocompleter::AutocompleteHelpers
 

--- a/spec/support/components/work_packages/query_title.rb
+++ b/spec/support/components/work_packages/query_title.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class QueryTitle
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def expect_changed

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -32,6 +32,7 @@ module Components
   module WorkPackages
     class Relations
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 

--- a/spec/support/components/work_packages/settings_menu.rb
+++ b/spec/support/components/work_packages/settings_menu.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class SettingsMenu
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def open_and_save_query(name)

--- a/spec/support/components/work_packages/sort_by.rb
+++ b/spec/support/components/work_packages/sort_by.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class SortBy
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       def sort_via_header(name, selector: nil, descending: false)

--- a/spec/support/components/work_packages/table_configuration/graph_general.rb
+++ b/spec/support/components/work_packages/table_configuration/graph_general.rb
@@ -31,6 +31,7 @@ module Components
     module TableConfiguration
       class GraphGeneral
         include Capybara::DSL
+        include Capybara::RSpecMatchers
         include RSpec::Matchers
 
         def set_type(name)

--- a/spec/support/components/work_packages/table_configuration/highlighting.rb
+++ b/spec/support/components/work_packages/table_configuration/highlighting.rb
@@ -30,9 +30,8 @@ module Components
   module WorkPackages
     class Highlighting
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
-
-      def initialize; end
 
       def switch_highlighting_mode(label)
         modal_open? or open_modal

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -30,6 +30,7 @@ module Components
   module WorkPackages
     class TableConfigurationModal
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_accessor :trigger_parent

--- a/spec/support/components/work_packages/tabs_counter.rb
+++ b/spec/support/components/work_packages/tabs_counter.rb
@@ -2,6 +2,7 @@ module Components
   module WorkPackages
     class Tabs
       include Capybara::DSL
+      include Capybara::RSpecMatchers
       include RSpec::Matchers
 
       attr_reader :work_package

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -1,6 +1,7 @@
 module Components
   class WysiwygEditor
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
     attr_reader :context_selector, :attachments
 

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -1,5 +1,6 @@
 class EditField
   include Capybara::DSL
+  include Capybara::RSpecMatchers
   include RSpec::Matchers
   include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 

--- a/spec/support/form_fields/form_field.rb
+++ b/spec/support/form_fields/form_field.rb
@@ -1,6 +1,7 @@
 module FormFields
   class FormField
     include Capybara::DSL
+    include Capybara::RSpecMatchers
     include RSpec::Matchers
 
     attr_reader :property, :selector

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -29,8 +29,6 @@ require 'support/pages/page'
 
 module Pages
   class WorkPackageCards < Page
-    include Capybara::DSL
-    include RSpec::Matchers
     attr_reader :project
 
     def initialize(project = nil)

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -33,6 +33,7 @@ describe 'layouts/base', type: :view do
   # we reach this spec, but for running this spec alone we need it here. Best
   # of both worlds.
   include Capybara::DSL
+  include Capybara::RSpecMatchers
 
   include Redmine::MenuManager::MenuHelper
   helper Redmine::MenuManager::MenuHelper


### PR DESCRIPTION
Capybara matchers are smart enough to have these two statements functionally equivalent:

    expect(page).not_to have_xpath('a')
    expect(page).to have_no_xpath('a')

But this only works if `Capybara::RSpecMatchers` module is included. It is included automatically for specs in `spec/features`, but not for pages objects or components.

This PR includes `Capybara::RSpecMatchers` everywhere where `Capybara::DSL` is included so that the `not_to` form does time out to return the result.