### PR TITLE
Change duration field step to 0.25h

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
@@ -35,7 +35,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 @Component({
   template: `
     <input type="number"
-           step="0.01"
+           step="0.25"
            class="inline-edit--field op-input"
            #input
            [attr.aria-required]="required"


### PR DESCRIPTION
0.01h is too small to be practically usable.

https://community.openproject.org/wp/45091