### PR TITLE
signaling for notifiction api

### DIFF
--- a/lib/api/v3/notifications/notification_sql_collection_representer.rb
+++ b/lib/api/v3/notifications/notification_sql_collection_representer.rb
@@ -1,0 +1,35 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module API
+  module V3
+    module Notifications
+      class NotificationSqlCollectionRepresenter < API::Decorators::SqlCollectionRepresenter; end
+    end
+  end
+end

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -60,7 +60,7 @@ module API
             end
           end
 
-          get &::API::V3::Utilities::Endpoints::Index
+          get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex
             .new(model: Notification, scope: -> { notification_scope })
             .mount
 

--- a/spec/lib/api/v3/projects/project_sql_collection_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_sql_collection_representer_rendering_spec.rb
@@ -142,4 +142,42 @@ describe API::V3::Projects::ProjectSqlCollectionRepresenter, 'rendering' do
         .to be_json_eql(expected)
     end
   end
+
+  context 'when not having a project to render' do
+    let(:scope) do
+      Project.none
+    end
+
+    let(:select) do
+      { '*' => {} }
+    end
+
+    let(:expected) do
+      {
+        _type: "Collection",
+        pageSize: 5,
+        total: 0,
+        count: 0,
+        offset: 1,
+        _links: {
+          self: {
+            href: "some_path?offset=1&pageSize=5&select=%2A"
+          },
+          changeSize: {
+            href: "some_path?offset=1&pageSize=%7Bsize%7D&select=%2A",
+            templated: true
+          },
+          jumpTo: {
+            href: "some_path?offset=%7Boffset%7D&pageSize=5&select=%2A",
+            templated: true
+          }
+        }
+      }.to_json
+    end
+
+    it 'renders as expected' do
+      expect(json)
+        .to be_json_eql(expected)
+    end
+  end
 end

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -341,6 +341,25 @@ describe API::V3::Notifications::NotificationsAPI,
 
       it_behaves_like 'API V3 collection response', 0, 0, 'Notification'
     end
+
+    context 'when signaling' do
+      let(:select) { 'total,count' }
+      let(:send_request) do
+        get api_v3_paths.path_for :notifications, select:
+      end
+
+      let(:expected) do
+        {
+          total: 2,
+          count: 2
+        }
+      end
+
+      it 'is the reduced set of properties of the embedded elements' do
+        expect(last_response.body)
+          .to be_json_eql(expected.to_json)
+      end
+    end
   end
 
   describe 'admin user' do


### PR DESCRIPTION
This was intended to improve the performance of the most often used
request, the one to query for the existence of new notifications.
However, there is no performance gain to be measurable so that idea was
abandoned.

The reason for this is that we have already an optimized case for the
default representer when a pageSize of 0 is provided.