### PR TITLE
Fix scope attribute for custom_field

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -41,7 +41,7 @@ class CustomField < ApplicationRecord
            inverse_of: 'custom_field'
   accepts_nested_attributes_for :custom_options
 
-  acts_as_list scope: "type = '#{self.class}'"
+  acts_as_list scope: [:type]
 
   validates :field_format, presence: true
   validates :custom_options,


### PR DESCRIPTION
This was eval'd and got broken in 8d46af092c33ede1e5f94b64d171c5926c04e2bf

Instead of relying on eval, just use the type

https://community.openproject.org/work_packages/45099