### PR TITLE
[#45385] Allow delete files from WiKi edit page

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.html
@@ -32,6 +32,7 @@
     class="spot-list--item-floating-actions op-file-list--item-floating-actions hidden-for-mobile"
   >
     <button
+      type="button"
       class="spot-link"
       [title]="deleteIconTitle"
       (click)="confirmRemoveAttachment()"


### PR DESCRIPTION
Closes https://community.openproject.org/work_packages/45385

Buttons without type are type=submit by default if they are associated with a form. We have a **lot** of `<button>` without any `type` attribute. Shouldn't we always set it, to prevent such bugs?