### PR TITLE
[#45438] Fix messy rendering of webhook show page

### DIFF
--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
@@ -2,23 +2,21 @@
   data-augmented-model-wrapper
   data-modal-class-name="webhooks--response-body-modal"
 >
-  <a class="modal-delivery-element--activation-link" title="<%= log_entry.class.human_attribute_name('response_body') %>">
+  <a class="modal-delivery-element--activation-link" title="<%= title %>">
     <%= op_icon('icon-info1') %>
     <%= t(:button_show) %>
   </a>
   <div class="modal-delivery-element">
     <div class="spot-modal--header">
-     <h1 class="spot-subheader-big"> <%= log_entry.class.human_attribute_name('response_body') %> </h1>
+     <h1 class="spot-subheader-big"> <%= title %> </h1>
     </div>
     <div class="spot-divider"></div>
     <div class="spot-modal--body spot-container">
       <h2 class="spot-subheader-extra-small">Headers</h2>
-      <pre class="webhooks--response-headers"><%- log_entry.response_headers.each do |k, v| -%><strong><%= k -%></strong>:  <span><%= v -%></span><br/><%- end -%></pre>
+      <pre class="webhooks--response-headers"><%- response_headers.each do |k, v| -%><strong><%= k -%></strong>:  <span><%= v -%></span><br/><%- end -%></pre>
         <div class="spot-divider"></div>
       <h2 class="spot-subheader-extra-small">Response body</h2>
-      <pre class="webhooks--response-body">
-        <%= log_entry.response_body %>
-      </pre>
+      <pre class="webhooks--response-body"><%= response_body %></pre>
     </div>
     <div class="spot-action-bar hidden-for-mobile">
       <div class="spot-action-bar--right">

--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response_cell.rb
@@ -1,0 +1,16 @@
+module ::Webhooks
+  module Outgoing
+    module Deliveries
+      class ResponseCell < RailsCell
+        view_paths << ::OpenProject::Webhooks::Engine.root.join("app/cells")
+
+        property :response_headers
+        property :response_body
+
+        def title
+          model.class.human_attribute_name('response_body')
+        end
+      end
+    end
+  end
+end

--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/row_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/row_cell.rb
@@ -13,8 +13,7 @@ module ::Webhooks
         end
 
         def response_body
-          render(locals: { log_entry: log },
-                 prefixes: ["#{::OpenProject::Webhooks::Engine.root}/app/cells/views"]).html_safe
+          cell(ResponseCell, log).()
         end
       end
     end


### PR DESCRIPTION
https://community.openproject.org/work_packages/45438

Using `ViewCell#render` directly does not escape values. Encapsulating it inside another cell does escape and fixes the issue.