### PR TITLE
Remove dead code

### DIFF
--- a/app/controllers/projects/archive_controller.rb
+++ b/app/controllers/projects/archive_controller.rb
@@ -45,11 +45,11 @@ class Projects::ArchiveController < ApplicationController
     service_call = change_status(status)
 
     if service_call.success?
-      redirect_to(project_path_with_status)
+      redirect_to(projects_path)
     else
       flash[:error] = t(:"error_can_not_#{status}_project",
                         errors: service_call.errors.full_messages.join(', '))
-      redirect_back fallback_location: project_path_with_status
+      redirect_back fallback_location: projects_path
     end
   end
 
@@ -64,11 +64,5 @@ class Projects::ArchiveController < ApplicationController
     when :archive then Projects::ArchiveService
     when :unarchive then Projects::UnarchiveService
     end
-  end
-
-  def project_path_with_status
-    acceptable_params = params.permit(:status).to_h.compact.select { |_, v| v.present? }
-
-    projects_path(acceptable_params)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -89,7 +89,7 @@ class ProjectsController < ApplicationController
       flash[:error] = I18n.t('projects.delete.schedule_failed', errors: service_call.errors.full_messages.join("\n"))
     end
 
-    redirect_to project_path_with_status
+    redirect_to projects_path
   end
 
   def destroy_info
@@ -117,12 +117,6 @@ class ProjectsController < ApplicationController
 
   def hide_project_in_layout
     @project = nil
-  end
-
-  def project_path_with_status
-    acceptable_params = params.permit(:status).to_h.compact.select { |_, v| v.present? }
-
-    projects_path(acceptable_params)
   end
 
   def load_query


### PR DESCRIPTION
`status` query parameter was used in ProjectsController years ago to keep the view in its current state after doing actions like delete, archive, and unarchive. This has not been cleaned up or adapted when switching from `status` to `filters` query parameter and is not useful anymore.