### PR TITLE
Set service_past_wait=true by default

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -11,7 +11,8 @@ if OpenProject::Configuration.web_workers >= 2
     ::Rack::Timeout,
     service_timeout: service_timeout, # time after which a request being served times out
     wait_timeout: wait_timeout, # time after which a request waiting to be served times out
-    term_on_timeout: 1 # shut down worker (gracefully) right away on timeout to be restarted
+    term_on_timeout: 1, # shut down worker (gracefully) right away on timeout to be restarted
+    service_past_wait: true # Treat the service timeout as independent from the wait timeout
   )
 
   Rails.application.config.after_initialize do


### PR DESCRIPTION
Our configuration of rack-timeout incorrectly assumed that the service timeout is added to the wait timeout.

But this is not the case:
https://github.com/zombocom/rack-timeout/blob/main/doc/settings.md#wait-timeout

Without service_past_wait, the service will be terminated whenever the wait_timeout is surpassed.

https://community.openproject.org/projects/openproject/work_packages/45417/activity?query_id=3510