### PR TITLE
Update CodeQL to v2

### DIFF
--- a/.github/workflows/brakeman-scan-core.yml
+++ b/.github/workflows/brakeman-scan-core.yml
@@ -38,6 +38,6 @@ jobs:
           brakeman -i config/brakeman.ignore -f sarif -o output.sarif.json .
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: output.sarif.json

--- a/.github/workflows/codeql-scan-core.yml
+++ b/.github/workflows/codeql-scan-core.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Fixing this error on our CI:

<img width="876" alt="image" src="https://user-images.githubusercontent.com/83396/213678901-3adc64f0-88a7-44ff-ae54-d40ca2351c5d.png">


https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/#what-do-i-need-to-change-in-my-workflow