### PR TITLE
Minor updates/bugfixes to user and admin guides

### DIFF
--- a/docs/release-notes/12-0-0/README.md
+++ b/docs/release-notes/12-0-0/README.md
@@ -21,14 +21,13 @@ The new in-app notifications let you never miss a change in your projects again.
 
 Go to our user guide to find out how to [configure in-app notifications](../../user-guide/notifications/).
 
-
+> **Info:** Please note that starting with version 12.0, OpenProject will no longer send individual emails for each notification. You can view your notifications via the new [Notification center](user-guide/notifications/#access-in-app-notifications). You can however still choose to receive daily [email reminders](../../getting-started/my-account/#email-reminders) at specific times of the day that you can configure.
 
 ## Notification center
 
-The new notification center shows all notifications about changes within your projects, including intuitive filter options in the menu on the left, e.g. by reason for notification or by projects. Clicking on the notification will open the details of a work package. you can directly edit it in a split view. The blue elliptical indicates the number of unread notifications about changes within one work package.
+The new Notification center shows all notifications about changes within your projects, including intuitive filter options in the menu on the left, e.g. by reason for notification or by projects. Clicking on the notification will open the details of a work package. you can directly edit it in a split view. The blue elliptical indicates the number of unread notifications about changes within one work package.
 
 ![notification-center](notification-center.png)
-
 
 
 ## Improved notification settings
@@ -36,7 +35,6 @@ The new notification center shows all notifications about changes within your pr
 The improved notification settings now allow to fine-tune for which actions and in which projects you want to receive a notification. With 12.0 you can now even add project-specific settings for changes you want to be notified about and override the default settings.
 
 ![notification-settings](notification-settings.png)
-
 
 
 ## Email summaries

--- a/docs/system-admin-guide/system-settings/display-settings/README.md
+++ b/docs/system-admin-guide/system-settings/display-settings/README.md
@@ -20,9 +20,9 @@ At the moment there are more than 30 languages available.
 
 You can [choose your language in your user profile](../../../getting-started/my-account/#change-your-language).
 
-## Time and date formatting, aggregation of changes in activity
+## Time and date formatting
 
-Change time and date formats in OpenProject and configure the display of journal aggregation.
+Change time and date formats in OpenProject:
 
 1. **Week starts on**: Configure what date the week starts (e.g. in the calendar view). Default is `Based on user's language`.
     You can also choose to start a week always on Monday, Sunday or Saturdays.
@@ -36,3 +36,5 @@ Change time and date formats in OpenProject and configure the display of journal
 4. **Time format**: default is based on user's language. You can choose various formats to display time in the system.
 5. **Users display format**: default is [First name] [Last name]. You can change to various different formats.
 6. Do not forget to **save** your changes.![image-20211209163420270](image-20211209163420270.png)
+
+> **Info:** Configuration options related to aggregation time (the time interval in which different user activities are displayed as one set of actions) have been moved to the [Incoming and Outgoing](../../incoming-and-outgoing/) section.

--- a/docs/user-guide/team-planner/README.md
+++ b/docs/user-guide/team-planner/README.md
@@ -89,12 +89,9 @@ You can create a new work package for a particular member of your team by clicki
 
 ![Creating a new work package by clicking and dragging across multiple day cells](TeamPlanner-12.4-newTask-drag.png)
 
-
-
 A **new work package dialog** will open. The assignee, start and finish dates will already be set based on where you clicked to create the work package. You can add any additional details, such as subject, work package type, a description and add attachments. Scrolling further down on the split screen also gives you access to other attributes such as cost and time and custom fields that might exist.
 
 ![An example of the new work package split screen view](TeamPlanner-12.4-newTask-splitScreen.png)
-
 
 
 #### Add an existing work package
@@ -122,7 +119,7 @@ The team planner allows you to quickly re-schedule and re-assign work packages c
 
 > **Info**: Work packages can also expand and retract in width depending on how many non-working days are spanned (for example, a 3-day task starting on Thursday and ending on Monday will spread across 5 calendar days;  dragging that same work package so that it starts on a Tuesday and ends on a Thursday means that it will spread across 3 calendar days. In both cases, the duration remains 3 days.
 
-Sometimes, it is not possible to modify the dates or the assignee of work packages for a variety of reasons. It could be, for example, because you might not have the necessary permissions to make that change or because existing relations make it impossible. In such cases, an error message will appear on the top of the screen to let you know that the change was was possible.
+Sometimes, it is not possible to modify the dates or the assignee of work packages for a variety of reasons. It could be, for example, because you might not have the necessary permissions to make that change or because existing relations make it impossible. In such cases, an error message will appear on the top of the screen to let you know that the change was not possible.
 
 ## Work package details view
 


### PR DESCRIPTION
This PR:

- Adds a note to the 12.0 release docs about OP no longer sending individual email notifications. Fixes: https://community.openproject.org/notifications/details/43853/activity

- Removes references to aggregation from the display settings admin page Fixes: https://community.openproject.org/notifications/details/45104/activity

- Fixes typo in team planner docs. Fixes: https://community.openproject.org/notifications/details/45388/activity