### PR TITLE
[#45536] The finish date slider for a task via the ganntt chart is not accurate

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -144,7 +144,12 @@ export class TimelineCellRenderer {
     if (direction === 'left') {
       dates.startDate = moment(initialStartDate || initialDueDate).add(delta, 'days');
     } else if (direction === 'right') {
-      dates.dueDate = moment(initialDueDate || now).add(delta, 'days');
+      // When no due date is present and the start date is in the past,
+      // we assume the task hasn't finished yet, meaning the end date is not in the past.
+      // To cover this case we have to choose the start date, only when it's in the future,
+      // and choose now if the start date is in the past.
+      const calculatedDueDate = initialDueDate || (now > initialStartDate ? now : initialStartDate);
+      dates.dueDate = moment(calculatedDueDate).add(delta, 'days');
     } else if (direction === 'both') {
       if (initialStartDate) {
         dates.startDate = moment(initialStartDate).add(delta, 'days');


### PR DESCRIPTION
https://community.openproject.org/work_packages/45536

<details>
<summary> Bug demo</summary>

![Dec-22-2022 14-33-33](https://user-images.githubusercontent.com/83396/209154961-a0eb088a-97f6-4dbb-b8de-674418770722.gif)

</details>

<details>
<summary> Fix demo</summary>

![Dec-22-2022 16-53-50](https://user-images.githubusercontent.com/83396/209160947-b3982c19-2150-4507-b260-58249972be92.gif)


</details>