### PR TITLE
Lock mail version to 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'responders', '~> 3.0'
 gem 'ffi', '~> 1.15'
 
 # Lock mail at 2.7 due to incompatibility
+# TODO: Remove it once the new version is fixed
 gem 'mail', '~> 2.7.1'
 
 gem 'rdoc', '>= 2.4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'responders', '~> 3.0'
 
 gem 'ffi', '~> 1.15'
 
+# Lock mail at 2.7 due to incompatibility
+gem 'mail', '~> 2.7.1'
+
 gem 'rdoc', '>= 2.4.2'
 
 gem 'doorkeeper', '~> 5.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -612,11 +612,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     messagebird-rest (1.4.2)
@@ -1066,6 +1063,7 @@ DEPENDENCIES
   listen (~> 3.7.0)
   livingstyleguide (~> 2.1.0)
   lograge (~> 0.12.0)
+  mail (~> 2.7.1)
   matrix (~> 0.4.2)
   meta-tags (~> 2.18.0)
   mini_magick (~> 4.12.0)


### PR DESCRIPTION
https://github.com/opf/openproject/commit/e1a3df5801 broke saas-openproject

I'm not sure why this only happens during deployment:

```
rake aborted!
:LoadError: cannot load such file -- mail/indifferent_hash

/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/mail-2.8.0/lib/mail.rb:14:in `<module:Mail>'
/app/vendor/bundle/ruby/3.1.0/gems/mail-2.8.0/lib/mail.rb:3:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/validate_email-0.1.6/lib/validate_email.rb:4:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/openid_connect-1.1.8/lib/openid_connect.rb:8:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/bundler/gems/omniauth-openid-connect-e9ed9005a71e/lib/omniauth/strategies/openid_connect.rb:6:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/bundler/gems/omniauth-openid_connect-providers-a6c0c3ed78fa/lib/omniauth/openid_connect/provider.rb:1:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/bundler/gems/omniauth-openid_connect-providers-a6c0c3ed78fa/lib/omniauth/openid_connect/providers.rb:2:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/runtime.rb:73:in `rescue in block in require'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/runtime.rb:51:in `block in require'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/runtime.rb:44:in `each'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/runtime.rb:44:in `require'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler.rb:176:in `require'
/app/config/application.rb:44:in `<top (required)>'
/app/Rakefile:33:in `require'
/app/Rakefile:33:in `<top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli.rb:483:in `exec'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli.rb:31:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/cli.rb:25:in `start'
/usr/local/bundle/gems/bundler-2.3.12/exe/bundle:48:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.12/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.3.12/exe/bundle:36:in `<top (required)>'
/usr/local/bundle/bin/bundle:25:in `load'
/usr/local/bundle/bin/bundle:25:in `<main>'
```