### PR TITLE
[#45032] Custom fields editing looks like it's possible in read-only status

### DIFF
--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -139,7 +139,12 @@ class BaseContract < Disposable::Twin
   end
 
   def writable?(attribute)
-    writable_attributes.include?(attribute.to_s)
+    property_name = ::API::Utilities::PropertyNameConverter.to_ar_name(
+      attribute,
+      context: model,
+      collapse_cf_name: false
+    )
+    writable_attributes.include?(property_name)
   end
 
   def valid?(*_args)

--- a/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.html
+++ b/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.html
@@ -1,6 +1,7 @@
 <span
   class="wp-replacement-label"
   (click)="activate($event)"
-  tabindex="-1">
+  tabindex="-1"
+  attr.data-qa-selector="{{fieldName}}">
   <ng-content></ng-content>
 </span>

--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -171,9 +171,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       return true;
     }
 
-    if (this.isEditable) {
-      this.handleUserActivate(event);
-    }
+    this.handleUserActivate(event);
 
     this.opContextMenu.close();
     event.preventDefault();
@@ -192,6 +190,10 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   }
 
   public handleUserActivate(evt:MouseEvent|KeyboardEvent|null):boolean {
+    if (!this.isEditable) {
+      return false;
+    }
+
     let positionOffset = 0;
 
     if (evt?.type === 'click') {

--- a/lib/api/utilities/property_name_converter.rb
+++ b/lib/api/utilities/property_name_converter.rb
@@ -64,9 +64,9 @@ module API
         # Converts the attribute name as referred to by the APIv3 to the source name of the attribute
         # in ActiveRecord. For that to work properly, an instance of the correct AR-class needs
         # to be passed as context.
-        def to_ar_name(attribute, context:, refer_to_ids: false)
+        def to_ar_name(attribute, context:, refer_to_ids: false, collapse_cf_name: true)
           attribute = underscore_attribute attribute.to_s.underscore
-          attribute = collapse_custom_field_name(attribute)
+          attribute = collapse_custom_field_name(attribute) if collapse_cf_name
 
           special_conversion = Constants::ARToAPIConversions.api_to_ar_conversions[attribute]
 

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -139,7 +139,6 @@ module API
                                                   represented
                                                     .assignable_custom_field_values(custom_field)
                                                 },
-                                                writable: true,
                                                 value_representer: Versions::VersionRepresenter,
                                                 link_factory: ->(version) {
                                                   {
@@ -153,7 +152,6 @@ module API
         def inject_user_schema(custom_field)
           @class.schema_with_allowed_link property_name(custom_field.id),
                                           type: resource_type(custom_field),
-                                          writable: true,
                                           name_source: ->(*) { custom_field.name },
                                           required: custom_field.is_required,
                                           href_callback: allowed_users_href_callback
@@ -166,19 +164,17 @@ module API
             name_source: ->(*) { custom_field.name },
             values_callback: list_schemas_values_callback(custom_field),
             value_representer: CustomOptions::CustomOptionRepresenter,
-            writable: true,
             link_factory: list_schemas_link_callback,
             required: custom_field.is_required
           )
         end
 
-        def inject_basic_schema(custom_field, writable: true)
+        def inject_basic_schema(custom_field)
           @class.schema property_name(custom_field.id),
                         type: resource_type(custom_field),
                         name_source: ->(*) { custom_field.name },
                         required: custom_field.is_required,
                         has_default: custom_field.default_value.present?,
-                        writable:,
                         min_length: cf_min_length(custom_field),
                         max_length: cf_max_length(custom_field),
                         regular_expression: cf_regexp(custom_field),
@@ -233,7 +229,7 @@ module API
           proc do
             # Do not embed list or multi values as their links contain all the
             # information needed (title and href) already.
-            next if !represented.available_custom_fields.include?(custom_field) ||
+            next if represented.available_custom_fields.exclude?(custom_field) ||
                     custom_field.list? ||
                     custom_field.multi_value?
 

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -59,8 +59,11 @@ module API
 
             @writable_attributes ||= contract.writable_attributes
 
-            property_name = ::API::Utilities::PropertyNameConverter.to_ar_name(property, context: work_package)
-
+            property_name = ::API::Utilities::PropertyNameConverter.to_ar_name(
+              property,
+              context: work_package,
+              collapse_cf_name: false
+            )
             @writable_attributes.include?(property_name)
           end
 

--- a/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
@@ -40,6 +40,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
   let(:user) { build_stubbed(:user) }
   let(:assigned_project) { nil }
   let(:activity) { build_stubbed(:time_entry_activity) }
+  let(:writable_attributes) { %w(spent_on hours project work_package activity comment user) }
 
   let(:contract) do
     contract = double('contract',
@@ -50,7 +51,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
 
     allow(contract)
       .to receive(:writable?) do |attribute|
-      %w(spent_on hours project work_package activity comment user).include?(attribute.to_s)
+      writable_attributes.include?(attribute.to_s)
     end
 
     allow(contract)
@@ -270,6 +271,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
     context 'custom value' do
       let(:custom_field) { build_stubbed(:text_time_entry_custom_field) }
       let(:path) { "customField#{custom_field.id}" }
+      let(:writable_attributes) { ["customField#{custom_field.id}"] }
 
       before do
         allow(contract)
@@ -282,6 +284,17 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
         let(:name) { custom_field.name }
         let(:required) { false }
         let(:writable) { true }
+      end
+
+      context 'with schema not writable' do
+        let(:writable_attributes) { [] }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'Formattable' }
+          let(:name) { custom_field.name }
+          let(:required) { false }
+          let(:writable) { false }
+        end
       end
     end
   end

--- a/spec/features/statuses/read_only_statuses_spec.rb
+++ b/spec/features/statuses/read_only_statuses_spec.rb
@@ -29,41 +29,42 @@
 require 'spec_helper'
 
 describe 'Read-only statuses affect work package editing',
-         with_ee: %i[readonly_work_packages],
-         type: :feature,
-         js: true do
-  let(:locked_status) { create :status, name: 'Locked', is_readonly: true }
-  let(:unlocked_status) { create :status, name: 'Unlocked', is_readonly: false }
-
-  let(:type) { create :type_bug }
-  let(:project) { create :project, types: [type] }
-  let!(:work_package) do
-    create :work_package,
-           project:,
-           type:,
-           status: unlocked_status
+         js: true, with_ee: %i[readonly_work_packages] do
+  let(:locked_status) { create(:status, name: 'Locked', is_readonly: true) }
+  let(:unlocked_status) { create(:status, name: 'Unlocked', is_readonly: false) }
+  let(:cf_all) do
+    create(:work_package_custom_field, is_for_all: true, field_format: 'text')
   end
 
-  let(:role) { create :role, permissions: %i[edit_work_packages view_work_packages] }
+  let(:type) { create(:type_bug, custom_fields: [cf_all]) }
+  let(:project) { create(:project, types: [type]) }
+  let!(:work_package) do
+    create(:work_package,
+           project:,
+           type:,
+           status: unlocked_status)
+  end
+
+  let(:role) { create(:role, permissions: %i[edit_work_packages view_work_packages]) }
   let(:user) do
-    create :user,
+    create(:user,
            member_in_project: project,
-           member_through_role: role
+           member_through_role: role)
   end
 
   let!(:workflow1) do
-    create :workflow,
+    create(:workflow,
            type_id: type.id,
            old_status: unlocked_status,
            new_status: locked_status,
-           role:
+           role:)
   end
   let!(:workflow2) do
-    create :workflow,
+    create(:workflow,
            type_id: type.id,
            old_status: locked_status,
            new_status: unlocked_status,
-           role:
+           role:)
   end
 
   let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
@@ -94,6 +95,15 @@ describe 'Read-only statuses affect work package editing',
     subject_field.expect_read_only
 
     # Expect attachments not available
-    expect(page).to have_no_selector '.work-package--attachments--drop-box'
+    expect(page).not_to have_selector '.work-package--attachments--drop-box'
+
+    # Expect labels to not activate field editing (Regression#45032)
+    assignee_field = wp_page.edit_field :assignee
+    assignee_field.label_element.click
+    assignee_field.expect_inactive!
+
+    custom_field = wp_page.edit_field cf_all.accessor_name.camelcase(:lower)
+    custom_field.label_element.click
+    custom_field.expect_inactive!
   end
 end

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -234,7 +234,7 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:type) { 'Integer' }
         let(:name) { custom_field.name }
         let(:required) { false }
-        let(:writable) { true }
+        let(:writable) { false }
       end
     end
 

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -51,11 +51,13 @@ describe ::API::V3::Utilities::CustomFieldInjector do
   describe '#inject_schema' do
     let(:base_class) { Class.new(::API::Decorators::SchemaRepresenter) }
     let(:modified_class) { described_class.create_schema_representer([custom_field], base_class) }
+    let(:schema_writable) { true }
     let(:schema) do
       double('WorkPackageSchema',
              project_id: 42,
              defines_assignable_values?: true,
-             available_custom_fields: [custom_field])
+             available_custom_fields: [custom_field],
+             writable?: schema_writable)
     end
 
     subject { modified_class.new(schema, current_user: nil, form_embedded: true).to_json }
@@ -69,6 +71,18 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:required) { true }
         let(:writable) { true }
         let(:has_default) { false }
+      end
+
+      context 'with schema not writable' do
+        let(:schema_writable) { false }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'Boolean' }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { false }
+          let(:has_default) { false }
+        end
       end
 
       context 'with default set' do
@@ -155,6 +169,19 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:location) { '_links' }
       end
 
+      context 'with schema not writable' do
+        let(:schema_writable) { false }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { cf_path }
+          let(:type) { 'Version' }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { false }
+          let(:location) { '_links' }
+        end
+      end
+
       it_behaves_like 'links to allowed values directly' do
         let(:path) { cf_path }
         let(:hrefs) { assignable_versions.map { |version| api_v3_paths.version version.id } }
@@ -196,6 +223,19 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:location) { '_links' }
       end
 
+      context 'with schema not writable' do
+        let(:schema_writable) { false }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { cf_path }
+          let(:type) { 'CustomOption' }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { false }
+          let(:location) { '_links' }
+        end
+      end
+
       it_behaves_like 'links to and embeds allowed values directly' do
         let(:path) { cf_path }
         let(:hrefs) do
@@ -220,6 +260,19 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:required) { true }
         let(:writable) { true }
         let(:location) { '_links' }
+      end
+
+      context 'with schema not writable' do
+        let(:schema_writable) { false }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { cf_path }
+          let(:type) { 'User' }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { false }
+          let(:location) { '_links' }
+        end
       end
 
       it_behaves_like 'links to allowed values via collection link' do

--- a/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
+++ b/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
@@ -156,7 +156,7 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:type) { 'Integer' }
         let(:name) { custom_field.name }
         let(:required) { false }
-        let(:writable) { true }
+        let(:writable) { false }
       end
     end
 

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -29,14 +29,16 @@
 require 'spec_helper'
 require 'rack/test'
 
-describe 'API v3 Work package form resource', type: :request, with_mail: false do
+describe 'API v3 Work package form resource', with_mail: false do
   include Rack::Test::Methods
   include Capybara::RSpecMatchers
   include API::V3::Utilities::PathHelper
 
   shared_let(:all_allowed_permissions) { %i[view_work_packages edit_work_packages assign_versions view_budgets] }
   shared_let(:assign_permissions) { %i[view_work_packages assign_versions] }
-  shared_let(:project) { create(:project, public: false) }
+  shared_let(:cf_all) { create(:work_package_custom_field, is_for_all: true, field_format: 'text') }
+  shared_let(:type) { create(:type_bug, custom_fields: [cf_all]) }
+  shared_let(:project) { create(:project, public: false, types: [type]) }
   shared_let(:authorized_user) do
     create(:user, member_in_project: project, member_with_permissions: all_allowed_permissions)
   end
@@ -114,6 +116,24 @@ describe 'API v3 Work package form resource', type: :request, with_mail: false d
             let(:html) do
               defined?(html_value) ? html_value : "<p class=\"op-uc-p\">#{work_package.description}</p>"
             end
+          end
+
+          it 'denotes subject to be writable' do
+            expect(subject)
+              .to be_json_eql(true)
+              .at_path('_embedded/schema/subject/writable')
+          end
+
+          it 'denotes version to be writable' do
+            expect(subject)
+              .to be_json_eql(true)
+              .at_path('_embedded/schema/version/writable')
+          end
+
+          it 'denotes string custom_field to be writable' do
+            expect(subject)
+              .to be_json_eql(true)
+              .at_path("_embedded/schema/#{cf_all.accessor_name.camelcase(:lower)}/writable")
           end
         end
 
@@ -618,7 +638,7 @@ describe 'API v3 Work package form resource', type: :request, with_mail: false d
             describe 'type' do
               let(:path) { '_embedded/payload/_links/type/href' }
               let(:links_path) { '_embedded/schema/type/_links' }
-              let(:target_type) { create(:type) }
+              let(:target_type) { create(:type, custom_fields: [cf_all]) }
               let(:other_type) { work_package.type }
               let(:type_link) { api_v3_paths.type target_type.id }
               let(:other_type_link) { api_v3_paths.type other_type.id }
@@ -741,7 +761,7 @@ describe 'API v3 Work package form resource', type: :request, with_mail: false d
 
             describe 'formattable custom field set to nil' do
               let(:custom_field) do
-                create :work_package_custom_field, field_format: 'text'
+                create(:work_package_custom_field, field_format: 'text')
               end
 
               let(:cf_param) { { "customField#{custom_field.id}" => nil } }
@@ -803,6 +823,12 @@ describe 'API v3 Work package form resource', type: :request, with_mail: false d
         expect(subject)
           .to be_json_eql(true)
           .at_path('_embedded/schema/version/writable')
+      end
+
+      it 'denotes custom_field to not be writable' do
+        expect(subject)
+          .to be_json_eql(false)
+          .at_path("_embedded/schema/#{cf_all.accessor_name.camelcase(:lower)}/writable")
       end
     end
   end

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -37,6 +37,10 @@ class EditField
     context.find "#{@selector} #{input_selector}"
   end
 
+  def label_element
+    context.find ".wp-replacement-label[data-qa-selector='#{property_name}']"
+  end
+
   def clear(with_backspace: false)
     if with_backspace
       input_element.set(' ', fill_options: { clear: :backspace })
@@ -111,11 +115,11 @@ class EditField
 
   def expect_inactive!
     expect(field_container).to have_selector(display_selector, wait: 10)
-    expect(field_container).to have_no_selector(field_type)
+    expect(field_container).not_to have_selector(field_type)
   end
 
   def expect_enabled!
-    expect(@context).to have_no_selector "#{@selector} #{input_selector}[disabled]"
+    expect(@context).not_to have_selector "#{@selector} #{input_selector}[disabled]"
   end
 
   def expect_invalid
@@ -187,7 +191,7 @@ class EditField
     scroll_to_element(input_element)
     input_element.find('input').set content
 
-    page.find('.ng-option', text: 'Create: ' + content).click
+    page.find('.ng-option', text: "Create: #{content}").click
   end
 
   def type(text)


### PR DESCRIPTION
https://community.openproject.org/work_packages/45032

The fix consists of two parts:
 1. Check in the [handleUserActivate](https://github.com/opf/openproject/pull/11709/files#diff-6ffd32b693ee3c4dc5b2088f41d9770a8212f96f4a4e89cda193130f3551dcbb) function that the field is editable and return accordingly. This method is being used also by the field label in the [wp-replacement-label.component.ts](https://github.com/opf/openproject/blob/c7004e6dd62a4ebe9e6487375d3c54ae7045630a/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.component.ts#L59), thus the clickability of the label is depending on the `handleUserActivate` function.
 2. During debugging the issue, I spotted a bug in the work package schema writable attribute for custom fields. It was always  returning true, which was incorrect, allowing the PR's main bug to happen. In order to solve the issue, I removed the `writable` values set in the schema representer, this way they are being decided in the default [`BaseWorkPackageSchema #writable?`](https://github.com/opf/openproject/pull/11709/files#diff-2aaabd52f91cec4236257db338f4484d2eea4b00ffec08dff21ec8070b125218R62). The [`BaseWorkPackageSchema #writable?`](https://github.com/opf/openproject/pull/11709/files#diff-2aaabd52f91cec4236257db338f4484d2eea4b00ffec08dff21ec8070b125218R62) method was also not inferring the custom field names correctly, I fixed that by extending the [`::API::Utilities::PropertyNameConverter.to_ar_name`](https://github.com/opf/openproject/pull/11709/files#diff-619f634dada0c28e3bb064df898b290f371812b21de9225180540fc577da08a1R69) with a new argument.