### PR TITLE
[43253] Wrong right margin in the side menu new team planner button

### DIFF
--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -17,5 +17,8 @@
     text-align: center
     padding: 1rem
 
+    @supports (-webkit-touch-callout: none)
+      padding: 1rem 1rem 5rem
+
     .button .spot-icon
       margin-right: 0.5rem


### PR DESCRIPTION
Since the browser search bar in IoS devices is at the bottom of the screen, side bar footer should have more padding-bottom. 

https://community.openproject.org/work_packages/43253/activity