### PR TITLE
Add debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -284,6 +284,9 @@ group :development, :test do
   gem 'ruby-prof', require: false
   gem 'stackprof', require: false
 
+  # REPL with debug commands
+  gem 'debug'
+
   gem 'pry-byebug', '~> 3.10.0', platforms: [:mri]
   gem 'pry-rails', '~> 0.3.6'
   gem 'pry-rescue', '~> 1.5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,9 @@ GEM
     date_validator (0.12.0)
       activemodel (>= 3)
       activesupport (>= 3)
+    debug (1.7.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     deckar01-task_list (2.3.2)
       html-pipeline
     declarative (0.0.20)
@@ -558,6 +561,9 @@ GEM
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
     interception (0.5)
+    io-console (0.5.11)
+    irb (1.5.1)
+      reline (>= 0.3.0)
     iso8601 (0.13.0)
     jmespath (1.6.2)
     json (2.6.2)
@@ -795,6 +801,8 @@ GEM
       json
     redcarpet (3.5.1)
     regexp_parser (2.6.1)
+    reline (0.3.1)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -1021,6 +1029,7 @@ DEPENDENCIES
   danger-brakeman
   dashboards!
   date_validator (~> 0.12.0)
+  debug
   deckar01-task_list (~> 2.3.1)
   delayed_cron_job (~> 0.9.0)
   delayed_job_active_record (~> 4.1.5)


### PR DESCRIPTION
Start a debugging REPL with `binding.d`.

This follows the conversation we had on Elements about using `debug` instead of `pry`/`pry-byebug`. Adding `debug` to the Gemfile automatically loads it and makes `binding.d` available.