### PR TITLE
[44899] avatars causing misalignment issues for project members lists

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.sass
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.sass
@@ -12,3 +12,6 @@
   &--attributes-map
     padding-bottom: 0.875rem
     line-height: 1.5rem
+
+    .attributes-map--value:not(:last-of-type)
+      margin-bottom: 0.5rem

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -2,6 +2,7 @@
   display: inline-flex
   align-items: center
   justify-content: center
+  vertical-align: middle
 
   &--avatar
     flex-grow: 0


### PR DESCRIPTION
Align the elements inside the principal component vertically.

Add margin-bottom for the text under each header in members widget.

https://community.openproject.org/projects/openproject/work_packages/44899/activity