### PR TITLE
Escape response headers and display response correctly in webhook deliveries page

### DIFF
--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
@@ -13,7 +13,7 @@
     <div class="spot-divider"></div>
     <div class="spot-modal--body spot-container">
       <h2 class="spot-subheader-extra-small">Headers</h2>
-      <pre class="webhooks--response-headers"><%- response_headers.each do |k, v| -%><strong><%= k -%></strong>:  <span><%= v -%></span><br/><%- end -%></pre>
+      <pre class="webhooks--response-headers"><%- response_headers.each do |k, v| -%><strong><%=h k -%></strong>:  <span><%=h v -%></span><br/><%- end -%></pre>
         <div class="spot-divider"></div>
       <h2 class="spot-subheader-extra-small">Response body</h2>
       <pre class="webhooks--response-body"><%= response_body %></pre>

--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response/show.erb
@@ -1,8 +1,9 @@
 <section
   data-augmented-model-wrapper
+  data-activation-selector=".log-response-<%= id %>-modal--activation-link"
   data-modal-class-name="webhooks--response-body-modal"
 >
-  <a class="modal-delivery-element--activation-link" title="<%= title %>">
+  <a class="log-response-<%= id %>-modal--activation-link" title="<%= title %>">
     <%= op_icon('icon-info1') %>
     <%= t(:button_show) %>
   </a>

--- a/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/deliveries/response_cell.rb
@@ -4,6 +4,7 @@ module ::Webhooks
       class ResponseCell < RailsCell
         view_paths << ::OpenProject::Webhooks::Engine.root.join("app/cells")
 
+        property :id
         property :response_headers
         property :response_body
 

--- a/modules/webhooks/spec/cells/webhooks/outgoing/deliveries/table_cell_spec.rb
+++ b/modules/webhooks/spec/cells/webhooks/outgoing/deliveries/table_cell_spec.rb
@@ -1,0 +1,57 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require 'spec_helper'
+
+describe Webhooks::Outgoing::Deliveries::TableCell do
+  include Cell::Testing
+
+  # used internally by Cell::Testing when calling #cell helper
+  let(:controller) { instance_double(ApplicationController, request: :dummy_request) }
+
+  it 'escapes response body html' do
+    delivery = create(:webhook_log, response_body: 'Hello <b>world<b/>!')
+    html = cell(described_class, [delivery]).()
+
+    response_body_node = Capybara.string(html).find('pre.webhooks--response-body')
+    expect(response_body_node.text).to eq(delivery.response_body)
+  end
+
+  it 'escapes response headers html' do
+    header_name = "x_header_<b>evil</b>_name"
+    header_value = "header <b>evil</b> value"
+    delivery = create(:webhook_log, response_headers: { header_name => header_value })
+    html = cell(described_class, [delivery]).()
+
+    response_headers_node = Capybara.string(html).find('pre.webhooks--response-headers')
+    aggregate_failures do
+      expect(response_headers_node).not_to have_selector('b', text: 'evil')
+      expect(response_headers_node.text).to include(header_name)
+      expect(response_headers_node.text).to include(header_value)
+    end
+  end
+end


### PR DESCRIPTION
This completes https://community.openproject.org/work_packages/45438 and commit https://github.com/opf/openproject/commit/c1fdb1a3ad783068a9aba932d681278a1d9c8b9f