### PR TITLE
Get the correct field container type for attribute macros

### DIFF
--- a/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field-renderer.ts
@@ -109,28 +109,6 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
 
   private getFieldForCurrentContext(resource:T, attributeName:string, fieldSchema:IFieldSchema):DisplayField {
     const context:DisplayFieldContext = { container: this.container, injector: this.injector, options: this.options };
-
-    // We handle multi value fields differently in the single view context
-    const isCustomMultiLinesField = ['[]CustomOption'].indexOf(fieldSchema.type) >= 0;
-    if (this.container === 'single-view' && isCustomMultiLinesField) {
-      return new MultipleLinesCustomOptionsDisplayField(attributeName, context) as DisplayField;
-    }
-    const isUserMultiLinesField = ['[]User'].indexOf(fieldSchema.type) >= 0;
-    if (this.container === 'single-view' && isUserMultiLinesField) {
-      return new MultipleLinesUserFieldModule(attributeName, context) as DisplayField;
-    }
-
-    // We handle progress differently in the timeline
-    if (this.container === 'timeline' && attributeName === 'percentageDone') {
-      return new ProgressTextDisplayField(attributeName, context);
-    }
-
-    // We want to render an combined edit field but the display field must
-    // show the original attribute
-    if (this.container === 'table' && ['startDate', 'dueDate', 'date'].includes(attributeName)) {
-      return new DateDisplayField(attributeName, context);
-    }
-
     return this.displayFieldService.getField(resource, attributeName, fieldSchema, context);
   }
 

--- a/frontend/src/app/shared/components/fields/display/display-field.component.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.component.ts
@@ -1,5 +1,11 @@
 import {
-  ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnInit, ViewChild,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  Input,
+  OnInit,
+  ViewChild,
 } from '@angular/core';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
@@ -31,16 +37,17 @@ export class DisplayFieldComponent implements OnInit {
     private schemaCache:SchemaCacheService) {
   }
 
-  ngOnInit() {
-    this.schemaCache
+  ngOnInit():void {
+    void this.schemaCache
       .ensureLoaded(this.resource)
       .then((schema) => {
         this.render(schema[this.fieldName]);
       });
   }
 
-  render(fieldSchema:IFieldSchema) {
+  render(fieldSchema:IFieldSchema):void {
     const field = this.getDisplayFieldInstance(fieldSchema);
+    field.apply(this.resource, fieldSchema);
 
     const container = this.container.nativeElement;
     container.hidden = false;
@@ -55,6 +62,7 @@ export class DisplayFieldComponent implements OnInit {
 
   private getDisplayFieldInstance(fieldSchema:IFieldSchema) {
     if (this.displayClass) {
+      // eslint-disable-next-line new-cap
       const instance = new this.displayClass(this.fieldName, this.displayFieldContext);
       instance.apply(this.resource, fieldSchema);
       return instance;

--- a/frontend/src/app/shared/components/fields/display/display-field.service.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.ts
@@ -31,6 +31,10 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { AbstractFieldService, IFieldType } from 'core-app/shared/components/fields/field.service';
 import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+import { MultipleLinesCustomOptionsDisplayField } from 'core-app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module';
+import { MultipleLinesUserFieldModule } from 'core-app/shared/components/fields/display/field-types/multiple-lines-user-display-field.module';
+import { ProgressTextDisplayField } from 'core-app/shared/components/fields/display/field-types/progress-text-display-field.module';
+import { DateDisplayField } from 'core-app/shared/components/fields/display/field-types/date-display-field.module';
 
 export interface IDisplayFieldType extends IFieldType<DisplayField> {
   new(resource:HalResource, attributeType:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField;
@@ -64,9 +68,37 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
    * @returns {T}
    */
   public getField(resource:HalResource, fieldName:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField {
-    const fieldClass = this.getSpecificClassFor(resource._type, fieldName, schema.type);
-    const instance = new fieldClass(fieldName, context);
+    // We handle multi value fields differently in the single view context
+    const instance = this.getFieldForContext(resource, fieldName, schema, context);
     instance.apply(resource, schema);
     return instance;
+  }
+
+  private getFieldForContext(resource:HalResource, fieldName:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField {
+    // We handle multi value fields differently in the single view context
+    const isCustomMultiLinesField = ['[]CustomOption'].indexOf(schema.type) >= 0;
+    if (context.container === 'single-view' && isCustomMultiLinesField) {
+      return new MultipleLinesCustomOptionsDisplayField(fieldName, context) as DisplayField;
+    }
+    const isUserMultiLinesField = ['[]User'].indexOf(schema.type) >= 0;
+    if (context.container === 'single-view' && isUserMultiLinesField) {
+      return new MultipleLinesUserFieldModule(fieldName, context) as DisplayField;
+    }
+
+    // We handle progress differently in the timeline
+    if (context.container === 'timeline' && fieldName === 'percentageDone') {
+      return new ProgressTextDisplayField(fieldName, context);
+    }
+
+    // We want to render an combined edit field but the display field must
+    // show the original attribute
+    if (context.container === 'table' && ['startDate', 'dueDate', 'date'].includes(fieldName)) {
+      return new DateDisplayField(fieldName, context);
+    }
+
+    const cls = this.getSpecificClassFor(resource._type, fieldName, schema.type);
+
+    // eslint-disable-next-line new-cap
+    return new cls(fieldName, context) as DisplayField;
   }
 }

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.html
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.html
@@ -4,6 +4,7 @@
 </span>
 <display-field *ngIf="!!resource"
                [resource]="resource"
+               containerType="single-view"
                [displayFieldOptions]="{ writable: false }"
                [fieldName]="fieldName">
 </display-field>

--- a/spec/features/wysiwyg/macros/attribute_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/attribute_macros_spec.rb
@@ -68,38 +68,76 @@ describe 'Wysiwyg attribute macros', type: :feature, js: true do
     login_as(user)
   end
 
-  describe 'in wikis' do
-    describe 'creating a wiki page' do
-      before do
-        visit project_wiki_path(project, :wiki)
+  describe 'creating a wiki page' do
+    before do
+      visit project_wiki_path(project, :wiki)
+    end
+
+    it 'can add and save multiple code blocks (Regression #28350)' do
+      editor.in_editor do |container,|
+        editor.set_markdown markdown
+        expect(container).to have_table
       end
 
-      it 'can add and save multiple code blocks (Regression #28350)' do
+      click_on 'Save'
+
+      expect(page).to have_selector('.flash.notice')
+
+      # Expect output widget
+      within('#content') do
+        expect(page).to have_selector('td', text: 'Subject')
+        expect(page).to have_selector('td', text: 'Foo Bar')
+        expect(page).to have_selector('td', text: 'Identifier')
+        expect(page).to have_selector('td', text: 'some-project')
+
+        expect(page).to have_selector('td', text: 'invalid subject Cannot expand macro: Requested resource could not be found')
+        expect(page).to have_selector('td', text: 'invalid project Cannot expand macro: Requested resource could not be found')
+      end
+
+      # Edit page again
+      click_on 'Edit'
+
+      editor.in_editor do |container,|
+        expect(container).to have_selector('tbody td', count: 6)
+      end
+    end
+
+    context 'with a multi-select CF' do
+      let!(:type) { create(:type, projects: [project]) }
+      let!(:custom_field) do
+        create(
+          :list_wp_custom_field,
+          name: "Ingredients",
+          multi_value: true,
+          types: [type],
+          projects: [project],
+          possible_values: %w[A B C D E F G H]
+        )
+      end
+
+      let!(:work_package) do
+        wp = build(:work_package, subject: "Foo Bar", project:, type:)
+
+        wp.custom_field_values = {
+          custom_field.id => %w[A B C D E F].map { |s| custom_field.custom_options.find { |co| co.value == s }.id }
+        }
+
+        wp.save!
+        wp
+      end
+
+      it 'expands all custom values (Regression #45538)' do
         editor.in_editor do |container,|
-          editor.set_markdown markdown
-          expect(container).to have_selector('table')
+          editor.set_markdown 'workPackageValue:"Foo Bar":Ingredients'
+          expect(container).to have_text 'workPackageValue'
         end
 
         click_on 'Save'
 
         expect(page).to have_selector('.flash.notice')
 
-        # Expect output widget
         within('#content') do
-          expect(page).to have_selector('td', text: 'Subject')
-          expect(page).to have_selector('td', text: 'Foo Bar')
-          expect(page).to have_selector('td', text: 'Identifier')
-          expect(page).to have_selector('td', text: 'some-project')
-
-          expect(page).to have_selector('td', text: 'invalid subject Cannot expand macro: Requested resource could not be found')
-          expect(page).to have_selector('td', text: 'invalid project Cannot expand macro: Requested resource could not be found')
-        end
-
-        # Edit page again
-        click_on 'Edit'
-
-        editor.in_editor do |container,|
-          expect(container).to have_selector('tbody td', count: 6)
+          expect(page).to have_selector('.custom-option', count: 6)
         end
       end
     end


### PR DESCRIPTION
The display field macro defaulted to the table style displaying, which truncates some things such as multi value custom fields.

By moving that logic to the fields service, not the manual display field renderer, we can reuse the distinctions and ensure the custom values are not truncated.

As this potentially changes some displaying, I'll add it to 12.5

https://community.openproject.org/wp/45538