### PR TITLE
Blur active field before resetting or saving an edit field

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
@@ -55,13 +55,15 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
   // Current errors of the field
   public errors:string[];
 
-  constructor(public injector:Injector,
+  constructor(
+    public injector:Injector,
     public form:EditForm,
     public fieldName:string,
     public schema:IFieldSchema,
     public element:HTMLElement,
     protected pathHelper:PathHelperService,
-    protected withErrors?:string[]) {
+    protected withErrors?:string[],
+  ) {
     super();
 
     if (withErrors !== undefined) {
@@ -105,11 +107,11 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
     }
   }
 
-  public onFocusOut() {
+  public async onFocusOut() {
     // In case of inline create or erroneous forms: do not save on focus loss
     // const specialField = this.resource.shouldCloseOnFocusOut(this.fieldName);
     if (this.resource.subject && this.withErrors && this.withErrors.length === 0) {
-      this.handleUserSubmit();
+      await this.handleUserSubmit();
     }
   }
 
@@ -140,11 +142,11 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
    * In an edit mode, we can't derive from a submit event whether the user pressed enter
    * (and on what field he did that).
    */
-  public handleUserKeydown(event:JQuery.TriggeredEvent, onlyCancel = false) {
+  public async handleUserKeydown(event:JQuery.TriggeredEvent, onlyCancel = false) {
     // Only handle submission in edit mode
     if (this.inEditMode && !onlyCancel) {
       if (event.which === KeyCodes.ENTER) {
-        this.form.submit();
+        await this.form.submit();
         return false;
       }
       return true;
@@ -192,10 +194,9 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
    * field that is about to be destroyed. So we blur it beforehand.
    * @private
    */
-  private blurActiveField() {
-    const active = document.activeElement as HTMLElement|null;
-    if (active?.blur) {
-      active.blur();
+  public blurActiveField() {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
     }
   }
 
@@ -231,8 +232,10 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
     if (!this.isErrorenous) {
       return '';
     }
-    return this.I18n.t('js.inplace.errors.messages_on_field',
-      { messages: this.errors.join(' ') });
+    return this.I18n.t(
+      'js.inplace.errors.messages_on_field',
+      { messages: this.errors.join(' ') },
+    );
   }
 
   public previewContext(resource:HalResource) {

--- a/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
@@ -122,6 +122,7 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
    * Handle a user submitting the field (e.g, ng-change)
    */
   public handleUserSubmit():Promise<any> {
+    this.blurActiveField();
     this.onBeforeSubmit();
 
     if (this.inFlight || this.form.editMode) {
@@ -179,10 +180,23 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
    * Close the field, resetting it with its display value.
    */
   public deactivate(focus = false) {
+    this.blurActiveField();
     delete this.form.activeFields[this.fieldName];
     this.onDestroy.next();
     this.onDestroy.complete();
     this.form.reset(this.fieldName, focus);
+  }
+
+  /**
+   * Safari scrolls around like crazy if you have a focused
+   * field that is about to be destroyed. So we blur it beforehand.
+   * @private
+   */
+  private blurActiveField() {
+    const active = document.activeElement as HTMLElement|null;
+    if (active?.blur) {
+      active.blur();
+    }
   }
 
   /**

--- a/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
@@ -123,8 +123,7 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
   /**
    * Handle a user submitting the field (e.g, ng-change)
    */
-  public handleUserSubmit():Promise<any> {
-    this.blurActiveField();
+  public handleUserSubmit():Promise<unknown> {
     this.onBeforeSubmit();
 
     if (this.inFlight || this.form.editMode) {
@@ -133,7 +132,10 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
 
     return this
       .onSubmit()
-      .then(() => this.form.submit());
+      .then(() => {
+        void this.form.submit();
+        this.blurActiveField();
+      });
   }
 
   /**


### PR DESCRIPTION
Safari appears to scroll around if the active field is being removed. This doesn't happen in any other browser we've tested

I haven't found a way to reliably reproduce this, but blurring the active field before resetting or submitting appears to work.

https://community.openproject.org/work_packages/42989