### PR TITLE
[44903] Initial focus not within work package export modal

### DIFF
--- a/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
+++ b/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
@@ -1,4 +1,8 @@
-<div class="spot-modal spot-modal_wide op-wp-table-export">
+<div class="spot-modal spot-modal_wide op-wp-table-export"
+    tabindex="0"
+    cdkFocusInitial
+    cdkTrapFocus
+    [cdkTrapFocusAutoCapture]="true">
 
   <div class="spot-modal--header">{{text.title}}</div>
 


### PR DESCRIPTION
Focus on WP export modal elements using tabindex and cdk.

https://community.openproject.org/projects/openproject/work_packages/44903/activity