### PR TITLE
Hide next and prev months days from single datepicker

### DIFF
--- a/frontend/src/global_styles/vendor/_flatpickr-overrides.sass
+++ b/frontend/src/global_styles/vendor/_flatpickr-overrides.sass
@@ -1,8 +1,25 @@
 .flatpickr-innerContainer
-
   @at-root div#{&}
     overflow: auto
+
+  // Force grid to not have hidden next/prev month days change layout
+  .dayContainer
+    display: grid
+    grid-template-columns: repeat(7, 1fr)
+    justify-items: center
+
+  // Set day width to properly align columns
+  .flatpickr-day
+    width: 40px
 
 .flatpickr-calendar.inline
   // flatpickr default styles introduce a top: 2px, that causes strange scrolling behavior
   top: unset !important
+
+.flatpickr-day.prevMonthDay
+  height: 0
+  width: 0
+  visibility: hidden
+
+.flatpickr-day.nextMonthDay
+  display: none


### PR DESCRIPTION
They are already hidden by default in ranged datepicker, but for showMonths=1, flatpickr behaves differently and adds a lot more days

To circumvent that, hide the previous month days but keep visible. For next month days, this won't work as they result in more whitespace added.

That's why we have to override the styling of flatpickr to use a grid with better positioning of the days, to prevent shifts to layout when some of the columns are missing

https://community.openproject.org/wp/46189