### PR TITLE
Keep comment draft when switching between work package tabs

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -79,7 +79,6 @@ import { OpHeaderProjectSelectListComponent } from 'core-app/shared/components/h
 
 import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
 import { MainMenuResizerComponent } from 'core-app/shared/components/resizer/resizer/main-menu-resizer.component';
-import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import { OpenprojectAdminModule } from 'core-app/features/admin/openproject-admin.module';
 import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
@@ -210,8 +209,6 @@ export function initializeServices(injector:Injector) {
     OpenProjectBackupService,
     OpenProjectFileUploadService,
     OpenProjectDirectFileUploadService,
-    // Split view
-    CommentService,
     ConfirmDialogService,
     RevitAddInSettingsButtonService,
   ],

--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.ts
@@ -51,6 +51,10 @@ import { WorkPackagesActivityService } from 'core-app/features/work-packages/com
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ErrorResource } from 'core-app/features/hal/resources/error-resource';
 import { HalError } from 'core-app/features/hal/services/hal-error';
+import {
+  filter,
+  take,
+} from 'rxjs/operators';
 
 @Component({
   selector: 'work-package-comment',
@@ -85,7 +89,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
     protected injector:Injector,
     protected commentService:CommentService,
     protected wpLinkedActivities:WorkPackagesActivityService,
-    protected ConfigurationService:ConfigurationService,
+    protected configurationService:ConfigurationService,
     protected loadingIndicator:LoadingIndicatorService,
     protected apiV3Service:ApiV3Service,
     protected workPackageNotificationService:WorkPackageNotificationService,
@@ -95,13 +99,23 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
     super(elementRef, injector);
   }
 
-  public ngOnInit() {
+  public ngOnInit():void {
     super.ngOnInit();
 
     this.canAddComment = !!this.workPackage.addComment;
-    this.showAbove = this.ConfigurationService.commentsSortedInDescendingOrder();
+    this.showAbove = this.configurationService.commentsSortedInDescendingOrder();
 
-    this.commentService.quoteEvents
+    this.commentService.draft$
+      .pipe(
+        this.untilDestroyed(),
+        take(1),
+        filter((val) => !!val),
+      )
+      .subscribe((draft:string) => {
+        this.activate(draft);
+      });
+
+    this.commentService.quoteEvents$
       .pipe(
         this.untilDestroyed(),
       )
@@ -111,8 +125,13 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
       });
   }
 
+  public ngOnDestroy():void {
+    super.ngOnDestroy();
+    this.commentService.draft$.next(this.active ? this.rawComment : null);
+  }
+
   // Open the field when its closed and relay drag & drop events to it.
-  public startDragOverActivation(event:JQuery.TriggeredEvent) {
+  public startDragOverActivation(event:JQuery.TriggeredEvent):boolean {
     if (this.active) {
       return true;
     }
@@ -123,7 +142,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
     return false;
   }
 
-  public activate(withText?:string) {
+  public activate(withText?:string):void {
     super.activate(withText);
 
     if (!this.showAbove) {
@@ -133,13 +152,13 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
     this.cdRef.detectChanges();
   }
 
-  public deactivate(focus:boolean) {
+  public deactivate(focus:boolean):void {
     focus && this.focus();
     this.active = false;
     this.cdRef.detectChanges();
   }
 
-  public async handleUserSubmit() {
+  public async handleUserSubmit():Promise<unknown> {
     if (this.inFlight || !this.rawComment) {
       return Promise.resolve();
     }

--- a/frontend/src/app/features/work-packages/components/wp-activity/comment-service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-activity/comment-service.ts
@@ -29,16 +29,19 @@
 import { Injectable } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { Subject } from 'rxjs';
+import {
+  BehaviorSubject,
+  Subject,
+} from 'rxjs';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 @Injectable()
 export class CommentService {
-  // Replacement for ng1 $scope.$emit on activty-entry to mark comments to be quoted.
-  // Should be generalized if needed for more than that.
-  public quoteEvents = new Subject<string>();
+  public quoteEvents$ = new Subject<string>();
+
+  public draft$ = new BehaviorSubject<string|null>(null);
 
   constructor(
     readonly I18n:I18nService,

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.ts
@@ -171,7 +171,8 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
   }
 
   public quoteComment() {
-    this.commentService.quoteEvents.next(this.quotedText(this.activity.comment.raw));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.commentService.quoteEvents$.next(this.quotedText(this.activity.comment.raw));
   }
 
   public get bcfSnapshotUrl() {

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -35,6 +35,7 @@ import { WorkPackageSingleViewBase } from 'core-app/features/work-packages/routi
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
+import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
 
 @Component({
   templateUrl: './wp-full-view.html',
@@ -43,6 +44,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
   host: { class: 'work-packages-page--ui-view' },
   providers: [
     WpSingleViewService,
+    CommentService,
     { provide: HalResourceNotificationService, useExisting: WorkPackageNotificationService },
   ],
 })

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -43,6 +43,7 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { BackRoutingService } from 'core-app/features/work-packages/components/back-routing/back-routing.service';
 import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
+import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
 
 @Component({
   templateUrl: './wp-split-view.html',
@@ -50,6 +51,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
   selector: 'op-wp-split-view',
   providers: [
     WpSingleViewService,
+    CommentService,
     { provide: HalResourceNotificationService, useClass: WorkPackageNotificationService },
   ],
 })

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
@@ -11,7 +11,7 @@
   <edit-field-controls *ngIf="!(handler.inEditMode || initializationError)"
                        [fieldController]="field"
                        (onSave)="handleUserSubmit()"
-                       (onCancel)="handler.handleUserCancel()"
+                       (onCancel)="handleUserCancel()"
                        [saveTitle]="text.save"
                        [cancelTitle]="text.cancel">
   </edit-field-controls>

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
@@ -26,7 +26,11 @@
 // ++
 
 import {
-  ChangeDetectionStrategy, Component, OnInit, ViewChild,
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
 } from '@angular/core';
 import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
 import { OpCkeditorComponent } from 'core-app/shared/components/editor/components/ckeditor/op-ckeditor.component';
@@ -40,7 +44,7 @@ import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
   templateUrl: './formattable-edit-field.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FormattableEditFieldComponent extends EditFieldComponent implements OnInit {
+export class FormattableEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
   public readonly field = this;
 
   // Detect when inner component could not be initialized
@@ -75,6 +79,16 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
       cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name }),
     };
+  }
+
+  ngOnDestroy():void {
+    super.ngOnDestroy();
+
+    try {
+      this.rawValue = this.editor?.getRawData();
+    } catch (e) {
+      console.error(`Failed to save CKEditor state on destroy: ${e as string}.`);
+    }
   }
 
   public onCkeditorSetup(editor:ICKEditorInstance):void {

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
@@ -57,6 +57,8 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
 
   public previewHtml = '';
 
+  private cancelled = false;
+
   public text:Record<string, string> = {};
 
   public initialContent:string;
@@ -84,10 +86,12 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   ngOnDestroy():void {
     super.ngOnDestroy();
 
-    try {
-      this.rawValue = this.editor?.getRawData();
-    } catch (e) {
-      console.error(`Failed to save CKEditor state on destroy: ${e as string}.`);
+    if (!this.cancelled) {
+      try {
+        this.rawValue = this.editor?.getRawData();
+      } catch (e) {
+        console.error(`Failed to save CKEditor state on destroy: ${e as string}.`);
+      }
     }
   }
 
@@ -120,6 +124,11 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       });
 
     return false;
+  }
+
+  public handleUserCancel():void {
+    this.cancelled = true;
+    this.handler.handleUserCancel();
   }
 
   private get previewContext() {

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -250,6 +250,37 @@ describe 'activity comments', js: true, with_mail: false do
         expect(page).to have_selector('.user-comment .work-package--quickinfo.preview-trigger', count: 2)
       end
     end
+
+    it 'can move away to another tab, keeping the draft comment' do
+      comment_field.activate!
+      comment_field.input_element.send_keys "I'm typing an important message here ..."
+
+      wp_page.switch_to_tab tab: :files
+      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]')
+
+      wp_page.switch_to_tab tab: :activity
+
+      comment_field.expect_active!
+      comment_field.ckeditor.expect_value "I'm typing an important message here ..."
+
+      wp_page.switch_to_tab tab: :overview
+
+      comment_field.expect_active!
+      comment_field.ckeditor.expect_value "I'm typing an important message here ..."
+
+      comment_field.cancel_by_click
+
+      # Has removed the draft now
+
+      wp_page.switch_to_tab tab: :files
+      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]')
+
+      wp_page.switch_to_tab tab: :activity
+      comment_field.expect_inactive!
+
+      wp_page.switch_to_tab tab: :overview
+      comment_field.expect_inactive!
+    end
   end
 
   context 'with no permission' do


### PR DESCRIPTION
- [x] When a comment was activated and destroyed while being active, remember the draft in the comment service
- [x] Scope the comment service to the single view instances so drafts get destroyed when moving to other work packages. (We might want to re-evaluate this)
- [x] Ensure when the formattable field gets destroyed, it saves its current state to the changeset

https://community.openproject.org/wp/45060