### PR TITLE
Raise an error in the github pr errors script when the PR cannot be found

### DIFF
--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -206,7 +206,8 @@ end
 def display_pull_request_info(workflow_run)
   return unless workflow_run['event'] == 'pull_request'
 
-  pr = workflow_run['pull_requests'].first
+  pr = workflow_run['pull_requests'].first or
+    raise "Pull Request info cannot be found, perhaps it is already merged or closed?"
   pr_number = "##{pr['number']}"
   pr_html_url = "#{GITHUB_HTML_OPENPROJECT_PREFIX}/pull/#{pr['number']}"
   pr_display_title = "#{workflow_run['display_title']} #{pr_number.white.dark} #{pr_html_url.white.dark}"


### PR DESCRIPTION
A meaningful error message is raised when an associated PR cannot be found while displaying the PR info.