### PR TITLE
Change order of admin settings script variables

### DIFF
--- a/frontend/src/app/core/augmenting/dynamic-scripts/administration_settings.js
+++ b/frontend/src/app/core/augmenting/dynamic-scripts/administration_settings.js
@@ -1,9 +1,12 @@
 var Administration = (function ($) {
-  var update_default_language_options,
-    init_language_selection_handling,
-    toggle_default_language_select;
+  const toggle_disabled_state = function (active) {
+    jQuery('#setting_default_language select').attr('disabled', active)
+      .closest('form')
+      .find('input:submit')
+      .attr('disabled', active);
+  };
 
-  update_default_language_options = function (input) {
+  const update_default_language_options = function (input) {
     var default_language_select = $('#setting_default_language select'),
       default_language_select_active;
 
@@ -24,14 +27,7 @@ var Administration = (function ($) {
     }
   };
 
-  toggle_disabled_state = function (active) {
-    jQuery('#setting_default_language select').attr('disabled', active)
-      .closest('form')
-      .find('input:submit')
-      .attr('disabled', active);
-  };
-
-  init_language_selection_handling = function () {
+  const init_language_selection_handling = function () {
     jQuery('#setting_available_languages input:not([checked="checked"])').each(function (index, input) {
       update_default_language_options($(input));
     });


### PR DESCRIPTION
A ReferenceError was being thrown for the toggle_disabled_state function.

I was not able to directly reproduce this, but since this is only used once in the same file, I'm pretty sure this is because it is used before it is defined. This commit changes the order in which the functions in that file are defined.

Closes https://community.openproject.org/projects/openproject/work_packages/43230/activity