### PR TITLE
[43305] Mobile: The mark as read icon in the notification centre is not visible

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -51,7 +51,7 @@ $subject-font-size: 14px
   &--top-line
     grid-area: header
     display: grid
-    grid-template-columns: max-content max-content minmax(0, max-content) max-content auto minmax(20px, max-content)
+    grid-template-columns: max-content max-content minmax(0, max-content) minmax(0, max-content) auto minmax(20px, max-content)
     grid-template-areas: "status wpIdLink project reason count buttons"
     grid-column-gap: 5px
     font-size: 14px
@@ -92,11 +92,10 @@ $subject-font-size: 14px
     justify-self: flex-end
     margin-right: 5px
 
-  &--reason
+  &--reason-wrapper
     grid-area: reason
     @include text-shortener
     color: var(--gray-dark)
-    max-width: 100%
 
   &--status
     grid-area: status


### PR DESCRIPTION
Hide the overflown text of reasons and shorten it in mobile mode.


https://community.openproject.org/projects/openproject/work_packages/43305/activity