### PR TITLE
properly include ancestors/descendants for child and rely on includes…

### DIFF
--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -365,9 +365,6 @@ module WorkPackages::Scopes
       # rubocop:enable Metrics/PerceivedComplexity
 
       def existing_hierarchy_lateral(with_descendants: true)
-        hierarchy_condition = ["work_package_hierarchies.descendant_id = related.id"]
-        hierarchy_condition << "work_package_hierarchies.ancestor_id = related.id" if with_descendants
-
         <<~SQL.squish
           SELECT
             CASE
@@ -385,7 +382,7 @@ module WorkPackages::Scopes
             work_package_hierarchies
           WHERE
             related.from_hierarchy = false AND
-            (#{hierarchy_condition.join(' OR ')})
+            (work_package_hierarchies.descendant_id = related.id OR work_package_hierarchies.ancestor_id = related.id)
             AND (work_package_hierarchies.generations != 0)
         SQL
       end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -1431,7 +1431,7 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     end
   end
 
-  context 'with a predecessor chain where the first has parent and child' do
+  context 'with a predecessor chain where the first has parent and child and that child has a predecessor' do
     let(:direct_predecessor) do
       create(:work_package).tap do |pre|
         create(:follows_relation, from: origin, to: pre)
@@ -1448,8 +1448,17 @@ describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     let(:transitive_predecessor_child) do
       create(:work_package, parent: transitive_predecessor)
     end
+    let(:transitive_predecessor_child_predecessor) do
+      create(:work_package).tap do |pre|
+        create(:follows_relation, from: transitive_predecessor_child, to: pre)
+      end
+    end
     let!(:existing_work_packages) do
-      [direct_predecessor, transitive_predecessor, transitive_predecessor_parent, transitive_predecessor_child]
+      [direct_predecessor,
+       transitive_predecessor,
+       transitive_predecessor_parent,
+       transitive_predecessor_child,
+       transitive_predecessor_child_predecessor]
     end
 
     context "for a 'parent' relation" do


### PR DESCRIPTION
Follows up on #11655 to fix the issue mentioned by @cbliard 

```
                         WP2 <────follows──── WP1 <────follows──── WP0
                          │
                          │
                       hierarchy
                          │
                          v
   WP4 <────follows────  WP3
    │       
    │       
 hierarchy  
    │       
    v       
   WP5      
```

> When WP1 is selected (or WP0), adding existing child WP4 is possible, and it should not be. There is something guarding from doing it and the error message `Parent A work package cannot be linked to one of its subtasks. ` is displayed after trying.


https://community.openproject.org/wp/45171