### PR TITLE
[44237] No spacing between plus sign and label on buttons

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -9,7 +9,7 @@
     [dropdownActive]="allowed"
     [title]="text.title"
   >
-    <op-icon icon-classes="button--icon icon-add"></op-icon>
+    <span class="spot-icon spot-icon_add"></span>
     <span class="button--text"
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>


### PR DESCRIPTION
Use spot-icon instead of op-icon for create button in WP page

https://community.openproject.org/projects/openproject/work_packages/44237/activity