### PR TITLE
Fix relatable scope used for determining possible work packages to create a relation to.

### DIFF
--- a/app/models/queries/filters/strategies/relation.rb
+++ b/app/models/queries/filters/strategies/relation.rb
@@ -31,7 +31,8 @@ module Queries::Filters::Strategies
     delegate :allowed_values_subset,
              to: :filter
 
-    self.supported_operators = ::Relation::TYPES.keys + %w(parent children)
+    # 'children' used to be supported by the API although 'child' would be more fitting.
+    self.supported_operators = ::Relation::TYPES.keys + [::Relation::TYPE_PARENT, ::Relation::TYPE_CHILD, 'children']
     self.default_operator = ::Relation::TYPE_RELATES
 
     def validate

--- a/app/models/queries/operators.rb
+++ b/app/models/queries/operators.rb
@@ -59,7 +59,8 @@ module Queries::Operators
     Queries::Operators::Requires,
     Queries::Operators::Required,
     Queries::Operators::Parent,
-    Queries::Operators::Children
+    Queries::Operators::Children,
+    Queries::Operators::Child
   ]
 
   OPERATORS = Hash[*(operators.map { |o| [o.symbol.to_s, o] }).flatten].freeze

--- a/app/models/queries/operators/child.rb
+++ b/app/models/queries/operators/child.rb
@@ -1,0 +1,34 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Queries::Operators
+  class Child < Base
+    label 'child'
+    set_symbol 'child'
+  end
+end

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -47,12 +47,6 @@ class Queries::WorkPackages::Filter::RelatableFilter < Queries::WorkPackages::Fi
   end
 
   def scope
-    WorkPackage.relatable(WorkPackage.find_by(id: values.first), Relation.canonical_type(operator))
-  end
-
-  private
-
-  def canonical_operator
-    Relation.canonical_type(operator)
+    WorkPackage.relatable(WorkPackage.find_by(id: values.first), operator)
   end
 end

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -47,6 +47,17 @@ class Queries::WorkPackages::Filter::RelatableFilter < Queries::WorkPackages::Fi
   end
 
   def scope
-    WorkPackage.relatable(WorkPackage.find_by(id: values.first), operator)
+    WorkPackage.relatable(WorkPackage.find_by(id: values.first), scope_operator)
+  end
+
+  private
+
+  # 'children' used to be supported by the API although 'child' would be more fitting.
+  def scope_operator
+    if operator == 'children'
+      Relation::TYPE_CHILD
+    else
+      operator
+    end
   end
 end

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -41,10 +41,11 @@ class Relation < ApplicationRecord
   TYPE_PARTOF       = 'partof'.freeze
   TYPE_REQUIRES     = 'requires'.freeze
   TYPE_REQUIRED     = 'required'.freeze
-  # The parent relation is maintained separately
+  # The parent/child relation is maintained separately
   # (in WorkPackage and WorkPackageHierarchy) and a relation cannot
   # have the type 'parent' but this is abstracted to simplify the code.
   TYPE_PARENT       = 'parent'.freeze
+  TYPE_CHILD        = 'child'.freeze
 
   TYPES = {
     TYPE_RELATES => {

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -126,7 +126,8 @@ class WorkPackage < ApplicationRecord
          :include_spent_time,
          :involving_user,
          :left_join_self_and_descendants,
-         :relatable
+         :relatable,
+         :directly_related
 
   acts_as_watchable
 

--- a/app/models/work_packages/scopes/directly_related.rb
+++ b/app/models/work_packages/scopes/directly_related.rb
@@ -1,0 +1,40 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages::Scopes
+  module DirectlyRelated
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def directly_related(work_package)
+        where(id: Relation.where(from_id: work_package).select(:to_id))
+          .or(where(id: Relation.where(to_id: work_package).select(:from_id)))
+      end
+    end
+  end
+end

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -380,7 +380,7 @@ module WorkPackages::Scopes
             false from_to_id,
             related.includes_from_relation,
             related.includes_to_relation,
-            true includes_hierarchy
+            #{with_descendants ? 'work_package_hierarchies.descendant_id = related.id' : 'work_package_hierarchies.ancestor_id = related.id'} includes_hierarchy
           FROM
             work_package_hierarchies
           WHERE

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -159,8 +159,6 @@ module WorkPackages::Scopes
       # * id - the id of the work packages currently related. This is the result of the CTE.
       # * from_(hierarchy/from_id/to_id) - booleans to prevent that the CTE returns back the path calculated in the previous
       #                                    iteration.
-      # * origin - boolean to indicate whether the work package is the queried for work package or its ancestor/descendant
-      #            (only descendant for PARENT). Such a work package is never a valid target.
       # * includes_(from_relation/to_relation) - booleans about the direction (from_id -> to_id or to_id -> from_id) of the path
       #                                          (the relations followed).
       #                                          This is relevant for a queried for PARENT relation. In that case, relations need
@@ -253,8 +251,7 @@ module WorkPackages::Scopes
                    from_to_id,
                    includes_from_relation,
                    includes_to_relation,
-                   includes_hierarchy,
-                   origin) AS (
+                   includes_hierarchy) AS (
 
               #{non_recursive_relatable_values(work_package, relation_type)}
 
@@ -267,8 +264,7 @@ module WorkPackages::Scopes
                 relations.from_to_id,
                 relations.includes_from_relation,
                 relations.includes_to_relation,
-                relations.includes_hierarchy,
-                relations.origin
+                relations.includes_hierarchy
               FROM
                 related
               JOIN LATERAL (
@@ -300,8 +296,7 @@ module WorkPackages::Scopes
             false from_to_id,
             false includes_from_relation,
             false includes_to_relation,
-            false includes_hierarchy,
-            true origin
+            false includes_hierarchy
           FROM
             work_package_hierarchies
           WHERE
@@ -355,8 +350,7 @@ module WorkPackages::Scopes
             #{false_on_canonical} from_to_id,
             related.includes_from_relation OR #{true_on_canonical} includes_from_relation,
             related.includes_to_relation OR #{false_on_canonical} includes_to_relation,
-            false includes_hierarchy,
-            false origin
+            false includes_hierarchy
           FROM
             relations
           WHERE (relations.#{direction2} = related.id AND relations.relation_type = :relation_type)
@@ -386,8 +380,7 @@ module WorkPackages::Scopes
             false from_to_id,
             related.includes_from_relation,
             related.includes_to_relation,
-            true includes_hierarchy,
-            false origin
+            true includes_hierarchy
           FROM
             work_package_hierarchies
           WHERE

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -29,27 +29,40 @@ module WorkPackages::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      # Returns all work packages that are relatable to the provided work package via new a relation of the provided type.
+      # Returns all work packages which can become part of a new relation from or to the provided work package where the
+      # new relation would receive the provided type (e.g. 'blocks').
       #
       # For most relation types, e.g. 'includes', the four following rules must be satisfied:
       # * Non circular: relations cannot form a circle, e.g. a -> b -> c -> a.
       # * Single relation: only one relation can be created between any two work packages. E.g. it is not possible to create
       #   two relations like this:
-      #   * WP 1 --- follows  ---> WP 2
-      #   * WP 1 --- includes ---> WP 2
+      #   * WP 1 ────follows────> WP 2
+      #   * WP 1 ────includes────> WP 2
+      #   The type of the relation is of no relevance for this constraint.
       # * Ancestor/descendant: relations cannot be drawn between ancestor and descendants. It is important to note though,
       #   that relations can be created between any two work packages within the same tree as long as they are not in a direct
-      #   or transitive ancestor/descendant relationship. So a relation between siblings is just as possible as one between
-      #   aunt and nephew. Additionally, a transitive relationship which leaves the tree for any one hop, is exempt from that rule
-      #   so it is possible to have child --- blocks ---> other --- blocks ---> parent.
+      #   or transitive (e.g. parent of the parent or child of the child) ancestor/descendant relationship. So a relation between
+      #   siblings is just as possible as one between aunt and nephew. Additionally, a transitive relationship which leaves the
+      #   tree for any one hop, is exempt from that rule so it is possible to have:
+      #                  WP parent ────┐
+      #                    │         includes
+      #                    │           │
+      #                    │           v
+      #                 hierarchy    other WP
+      #                    │           │
+      #                    │           │
+      #                    v        includes
+      #                  WP child <────┘
       # * No circles between trees: The ancestor/descendant chain is considered bidirectional when calculating relatability.
       #   This means that starting from the work package both the descendants as well as the ancestors are considered. That
       #   way, relations like
-      #     Child tree 1
-      #       --- parent ---> Parent tree 1
-      #       --- follows ---> Parent tree 2
-      #       --- child ---> Child tree 2
-      #       --- follows ---> Child tree 1
+      #                  WP parent1 <────follows──── WP parent2
+      #                    │                            │
+      #                    │                            │
+      #                 hierarchy                    hierarchy
+      #                    │                            │
+      #                    v                            v
+      #                  WP child1 ────follows────> WP child2
       #   are prevented.
       #
       # For some of the relations, this has actual relevance (FOLLOWS, PRECEDES, PARENT because of scheduling) while for the
@@ -69,14 +82,21 @@ module WorkPackages::Scopes
       #   (FOLLOWS relationship) may also not be related to via a PARENT relation. However, parents and children of those
       #   predecessors/successors can be related to. But they still need to be considered in the code since they might be
       #   part of an almost completed circle which would be closed if a work package is added as a parent. E.g. in
-      #     WP1 --- follows ---> WP2 --- parent ---> WP3 --- follows ---> WP4
-      #   WP4 is not a valid parent candidate whereas WP3 is.
+      #                    WP4 <────follows──── WP3
+      #                                          │
+      #                                          │
+      #                                       hierarchy
+      #                                          │
+      #                                          v
+      #                                         WP2 <────follows──── WP1
+      #   WP4 is not a valid parent candidate for WP1 since it would create the structure used as an example in
+      #   "No circle for trees". However WP3 would be relatable to.
       #   Work packages related via follows/precedes to any descendant of a work package are exempt from being relatable right
       #   away as it would create a circle.
       #
       # The implementation focuses on excluding candidates. It does so in two parts:
       #   * Excluding all work packages with which a direct relation already exist.
-      #   * Excluding work packages that are related transitively.
+      #   * Excluding work packages that are related transitively (following a path of direct relationships).
       #
       # The first is straightforward. The second is more complicated and also depends on the type of relation that is
       # queried for. It uses a CTE to recursively find all work packages with which a transitive relationship of interest based
@@ -88,35 +108,40 @@ module WorkPackages::Scopes
       # type. This is to prevent a circle of relationships. For the 'related' type, only the ancestors and descendants are of
       # interest.
       #
-      # For FOLLOWS/PRECEDES relationships both directions need to be taken into account, and again, this includes those of the
-      # hierarchy. This prevents creating relations in a structure like this:
-      #     queried WP
-      #       --- follows ---> Predecessor WP
-      #       --- parent ---> Predecessor's parent WP
-      #       <-- follows --- Predecessor's parent's successor WP
-      # Where neither of the work packages is allowed to become a successor. However, taking both directions is not
-      # necessary from the tree of the queried for work package itself. Just inversing the example above (not the parent child):
-      #     queried WP
-      #       <-- follows --- Successor WP
-      #       --- parent ---> Successor's parent WP
-      #       --- follows --> Successor's parent's predecessor WP
-      # all work package are potential successors.
+      # For PARENT relationships both directions of FOLLOWS/PRECEDES need to be taken into account, and of course,
+      # hierarchy relation are to be included as well. This prevents creating invalid relations in a structure like this:
       #
-      # For PARENT relationships, both directions actually need to be followed even from the queried for work package and
-      # its descendants. However, if the direction of the path is inverted all the work packages on the path
-      # afterwards are valid targets and need not be followed up on. In the example above for FOLLOWS/PRECEDES, both
-      # "Predecessor's parent's successor WP" as well as "Successor's parent's predecessor WP" are valid.
-      # Just for completeness of the example, both parent work packages are valid targets as well. But a predecessor of
-      # the predecessor's target would not be valid.
+      #          WP4 <────follows──── WP3                                        WP6 <────follows──── WP7
+      #                                │                                          │
+      #                                │                                          │
+      #                             hierarchy                                  hierarchy
+      #                                │                                          │
+      #                                v                                          v
+      #                               WP2 <────follows────  WP1 <────follows──── WP5
+      #
+      # where creating a parent relation to both WP4 or WP7 would create a circle between trees.
+      #
+      # The necessity to follow both directions spans to the queried for work package as well as to its descendants.
+      # However, once started from that origin, if the direction of the path is inverted all the work packages on the path
+      # afterwards are valid targets and need not be followed up on:
+      #
+      #                               WP3 <────follows──── WP4     WP7 <────follows──── WP6
+      #                                │                                                 │
+      #                                │                                                 │
+      #                             hierarchy                                         hierarchy
+      #                                │                                                 │
+      #                                v                                                 v
+      #                               WP2 <────follows──────── WP1 <────────follows──── WP5
+      #
+      # In the example above, WP4 as well as WP7 (and for completeness sake WP3 as well as WP6) are valid relation targets,
+      # and every work package related to those two would be as well.
       # It is also important to note, that existing ancestors are of no importance since this part of the structure will change.
       # Creating a parent relationship is destructive since there can only ever be one.
       #
       # The result is a blocklist which will include work packages that can not be related to. The list is not complete
       # as it will not include the work packages related by different relation types so those are added additionally. For the
-      # PARENT relationship, work packages directly related to any of the descendants are added as well. Since work packages
-      # related to the queried work packages only by a path containing both FOLLOWS and PRECEDES relationships are valid targets,
-      # these are filtered out as well. It would be possible to optimize the CTE here to not have them included
-      # in the first place.
+      # PARENT relationship, work packages directly related to any of the descendants are added as well. Ancestors of predecessors
+      # and successors, which needed to be followed are to be removed from the blocklist since they are valid targets.
       #
       # The CTE has the following columns:
       # * id - the id of the work packages currently related. This is the result of the CTE.
@@ -124,7 +149,6 @@ module WorkPackages::Scopes
       #                                    iteration.
       # * origin - boolean to indicate whether the work package is the queried for work package or its ancestor/descendant
       #            (only descendant for PARENT). Such a work package is never a valid target.
-      #            Additionally, it is used to limit proceeding in both directions for FOLLOWS/PRECEDES.
       # * includes_(from_relation/to_relation) - booleans about the direction (from_id -> to_id or to_id -> from_id) of the path
       #                                          (the relations followed).
       #                                          This is relevant for a queried for PARENT relation. In that case, relations need
@@ -137,8 +161,8 @@ module WorkPackages::Scopes
       def relatable(work_package, relation_type)
         return all if work_package.new_record?
 
-        scope = not_having_directed_relation(work_package, relation_type)
-                  .not_having_direct_relation(work_package, relation_type)
+        scope = not_having_direct_relation(work_package, relation_type)
+                  .not_having_transitive_relation(work_package, relation_type)
                   .where.not(id: work_package.id)
 
         # On a parent relationship, explicitly remove the former parent (which might be the current one as well)
@@ -169,7 +193,7 @@ module WorkPackages::Scopes
              .where.not(id: Relation.where(to_id: origin).select(:from_id))
       end
 
-      def not_having_directed_relation(work_package, relation_type)
+      def not_having_transitive_relation(work_package, relation_type)
         sql = <<~SQL.squish
           WITH
             RECURSIVE
@@ -254,12 +278,6 @@ module WorkPackages::Scopes
         unions = [existing_hierarchy_lateral]
 
         case relation_type
-        when Relation::TYPE_FOLLOWS
-          unions << existing_relation_of_type_lateral(Relation::TYPE_FOLLOWS)
-          unions << existing_relation_of_type_lateral(Relation::TYPE_PRECEDES, limit_origin: true)
-        when Relation::TYPE_PRECEDES
-          unions << existing_relation_of_type_lateral(Relation::TYPE_FOLLOWS, limit_origin: true)
-          unions << existing_relation_of_type_lateral(Relation::TYPE_PRECEDES)
         when Relation::TYPE_PARENT
           unions << existing_relation_of_type_lateral(Relation::TYPE_FOLLOWS, limit_direction: true)
           unions << existing_relation_of_type_lateral(Relation::TYPE_PRECEDES, limit_direction: true)
@@ -273,7 +291,7 @@ module WorkPackages::Scopes
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def existing_relation_of_type_lateral(relation_type, limit_origin: false, limit_direction: false)
+      def existing_relation_of_type_lateral(relation_type, limit_direction: false)
         canonical_type = Relation.canonical_type(relation_type)
 
         is_canonical = canonical_type == relation_type
@@ -306,7 +324,6 @@ module WorkPackages::Scopes
             relations
           WHERE (relations.#{direction2} = related.id AND relations.relation_type = :relation_type)
             AND NOT related.from_#{direction2}
-            #{limit_origin ? 'AND NOT related.origin' : ''}
             #{direction_limit ? "AND NOT #{direction_limit}" : ''}
         SQL
 

--- a/spec/models/work_packages/scopes/directly_related_spec.rb
+++ b/spec/models/work_packages/scopes/directly_related_spec.rb
@@ -1,0 +1,85 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:origin) { create(:work_package) }
+  shared_let(:related_work_package_to) { create(:work_package) }
+  shared_let(:transitively_related_work_package_to) { create(:work_package) }
+  shared_let(:related_work_package_from) { create(:work_package) }
+  shared_let(:transitively_related_work_package_from) { create(:work_package) }
+  shared_let(:unrelated_work_package) { create(:work_package) }
+
+  let(:relation_from) do
+    create(:relation,
+           relation_type:,
+           from: origin,
+           to: related_work_package_from)
+  end
+  let(:relation_to) do
+    create(:relation,
+           relation_type:,
+           to: origin,
+           from: related_work_package_to)
+  end
+  let(:transitive_relation_from) do
+    create(:relation,
+           relation_type:,
+           from: related_work_package_from,
+           to: transitively_related_work_package_from)
+  end
+  let(:transitive_relation_to) do
+    create(:relation,
+           relation_type:,
+           to: related_work_package_to,
+           from: transitively_related_work_package_to)
+  end
+
+  let!(:existing_relations) { [relation_to, transitive_relation_to, relation_from, transitive_relation_from] }
+
+  subject(:directly_related) { WorkPackage.directly_related(origin) }
+
+  it 'is an AR scope' do
+    expect(directly_related)
+      .to be_a ActiveRecord::Relation
+  end
+
+  Relation::TYPES.each_key do |current_type|
+    let(:relation_type) { current_type }
+
+    context "with existing relations of type '#{current_type}'" do
+      it 'contains the directly related work packages in both directions' do
+        expect(directly_related)
+          .to match_array([related_work_package_to, related_work_package_from])
+      end
+    end
+  end
+end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -390,18 +390,18 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
         create(:follows_relation, from: origin_child, to: aunt)
       end
 
-      it 'contains aunt' do
+      it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt]
+          .to match_array [aunt, grandparent]
       end
     end
 
     context "for a 'relates' relation" do
       let(:relation_type) { Relation::TYPE_RELATES }
 
-      it 'contains aunt' do
+      it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt]
+          .to match_array [aunt, grandparent]
       end
     end
   end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -586,7 +586,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'follows' relation" do
       let(:relation_type) { Relation::TYPE_FOLLOWS }
 
-      it "contains the predecessor's parent and that parent's predecessor" do
+      it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
           .to match_array [predecessor_parent, predecessor_parent_successor]
       end
@@ -595,16 +595,16 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'precedes' relation" do
       let(:relation_type) { Relation::TYPE_PRECEDES }
 
-      it "is empty" do
+      it "contains the predecessor's parent's successor" do
         expect(relatable)
-          .to be_empty
+          .to match_array [predecessor_parent_successor]
       end
     end
 
     context "for a 'blocks' relation" do
       let(:relation_type) { Relation::TYPE_BLOCKS }
 
-      it "contains the predecessor's parent and that parent's predecessor" do
+      it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
           .to match_array [predecessor_parent, predecessor_parent_successor]
       end
@@ -613,7 +613,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'blocked' relation" do
       let(:relation_type) { Relation::TYPE_BLOCKED }
 
-      it "contains the predecessor's parent and that parent's predecessor" do
+      it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
           .to match_array [predecessor_parent, predecessor_parent_successor]
       end
@@ -622,7 +622,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'relates' relation" do
       let(:relation_type) { Relation::TYPE_RELATES }
 
-      it "contains the predecessor's parent and that parent's predecessor" do
+      it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
           .to match_array [predecessor_parent, predecessor_parent_successor]
       end
@@ -728,9 +728,9 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'follows' relation" do
       let(:relation_type) { Relation::TYPE_FOLLOWS }
 
-      it "is empty" do
+      it "is contains the successor's parent's predecessor" do
         expect(relatable)
-          .to be_empty
+          .to match_array [successor_parent_predecessor]
       end
     end
 
@@ -1061,6 +1061,39 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       it "contains the predecessor's child" do
         expect(relatable)
           .to match_array [predecessor_child]
+      end
+    end
+  end
+
+  context 'with a blocks work package that has a child and a parent' do
+    let(:blocks_child) do
+      create(:work_package, parent: blocks)
+    end
+    let(:blocks) do
+      create(:work_package, parent: blocks_parent).tap do |bl|
+        create(:relation, from: origin, to: bl, relation_type: Relation::TYPE_BLOCKS)
+      end
+    end
+    let(:blocks_parent) do
+      create(:work_package)
+    end
+    let!(:existing_work_packages) { [origin, blocks, blocks_parent, blocks_child] }
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the parent and the child" do
+        expect(relatable)
+          .to match_array [blocks_parent, blocks_child]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
       end
     end
   end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -29,12 +29,11 @@ require 'spec_helper'
 describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   create_shared_association_defaults_for_work_package_factory
 
-  let(:project) { create(:project) }
-  let(:origin) { create(:work_package, project:) }
-  let(:unrelated_work_package) { create(:work_package, project:) }
+  let(:origin) { create(:work_package) }
+  let(:unrelated_work_package) { create(:work_package) }
 
   let(:directly_related_work_package) do
-    create(:work_package, project:).tap do |related_wp|
+    create(:work_package).tap do |related_wp|
       create(:relation,
              relation_type: directly_related_work_package_type,
              from: origin,
@@ -43,7 +42,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   end
   let(:directly_related_work_package_type) { relation_type }
   let(:transitively_related_work_package) do
-    create(:work_package, project:).tap do |related_wp|
+    create(:work_package).tap do |related_wp|
       create(:relation,
              relation_type: transitively_related_work_package_type,
              from: directly_related_work_package,
@@ -53,23 +52,23 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   let(:transitively_related_work_package_type) { relation_type }
 
   let(:parent) do
-    create(:work_package, project:).tap do |p|
+    create(:work_package).tap do |p|
       origin.update(parent: p)
     end
   end
   let(:sibling) do
-    create(:work_package, project:, parent:)
+    create(:work_package, parent:)
   end
   let(:grandparent) do
-    create(:work_package, project:).tap do |p|
+    create(:work_package).tap do |p|
       parent.update(parent: p)
     end
   end
   let(:aunt) do
-    create(:work_package, project:, parent: grandparent)
+    create(:work_package, parent: grandparent)
   end
   let(:origin_child) do
-    create(:work_package, project:, parent: origin)
+    create(:work_package, parent: origin)
   end
   let(:existing_work_packages) { [] }
 
@@ -289,10 +288,10 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context "with two parent child pairs connected by a relation" do
     let(:other_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:other_child) do
-      create(:work_package, project:, parent: other_parent).tap do |wp|
+      create(:work_package, parent: other_parent).tap do |wp|
         create(:relation, from: wp, to: origin_child, relation_type: existing_relation_type)
       end
     end
@@ -409,7 +408,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with an ancestor chain of 3 work packages' do
     let(:grand_grandparent) do
-      create(:work_package, project:).tap do |par|
+      create(:work_package).tap do |par|
         grandparent.update(parent: par)
       end
     end
@@ -446,10 +445,10 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a predecessor having a parent' do
     let(:predecessor_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:predecessor) do
-      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+      create(:work_package, parent: predecessor_parent).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -467,12 +466,12 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with two predecessors being in a hierarchy' do
     let(:predecessor_parent) do
-      create(:work_package, project:).tap do |pre|
+      create(:work_package).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
     let(:predecessor) do
-      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+      create(:work_package, parent: predecessor_parent).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -490,15 +489,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a predecessor having a parent that has a predecessor' do
     let(:predecessor_parent_predecessor) do
-      create(:work_package, project:).tap do |pre|
+      create(:work_package).tap do |pre|
         create(:relation, from: predecessor_parent, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
     let(:predecessor_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:predecessor) do
-      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+      create(:work_package, parent: predecessor_parent).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -561,15 +560,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a predecessor having a parent that has a successor' do
     let(:predecessor_parent_successor) do
-      create(:work_package, project:).tap do |suc|
+      create(:work_package).tap do |suc|
         create(:relation, to: predecessor_parent, from: suc, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
     let(:predecessor_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:predecessor) do
-      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+      create(:work_package, parent: predecessor_parent).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -632,15 +631,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a successor having a parent that has a successor' do
     let(:successor_parent_successor) do
-      create(:work_package, project:).tap do |suc|
+      create(:work_package).tap do |suc|
         create(:relation, to: successor_parent, from: suc, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
     let(:successor_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:successor) do
-      create(:work_package, project:, parent: successor_parent).tap do |suc|
+      create(:work_package, parent: successor_parent).tap do |suc|
         create(:relation, to: origin, from: suc, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -703,15 +702,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a successor having a parent that has a predecessor' do
     let(:successor_parent_predecessor) do
-      create(:work_package, project:).tap do |pre|
+      create(:work_package).tap do |pre|
         create(:relation, from: successor_parent, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
     let(:successor_parent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let(:successor) do
-      create(:work_package, project:, parent: successor_parent).tap do |suc|
+      create(:work_package, parent: successor_parent).tap do |suc|
         create(:relation, to: origin, from: suc, relation_type: Relation::TYPE_FOLLOWS)
       end
     end
@@ -774,7 +773,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a parent that has a predecessor' do
     let(:parent_predecessor) do
-      create(:work_package, project:).tap do |pre|
+      create(:work_package).tap do |pre|
         create(:follows_relation, from: parent, to: pre)
       end
     end
@@ -828,7 +827,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a parent that has a successor' do
     let(:parent_successor) do
-      create(:work_package, project:).tap do |suc|
+      create(:work_package).tap do |suc|
         create(:follows_relation, to: parent, from: suc)
       end
     end
@@ -882,15 +881,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a child that has a successor that has a parent and a grandparent' do
     let(:child_successor) do
-      create(:work_package, project:, parent: child_successor_parent).tap do |suc|
+      create(:work_package, parent: child_successor_parent).tap do |suc|
         create(:follows_relation, from: suc, to: origin_child)
       end
     end
     let(:child_successor_parent) do
-      create(:work_package, project:, parent: child_successor_grandparent)
+      create(:work_package, parent: child_successor_grandparent)
     end
     let(:child_successor_grandparent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let!(:existing_work_packages) { [origin_child, child_successor, child_successor_parent, child_successor_grandparent] }
 
@@ -933,15 +932,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a child that blocks a work package that has a parent and a grandparent' do
     let(:child_blocked) do
-      create(:work_package, project:, parent: child_blocked_parent).tap do |wp|
+      create(:work_package, parent: child_blocked_parent).tap do |wp|
         create(:relation, relation_type: Relation::TYPE_BLOCKS, from: origin_child, to: wp)
       end
     end
     let(:child_blocked_parent) do
-      create(:work_package, project:, parent: child_blocked_grandparent)
+      create(:work_package, parent: child_blocked_grandparent)
     end
     let(:child_blocked_grandparent) do
-      create(:work_package, project:)
+      create(:work_package)
     end
     let!(:existing_work_packages) { [origin_child, child_blocked, child_blocked_parent, child_blocked_grandparent] }
 
@@ -1002,10 +1001,10 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
   context 'with a predecessor that has a child' do
     let(:predecessor_child) do
-      create(:work_package, project:, parent: predecessor)
+      create(:work_package, parent: predecessor)
     end
     let(:predecessor) do
-      create(:work_package, project:).tap do |pre|
+      create(:work_package).tap do |pre|
         create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
       end
     end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -27,6 +27,8 @@
 require 'spec_helper'
 
 describe WorkPackages::Scopes::Relatable, '.relatable scope' do
+  create_shared_association_defaults_for_work_package_factory
+
   let(:project) { create(:project) }
   let(:origin) { create(:work_package, project:) }
   let(:unrelated_work_package) { create(:work_package, project:) }
@@ -148,6 +150,16 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
             .to be_empty
         end
       end
+
+      context "with the queried for relation being '#{current_type}' and the existing one something different" do
+        let(:relation_type) { current_type }
+        let(:directly_related_work_package_type) { Relation::TYPES.keys[(Relation::TYPES.keys.find_index(current_type) + 1)] }
+
+        it 'is empty' do
+          expect(relatable)
+            .to be_empty
+        end
+      end
     end
   end
 
@@ -206,9 +218,56 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       # complicated to switch around the relations
       subject(:relatable) { WorkPackage.relatable(transitively_related_work_package, relation_type) }
 
-      it 'is empty' do
+      it 'includes the not directly related work package' do
         expect(relatable)
           .to match_array [origin]
+      end
+    end
+
+    context "for a 'parent' relation and the existing relations being 'follows'" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+      let(:directly_related_work_package_type) { Relation::TYPE_FOLLOWS }
+      let(:transitively_related_work_package_type) { Relation::TYPE_FOLLOWS }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'parent' relation and the existing relations being 'precedes'" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'parent' relation and the existing relations being 'blocks'" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+      let(:directly_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:transitively_related_work_package_type) { Relation::TYPE_BLOCKS }
+
+      # This leads to a relationship that, on the domain level does not really make sense where at least
+      # transitively, the child blocks the parent. But since such a relation does not strictly carry that
+      # semantic in the system, the relationship is not prohibited.
+      it 'contains the transitively related work package' do
+        expect(relatable)
+          .to match_array([transitively_related_work_package])
+      end
+    end
+
+    context "for a 'blocks' relation and the existing relations being 'blocks'" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+      let(:directly_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:transitively_related_work_package_type) { Relation::TYPE_BLOCKS }
+
+      it 'contains the transitively related work package' do
+        expect(relatable)
+          .to match_array([transitively_related_work_package])
       end
     end
   end
@@ -234,13 +293,13 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     end
     let(:other_child) do
       create(:work_package, project:, parent: other_parent).tap do |wp|
-        create(:relation, from: wp, to: origin_child, relation_type: other_relation_type)
+        create(:relation, from: wp, to: origin_child, relation_type: existing_relation_type)
       end
     end
     let!(:existing_work_packages) { [origin_child, other_parent, other_child] }
 
     context "for a 'follows' and the existing relation being a follows in the opposite direction" do
-      let(:other_relation_type) { Relation::TYPE_FOLLOWS }
+      let(:existing_relation_type) { Relation::TYPE_FOLLOWS }
       let(:relation_type) { Relation::TYPE_FOLLOWS }
 
       it 'is empty' do
@@ -251,12 +310,33 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
     context "for a 'follows' and the existing relation being a follows in the same direction" do
       # Using precedes will lead to the relation being reversed
-      let(:other_relation_type) { Relation::TYPE_PRECEDES }
+      let(:existing_relation_type) { Relation::TYPE_PRECEDES }
       let(:relation_type) { Relation::TYPE_FOLLOWS }
 
       it 'contains the work packages in the other hierarchy' do
         expect(relatable)
           .to match_array [other_parent, other_child]
+      end
+    end
+
+    context "for a 'blocks' and the existing relation being a blocks in the same direction" do
+      # Using blocked will lead to the relation being reversed
+      let(:existing_relation_type) { Relation::TYPE_BLOCKED }
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it 'contains the work packages in the other hierarchy' do
+        expect(relatable)
+          .to match_array [other_parent, other_child]
+      end
+    end
+
+    context "for a 'blocks' and the existing relation being a blocks in the opposite direction" do
+      let(:existing_relation_type) { Relation::TYPE_BLOCKS }
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
       end
     end
   end
@@ -270,6 +350,24 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       it 'contains grandparent and aunt' do
         expect(relatable)
           .to match_array [grandparent, aunt]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it 'contains aunt' do
+        expect(relatable)
+          .to match_array [aunt]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it 'contains aunt' do
+        expect(relatable)
+          .to match_array [aunt]
       end
     end
 
@@ -298,6 +396,15 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
           .to match_array [aunt]
       end
     end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it 'contains aunt' do
+        expect(relatable)
+          .to match_array [aunt]
+      end
+    end
   end
 
   context 'with an ancestor chain of 3 work packages' do
@@ -315,6 +422,646 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       it 'contains grandparent and grand_grandparent' do
         expect(relatable)
           .to match_array [grandparent, grand_grandparent]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+  end
+
+  context 'with a predecessor having a parent' do
+    let(:predecessor_parent) do
+      create(:work_package, project:)
+    end
+    let(:predecessor) do
+      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [predecessor_parent, predecessor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the predecessor's parent" do
+        expect(relatable)
+          .to match_array [predecessor_parent]
+      end
+    end
+  end
+
+  context 'with two predecessors being in a hierarchy' do
+    let(:predecessor_parent) do
+      create(:work_package, project:).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let(:predecessor) do
+      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [predecessor_parent, predecessor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+  end
+
+  context 'with a predecessor having a parent that has a predecessor' do
+    let(:predecessor_parent_predecessor) do
+      create(:work_package, project:).tap do |pre|
+        create(:relation, from: predecessor_parent, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let(:predecessor_parent) do
+      create(:work_package, project:)
+    end
+    let(:predecessor) do
+      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [predecessor_parent_predecessor, predecessor_parent, predecessor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the predecessor's parent" do
+        expect(relatable)
+          .to match_array [predecessor_parent]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+      end
+    end
+  end
+
+  context 'with a predecessor having a parent that has a successor' do
+    let(:predecessor_parent_successor) do
+      create(:work_package, project:).tap do |suc|
+        create(:relation, to: predecessor_parent, from: suc, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let(:predecessor_parent) do
+      create(:work_package, project:)
+    end
+    let(:predecessor) do
+      create(:work_package, project:, parent: predecessor_parent).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [predecessor_parent_successor, predecessor_parent, predecessor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the predecessor's parent and its successor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_successor]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_successor]
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_successor]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_successor]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the predecessor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [predecessor_parent, predecessor_parent_successor]
+      end
+    end
+  end
+
+  context 'with a successor having a parent that has a successor' do
+    let(:successor_parent_successor) do
+      create(:work_package, project:).tap do |suc|
+        create(:relation, to: successor_parent, from: suc, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let(:successor_parent) do
+      create(:work_package, project:)
+    end
+    let(:successor) do
+      create(:work_package, project:, parent: successor_parent).tap do |suc|
+        create(:relation, to: origin, from: suc, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [successor_parent_successor, successor_parent, successor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the successor's parent" do
+        expect(relatable)
+          .to match_array [successor_parent]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is contains the successor's parent and that parent's successor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_successor]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the successor's parent and that parent's successor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_successor]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the successor's parent and that parent's successor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_successor]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the successor's parent and that parent's successor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_successor]
+      end
+    end
+  end
+
+  context 'with a successor having a parent that has a predecessor' do
+    let(:successor_parent_predecessor) do
+      create(:work_package, project:).tap do |pre|
+        create(:relation, from: successor_parent, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let(:successor_parent) do
+      create(:work_package, project:)
+    end
+    let(:successor) do
+      create(:work_package, project:, parent: successor_parent).tap do |suc|
+        create(:relation, to: origin, from: suc, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [successor_parent_predecessor, successor_parent, successor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the successor's parent and its predecessor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_predecessor]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is contains the successor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_predecessor]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the successor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_predecessor]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the successor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_predecessor]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the successor's parent and that parent's predecessor" do
+        expect(relatable)
+          .to match_array [successor_parent, successor_parent_predecessor]
+      end
+    end
+  end
+
+  context 'with a parent that has a predecessor' do
+    let(:parent_predecessor) do
+      create(:work_package, project:).tap do |pre|
+        create(:follows_relation, from: parent, to: pre)
+      end
+    end
+    let!(:existing_work_packages) { [parent, parent_predecessor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent's predecessor" do
+        expect(relatable)
+          .to match_array [parent_predecessor]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "contains the parent's predecessor" do
+        expect(relatable)
+          .to match_array [parent_predecessor]
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the parent's predecessor" do
+        expect(relatable)
+          .to match_array [parent_predecessor]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the parent's predecessor" do
+        expect(relatable)
+          .to match_array [parent_predecessor]
+      end
+    end
+  end
+
+  context 'with a parent that has a successor' do
+    let(:parent_successor) do
+      create(:work_package, project:).tap do |suc|
+        create(:follows_relation, to: parent, from: suc)
+      end
+    end
+    let!(:existing_work_packages) { [parent, parent_successor] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent's successor" do
+        expect(relatable)
+          .to match_array [parent_successor]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "contains the parent's successor" do
+        expect(relatable)
+          .to match_array [parent_successor]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the parent's successor" do
+        expect(relatable)
+          .to match_array [parent_successor]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the parent's successor" do
+        expect(relatable)
+          .to match_array [parent_successor]
+      end
+    end
+  end
+
+  context 'with a child that has a successor that has a parent and a grandparent' do
+    let(:child_successor) do
+      create(:work_package, project:, parent: child_successor_parent).tap do |suc|
+        create(:follows_relation, from: suc, to: origin_child)
+      end
+    end
+    let(:child_successor_parent) do
+      create(:work_package, project:, parent: child_successor_grandparent)
+    end
+    let(:child_successor_grandparent) do
+      create(:work_package, project:)
+    end
+    let!(:existing_work_packages) { [origin_child, child_successor, child_successor_parent, child_successor_grandparent] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent of the child's successor" do
+        expect(relatable)
+          .to match_array [child_successor_parent, child_successor_grandparent]
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "contains the child's successor and the parent of that" do
+        expect(relatable)
+          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the child's successor and the parent of that" do
+        expect(relatable)
+          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+      end
+    end
+  end
+
+  context 'with a child that blocks a work package that has a parent and a grandparent' do
+    let(:child_blocked) do
+      create(:work_package, project:, parent: child_blocked_parent).tap do |wp|
+        create(:relation, relation_type: Relation::TYPE_BLOCKS, from: origin_child, to: wp)
+      end
+    end
+    let(:child_blocked_parent) do
+      create(:work_package, project:, parent: child_blocked_grandparent)
+    end
+    let(:child_blocked_grandparent) do
+      create(:work_package, project:)
+    end
+    let!(:existing_work_packages) { [origin_child, child_blocked, child_blocked_parent, child_blocked_grandparent] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent of the child's blocked work package" do
+        expect(relatable)
+          .to match_array [child_blocked_parent, child_blocked_grandparent]
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "contains the child's blocked work package and its ancestors" do
+        expect(relatable)
+          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "contains the child's blocked work package and its ancestors" do
+        expect(relatable)
+          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the child's blocked work package and its ancestors" do
+        expect(relatable)
+          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the child's blocked work package and its ancestors" do
+        expect(relatable)
+          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+  end
+
+  context 'with a predecessor that has a child' do
+    let(:predecessor_child) do
+      create(:work_package, project:, parent: predecessor)
+    end
+    let(:predecessor) do
+      create(:work_package, project:).tap do |pre|
+        create(:relation, from: origin, to: pre, relation_type: Relation::TYPE_FOLLOWS)
+      end
+    end
+    let!(:existing_work_packages) { [origin, predecessor, predecessor_child] }
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'precedes' relation" do
+      let(:relation_type) { Relation::TYPE_PRECEDES }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'follows' relation" do
+      let(:relation_type) { Relation::TYPE_FOLLOWS }
+
+      it "contains the predecessor's child" do
+        expect(relatable)
+          .to match_array [predecessor_child]
+      end
+    end
+
+    context "for a 'relates' relation" do
+      let(:relation_type) { Relation::TYPE_RELATES }
+
+      it "contains the predecessor's child" do
+        expect(relatable)
+          .to match_array [predecessor_child]
+      end
+    end
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "contains the predecessor's child" do
+        expect(relatable)
+          .to match_array [predecessor_child]
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the predecessor's child" do
+        expect(relatable)
+          .to match_array [predecessor_child]
       end
     end
   end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -1096,5 +1096,56 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
           .to be_empty
       end
     end
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent" do
+        expect(relatable)
+          .to match_array [blocks_parent]
+      end
+    end
+  end
+
+  context 'with a blocked work package that has a child and a parent' do
+    let(:blocked_child) do
+      create(:work_package, parent: blocked)
+    end
+    let(:blocked) do
+      create(:work_package, parent: blocked_parent).tap do |bl|
+        create(:relation, from: origin, to: bl, relation_type: Relation::TYPE_BLOCKED)
+      end
+    end
+    let(:blocked_parent) do
+      create(:work_package)
+    end
+    let!(:existing_work_packages) { [origin, blocked, blocked_parent, blocked_child] }
+
+    context "for a 'blocks' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+
+      it "is empty" do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'blocked' relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKED }
+
+      it "contains the parent and the child" do
+        expect(relatable)
+          .to match_array [blocked_parent, blocked_child]
+      end
+    end
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent" do
+        expect(relatable)
+          .to match_array [blocked_parent]
+      end
+    end
   end
 end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -1430,4 +1430,84 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       end
     end
   end
+
+  context 'with a predecessor chain where the first has parent and child' do
+    let(:direct_predecessor) do
+      create(:work_package).tap do |pre|
+        create(:follows_relation, from: origin, to: pre)
+      end
+    end
+    let(:transitive_predecessor) do
+      create(:work_package, parent: transitive_predecessor_parent).tap do |pre|
+        create(:follows_relation, from: direct_predecessor, to: pre)
+      end
+    end
+    let(:transitive_predecessor_parent) do
+      create(:work_package)
+    end
+    let(:transitive_predecessor_child) do
+      create(:work_package, parent: transitive_predecessor)
+    end
+    let!(:existing_work_packages) do
+      [direct_predecessor, transitive_predecessor, transitive_predecessor_parent, transitive_predecessor_child]
+    end
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent at the beginning of the chain" do
+        expect(relatable)
+          .to match_array [transitive_predecessor_parent]
+      end
+    end
+
+    context "for a 'child' relation" do
+      let(:relation_type) { Relation::TYPE_CHILD }
+
+      it "contains the child at the beginning of the chain" do
+        expect(relatable)
+          .to match_array [transitive_predecessor_child]
+      end
+    end
+  end
+
+  context 'with a successor chain where the last has parent and child' do
+    let(:direct_successor) do
+      create(:work_package).tap do |suc|
+        create(:follows_relation, to: origin, from: suc)
+      end
+    end
+    let(:transitive_successor) do
+      create(:work_package, parent: transitive_successor_parent).tap do |suc|
+        create(:follows_relation, to: direct_successor, from: suc)
+      end
+    end
+    let(:transitive_successor_parent) do
+      create(:work_package)
+    end
+    let(:transitive_successor_child) do
+      create(:work_package, parent: transitive_successor)
+    end
+    let!(:existing_work_packages) do
+      [direct_successor, transitive_successor, transitive_successor_parent, transitive_successor_child]
+    end
+
+    context "for a 'parent' relation" do
+      let(:relation_type) { Relation::TYPE_PARENT }
+
+      it "contains the parent at the beginning of the chain" do
+        expect(relatable)
+          .to match_array [transitive_successor_parent]
+      end
+    end
+
+    context "for a 'child' relation" do
+      let(:relation_type) { Relation::TYPE_CHILD }
+
+      it "contains the child at the beginning of the chain" do
+        expect(relatable)
+          .to match_array [transitive_successor_child]
+      end
+    end
+  end
 end

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -84,8 +84,8 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI do
   context "without cross project relations",
           with_settings: { cross_project_work_package_relations: false } do
     describe "relation candidates for wp1 (in hierarchy)" do
-      it "returns an empty list" do # as relations to ancestors or descendents is not allowed
-        expect(result["count"]).to eq 0
+      it "returns an empty list" do
+        expect(subjects).to match_array ["WP 1.2.1"]
       end
     end
 
@@ -119,8 +119,8 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI do
     describe "relation candidates for wp1 (in hierarchy)" do
       let(:href) { "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=WP" }
 
-      it "returns WP 2 and all WP 2.x" do
-        expect(subjects).to match_array ["WP 2", "WP 2.1", "WP 2.2"]
+      it "returns WP 2 and all WP 2.x as well at the grandchild WP 1.2.1" do
+        expect(subjects).to match_array ["WP 2", "WP 2.1", "WP 2.2", "WP 1.2.1"]
       end
     end
 
@@ -133,7 +133,7 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       end
 
       it "returns WP 2 and all WP 2.x sorted by updated_at DESC" do
-        expect(subjects).to match ["WP 2.1", "WP 2", "WP 2.2"]
+        expect(subjects).to match ["WP 2.1", "WP 1.2.1", "WP 2", "WP 2.2"]
       end
     end
 

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -147,24 +147,48 @@ describe ::API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       describe 'with an already existing relationship from the work package' do
         # rubocop:disable Naming/VariableNumber
         shared_let(:relation_wp2_to_wp2_2) do
-          create(:relation, from: wp2, to: wp2_2, relation_type: "relates")
+          create(:relation, from: wp2, to: wp2_2, relation_type: "follows")
         end
 
         shared_let(:relation_wp1_1_to_wp2) do
-          create(:relation, from: wp1_1, to: wp2, relation_type: "relates")
+          create(:relation, from: wp1_1, to: wp2, relation_type: "follows")
         end
         # rubocop:enable Naming/VariableNumber
 
         context 'for a follows relationship' do
-          it 'does not contain the work packages with which a relationship already exists but the parent' do
+          it 'does not contain the work packages already related in the opposite direction nor the parent' do
+            expect(subjects).to match_array ["WP 1.2", "WP 1.2.1", "WP 2.1"]
+          end
+        end
+
+        context 'for a precedes relationship' do
+          let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=precedes" }
+
+          it 'does not contain the work packages already related but the parent' do
             expect(subjects).to match_array ["WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1"]
+          end
+        end
+
+        context 'for a parent relationship' do
+          let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=parent" }
+
+          it 'does not contain the work packages already related but the parent' do
+            expect(subjects).to match_array ["WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1"]
+          end
+        end
+
+        context 'for a child relationship' do
+          let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=child" }
+
+          it 'does not contain the work packages already related nor the parent' do
+            expect(subjects).to match_array ["WP 1.2", "WP 1.2.1", "WP 2.1"]
           end
         end
 
         context 'for a relates relationship' do
           let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=relates" }
 
-          it 'does not contain the work packages with which a relationship already exists but the parent' do
+          it 'does not contain the work packages already related but the parent' do
             expect(subjects).to match_array ["WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1"]
           end
         end


### PR DESCRIPTION
Both allows and prevents relations to be constructed in additional structures, e.g.:

* [For a work package with a predecessor. With that predecessor having a parent: That parent can now be set as the parent of the original work package.](https://community.openproject.org/wp/44827) 
* For a work package with a predecessor. With that predecessor having a predecessor of its own: That predecessor's predecessor can no longer be set as a parent.
* For a work package with a child. With that child having a successor: That successor can no longer be set to be the parent.
* For a work package with a parent currently. With that parent having a predecessor: The predecessor can now be set to be the new parent.  
 
## TODO

* [x] additional documentation
* [x] additional testing