### PR TITLE
[45224] optimize creating memberships for groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -72,6 +72,6 @@ class Group < Principal
   end
 
   def fail_add
-    fail "Do not add users through association, use `group.add_members!` instead."
+    fail "Do not add users through association, use `Groups::AddUsersService` instead."
   end
 end

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -29,7 +29,6 @@
 module Groups
   class AddUsersService < ::BaseServices::BaseContracted
     using CoreExtensions::SquishSql
-    include Groups::Concerns::MembershipManipulation
 
     def initialize(group, current_user:, contract_class: AdminOnlyContract)
       self.model = group
@@ -40,95 +39,37 @@ module Groups
 
     private
 
-    def modify_members_and_roles(params)
+    def persist(call)
       sql_query = ::OpenProject::SqlSanitization
-                  .sanitize add_to_user_and_projects_cte,
-                            group_id: model.id,
-                            user_ids: params[:ids]
-
+                    .sanitize add_to_group,
+                              group_id: model.id,
+                              user_ids: params[:ids]
       execute_query(sql_query)
+
+      call
     end
 
-    def add_to_user_and_projects_cte
-      <<~SQL.squish
-        -- select existing users from given IDs
-        WITH found_users AS (
-          SELECT id as user_id FROM #{User.table_name} WHERE id IN (:user_ids)
-        ),
-        timestamp AS (
-          SELECT CURRENT_TIMESTAMP as time
-        ),
-        -- select existing memberships of the group
-        group_memberships AS (
-          SELECT project_id, user_id FROM #{Member.table_name} WHERE user_id = :group_id
-        ),
-        -- select existing member_roles of the group
-        group_roles AS (
-          SELECT members.project_id AS project_id,
-                 members.user_id AS user_id,
-                 members.id AS member_id,
-                 member_roles.role_id AS role_id,
-                 member_roles.id AS member_role_id
-          FROM #{MemberRole.table_name} member_roles
-          JOIN #{Member.table_name} members
-          ON members.id = member_roles.member_id AND members.user_id = :group_id
-        ),
-        -- insert into group_users association
-        new_group_users AS (
-          INSERT INTO group_users (group_id, user_id)
-          SELECT :group_id as group_id, user_id FROM found_users
-          ON CONFLICT DO NOTHING
-        ),
-        -- find members that already exist
-        existing_members AS (
-          SELECT members.id, found_users.user_id, members.project_id
-          FROM members, found_users, group_memberships
-          WHERE members.user_id = found_users.user_id
-          AND members.project_id IS NOT DISTINCT FROM group_memberships.project_id
-          AND members.id IS NOT NULL
-        ),
-        -- insert the group user into members
-        new_members AS (
-          INSERT INTO #{Member.table_name} (project_id, user_id, updated_at, created_at)
-          SELECT group_memberships.project_id, found_users.user_id, (SELECT time from timestamp), (SELECT time from timestamp)
-          FROM found_users, group_memberships
-          WHERE NOT EXISTS (SELECT 1 FROM existing_members WHERE existing_members.user_id = found_users.user_id AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id)
-          ON CONFLICT(project_id, user_id) DO NOTHING
-          RETURNING id, user_id, project_id
-        ),
-        -- copy the member roles of the group
-        add_roles AS (
-          INSERT INTO #{MemberRole.table_name} (member_id, role_id, inherited_from)
-          SELECT members.id, group_roles.role_id, group_roles.member_role_id
-          FROM group_roles
-          JOIN
-            (SELECT * FROM new_members UNION SELECT * from existing_members) members ON group_roles.project_id IS NOT DISTINCT FROM members.project_id
-          -- Ignore if the role was already inserted by us
-          ON CONFLICT DO NOTHING
-          RETURNING id, member_id, role_id
-        ),
-        -- get the ids of members where roles have been added the member did not have before
-        members_with_added_roles AS (
-          SELECT DISTINCT add_roles.member_id
-          FROM add_roles
-          WHERE NOT EXISTS
-            (SELECT 1 FROM #{MemberRole.table_name}
-              WHERE #{MemberRole.table_name}.member_id = add_roles.member_id
-              AND #{MemberRole.table_name}.role_id = add_roles.role_id
-              AND #{MemberRole.table_name}.id != add_roles.id)
-        ),
-        touch_existing_members AS (
-          UPDATE members SET updated_AT = CURRENT_TIMESTAMP
-          WHERE id IN (SELECT id from existing_members)
-          AND id IN (SELECT member_id from members_with_added_roles)
-        )
+    def after_perform(call)
+      Groups::CreateInheritedRolesService
+        .new(model, current_user: user, contract_class:)
+        .call(user_ids: params[:ids], message: params[:message])
 
-        SELECT member_id from members_with_added_roles
+      call
+    end
+
+    def add_to_group
+      <<~SQL.squish
+        INSERT INTO group_users (group_id, user_id)
+        SELECT :group_id as group_id, user_id FROM
+          (SELECT id as user_id FROM #{User.table_name} WHERE id IN (:user_ids)) users
+        ON CONFLICT DO NOTHING
       SQL
     end
 
-    def touch_updated(member_ids)
-      # do nothing in this case as we already touch while updating
+    def execute_query(query)
+      ::Group
+        .connection
+        .exec_query(query)
     end
   end
 end

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -1,0 +1,137 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Groups
+  # Adds inherited roles to the users provided to mirror the roles the group has.
+  # This can be scoped to only a certain project which results in considerably better performance.
+  class CreateInheritedRolesService < ::BaseServices::BaseContracted
+    using CoreExtensions::SquishSql
+    include Groups::Concerns::MembershipManipulation
+
+    def initialize(group, current_user:, contract_class: AdminOnlyContract)
+      self.model = group
+
+      super user: current_user,
+            contract_class:
+    end
+
+    private
+
+    def modify_members_and_roles(params)
+      sql_query = ::OpenProject::SqlSanitization
+                  .sanitize add_to_user_and_projects_cte(project_ids: params[:project_ids]),
+                            group_id: model.id,
+                            user_ids: params[:user_ids],
+                            project_ids: params[:project_ids]
+
+      execute_query(sql_query)
+    end
+
+    def add_to_user_and_projects_cte(project_ids: nil)
+      project_limit = if project_ids
+                        "project_id IN (:project_ids)"
+                      else
+                        "1=1"
+                      end
+
+      <<~SQL.squish
+        -- select existing users from given IDs
+        WITH found_users AS (
+          SELECT id as user_id FROM #{User.table_name} WHERE id IN (:user_ids)
+        ),
+        timestamp AS (
+          SELECT CURRENT_TIMESTAMP as time
+        ),
+        -- select existing memberships of the group
+        group_memberships AS (
+          SELECT project_id, user_id FROM #{Member.table_name} WHERE user_id = :group_id AND #{project_limit}
+        ),
+        -- select existing member_roles of the group
+        group_roles AS (
+          SELECT members.project_id AS project_id,
+                 members.user_id AS user_id,
+                 members.id AS member_id,
+                 member_roles.role_id AS role_id,
+                 member_roles.id AS member_role_id
+          FROM #{MemberRole.table_name} member_roles
+          JOIN #{Member.table_name} members
+          ON members.id = member_roles.member_id AND members.user_id = :group_id
+        ),
+        -- find members that already exist
+        existing_members AS (
+          SELECT members.id, found_users.user_id, members.project_id
+          FROM members, found_users, group_memberships
+          WHERE members.user_id = found_users.user_id
+          AND members.project_id IS NOT DISTINCT FROM group_memberships.project_id
+          AND members.id IS NOT NULL
+        ),
+        -- insert the group user into members
+        new_members AS (
+          INSERT INTO #{Member.table_name} (project_id, user_id, updated_at, created_at)
+          SELECT group_memberships.project_id, found_users.user_id, (SELECT time from timestamp), (SELECT time from timestamp)
+          FROM found_users, group_memberships
+          WHERE NOT EXISTS (SELECT 1 FROM existing_members WHERE existing_members.user_id = found_users.user_id AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id)
+          ON CONFLICT(project_id, user_id) DO NOTHING
+          RETURNING id, user_id, project_id
+        ),
+        -- copy the member roles of the group
+        add_roles AS (
+          INSERT INTO #{MemberRole.table_name} (member_id, role_id, inherited_from)
+          SELECT members.id, group_roles.role_id, group_roles.member_role_id
+          FROM group_roles
+          JOIN
+            (SELECT * FROM new_members UNION SELECT * from existing_members) members ON group_roles.project_id IS NOT DISTINCT FROM members.project_id
+          -- Ignore if the role was already inserted by us
+          ON CONFLICT DO NOTHING
+          RETURNING id, member_id, role_id
+        ),
+        -- get the ids of members where roles have been added the member did not have before
+        members_with_added_roles AS (
+          SELECT DISTINCT add_roles.member_id
+          FROM add_roles
+          WHERE NOT EXISTS
+            (SELECT 1 FROM #{MemberRole.table_name}
+              WHERE #{MemberRole.table_name}.member_id = add_roles.member_id
+              AND #{MemberRole.table_name}.role_id = add_roles.role_id
+              AND #{MemberRole.table_name}.id != add_roles.id)
+        ),
+        touch_existing_members AS (
+          UPDATE members SET updated_at = CURRENT_TIMESTAMP
+          WHERE id IN (SELECT id from existing_members)
+          AND id IN (SELECT member_id from members_with_added_roles)
+        )
+
+        SELECT member_id from members_with_added_roles
+      SQL
+    end
+
+    def touch_updated(member_ids)
+      # do nothing in this case as we already touch while updating
+    end
+  end
+end

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -47,9 +47,9 @@ class Members::CreateService < ::BaseServices::Create
   def add_group_memberships(member)
     return unless member.principal.is_a?(Group)
 
-    Groups::AddUsersService
+    Groups::CreateInheritedRolesService
       .new(member.principal, current_user: user, contract_class: EmptyContract)
-      .call(ids: member.principal.user_ids, send_notifications: false)
+      .call(user_ids: member.principal.user_ids, send_notifications: false, project_ids: [member.project_id])
   end
 
   def event_type

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       next if members.empty?
 
       User.system.run_given do |system_user|
-        ::Groups::AddUsersService
+        Groups::AddUsersService
           .new(group, current_user: system_user)
           .call(ids: members.map(&:id))
           .on_failure { |call| raise call.message }

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -72,9 +72,9 @@ describe Member, type: :model do
       member
       group = create(:group, members: [user])
       create(:member, project:, principal: group, roles: [role])
-      ::Groups::AddUsersService
+      ::Groups::CreateInheritedRolesService
         .new(group, current_user: User.system, contract_class: EmptyContract)
-        .call(ids: [user.id])
+        .call(user_ids: [user.id])
 
       expect(user.reload.memberships.map { _1.deletable_role?(role) }).to match_array([true, false])
     end

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -213,9 +213,9 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
 
     before do
       # Setup the memberships the group has
-      ::Groups::AddUsersService
+      ::Groups::CreateInheritedRolesService
         .new(group, current_user: admin)
-        .call(ids: members.map(&:id))
+        .call(user_ids: members.map(&:id))
 
       another_user
       group_updated_at
@@ -343,9 +343,9 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
 
     before do
       # Setup the memberships in the group has
-      ::Groups::AddUsersService
+      ::Groups::CreateInheritedRolesService
         .new(group, current_user: admin)
-        .call(ids: members.map(&:id))
+        .call(user_ids: members.map(&:id))
 
       # Have one user have a role independent of the group
       Member

--- a/spec/services/groups/add_users_service_integration_spec.rb
+++ b/spec/services/groups/add_users_service_integration_spec.rb
@@ -28,21 +28,21 @@
 
 require 'spec_helper'
 
-describe Groups::AddUsersService, 'integration', type: :model do
+describe Groups::AddUsersService, 'integration' do
   subject(:service_call) { instance.call(ids: user_ids, message:) }
 
-  let(:projects) { create_list :project, 2 }
-  let(:role) { create :role }
-  let(:admin) { create :admin }
+  let(:projects) { create_list(:project, 2) }
+  let(:role) { create(:role) }
+  let(:admin) { create(:admin) }
 
   let!(:group) do
-    create :group,
+    create(:group,
            member_in_projects: projects,
-           member_through_role: role
+           member_through_role: role)
   end
 
-  let(:user1) { create :user }
-  let(:user2) { create :user }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
   let(:user_ids) { [user1.id, user2.id] }
   let(:message) { 'Some message' }
 
@@ -76,10 +76,10 @@ describe Groups::AddUsersService, 'integration', type: :model do
 
       expect(Notifications::GroupMemberAlteredJob)
         .to have_received(:perform_later)
-        .with(current_user,
-              a_collection_containing_exactly(*ids),
-              message,
-              true)
+              .with(current_user,
+                    a_collection_containing_exactly(*ids),
+                    message,
+                    true)
     end
   end
 
@@ -138,7 +138,7 @@ describe Groups::AddUsersService, 'integration', type: :model do
       let(:project) { create(:project) }
       let(:roles) { create_list(:role, 2) }
       let!(:group) do
-        create :group do |g|
+        create(:group) do |g|
           create(:member,
                  project:,
                  principal: g,
@@ -211,11 +211,11 @@ describe Groups::AddUsersService, 'integration', type: :model do
     end
 
     context 'with global role' do
-      let(:role) { create :global_role }
+      let(:role) { create(:global_role) }
       let!(:group) do
-        create :group,
+        create(:group,
                global_role: role,
-               global_permission: :add_project
+               global_permission: :add_project)
       end
 
       it 'adds the users to the group and their membership to the global role' do
@@ -231,7 +231,7 @@ describe Groups::AddUsersService, 'integration', type: :model do
       context 'when one user already has a global role that the group would add' do
         let(:global_roles) { create_list(:global_role, 2) }
         let!(:group) do
-          create :group do |g|
+          create(:group) do |g|
             create(:member,
                    project: nil,
                    principal: g,

--- a/spec/services/groups/cleanup_inherited_roles_service_integration_spec.rb
+++ b/spec/services/groups/cleanup_inherited_roles_service_integration_spec.rb
@@ -34,10 +34,10 @@ describe Groups::CleanupInheritedRolesService, 'integration', type: :model do
     instance.call(params)
   end
 
-  let(:project) { create :project }
-  let(:role) { create :role }
-  let(:global_role) { create :global_role }
-  let(:current_user) { create :admin }
+  let(:project) { create(:project) }
+  let(:role) { create(:role) }
+  let(:global_role) { create(:global_role) }
+  let(:current_user) { create(:admin) }
   let(:roles) { [role] }
   let(:global_roles) { [global_role] }
   let(:params) { { message: } }
@@ -54,12 +54,12 @@ describe Groups::CleanupInheritedRolesService, 'integration', type: :model do
              principal: group,
              roles: global_roles)
 
-      ::Groups::AddUsersService
+      ::Groups::CreateInheritedRolesService
         .new(group, current_user: User.system, contract_class: EmptyContract)
-        .call(ids: users.map(&:id))
+        .call(user_ids: users.map(&:id))
     end
   end
-  let(:users) { create_list :user, 2 }
+  let(:users) { create_list(:user, 2) }
   let(:members) { Member.where(principal: group) }
 
   let(:instance) do

--- a/spec/services/groups/create_inherited_roles_service_integration_spec.rb
+++ b/spec/services/groups/create_inherited_roles_service_integration_spec.rb
@@ -1,0 +1,272 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Groups::CreateInheritedRolesService, 'integration' do
+  # The setup for these specs are a bit weird. First, the group is set up with its users already
+  # attached. Then, the memberships of the group are added afterwards.
+  # That way, the inherited roles are not yet created which they would otherwise by the group factory.
+  # This mimicks have a group with users already set up which can happen in two cases:
+  # * The Groups::AddUsersService service has run before because an additional user has been added to the group.
+  #   The AddUsersService then calls the CreateInheritedRolesService
+  # * The group receives an additional membership (in a project)
+  # The setup reflects both cases at the same time.
+  subject(:service_call) { instance.call(user_ids:, project_ids:, message:) }
+
+  shared_let(:project1) { create(:project) }
+  shared_let(:project2) { create(:project) }
+  shared_let(:user1) { create(:user) }
+  shared_let(:user2) { create(:user) }
+  shared_let(:role1) { create(:role) }
+  shared_let(:admin) { create(:admin) }
+
+  let(:group_projects) { [project1, project2] }
+  let(:group_roles) { [role1] }
+  let(:group_users) { [user1, user2] }
+
+  let!(:group) do
+    create(:group).tap do |g|
+      # Setting up the user being part of the group without triggering the inherited roles
+      # to be assigned before the test is actually run.
+      group_users.each do |u|
+        GroupUser.create group: g, user: u
+      end
+
+      group_projects.each do |gp|
+        create(:member,
+               principal: g,
+               roles: group_roles,
+               project: gp)
+      end
+    end
+  end
+
+  let(:user_ids) { group_users.map(&:id) }
+  let(:project_ids) { group_projects.map(&:id) }
+  let(:message) { 'Some message' }
+  let(:current_user) { admin }
+
+  let(:instance) do
+    described_class.new(group, current_user:)
+  end
+
+  before do
+    allow(Notifications::GroupMemberAlteredJob)
+      .to receive(:perform_later)
+  end
+
+  shared_examples_for 'inherits the roles of the group to the users' do
+    it 'inherits the roles of the group to the users' do
+      expect(service_call).to be_success
+
+      user_ids.each do |user_id|
+        expect(Member.where(project_id: project_ids, user_id:).count)
+          .to eq group_projects.count
+        expect(Member.where(project_id: project_ids, user_id:).map(&:roles).flatten)
+          .to match_array group_projects.count.times.map { group_roles }.flatten
+      end
+    end
+  end
+
+  shared_examples_for 'sends notification' do
+    it 'on the updated membership' do
+      service_call
+
+      ids = defined?(members) ? members : Member.where(principal: user).pluck(:id)
+
+      expect(Notifications::GroupMemberAlteredJob)
+        .to have_received(:perform_later)
+        .with(current_user,
+              a_collection_containing_exactly(*ids),
+              message,
+              true)
+    end
+  end
+
+  it_behaves_like 'inherits the roles of the group to the users'
+
+  it_behaves_like 'sends notification' do
+    let(:user) { user_ids }
+  end
+
+  context 'when the group is invalid (e.g. required cf not set)' do
+    before do
+      group
+      # The group is now invalid as it has no cv for this field
+      create(:custom_field, type: 'GroupCustomField', is_required: true, field_format: 'int')
+    end
+
+    it_behaves_like 'inherits the roles of the group to the users'
+
+    it_behaves_like 'sends notification' do
+      let(:user) { user_ids }
+    end
+  end
+
+  context 'when the user was already a member in a project with the same role' do
+    let(:previous_project) { group_projects.first }
+    let!(:user_member) do
+      create(:member,
+             project: previous_project,
+             roles: group_roles,
+             principal: user1)
+    end
+
+    it_behaves_like 'inherits the roles of the group to the users'
+
+    it 'does not update the timestamps on the preexisting membership' do
+      # Need to reload so that the timestamps are set by the database
+      user_member.reload
+
+      service_call
+
+      expect(Member.find(user_member.id).updated_at)
+        .to eql(user_member.updated_at)
+    end
+
+    it_behaves_like 'sends notification' do
+      # But only to the user that wasn't a member yet.
+      let(:members) do
+        Member.where(user_id: user_ids).where.not(id: user_member).pluck(:id)
+      end
+    end
+  end
+
+  context 'when the user was already a member in a project with only one role the group adds' do
+    let(:group_roles) { create_list(:role, 2) }
+    let!(:user_member) do
+      create(:member,
+             project: group_projects.first,
+             roles: [group_roles.first],
+             principal: user1)
+    end
+
+    it_behaves_like 'inherits the roles of the group to the users'
+
+    it 'updates the timestamps on the preexisting membership' do
+      service_call
+
+      expect(Member.find(user_member.id).updated_at)
+        .not_to eql(user_member.updated_at)
+    end
+
+    it_behaves_like 'sends notification' do
+      let(:user) { user_ids }
+    end
+  end
+
+  context 'when a user was already a member in a project with a different role' do
+    let(:other_role) { create(:role) }
+    let(:previous_project) { group_projects.first }
+    let!(:user_member) do
+      create(:member,
+             project: previous_project,
+             roles: [other_role],
+             principal: user1)
+    end
+
+    it 'inherits the roles of the group to the users' do
+      expect(service_call).to be_success
+
+      user_ids.each do |user_id|
+        expect(Member.where(project_id: project_ids, user_id:).count)
+          .to eq group_projects.count
+      end
+
+      expect(Member.where(project_id: previous_project, user_id: user1.id).map(&:roles).flatten)
+        .to match_array [group_roles, other_role].flatten
+      expect(Member.where(project_id: group_projects - [previous_project], user_id: user1.id).map(&:roles).flatten)
+        .to match_array [group_roles].flatten
+      expect(Member.where(project_id: project_ids, user_id: user2.id).map(&:roles).flatten)
+        .to match_array group_projects.count.times.map { group_roles }.flatten
+    end
+
+    it 'updates the timestamps on the preexisting membership' do
+      service_call
+
+      expect(Member.find(user_member.id).updated_at)
+        .not_to eql(user_member.updated_at)
+    end
+
+    it_behaves_like 'sends notification' do
+      let(:user) { user_ids }
+    end
+  end
+
+  context 'with global role' do
+    let(:group_roles) { [create(:global_role)] }
+    let(:group_projects) { [] }
+    let(:project_ids) { nil }
+    let!(:group_member) { create(:global_member, principal: group, roles: group_roles) }
+
+    it 'inherits the roles of the group to the users' do
+      expect(service_call).to be_success
+
+      expect(user1.memberships.where(project_id: nil).count).to eq 1
+      expect(user1.memberships.flat_map(&:roles)).to match_array group_roles
+      expect(user2.memberships.where(project_id: nil).count).to eq 1
+      expect(user2.memberships.flat_map(&:roles)).to match_array group_roles
+    end
+  end
+
+  context 'with limiting the user and project to create the roles in' do
+    let(:added_project) { group_projects.first }
+    let(:ignored_project) { group_projects.last }
+    let(:added_user) { user_ids.first }
+    let(:ignored_user) { user_ids.last }
+
+    subject(:service_call) { instance.call(user_ids: [added_user], message:, project_ids: added_project.id) }
+
+    it 'adds the roles to users of the group for the project specified', :aggregate_failure do
+      expect(service_call).to be_success
+
+      # Adds the role for the user and project specified
+      expect(Member.where(user_id: added_user, project: added_project).count).to eq 1
+      expect(Member.where(user_id: added_user, project: added_project).flat_map(&:roles))
+        .to match_array group_roles
+
+      # Does not add the role to a user not specified
+      expect(Member.where(user_id: ignored_user, project: added_project))
+        .not_to exist
+
+      # Does not add the role to a project not specified
+      expect(Member.where(user_id: added_user, project: ignored_project))
+        .not_to exist
+    end
+  end
+
+  context 'when not an admin' do
+    let(:current_user) { User.anonymous }
+
+    it 'fails the request' do
+      expect(service_call).to be_failure
+      expect(service_call.message).to match /may not be accessed/
+    end
+  end
+end

--- a/spec/services/groups/update_roles_service_integration_spec.rb
+++ b/spec/services/groups/update_roles_service_integration_spec.rb
@@ -44,9 +44,9 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
              principal: group,
              roles:)
 
-      ::Groups::AddUsersService
+      ::Groups::CreateInheritedRolesService
         .new(group, current_user: User.system, contract_class: EmptyContract)
-        .call(ids: users.map(&:id))
+        .call(user_ids: users.map(&:id))
     end
   end
   let(:users) { create_list :user, 2 }
@@ -124,9 +124,9 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
                principal: group,
                roles:)
 
-        ::Groups::AddUsersService
+        ::Groups::CreateInheritedRolesService
           .new(group, current_user: User.system, contract_class: EmptyContract)
-          .call(ids: users.map(&:id))
+          .call(user_ids: users.map(&:id))
       end
     end
 
@@ -371,9 +371,9 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
                principal: group,
                roles: [other_role])
 
-        ::Groups::AddUsersService
+        ::Groups::CreateInheritedRolesService
           .new(group, current_user: User.system, contract_class: EmptyContract)
-          .call(ids: users.map(&:id))
+          .call(user_ids: users.map(&:id))
       end
     end
 

--- a/spec/services/members/create_service_spec.rb
+++ b/spec/services/members/create_service_spec.rb
@@ -30,6 +30,30 @@ require 'spec_helper'
 require 'services/base_services/behaves_like_create_service'
 
 describe Members::CreateService, type: :model do
+  let(:user1) { build_stubbed(:user) }
+  let(:user2) { build_stubbed(:user) }
+  let(:group) do
+    build_stubbed(:group).tap do |g|
+      allow(g)
+        .to receive(:user_ids)
+              .and_return([user1.id, user2.id])
+    end
+  end
+  let!(:inherited_roles_service) do
+    instance_double(Groups::CreateInheritedRolesService).tap do |inherited_roles_service|
+      allow(Groups::CreateInheritedRolesService)
+        .to receive(:new)
+              .and_return(inherited_roles_service)
+
+      allow(inherited_roles_service)
+        .to receive(:call)
+    end
+  end
+  let!(:notifications) do
+    allow(OpenProject::Notifications)
+      .to receive(:send)
+  end
+
   it_behaves_like 'BaseServices create service' do
     let(:call_attributes) do
       {
@@ -41,21 +65,37 @@ describe Members::CreateService, type: :model do
       }
     end
 
-    let!(:allow_notification_call) do
-      allow(OpenProject::Notifications)
-        .to receive(:send)
-    end
-
     describe 'if successful' do
       it 'sends a notification' do
-        expect(OpenProject::Notifications)
-          .to receive(:send)
-          .with(OpenProject::Events::MEMBER_CREATED,
-                member: model_instance,
-                message: call_attributes[:notification_message],
-                send_notifications: true)
-
         subject
+
+        expect(OpenProject::Notifications)
+          .to have_received(:send)
+                .with(OpenProject::Events::MEMBER_CREATED,
+                      member: model_instance,
+                      message: call_attributes[:notification_message],
+                      send_notifications: true)
+
+      end
+
+      describe 'for a group' do
+        let!(:model_instance) { build_stubbed(:member, principal: group) }
+
+        it "generates the members and roles for the group's users" do
+          subject
+
+          expect(Groups::CreateInheritedRolesService)
+            .to have_received(:new)
+                  .with(group,
+                        current_user: user,
+                        contract_class: EmptyContract)
+
+          expect(inherited_roles_service)
+            .to have_received(:call)
+                  .with(user_ids: group.user_ids,
+                        project_ids: [model_instance.project_id],
+                        send_notifications: false)
+        end
       end
     end
 
@@ -63,10 +103,21 @@ describe Members::CreateService, type: :model do
       let(:set_attributes_success) { false }
 
       it 'sends no notification' do
-        expect(OpenProject::Notifications)
-          .not_to receive(:send)
-
         subject
+
+        expect(OpenProject::Notifications)
+          .not_to have_received(:send)
+      end
+
+      describe 'for a group' do
+        let!(:model_instance) { build_stubbed(:member, principal: group) }
+
+        it "does not create any inherited roles" do
+          subject
+
+          expect(Groups::CreateInheritedRolesService)
+            .not_to have_received(:new)
+        end
       end
     end
 
@@ -74,10 +125,21 @@ describe Members::CreateService, type: :model do
       let(:model_save_result) { false }
 
       it 'sends no notification' do
-        expect(OpenProject::Notifications)
-          .not_to receive(:send)
-
         subject
+
+        expect(OpenProject::Notifications)
+          .not_to have_received(:send)
+      end
+
+      context 'for a group' do
+        let!(:model_instance) { build_stubbed(:member, principal: group) }
+
+        it "does not create any inherited roles" do
+          subject
+
+          expect(Groups::CreateInheritedRolesService)
+            .not_to have_received(:new)
+        end
       end
     end
   end


### PR DESCRIPTION
Before, all the projects the group might have been in before the new membership got created were considered by the SQL which potentially results in a lot of records to be processed (the results were correct). For some larger instances with a lot of groups, the request timed out.

Now, only the project the new membership is created for is considered in the SQL as that is the only project in which the group's users could rightfully become members now.

https://community.openproject.org/wp/45224