### PR TITLE
Fix multiple day filter bug, by explicitly applying the from clause

### DIFF
--- a/app/models/queries/days/day_query.rb
+++ b/app/models/queries/days/day_query.rb
@@ -36,14 +36,13 @@ class Queries::Days::DayQuery < Queries::BaseQuery
   end
 
   ##
-  # This override is necessary, the dates interval filter needs to adjust the
-  # `from` clause of the query. To update the `from` clause, we reverse merge the filters,
-  # otherwise the `from` clause of the filter is ignored.
+  # The dates interval filter needs to adjust the `from` clause of the query.
+  # If there are multiple filters with custom from clause (currently not possible),
+  # the first one is applied and the rest is ignored.
   def apply_filters(scope)
-    filters.each do |filter|
-      scope = filter.scope.merge(scope)
-    end
-
+    scope = super(scope)
+    from_clause_filter = filters.find(&:from)
+    scope = scope.from(from_clause_filter.from) if from_clause_filter
     scope
   end
 

--- a/spec/models/queries/days/day_query_spec.rb
+++ b/spec/models/queries/days/day_query_spec.rb
@@ -60,22 +60,25 @@ describe Queries::Days::DayQuery, type: :model do
       instance.where('date', '<>d', date_range)
     end
 
-    context 'with dates within the default range' do
+    shared_examples_for 'dates within the default range' do |working: nil|
       let(:from) { Time.zone.today }
       let(:to) { 5.days.from_now.to_date }
       let(:base_scope) { Day.from_range(from:, to:).reorder(date: :asc) }
-
       it 'is the same as handwriting the query' do
         # Expectation has to be weirdly specific to the logic of Queries::Operators::DateRangeClauses
-        expected = base_scope.where("days.date > ? AND days.date <= ?",
+        expected_scope = base_scope.where("days.date > ? AND days.date <= ?",
                                     (from - 1.day).end_of_day,
                                     to.end_of_day)
 
-        expect(instance.results.to_sql).to eql expected.to_sql
+        unless working.nil?
+          expected_scope = expected_scope.where("days.working IN ('#{working}')")
+        end
+
+        expect(instance.results.to_sql).to eql expected_scope.to_sql
       end
     end
 
-    context 'with dates out of the default range' do
+    shared_examples_for 'dates out of the default range' do
       let(:from) { 5.days.from_now.to_date }
       let(:to) { 153.days.from_now.to_date }
 
@@ -100,6 +103,18 @@ describe Queries::Days::DayQuery, type: :model do
           expect(instance.results.size).to be expected_size
         end
       end
+    end
+
+    include_examples 'dates within the default range'
+    include_examples 'dates out of the default range'
+
+    context 'when having a working filter too' do
+      before do
+        instance.where('working', '=', 't')
+      end
+
+      include_examples 'dates within the default range', working: 't'
+      include_examples 'dates out of the default range'
     end
   end
 end


### PR DESCRIPTION
When applying multiple filters on the `Queries::Days::DayQuery` with one of the filters being a `Queries::Days::Filters::DatesIntervalFilter`, the provided date range values might get ignored depending on the filter order.

This happens, because the date range filter operates by updating the `from` clause of the query and when multiple scopes are merged, the `from` clause gets overridden by the last merged scope. To make sure the right `from` clause is used, I explicitly set the `from` clause of the scope, whenever a custom `from` clause is defined on a filter.