### PR TITLE
Fix notification setting label width

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.sass
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.sass
@@ -13,7 +13,7 @@
     align-items: center
 
   &--label
-    flex: 0 0 100px
+    flex: 0 0 120px
     margin-bottom: 0
     @include text-shortener
 

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.sass
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.sass
@@ -5,11 +5,15 @@
 .op-table
   margin-bottom: 1rem
 
+  select
+    padding-right: 1rem
+
 .op-reminder-settings-table-date-alerts
   &--time
     height: 32px
-    width: 137px
-    padding: 4px 8px 4px 12px
+    width: auto
+    min-width: 100%
+    padding: 4px 22px 4px 12px
     margin: auto
 
 .op-table--cell--date-alerts


### PR DESCRIPTION
The labels were fixed to a width that was too small for some translations strings. 

Closes https://community.openproject.org/work_packages/45163/activity