### PR TITLE
Better logging for omniauth with oidc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/opf/omniauth-openid-connect.git
-  revision: 27d9d4a05c80a9b29709ae8681696de11156e0e5
-  ref: 27d9d4a05c80a9b29709ae8681696de11156e0e5
+  revision: 0d2cd719e87021a14dd2b5cf8a6bf1831d4a497e
+  ref: 0d2cd71
   specs:
     omniauth-openid-connect (0.4.0)
       addressable (~> 2.5)

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -14,7 +14,7 @@ gem 'omniauth-openid_connect-providers',
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',
-    ref: '27d9d4a05c80a9b29709ae8681696de11156e0e5'
+    ref: '0d2cd71'
 
 group :opf_plugins do
     # included so that engines can reference OpenProject::Version

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -529,7 +529,7 @@ Settings::Definition.define do
       writable: true
 
   add :log_level,
-      default: 'info',
+      default: Rails.env.development? ? 'debug' : 'info',
       writable: false
 
   add :log_requesting_user,

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -26,6 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+OmniAuth.config.logger = Rails.logger
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   unless Rails.env.production?
     provider :developer, fields: %i[first_name last_name email]

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -48,7 +48,7 @@ module OpenProject::OpenIDConnect
           end
 
           # Remember oidc session values when logging in user
-          h[:retain_from_session] = %w[omniauth.openid_sid]
+          h[:retain_from_session] = %w[omniauth.oidc_sid]
 
           h[:backchannel_logout_callback] = ->(logout_token) do
             ::OpenProject::OpenIDConnect::SessionMapper.handle_logout(logout_token)

--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -34,7 +34,7 @@ module OpenProject::OpenIDConnect
       # we want to map that to the internal session
       def user_logged_in(context)
         session = context[:session]
-        oidc_sid = session['omniauth.openid_sid']
+        oidc_sid = session['omniauth.oidc_sid']
         return if oidc_sid.nil?
 
         ::OpenProject::OpenIDConnect::SessionMapper.handle_login(oidc_sid, session)

--- a/modules/openid_connect/lib/open_project/openid_connect/session_mapper.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/session_mapper.rb
@@ -22,7 +22,7 @@ module OpenProject::OpenIDConnect
 
     attr_reader :session_link
 
-    delegate :oidc_session, to: :session_link
+    delegate :oidc_session, to: :session_link, allow_nil: true
 
     def initialize(link)
       @session_link = link


### PR DESCRIPTION
The default omniauth logger only logs to STDOUT. We want to redirect it to the rails logger to have it available whereever we log things there.