### PR TITLE
WIP - [Wiki] Breadcrumbs for Search Results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -94,6 +94,24 @@ module SearchHelper
     end
   end
 
+  def breadcrumb_from_event(event)
+    if event.is_a? WikiPage
+      prefix = breadcrumb_prefix(event.project)
+      prefix += (event.ancestors.reverse + [event]).collect { |w| link_to h(w.breadcrumb_title), { controller: '/wiki', action: 'show', project_id: w.wiki.project, id: w.title } }
+      prefix[-1] += " (#{event.model_name.human})"
+      return prefix
+    end
+    if event.is_a? Project
+      prefix = breadcrumb_prefix(event)
+      prefix[-1] += " (#{event.model_name.human})"
+      return prefix
+    end
+  end
+
+  def breadcrumb_prefix(project)
+    (project.ancestors.reverse + [project]).collect { |p| link_to h(p.name), p }
+  end
+
   def type_label(t)
     OpenProject::GlobalSearch.tab_name(t)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -99,7 +99,7 @@ class Project < ApplicationRecord
   acts_as_journalized
 
   # Necessary for acts_as_searchable which depends on the event_datetime method for sorting
-  acts_as_event title: Proc.new { |o| "#{Project.model_name.human}: #{o.name}" },
+  acts_as_event title: Proc.new { |o| o.name },
                 url: Proc.new { |o| { controller: 'overviews/overviews', action: 'show', project_id: o } },
                 author: nil,
                 datetime: :created_at

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -42,7 +42,7 @@ class WikiPage < ApplicationRecord
               adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord # use a custom adapter able to handle edge cases
 
   acts_as_watchable
-  acts_as_event title: Proc.new { |o| "#{Wiki.model_name.human}: #{o.title}" },
+  acts_as_event title: Proc.new { |o| o.title },
                 description: :text,
                 url: Proc.new { |o| { controller: '/wiki', action: 'show', project_id: o.wiki.project, id: o.title } }
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,14 +55,12 @@ See COPYRIGHT and LICENSE files for more details.
           <% event_type = e.event_type == 'reply' ? 'forums' : event_type %>
           <%= icon_wrapper("icon-context icon-#{event_type}", e.event_name) %>
 
-          <% if e.project != @project %>
-            <span class="project"><%= e.project %></span>
-            <span> - </span>
-          <% end %>
-
-          <%= link_to highlight_tokens(truncate(e.event_title, escape: false, length: 255), @tokens), with_notes_anchor(e, @tokens) %>
+          <%= link_to highlight_tokens(truncate(e.event_title, escape: false, length: 255), @tokens, text_on_not_found: true), with_notes_anchor(e, @tokens) %>
         </dt>
         <dd>
+          <div class="search-breadcrumb -show">
+            <%= breadcrumb_list(*breadcrumb_from_event(e)) %>
+          </div>
           <span class="description"><%= highlight_tokens_in_event(e, @tokens) %></span>
           <span class="author"><%= format_time(e.event_datetime) %></span>
         </dd>

--- a/frontend/src/global_styles/layout/_breadcrumb.sass
+++ b/frontend/src/global_styles/layout/_breadcrumb.sass
@@ -34,3 +34,11 @@
 
   li
     white-space: nowrap
+
+.search-breadcrumb
+  @include global-breadcrumb-styles
+  margin-top: 0
+  margin-bottom: 10px
+
+  li
+    white-space: nowrap


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/38521/activity

It's just a rough draft of how it would look like. The acts_as_event API unfortunately does not exhibit a good way to transfer additional data (at least I didn't find anything in the docs and the source).

This commit fixes:
- display of title of a found object when the search token is found in the title (heading was broken)

This commit includes changes:
- breadcrumbs for projects and wiki pages in the search results (added event type in parentheses to these)
- removes project and event_type hin from the first line (cleaner heading)

![image](https://user-images.githubusercontent.com/1389648/209434497-34a58e2a-d22d-47aa-a390-83ab72997104.png)
