### PR TITLE
Use configured hostname and port in CSP proxied values

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -41,9 +41,8 @@ Rails.application.config.after_initialize do
 
     # Add proxy configuration for Angular CLI to csp
     if FrontendAssetHelper.assets_proxied?
-      proxied = ['ws://localhost:3000', 'http://localhost:3000',
-                 'ws://localhost:4200', 'http://localhost:4200',
-                 FrontendAssetHelper.cli_proxy]
+      proxied = ["ws://#{Setting.host_name}", "http://#{Setting.host_name}",
+                 FrontendAssetHelper.cli_proxy.sub('http', 'ws'), FrontendAssetHelper.cli_proxy]
       connect_src += proxied
       assets_src += proxied
       media_src += proxied

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -84,9 +84,9 @@ module Pages
     end
 
     def switch_view_mode(text)
-      find('[data-qa-selector="op-team-planner--view-select-dropdown"]').click
-
       retry_block do
+        find('[data-qa-selector="op-team-planner--view-select-dropdown"]').click
+
         within('#op-team-planner--view-select-dropdown') do
           click_button(text)
         end

--- a/script/bulk_run_rspec
+++ b/script/bulk_run_rspec
@@ -104,6 +104,7 @@ class BulkRunner
     FileUtils.rm_rf(bulk_run_dir('logs')) if bulk_run_dir('logs').exist?
     `mkdir -p #{bulk_run_dir('logs')}`
     puts "#{tests.count} tests to run"
+    puts "logs: #{bulk_run_dir('logs')}"
     tests.each do |test|
       puts '=' * 80
       puts "Running #{test.path} #{RUN_COUNT} times"
@@ -111,7 +112,7 @@ class BulkRunner
       RUN_COUNT.times do |i|
         puts " Run #{i} ".center(80, '-')
         run = Run.new(test.path)
-        run.output = `CI=true bundle exec rspec '#{run.path}' 2>&1`
+        run.output = `DISABLE_PRY=1 CI=true bundle exec rspec '#{run.path}' 2>&1`
         if $?.success?
           puts 'ok'.green
           run.passed!

--- a/spec/support/rspec_retry.rb
+++ b/spec/support/rspec_retry.rb
@@ -42,9 +42,17 @@ def retry_block(args: {}, screenshot: false, &block)
   end
 
   log_errors = Proc.new do |exception, try, elapsed_time, next_interval|
-    warn <<~EOS
+    max_tries = RSpec.current_example.metadata[:retry] + 1
+    exception_source_line = exception.backtrace.find { |line| line.start_with?(Rails.root.to_s) }
+    next_try_message = next_interval ? "#{next_interval} seconds until the next try" : "last try"
+    # use stderr directly to prevent having StructuredWarnings::StandardWarning
+    # messy and useless output
+    $stderr.puts <<~EOS # rubocop:disable Style/StderrPuts
+      -- rspec-retry #{try}/#{max_tries}--
       #{exception.class}: '#{exception.message}'
-      #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.
+      occurred on #{exception_source_line}
+      #{try} tries in #{elapsed_time} seconds, #{next_try_message}.
+      --
     EOS
 
     if screenshot
@@ -56,5 +64,5 @@ def retry_block(args: {}, screenshot: false, &block)
     end
   end
 
-  Retriable.retriable(args.merge(on_retry: log_errors), &block)
+  Retriable.retriable(on_retry: log_errors, **args, &block)
 end


### PR DESCRIPTION
The motivation is to be able to run the application locally in development on two different ports and hostnames: one running `dev` on port 3000, the other running `release/12.4` branch on port 3030. This was not possible because CSP hosts and ports for development were hardcoded.