### PR TITLE
Fix viewpoint seeding in multitenancy

### DIFF
--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
@@ -186,17 +186,19 @@ module OpenProject::Bim::BcfXml
       extractor.viewpoints.each do |vp|
         next if issue.viewpoints.has_uuid?(vp[:uuid])
 
-        issue.viewpoints.build(
+        viewpoint = issue.viewpoints.build(
           issue:,
           uuid: vp[:uuid],
 
           # Save the viewpoint as json
           json_viewpoint: viewpoint_as_json(vp[:uuid], read_entry(vp[:viewpoint])),
           viewpoint_name: vp[:viewpoint],
-
-          # Save the snapshot as file attachment
-          snapshot: as_file_entry(vp[:snapshot])
         )
+
+        # Save the snapshot as file attachment
+        file = as_file_entry(vp[:snapshot])
+        # Call build_snapshot manually so we can ensure the correct user is passed
+        viewpoint.build_snapshot(file, user:)
       end
     end
 


### PR DESCRIPTION
As soon as the first attachment is saved, a notification delayed job is now triggered.

That in itself is not a a problem, however the CreateTenantJob calls `DelayedJob.delay_jobs = false` which results in them running inline.

At the same time, an `Apartment::Tenant.switch` happens within the job to get to the correct schema. This switch includes a `RequestStore.clear!` which removes the current_user value.

That is why in multitenancy, seeding the first viewpoint works, then the next viewpoint is built with the AnonymousUser, resulting in failing permissions.