### PR TITLE
return empty array instead of `null` for '_embedded/elements' 

### DIFF
--- a/lib/api/decorators/sql_collection_representer.rb
+++ b/lib/api/decorators/sql_collection_representer.rb
@@ -130,7 +130,7 @@ module API
                representation: ->(walker_result) do
                  replacement = walker_result.replace_map['elements']
 
-                 replacement ? "json_agg(#{replacement})" : nil
+                 replacement ? "COALESCE(json_agg(#{replacement}), '[]')" : nil
                end
     end
   end

--- a/spec/requests/api/v3/capability_resource_spec.rb
+++ b/spec/requests/api/v3/capability_resource_spec.rb
@@ -372,10 +372,14 @@ describe 'API v3 capabilities resource', type: :request, content_type: :json do
         } }]
       end
 
-      it 'is empty' do
+      it 'is empty and includes an empty element set', :aggregate_failures do
         expect(subject.body)
           .to be_json_eql('0')
           .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql([].to_json)
+                .at_path('_embedded/elements')
       end
     end
 


### PR DESCRIPTION
`_embedded/elements` should always have an array, even if it is empty to not trip up clients.

Will not add the necessary permissions to fix https://community.openproject.org/wp/44850 reduces surprises.