### PR TITLE
Remove .angular cache in docker after building

### DIFF
--- a/docker/prod/setup/postinstall-common.sh
+++ b/docker/prod/setup/postinstall-common.sh
@@ -39,6 +39,9 @@ rm -rf "$APP_PATH/tmp/cache/assets"
 # Remove node_modules and entire frontend
 rm -rf "$APP_PATH/node_modules/" "$APP_PATH/frontend/node_modules/"
 
+# Remove angular cache
+rm -rf "$APP_PATH/frontend/.angular"
+
 # Clean cache in root
 rm -rf /root/.npm
 


### PR DESCRIPTION
Follow up to the packaging fix to remove angular cache after builds https://github.com/opf/openproject/commit/f7d413b0618902e53b705e75b0d4274fa16e7b94