### PR TITLE
Group versions information together on roadmap page  (#45392)

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -50,6 +50,14 @@ module VersionsHelper
                html_options
   end
 
+  def version_dates(version)
+    formatted_dates =
+      %i[start_date due_date]
+        .filter { |attr| version.send(attr) }
+        .map { |attr| "#{Version.human_attribute_name(attr)} #{format_date(version.send(attr))}" }
+    safe_join(formatted_dates, "<br>".html_safe)
+  end
+
   def link_to_version_id(version)
     ERB::Util.url_encode("version-#{version.name}")
   end

--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -27,30 +27,31 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<p>
-  <% if version.start_date %>
-    <%= Version.human_attribute_name(:start_date) %> <%= h(format_date(version.start_date)) %>
-  <% end %>
-  <% if version.due_date %>
-      <br>
-    <%= Version.human_attribute_name(:due_date) %> <%= h(format_date(version.due_date)) %>
-  <% end %>
-</p>
+<% if version.start_date || version.due_date %>
+  <p>
+    <%= version_dates(version) %>
+  </p>
+<% end %>
 
 <% if !version.completed? && version.due_date %>
   <p><strong><%= due_date_distance_in_words(version.effective_date) %></strong></p>
 <% end %>
 
-<p><%=h version.description %></p>
-<ul>
-  <% version.custom_values.each do |custom_value| %>
-    <% if custom_value.value.present? && custom_value.custom_field.field_format == 'text' %>
-      <li><%=h custom_value.custom_field.name %>:<div class="op-uc-container"><%=h show_value(custom_value) %></div></li>
-    <% elsif custom_value.value.present? %>
-      <li><%=h custom_value.custom_field.name %>: <%=h show_value(custom_value) %></li>
+<% if version.description.present? %>
+  <p><%= version.description %></p>
+<% end %>
+
+<% if version.custom_values.any? %>
+  <ul>
+    <% version.custom_values.each do |custom_value| %>
+      <% if custom_value.value.present? && custom_value.custom_field.field_format == 'text' %>
+        <li><%=h custom_value.custom_field.name %>:<div class="op-uc-container"><%=h show_value(custom_value) %></div></li>
+      <% elsif custom_value.value.present? %>
+        <li><%=h custom_value.custom_field.name %>: <%=h show_value(custom_value) %></li>
+      <% end %>
     <% end %>
-  <% end %>
-</ul>
+  </ul>
+<% end %>
 
 <% if version.work_packages.count > 0 %>
   <%= progress_bar([version.closed_percent, version.completed_percent], width: '40%', legend: ('%0.0f' % version.completed_percent)) %>
@@ -67,4 +68,5 @@ See COPYRIGHT and LICENSE files for more details.
   </p>
 <% else %>
   <%= no_results_box %>
+  <p><br></p>
 <% end %>


### PR DESCRIPTION
https://community.openproject.org/wp/45392

![image](https://user-images.githubusercontent.com/176055/207052696-bbc9c390-9b2e-453f-966e-343fb76be182.png)

The `<p><br/></p>` may sound a bit ugly, but it's good enough until the page gets reworked by our UX people.