### PR TITLE
Handle default language on user register flow

### DIFF
--- a/app/services/users/set_attributes_service.rb
+++ b/app/services/users/set_attributes_service.rb
@@ -48,9 +48,8 @@ module Users
 
     def set_default_attributes(params)
       # Assign values other than mail to new_user when invited
-      if model.invited? && model.valid_attribute?(:mail)
-        assign_invited_attributes!(params)
-      end
+      assign_name_attributes_from_mail(params) if model.invited? && model.valid_attribute?(:mail)
+      assign_default_language
 
       model.notification_settings.build unless model.notification_settings.any?
     end
@@ -62,15 +61,18 @@ module Users
     end
 
     # rubocop:disable Metrics/AbcSize
-    def assign_invited_attributes!(params)
+    def assign_name_attributes_from_mail(params)
       placeholder = placeholder_name(params[:mail])
 
       model.login = model.login.presence || params[:mail]
       model.firstname = model.firstname.presence || placeholder.first
       model.lastname = model.lastname.presence || placeholder.last
-      model.language = model.language.presence || Setting.default_language
     end
     # rubocop:enable Metrics/AbcSize
+
+    def assign_default_language
+      model.language = model.language.presence || Setting.default_language
+    end
 
     ##
     # Creates a placeholder name for the user based on their email address.

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -51,7 +51,10 @@ describe ::API::V3::Users::CreateFormAPI, content_type: :json do
         {}
       end
 
-      it 'returns a payload with validation errors', :aggregate_failures do
+      # rubocop:disable RSpec/ExampleLength
+      it 'returns a payload with validation errors',
+         :aggregate_failures,
+         with_settings: { default_language: :es } do
         expect(response.status).to eq(200)
         expect(response.body).to be_json_eql('Form'.to_json).at_path('_type')
 
@@ -62,7 +65,7 @@ describe ::API::V3::Users::CreateFormAPI, content_type: :json do
           .to be_json_eql(''.to_json)
                 .at_path('_embedded/payload/email')
         expect(body)
-          .to be_json_eql(''.to_json)
+          .to be_json_eql('es'.to_json)
                 .at_path('_embedded/payload/language')
         expect(body)
           .to be_json_eql('active'.to_json)
@@ -74,22 +77,19 @@ describe ::API::V3::Users::CreateFormAPI, content_type: :json do
 
         expect(body)
           .to have_json_path('_embedded/validationErrors/password')
-
         expect(body)
           .to have_json_path('_embedded/validationErrors/login')
-
         expect(body)
           .to have_json_path('_embedded/validationErrors/email')
-
         expect(body)
           .to have_json_path('_embedded/validationErrors/firstName')
-
         expect(body)
           .to have_json_path('_embedded/validationErrors/lastName')
 
         expect(body)
           .not_to have_json_path('_links/commit')
       end
+      # rubocop:enable RSpec/ExampleLength
     end
 
     describe 'inviting a user' do

--- a/spec/services/users/set_attributes_service_spec.rb
+++ b/spec/services/users/set_attributes_service_spec.rb
@@ -94,6 +94,13 @@ describe Users::SetAttributesService, type: :model do
         .to(all(be_a(NotificationSetting).and(be_new_record)))
     end
 
+    it 'sets the default language', with_settings: { default_language: 'de' } do
+      call
+
+      expect(model_instance.language)
+        .to eql 'de'
+    end
+
     context 'with params' do
       let(:params) do
         {


### PR DESCRIPTION
The `Users::SetAttributesService` was only programmed for setting the default values for an invited user. If the user self registered however, the default values like the language were not applied.

https://community.openproject.org/wp/36162  