### PR TITLE
Fix work package title overflow

### DIFF
--- a/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
+++ b/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
@@ -40,7 +40,8 @@
 
     .inline-edit--display-field
       white-space: normal
-      word-break: break-all
+      overflow-wrap: break-word
+      hyphens: auto
 
 // Subject field
 .wp-new--subject-wrapper

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -119,6 +119,11 @@
     .work-package-details-activities-activity-contents ul.work-package-details-activities-messages
       padding-left: 0
 
+    li .message
+      white-space: normal
+      overflow-wrap: break-word
+      hyphens: auto
+
     .activity-comment
       margin-top: 15px
 


### PR DESCRIPTION
The work package title was being cut in the middle of words on the full view, as well as overflowing out of the content box in the activity messages. This commit fixes both to discourage breaking inside words and to use hyphenation.

Closes https://community.openproject.org/work_packages/45022/activity