### PR TITLE
Increase line-height in global search

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -18,6 +18,7 @@
     class="global-search"
     [placeholder]="text.search_dots"
     [classes]="{'top-menu-search--input': true, '-markable': markable, '-expanded': expanded }"
+    [inputAttrs]="{ 'class': 'global-search--input' }"
     [openOnEnter]="false"
     [labelRequired]="false"
     [focusDirectly]="isFocusedDirectly"

--- a/frontend/src/app/core/global_search/input/global-search.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search.component.sass
@@ -6,6 +6,10 @@
   @media screen and (max-width: 679px)
     display: none
 
+  &--input[type="text"]
+    // Uppercase letters with accents like Ü and Â would get cut off
+    line-height: 20px
+
   &--option,
   &--option:hover
     padding: 5px 5px
@@ -70,3 +74,4 @@
     overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis
+    line-height: 1.5


### PR DESCRIPTION
Both in the input as well as in the results of the global search, upper- case letters that had umlauts or other accents (e.g. `Ü`, `Ç` or `Â`) would be cut off on top or bottom. Increasing the line-height fixes this issue.

Closes https://community.openproject.org/projects/openproject/work_packages/45218/activity