### PR TITLE
Bug/34978 custom field in cost report show not found after custom fileds value

### DIFF
--- a/modules/reporting/app/models/cost_query/custom_field_mixin.rb
+++ b/modules/reporting/app/models/cost_query/custom_field_mixin.rb
@@ -112,9 +112,6 @@ module CostQuery::CustomFieldMixin
     custom_values_table = CustomValue.table_name
     custom_options_table = CustomOption.table_name
 
-    # CustomValues of lists MAY have non-integer values when the list contained invalid values.
-    # Because of this, we do not cast the cv.value but rather the co.id
-
     <<-SQL
     -- BEGIN Custom Field Join: #{db_field}
     LEFT OUTER JOIN (

--- a/modules/reporting/app/models/cost_query/custom_field_mixin.rb
+++ b/modules/reporting/app/models/cost_query/custom_field_mixin.rb
@@ -109,9 +109,6 @@ module CostQuery::CustomFieldMixin
   end
 
   def list_join_table(field)
-    cast_as = SQL_TYPES[field.field_format]
-    cf_name = "custom_field#{field.id}"
-
     custom_values_table = CustomValue.table_name
     custom_options_table = CustomOption.table_name
 
@@ -119,10 +116,10 @@ module CostQuery::CustomFieldMixin
     # Because of this, we do not cast the cv.value but rather the co.id
 
     <<-SQL
-    -- BEGIN Custom Field Join: #{cf_name}
+    -- BEGIN Custom Field Join: #{db_field}
     LEFT OUTER JOIN (
     SELECT
-      co.id AS #{cf_name},
+      co.id AS #{db_field},
       co.value,
       cv.customized_type,
       cv.custom_field_id,
@@ -130,12 +127,12 @@ module CostQuery::CustomFieldMixin
       FROM #{custom_values_table} cv
       INNER JOIN #{custom_options_table} co
       ON cv.custom_field_id = co.custom_field_id AND cv.value = co.id::VARCHAR
-    ) AS #{cf_name}
-    ON #{cf_name}.customized_type = 'WorkPackage'
+    ) AS #{db_field}
+    ON #{db_field}.customized_type = 'WorkPackage'
 
-    AND #{cf_name}.custom_field_id = #{field.id}
-    AND #{cf_name}.customized_id = entries.work_package_id
-    -- END Custom Field Join: #{cf_name}
+    AND #{db_field}.custom_field_id = #{field.id}
+    AND #{db_field}.customized_id = entries.work_package_id
+    -- END Custom Field Join: #{db_field}
     SQL
   end
 

--- a/modules/reporting/app/models/cost_query/custom_field_mixin.rb
+++ b/modules/reporting/app/models/cost_query/custom_field_mixin.rb
@@ -122,7 +122,8 @@ module CostQuery::CustomFieldMixin
     -- BEGIN Custom Field Join: #{cf_name}
     LEFT OUTER JOIN (
     SELECT
-      CAST(co.value AS #{cast_as}) AS #{cf_name},
+      co.id AS #{cf_name},
+      co.value,
       cv.customized_type,
       cv.custom_field_id,
       cv.customized_id

--- a/modules/reporting/app/models/cost_query/filter/custom_field_entries.rb
+++ b/modules/reporting/app/models/cost_query/filter/custom_field_entries.rb
@@ -45,6 +45,21 @@ class CostQuery::Filter::CustomFieldEntries < Report::Filter::Base
     end
   end
 
+  def self.field
+    # There is a special treatment for how list custom values are retrieved as those
+    # are not taken directly from the custom_values but from the custom_options table.
+    # But the value still has to be the id of the option which is later on mapped to the
+    # human readable value.
+    # Mapping to the human readable value is done for all custom values (e.g. users, versions)
+    # following the same pattern of code, so simply making the exception here to use the value
+    # would complicated the code later on.
+    if custom_field.field_format == 'list'
+      "#{db_field}.value"
+    else
+      super
+    end
+  end
+
   def self.available_values(*)
     @possible_values || get_possible_values
   end

--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -188,6 +188,7 @@ describe 'Custom fields reporting', type: :feature, js: true do
         select 'Invalid List CF', from: 'group-by--add-columns'
         select 'Work package', from: 'group-by--add-rows'
 
+        sleep(0.1)
         click_link 'Apply'
 
         # Expect row of work package

--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -105,7 +105,7 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
       # Expect empty result table
       within('#result-table') do
-        expect(page).to have_no_selector('.top.result', text: '12.50 hours')
+        expect(page).not_to have_selector('.top.result', text: '12.50 hours')
       end
       expect(page).to have_selector('.generic-table--no-results-title')
 
@@ -132,8 +132,9 @@ describe 'Custom fields reporting', type: :feature, js: true do
       # Expect row of work package
       within('#result-table') do
         expect(page).to have_selector('a.work_package', text: "#{work_package.type} ##{work_package.id}")
-        expect(page).to have_selector('th.inner', text: 'First option')
-        expect(page).to have_no_selector('th.inner', text: 'Second option')
+        # There used to be additional and unwanted text after the option name being rendered.
+        expect(page).to have_selector('th.inner', text: /^First option$/)
+        expect(page).not_to have_selector('th.inner', text: 'Second option')
 
         # Only first option should have content for the work package
         expect(page).to have_selector('table.report tbody tr', count: 1)
@@ -195,7 +196,7 @@ describe 'Custom fields reporting', type: :feature, js: true do
         within('#result-table') do
           expect(page).to have_selector('a.work_package', text: "#{work_package.type} ##{work_package.id}")
           expect(page).to have_selector('th.inner', text: '1')
-          expect(page).to have_no_selector('th.inner', text: 'invalid!')
+          expect(page).not_to have_selector('th.inner', text: 'invalid!')
         end
       end
     end
@@ -228,7 +229,7 @@ describe 'Custom fields reporting', type: :feature, js: true do
       within('#result-table') do
         expect(page).to have_selector('a.work_package', text: "#{work_package.type} ##{work_package.id}")
         expect(page).to have_selector('th.inner', text: 'foo')
-        expect(page).to have_no_selector('th.inner', text: 'None')
+        expect(page).not_to have_selector('th.inner', text: 'None')
 
         # Only first option should have content for the work package
         expect(page).to have_selector('table.report tbody tr', count: 1)


### PR DESCRIPTION
All custom field values in the cost reports are casted to their human readable value (e.g. User, Float) upon rendering as a table header. For list custom fields, [if the value cannot be retrieved, a 'not found' is appended to the value](https://github.com/opf/openproject/blob/dev/app/models/custom_value/list_strategy.rb#L48-L53) passed to the casting method. 

But the value returned for the custom field was always the human readable string right away and not the id of the custom option. The PR changes this to have the id of the custom option returned which can later on be casted successfully. This is somewhat of an indirection but changing to just use the value returned, without casting later on, would have required to add more conditionals later on. 

At the same time, the SQL could also not be simplified by only dealing with id since stored `CostQuery` and values returned from the frontend are currently working with the custom option value. This is a problem in itself as it might lead to errors in case the option is renamed but changing it would be too large a change now.

https://community.openproject.org/wp/34978