### PR TITLE
[43253] Wrong right margin in the side menu new team planner button

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -10,7 +10,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="(canAddTeamPlanner$ | async)"
-    class="button -alt-highlight"
+    class="button -alt-highlight -expand"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
     [title]="createButton.title"


### PR DESCRIPTION
Add expand class to the button to remove its margin-right style.


https://community.openproject.org/projects/openproject/work_packages/43253