### PR TITLE
Datepicker bugfixes

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.component.ts
@@ -38,6 +38,8 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
       [(ngModel)]="value"
       [id]="handler.htmlId"
       class="inline-edit--field"
+      [opened]="opened"
+      (closed)="onModalClosed()"
     ></op-single-date-picker>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -45,8 +47,12 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 export class DateEditFieldComponent extends EditFieldComponent implements OnInit {
   @InjectField() readonly timezoneService:TimezoneService;
 
+  opened = false;
+
   ngOnInit():void {
     super.ngOnInit();
+    // Open the datepicker when the field is not part of an editing form.
+    this.opened = !this.handler.inEditMode;
   }
 
   public get value() {
@@ -60,6 +66,7 @@ export class DateEditFieldComponent extends EditFieldComponent implements OnInit
 
   public onCancel():void {
     this.handler.handleUserCancel();
+    this.onModalClosed();
   }
 
   public formatter(data:string):string|null {
@@ -68,5 +75,13 @@ export class DateEditFieldComponent extends EditFieldComponent implements OnInit
       return this.timezoneService.formattedISODate(d);
     }
     return null;
+  }
+
+  public onModalClosed():void {
+    this.opened = false;
+
+    if (!this.handler.inEditMode) {
+      this.handler.deactivate(false);
+    }
   }
 }

--- a/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
@@ -4,7 +4,7 @@
   left: 0
   right: 0
   bottom: 0
-  z-index: 9000
+  @include spot-z-index("drop-modal")
   background: rgba(0, 0, 0, 0.75)
   justify-content: center
   align-items: center

--- a/spec/features/support/components/time_logging_modal.rb
+++ b/spec/features/support/components/time_logging_modal.rb
@@ -55,7 +55,7 @@ module Components
             .to have_text(I18n.t('js.button_log_time'))
         end
       else
-        expect(page).to have_no_selector '.spot-modal'
+        expect(page).not_to have_selector '.spot-modal'
       end
     end
 
@@ -76,7 +76,7 @@ module Components
         if visible
           expect(page).to have_selector "##{field_identifier(field)}"
         else
-          expect(page).to have_no_selector "##{field_identifier(field)}"
+          expect(page).not_to have_selector "##{field_identifier(field)}"
         end
       end
     end
@@ -120,8 +120,6 @@ module Components
       end
     end
 
-    private
-
     def field_identifier(field_name)
       case field_name
       when 'spent_on'
@@ -132,6 +130,8 @@ module Components
         'wp-new-inline-edit--field-user'
       end
     end
+
+    private
 
     def field_object(field_name)
       send("#{field_name}_field")

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -34,11 +34,24 @@ require 'support/edit_fields/edit_field'
 require 'features/work_packages/work_packages_page'
 
 describe 'date inplace editor',
-         with_settings: { date_format: '%Y-%m-%d' },
-         js: true, selenium: true do
-  let(:project) { create :project_with_types, public: true }
-  let(:work_package) { create :work_package, project:, start_date: Date.parse('2016-01-02'), duration: nil }
-  let(:user) { create :admin }
+         js: true, selenium: true, with_settings: { date_format: '%Y-%m-%d' } do
+  shared_let(:project) { create(:project_with_types, public: true) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:type) { project.types.first }
+  shared_let(:priority) { create(:default_priority) }
+  shared_let(:status) { create(:default_status) }
+
+  shared_let(:date_cf) do
+    create(
+      :date_wp_custom_field,
+      name: "My date",
+      types: [type],
+      projects: [project]
+    )
+  end
+
+  let(:work_package) { create(:work_package, project:, start_date: Date.parse('2016-01-02'), duration: nil) }
+
   let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   let(:wp_timeline) { Pages::WorkPackagesTimeline.new }
@@ -94,10 +107,10 @@ describe 'date inplace editor',
 
   context 'with start and end date set' do
     let(:work_package) do
-      create :work_package,
+      create(:work_package,
              project:,
              start_date: Date.parse('2016-01-02'),
-             due_date: Date.parse('2016-01-25')
+             due_date: Date.parse('2016-01-25'))
     end
 
     it 'selecting a date before the current start date will move the finish date' do
@@ -170,7 +183,7 @@ describe 'date inplace editor',
   end
 
   context 'with the start date empty' do
-    let(:work_package) { create :work_package, project:, start_date: nil, duration: nil }
+    let(:work_package) { create(:work_package, project:, start_date: nil, duration: nil) }
 
     it 'can set "today" as a date via the provided link' do
       start_date.activate!
@@ -258,30 +271,18 @@ describe 'date inplace editor',
     work_packages_page.accept_alert_dialog! if work_packages_page.has_alert_dialog?
 
     # Ensure no modal survives
-    expect(page).to have_no_selector('.spot-modal')
+    expect(page).not_to have_selector('.spot-modal')
   end
 
   context 'with a date custom field' do
-    let!(:type) { create :type }
-    let!(:project) { create :project, types: [type] }
-    let!(:priority) { create :default_priority }
-    let!(:status) { create :default_status }
-
-    let!(:date_cf) do
-      create(
-        :date_wp_custom_field,
-        name: "My date",
-        types: [type],
-        projects: [project]
-      )
-    end
-
     let(:cf_field) { EditField.new page, date_cf.attribute_name(:camel_case) }
     let(:datepicker) { Components::Datepicker.new }
     let(:create_page) { Pages::FullWorkPackageCreate.new(project:) }
 
     it 'can handle creating a CF date' do
       create_page.visit!
+
+      datepicker.expect_not_visible
 
       type_field = create_page.edit_field(:type)
       type_field.activate!
@@ -308,10 +309,27 @@ describe 'date inplace editor',
       wp = WorkPackage.last
       expect(wp.custom_value_for(date_cf.id).value).to eq Time.zone.today.iso8601
     end
+
+    it 'can set the date via the in-place editing' do
+      datepicker.expect_not_visible
+
+      cf_field.activate!
+      cf_field.expect_active!
+
+      datepicker.set_date Time.zone.today
+
+      datepicker.expect_year Time.zone.today.year
+      datepicker.expect_month Time.zone.today.strftime("%B")
+      datepicker.expect_day Time.zone.today.day
+
+      datepicker.save!
+      cf_field.expect_inactive!
+      cf_field.expect_state_text Time.zone.today.strftime('%Y-%m-%d')
+    end
   end
 
   context 'with the work package having no relations whatsoever' do
-    let!(:work_package) { create :work_package, project: }
+    let!(:work_package) { create(:work_package, project:) }
 
     before do
       start_date.activate!
@@ -319,20 +337,20 @@ describe 'date inplace editor',
     end
 
     it 'does not show a banner with or without manual scheduling' do
-      expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-warning"]')
-      expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-info"]')
+      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-warning"]')
+      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-info"]')
 
       # When toggling manually scheduled
       start_date.toggle_scheduling_mode
 
-      expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-warning"]')
-      expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-info"]')
+      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-warning"]')
+      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-info"]')
     end
   end
 
   context 'with the work package being the last in the hierarchy' do
-    let!(:parent) { create :work_package, project:, schedule_manually:, start_date: 1.day.ago, due_date: 5.days.from_now }
-    let!(:work_package) { create :work_package, project:, schedule_manually:, parent: }
+    let!(:parent) { create(:work_package, project:, schedule_manually:, start_date: 1.day.ago, due_date: 5.days.from_now) }
+    let!(:work_package) { create(:work_package, project:, schedule_manually:, parent:) }
 
     before do
       start_date.activate!
@@ -385,9 +403,9 @@ describe 'date inplace editor',
   end
 
   context 'with the work package being a parent' do
-    let!(:child) { create :work_package, project:, start_date: 1.day.ago, due_date: 5.days.from_now }
+    let!(:child) { create(:work_package, project:, start_date: 1.day.ago, due_date: 5.days.from_now) }
     let!(:work_package) do
-      wp = create :work_package, project: project, schedule_manually: schedule_manually
+      wp = create(:work_package, project:, schedule_manually:)
       child.update! parent: wp
       wp
     end
@@ -443,11 +461,11 @@ describe 'date inplace editor',
       context 'when parent is not manually scheduled, child has workdays only set' do
         let(:schedule_manually) { false }
         let!(:child) do
-          create :work_package,
+          create(:work_package,
                  project:,
                  ignore_non_working_days: false,
                  start_date: Date.parse('2022-09-27'),
-                 due_date: Date.parse('2022-09-29')
+                 due_date: Date.parse('2022-09-29'))
         end
 
         it 'allows switching to manual scheduling to set the ignore NWD (Regression #43933)' do
@@ -480,14 +498,14 @@ describe 'date inplace editor',
   end
 
   context 'with the work package having a precedes relation' do
-    let!(:work_package) { create :work_package, project:, schedule_manually: }
-    let!(:preceding) { create :work_package, project:, start_date: 10.days.ago, due_date: 5.days.ago }
+    let!(:work_package) { create(:work_package, project:, schedule_manually:) }
+    let!(:preceding) { create(:work_package, project:, start_date: 10.days.ago, due_date: 5.days.ago) }
 
     let!(:relationship) do
-      create :relation,
+      create(:relation,
              from: preceding,
              to: work_package,
-             relation_type: Relation::TYPE_PRECEDES
+             relation_type: Relation::TYPE_PRECEDES)
     end
 
     before do
@@ -535,14 +553,14 @@ describe 'date inplace editor',
   end
 
   context 'with the work package having a follows relation' do
-    let!(:work_package) { create :work_package, project:, schedule_manually: }
-    let!(:following) { create :work_package, project:, start_date: 5.days.from_now, due_date: 10.days.from_now }
+    let!(:work_package) { create(:work_package, project:, schedule_manually:) }
+    let!(:following) { create(:work_package, project:, start_date: 5.days.from_now, due_date: 10.days.from_now) }
 
     let!(:relationship) do
-      create :relation,
+      create(:relation,
              from: following,
              to: work_package,
-             relation_type: Relation::TYPE_FOLLOWS
+             relation_type: Relation::TYPE_FOLLOWS)
     end
 
     before do

--- a/spec/features/work_packages/display_fields/spent_time_display_spec.rb
+++ b/spec/features/work_packages/display_fields/spent_time_display_spec.rb
@@ -29,10 +29,10 @@
 require 'spec_helper'
 
 describe 'Logging time within the work package view', js: true do
-  shared_let(:project) { create :project }
-  shared_let(:admin) { create :admin }
-  shared_let(:work_package) { create :work_package, project: }
-  shared_let(:activity) { create :time_entry_activity, project: }
+  shared_let(:project) { create(:project) }
+  shared_let(:admin) { create(:admin) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:activity) { create(:time_entry_activity, project:) }
 
   let(:user) { admin }
 
@@ -42,15 +42,21 @@ describe 'Logging time within the work package view', js: true do
 
   let(:time_logging_modal) { Components::TimeLoggingModal.new }
 
-  def log_time_via_modal(user_field_visible: true, log_for_user: nil)
+  def log_time_via_modal(user_field_visible: true, log_for_user: nil, date: Time.zone.today)
     time_logging_modal.is_visible true
 
     # the fields are visible
-    time_logging_modal.has_field_with_value 'spent_on', Date.today.strftime("%Y-%m-%d")
+    time_logging_modal.has_field_with_value 'spent_on', Time.zone.today.strftime("%Y-%m-%d")
     time_logging_modal.shows_field 'work_package', false
     time_logging_modal.shows_field 'user', user_field_visible
 
+    # Update the fields
     time_logging_modal.update_field 'activity', activity.name
+
+    Components::Datepicker.update_field(
+      "##{time_logging_modal.field_identifier('spent_on')}",
+      date.strftime("%Y-%m-%d")
+    )
 
     if log_for_user
       time_logging_modal.update_field 'user', log_for_user.name
@@ -74,11 +80,21 @@ describe 'Logging time within the work package view', js: true do
     it 'shows a logging button within the display field and can log time via a modal' do
       # click on button opens modal
       spent_time_field.open_time_log_modal
-
-      log_time_via_modal
+      expect do
+        log_time_via_modal(date: Date.yesterday)
+      end.to change(TimeEntry, :count).by(1)
 
       # the value is updated automatically
       spent_time_field.expect_display_value '1 h'
+
+      TimeEntry.last.tap do |te|
+        expect(te.work_package).to eq(work_package)
+        expect(te.project).to eq(project)
+        expect(te.activity).to eq(activity)
+        expect(te.user).to eq(user)
+        expect(te.spent_on).to eq(Date.yesterday)
+        expect(te.hours).to eq(1)
+      end
     end
 
     context 'with another user in the project' do
@@ -117,7 +133,7 @@ describe 'Logging time within the work package view', js: true do
     end
 
     context 'with a user with non-one unit numbers', with_settings: { available_languages: %w[en ja] } do
-      let(:user) { create :admin, language: 'ja' }
+      let(:user) { create(:admin, language: 'ja') }
 
       before do
         I18n.locale = 'ja'
@@ -181,8 +197,8 @@ describe 'Logging time within the work package view', js: true do
 
   context 'when in the table' do
     let(:wp_table) { Pages::WorkPackagesTable.new(project) }
-    let(:second_work_package) { create :work_package, project: }
-    let(:query) { create :public_query, project:, column_names: ['subject', 'spent_hours'] }
+    let(:second_work_package) { create(:work_package, project:) }
+    let(:query) { create(:public_query, project:, column_names: ['subject', 'spent_hours']) }
 
     before do
       work_package

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -94,7 +94,7 @@ module Components
       date = Date.parse(date) unless date.is_a?(Date)
 
       select_year date.year
-      select_month date.strftime('%B')
+      select_month date.month
     end
 
     # Set a ISO8601 date through the datepicker
@@ -106,7 +106,7 @@ module Components
     end
 
     def save!
-      container.find('[data-qa-selector="op-datepicker-modal"] .button', text: "Save").click
+      container.find('[data-qa-selector="op-datepicker-modal"] .button', text: I18n.t(:button_save)).click
     end
 
     ##

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -50,6 +50,10 @@ module Components
       expect(container).to have_selector('.flatpickr-calendar .flatpickr-current-month', wait: 10)
     end
 
+    def expect_not_visible
+      expect(container).not_to have_selector('.flatpickr-calendar .flatpickr-current-month', wait: 10)
+    end
+
     ##
     # Select year from input
     def select_year(value)


### PR DESCRIPTION
See this comment for context: https://community.openproject.org/projects/openproject/work_packages/42358/activity?query_id=3593#activity-29

1. [X]  When date picker is opened from the Log time module, it is behind the module.
2. [x] Open one of the already created work packages that have custom field of date type and try setting a date - on first click, nothing happens. On 2nd click, the date picker opens. With the old date picker, it worked on the 1st click.

