### PR TITLE
default value for latest project activity timestamp column

### DIFF
--- a/config/constants/open_project/project_latest_activity.rb
+++ b/config/constants/open_project/project_latest_activity.rb
@@ -27,7 +27,7 @@
 module OpenProject
   module ProjectLatestActivity
     class << self
-      def register(on:, attribute:, chain: [], project_id_attribute: :project_id)
+      def register(on:, attribute: :updated_at, chain: [], project_id_attribute: :project_id)
         @registered ||= Set.new
 
         @registered << { on:,

--- a/config/initializers/activity.rb
+++ b/config/initializers/activity.rb
@@ -42,25 +42,20 @@ Rails.application.reloader.to_prepare do
                                  default: false
   end
 
-  OpenProject::ProjectLatestActivity.register on: 'WorkPackage',
-                                              attribute: :updated_at
+  OpenProject::ProjectLatestActivity.register on: 'WorkPackage'
 
   OpenProject::ProjectLatestActivity.register on: 'Project',
-                                              attribute: :updated_at,
                                               project_id_attribute: :id
 
   OpenProject::ProjectLatestActivity.register on: 'Changeset',
                                               chain: 'Repository',
                                               attribute: :committed_on
 
-  OpenProject::ProjectLatestActivity.register on: 'News',
-                                              attribute: :updated_at
+  OpenProject::ProjectLatestActivity.register on: 'News'
 
   OpenProject::ProjectLatestActivity.register on: 'WikiContent',
-                                              chain: %w(Wiki WikiPage),
-                                              attribute: :updated_at
+                                              chain: %w(Wiki WikiPage)
 
   OpenProject::ProjectLatestActivity.register on: 'Message',
-                                              chain: 'Forum',
-                                              attribute: :updated_at
+                                              chain: 'Forum'
 end

--- a/modules/budgets/lib/budgets/engine.rb
+++ b/modules/budgets/lib/budgets/engine.rb
@@ -47,8 +47,7 @@ module Budgets
     end
 
     config.to_prepare do
-      OpenProject::ProjectLatestActivity.register on: 'Budget',
-                                                  attribute: :updated_at
+      OpenProject::ProjectLatestActivity.register on: 'Budget'
 
       # Add to the budget to the costs group
       ::Type.add_default_mapping(:costs, :budget)

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -253,8 +253,7 @@ module Costs
     end
 
     config.to_prepare do
-      OpenProject::ProjectLatestActivity.register on: 'TimeEntry',
-                                                  attribute: :updated_at
+      OpenProject::ProjectLatestActivity.register on: 'TimeEntry'
 
       Costs::Patches::MembersPatch.mixin!
 

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -81,8 +81,7 @@ module OpenProject::Meeting
     end
 
     config.to_prepare do
-      OpenProject::ProjectLatestActivity.register on: 'Meeting',
-                                                  attribute: :updated_at
+      OpenProject::ProjectLatestActivity.register on: 'Meeting'
 
       PermittedParams.permit(:search, :meetings)
     end


### PR DESCRIPTION
Follow up on https://github.com/opf/openproject/pull/11768#discussion_r1045662812 since the timestamp columns are by now almost harmonized.