### PR TITLE
Provide same post-logout flow for OIDC as with SAML

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -40,7 +40,15 @@ module OpenProject::OpenIDConnect
       ]
 
       strategy :openid_connect do
-        OpenProject::OpenIDConnect.providers.map(&:to_h)
+        OpenProject::OpenIDConnect.providers.map(&:to_h).map do
+          h[:single_sign_out_callback] = Proc.new do
+            next unless h[:end_session_endpoint]
+
+            redirect_to "#{omniauth_start_path(h[:name])}/logout"
+          end
+
+          h
+        end
       end
     end
 


### PR DESCRIPTION
We have a post-logout hook to call omniauth strategies so they can forward to whatever session termination flows they have in place. Our OpenID connect provider supports an `end_session_endpoint` already, but that does not get redirect to upon session termination.

Behaves the same as in https://github.com/opf/openproject/blob/dev/modules/auth_saml/lib/open_project/auth_saml/engine.rb#L66-L74

https://community.openproject.org/wp/44970