### PR TITLE
Fix positioning for preview modal

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -96,6 +96,7 @@
       grid-area: subject
       @include text-shortener(false)
     &-assignee
+      margin-right: auto
       grid-area: avatar
       max-width: 140px
       color: $spot-color-basic-gray-3

--- a/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
+++ b/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
@@ -1,6 +1,10 @@
-<div class="op-wp-preview-modal" wp-isolated-query-space *ngIf="workPackage">
-   <wp-single-card [workPackage]="workPackage"
-                   orientation="horizontal"
-                   (stateLinkClicked)="openStateLink($event)">
-   </wp-single-card>
+<div
+  class="op-wp-preview-modal" wp-isolated-query-space
+  *ngIf="workPackage"
+>
+   <wp-single-card
+     [workPackage]="workPackage"
+     orientation="horizontal"
+     (stateLinkClicked)="openStateLink($event)"
+   ></wp-single-card>
 </div>

--- a/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
+++ b/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
@@ -74,7 +74,7 @@ export class WpPreviewModalComponent extends OpModalComponent implements OnInit 
         this.workPackage = workPackage;
         this.cdRef.detectChanges();
 
-        const modal = jQuery(this.elementRef.nativeElement).find('.op-wp-preview-modal');
+        const modal = jQuery(this.elementRef.nativeElement);
         this.reposition(modal, this.locals.event.target);
       });
   }


### PR DESCRIPTION
After the spot-modal plumbing rewrite, the preview modal was not being
positioned correctly when opened a second time. It was a combination
of two things; when opening the second time, the contents of the modal
are already cached, and thus the reposition call that results from
updated content was faster than the reposition call from the preview
trigger service.

The actual bug was in that specific reposition call; it was using the
wrong elements to do the positioning; namely one level down from where
it should be happening.

Also includes a small style fix for the preview modal

The assignee `op-principal` component was filling space it didn't need,
causing the avatar to become misaligned.

Closes https://community.openproject.org/work_packages/45058/activity