### PR TITLE
Ensure we're navigating to the date we're testing

### DIFF
--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -68,10 +68,10 @@ describe 'Datepicker modal individual non working days (WP #44453)',
       # Wait for the datepicker to be initialized
       datepicker.expect_visible
 
+      datepicker.show_date non_working_day_this_week.date
       datepicker.expect_non_working non_working_day_this_week.date
 
-      datepicker.select_year non_working_day_next_year.date.year
-      datepicker.select_month non_working_day_next_year.date.month
+      datepicker.show_date non_working_day_next_year.date
 
       datepicker.expect_non_working non_working_day_next_year.date
     end

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -65,13 +65,22 @@ module Components
       end
     end
 
-    ##
-    # Set a ISO8601 date through the datepicker
-    def set_date(date)
+    # Change the datepicker visible area.
+    #
+    # @param date the date to navigate to. Can be a Date or a String with
+    # ISO8601 formatted date.
+    def show_date(date)
       date = Date.parse(date) unless date.is_a?(Date)
 
       select_year date.year
       select_month date.strftime('%B')
+    end
+
+    # Set a ISO8601 date through the datepicker
+    def set_date(date)
+      date = Date.parse(date) unless date.is_a?(Date)
+
+      show_date(date)
       select_day date.day
     end
 


### PR DESCRIPTION
For the current date, the start of the week monday is not shown in calendar, so it cannot be seen

<img width="662" alt="Bildschirm­foto 2023-02-01 um 07 42 01" src="https://user-images.githubusercontent.com/459462/215970620-4e9718f8-bd8f-4c31-b738-17951772b088.png">
