### PR TITLE
script for uploading backups to OpenProject directly on server via curl

### DIFF
--- a/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/README.md
+++ b/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/README.md
@@ -68,7 +68,10 @@ To import your community instance into our cloud environment, please send us the
 For a package-based installation, you can create both as root user on your environment as follows: `openproject run backup`
 This creates the attachment and PostgreSQL-dump or MySQL-dump under /var/db/openproject/backup.
 If you are still running OpenProject under MySQL, your dump will be converted to PostgreSQL before importing, we will do this for you. More information about the backup tool can be found [here](../../../installation-and-operations/operation/backing-up/).
+
 Please upload these documents as an attachment to a work package within your new OpenProject Enterprise cloud environment and send us the link to this work package via email.
+
+If you are having trouble accessing the files on your server with your browser, you can upload them directly from the server using [this script](./op-file-upload.sh). Simply download it and run it (`bash op-file-upload.sh`) to find out more.
 
 ## How can I export the documents loaded on OpenProject?
 

--- a/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/op-file-upload.sh
+++ b/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/op-file-upload.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+DOMAIN=$1
+API_KEY=$2
+WP_ID=$3
+FILE_PATH=$4
+
+if [ -z "$DOMAIN" ] || [ -z "$API_KEY" ] || [ -z "$WP_ID" ] || [ -z "FILE_PATH" ]; then
+  echo
+  echo "Usage: "
+  echo
+  echo "  bash op-file-upload.sh <domain> <api-key> <work package ID> <file path>"
+  echo
+  echo "Example: "
+  echo
+  echo "  bash op-file-upload.sh my.openproject.com 1d58c380e10b211b9535f47e1fd8c34fa2a93187c87b3561dc33454888cca882 1141 /home/me/Pictures/logo.png"
+  echo
+  echo "This will upload the file 'logo.png' as an attachment to the work package with the ID 1141."
+  echo "You have to create the work package beforehand using your browser (e.g. https://my.openproject.com/work_packages/new)"
+  echo
+  echo "You can create an API key on the OpenProject console (\`sudo openproject run console\`) like this: "
+  echo
+  echo "  puts Token::API.create!(user: User.find_by(login: 'm.user@openproject.com')).plain_value; exit"
+  echo
+  echo "Where \"m.user@openproject.com\" would be your user's login in your OpenProject environment."
+  echo "Alternatively you can simply create the API key using your browser under My Account -> Access Tokens -> API."
+
+  exit 1
+fi
+
+if [ ! -f "$FILE_PATH" ]; then
+  echo "Could not find file '$FILE_PATH'"
+  exit 1
+fi
+
+FILE_NAME=`basename $FILE_PATH`
+CONTENT_TYPE=`file --mime-type $FILE_PATH | cut -d: -f2 | tr -d ' '`
+
+curl "https://$DOMAIN/api/v3/work_packages/$WP_ID/attachments" \
+  -u "apikey:$API_KEY" \
+  -H 'accept: application/json, text/plain, */*' \
+  -F "metadata={\"fileName\":\"$FILE_NAME\",\"contentType\":\"$CONTENT_TYPE\"}" \
+  -F "file=@$FILE_PATH" \
+  > .op-file-upload-output.json
+
+cat .op-file-upload-output.json


### PR DESCRIPTION
We've had multiple customers now asking to be imported into our Cloud who were unable to upload the backups via browser since they didn't know how to get the files from their Linux server to their respective desktops.

This is a simple curl script that allows them to do this directly from the terminal.