### PR TITLE
Improve performance of /api/v3/capabilities endpoint

### DIFF
--- a/app/models/actions/scopes/default.rb
+++ b/app/models/actions/scopes/default.rb
@@ -32,13 +32,16 @@ module Actions::Scopes
 
     class_methods do
       def default
-        actions_sql = <<~SQL.squish
-          (SELECT id, permission, global, module, grant_to_admin
-           FROM (VALUES #{action_map}) AS t(id, permission, global, module, grant_to_admin)) actions
-        SQL
+        RequestStore[:action_default_scope] ||= begin
+          actions_sql = <<~SQL.squish
+            (SELECT id, permission, global, module, grant_to_admin
+            FROM (VALUES #{action_map}) AS t(id, permission, global, module, grant_to_admin)) actions
+          SQL
 
-        select('actions.*')
-          .from(actions_sql)
+          unscoped # prevent triggering the default scope again
+            .select('actions.*')
+            .from(actions_sql)
+        end
       end
 
       private

--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -46,14 +46,15 @@ module Capabilities::Scopes
           ) capabilities
         SQL
 
-        select('capabilities.*')
+        unscoped # prevent triggering the default scope again
+          .select('capabilities.*')
           .from(capabilities_sql)
       end
 
       private
 
       def default_sql_by_member
-        <<~SQL.squish
+        <<~SQL_PART
           SELECT DISTINCT
             actions.id "action",
             users.id principal_id,
@@ -72,11 +73,11 @@ module Capabilities::Scopes
              AND actions.module = enabled_modules.name
           WHERE (projects.active AND (enabled_modules.project_id IS NOT NULL OR "actions".module IS NULL))
           OR (projects.id IS NULL AND "actions".global)
-        SQL
+        SQL_PART
       end
 
       def default_sql_by_admin
-        <<~SQL.squish
+        <<~SQL_PART
           SELECT DISTINCT
             actions.id "action",
             users.id principal_id,
@@ -91,11 +92,11 @@ module Capabilities::Scopes
             ON enabled_modules.project_id = projects.id
             AND actions.module = enabled_modules.name
           WHERE (projects.id IS NOT NULL AND (enabled_modules.project_id IS NOT NULL OR "actions".module IS NULL)) OR "actions".global
-        SQL
+        SQL_PART
       end
 
       def default_sql_by_non_member
-        <<~SQL.squish
+        <<~SQL_PART
           SELECT DISTINCT
             actions.id "action",
             users.id principal_id,
@@ -117,11 +118,11 @@ module Capabilities::Scopes
             AND actions.module = enabled_modules.name
 
           WHERE enabled_modules.project_id IS NOT NULL OR "actions".module IS NULL
-        SQL
+        SQL_PART
       end
 
       def default_sql_by_non_member_with_anonymous
-        <<~SQL.squish
+        <<~SQL_PART
           SELECT DISTINCT
             actions.id "action",
             users.id principal_id,
@@ -138,7 +139,7 @@ module Capabilities::Scopes
             AND actions.module = enabled_modules.name
 
           WHERE enabled_modules.project_id IS NOT NULL OR "actions".module IS NULL
-        SQL
+        SQL_PART
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/45776

On my machine, in dev environment, went from ~113ms to ~36ms as reported by Rails logger when doing an unauthenticated request.

The following was done to improve performance:
* squish only once the big sql in `Capabilities::Scope::Default`
* cache `Actions::Scope::Default.default` in `RequestStore`
* unscope the call to `select` to prevent calling `#default` again and computing a bunch of things for nothing.

Some other things could have been done, but it may improve performance enough. I'd like to see how it behaves first before going further.