### PR TITLE
Bypass self registration for omniauth users

### DIFF
--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -191,13 +191,23 @@ module Authentication
     end
 
     def activate_user!
-      if user.new_record? || user.invited?
+      if activatable?
         ::Users::RegisterUserService
           .new(user)
           .call
       else
         ServiceResult.success(result: user)
       end
+    end
+
+    ##
+    # Determines if the given user is activatable on the fly, that is:
+    #
+    # 1. The user has just been initialized by us
+    # 2. The user has been invited
+    # 3. The user had been registered manually (e.g., through a previous self-registration setting)
+    def activatable?
+      user.new_record? || user.invited? || user.registered?
     end
 
     ##

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -231,7 +231,7 @@ module Authentication
 
       # Remove any nil values to avoid
       # overriding existing attributes
-      attribute_map.compact!
+      attribute_map.compact_blank!
 
       Rails.logger.debug { "Mapped auth_hash user attributes #{attribute_map.inspect}" }
       attribute_map

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -39,6 +39,7 @@ module Users
         ensure_user_limit_not_reached!
         register_invited_user
         register_ldap_user
+        register_omniauth_user
         ensure_registration_allowed!
         register_by_email_activation
         register_automatically
@@ -88,14 +89,27 @@ module Users
 
     ##
     # Try to register a user with an auth source connection
-    # bypassing regular restrictions
+    # bypassing regular account registration restrictions
     def register_ldap_user
-      return unless user.auth_source_id.present?
+      return if user.auth_source_id.blank?
 
       user.activate
 
       with_saved_user_result(success_message: I18n.t(:notice_account_registered_and_logged_in)) do
-        Rails.logger.info { "User #{user.login} was successfully activated after invitation." }
+        Rails.logger.info { "User #{user.login} was successfully activated with LDAP association after invitation." }
+      end
+    end
+
+    ##
+    # Try to register a user with an existsing omniauth connection
+    # bypassing regular account registration restrictions
+    def register_omniauth_user
+      return if user.identity_url.blank?
+
+      user.activate
+
+      with_saved_user_result(success_message: I18n.t(:notice_account_registered_and_logged_in)) do
+        Rails.logger.info { "User #{user.login} was successfully activated after arriving from omniauth." }
       end
     end
 

--- a/modules/openid_connect/spec/requests/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec.rb
@@ -98,12 +98,19 @@ describe 'OpenID Connect',
       redirect_from_provider
 
       expect(response.status).to be 302
-      expect(response.location).to match /\/login$/
+      expect(response.location).to match /\/\?first_time_user=true$/
+
+      # after_login requires the optional third context parameter
+      # remove this guard once we are on v4.1
+      if OpenProject::OmniAuth::Authorization.method(:after_login!).arity.abs > 2
+        # check that cookie is stored in the access token
+        expect(response.cookies['_open_project_session_access_token']).to eq 'foo bar baz'
+      end
 
       user = User.find_by_mail(user_info[:email])
 
       expect(user).not_to be_nil
-      expect(user.active?).to be false
+      expect(user.active?).to be true
 
       ##
       # it should redirect to the provider again upon clicking on sign-in when the user has been activated
@@ -121,14 +128,7 @@ describe 'OpenID Connect',
       redirect_from_provider
 
       expect(response.status).to be 302
-      expect(response.location).to match /\/\?first_time_user=true$/
-
-      # after_login requires the optional third context parameter
-      # remove this guard once we are on v4.1
-      if OpenProject::OmniAuth::Authorization.method(:after_login!).arity.abs > 2
-        # check that cookie is stored in the access token
-        expect(response.cookies['_open_project_session_access_token']).to eq 'foo bar baz'
-      end
+      expect(response.location).to match /\/my\/page/
     end
 
     context 'with a custom claim and mapping' do

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -259,12 +259,14 @@ describe AccountController,
           post :omniauth_login, params: { provider: :google }
         end
 
-        it 'redirects to signin_path' do
-          expect(response).to redirect_to signin_path
-        end
+        it 'shows a notice about the activated account', :aggregate_failures do
+          expect(flash[:notice]).to eq(I18n.t('notice_account_registered_and_logged_in'))
+          user = User.last
 
-        it 'shows the right flash message' do
-          expect(flash[:error]).to eq(I18n.t('account.error_self_registration_disabled'))
+          expect(user.firstname).to eq 'foo'
+          expect(user.lastname).to eq 'bar'
+          expect(user.mail).to eq 'foo@bar.com'
+          expect(user).to be_active
         end
       end
     end
@@ -458,11 +460,8 @@ describe AccountController,
           post :omniauth_login, params: { provider: :google }
         end
 
-        it 'shows a notice about the activated account' do
+        it 'shows a notice about the activated account', :aggregate_failures do
           expect(flash[:notice]).to eq(I18n.t('notice_account_registered_and_logged_in'))
-        end
-
-        it 'activates the user' do
           expect(user.reload).to be_active
         end
       end
@@ -476,11 +475,8 @@ describe AccountController,
           post :omniauth_login, params: { provider: :google }
         end
 
-        it 'shows an error indicating a failed login' do
+        it 'shows an error indicating a failed login', :aggregate_failures do
           expect(flash[:error]).to eql(I18n.t(:notice_account_invalid_credentials))
-        end
-
-        it 'redirects to signin_path' do
           expect(response).to redirect_to signin_path
         end
       end

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -442,12 +442,9 @@ describe AccountController,
           post :omniauth_login, params: { provider: :google }
         end
 
-        it 'shows an error about a not activated account' do
-          expect(flash[:error]).to eql(I18n.t('account.error_inactive_activation_by_mail'))
-        end
-
-        it 'redirects to signin_path' do
-          expect(response).to redirect_to signin_path
+        it 'shows a notice about the activated account', :aggregate_failures do
+          expect(flash[:notice]).to eq(I18n.t('notice_account_registered_and_logged_in'))
+          expect(user.reload).to be_active
         end
       end
 

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -306,6 +306,28 @@ describe AccountController,
           expect(user.last_login_on.utc.to_i).to be >= post_at.utc.to_i
         end
 
+        context 'with a partially blank auth_hash' do
+          let(:omniauth_hash) do
+            OmniAuth::AuthHash.new(
+              provider: 'google',
+              uid: '123545',
+              info: { name: 'foo',
+                      first_name: '',
+                      last_name: 'newLastname',
+                      email: 'foo@bar.com' }
+            )
+          end
+
+          it 'signs in the user after successful external authentication' do
+            expect { post :omniauth_login, params: { provider: :google } }
+                .not_to change { user.reload.firstname }
+
+            expect(response).to redirect_to my_page_path
+
+            expect(user.lastname).to eq 'newLastname'
+          end
+        end
+
         describe 'authorization' do
           let(:config) do
             Struct.new(:google_name, :global_email).new 'foo', 'foo@bar.com'

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -221,22 +221,16 @@ describe 'Omniauth authentication', type: :feature do
             self_registration: Setting::SelfRegistration.by_email
           } do
     shared_examples 'registration with registration by email' do
-      it 'shows a note explaining that the account has to be activated' do
+      it 'still automatically activates the omniauth account' do
         visit login_path
 
         SeleniumHubWaiter.wait
         # login form developer strategy
-        fill_in 'first_name', with: 'Ifor'
-        fill_in 'last_name',  with: 'McAlistar'
-        fill_in 'email',      with: 'i.mcalistar@example.com'
+        fill_in 'email', with: user.mail
 
         click_link_or_button 'Sign In'
 
-        expect(page).to have_content(I18n.t(:notice_account_register_done))
-
-        if defined? instructions
-          expect(page).to have_content instructions
-        end
+        expect(page).to have_current_path my_page_path
       end
     end
 
@@ -251,10 +245,7 @@ describe 'Omniauth authentication', type: :feature do
       end
 
       it_behaves_like 'registration with registration by email' do
-        # i.e. it still shows a notice
-        # instead of redirecting straight back to the omniauth login provider
-        let(:login_path) { signin_path }
-        let(:instructions) { translation_substring I18n.t(:instructions_after_registration) }
+        let(:login_path) { '/auth/developer' }
       end
     end
   end


### PR DESCRIPTION
Currently, valid new users returning from omniauth are being treated as if they were self-registrating. This has caused a lot of frustration for admins as they want to allow automatic user creation through omniauth, but don't allow self-registration at the same time.

This PR ensures that omniauth can ignore this setting when creating accounts, in the same fashion it has already been implemented for LDAP

https://community.openproject.org/wp/42390