### PR TITLE
Don't include implicitly created default custom values into changes

### DIFF
--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -61,6 +61,10 @@ class CustomValue < ApplicationRecord
     end
   end
 
+  def default?
+    value == custom_field.default_value
+  end
+
   protected
 
   def validate_presence_of_required_value

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -256,6 +256,9 @@ module Redmine
             # Skip when the old value equals the new value (no change happened).
             next cfv_changes if value_was == cfv.value
 
+            # Skip when the new value is the default value
+            next cfv_changes if value_was.nil? && cfv.default?
+
             cfv_changes.merge("custom_field_#{cfv.custom_field_id}": [value_was, cfv.value])
           end
         end

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -149,10 +149,14 @@ RSpec.describe 'Work package timeline date formatting',
       expect(page).to have_selector('.wp-timeline--header-element', text: '01')
       expect(page).to have_selector('.wp-timeline--header-element', text: '02')
 
-      # Most years do not have 53 weeks. Some do.
-      unless Date.current.beginning_of_year.saturday?
-        expect(page).not_to have_selector('.wp-timeline--header-element', text: '53')
-      end
+      # According to the Canadian locale (https://savvytime.com/week-number/canada/2022)
+      # the first week of the year is the week where 1st of January falls.
+      # If that is last year, then we need to add an offset +1 week to the total number of years.
+      current_year = Date.current.year
+      week_offset = current_year - Date.new(current_year, 1, 1).beginning_of_week.year
+
+      weeks_this_year = Date.new(current_year, 12, 28).cweek + week_offset
+      expect(page).not_to have_selector('.wp-timeline--header-element', text: weeks_this_year + 1)
 
       # expect moment to return week 01 for start date and due date
       expect_date_week work_package.start_date.iso8601, '01'

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -135,5 +135,16 @@ describe WorkPackage, 'acts_as_customizable' do
     before do
       setup_custom_field(custom_field)
     end
+
+    context 'with a default value' do
+      before do
+        custom_field.update! default_value: 'foobar'
+        model_instance.custom_values.destroy_all
+      end
+
+      it 'returns no changes' do
+        expect(model_instance.custom_field_changes).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Custom field changes from an implicitly created custom value was added to the validation of the CreateNoteContract. To prevent this, we don't want implicitly added custom values to be part of the changes

https://community.openproject.org/wp/45724