### PR TITLE
[chore] Remove cache for storage representer

### DIFF
--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -49,7 +49,6 @@ module API::V3::Storages
     # LinkedResource module defines helper methods to describe attributes
     include API::Decorators::LinkedResource
     include API::Decorators::DateProperty
-    include ::API::Caching::CachedRepresenter
     include Storages::Peripherals::StorageUrlHelper
 
     module ClassMethods


### PR DESCRIPTION
- storage representer cannot be cached due to the fact that he retrieves live data with outbounding requests