### PR TITLE
Set oauth_allow_remapping_of_existing_users to true per default

### DIFF
--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -582,7 +582,7 @@ Settings::Definition.define do
       allowed: -> { Role.pluck(:id) }
 
   add :oauth_allow_remapping_of_existing_users,
-      default: false
+      default: true
 
   add :omniauth_direct_login_provider,
       format: :string,

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -176,6 +176,7 @@ Configuring OpenProject through environment variables is described in detail [in
 * `drop_old_sessions_on_login` (default: false)
 * [`auth_source_sso`](#auth-source-sso) (default: nil)
 * [`omniauth_direct_login_provider`](#omniauth-direct-login-provider) (default: nil)
+* [`oauth_allow_remapping_of_existing_users`](#prevent-omniauth-remapping-of-existing-users) (default: true)
 * [`disable_password_login`](#disable-password-login) (default: false)
 * [`attachments_storage`](#attachments-storage) (default: file)
 * [`direct_uploads`](#direct-uploads) (default: true)
@@ -266,6 +267,21 @@ If this option is active, a login will lead directly to the configured omniauth 
 
 ```yaml
 OPENPROJECT_OMNIAUTH__DIRECT__LOGIN__PROVIDER="google"
+```
+
+### prevent omniauth remapping of existing users
+
+Per default external authentication providers through OmniAuth (such as SAML or OpenID connect providers) are allowed to take over existing
+accounts if the mapped login is already taken. This is usually desirable, if you have e.g., accounts created through LDAP and want these
+accounts to be accessible through a SSO provider as well
+
+If you want to prevent this from happening, you can set this variable to false. In this case, accounts with matching logins will need
+to create a new account.
+
+*default: true*
+
+```yaml
+OPENPROJECT_OAUTH__ALLOW__REMAPPING__OF__EXISTING__USERS="false"
 ```
 
 

--- a/docs/installation-and-operations/misc/custom-openid-connect-providers/README.md
+++ b/docs/installation-and-operations/misc/custom-openid-connect-providers/README.md
@@ -283,3 +283,5 @@ sudo openproject run console
 ```
 
 Then, existing users should be able to log in using their OIDC identity. Note that this works only if the user is using password-based authentication, and is not linked to any other authentication source (e.g. LDAP) or identity provider.
+
+Note that this setting is set to true by default for new installations already.

--- a/docs/system-admin-guide/authentication/openid-providers/README.md
+++ b/docs/system-admin-guide/authentication/openid-providers/README.md
@@ -208,3 +208,6 @@ exit
 ```
 
 Then, existing users should be able to log in using their Azure identity. Note that this works only if the user is using password-based authentication, and is not linked to any other authentication source (e.g. LDAP) or OpenID provider.
+
+
+Note that this setting is set to true by default for new installations already.

--- a/docs/system-admin-guide/authentication/saml/README.md
+++ b/docs/system-admin-guide/authentication/saml/README.md
@@ -556,6 +556,7 @@ sudo openproject run console
 
 Then, existing users should be able to log in using their SAML identity. Note that this works only if the user is using password-based authentication, and is not linked to any other authentication source (e.g. LDAP) or OpenID provider.
 
+Note that this setting is set to true by default for new installations already.
 
 
 **Q: Could the users be automatically logged in to OpenProject if they are already authenticated at the SAML Identity Provider?**


### PR DESCRIPTION
By default, oauth_allow_remapping_of_existing_users is set to false. This means existing accounts cannot be re-authenticated with a new authentication provider.

This is very confusing to users that have, e.g., existing manual accounts and want to switch to SAML/OIDC, as they have to set this setting through console before being able to move their existing accounts over to the external authentication provider.

The same is true for user accounts created through LDAP sync.

- [x] Set setting to true per default for new installations
- [x] Remove troubleshooting section in OIDC/SAML guides
- [x] Add documentation on how to disable setting

https://community.openproject.org/wp/45672