### PR TITLE
Increase notification setting label width

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.sass
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.sass
@@ -13,7 +13,7 @@
     align-items: center
 
   &--label
-    flex: 0 0 120px
+    flex: 0 0 180px
     margin-bottom: 0
     @include text-shortener
 


### PR DESCRIPTION
The labels were fixed to a width that was too small for some translations strings. This was increased in
`cca52329d8aabd671d65d7663159c59b97436921` PR #11791, but that was not enough for Spanish and Russian. This commit increases it again.

Closes https://community.openproject.org/work_packages/45163/activity