### PR TITLE
Fix flaky token_strategy_manager_spec.rb test

### DIFF
--- a/spec/lib/rubocop/cop/open_project/no_do_end_block_with_rspec_capybara_matcher_in_expect_spec.rb
+++ b/spec/lib/rubocop/cop/open_project/no_do_end_block_with_rspec_capybara_matcher_in_expect_spec.rb
@@ -26,10 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'rubocop'
-require 'rubocop/rspec/shared_contexts'
 require 'spec_helper'
-require 'rubocop/rspec/support'
 require 'rubocop/cop/open_project/no_do_end_block_with_rspec_capybara_matcher_in_expect'
 
 RSpec.describe RuboCop::Cop::OpenProject::NoDoEndBlockWithRSpecCapybaraMatcherInExpect do

--- a/spec/lib/rubocop/cop/open_project/use_service_result_factory_methods_spec.rb
+++ b/spec/lib/rubocop/cop/open_project/use_service_result_factory_methods_spec.rb
@@ -26,10 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'rubocop'
-require 'rubocop/rspec/shared_contexts'
 require 'spec_helper'
-require 'rubocop/rspec/support'
 require 'rubocop/cop/open_project/use_service_result_factory_methods'
 
 RSpec.describe RuboCop::Cop::OpenProject::UseServiceResultFactoryMethods do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,15 @@ require "test_prof/recipes/rspec/factory_default"
 # https://github.com/paper-trail-gem/paper_trail#7b-rspec
 require 'paper_trail/frameworks/rspec'
 
+# Add rubocop rspec helpers for our cop tests. It needs to be done before RSpec
+# requires all files so that the CopHelper module does not hide some let
+# definitions.
+#
+# Ideally we should move our cops to their own gem.
+require 'rubocop'
+require 'rubocop/rspec/shared_contexts'
+require 'rubocop/rspec/support'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
If `rubocop/rspec/support` is required after some spec files, the module CopHelper will be available before the let definitions, which can interfere with the spec.

For instance, in `modules/two_factor_authentication/spec/lib/token_strategy_manager_spec.rb`, when `configuration` is called, it resolves to `CopHelper#configuration` instead of using the one defined by `let(:configuration)`. This can occur with this command: `rspec --order defined ./modules/two_factor_authentication/spec/lib/token_strategy_manager_spec.rb:56 spec/lib/rubocop/cop/open_project`.

Requiring rubocop rspec files fixes in rails_helper before any spec file is required fixes it, but adds an overhead. Long term solution would be to move the cops and their tests to their own gem.