### PR TITLE
Fix #45343: text overflow on Safari is cropping early in WP-attributes and sidebar

### DIFF
--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.sass
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.sass
@@ -52,6 +52,7 @@
     white-space: nowrap
     line-height: 30px
     text-decoration: none
+    width: 100%
 
   &--item-icon
     font-size: 24px

--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -44,6 +44,7 @@
     @include text-shortener
     flex: 0 1 auto
     padding-right: $spot-spacing-0_5
+    width: 100% // prevent text-overflow from capping too early on Safari
 
 .attributes-key-value--value-container
   display: flex


### PR DESCRIPTION
Fixed [#45343](https://community.openproject.org/work_packages/45343)