### PR TITLE
Feature/42358 standardise date pickers outside of the main work package date field

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
@@ -19,13 +19,20 @@
   &:not(.subject) input:not([type='checkbox']):not(.spot-text-field--input):not(.spot-input)
     // Full width to inline-edit inputs
     width: 100%
+    line-height: 24px
+    font-size: 14px
+    border-radius: 2px
+
+  input:not([type='checkbox'])
     // Same height as the row - padding
     height: 24px
-    line-height: 24px
     padding: 2px
-    font-size: 14px
     color: var(--body-font-color)
-    border-radius: 2px
+
+  input.spot-input
+    // The other inputs are getting a min-height from the .op-input class,
+    // for the spot input we have to define it in order to achieve the same height.
+    min-height: 2rem
 
   &.-tiny
     input:not([type='checkbox']):not(.spot-text-field--input)

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
@@ -28,7 +28,7 @@
     border-radius: 2px
 
   &.-tiny
-    input:not([type='checkbox']):not(.spot-text-field--input):not(.spot-input)
+    input:not([type='checkbox']):not(.spot-text-field--input)
       max-width: 100px
 
   .inline-label

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -50,7 +50,8 @@ See COPYRIGHT and LICENSE files for more details.
       <%= f.date_picker :start_date,
                         id: 'meeting-form-start-date',
                         required: true,
-                        no_label: true
+                        no_label: true,
+                        container_class: '-xslim'
       %>
       <label for="meeting-form-start-time" class="hidden-for-sighted">
         <%= Meeting.human_attribute_name(:start_time) %>


### PR DESCRIPTION
See [OP#42358](https://community.openproject.org/projects/openproject/work_packages/42358)

Fixing the bugs from the [comment](https://community.openproject.org/projects/openproject/work_packages/42358?query_id=3593#activity-29):

6. [X] On Meeting module, now there is no spacing between the date and time fields. 
7. [X]  The date field itself seems longer now than it used to be on the Log time modal.
8. [X] Looking at the two Log time modals from the previous point, in the new date field, the color and font size of the date seems different and not in line with the rest of the text from other fields. 