### PR TITLE
Fix deprecated set-output and save-state commands

### DIFF
--- a/.github/workflows/brakeman-scan-core.yml
+++ b/.github/workflows/brakeman-scan-core.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/codeql-scan-core.yml
+++ b/.github/workflows/codeql-scan-core.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -23,7 +23,7 @@ jobs:
           exit 1
         fi
 
-        echo "::set-output name=branch::${BRANCH}"
+        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
   crowdin:
     permissions:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -25,8 +25,7 @@ jobs:
           exit 1
         fi
 
-        echo "::set-output name=branch::${BRANCH}"
-        echo "::set-output name=crowdin_release_branch::release"
+        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
   crowdin:
     permissions:
@@ -42,7 +41,7 @@ jobs:
           - dev
           - "${{ needs.setup.outputs.latest_release_branch }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 1
@@ -54,9 +53,9 @@ jobs:
         run: |
           echo "Setting crowdin branch from $BRANCH"
           if [ "$BRANCH" = "dev" ]; then
-            echo "::set-output name=crowdin_branch::dev"
+            echo "crowdin_branch=dev" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=crowdin_branch::release"
+            echo "crowdin_branch=release" >> $GITHUB_OUTPUT
           fi
       - name: "Updating translations"
         uses: crowdin/github-action@1.4.4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       INPUT_BUILDOPTIONS: --pull
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Prepare docker files
         run: |
           cp ./docker/prod/Dockerfile ./Dockerfile

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -14,7 +14,7 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: opf/action-eslint@v2

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Generate .env.pullpreview file
       run: |
         echo "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off" >> .env.pullpreview

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -13,7 +13,7 @@ jobs:
     name: rubocop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -28,9 +28,9 @@ jobs:
       CI_RETRY_COUNT: 3
       LOCAL_DEV_CHECK: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/cache
         key: ${{ runner.os }}-ruby32-core-tests-units-${{ hashFiles('**/Gemfile.lock') }}
@@ -58,9 +58,9 @@ jobs:
       CAPYBARA_AWS_ACCESS_KEY_ID: "${{ secrets.CAPYBARA_AWS_ACCESS_KEY_ID }}"
       CAPYBARA_AWS_SECRET_ACCESS_KEY: "${{ secrets.CAPYBARA_AWS_SECRET_ACCESS_KEY }}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/cache
         key: ${{ runner.os }}-ruby32-core-tests-features-${{ hashFiles('**/Gemfile.lock') }}
@@ -81,11 +81,11 @@ jobs:
     if: github.repository == 'opf/openproject'
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '14'
     - run: ./script/api/validate_spec


### PR DESCRIPTION
https://community.openproject.org/wp/45885

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more details.

As actions/cache@v2 was using deprecated `save-state` command, its usage has been updated to use v3. For good measure, other actions have also been upgraded to their latest version.