### PR TITLE
[#45964] Use Primary/Main colour for folder file type and storage icons

### DIFF
--- a/frontend/src/app/shared/components/storages/icons.mapping.ts
+++ b/frontend/src/app/shared/components/storages/icons.mapping.ts
@@ -30,7 +30,7 @@ import { nextcloud } from 'core-app/shared/components/storages/storages-constant
 
 export interface IFileIcon {
   icon:'image1'|'movie'|'file-text'|'export-pdf-descr'|'file-doc'|'file-sheet'|'file-presentation'|'folder'|'ticket'
-  clazz:'pdf'|'img'|'txt'|'doc'|'sheet'|'presentation'|'form'|'dir'|'mov'|'default'
+  clazz:'pdf'|'img'|'txt'|'doc'|'sheet'|'presentation'|'form'|'primary'|'mov'|'default'
 }
 
 export const fileIconMappings:Record<string, IFileIcon> = {
@@ -99,7 +99,7 @@ export const fileIconMappings:Record<string, IFileIcon> = {
   'video/3gpp-tt': { icon: 'movie', clazz: 'mov' },
   'video/3gpp-2': { icon: 'movie', clazz: 'mov' },
 
-  'application/x-op-directory': { icon: 'folder', clazz: 'dir' },
+  'application/x-op-directory': { icon: 'folder', clazz: 'primary' },
 
   default: { icon: 'ticket', clazz: 'default' },
 };

--- a/frontend/src/app/shared/components/storages/storage/storage.component.html
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.html
@@ -3,7 +3,7 @@
 >
   <div class=op-tab-content--header>
     <span
-      class="op-tab-content--header-icon spot-icon spot-icon_nextcloud-circle op-files-tab--icon op-files-tab--icon_nextcloud"
+      class="op-tab-content--header-icon spot-icon spot-icon_nextcloud-circle op-files-tab--icon op-files-tab--icon_primary"
     ></span>
     <span class="op-tab-content--header-text" [textContent]="storage.name"></span>
     <a

--- a/frontend/src/app/spot/styles/sass/components/breadcrumbs.sass
+++ b/frontend/src/app/spot/styles/sass/components/breadcrumbs.sass
@@ -13,6 +13,7 @@
     > .spot-icon
       width: $spot-spacing-1_5
       height: $spot-spacing-1_5
+      color: var(--primary-color)
 
     &_collapsed:before
       content: '...'

--- a/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
@@ -99,14 +99,11 @@
     &_form
       color: #87E2C1
 
-    &_dir
-      color: #00BDF3
+    &_primary
+      color: var(--primary-color)
 
     &_default
       color: #9A9A9A
 
     &_clip
       color: #333333
-
-    &_nextcloud
-      color: #1A67A3


### PR DESCRIPTION
- https://community.openproject.org/work_packages/45964
- use primary color for folder icon classes
- use primary color for storage icons