### PR TITLE
Cover groups, placeholder users, and system users cases

### DIFF
--- a/spec/models/principals/scopes/visible_spec.rb
+++ b/spec/models/principals/scopes/visible_spec.rb
@@ -28,45 +28,102 @@
 
 require 'spec_helper'
 
-describe Principals::Scopes::Visible, type: :model do
+describe Principals::Scopes::Visible do
   describe '.visible' do
-    shared_let(:project) { create :project }
-    shared_let(:other_project) { create :project }
-    shared_let(:role) { create :role, permissions: %i[manage_members] }
+    shared_let(:role) { create(:role, permissions: %i[manage_members]) }
 
-    shared_let(:other_project_user) { create :user, member_in_project: other_project, member_through_role: role }
-    shared_let(:global_user) { create :user }
+    shared_let(:anonymous_user) { User.anonymous }
+    shared_let(:system_user) { User.system }
+
+    shared_let(:project) { create(:project) }
+    shared_let(:project_user) do
+      create(:user, firstname: 'project user',
+                    member_in_project: project,
+                    member_through_role: role)
+    end
+    shared_let(:project_group) do
+      create(:group, firstname: 'project group',
+                     member_in_project: project,
+                     member_through_role: role)
+    end
+    shared_let(:project_placeholder_user) do
+      create(:placeholder_user, firstname: 'project placeholder user',
+                                member_in_project: project,
+                                member_through_role: role)
+    end
+
+    # The 'other project' is here to ensure their members are not visible from
+    # the outside for people lacking manage_members or manage_user permissions
+    shared_let(:other_project) { create(:project) }
+    shared_let(:other_project_user) do
+      create(:user, firstname: 'other project user',
+                    member_in_project: other_project,
+                    member_through_role: role)
+    end
+    shared_let(:other_project_group) do
+      create(:group, firstname: 'other project group',
+                     member_in_project: other_project,
+                     member_through_role: role)
+    end
+    shared_let(:other_placeholder_user) do
+      create(:placeholder_user, firstname: 'other project placeholder user',
+                                member_in_project: other_project,
+                                member_through_role: role)
+    end
+
+    shared_let(:global_user) { create(:user, firstname: 'global user') }
+    shared_let(:global_group) { create(:group, firstname: 'global group') }
+    shared_let(:global_placeholder_user) { create(:placeholder_user, firstname: 'global placeholder') }
 
     subject { ::Principal.visible.to_a }
 
-    context 'when user has manage_members permission' do
-      current_user { create :user, member_in_project: project, member_through_role: role }
-
-      it 'sees all users' do
-        expect(subject).to match_array [current_user, other_project_user, global_user]
+    shared_examples 'sees all principals' do
+      it 'sees all users, groups, and placeholder users' do
+        expect(subject).to match_array [
+          # system and anonymous users
+          anonymous_user, system_user,
+          # regular users
+          current_user, project_user, other_project_user, global_user,
+          # groups,
+          project_group, other_project_group, global_group,
+          # placeholder users
+          project_placeholder_user, other_placeholder_user, global_placeholder_user
+        ]
       end
     end
 
-    context 'when user has no manage_members permission, but it is in other project' do
-      current_user { create :user, member_in_project: other_project, member_with_permissions: %i[view_work_packages] }
+    context 'when user has manage_members project permission' do
+      current_user do
+        create(:user, firstname: 'current user',
+                      member_in_project: project,
+                      member_through_role: role)
+      end
 
-      it 'sees the other user in the same project' do
-        expect(subject).to match_array [current_user, other_project_user]
+      include_examples 'sees all principals'
+    end
+
+    context 'when user has no manage_members project permission, and is member of a project' do
+      current_user do
+        create(:user, firstname: 'current user',
+                      member_in_project: project,
+                      member_with_permissions: %i[view_work_packages])
+      end
+
+      it 'sees only the users, groups, and placeholder users in the same project' do
+        expect(subject).to match_array [current_user, project_user, project_group, project_placeholder_user]
       end
     end
 
-    context 'when user has no manage_members permission, but has manage_user global permission' do
-      current_user { create :user, global_permissions: %i[manage_user] }
+    context 'when user has manage_user global permission' do
+      current_user { create(:user, firstname: 'current user', global_permissions: %i[manage_user]) }
 
-      it 'sees all users' do
-        expect(subject).to match_array [current_user, other_project_user, global_user]
-      end
+      include_examples 'sees all principals'
     end
 
     context 'when user has no permission' do
-      current_user { create :user }
+      current_user { create(:user, firstname: 'current user') }
 
-      it 'sees only herself' do
+      it 'sees only themself' do
         expect(subject).to match_array [current_user]
       end
     end


### PR DESCRIPTION
As suggested in https://github.com/opf/openproject/pull/11741#discussion_r1039358241, extend `Principal.visible` test cases to ensure groups, placeholder users, system user and anonymous user can be returned as well.