### PR TITLE
refactor: Extract #attribute_name and #column_name for CustomField

### DIFF
--- a/app/cells/projects/table_cell.rb
+++ b/app/cells/projects/table_cell.rb
@@ -88,7 +88,7 @@ module Projects
 
     def custom_field_columns
       project_custom_fields.values.map do |custom_field|
-        [:"cf_#{custom_field.id}", { caption: custom_field.name, custom_field: true }]
+        [custom_field.column_name.to_sym, { caption: custom_field.name, custom_field: true }]
       end
     end
 
@@ -102,7 +102,7 @@ module Projects
           end
 
         fields
-          .index_by { |cf| :"cf_#{cf.id}" }
+          .index_by { |cf| cf.column_name.to_sym }
       end
     end
   end

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -227,7 +227,7 @@ class BaseContract < Disposable::Twin
     end
 
     if model.respond_to?(:available_custom_fields)
-      writable += model.available_custom_fields.map { |cf| "custom_field_#{cf.id}" }
+      writable += model.available_custom_fields.map(&:attribute_name)
     end
 
     writable

--- a/app/models/attribute_help_text/project.rb
+++ b/app/models/attribute_help_text/project.rb
@@ -35,8 +35,8 @@ class AttributeHelpText::Project < AttributeHelpText
       .reject { |key, _| skip.include?(key.to_s) }
       .transform_values { |definition| definition[:name_source].call }
 
-    ProjectCustomField.all.find_each do |field|
-      attributes["custom_field_#{field.id}"] = field.name
+    ProjectCustomField.find_each do |field|
+      attributes[field.attribute_name] = field.name
     end
 
     attributes

--- a/app/models/custom_actions/actions/custom_field.rb
+++ b/app/models/custom_actions/actions/custom_field.rb
@@ -28,7 +28,7 @@
 
 class CustomActions::Actions::CustomField < CustomActions::Actions::Base
   def self.key
-    :"custom_field_#{custom_field.id}"
+    custom_field.attribute_name.to_sym
   end
 
   def self.custom_field
@@ -44,7 +44,7 @@ class CustomActions::Actions::CustomField < CustomActions::Actions::Base
   end
 
   def apply(work_package)
-    work_package.send(:"#{custom_field.accessor_name}=", values) if work_package.respond_to?(:"#{custom_field.accessor_name}=")
+    work_package.send(custom_field.attribute_setter, values) if work_package.respond_to?(custom_field.attribute_setter)
   end
 
   def self.all

--- a/app/models/custom_actions/actions/strategies/custom_field.rb
+++ b/app/models/custom_actions/actions/strategies/custom_field.rb
@@ -28,7 +28,7 @@
 
 module CustomActions::Actions::Strategies::CustomField
   def apply(work_package)
-    work_package.send(:"#{custom_field.accessor_name}=", values) if work_package.respond_to?(:"#{custom_field.accessor_name}=")
+    work_package.send(custom_field.attribute_setter, values) if work_package.respond_to?(custom_field.attribute_setter)
   end
 
   delegate :required?, to: :custom_field

--- a/app/models/custom_actions/actions/strategies/user_custom_field.rb
+++ b/app/models/custom_actions/actions/strategies/user_custom_field.rb
@@ -31,8 +31,8 @@ module CustomActions::Actions::Strategies::UserCustomField
   include ::CustomActions::Actions::Strategies::MeAssociated
 
   def apply(work_package)
-    if work_package.respond_to?(:"#{custom_field.accessor_name}=")
-      work_package.send(:"#{custom_field.accessor_name}=", transformed_value(values.first))
+    if work_package.respond_to?(custom_field.attribute_setter)
+      work_package.send(custom_field.attribute_setter, transformed_value(values.first))
     end
   end
 

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -244,6 +244,10 @@ class CustomField < ApplicationRecord
     :"#{attribute_name}="
   end
 
+  def column_name
+    "cf_#{id}"
+  end
+
   def type_name
     nil
   end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -232,8 +232,16 @@ class CustomField < ApplicationRecord
     where(is_filter: true)
   end
 
-  def accessor_name
+  def attribute_name
     "custom_field_#{id}"
+  end
+
+  def attribute_getter
+    attribute_name.to_sym
+  end
+
+  def attribute_setter
+    :"#{attribute_name}="
   end
 
   def type_name
@@ -325,7 +333,7 @@ class CustomField < ApplicationRecord
 
   def destroy_help_text
     AttributeHelpText
-      .where(attribute_name: "custom_field_#{id}")
+      .where(attribute_name:)
       .destroy_all
   end
 end

--- a/app/models/queries/filters/shared/custom_field_filter.rb
+++ b/app/models/queries/filters/shared/custom_field_filter.rb
@@ -40,7 +40,7 @@ module Queries::Filters::Shared::CustomFieldFilter
     end
 
     ##
-    # TODO this differs from CustomField#accessor_name for reasons I don't see,
+    # TODO this differs from CustomField#attribute_name for reasons I don't see,
     # however this name will be persisted in queries so we can't just map one to the other.
     def custom_field_accessor(custom_field)
       "cf_#{custom_field.id}"

--- a/app/models/queries/filters/shared/custom_field_filter.rb
+++ b/app/models/queries/filters/shared/custom_field_filter.rb
@@ -39,23 +39,13 @@ module Queries::Filters::Shared::CustomFieldFilter
       /cf_(\d+)/
     end
 
-    ##
-    # TODO this differs from CustomField#attribute_name for reasons I don't see,
-    # however this name will be persisted in queries so we can't just map one to the other.
-    def custom_field_accessor(custom_field)
-      "cf_#{custom_field.id}"
-    end
-
     def all_for(context = nil)
-      custom_field_context.custom_fields(context).map do |cf|
-        cf_accessor = custom_field_accessor(cf)
-        begin
-          create!(name: cf_accessor, custom_field: cf, context:)
-        rescue ::Queries::Filters::InvalidError
-          Rails.logger.error "Failed to map custom field filter for #{cf_accessor} (CF##{cf.id}."
-          nil
-        end
-      end.compact
+      custom_field_context.custom_fields(context).filter_map do |cf|
+        create!(name: cf.column_name, custom_field: cf, context:)
+      rescue ::Queries::Filters::InvalidError
+        Rails.logger.error "Failed to map custom field filter for #{cf.column_name} (CF##{cf.id})."
+        nil
+      end
     end
 
     ##

--- a/app/models/queries/filters/shared/custom_fields/base.rb
+++ b/app/models/queries/filters/shared/custom_fields/base.rb
@@ -34,7 +34,7 @@ module Queries::Filters::Shared
       attr_reader :custom_field, :custom_field_context
 
       def initialize(custom_field:, custom_field_context:, **options)
-        name = :"cf_#{custom_field.id}"
+        name = custom_field.column_name.to_sym
 
         @custom_field = custom_field
         @custom_field_context = custom_field_context

--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -69,7 +69,7 @@ class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages:
   private
 
   def set_name!
-    self.name = "cf_#{custom_field.id}".to_sym
+    self.name = custom_field.column_name.to_sym
   end
 
   def set_sortable!

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -91,7 +91,7 @@ class Queries::WorkPackages::Filter::SearchFilter <
     custom_fields.map do |custom_field|
       Queries::WorkPackages::Filter::FilterConfiguration.new(
         Queries::WorkPackages::Filter::CustomFieldFilter,
-        "cf_#{custom_field.id}",
+        custom_field.column_name,
         CONTAINS_OPERATOR
       )
     end

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -144,7 +144,7 @@ module Type::Attributes
 
     def add_custom_fields_to_form_attributes(attributes)
       WorkPackageCustomField.includes(:custom_options).all.find_each do |field|
-        attributes["custom_field_#{field.id}"] = {
+        attributes[field.attribute_name] = {
           required: field.is_required,
           has_default: field.default_value.present?,
           is_cf: true,

--- a/app/seeders/development_data/custom_fields_seeder.rb
+++ b/app/seeders/development_data/custom_fields_seeder.rb
@@ -44,14 +44,14 @@ module DevelopmentData
 
     def create_types!(cfs)
       # Create ALL CFs types
-      non_req_cfs = cfs.reject(&:is_required).map { |cf| "custom_field_#{cf.id}" }
+      non_req_cfs = cfs.reject(&:is_required).map(&:attribute_name)
       type = FactoryBot.build :type, name: 'All CFS'
       extend_group(type, ['Custom fields', non_req_cfs])
       type.save!
       print_status '.'
 
       # Create type
-      req_cfs = cfs.select(&:is_required).map { |cf| "custom_field_#{cf.id}" }
+      req_cfs = cfs.select(&:is_required).map(&:attribute_name)
       type_req = FactoryBot.build :type, name: 'Required CF'
       extend_group(type_req, ['Custom fields', req_cfs])
       type_req.save!

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -55,7 +55,7 @@ module CustomFields
       cf = call.result
 
       if cf.is_a?(ProjectCustomField)
-        add_cf_to_visible_columns(cf.id)
+        add_cf_to_visible_columns(cf)
       end
 
       call
@@ -63,8 +63,8 @@ module CustomFields
 
     private
 
-    def add_cf_to_visible_columns(id)
-      Setting.enabled_projects_columns = (Setting.enabled_projects_columns + ["cf_#{id}"]).uniq
+    def add_cf_to_visible_columns(custom_field)
+      Setting.enabled_projects_columns = (Setting.enabled_projects_columns + [custom_field.column_name]).uniq
     end
   end
 end

--- a/app/views/customizable/_form.html.erb
+++ b/app/views/customizable/_form.html.erb
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% show_required = custom_field.is_required? && !custom_field.boolean? %>
     <%= content_tag :div,
                     class: ['form--field',
-                            "custom_field_#{custom_field.id}",
+                            custom_field.attribute_name,
                             (show_required ? '-required' : ''),
                             wide_labels] do
       options = {

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -219,7 +219,7 @@ module API
               [value].compact
             end
 
-            represented.send(:"custom_field_#{custom_field.id}=", values)
+            represented.send(custom_field.attribute_setter, values)
           }
         end
 
@@ -233,7 +233,7 @@ module API
                     custom_field.list? ||
                     custom_field.multi_value?
 
-            value = represented.send custom_field.accessor_name
+            value = represented.send custom_field.attribute_getter
 
             next unless value
 
@@ -243,7 +243,7 @@ module API
         end
 
         def inject_property_value(custom_field)
-          @class.property "custom_field_#{custom_field.id}".to_sym,
+          @class.property custom_field.attribute_name.to_sym,
                           as: property_name(custom_field.id),
                           getter: property_value_getter_for(custom_field),
                           setter: property_value_setter_for(custom_field),
@@ -254,7 +254,7 @@ module API
           ->(*) {
             next unless available_custom_fields.include?(custom_field)
 
-            value = send custom_field.accessor_name
+            value = send(custom_field.attribute_getter)
 
             if custom_field.field_format == 'text'
               ::API::Decorators::Formattable.new(value, object: self)
@@ -271,7 +271,7 @@ module API
                     else
                       fragment
                     end
-            send(:"custom_field_#{custom_field.id}=", value)
+            send(custom_field.attribute_setter, value)
           }
         end
 

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -58,7 +58,7 @@ class CustomFieldFormBuilder < TabularFormBuilder
   private
 
   def custom_field_input(options = {})
-    field = custom_field.accessor_name
+    field = custom_field.attribute_name
 
     input_options = options.merge(no_label: true,
                                   name: custom_field_field_name,

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -269,7 +269,7 @@ module Redmine
 
         def add_custom_value_errors!(custom_value)
           custom_value.errors.each do |error|
-            name = custom_value.custom_field.accessor_name.to_sym
+            name = custom_value.custom_field.attribute_name.to_sym
 
             details = error.details
 
@@ -319,15 +319,12 @@ module Redmine
         end
 
         def add_custom_field_accessors(custom_field)
-          getter_name = custom_field.accessor_name
-          setter_name = "#{getter_name}="
-
-          define_custom_field_getter(getter_name, custom_field)
-          define_custom_field_setter(setter_name, custom_field)
+          define_custom_field_getter(custom_field)
+          define_custom_field_setter(custom_field)
         end
 
-        def define_custom_field_getter(getter_name, custom_field)
-          define_singleton_method getter_name do
+        def define_custom_field_getter(custom_field)
+          define_singleton_method custom_field.attribute_getter do
             custom_values = Array(custom_value_for(custom_field)).map do |custom_value|
               custom_value ? custom_value.typed_value : nil
             end
@@ -340,8 +337,8 @@ module Redmine
           end
         end
 
-        def define_custom_field_setter(setter_name, custom_field)
-          define_singleton_method setter_name do |value|
+        def define_custom_field_setter(custom_field)
+          define_singleton_method custom_field.attribute_setter do |value|
             # N.B. we do no strict type checking here, it would be possible to assign a user
             # to an integer custom field...
             value = value.id if value.respond_to?(:id)

--- a/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
@@ -273,7 +273,7 @@ describe API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
     context 'for a custom value' do
       let(:custom_field) { build_stubbed(:text_time_entry_custom_field) }
       let(:path) { "customField#{custom_field.id}" }
-      let(:writable_attributes) { ["custom_field_#{custom_field.id}"] }
+      let(:writable_attributes) { [custom_field.attribute_name] }
 
       before do
         allow(contract)

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -125,7 +125,7 @@ describe API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
           .and_return([custom_field])
 
         allow(time_entry)
-          .to receive(:"custom_field_#{custom_field.id}")
+          .to receive(custom_field.attribute_getter)
           .and_return(user)
 
         allow(time_entry)
@@ -268,7 +268,7 @@ describe API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
           .and_return([custom_field])
 
         allow(time_entry)
-          .to receive(:"custom_field_#{custom_field.id}")
+          .to receive(custom_field.attribute_getter)
           .and_return(custom_value.value)
       end
 

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -438,7 +438,7 @@ describe 'API v3 time_entry resource' do
       expect(new_entry.spent_on)
         .to eql Date.parse("2017-07-28")
 
-      expect(new_entry.send(:"custom_field_#{custom_field.id}"))
+      expect(new_entry.send(custom_field.attribute_getter))
         .to eql 'some cf text'
     end
 

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -44,14 +44,14 @@ describe 'Project details widget on dashboard', js: true do
 
   let!(:project) do
     create(:project, members: { other_user => role }).tap do |p|
-      p.send(:"custom_field_#{int_cf.id}=", 5)
-      p.send(:"custom_field_#{bool_cf.id}=", true)
-      p.send(:"custom_field_#{version_cf.id}=", system_version)
-      p.send(:"custom_field_#{float_cf.id}=", 4.5)
-      p.send(:"custom_field_#{text_cf.id}=", 'Some **long** text')
-      p.send(:"custom_field_#{string_cf.id}=", 'Some small text')
-      p.send(:"custom_field_#{date_cf.id}=", Date.today)
-      p.send(:"custom_field_#{user_cf.id}=", other_user)
+      p.send(int_cf.attribute_setter, 5)
+      p.send(bool_cf.attribute_setter, true)
+      p.send(version_cf.attribute_setter, system_version)
+      p.send(float_cf.attribute_setter, 4.5)
+      p.send(text_cf.attribute_setter, 'Some **long** text')
+      p.send(string_cf.attribute_setter, 'Some small text')
+      p.send(date_cf.attribute_setter, Date.today)
+      p.send(user_cf.attribute_setter, other_user)
 
       p.save!(validate: false)
     end

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -50,7 +50,7 @@ describe 'Project details widget on dashboard', js: true do
       p.send(float_cf.attribute_setter, 4.5)
       p.send(text_cf.attribute_setter, 'Some **long** text')
       p.send(string_cf.attribute_setter, 'Some small text')
-      p.send(date_cf.attribute_setter, Date.today)
+      p.send(date_cf.attribute_setter, Date.current)
       p.send(user_cf.attribute_setter, other_user)
 
       p.save!(validate: false)

--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -180,7 +180,7 @@ describe 'Custom fields reporting', js: true do
       end
 
       it 'groups by the raw values when an invalid value exists' do
-        expect(work_package2.send("custom_field_#{custom_field_2.id}")).to eq(['invalid not found'])
+        expect(work_package2.send(custom_field_2.attribute_getter)).to eq(['invalid not found'])
 
         expect(page).to have_selector('#group-by--add-columns')
         expect(page).to have_selector('#group-by--add-rows')

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -457,15 +457,15 @@ describe CostQuery, reporting_query_helper: true do
 
       it "is usable as filter" do
         create_searchable_fields_and_values
-        id = WorkPackageCustomField.find_by(name: "Searchable Field").id
-        query.filter "custom_field_#{id}".to_sym, operator: '=', value: "125"
+        cf = WorkPackageCustomField.find_by(name: "Searchable Field")
+        query.filter cf.attribute_name, operator: '=', value: "125"
         expect(query.result.count).to eq(2)
       end
 
       it "is usable as filter #2" do
         create_searchable_fields_and_values
-        id = WorkPackageCustomField.find_by(name: "Searchable Field").id
-        query.filter "custom_field_#{id}".to_sym, operator: '=', value: "finnlabs"
+        cf = WorkPackageCustomField.find_by(name: "Searchable Field")
+        query.filter cf.attribute_name, operator: '=', value: "finnlabs"
         expect(query.result.count).to eq(0)
       end
     end

--- a/modules/reporting/spec/models/cost_query/group_by_spec.rb
+++ b/modules/reporting/spec/models/cost_query/group_by_spec.rb
@@ -306,7 +306,7 @@ describe CostQuery, reporting_query_helper: true do
 
         check_cache
 
-        query.group_by "custom_field_#{custom_field2.id}".to_sym
+        query.group_by custom_field2.attribute_name
         footprint = query.result.each_direct_result.map { |c| [c.count, c.units.to_i] }.sort
         expect(footprint).to eq([[8, 8]])
       end

--- a/modules/xls_export/spec/lib/custom_field_xls_export_spec.rb
+++ b/modules/xls_export/spec/lib/custom_field_xls_export_spec.rb
@@ -40,7 +40,7 @@ describe "WorkPackageXlsExport Custom Fields" do
 
   let!(:query) do
     query              = build(:query, user: current_user, project:)
-    query.column_names = ['subject', "cf_#{custom_field.id}"]
+    query.column_names = ['subject', custom_field.column_name]
     query.sort_criteria = [%w[id asc]]
 
     query.save!
@@ -67,7 +67,7 @@ describe "WorkPackageXlsExport Custom Fields" do
   end
 
   it 'produces the valid XLS result' do
-    expect(query.columns.map(&:name)).to eq [:subject, :"cf_#{custom_field.id}"]
+    expect(query.columns.map(&:name)).to eq [:subject, custom_field.column_name.to_sym]
     expect(sheet.rows.first.take(2)).to eq ['Subject', 'Ingredients']
 
     # Subjects

--- a/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
@@ -46,7 +46,7 @@ describe XlsExport::Project::Exporter::XLS do
 
   describe 'custom field columns selected' do
     before do
-      Setting.enabled_projects_columns += custom_fields.map { |cf| "cf_#{cf.id}" }
+      Setting.enabled_projects_columns += custom_fields.map(&:column_name)
     end
 
     context 'when ee enabled', with_ee: %i[custom_fields_in_projects_list] do

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -195,7 +195,7 @@ describe XlsExport::WorkPackage::Exporter::XLS do
       wps[3].save!
       wps
     end
-    let(:column_names) { ['subject', 'status', 'estimated_hours', "cf_#{custom_field.id}"] }
+    let(:column_names) { ['subject', 'status', 'estimated_hours', custom_field.column_name] }
 
     before do
       allow(Setting)

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -187,11 +187,11 @@ describe XlsExport::WorkPackage::Exporter::XLS do
                         type:)
       wps[0].estimated_hours = 27.5
       wps[0].save!
-      wps[1].send(:"custom_field_#{custom_field.id}=", 1)
+      wps[1].send(custom_field.attribute_setter, 1)
       wps[1].save!
-      wps[2].send(:"custom_field_#{custom_field.id}=", 99.99)
+      wps[2].send(custom_field.attribute_setter, 99.99)
       wps[2].save!
-      wps[3].send(:"custom_field_#{custom_field.id}=", 1000)
+      wps[3].send(custom_field.attribute_setter, 1000)
       wps[3].save!
       wps
     end

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -419,7 +419,7 @@ describe WorkPackages::UpdateContract do
 
         shared_examples_for 'custom_field readonly errors' do
           it 'adds an error to the written custom field attribute' do
-            expect(contract.errors.symbols_for(:"custom_field_#{cf1.id}"))
+            expect(contract.errors.symbols_for(cf1.attribute_name.to_sym))
               .to include(:error_readonly)
           end
 

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -190,10 +190,10 @@ describe "multi select custom values", js: true do
       let(:wp2_field) { table_edit_field(work_package2) }
       let!(:query) do
         query = build(:query, user:, project:)
-        query.column_names = ['id', 'type', 'subject', "cf_#{custom_field.id}"]
+        query.column_names = ['id', 'type', 'subject', custom_field.column_name]
         query.filters.clear
         query.timeline_visible = false
-        query.sort_criteria = [["cf_#{custom_field.id}", 'asc']]
+        query.sort_criteria = [[custom_field.column_name, 'asc']]
 
         query.save!
         query

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -209,7 +209,7 @@ describe 'Projects index page',
     end
 
     it 'CF columns and filters are visible when added to settings' do
-      Setting.enabled_projects_columns += ["cf_#{custom_field.id}", "cf_#{invisible_custom_field.id}"]
+      Setting.enabled_projects_columns += [custom_field.column_name, invisible_custom_field.column_name]
       load_and_open_filters admin
 
       # CF's column is present:
@@ -669,7 +669,7 @@ describe 'Projects index page',
         SeleniumHubWaiter.wait
         remove_filter('latest_activity_at')
 
-        projects_page.set_filter("cf_#{list_custom_field.id}",
+        projects_page.set_filter(list_custom_field.column_name,
                                  list_custom_field.name,
                                  'is',
                                  [list_custom_field.possible_values[2].value])
@@ -680,7 +680,7 @@ describe 'Projects index page',
         expect(page).not_to have_text(project_created_on_fixed_date.name)
 
         # switching to multiselect keeps the current selection
-        cf_filter = page.find("li[filter-name='cf_#{list_custom_field.id}']")
+        cf_filter = page.find("li[filter-name='#{list_custom_field.column_name}']")
         within(cf_filter) do
           # Initial filter is a 'single select'
           expect(cf_filter.find(:select, 'value')).not_to be_multiple
@@ -696,7 +696,7 @@ describe 'Projects index page',
 
         click_on 'Apply'
 
-        cf_filter = page.find("li[filter-name='cf_#{list_custom_field.id}']")
+        cf_filter = page.find("li[filter-name='#{list_custom_field.column_name}']")
         within(cf_filter) do
           # Query has two values for that filter, so it should show a 'multi select'.
           expect(cf_filter.find(:select, 'value')).to be_multiple
@@ -718,7 +718,7 @@ describe 'Projects index page',
 
         click_on 'Apply'
 
-        cf_filter = page.find("li[filter-name='cf_#{list_custom_field.id}']")
+        cf_filter = page.find("li[filter-name='#{list_custom_field.column_name}']")
         within(cf_filter) do
           # Query has one value for that filter, so it should show a 'single select'.
           expect(cf_filter.find(:select, 'value')).not_to be_multiple
@@ -726,9 +726,9 @@ describe 'Projects index page',
 
         # CF date filter work (at least for one operator)
         SeleniumHubWaiter.wait
-        remove_filter("cf_#{list_custom_field.id}")
+        remove_filter(list_custom_field.column_name)
 
-        projects_page.set_filter("cf_#{date_custom_field.id}",
+        projects_page.set_filter(date_custom_field.column_name,
                                  date_custom_field.name,
                                  'on',
                                  ['2011-11-11'])
@@ -914,7 +914,7 @@ describe 'Projects index page',
     end
 
     it 'allows to alter the order in which projects are displayed' do
-      Setting.enabled_projects_columns += ["cf_#{integer_custom_field.id}"]
+      Setting.enabled_projects_columns += [integer_custom_field.column_name]
 
       # initially, ordered by name asc on each hierarchical level
       expect_projects_in_order(development_project,
@@ -991,8 +991,8 @@ describe 'Projects index page',
 
       allow_enterprise_edition
       allow(Setting)
-        .to receive(:enabled_projects_columns) # << "cf_#{list_custom_field.id}"
-        .and_return ["cf_#{list_custom_field.id}"]
+        .to receive(:enabled_projects_columns)
+        .and_return [list_custom_field.column_name]
 
       login_as(admin)
       visit projects_path
@@ -1004,7 +1004,7 @@ describe 'Projects index page',
                         .where(value: %w[A B])
                         .reorder(:id)
                         .pluck(:value)
-      expect(page).to have_selector(".cf_#{list_custom_field.id}.format-list", text: expected_sort.join(", "))
+      expect(page).to have_selector(".#{list_custom_field.column_name}.format-list", text: expected_sort.join(", "))
     end
   end
 end

--- a/spec/features/projects/projects_portfolio_spec.rb
+++ b/spec/features/projects/projects_portfolio_spec.rb
@@ -96,10 +96,10 @@ describe 'Projects index page',
 
       # Check the status and custom field only
       find('input[value="project_status"]').check
-      find(%(input[value="cf_#{string_cf.id}"])).check
+      find(%(input[value="#{string_cf.column_name}"])).check
 
       expect(page).to have_selector('input[value="project_status"]:checked')
-      expect(page).to have_selector(%(input[value="cf_#{string_cf.id}"]:checked))
+      expect(page).to have_selector(%(input[value="#{string_cf.column_name}"]:checked))
 
       # Edit the project gantt query
       scroll_to_and_click(find('button', text: 'Edit query'))

--- a/spec/features/statuses/read_only_statuses_spec.rb
+++ b/spec/features/statuses/read_only_statuses_spec.rb
@@ -102,7 +102,7 @@ describe 'Read-only statuses affect work package editing',
     assignee_field.label_element.click
     assignee_field.expect_inactive!
 
-    custom_field = wp_page.edit_field cf_all.accessor_name.camelcase(:lower)
+    custom_field = wp_page.edit_field cf_all.attribute_name.camelcase(:lower)
     custom_field.label_element.click
     custom_field.expect_inactive!
   end

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -249,8 +249,8 @@ describe 'form configuration', js: true do
     describe 'required custom field' do
       let(:custom_fields) { [custom_field] }
       let(:custom_field) { create(:integer_issue_custom_field, is_required: true, name: 'MyNumber') }
-      let(:cf_identifier) { "custom_field_#{custom_field.id}" }
-      let(:cf_identifier_api) { "customField#{custom_field.id}" }
+      let(:cf_identifier) { custom_field.attribute_name }
+      let(:cf_identifier_api) { cf_identifier.camelcase(:lower) }
 
       before do
         project
@@ -279,8 +279,8 @@ describe 'form configuration', js: true do
 
       let(:custom_fields) { [custom_field] }
       let(:custom_field) { create(:integer_issue_custom_field, name: 'MyNumber') }
-      let(:cf_identifier) { "custom_field_#{custom_field.id}" }
-      let(:cf_identifier_api) { "customField#{custom_field.id}" }
+      let(:cf_identifier) { custom_field.attribute_name }
+      let(:cf_identifier_api) { cf_identifier.camelcase(:lower) }
 
       before do
         project

--- a/spec/features/types/reset_form_configuration_spec.rb
+++ b/spec/features/types/reset_form_configuration_spec.rb
@@ -39,8 +39,8 @@ describe 'Reset form configuration', js: true do
   describe "with EE token and CFs" do
     let(:custom_fields) { [custom_field] }
     let(:custom_field) { create(:integer_issue_custom_field, is_required: true, name: 'MyNumber') }
-    let(:cf_identifier) { "custom_field_#{custom_field.id}" }
-    let(:cf_identifier_api) { "customField#{custom_field.id}" }
+    let(:cf_identifier) { custom_field.attribute_name }
+    let(:cf_identifier_api) { cf_identifier.camelcase(:lower) }
 
     before do
       with_enterprise_token(:edit_attribute_groups)

--- a/spec/features/work_packages/bulk/update_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/update_work_package_spec.rb
@@ -144,8 +144,8 @@ describe 'Bulk update work packages through Rails view', js: true do
 
       context 'with enterprise', with_ee: [:readonly_work_packages] do
         it 'does not update the work packages' do
-          expect(work_package.send(custom_field.accessor_name)).to be_nil
-          expect(work_package2.send(custom_field.accessor_name)).to be_nil
+          expect(work_package.send(custom_field.attribute_getter)).to be_nil
+          expect(work_package2.send(custom_field.attribute_getter)).to be_nil
 
           fill_in custom_field.name, with: 'Custom field text'
           click_on 'Submit'
@@ -170,18 +170,18 @@ describe 'Bulk update work packages through Rails view', js: true do
           work_package.reload
           work_package2.reload
 
-          expect(work_package.send(custom_field.accessor_name))
+          expect(work_package.send(custom_field.attribute_getter))
             .to eq('Custom field text')
 
-          expect(work_package2.send(custom_field.accessor_name))
+          expect(work_package2.send(custom_field.attribute_getter))
             .to be_nil
         end
       end
 
       context 'without enterprise', with_ee: false do
         it 'ignores the readonly status and updates the work packages' do
-          expect(work_package.send(custom_field.accessor_name)).to be_nil
-          expect(work_package2.send(custom_field.accessor_name)).to be_nil
+          expect(work_package.send(custom_field.attribute_getter)).to be_nil
+          expect(work_package2.send(custom_field.attribute_getter)).to be_nil
 
           fill_in custom_field.name, with: 'Custom field text'
           click_on 'Submit'
@@ -192,10 +192,10 @@ describe 'Bulk update work packages through Rails view', js: true do
           work_package.reload
           work_package2.reload
 
-          expect(work_package.send(custom_field.accessor_name))
+          expect(work_package.send(custom_field.attribute_getter))
             .to eq('Custom field text')
 
-          expect(work_package2.send(custom_field.accessor_name))
+          expect(work_package2.send(custom_field.attribute_getter))
             .to eq('Custom field text')
         end
       end

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -241,7 +241,7 @@ describe 'Custom actions', js: true do
 
       # This custom field is not applicable
       new_ca_page.add_action(int_custom_field.name, '1')
-      new_ca_page.expect_action("custom_field_#{int_custom_field.id}", '1')
+      new_ca_page.expect_action(int_custom_field.attribute_name, '1')
 
       new_ca_page.set_condition('Status', closed_status.name)
       new_ca_page.expect_selected_option closed_status.name

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -188,7 +188,7 @@ describe 'custom field inplace editor', js: true do
         field.save!
 
         work_package.reload
-        expect(work_package.send("custom_field_#{custom_field.id}")).to eq 123
+        expect(work_package.send(custom_field.attribute_getter)).to eq 123
       end
     end
   end

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
 
     let(:filters) do
       [['type_id', '=', [type_task.id]],
-       ["cf_#{custom_field.id}", '=', [custom_field.custom_options.detect { |o| o.value == 'A' }.id]]]
+       [custom_field.column_name, '=', [custom_field.custom_options.detect { |o| o.value == 'A' }.id]]]
     end
 
     it 'allows to save with a single value (Regression test #27833)' do

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
       )
       wp = WorkPackage.last
       expect(wp.subject).to eq 'Foobar!'
-      expect(wp.send("custom_field_#{custom_field.id}")).to eq %w(A)
+      expect(wp.send(custom_field.attribute_getter)).to eq %w(A)
       expect(wp.type_id).to eq type_task.id
     end
   end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -193,8 +193,8 @@ describe 'Inline editing work packages', js: true do
       )
 
       work_package.reload
-      expect(work_package.send(custom_fields.first.accessor_name)).to eq('bar')
-      expect(work_package.send(custom_fields.last.accessor_name)).to eq('my custom text')
+      expect(work_package.send(custom_fields.first.attribute_getter)).to eq('bar')
+      expect(work_package.send(custom_fields.last.attribute_getter)).to eq('my custom text')
 
       # Saveguard to let the background update complete
       wp_table.visit!

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -216,14 +216,14 @@ describe 'filter work packages', js: true do
 
     let(:work_package_with_list_value) do
       wp = create :work_package, project: project, type: type
-      wp.send("#{list_cf.accessor_name}=", list_cf.custom_options.first.id)
+      wp.send(list_cf.attribute_setter, list_cf.custom_options.first.id)
       wp.save!
       wp
     end
 
     let(:work_package_with_anti_list_value) do
       wp = create :work_package, project: project, type: type
-      wp.send("#{list_cf.accessor_name}=", list_cf.custom_options.last.id)
+      wp.send(list_cf.attribute_setter, list_cf.custom_options.last.id)
       wp.save!
       wp
     end
@@ -294,14 +294,14 @@ describe 'filter work packages', js: true do
 
     let(:work_package_plus) do
       wp = create :work_package, project: project, type: type
-      wp.send("#{string_cf.accessor_name}=", 'G+H')
+      wp.send(string_cf.attribute_setter, 'G+H')
       wp.save!
       wp
     end
 
     let(:work_package_and) do
       wp = create :work_package, project: project, type: type
-      wp.send("#{string_cf.accessor_name}=", 'A&B')
+      wp.send(string_cf.attribute_setter, 'A&B')
       wp.save!
       wp
     end

--- a/spec/features/work_packages/table/queries/me_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/me_filter_spec.rb
@@ -147,8 +147,8 @@ describe 'filter me value', js: true do
              members: project_members)
     end
 
-    let(:cf_accessor) { "cf_#{custom_field.id}" }
-    let(:cf_accessor_frontend) { "customField#{custom_field.id}" }
+    let(:cf_accessor) { custom_field.attribute_name }
+    let(:cf_accessor_frontend) { cf_accessor.camelcase(:lower) }
     let(:wp_admin) do
       create :work_package,
              type: type_task,

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -42,7 +42,7 @@ describe 'Switching types in work package table', js: true do
 
     let(:query) do
       query = build(:query, user:, project:)
-      query.column_names = ['id', 'subject', 'type', "cf_#{cf_text.id}"]
+      query.column_names = ['id', 'subject', 'type', cf_text.column_name]
 
       query.save!
       query

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -257,7 +257,7 @@ describe 'Switching types in work package table', js: true do
 
       work_package.reload
       expect(work_package.type_id).to eq(type_bug.id)
-      expect(work_package.send("custom_field_#{cf_req_bool.id}")).to be(false)
+      expect(work_package.send(cf_req_bool.attribute_getter)).to be(false)
     end
   end
 

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -43,7 +43,7 @@ describe API::V3::Projects::ProjectRepresenter, 'rendering' do
               .and_return([int_custom_field, version_custom_field])
 
       allow(p)
-        .to receive(:"custom_field_#{int_custom_field.id}")
+        .to receive(int_custom_field.attribute_getter)
               .and_return(int_custom_value.value)
 
       allow(p)

--- a/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -207,7 +207,7 @@ describe API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
     context 'with a bool custom field filter' do
       let(:bool_cf) { create(:bool_wp_custom_field) }
       let(:filter) do
-        Queries::WorkPackages::Filter::CustomFieldFilter.create!(name: "cf_#{bool_cf.id}", operator:, values:)
+        Queries::WorkPackages::Filter::CustomFieldFilter.create!(name: bool_cf.column_name, operator:, values:)
       end
 
       context "with 't' as filter value" do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -333,7 +333,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       it 'on writing it sets on the represented' do
         expected = { custom_field.id => expected_setter }
         expect(represented)
-          .to receive(:"custom_field_#{custom_field.id}=")
+          .to receive(custom_field.attribute_setter)
           .with(expected_setter)
         modified_class
           .new(represented, current_user: nil)
@@ -346,7 +346,7 @@ describe API::V3::Utilities::CustomFieldInjector do
     let(:represented) do
       double('represented',
              available_custom_fields: [custom_field],
-             custom_field.accessor_name => value)
+             custom_field.attribute_name => value)
     end
     let(:custom_value) { double('CustomValue', value: raw_value, typed_value:) }
     let(:raw_value) { nil }
@@ -539,7 +539,7 @@ describe API::V3::Utilities::CustomFieldInjector do
 
     before do
       allow(represented).to receive(:custom_value_for).with(custom_field).and_return(custom_value)
-      allow(represented).to receive(:"custom_field_#{custom_field.id}").and_return(typed_value)
+      allow(represented).to receive(custom_field.attribute_getter).and_return(typed_value)
     end
 
     context 'reading' do
@@ -578,7 +578,7 @@ describe API::V3::Utilities::CustomFieldInjector do
           json = { cf_path => { href: path } }.to_json
           expected = ['2']
 
-          expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
+          expect(represented).to receive(custom_field.attribute_setter).with(expected)
           modified_class.new(represented, current_user: nil).from_json(json)
         end
       end
@@ -587,7 +587,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         json = { cf_path => { href: nil } }.to_json
         expected = []
 
-        expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
+        expect(represented).to receive(custom_field.attribute_setter).with(expected)
         modified_class.new(represented, current_user: nil).from_json(json)
       end
     end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -54,12 +54,11 @@ describe API::V3::Utilities::CustomFieldInjector do
     let(:schema_writable) { true }
     let(:model) { build_stubbed(:work_package) }
     let(:schema) do
-      double('WorkPackageSchema',
-             project_id: 42,
-             model:,
-             defines_assignable_values?: true,
-             available_custom_fields: [custom_field],
-             writable?: schema_writable)
+      instance_double(API::V3::WorkPackages::Schema::SpecificWorkPackageSchema,
+                      project_id: 42,
+                      model:,
+                      available_custom_fields: [custom_field],
+                      writable?: schema_writable)
     end
 
     subject { modified_class.new(schema, current_user: nil, form_embedded: true).to_json }
@@ -112,7 +111,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       # meaning they won't as no values are specified
       it_behaves_like 'indicates length requirements'
 
-      context 'custom field is not required' do
+      context 'when custom field is not required' do
         let(:custom_field) { build(:custom_field, is_required: false) }
 
         it 'marks the field as not required' do
@@ -120,7 +119,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'custom field has regex' do
+      context 'when custom field has regex' do
         let(:custom_field) { build(:custom_field, regexp: 'Foo+bar') }
 
         it 'renders the regular expression' do
@@ -128,7 +127,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'custom field has minimum length' do
+      context 'when custom field has minimum length' do
         let(:custom_field) { build(:custom_field, min_length: 5) }
 
         it_behaves_like 'indicates length requirements' do
@@ -136,7 +135,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'custom field has maximum length' do
+      context 'when custom field has maximum length' do
         let(:custom_field) { build(:custom_field, max_length: 5) }
 
         it_behaves_like 'indicates length requirements' do
@@ -295,11 +294,10 @@ describe API::V3::Utilities::CustomFieldInjector do
 
     describe 'user custom field on new project' do
       let(:schema) do
-        double('ProjectSchema',
-               id: nil,
-               model: Project.new,
-               defines_assignable_values?: true,
-               available_custom_fields: [custom_field])
+        instance_double(API::V3::WorkPackages::Schema::SpecificWorkPackageSchema,
+                        id: nil,
+                        model: Project.new,
+                        available_custom_fields: [custom_field])
       end
       let(:custom_field) do
         build(:custom_field,
@@ -331,13 +329,14 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
 
       it 'on writing it sets on the represented' do
-        expected = { custom_field.id => expected_setter }
-        expect(represented)
-          .to receive(custom_field.attribute_setter)
-          .with(expected_setter)
+        allow(represented).to receive(custom_field.attribute_setter)
         modified_class
           .new(represented, current_user: nil)
           .from_json({ cf_path => json_value }.to_json)
+
+        expect(represented)
+          .to have_received(custom_field.attribute_setter)
+          .with(expected_setter)
       end
     end
 
@@ -348,7 +347,7 @@ describe API::V3::Utilities::CustomFieldInjector do
              available_custom_fields: [custom_field],
              custom_field.attribute_name => value)
     end
-    let(:custom_value) { double('CustomValue', value: raw_value, typed_value:) }
+    let(:custom_value) { instance_double(CustomValue, value: raw_value, typed_value:) }
     let(:raw_value) { nil }
     let(:typed_value) { raw_value }
     let(:value) { '' }
@@ -361,7 +360,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       allow(represented).to receive(:custom_value_for).with(custom_field).and_return(custom_value)
     end
 
-    context 'user custom field' do
+    context 'for user custom field' do
       let(:raw_value) { value.id.to_s }
       let(:typed_value) { value }
       let(:field_format) { 'user' }
@@ -383,7 +382,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'value is nil' do
+      context 'when value is nil' do
         let(:value) { nil }
         let(:raw_value) { '' }
 
@@ -393,7 +392,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'version custom field' do
+    context 'for version custom field' do
       let(:value) { build_stubbed(:version, id: 2) }
       let(:raw_value) { value.id.to_s }
       let(:typed_value) { value }
@@ -410,7 +409,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         expect(subject).to be_json_eql(value.name.to_json).at_path("_embedded/#{cf_path}/name")
       end
 
-      context 'value is nil' do
+      context 'when value is nil' do
         let(:value) { nil }
         let(:raw_value) { '' }
 
@@ -420,7 +419,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'list custom field' do
+    context 'for list custom field' do
       let(:value) { build_stubbed(:custom_option) }
       let(:typed_value) { value.value }
       let(:raw_value) { value.id.to_s }
@@ -432,7 +431,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         let(:title) { value.value }
       end
 
-      context 'value is nil' do
+      context 'when value is nil' do
         let(:value) { nil }
         let(:raw_value) { '' }
         let(:typed_value) { '' }
@@ -442,7 +441,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'value is some invalid string' do
+      context 'when value is some invalid string' do
         let(:value) { 'some invalid string' }
         let(:raw_value) { 'some invalid string' }
         let(:typed_value) { 'some invalid string not found' }
@@ -461,7 +460,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'string custom field' do
+    context 'for string custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'string' }
         let(:value) { 'Foobar' }
@@ -470,7 +469,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'int custom field' do
+    context 'for int custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'int' }
         let(:value) { 42 }
@@ -479,7 +478,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'float custom field' do
+    context 'for float custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'float' }
         let(:value) { 3.14 }
@@ -488,7 +487,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'bool custom field' do
+    context 'for bool custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'bool' }
         let(:value) { true }
@@ -497,16 +496,16 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'date custom field' do
+    context 'for date custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'date' }
-        let(:value) { Date.today.to_date }
+        let(:value) { Date.current }
         let(:json_value) { value.to_date.iso8601 }
         let(:expected_setter) { json_value }
       end
     end
 
-    context 'text custom field' do
+    context 'for text custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'text' }
         let(:value) { '**Foobar**' }
@@ -530,7 +529,7 @@ describe API::V3::Utilities::CustomFieldInjector do
     let(:represented) do
       double('represented', available_custom_fields: [custom_field])
     end
-    let(:custom_value) { double('CustomValue', value:, typed_value:) }
+    let(:custom_value) { instance_double(CustomValue, value:, typed_value:) }
     let(:value) { '' }
     let(:user) { build_stubbed(:user) }
     let(:typed_value) { value }
@@ -542,7 +541,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       allow(represented).to receive(custom_field.attribute_getter).and_return(typed_value)
     end
 
-    context 'reading' do
+    context 'for reading' do
       let(:value) { '2' }
       let(:field_format) { 'user' }
 
@@ -558,7 +557,7 @@ describe API::V3::Utilities::CustomFieldInjector do
         end
       end
 
-      context 'value is nil' do
+      context 'when value is nil' do
         let(:value) { nil }
         let(:typed_value) { nil }
 
@@ -568,7 +567,7 @@ describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
-    context 'writing' do
+    context 'for writing' do
       let(:value) { nil }
       let(:field_format) { 'user' }
 
@@ -578,8 +577,10 @@ describe API::V3::Utilities::CustomFieldInjector do
           json = { cf_path => { href: path } }.to_json
           expected = ['2']
 
-          expect(represented).to receive(custom_field.attribute_setter).with(expected)
+          allow(represented).to receive(custom_field.attribute_setter)
           modified_class.new(represented, current_user: nil).from_json(json)
+
+          expect(represented).to have_received(custom_field.attribute_setter).with(expected)
         end
       end
 
@@ -587,8 +588,10 @@ describe API::V3::Utilities::CustomFieldInjector do
         json = { cf_path => { href: nil } }.to_json
         expected = []
 
-        expect(represented).to receive(custom_field.attribute_setter).with(expected)
+        allow(represented).to receive(custom_field.attribute_setter)
         modified_class.new(represented, current_user: nil).from_json(json)
+
+        expect(represented).to have_received(custom_field.attribute_setter).with(expected)
       end
     end
   end

--- a/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
@@ -211,7 +211,7 @@ describe API::V3::Versions::VersionRepresenter, 'rendering' do
           .and_return([custom_field])
 
         allow(version)
-          .to receive(:"custom_field_#{custom_field.id}")
+          .to receive(custom_field.attribute_getter)
           .and_return(custom_value.value)
       end
 
@@ -283,7 +283,7 @@ describe API::V3::Versions::VersionRepresenter, 'rendering' do
             .and_return([custom_field])
 
           allow(version)
-            .to receive(:"custom_field_#{custom_field.id}")
+            .to receive(custom_field.attribute_getter)
             .and_return('123')
         end
 

--- a/spec/lib/api/v3/work_packages/eager_loading/custom_value_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/custom_value_integration_spec.rb
@@ -118,11 +118,11 @@ describe API::V3::WorkPackages::EagerLoading::CustomValue do
                              type_project_user_cf,
                              for_all_type_cf]
 
-          expect(work_package.send(:"custom_field_#{type_project_version_cf.id}"))
+          expect(work_package.send(type_project_version_cf.attribute_getter))
             .to eql version
-          expect(work_package.send(:"custom_field_#{type_project_list_cf.id}"))
+          expect(work_package.send(type_project_list_cf.attribute_getter))
             .to eql type_project_list_cf.custom_options.last.name
-          expect(work_package.send(:"custom_field_#{type_project_user_cf.id}"))
+          expect(work_package.send(type_project_user_cf.attribute_getter))
             .to eql user
         end
       end

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -59,7 +59,7 @@ describe CustomFieldFormBuilder do
 
     before do
       allow(resource)
-        .to receive(custom_field.accessor_name)
+        .to receive(custom_field.attribute_getter)
               .and_return(typed_value)
     end
 
@@ -256,7 +256,7 @@ describe CustomFieldFormBuilder do
         custom_field.field_format = 'user'
 
         allow(project)
-          .to receive(custom_field.accessor_name)
+          .to receive(custom_field.attribute_getter)
           .and_return typed_value
 
         allow(project)
@@ -311,7 +311,7 @@ describe CustomFieldFormBuilder do
       before do
         custom_field.field_format = 'version'
         allow(project)
-          .to receive(custom_field.accessor_name)
+          .to receive(custom_field.attribute_getter)
                 .and_return typed_value
 
         allow(project)

--- a/spec/lib/open_project/changed_by_system_spec.rb
+++ b/spec/lib/open_project/changed_by_system_spec.rb
@@ -109,7 +109,7 @@ describe OpenProject::ChangedBySystem do
       it 'returns the custom fields too' do
         model.custom_field_values = { cf1.id => 'test' }
         expect(model.changed_by_user)
-          .to include("custom_field_#{cf1.id}")
+          .to include(cf1.attribute_name)
       end
     end
   end

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -35,7 +35,7 @@ describe AttributeHelpText::WorkPackage do
     # need to clear the cache to free the memoized
     # Type.translated_work_package_form_attributes
     Rails.cache.clear
-    create(:work_package_help_text, attribute_name: "custom_field_#{custom_field.id}")
+    create(:work_package_help_text, attribute_name: custom_field.attribute_name)
   end
 
   let(:wp_custom_field) { create :text_wp_custom_field }

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -105,8 +105,9 @@ describe CustomActions::Actions::CustomField do
       expect(described_class.all.map(&:custom_field))
         .to match_array(custom_fields)
 
-      expect(described_class.all.all? { |a| described_class >= a })
-        .to be_truthy
+      described_class.all.each do |subclass|
+        expect(subclass.ancestors).to include(described_class)
+      end
     end
   end
 
@@ -334,7 +335,7 @@ describe CustomActions::Actions::CustomField do
       end
     end
 
-    context 'for a non multi value field' do
+    context 'for a multi value field' do
       let(:custom_field) { list_multi_custom_field }
 
       it 'is true' do
@@ -477,6 +478,8 @@ describe CustomActions::Actions::CustomField do
     end
 
     context 'for a multi list custom field' do
+      let(:custom_field) { list_multi_custom_field }
+
       it_behaves_like 'associated custom action validations' do
         let(:allowed_values) do
           custom_field
@@ -571,7 +574,7 @@ describe CustomActions::Actions::CustomField do
   end
 
   describe '#apply' do
-    let(:work_package) { double('work_package') }
+    let(:work_package) { build(:work_package) }
 
     %i[list
        version
@@ -586,13 +589,15 @@ describe CustomActions::Actions::CustomField do
       let(:custom_field) { send(:"#{type}_custom_field") }
 
       it "sets the value for #{type} custom fields" do
-        expect(work_package)
+        allow(work_package)
           .to receive(custom_field.attribute_setter)
-          .with([42])
 
         instance.values = 42
-
         instance.apply(work_package)
+
+        expect(work_package)
+          .to have_received(custom_field.attribute_setter)
+          .with([42])
       end
     end
 
@@ -600,13 +605,15 @@ describe CustomActions::Actions::CustomField do
       let(:custom_field) { date_custom_field }
 
       it "sets the value to today for a dynamic value" do
-        expect(work_package)
+        allow(work_package)
           .to receive(custom_field.attribute_setter)
-                .with(Date.today)
 
         instance.values = '%CURRENT_DATE%'
-
         instance.apply(work_package)
+
+        expect(work_package)
+          .to have_received(custom_field.attribute_setter)
+                .with(Date.current)
       end
     end
   end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -85,7 +85,7 @@ describe CustomActions::Actions::CustomField do
       .with(id: custom_field.id.to_s)
       .and_return(custom_field)
 
-    described_class.for(:"custom_field_#{custom_field.id}")
+    described_class.for(custom_field.attribute_name)
   end
   let(:instance) do
     klass.new
@@ -113,14 +113,14 @@ describe CustomActions::Actions::CustomField do
   describe '.key' do
     it 'is the custom field accessor' do
       expect(klass.key)
-        .to eql(:"custom_field_#{custom_field.id}")
+        .to eql(custom_field.attribute_getter)
     end
   end
 
   describe '#key' do
     it 'is the custom field accessor' do
       expect(instance.key)
-        .to eql(:"custom_field_#{custom_field.id}")
+        .to eql(custom_field.attribute_getter)
     end
   end
 
@@ -587,7 +587,7 @@ describe CustomActions::Actions::CustomField do
 
       it "sets the value for #{type} custom fields" do
         expect(work_package)
-          .to receive(:"custom_field_#{custom_field.id}=")
+          .to receive(custom_field.attribute_setter)
           .with([42])
 
         instance.values = 42
@@ -601,7 +601,7 @@ describe CustomActions::Actions::CustomField do
 
       it "sets the value to today for a dynamic value" do
         expect(work_package)
-          .to receive(:"custom_field_#{custom_field.id}=")
+          .to receive(custom_field.attribute_setter)
                 .with(Date.today)
 
         instance.values = '%CURRENT_DATE%'

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -207,6 +207,14 @@ describe CustomField do
     it { is_expected.to eq(:"custom_field_#{field.id}=") }
   end
 
+  describe '#column_name' do
+    let(:field) { build_stubbed(:custom_field) }
+
+    subject { field.column_name }
+
+    it { is_expected.to eq("cf_#{field.id}") }
+  end
+
   describe '#possible_values_options' do
     let(:project) { build_stubbed(:project) }
     let(:user1) { build_stubbed(:user) }

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -183,12 +183,28 @@ describe CustomField do
     end
   end
 
-  describe '#accessor_name' do
-    let(:field) { build_stubbed :custom_field }
+  describe '#attribute_name' do
+    let(:field) { build_stubbed(:custom_field) }
 
-    it 'is formatted as expected' do
-      expect(field.accessor_name).to eql("custom_field_#{field.id}")
-    end
+    subject { field.attribute_name }
+
+    it { is_expected.to eq("custom_field_#{field.id}") }
+  end
+
+  describe '#attribute_getter' do
+    let(:field) { build_stubbed(:custom_field) }
+
+    subject { field.attribute_getter }
+
+    it { is_expected.to eq(:"custom_field_#{field.id}") }
+  end
+
+  describe '#attribute_setter' do
+    let(:field) { build_stubbed(:custom_field) }
+
+    subject { field.attribute_setter }
+
+    it { is_expected.to eq(:"custom_field_#{field.id}=") }
   end
 
   describe '#possible_values_options' do

--- a/spec/models/custom_value/list_strategy_integration_spec.rb
+++ b/spec/models/custom_value/list_strategy_integration_spec.rb
@@ -50,13 +50,13 @@ describe CustomValue::ListStrategy, 'integration tests' do
   end
 
   it 'can handle invalid CustomOptions (Regression test)' do
-    expect(work_package.public_send(:"custom_field_#{custom_field.id}")).to eq(%w(A))
+    expect(work_package.public_send(custom_field.attribute_getter)).to eq(%w(A))
 
     # Remove the custom value without replacement
     CustomValue.find_by(customized_id: work_package.id).update_columns(value: 'invalid')
     work_package.reload
     work_package.reset_custom_values!
 
-    expect(work_package.public_send(:"custom_field_#{custom_field.id}")).to eq(['invalid not found'])
+    expect(work_package.public_send(custom_field.attribute_getter)).to eq(['invalid not found'])
   end
 end

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -62,7 +62,7 @@ describe Projects::Exports::CSV, 'integration' do
 
   describe 'custom field columns selected' do
     before do
-      Setting.enabled_projects_columns += custom_fields.map { |cf| "cf_#{cf.id}" }
+      Setting.enabled_projects_columns += custom_fields.map(&:column_name)
     end
 
     context 'when ee enabled', with_ee: %i[custom_fields_in_projects_list] do

--- a/spec/models/projects/exporter/exportable_project_context.rb
+++ b/spec/models/projects/exporter/exportable_project_context.rb
@@ -51,14 +51,14 @@ shared_context 'with a project with an arrangement of custom fields' do
   shared_let(:project) do
     create(:project, members: { other_user => role }).tap do |p|
       p.description = "The description of the project"
-      p.send(:"custom_field_#{int_cf.id}=", 5)
-      p.send(:"custom_field_#{bool_cf.id}=", true)
-      p.send(:"custom_field_#{version_cf.id}=", system_version)
-      p.send(:"custom_field_#{float_cf.id}=", 4.5)
-      p.send(:"custom_field_#{text_cf.id}=", 'Some **long** text')
-      p.send(:"custom_field_#{string_cf.id}=", 'Some small text')
-      p.send(:"custom_field_#{date_cf.id}=", Time.zone.today)
-      p.send(:"custom_field_#{user_cf.id}=", other_user)
+      p.send(int_cf.attribute_setter, 5)
+      p.send(bool_cf.attribute_setter, true)
+      p.send(version_cf.attribute_setter, system_version)
+      p.send(float_cf.attribute_setter, 4.5)
+      p.send(text_cf.attribute_setter, 'Some **long** text')
+      p.send(string_cf.attribute_setter, 'Some small text')
+      p.send(date_cf.attribute_setter, Time.zone.today)
+      p.send(user_cf.attribute_setter, other_user)
 
       p.build_status(code: :off_track)
 

--- a/spec/models/queries/projects/filters/custom_field_filter_spec.rb
+++ b/spec/models/queries/projects/filters/custom_field_filter_spec.rb
@@ -50,7 +50,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
      date_project_custom_field,
      string_project_custom_field]
   end
-  let(:cf_accessor) { "cf_#{custom_field.id}" }
+  let(:cf_accessor) { custom_field.column_name }
   let(:instance) do
     described_class.create!(name: cf_accessor, operator: '=', context: query)
   end
@@ -128,7 +128,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
       all_custom_fields.each do |cf|
         name = "cf_#{cf.id}"
         filter = described_class.create!(name:)
-        expect(filter.name).to eql(:"cf_#{cf.id}")
+        expect(filter.name).to eql(cf.column_name.to_sym)
         expect(filter.order).to be(20)
       end
     end
@@ -136,7 +136,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
 
   describe '#type' do
     context 'integer' do
-      let(:cf_accessor) { "cf_#{int_project_custom_field.id}" }
+      let(:cf_accessor) { int_project_custom_field.column_name }
 
       it 'is integer for an integer' do
         expect(instance.type)
@@ -145,7 +145,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'float' do
-      let(:cf_accessor) { "cf_#{float_project_custom_field.id}" }
+      let(:cf_accessor) { float_project_custom_field.column_name }
 
       it 'is integer for a float' do
         expect(instance.type)
@@ -154,7 +154,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'text' do
-      let(:cf_accessor) { "cf_#{text_project_custom_field.id}" }
+      let(:cf_accessor) { text_project_custom_field.column_name }
 
       it 'is text for a text' do
         expect(instance.type)
@@ -163,7 +163,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'list optional' do
-      let(:cf_accessor) { "cf_#{list_project_custom_field.id}" }
+      let(:cf_accessor) { list_project_custom_field.column_name }
 
       it 'is list_optional for a list' do
         expect(instance.type)
@@ -172,7 +172,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'user' do
-      let(:cf_accessor) { "cf_#{user_project_custom_field.id}" }
+      let(:cf_accessor) { user_project_custom_field.column_name }
 
       it 'is list_optional for a user' do
         expect(instance.type)
@@ -181,7 +181,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{version_project_custom_field.id}" }
+      let(:cf_accessor) { version_project_custom_field.column_name }
 
       it 'is list_optional for a version' do
         expect(instance.type)
@@ -190,7 +190,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{date_project_custom_field.id}" }
+      let(:cf_accessor) { date_project_custom_field.column_name }
 
       it 'is date for a date' do
         expect(instance.type)
@@ -199,7 +199,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'bool' do
-      let(:cf_accessor) { "cf_#{bool_project_custom_field.id}" }
+      let(:cf_accessor) { bool_project_custom_field.column_name }
 
       it 'is list for a bool' do
         expect(instance.type)
@@ -208,7 +208,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'string' do
-      let(:cf_accessor) { "cf_#{string_project_custom_field.id}" }
+      let(:cf_accessor) { string_project_custom_field.column_name }
 
       it 'is string for a string' do
         expect(instance.type)
@@ -226,7 +226,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
 
   describe '#allowed_values' do
     context 'integer' do
-      let(:cf_accessor) { "cf_#{int_project_custom_field.id}" }
+      let(:cf_accessor) { int_project_custom_field.column_name }
 
       it 'is nil for an integer' do
         expect(instance.allowed_values)
@@ -235,7 +235,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'float' do
-      let(:cf_accessor) { "cf_#{float_project_custom_field.id}" }
+      let(:cf_accessor) { float_project_custom_field.column_name }
 
       it 'is integer for a float' do
         expect(instance.allowed_values)
@@ -244,7 +244,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'text' do
-      let(:cf_accessor) { "cf_#{text_project_custom_field.id}" }
+      let(:cf_accessor) { text_project_custom_field.column_name }
 
       it 'is text for a text' do
         expect(instance.allowed_values)
@@ -253,7 +253,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'list' do
-      let(:cf_accessor) { "cf_#{list_project_custom_field.id}" }
+      let(:cf_accessor) { list_project_custom_field.column_name }
 
       it 'is list_optional for a list' do
         expect(instance.allowed_values)
@@ -262,7 +262,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'user' do
-      let(:cf_accessor) { "cf_#{user_project_custom_field.id}" }
+      let(:cf_accessor) { user_project_custom_field.column_name }
 
       it 'is list_optional for a user' do
         bogus_return_value = ['user1', 'user2']
@@ -276,7 +276,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{version_project_custom_field.id}" }
+      let(:cf_accessor) { version_project_custom_field.column_name }
 
       it 'is list_optional for a version' do
         bogus_return_value = ['version1', 'version2']
@@ -290,7 +290,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'date' do
-      let(:cf_accessor) { "cf_#{date_project_custom_field.id}" }
+      let(:cf_accessor) { date_project_custom_field.column_name }
 
       it 'is nil for a date' do
         expect(instance.allowed_values)
@@ -299,7 +299,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'bool' do
-      let(:cf_accessor) { "cf_#{bool_project_custom_field.id}" }
+      let(:cf_accessor) { bool_project_custom_field.column_name }
 
       it 'is list for a bool' do
         expect(instance.allowed_values)
@@ -309,7 +309,7 @@ describe Queries::Projects::Filters::CustomFieldFilter do
     end
 
     context 'string' do
-      let(:cf_accessor) { "cf_#{string_project_custom_field.id}" }
+      let(:cf_accessor) { string_project_custom_field.column_name }
 
       it 'is nil for a string' do
         expect(instance.allowed_values)
@@ -341,12 +341,12 @@ describe Queries::Projects::Filters::CustomFieldFilter do
        text_project_custom_field,
        date_project_custom_field,
        string_project_custom_field].each do |cf|
-        expect(filters.detect { |filter| filter.name == :"cf_#{cf.id}" }).not_to be_nil
+        expect(filters.detect { |filter| filter.name == cf.column_name.to_sym }).not_to be_nil
       end
 
-      expect(filters.detect { |filter| filter.name == :"cf_#{version_project_custom_field.id}" })
+      expect(filters.detect { |filter| filter.name == version_project_custom_field.column_name.to_sym })
         .to be_nil
-      expect(filters.detect { |filter| filter.name == :"cf_#{user_project_custom_field.id}" })
+      expect(filters.detect { |filter| filter.name == user_project_custom_field.column_name.to_sym })
         .to be_nil
     end
   end

--- a/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
@@ -31,15 +31,10 @@ require_relative 'shared_query_column_specs'
 
 describe Queries::WorkPackages::Columns::CustomFieldColumn do
   let(:project) { build_stubbed(:project) }
-  let(:custom_field) do
-    double('CustomField',
-           field_format: 'string',
-           id: 5,
-           order_statements: nil)
-  end
+  let(:custom_field) { build_stubbed(:string_wp_custom_field) }
   let(:instance) { described_class.new(custom_field) }
 
-  it_behaves_like 'query column'
+  it_behaves_like 'query column', sortable_by_default: true
 
   describe 'instances' do
     let(:text_custom_field) do
@@ -86,7 +81,7 @@ describe Queries::WorkPackages::Columns::CustomFieldColumn do
   end
 
   describe '#value' do
-    let(:mock) { double(WorkPackage) }
+    let(:mock) { instance_double(WorkPackage) }
 
     it 'delegates to formatted_custom_value_for' do
       expect(mock).to receive(:formatted_custom_value_for).with(custom_field.id)

--- a/spec/models/queries/work_packages/columns/shared_query_column_specs.rb
+++ b/spec/models/queries/work_packages/columns/shared_query_column_specs.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-shared_examples_for 'query column' do
+shared_examples_for 'query column' do |sortable_by_default: false|
   describe '#groupable' do
     it 'is the name if true is provided' do
       instance.groupable = true
@@ -34,7 +34,7 @@ shared_examples_for 'query column' do
       expect(instance.groupable).to eql(instance.name.to_s)
     end
 
-    it 'is the value if something trueish is provided' do
+    it 'is the value if something truthy is provided' do
       instance.groupable = 'lorem ipsum'
 
       expect(instance.groupable).to eql('lorem ipsum')
@@ -60,7 +60,7 @@ shared_examples_for 'query column' do
       expect(instance.sortable).to eql(instance.name.to_s)
     end
 
-    it 'is the value if something trueish is provided' do
+    it 'is the value if something truthy is provided' do
       instance.sortable = 'lorem ipsum'
 
       expect(instance.sortable).to eql('lorem ipsum')
@@ -81,37 +81,41 @@ shared_examples_for 'query column' do
 
   describe '#groupable?' do
     it 'is false by default' do
-      expect(instance.groupable?).to be_falsey
+      expect(instance).not_to be_groupable
     end
 
     it 'is true if told so' do
       instance.groupable = true
 
-      expect(instance.groupable?).to be_truthy
+      expect(instance).to be_groupable
     end
 
     it 'is true if a value is provided (e.g. for specifying sql code)' do
       instance.groupable = 'COALESCE(null, 1)'
 
-      expect(instance.groupable?).to be_truthy
+      expect(instance).to be_groupable
     end
   end
 
   describe '#sortable?' do
-    it 'is false by default' do
-      expect(instance.sortable?).to be_falsey
+    it "is #{sortable_by_default} by default" do
+      if sortable_by_default
+        expect(instance).to be_sortable
+      else
+        expect(instance).not_to be_sortable
+      end
     end
 
     it 'is true if told so' do
       instance.sortable = true
 
-      expect(instance.sortable?).to be_truthy
+      expect(instance).to be_sortable
     end
 
     it 'is true if a value is provided (e.g. for specifying sql code)' do
       instance.sortable = 'COALESCE(null, 1)'
 
-      expect(instance.sortable?).to be_truthy
+      expect(instance).to be_sortable
     end
   end
 end

--- a/spec/models/queries/work_packages/filter/custom_fields/contains_text_custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/contains_text_custom_field_filter_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::WorkPackages::Filter::CustomFieldFilter,
          'with contains filter (Regression test #28348)' do
-  let(:cf_accessor) { "cf_#{custom_field.id}" }
+  let(:cf_accessor) { custom_field.column_name }
   let(:query) { build_stubbed(:query, project:) }
   let(:instance) do
     described_class.create!(name: cf_accessor, operator:, values: %w(foo), context: query)

--- a/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
@@ -51,7 +51,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
      string_wp_custom_field]
   end
   let(:query) { build_stubbed(:query, project:) }
-  let(:cf_accessor) { "cf_#{custom_field.id}" }
+  let(:cf_accessor) { custom_field.column_name }
   let(:instance) do
     described_class.create!(name: cf_accessor, operator: '=', context: query)
   end
@@ -127,16 +127,15 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
   describe 'instance attributes' do
     it 'are valid' do
       all_custom_fields.each do |cf|
-        name = "cf_#{cf.id}"
-        filter = described_class.create!(name:)
-        expect(filter.name).to eql(:"cf_#{cf.id}")
+        filter = described_class.create!(name: cf.column_name)
+        expect(filter.name).to eql(cf.column_name.to_sym)
       end
     end
   end
 
   describe '#type' do
     context 'integer' do
-      let(:cf_accessor) { "cf_#{int_wp_custom_field.id}" }
+      let(:cf_accessor) { int_wp_custom_field.column_name }
 
       it 'is integer for an integer' do
         expect(instance.type)
@@ -145,7 +144,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'float' do
-      let(:cf_accessor) { "cf_#{float_wp_custom_field.id}" }
+      let(:cf_accessor) { float_wp_custom_field.column_name }
 
       it 'is integer for a float' do
         expect(instance.type)
@@ -154,7 +153,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'text' do
-      let(:cf_accessor) { "cf_#{text_wp_custom_field.id}" }
+      let(:cf_accessor) { text_wp_custom_field.column_name }
 
       it 'is text for a text' do
         expect(instance.type)
@@ -163,7 +162,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'list optional' do
-      let(:cf_accessor) { "cf_#{list_wp_custom_field.id}" }
+      let(:cf_accessor) { list_wp_custom_field.column_name }
 
       it 'is list_optional for a list' do
         expect(instance.type)
@@ -172,7 +171,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'user' do
-      let(:cf_accessor) { "cf_#{user_wp_custom_field.id}" }
+      let(:cf_accessor) { user_wp_custom_field.column_name }
 
       it 'is list_optional for a user' do
         expect(instance.type)
@@ -181,7 +180,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{version_wp_custom_field.id}" }
+      let(:cf_accessor) { version_wp_custom_field.column_name }
 
       it 'is list_optional for a version' do
         expect(instance.type)
@@ -190,7 +189,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{date_wp_custom_field.id}" }
+      let(:cf_accessor) { date_wp_custom_field.column_name }
 
       it 'is date for a date' do
         expect(instance.type)
@@ -199,7 +198,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'bool' do
-      let(:cf_accessor) { "cf_#{bool_wp_custom_field.id}" }
+      let(:cf_accessor) { bool_wp_custom_field.column_name }
 
       it 'is list for a bool' do
         expect(instance.type)
@@ -208,7 +207,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'string' do
-      let(:cf_accessor) { "cf_#{string_wp_custom_field.id}" }
+      let(:cf_accessor) { string_wp_custom_field.column_name }
 
       it 'is string for a string' do
         expect(instance.type)
@@ -226,7 +225,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
 
   describe '#allowed_values' do
     context 'integer' do
-      let(:cf_accessor) { "cf_#{int_wp_custom_field.id}" }
+      let(:cf_accessor) { int_wp_custom_field.column_name }
 
       it 'is nil for an integer' do
         expect(instance.allowed_values)
@@ -235,7 +234,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'float' do
-      let(:cf_accessor) { "cf_#{float_wp_custom_field.id}" }
+      let(:cf_accessor) { float_wp_custom_field.column_name }
 
       it 'is integer for a float' do
         expect(instance.allowed_values)
@@ -244,7 +243,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'text' do
-      let(:cf_accessor) { "cf_#{text_wp_custom_field.id}" }
+      let(:cf_accessor) { text_wp_custom_field.column_name }
 
       it 'is text for a text' do
         expect(instance.allowed_values)
@@ -253,7 +252,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'list' do
-      let(:cf_accessor) { "cf_#{list_wp_custom_field.id}" }
+      let(:cf_accessor) { list_wp_custom_field.column_name }
 
       it 'is list_optional for a list' do
         expect(instance.allowed_values)
@@ -262,7 +261,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'user' do
-      let(:cf_accessor) { "cf_#{user_wp_custom_field.id}" }
+      let(:cf_accessor) { user_wp_custom_field.column_name }
 
       it 'is list_optional for a user' do
         bogus_return_value = ['user1', 'user2']
@@ -278,7 +277,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'version' do
-      let(:cf_accessor) { "cf_#{version_wp_custom_field.id}" }
+      let(:cf_accessor) { version_wp_custom_field.column_name }
 
       it 'is list_optional for a version' do
         bogus_return_value = ['version1', 'version2']
@@ -294,7 +293,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'date' do
-      let(:cf_accessor) { "cf_#{date_wp_custom_field.id}" }
+      let(:cf_accessor) { date_wp_custom_field.column_name }
 
       it 'is nil for a date' do
         expect(instance.allowed_values)
@@ -303,7 +302,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'bool' do
-      let(:cf_accessor) { "cf_#{bool_wp_custom_field.id}" }
+      let(:cf_accessor) { bool_wp_custom_field.column_name }
 
       it 'is list for a bool' do
         expect(instance.allowed_values)
@@ -313,7 +312,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
     end
 
     context 'string' do
-      let(:cf_accessor) { "cf_#{string_wp_custom_field.id}" }
+      let(:cf_accessor) { string_wp_custom_field.column_name }
 
       it 'is nil for a string' do
         expect(instance.allowed_values)
@@ -347,7 +346,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
         filters = described_class.all_for(query)
 
         all_custom_fields.each do |cf|
-          expect(filters.detect { |filter| filter.name == :"cf_#{cf.id}" }).not_to be_nil
+          expect(filters.detect { |filter| filter.name == cf.column_name.to_sym }).not_to be_nil
         end
       end
 
@@ -355,7 +354,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
         filters = described_class.all_for(query)
 
         all_custom_fields.each do |cf|
-          expect(filters.detect { |filter| filter.name == :"cf_#{cf.id}" }.context.project)
+          expect(filters.detect { |filter| filter.name == cf.column_name.to_sym }.context.project)
             .to eq project
         end
       end
@@ -386,12 +385,12 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter do
          text_wp_custom_field,
          date_wp_custom_field,
          string_wp_custom_field].each do |cf|
-          expect(filters.detect { |filter| filter.name == :"cf_#{cf.id}" }).not_to be_nil
+          expect(filters.detect { |filter| filter.name == cf.column_name.to_sym }).not_to be_nil
         end
 
-        expect(filters.detect { |filter| filter.name == :"cf_#{version_wp_custom_field.id}" })
+        expect(filters.detect { |filter| filter.name == version_wp_custom_field.column_name.to_sym })
           .to be_nil
-        expect(filters.detect { |filter| filter.name == :"cf_#{user_wp_custom_field.id}" })
+        expect(filters.detect { |filter| filter.name == user_wp_custom_field.column_name.to_sym })
           .to be_nil
       end
     end

--- a/spec/models/query/results_cf_sorting_integration_spec.rb
+++ b/spec/models/query/results_cf_sorting_integration_spec.rb
@@ -80,7 +80,7 @@ describe Query::Results, 'Sorting of custom field floats', with_mail: false do
   end
 
   describe 'sorting ASC by float cf' do
-    let(:sort_criteria) { [["cf_#{custom_field.id}", 'asc']] }
+    let(:sort_criteria) { [[custom_field.column_name, 'asc']] }
 
     it 'returns the correctly sorted result' do
       expect(query_results.work_packages.pluck(:id))
@@ -89,7 +89,7 @@ describe Query::Results, 'Sorting of custom field floats', with_mail: false do
   end
 
   describe 'sorting DESC by float cf' do
-    let(:sort_criteria) { [["cf_#{custom_field.id}", 'desc']] }
+    let(:sort_criteria) { [[custom_field.column_name, 'desc']] }
 
     it 'returns the correctly sorted result' do
       expect(query_results.work_packages.pluck(:id))

--- a/spec/models/query/results_sort_intergration_spec.rb
+++ b/spec/models/query/results_sort_intergration_spec.rb
@@ -424,7 +424,7 @@ describe Query::Results, 'sorting and grouping', with_mail: false do
     end
 
     context 'when ascending' do
-      let(:sort_by) { [["cf_#{string_cf.id}", 'asc']] }
+      let(:sort_by) { [[string_cf.column_name, 'asc']] }
 
       it 'sorts case insensitive' do
         expect(query_results.work_packages)
@@ -483,7 +483,7 @@ describe Query::Results, 'sorting and grouping', with_mail: false do
     end
 
     context 'when ascending' do
-      let(:sort_by) { [["cf_#{int_cf.id}", 'asc']] }
+      let(:sort_by) { [[int_cf.column_name, 'asc']] }
 
       it 'sorts case insensitive' do
         expect(query_results.work_packages)
@@ -492,7 +492,7 @@ describe Query::Results, 'sorting and grouping', with_mail: false do
     end
 
     context 'when descending' do
-      let(:sort_by) { [["cf_#{int_cf.id}", 'desc']] }
+      let(:sort_by) { [[int_cf.column_name, 'desc']] }
 
       it 'sorts case insensitive' do
         expect(query_results.work_packages)

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -191,7 +191,7 @@ describe Query::Results, with_mail: false do
       let(:last_value) do
         custom_field.custom_options.last
       end
-      let(:group_by) { "cf_#{custom_field.id}" }
+      let(:group_by) { custom_field.column_name }
 
       before do
         login_as(user1)
@@ -221,7 +221,7 @@ describe Query::Results, with_mail: false do
         create(:int_wp_custom_field, is_for_all: true, is_filter: true)
       end
 
-      let(:group_by) { "cf_#{custom_field.id}" }
+      let(:group_by) { custom_field.column_name }
 
       before do
         login_as(user1)
@@ -245,7 +245,7 @@ describe Query::Results, with_mail: false do
         create(:user_wp_custom_field, is_for_all: true, is_filter: true)
       end
 
-      let(:group_by) { "cf_#{custom_field.id}" }
+      let(:group_by) { custom_field.column_name }
 
       before do
         login_as(user1)
@@ -264,7 +264,7 @@ describe Query::Results, with_mail: false do
         create(:bool_wp_custom_field, is_for_all: true, is_filter: true)
       end
 
-      let(:group_by) { "cf_#{custom_field.id}" }
+      let(:group_by) { custom_field.column_name }
 
       before do
         login_as(user1)
@@ -288,7 +288,7 @@ describe Query::Results, with_mail: false do
         create(:date_wp_custom_field, is_for_all: true, is_filter: true)
       end
 
-      let(:group_by) { "cf_#{custom_field.id}" }
+      let(:group_by) { custom_field.column_name }
 
       before do
         login_as(user1)
@@ -388,7 +388,7 @@ describe Query::Results, with_mail: false do
 
       context 'when grouping by assignees' do
         before do
-          query.column_names = [:assigned_to, :"cf_#{custom_field.id}"]
+          query.column_names = [:assigned_to, custom_field.column_name.to_sym]
           query.group_by = 'assigned_to'
         end
 
@@ -407,7 +407,7 @@ describe Query::Results, with_mail: false do
         let(:group_by) { 'responsible' }
 
         before do
-          query.column_names = [:responsible, :"cf_#{custom_field.id}"]
+          query.column_names = [:responsible, custom_field.column_name.to_sym]
         end
 
         it 'returns all work packages of project 2' do
@@ -513,7 +513,7 @@ describe Query::Results, with_mail: false do
 
       activate_cf
 
-      query.add_filter(:"cf_#{bool_cf.id}", '=', [filter_value])
+      query.add_filter(bool_cf.column_name.to_sym, '=', [filter_value])
     end
 
     shared_examples_for 'is empty' do

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -199,7 +199,7 @@ describe Query::Results, with_mail: false do
         work_package1.send(custom_field.attribute_setter, first_value)
         work_package1.save!
         work_package2.send(custom_field.attribute_setter, [first_value,
-                                                      last_value])
+                                                           last_value])
         work_package2.save!
       end
 

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -196,10 +196,10 @@ describe Query::Results, with_mail: false do
       before do
         login_as(user1)
 
-        work_package1.send(:"custom_field_#{custom_field.id}=", first_value)
+        work_package1.send(custom_field.attribute_setter, first_value)
         work_package1.save!
-        work_package2.send(:"custom_field_#{custom_field.id}=", [first_value,
-                                                                 last_value])
+        work_package2.send(custom_field.attribute_setter, [first_value,
+                                                      last_value])
         work_package2.save!
       end
 
@@ -229,9 +229,9 @@ describe Query::Results, with_mail: false do
         wp_p1[0].type.custom_fields << custom_field
         project1.work_package_custom_fields << custom_field
 
-        wp_p1[0].update_attribute(:"custom_field_#{custom_field.id}", 42)
+        wp_p1[0].update_attribute(custom_field.attribute_name, 42)
         wp_p1[0].save
-        wp_p1[1].update_attribute(:"custom_field_#{custom_field.id}", 42)
+        wp_p1[1].update_attribute(custom_field.attribute_name, 42)
         wp_p1[1].save
       end
 
@@ -272,9 +272,9 @@ describe Query::Results, with_mail: false do
         wp_p1[0].type.custom_fields << custom_field
         project1.work_package_custom_fields << custom_field
 
-        wp_p1[0].update_attribute(:"custom_field_#{custom_field.id}", true)
+        wp_p1[0].update_attribute(custom_field.attribute_name, true)
         wp_p1[0].save
-        wp_p1[1].update_attribute(:"custom_field_#{custom_field.id}", true)
+        wp_p1[1].update_attribute(custom_field.attribute_name, true)
         wp_p1[1].save
       end
 
@@ -296,9 +296,9 @@ describe Query::Results, with_mail: false do
         wp_p1[0].type.custom_fields << custom_field
         project1.work_package_custom_fields << custom_field
 
-        wp_p1[0].update_attribute(:"custom_field_#{custom_field.id}", Time.zone.today)
+        wp_p1[0].update_attribute(custom_field.attribute_name, Time.zone.today)
         wp_p1[0].save
-        wp_p1[1].update_attribute(:"custom_field_#{custom_field.id}", Time.zone.today)
+        wp_p1[1].update_attribute(custom_field.attribute_name, Time.zone.today)
         wp_p1[1].save
       end
 

--- a/spec/models/query/results_sums_integration_spec.rb
+++ b/spec/models/query/results_sums_integration_spec.rb
@@ -36,8 +36,8 @@ describe Query::Results, 'sums' do
     end
   end
   let(:estimated_hours_column) { query.displayable_columns.detect { |c| c.name.to_s == 'estimated_hours' } }
-  let(:int_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == "cf_#{int_cf.id}" } }
-  let(:float_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == "cf_#{float_cf.id}" } }
+  let(:int_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == int_cf.column_name } }
+  let(:float_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == float_cf.column_name } }
   let(:material_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "material_costs" } }
   let(:labor_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "labor_costs" } }
   let(:overall_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "overall_costs" } }

--- a/spec/models/query/results_sums_integration_spec.rb
+++ b/spec/models/query/results_sums_integration_spec.rb
@@ -55,8 +55,8 @@ describe Query::Results, 'sums' do
            project:,
            estimated_hours: 5,
            done_ratio: 10,
-           "custom_field_#{int_cf.id}" => 10,
-           "custom_field_#{float_cf.id}" => 3.414,
+           int_cf.attribute_name => 10,
+           float_cf.attribute_name => 3.414,
            remaining_hours: 3,
            story_points: 7)
   end
@@ -67,8 +67,8 @@ describe Query::Results, 'sums' do
            assigned_to: current_user,
            done_ratio: 50,
            estimated_hours: 5,
-           "custom_field_#{int_cf.id}" => 10,
-           "custom_field_#{float_cf.id}" => 3.414,
+           int_cf.attribute_name => 10,
+           float_cf.attribute_name => 3.414,
            remaining_hours: 3,
            story_points: 7)
   end
@@ -80,8 +80,8 @@ describe Query::Results, 'sums' do
            responsible: current_user,
            done_ratio: 50,
            estimated_hours: 5,
-           "custom_field_#{int_cf.id}" => 10,
-           "custom_field_#{float_cf.id}" => 3.414,
+           int_cf.attribute_name => 10,
+           float_cf.attribute_name => 3.414,
            remaining_hours: 3,
            story_points: 7)
   end
@@ -90,8 +90,8 @@ describe Query::Results, 'sums' do
            type:,
            project: other_project,
            estimated_hours: 5,
-           "custom_field_#{int_cf.id}" => 10,
-           "custom_field_#{float_cf.id}" => 3.414,
+           int_cf.attribute_name => 10,
+           float_cf.attribute_name => 3.414,
            remaining_hours: 3,
            story_points: 7)
   end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -403,7 +403,7 @@ describe Query do
                               parent done_ratio priority responsible
                               spent_hours start_date status subject type
                               updated_at version) +
-                           [:"cf_#{custom_field.id}"] +
+                           [custom_field.column_name.to_sym] +
                            [:"relations_to_type_#{type.id}"] +
                            %i(relations_of_type_relation1 relations_of_type_relation2)
 
@@ -420,7 +420,7 @@ describe Query do
                               parent done_ratio priority responsible
                               spent_hours start_date status subject type
                               updated_at version) +
-                           [:"cf_#{custom_field.id}"]
+                           [custom_field.column_name.to_sym]
 
         unexpected_columns = [:"relations_to_type_#{type.id}"] +
                              %i(relations_of_type_relation1 relations_of_type_relation2)
@@ -465,7 +465,7 @@ describe Query do
       end
 
       before do
-        query.add_filter('cf_' + custom_field.id.to_s, '=', [''])
+        query.add_filter(custom_field.column_name, '=', [''])
       end
 
       it 'has the name of the custom field in the error message' do

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -163,7 +163,7 @@ describe Type do
       )
     end
     let(:cf_identifier) do
-      :"custom_field_#{custom_field.id}"
+      custom_field.attribute_name
     end
 
     it 'can be put into attribute groups' do
@@ -171,7 +171,7 @@ describe Type do
       OpenProject::Cache.clear
 
       # Can be enabled
-      type.attribute_groups = [['foo', [cf_identifier.to_s]]]
+      type.attribute_groups = [['foo', [cf_identifier]]]
       expect(type.save).to be_truthy
       expect(type.read_attribute(:attribute_groups)).not_to be_empty
     end
@@ -184,7 +184,7 @@ describe Type do
         )
       end
       let(:cf_identifier2) do
-        :"custom_field_#{custom_field2.id}"
+        custom_field2.attribute_name
       end
 
       it 'they are kept in their respective positions in the group (Regression test #27940)' do
@@ -192,12 +192,12 @@ describe Type do
         OpenProject::Cache.clear
 
         # Can be enabled
-        type.attribute_groups = [['foo', [cf_identifier2.to_s, cf_identifier.to_s]]]
+        type.attribute_groups = [['foo', [cf_identifier2, cf_identifier]]]
         expect(type.save).to be_truthy
         expect(type.read_attribute(:attribute_groups)).not_to be_empty
 
         cf_group = type.attribute_groups[0]
-        expect(cf_group.members).to eq([cf_identifier2.to_s, cf_identifier.to_s])
+        expect(cf_group.members).to eq([cf_identifier2, cf_identifier])
       end
     end
   end
@@ -220,7 +220,7 @@ describe Type do
 
       other_group = type.attribute_groups.detect { |g| g.key == :other }
       expect(other_group).to be_present
-      expect(other_group.attributes).to eq([custom_field.accessor_name])
+      expect(other_group.attributes).to eq([custom_field.attribute_name])
 
       # It is removed again when resetting it
       type.reset_attribute_groups

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -67,7 +67,7 @@ describe WorkPackage, 'acts_as_customizable' do
       end
 
       it 'sets the value' do
-        expect(wp_with_assignee_cf.send(version_cf.accessor_name))
+        expect(wp_with_assignee_cf.send(version_cf.attribute_getter))
           .to eql version
       end
     end
@@ -85,19 +85,19 @@ describe WorkPackage, 'acts_as_customizable' do
     end
 
     it 'says to respond to valid custom field accessors' do
-      expect(work_package).to respond_to(included_cf.accessor_name)
+      expect(work_package).to respond_to(included_cf.attribute_getter)
     end
 
     it 'really responds to valid custom field accessors' do
-      expect(work_package.send(included_cf.accessor_name)).to be_nil
+      expect(work_package.send(included_cf.attribute_getter)).to be_nil
     end
 
     it 'says to not respond to foreign custom field accessors' do
-      expect(work_package).not_to respond_to(other_cf.accessor_name)
+      expect(work_package).not_to respond_to(other_cf.attribute_getter)
     end
 
     it 'does really not respond to foreign custom field accessors' do
-      expect { work_package.send(other_cf.accessor_name) }.to raise_error(NoMethodError)
+      expect { work_package.send(other_cf.attribute_getter) }.to raise_error(NoMethodError)
     end
   end
 
@@ -125,7 +125,7 @@ describe WorkPackage, 'acts_as_customizable' do
 
       # assert that there is only one error
       expect(work_package.errors.size).to eq 1
-      expect(work_package.errors["custom_field_#{cf2.id}"].size).to eq 1
+      expect(work_package.errors[cf2.attribute_name].size).to eq 1
     end
   end
 

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -145,7 +145,7 @@ describe WorkPackage do
       describe 'invalid custom field values' do
         context 'short error message' do
           shared_examples_for 'custom field with invalid value' do
-            let(:custom_field_key) { "custom_field_#{custom_field.id}".to_sym }
+            let(:custom_field_key) { custom_field.attribute_name.to_sym }
 
             before do
               change_custom_field_value(work_package, custom_field_value)

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -97,7 +97,7 @@ describe WorkPackage do
         work_package.custom_field_values = { custom_field.id => ids }
         work_package.save
 
-        expect(work_package.send("custom_field_#{custom_field.id}"))
+        expect(work_package.send(custom_field.attribute_getter))
           .to eql values
       end
     end

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -51,7 +51,7 @@ describe 'API v3 Help texts resource' do
     [
       create(:work_package_help_text, attribute_name: 'assignee'),
       create(:work_package_help_text, attribute_name: 'status'),
-      create(:work_package_help_text, attribute_name: "custom_field_#{custom_field.id}")
+      create(:work_package_help_text, attribute_name: custom_field.attribute_name)
     ]
   end
 

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -34,8 +34,8 @@ describe API::V3::Projects::UpdateFormAPI, content_type: :json do
 
   let(:project) do
     create(:project,
-           "custom_field_#{text_custom_field.id}": "CF text",
-           "custom_field_#{list_custom_field.id}": list_custom_field.custom_options.first)
+           text_custom_field.attribute_name => "CF text",
+           list_custom_field.attribute_name => list_custom_field.custom_options.first)
   end
   let(:current_user) do
     create(:user,
@@ -224,10 +224,10 @@ describe API::V3::Projects::UpdateFormAPI, content_type: :json do
         expect(project.identifier)
           .to eql attributes_before['identifier']
 
-        expect(project.send("custom_field_#{text_custom_field.id}"))
+        expect(project.send(text_custom_field.attribute_getter))
           .to eql 'CF text'
 
-        expect(project.send("custom_field_#{list_custom_field.id}"))
+        expect(project.send(list_custom_field.attribute_getter))
           .to eql list_custom_field.custom_options.first.value
 
         expect(project.status)

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -105,7 +105,7 @@ describe 'API v3 Project resource update', content_type: :json do
     end
 
     it 'sets the cf value' do
-      expect(project.reload.send("custom_field_#{custom_field.id}"))
+      expect(project.reload.send(custom_field.attribute_getter))
         .to eql("CF text")
     end
   end
@@ -377,7 +377,7 @@ describe 'API v3 Project resource update', content_type: :json do
       end
 
       it 'sets the cf value' do
-        expect(project.reload.send("custom_field_#{custom_field.id}"))
+        expect(project.reload.send(custom_field.attribute_getter))
           .to eql("CF text")
       end
 

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -40,8 +40,8 @@ describe API::V3::Users::UpdateFormAPI, content_type: :json do
   end
   shared_let(:user) do
     create(:user,
-           "custom_field_#{text_custom_field.id}": "CF text",
-           "custom_field_#{list_custom_field.id}": list_custom_field.custom_options.first)
+           text_custom_field.attribute_getter => "CF text",
+           list_custom_field.attribute_getter => list_custom_field.custom_options.first)
   end
 
   let(:path) { api_v3_paths.user_form(user.id) }

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -133,7 +133,7 @@ describe 'API v3 Work package form resource', with_mail: false do
           it 'denotes string custom_field to be writable' do
             expect(subject)
               .to be_json_eql(true)
-              .at_path("_embedded/schema/#{cf_all.accessor_name.camelcase(:lower)}/writable")
+              .at_path("_embedded/schema/#{cf_all.attribute_name.camelcase(:lower)}/writable")
           end
         end
 
@@ -828,7 +828,7 @@ describe 'API v3 Work package form resource', with_mail: false do
       it 'denotes custom_field to not be writable' do
         expect(subject)
           .to be_json_eql(false)
-          .at_path("_embedded/schema/#{cf_all.accessor_name.camelcase(:lower)}/writable")
+          .at_path("_embedded/schema/#{cf_all.attribute_name.camelcase(:lower)}/writable")
       end
     end
   end

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -718,7 +718,7 @@ describe 'API v3 Work package resource',
         end
 
         let(:value_parameter) do
-          { _links: { custom_field.accessor_name.camelize(:lower) => { href: value_link } } }
+          { _links: { custom_field.attribute_name.camelize(:lower) => { href: value_link } } }
         end
         let(:params) { valid_params.merge(value_parameter) }
 
@@ -736,7 +736,7 @@ describe 'API v3 Work package resource',
           it 'responds with the work package assigned to the new value' do
             expect(subject.body)
               .to be_json_eql(value_link.to_json)
-                    .at_path("_links/#{custom_field.accessor_name.camelize(:lower)}/href")
+                    .at_path("_links/#{custom_field.attribute_name.camelize(:lower)}/href")
           end
 
           it_behaves_like 'lock version updated'

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -32,11 +32,11 @@ require 'services/base_services/behaves_like_create_service'
 describe CustomFields::CreateService, type: :model do
   it_behaves_like 'BaseServices create service' do
     context 'when creating a project cf' do
-      let(:model_instance) { build_stubbed :project_custom_field }
+      let(:model_instance) { build_stubbed(:project_custom_field) }
 
       it 'modifies the settings on successful call' do
         subject
-        expect(Setting.enabled_projects_columns).to include "cf_#{model_instance.id}"
+        expect(Setting.enabled_projects_columns).to include(model_instance.column_name)
       end
     end
   end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -672,7 +672,7 @@ describe Projects::CopyService, 'integration', type: :model do
         before do
           custom_field
           work_package.reload
-          work_package.send(:"custom_field_#{custom_field.id}=", current_user.id)
+          work_package.send(custom_field.attribute_setter, current_user.id)
           work_package.save!(validate: false)
         end
 
@@ -682,7 +682,7 @@ describe Projects::CopyService, 'integration', type: :model do
           it 'copies the custom_field' do
             expect(subject).to be_success
             wp = project_copy.work_packages.find_by(subject: work_package.subject)
-            expect(wp.send(:"custom_field_#{custom_field.id}"))
+            expect(wp.send(custom_field.attribute_getter))
               .to eql current_user
           end
         end
@@ -693,7 +693,7 @@ describe Projects::CopyService, 'integration', type: :model do
           it 'nils the custom_field' do
             expect(subject).to be_success
             wp = project_copy.work_packages.find_by(subject: work_package.subject)
-            expect(wp.send(:"custom_field_#{custom_field.id}"))
+            expect(wp.send(custom_field.attribute_getter))
               .to be_nil
           end
         end

--- a/spec/services/projects/update_service_integration_spec.rb
+++ b/spec/services/projects/update_service_integration_spec.rb
@@ -44,7 +44,7 @@ describe Projects::UpdateService, 'integration', type: :model do
 
   let!(:project) do
     create(:project,
-           "custom_field_#{custom_field.id}" => 1,
+           custom_field.attribute_name => 1,
            status: project_status)
   end
   let(:instance) { described_class.new(user:, model: project) }
@@ -60,7 +60,7 @@ describe Projects::UpdateService, 'integration', type: :model do
   describe '#call' do
     context 'if only a custom field is updated' do
       let(:attributes) do
-        { "custom_field_#{custom_field.id}" => 8 }
+        { custom_field.attribute_name => 8 }
       end
 
       it 'touches the project after saving' do
@@ -79,7 +79,7 @@ describe Projects::UpdateService, 'integration', type: :model do
       let(:custom_field2) { create(:text_project_custom_field) }
 
       let(:attributes) do
-        { "custom_field_#{custom_field2.id}" => 'some text' }
+        { custom_field2.attribute_name => 'some text' }
       end
 
       it 'touches the project after saving' do

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -36,10 +36,10 @@ shared_context 'with custom field params' do
       attribute_groups: [
         { 'type' => 'attribute',
           'name' => 'group1',
-          'attributes' => [{ 'key' => "custom_field_#{cf1.id}" }, { 'key' => "custom_field_#{cf2.id}" }] },
+          'attributes' => [{ 'key' => cf1.attribute_name }, { 'key' => cf2.attribute_name }] },
         { 'type' => 'attribute',
           'name' => 'groups',
-          'attributes' => [{ 'key' => "custom_field_#{cf2.id}" }] }
+          'attributes' => [{ 'key' => cf2.attribute_name }] }
       ]
     }
   end
@@ -138,7 +138,7 @@ shared_examples_for 'type service' do
       it 'enables the custom fields that are passed via attribute_groups' do
         allow(type)
           .to receive(:work_package_attributes)
-          .and_return("custom_field_#{cf1.id}" => {}, "custom_field_#{cf2.id}" => {})
+          .and_return(cf1.attribute_name => {}, cf2.attribute_name => {})
 
         allow(type)
           .to receive(:custom_field_ids=)

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1253,7 +1253,7 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
              parent:,
              start_date: Time.zone.today + 1.day,
              due_date: Time.zone.today + 5.days,
-             "custom_field_#{custom_field.id}": 5)
+             custom_field.attribute_name => 5)
     end
     let!(:attributes) { { parent: nil } }
 
@@ -1264,7 +1264,7 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
         project:,
         type: project.types.first,
         parent:,
-        "custom_field_#{custom_field.id}": 8
+        custom_field.attribute_name => 8
       }
     end
 
@@ -1335,7 +1335,7 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model, with_ma
       {
         type:,
         project:,
-        "custom_field_#{custom_field_of_current_type.id}": 5
+        custom_field_of_current_type.attribute_name => 5
       }
     end
 

--- a/spec/support/shared/acts_as_customizable.rb
+++ b/spec/support/shared/acts_as_customizable.rb
@@ -45,7 +45,7 @@ shared_examples_for 'acts_as_customizable included' do
         it 'returns the field changes' do
           model_instance.custom_field_values = { custom_field.id => 'test' }
           expect(model_instance.custom_field_changes)
-            .to eq({ "custom_field_#{custom_field.id}": [nil, 'test'] })
+            .to eq({ custom_field.attribute_name.to_sym => [nil, 'test'] })
         end
       end
     end
@@ -54,7 +54,7 @@ shared_examples_for 'acts_as_customizable included' do
       it 'returns the field changes' do
         model_instance.custom_field_values = { custom_field.id => 'test' }
         expect(model_instance.custom_field_changes)
-          .to eq({ "custom_field_#{custom_field.id}": [nil, 'test'] })
+          .to eq({ custom_field.attribute_name.to_sym => [nil, 'test'] })
       end
     end
 
@@ -67,7 +67,7 @@ shared_examples_for 'acts_as_customizable included' do
       it 'returns the field changes' do
         model_instance.custom_field_values = { custom_field.id => 'test2' }
         expect(model_instance.custom_field_changes)
-          .to eq({ "custom_field_#{custom_field.id}": ['test', 'test2'] })
+          .to eq({ custom_field.attribute_name.to_sym => ['test', 'test2'] })
       end
     end
 
@@ -92,7 +92,7 @@ shared_examples_for 'acts_as_customizable included' do
       it 'returns the field changes' do
         model_instance.custom_field_values = { custom_field.id => nil }
         expect(model_instance.custom_field_changes)
-          .to eq({ "custom_field_#{custom_field.id}": ['test', nil] })
+          .to eq({ custom_field.attribute_name.to_sym => ['test', nil] })
       end
     end
   end


### PR DESCRIPTION
Code contained a lot of `"custom_field_#{cf.id}"` and `"cf_#{cf.id}"`. This knowledge is scattered all over the code.
* `"custom_field_#{cf.id}"` form is used in a lot of places despite having a `#accessor_name` method doing the computation.
* `"cf_#{cf.id}"` form did not have a specific method for it.

This PR makes it DRYer:
* replace `#accessor_name` with
	* `#attribute_getter` and `#attribute_setter` methods when used with `respond_to?` or `send`. They are returning `:"custom_field_#{cf.id}"` and `:"custom_field_#{cf.id}="` respectively
	* `#attribute_name` as it reads better when using it in a non-accessor context
* extract `#column_name` to cope with `"cf_#{cf.id}"`. It looks like this name is used only with filters and custom columns, so naming seems appropriate.

Nothing has been done for forms like `/cf_\d/` (regular expression) or `cf_#{id}` (without an actual CustomField instance) or `s.start_with?("cf_")` (usage of prefix alone). Same for `custom_field_`.