### PR TITLE
refactor: Extract customField1 json format into the CustomField#attribute_name method

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -232,7 +232,9 @@ class CustomField < ApplicationRecord
     where(is_filter: true)
   end
 
-  def attribute_name
+  def attribute_name(format = nil)
+    return "customField#{id}" if format == :camel_case
+
     "custom_field_#{id}"
   end
 

--- a/app/views/customizable/_form.html.erb
+++ b/app/views/customizable/_form.html.erb
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
       }
 
       if help_text
-        options[:help_text] = help_text.merge(attribute: "customField#{custom_field.id}")
+        options[:help_text] = help_text.merge(attribute: custom_field.attribute_name(:camel_case))
       end
 
       cf_form.cf_form_field(options)

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -127,12 +127,12 @@ module API
 
         private
 
-        def property_name(id)
-          "customField#{id}".to_sym
+        def property_name(custom_field)
+          custom_field.attribute_name(:camel_case).to_sym
         end
 
         def inject_version_schema(custom_field)
-          @class.schema_with_allowed_collection property_name(custom_field.id),
+          @class.schema_with_allowed_collection property_name(custom_field),
                                                 type: resource_type(custom_field),
                                                 name_source: ->(*) { custom_field.name },
                                                 values_callback: ->(*) {
@@ -150,7 +150,7 @@ module API
         end
 
         def inject_user_schema(custom_field)
-          @class.schema_with_allowed_link property_name(custom_field.id),
+          @class.schema_with_allowed_link property_name(custom_field),
                                           type: resource_type(custom_field),
                                           name_source: ->(*) { custom_field.name },
                                           required: custom_field.is_required,
@@ -159,7 +159,7 @@ module API
 
         def inject_list_schema(custom_field)
           @class.schema_with_allowed_collection(
-            property_name(custom_field.id),
+            property_name(custom_field),
             type: resource_type(custom_field),
             name_source: ->(*) { custom_field.name },
             values_callback: list_schemas_values_callback(custom_field),
@@ -170,7 +170,7 @@ module API
         end
 
         def inject_basic_schema(custom_field)
-          @class.schema property_name(custom_field.id),
+          @class.schema property_name(custom_field),
                         type: resource_type(custom_field),
                         name_source: ->(*) { custom_field.name },
                         required: custom_field.is_required,
@@ -182,7 +182,7 @@ module API
         end
 
         def inject_link_value(custom_field)
-          name = property_name(custom_field.id)
+          name = property_name(custom_field)
           expected_namespace = NAMESPACE_MAP[custom_field.field_format]
 
           link = LinkValueGetter.link_for custom_field
@@ -196,7 +196,7 @@ module API
                    end
 
           @class.send(method,
-                      property_name(custom_field.id),
+                      property_name(custom_field),
                       link:,
                       setter:,
                       getter:)
@@ -244,7 +244,7 @@ module API
 
         def inject_property_value(custom_field)
           @class.property custom_field.attribute_name.to_sym,
-                          as: property_name(custom_field.id),
+                          as: property_name(custom_field),
                           getter: property_value_getter_for(custom_field),
                           setter: property_value_setter_for(custom_field),
                           render_nil: true

--- a/lib/api/v3/utilities/custom_field_sum_injector.rb
+++ b/lib/api/v3/utilities/custom_field_sum_injector.rb
@@ -35,7 +35,7 @@ module API
         end
 
         def inject_basic_schema(custom_field)
-          @class.schema property_name(custom_field.id),
+          @class.schema property_name(custom_field),
                         type: TYPE_MAP[custom_field.field_format],
                         name_source: ->(*) { custom_field.name },
                         required: false,
@@ -44,7 +44,7 @@ module API
         end
 
         def inject_property_value(custom_field)
-          @class.property property_name(custom_field.id),
+          @class.property property_name(custom_field),
                           getter: property_value_getter_for(custom_field),
                           setter: property_value_setter_for(custom_field),
                           render_nil: true,

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -13,12 +13,12 @@ describe 'Create BCF',
   let(:index_page) { Pages::IfcModels::ShowDefault.new(project) }
   let(:permissions) { %i[view_ifc_models view_linked_issues manage_bcf add_work_packages edit_work_packages view_work_packages] }
   let!(:status) { create(:default_status) }
-  let!(:priority) { create :priority, is_default: true }
+  let!(:priority) { create(:priority, is_default: true) }
 
   let(:user) do
-    create :user,
+    create(:user,
            member_in_project: project,
-           member_with_permissions: permissions
+           member_with_permissions: permissions)
   end
 
   let!(:model) do
@@ -67,7 +67,7 @@ describe 'Create BCF',
       type_field.activate!
       type_field.set_value type_with_cf.name
 
-      cf_field = create_page.edit_field(:"customField#{integer_cf.id}")
+      cf_field = create_page.edit_field(integer_cf.attribute_name(:camel_case).to_sym)
       cf_field.set_value(815)
 
       create_page.save!
@@ -141,7 +141,7 @@ describe 'Create BCF',
     end
 
     context 'when starting on the details page of an existing work package' do
-      let(:work_package) { create :work_package, project: }
+      let(:work_package) { create(:work_package, project:) }
 
       before do
         visit bcf_project_frontend_path(project, "details/#{work_package.id}")

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -47,16 +47,16 @@ describe 'Custom field filter in boards', js: true do
        edit_work_packages view_work_packages manage_public_queries]
   end
 
-  let!(:priority) { create :default_priority }
-  let!(:open_status) { create :default_status, name: 'Open' }
-  let!(:closed_status) { create :status, is_closed: true, name: 'Closed' }
+  let!(:priority) { create(:default_priority) }
+  let!(:open_status) { create(:default_status, name: 'Open') }
+  let!(:closed_status) { create(:status, is_closed: true, name: 'Closed') }
 
   let!(:work_package) do
-    wp = build :work_package,
-               project: project,
-               type: type,
+    wp = build(:work_package,
+               project:,
+               type:,
                subject: 'Foo',
-               status: open_status
+               status: open_status)
 
     wp.custom_field_values = {
       custom_field.id => %w[B].map { |s| custom_value_for(s) }
@@ -105,7 +105,7 @@ describe 'Custom field filter in boards', js: true do
     filters.add_filter_by(custom_field.name,
                           'is',
                           ['A', 'B'],
-                          "customField#{custom_field.id}")
+                          custom_field.attribute_name(:camel_case))
 
     board_page.expect_changed
 

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -72,7 +72,7 @@ describe API::V3::TimeEntries::TimeEntryRepresenter, 'parsing' do
           "href" => api_v3_paths.work_package(work_package2.id)
 
         },
-        "customField#{user_custom_field.id}" => {
+        user_custom_field.attribute_name(:camel_case) => {
           "href" => api_v3_paths.user(user2.id)
         }
       },
@@ -81,7 +81,7 @@ describe API::V3::TimeEntries::TimeEntryRepresenter, 'parsing' do
         "raw" => "some comment"
       },
       "spentOn" => "2017-07-28",
-      "customField#{test_custom_field.id}" => {
+      test_custom_field.attribute_name(:camel_case) => {
         "raw" => "some text"
       }
     }

--- a/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
@@ -125,7 +125,7 @@ describe API::V3::TimeEntries::CreateFormAPI, content_type: :json do
           comment: {
             raw: "some comment"
           },
-          "customField#{custom_field.id}": {
+          custom_field.attribute_name(:camel_case) => {
             raw: 'some cf text'
           }
         }

--- a/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
@@ -93,7 +93,7 @@ describe API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
           comment: {
             raw: "some comment"
           },
-          "customField#{custom_field.id}": {
+          custom_field.attribute_name(:camel_case) => {
             raw: 'some cf text'
           }
         }

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -392,7 +392,7 @@ describe 'API v3 time_entry resource' do
           raw: "some comment"
         },
         spentOn: "2017-07-28",
-        "customField#{custom_field.id}": {
+        custom_field.attribute_name(:camel_case) => {
           raw: 'some cf text'
         }
       }
@@ -485,7 +485,7 @@ describe 'API v3 time_entry resource' do
           hours: 'PT5H',
           comment: "some comment",
           spentOn: "2017-07-28",
-          "customField#{custom_field.id}": {
+          custom_field.attribute_name(:camel_case) => {
             raw: 'some cf text'
           }
         }

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -147,7 +147,7 @@ describe 'Project details widget on dashboard', js: true do
            .to have_content("#{user_cf.name}\n#{other_user.name.split.map(&:first).join}\n#{other_user.name}")
 
         # The fields are not editable
-        field = EditField.new dashboard_page, "customField#{bool_cf.id}"
+        field = EditField.new dashboard_page, bool_cf.attribute_name(:camel_case)
         field.expect_read_only
         field.activate! expect_open: false
       end
@@ -158,16 +158,16 @@ describe 'Project details widget on dashboard', js: true do
     let(:current_user) { editing_user }
 
     it 'can edit the custom fields' do
-      int_field = EditField.new dashboard_page, "customField#{int_cf.id}"
+      int_field = EditField.new dashboard_page, int_cf.attribute_name(:camel_case)
       change_cf_value int_field, "5", "3"
 
-      string_field = EditField.new dashboard_page, "customField#{string_cf.id}"
+      string_field = EditField.new dashboard_page, string_cf.attribute_name(:camel_case)
       change_cf_value string_field, 'Some small text', 'Some new text'
 
-      text_field = TextEditorField.new dashboard_page, "customField#{text_cf.id}"
+      text_field = TextEditorField.new dashboard_page, text_cf.attribute_name(:camel_case)
       change_cf_value text_field, 'Some long text', 'Some very long text'
 
-      user_field = SelectField.new dashboard_page, "customField#{user_cf.id}"
+      user_field = SelectField.new dashboard_page, user_cf.attribute_name(:camel_case)
       change_cf_value user_field, other_user.name, editing_user.name
     end
   end

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -111,7 +111,7 @@ describe 'My page time entries current user widget spec', js: true, with_mail: f
   let(:my_page) do
     Pages::My::Page.new
   end
-  let(:cf_field) { TextEditorField.new(page, "customField#{custom_field.id}") }
+  let(:cf_field) { TextEditorField.new(page, custom_field.attribute_name(:camel_case)) }
   let(:time_logging_modal) { Components::TimeLoggingModal.new }
 
   before do

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -6,7 +6,7 @@ describe "multi select custom values", js: true do
   let(:current_user) { admin }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
   let(:cf_edit_field) do
-    field = wp_page.edit_field "customField#{custom_field.id}"
+    field = wp_page.edit_field custom_field.attribute_name(:camel_case)
     field.field_type = 'create-autocompleter'
     field
   end

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -10,7 +10,7 @@ describe "multi select custom values", js: true do
   let(:group_by) { Components::WorkPackages::GroupBy.new }
   let(:sort_by) { Components::WorkPackages::SortBy.new }
   let(:user) { create :admin }
-  let(:cf_frontend) { "customField#{custom_field.id}" }
+  let(:cf_frontend) { custom_field.attribute_name(:camel_case) }
   let(:project) { create :project, types: [type] }
   let(:multi_value) { true }
 
@@ -30,7 +30,7 @@ describe "multi select custom values", js: true do
   end
 
   def table_edit_field(work_package)
-    field = wp_table.edit_field work_package, "customField#{custom_field.id}"
+    field = wp_table.edit_field work_package, custom_field.attribute_name(:camel_case)
     field.field_type = 'create-autocompleter'
     field
   end
@@ -62,7 +62,7 @@ describe "multi select custom values", js: true do
 
     describe 'in single view' do
       let(:edit_field) do
-        field = wp_page.edit_field "customField#{custom_field.id}"
+        field = wp_page.edit_field custom_field.attribute_name(:camel_case)
         field.field_type = 'create-autocompleter'
         field
       end
@@ -147,7 +147,7 @@ describe "multi select custom values", js: true do
 
         # Open split view
         split_view = wp_table.open_split_view work_package
-        field = SelectField.new(split_view.container, "customField#{custom_field.id}")
+        field = SelectField.new(split_view.container, custom_field.attribute_name(:camel_case))
 
         field.activate!
         field.unset_value "ham", multi: true

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -19,7 +19,7 @@ describe 'custom field inplace editor', js: true do
   end
   let(:wp_page) { Pages::SplitWorkPackage.new(work_package) }
 
-  let(:property_name) { "customField#{custom_field.id}" }
+  let(:property_name) { custom_field.attribute_name(:camel_case) }
   let(:field) { wp_page.edit_field(property_name) }
 
   before do

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -276,7 +276,7 @@ describe 'date inplace editor',
       )
     end
 
-    let(:cf_field) { EditField.new page, :"customField#{date_cf.id}" }
+    let(:cf_field) { EditField.new page, date_cf.attribute_name(:camel_case) }
     let(:datepicker) { Components::Datepicker.new }
     let(:create_page) { Pages::FullWorkPackageCreate.new(project:) }
 

--- a/spec/features/work_packages/details/relations/hierarchy_custom_fields_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_custom_fields_spec.rb
@@ -56,7 +56,7 @@ describe 'creating a child directly after the wp itself was created', js: true d
     subject.set_value 'My subject'
 
     # Set CF
-    cf = wp_page.edit_field "customField#{custom_field.id}"
+    cf = wp_page.edit_field custom_field.attribute_name(:camel_case)
     cf.set_value '42'
 
     # Save WP

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -120,7 +120,7 @@ shared_examples 'work package relations tab', js: true, selenium: true do
         wp_page.expect_toast message: "#{custom_field.name} can't be blank.",
                              type: 'error'
 
-        cf_field = wp_page.edit_field("customField#{custom_field.id}")
+        cf_field = wp_page.edit_field(custom_field.attribute_name(:camel_case))
         cf_field.expect_active!
         cf_field.expect_value('')
 

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -219,7 +219,7 @@ describe 'edit work package',
       wp_page.expect_toast message: "#{custom_field.name} can't be blank.",
                            type: 'error'
 
-      cf_field = wp_page.edit_field("customField#{custom_field.id}")
+      cf_field = wp_page.edit_field(custom_field.attribute_name(:camel_case))
       cf_field.expect_active!
       cf_field.expect_value('')
     end

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -193,12 +193,12 @@ describe 'new work package', js: true do
 
         it do
           ids = custom_fields.map(&:id)
-          cf1 = find(".customField#{ids.first} input")
+          cf1 = find(".#{custom_fields.first.attribute_name(:camel_case)} input")
           expect(cf1).not_to be_nil
 
-          expect(page).to have_selector(".customField#{ids.last} ng-select")
+          expect(page).to have_selector(".#{custom_fields.last.attribute_name(:camel_case)} ng-select")
 
-          cf = wp_page.edit_field "customField#{ids.last}"
+          cf = wp_page.edit_field custom_fields.last.attribute_name(:camel_case)
           cf.field_type = 'create-autocompleter'
           cf.openSelectField
           cf.set_value 'foo'

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -177,10 +177,10 @@ describe 'Inline editing work packages', js: true do
       expect(page).to have_selector('th a', text: cf_text_name.upcase)
       expect(wp_table.row(work_package)).to have_selector('.wp-table--cell-container.-error', count: 2)
 
-      cf_text = wp_table.edit_field(work_package, "customField#{custom_fields.last.id}")
+      cf_text = wp_table.edit_field(work_package, custom_fields.last.attribute_name(:camel_case))
       cf_text.update('my custom text', expect_failure: true)
 
-      cf_list = wp_table.edit_field(work_package, "customField#{custom_fields.first.id}")
+      cf_list = wp_table.edit_field(work_package, custom_fields.first.attribute_name(:camel_case))
       cf_list.field_type = 'create-autocompleter'
       cf_list.openSelectField
       cf_list.set_value('bar')

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -94,7 +94,7 @@ describe 'inline create work package', js: true do
       let(:cf_list) do
         create(:list_wp_custom_field, is_for_all: true, is_filter: true)
       end
-      let(:cf_accessor_frontend) { "customField#{cf_list.id}" }
+      let(:cf_accessor_frontend) { cf_list.attribute_name(:camel_case) }
       let(:types) { [type, cf_type] }
       let(:type) { create(:type_standard) }
       let(:cf_type) { create(:type, custom_fields: [cf_list]) }
@@ -136,7 +136,7 @@ describe 'inline create work package', js: true do
 
         created_wp = WorkPackage.last
 
-        cf_field = wp_table.edit_field(created_wp, :"customField#{cf_list.id}")
+        cf_field = wp_table.edit_field(created_wp, cf_list.attribute_name(:camel_case))
         cf_field.expect_text(cf_list.custom_options.second.name)
       end
     end

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -253,7 +253,7 @@ describe 'filter work packages', js: true do
       filters.add_filter_by(list_cf.name,
                             'is not',
                             list_cf.custom_options.last.value,
-                            "customField#{list_cf.id}")
+                            list_cf.attribute_name(:camel_case))
 
       loading_indicator_saveguard
       wp_table.expect_work_package_listed work_package_with_list_value
@@ -261,7 +261,7 @@ describe 'filter work packages', js: true do
 
       wp_table.save_as('Some query name')
 
-      filters.remove_filter "customField#{list_cf.id}"
+      filters.remove_filter list_cf.attribute_name(:camel_case)
 
       loading_indicator_saveguard
       wp_table.expect_work_package_listed work_package_with_list_value, work_package_with_anti_list_value
@@ -331,7 +331,7 @@ describe 'filter work packages', js: true do
       filters.add_filter_by(string_cf.name,
                             'is',
                             ['G+H'],
-                            "customField#{string_cf.id}")
+                            string_cf.attribute_name(:camel_case))
 
       loading_indicator_saveguard
       wp_table.expect_work_package_listed work_package_plus
@@ -339,7 +339,7 @@ describe 'filter work packages', js: true do
 
       wp_table.save_as('Some query name')
 
-      filters.remove_filter "customField#{string_cf.id}"
+      filters.remove_filter string_cf.attribute_name(:camel_case)
 
       loading_indicator_saveguard
       wp_table.expect_work_package_listed work_package_plus, work_package_and
@@ -362,7 +362,7 @@ describe 'filter work packages', js: true do
       filters.set_filter(string_cf,
                          'is',
                          ['A&B'],
-                         "customField#{string_cf.id}")
+                         string_cf.attribute_name(:camel_case))
 
       loading_indicator_saveguard
       wp_table.expect_work_package_listed work_package_and

--- a/spec/features/work_packages/table/queries/user_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/user_cf_filter_spec.rb
@@ -97,7 +97,7 @@ describe 'Work package filtering by user custom field', js: true do
 
     # Filtering by user
 
-    filters.add_filter_by(user_cf.name, 'is', [other_user.name], "customField#{user_cf.id}")
+    filters.add_filter_by(user_cf.name, 'is', [other_user.name], user_cf.attribute_name(:camel_case))
 
     wp_table.ensure_work_package_not_listed!(work_package_placeholder, work_package_group)
     wp_table.expect_work_package_listed(work_package_user)
@@ -116,16 +116,16 @@ describe 'Work package filtering by user custom field', js: true do
 
     # Filtering by placeholder
 
-    filters.remove_filter "customField#{user_cf.id}"
-    filters.add_filter_by(user_cf.name, 'is', [placeholder_user.name], "customField#{user_cf.id}")
+    filters.remove_filter user_cf.attribute_name(:camel_case)
+    filters.add_filter_by(user_cf.name, 'is', [placeholder_user.name], user_cf.attribute_name(:camel_case))
 
     wp_table.ensure_work_package_not_listed!(work_package_user, work_package_group)
     wp_table.expect_work_package_listed(work_package_placeholder)
 
     # Filtering by group
 
-    filters.remove_filter "customField#{user_cf.id}"
-    filters.add_filter_by(user_cf.name, 'is', [group.name], "customField#{user_cf.id}")
+    filters.remove_filter user_cf.attribute_name(:camel_case)
+    filters.add_filter_by(user_cf.name, 'is', [group.name], user_cf.attribute_name(:camel_case))
 
     wp_table.ensure_work_package_not_listed!(work_package_user, work_package_placeholder)
     wp_table.expect_work_package_listed(work_package_group)

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -49,8 +49,8 @@ describe 'Switching types in work package table', js: true do
     end
 
     let(:type_field) { wp_table.edit_field(work_package, :type) }
-    let(:text_field) { wp_table.edit_field(work_package, :"customField#{cf_text.id}") }
-    let(:req_text_field) { wp_table.edit_field(work_package, :"customField#{cf_req_text.id}") }
+    let(:text_field) { wp_table.edit_field(work_package, cf_text.attribute_name(:camel_case)) }
+    let(:req_text_field) { wp_table.edit_field(work_package, cf_req_text.attribute_name(:camel_case)) }
 
     before do
       login_as(user)
@@ -163,8 +163,8 @@ describe 'Switching types in work package table', js: true do
     context 'switching to single view' do
       let(:wp_split) { wp_table.open_split_view(work_package) }
       let(:type_field) { wp_split.edit_field(:type) }
-      let(:text_field) { wp_split.edit_field(:"customField#{cf_text.id}") }
-      let(:req_text_field) { wp_split.edit_field(:"customField#{cf_req_text.id}") }
+      let(:text_field) { wp_split.edit_field(cf_text.attribute_name(:camel_case)) }
+      let(:req_text_field) { wp_split.edit_field(cf_req_text.attribute_name(:camel_case)) }
 
       it 'allows editing and cancelling the new required fields' do
         wp_split
@@ -301,7 +301,7 @@ describe 'Switching types in work package table', js: true do
     let!(:priority) { create :priority, is_default: true }
 
     let(:cf_edit_field) do
-      field = wp_page.edit_field "customField#{custom_field.id}"
+      field = wp_page.edit_field custom_field.attribute_name(:camel_case)
       field.field_type = 'create-autocompleter'
       field
     end

--- a/spec/lib/api/v3/queries/filters/query_filter_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_representer_spec.rb
@@ -93,7 +93,7 @@ describe API::V3::Queries::Filters::QueryFilterRepresenter do
       describe '_links' do
         it_behaves_like 'has a titled link' do
           let(:link) { 'self' }
-          let(:href) { api_v3_paths.query_filter "customField#{custom_field.id}" }
+          let(:href) { api_v3_paths.query_filter custom_field.attribute_name(:camel_case) }
           let(:title) { custom_field.name }
         end
       end

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -131,7 +131,7 @@ describe API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
             let(:filter) { custom_field_filter }
 
             it_behaves_like 'links to and embeds allowed values directly' do
-              let(:hrefs) { [api_v3_paths.query_filter("customField#{custom_field.id}")] }
+              let(:hrefs) { [api_v3_paths.query_filter(custom_field.attribute_name(:camel_case))] }
             end
           end
         end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe API::V3::Utilities::CustomFieldInjector do
   include API::V3::Utilities::PathHelper
 
-  let(:cf_path) { "customField#{custom_field.id}" }
+  let(:cf_path) { custom_field.attribute_name(:camel_case) }
   let(:field_format) { 'bool' }
   let(:custom_field) do
     build(:custom_field,

--- a/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
+++ b/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
@@ -152,7 +152,7 @@ describe API::V3::Versions::Schemas::VersionSchemaRepresenter do
     end
 
     describe 'int custom field' do
-      let(:path) { "customField#{custom_field.id}" }
+      let(:path) { custom_field.attribute_name(:camel_case) }
 
       it_behaves_like 'has basic schema properties' do
         let(:type) { 'Integer' }

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -30,11 +30,11 @@ require 'spec_helper'
 
 describe CustomField do
   before do
-    CustomField.destroy_all
+    described_class.destroy_all
   end
 
-  let(:field)  { build :custom_field }
-  let(:field2) { build :custom_field }
+  let(:field)  { build(:custom_field) }
+  let(:field2) { build(:custom_field) }
 
   describe '#name' do
     it { is_expected.to validate_presence_of(:name) }
@@ -189,6 +189,12 @@ describe CustomField do
     subject { field.attribute_name }
 
     it { is_expected.to eq("custom_field_#{field.id}") }
+
+    context 'when a format is provided' do
+      subject { field.attribute_name(:camel_case) }
+
+      it { is_expected.to eq("customField#{field.id}") }
+    end
   end
 
   describe '#attribute_getter' do
@@ -242,7 +248,7 @@ describe CustomField do
 
       context 'for something that responds to project' do
         it 'is a list of name, id pairs' do
-          object = OpenStruct.new project: project
+          object = OpenStruct.new(project:)
 
           expect(field.possible_values_options(object))
             .to match_array [[user1.name, user1.id.to_s],
@@ -321,7 +327,7 @@ describe CustomField do
 
   describe '#possible_values' do
     context 'on a list custom field' do
-      let(:field) { CustomField.new field_format: "list" }
+      let(:field) { described_class.new field_format: "list" }
 
       context 'on providing an array' do
         before do
@@ -361,7 +367,7 @@ describe CustomField do
   describe 'nested attributes for custom options' do
     let(:option) { build(:custom_option) }
     let(:options) { [option] }
-    let(:field) { build :custom_field, field_format: 'list', custom_options: options }
+    let(:field) { build(:custom_field, field_format: 'list', custom_options: options) }
 
     before do
       field.save!
@@ -398,7 +404,7 @@ describe CustomField do
 
   describe '#multi_value_possible?' do
     context 'with a wp list cf' do
-      let(:field) { build_stubbed :list_wp_custom_field }
+      let(:field) { build_stubbed(:list_wp_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -407,7 +413,7 @@ describe CustomField do
     end
 
     context 'with a wp user cf' do
-      let(:field) { build_stubbed :user_wp_custom_field }
+      let(:field) { build_stubbed(:user_wp_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -416,7 +422,7 @@ describe CustomField do
     end
 
     context 'with a wp int cf' do
-      let(:field) { build_stubbed :int_wp_custom_field }
+      let(:field) { build_stubbed(:int_wp_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -425,7 +431,7 @@ describe CustomField do
     end
 
     context 'with a project list cf' do
-      let(:field) { build_stubbed :list_project_custom_field }
+      let(:field) { build_stubbed(:list_project_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -434,7 +440,7 @@ describe CustomField do
     end
 
     context 'with a project user cf' do
-      let(:field) { build_stubbed :user_project_custom_field }
+      let(:field) { build_stubbed(:user_project_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -443,7 +449,7 @@ describe CustomField do
     end
 
     context 'with a project int cf' do
-      let(:field) { build_stubbed :int_project_custom_field }
+      let(:field) { build_stubbed(:int_project_custom_field) }
 
       it 'is true' do
         expect(field)
@@ -452,7 +458,7 @@ describe CustomField do
     end
 
     context 'with a time_entry user cf' do
-      let(:field) { build_stubbed :time_entry_custom_field, field_format: 'user' }
+      let(:field) { build_stubbed(:time_entry_custom_field, field_format: 'user') }
 
       it 'is true' do
         expect(field)
@@ -461,7 +467,7 @@ describe CustomField do
     end
 
     context 'with a time_entry list cf' do
-      let(:field) { build_stubbed :time_entry_custom_field, field_format: 'list' }
+      let(:field) { build_stubbed(:time_entry_custom_field, field_format: 'list') }
 
       it 'is true' do
         expect(field)
@@ -475,9 +481,7 @@ describe CustomField do
       field.save!
 
       field.destroy
-
-      expect(CustomField.where(id: field.id).exists?)
-        .to be_falsey
+      expect(described_class.where(id: field.id)).not_to exist
     end
   end
 end

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -248,7 +248,7 @@ describe CustomField do
 
       context 'for something that responds to project' do
         it 'is a list of name, id pairs' do
-          object = OpenStruct.new(project:)
+          object = OpenStruct.new(project:) # rubocop:disable Style/OpenStructUse
 
           expect(field.possible_values_options(object))
             .to match_array [[user1.name, user1.id.to_s],

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -112,12 +112,12 @@ describe API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
       {
         name: 'My copied project',
         identifier: 'foobar',
-        "customField#{text_custom_field.id}": {
+        text_custom_field.attribute_name(:camel_case) => {
           raw: "CF text"
         },
         statusExplanation: { raw: "A magic dwells in each beginning." },
         _links: {
-          "customField#{list_custom_field.id}": {
+          list_custom_field.attribute_name(:camel_case) => {
             href: api_v3_paths.custom_option(list_custom_field.custom_options.first.id)
           },
           status: {

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -90,7 +90,7 @@ describe API::V3::Projects::Copy::CopyAPI, content_type: :json do
       let(:params) do
         { name: 'My copied project',
           identifier: 'my-copied-project',
-          "customField#{text_custom_field.id}": {
+          text_custom_field.attribute_name(:camel_case) => {
             raw: "CF text"
           } }
       end

--- a/spec/requests/api/v3/projects/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_form_resource_spec.rb
@@ -91,12 +91,12 @@ describe API::V3::Projects::CreateFormAPI, content_type: :json do
         {
           identifier: 'new_project_identifier',
           name: 'Project name',
-          "customField#{text_custom_field.id}": {
+          text_custom_field.attribute_name(:camel_case) => {
             raw: "CF text"
           },
           statusExplanation: { raw: "A magic dwells in each beginning." },
           _links: {
-            "customField#{list_custom_field.id}": {
+            list_custom_field.attribute_name(:camel_case) => {
               href: api_v3_paths.custom_option(list_custom_field.custom_options.first.id)
             },
             status: {

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -121,7 +121,7 @@ describe 'API v3 Project resource create', content_type: :json do
       {
         identifier: 'new_project_identifier',
         name: 'Project name',
-        "customField#{custom_field.id}": {
+        custom_field.attribute_name(:camel_case) => {
           raw: "CF text"
         }
       }.to_json

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -162,12 +162,12 @@ describe API::V3::Projects::UpdateFormAPI, content_type: :json do
         {
           identifier: 'new_project_identifier',
           name: 'Project name',
-          "customField#{text_custom_field.id}": {
+          text_custom_field.attribute_name(:camel_case) => {
             raw: "new CF text"
           },
           statusExplanation: { raw: 'Something goes awry.' },
           _links: {
-            "customField#{list_custom_field.id}": {
+            list_custom_field.attribute_name(:camel_case) => {
               href: api_v3_paths.custom_option(list_custom_field.custom_options.last.id)
             },
             status: {

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -94,7 +94,7 @@ describe 'API v3 Project resource update', content_type: :json do
   context 'with a custom field' do
     let(:body) do
       {
-        "customField#{custom_field.id}": {
+        custom_field.attribute_name(:camel_case) => {
           raw: "CF text"
         }
       }
@@ -352,7 +352,7 @@ describe 'API v3 Project resource update', content_type: :json do
     let(:body) do
       {
         active: false,
-        "customField#{custom_field.id}": {
+        custom_field.attribute_name(:camel_case) => {
           raw: "CF text"
         }
       }

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -580,7 +580,7 @@ describe "POST /api/v3/queries/form" do
     let(:path_with_cf) do
       uri = Addressable::URI.parse(path)
       uri.query = {
-        filters: [{ "customField#{custom_field.id}": { operator: "=", values: ["ABC"] } }]
+        filters: [{ custom_field.attribute_name(:camel_case) => { operator: "=", values: ["ABC"] } }]
       }.to_query
 
       uri.to_s

--- a/spec/requests/api/v3/queries/filters/query_filters_resource_spec.rb
+++ b/spec/requests/api/v3/queries/filters/query_filters_resource_spec.rb
@@ -81,7 +81,7 @@ describe 'API v3 Query Filter resource' do
 
     context 'custom field filter' do
       let(:list_wp_custom_field) { create(:list_wp_custom_field) }
-      let(:filter_name) { "customField#{list_wp_custom_field.id}" }
+      let(:filter_name) { list_wp_custom_field.attribute_name(:camel_case) }
 
       it 'succeeds' do
         expect(last_response.status)

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -139,9 +139,9 @@ describe API::V3::Users::CreateFormAPI, content_type: :json do
         {
           email: 'cfuser@example.com',
           status: 'invited',
-          "customField#{custom_field.id}": "A custom value",
+          custom_field.attribute_name(:camel_case) => "A custom value",
           _links: {
-            "customField#{list_custom_field.id}": {
+            list_custom_field.attribute_name(:camel_case) => {
               href: custom_option_href
             }
           }

--- a/spec/requests/api/v3/versions/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/create_form_resource_spec.rb
@@ -117,7 +117,7 @@ describe API::V3::Versions::CreateFormAPI, content_type: :json do
           description: {
             raw: 'A new description'
           },
-          "customField#{int_cf.id}": 5,
+          int_cf.attribute_name(:camel_case) => 5,
           startDate: "2018-01-01",
           endDate: "2018-01-09",
           status: "closed",
@@ -126,7 +126,7 @@ describe API::V3::Versions::CreateFormAPI, content_type: :json do
             definingProject: {
               href: api_v3_paths.project(project.id)
             },
-            "customField#{list_cf.id}": {
+            list_cf.attribute_name(:camel_case) => {
               href: api_v3_paths.custom_option(list_cf.custom_options.first.id)
             }
           }

--- a/spec/requests/api/v3/versions/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/update_form_resource_spec.rb
@@ -147,13 +147,13 @@ describe API::V3::Versions::UpdateFormAPI, content_type: :json do
           description: {
             raw: 'A new description'
           },
-          "customField#{int_cf.id}": 5,
+          int_cf.attribute_name(:camel_case) => 5,
           startDate: "2018-01-01",
           endDate: "2018-01-09",
           status: "closed",
           sharing: "descendants",
           _links: {
-            "customField#{list_cf.id}": {
+            list_cf.attribute_name(:camel_case) => {
               href: api_v3_paths.custom_option(list_cf.custom_options.first.id)
             }
           }

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -764,7 +764,7 @@ describe 'API v3 Work package form resource', with_mail: false do
                 create(:work_package_custom_field, field_format: 'text')
               end
 
-              let(:cf_param) { { "customField#{custom_field.id}" => nil } }
+              let(:cf_param) { { custom_field.attribute_name(:camel_case) => nil } }
               let(:params) { valid_params.merge(cf_param) }
 
               before do

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -349,7 +349,7 @@ describe 'API v3 Work package resource',
 
         context 'valid type changing custom fields' do
           let(:custom_field) { create(:work_package_custom_field) }
-          let(:custom_field_parameter) { { "customField#{custom_field.id}": true } }
+          let(:custom_field_parameter) { { custom_field.attribute_name(:camel_case) => true } }
           let(:params) { valid_params.merge(type_parameter).merge(custom_field_parameter) }
 
           before do
@@ -430,7 +430,7 @@ describe 'API v3 Work package resource',
         context 'with a custom field defined on the target project' do
           let(:member_permissions) { %i[move_work_packages edit_work_packages] }
           let(:custom_field) { create(:work_package_custom_field) }
-          let(:custom_field_parameter) { { "customField#{custom_field.id}": true } }
+          let(:custom_field_parameter) { { custom_field.attribute_name(:camel_case) => true } }
           let(:params) { valid_params.merge(project_parameter).merge(custom_field_parameter) }
 
           before do

--- a/spec/support/form_fields/form_field.rb
+++ b/spec/support/form_fields/form_field.rb
@@ -26,7 +26,7 @@ module FormFields
 
     def property_name
       if property.is_a? CustomField
-        "customField#{property.id}"
+        property.attribute_name(:camel_case)
       else
         property.to_s
       end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -54,7 +54,7 @@ module Pages
     end
 
     def custom_edit_field(custom_field)
-      edit_field("customField#{custom_field.id}").tap do |field|
+      edit_field(custom_field.attribute_name(:camel_case)).tap do |field|
         if custom_field.list?
           field.field_type = 'create-autocompleter'
         end


### PR DESCRIPTION
Follow up PR on this https://github.com/opf/openproject/pull/11932#issuecomment-1396963446 .
Since we have a lot of occurrences of the string `"customField#{cf.id}"` it makes sense to extract it into a method.