### PR TITLE
Fix specs depending on the day of the week

### DIFF
--- a/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative './shared_context'
 
-describe 'Team planner error handling', js: true do
+describe 'Team planner error handling', beginning_of_week: :locale, js: true do
   include_context 'with team planner full access'
 
   let!(:work_package) do

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Working Days', js: true do
+describe 'Working Days', beginning_of_week: :locale, js: true do
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -199,12 +199,16 @@ describe 'Working Days', js: true do
         fill_in 'name', with: 'My holiday'
       end
 
-      date1 = Time.zone.today.next_week.next_occurring(:monday)
+      date1 = Time.zone.today.next_week.next_occurring(:monday) + 1.week
       datepicker.set_date date1
 
       page.within('[data-qa-selector="op-datepicker-modal"]') do
         click_on 'Save'
       end
+
+      expect(page).to have_no_text "A non-working day for this date exists already. " \
+                                   "There can only be one non-working day created for " \
+                                   "each unique date."
 
       expect(page).to have_selector('.fc-list-event-title', text: 'My holiday')
 
@@ -215,12 +219,16 @@ describe 'Working Days', js: true do
         fill_in 'name', with: 'Another important day'
       end
 
-      date2 = Time.zone.today.next_week.next_occurring(:tuesday)
+      date2 = Time.zone.today.next_week.next_occurring(:tuesday) + 1.week
       datepicker.set_date date2
 
       page.within('[data-qa-selector="op-datepicker-modal"]') do
         click_on 'Save'
       end
+
+      expect(page).to have_no_text "A non-working day for this date exists already. " \
+                                   "There can only be one non-working day created for " \
+                                   "each unique date."
 
       click_on 'Apply changes'
       click_on 'Save and reschedule'

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -199,16 +199,12 @@ describe 'Working Days', js: true do
         fill_in 'name', with: 'My holiday'
       end
 
-      date1 = Time.zone.today.next_week.next_occurring(:monday) + 1.week
+      date1 = Time.zone.today.next_week.next_occurring(:monday)
       datepicker.set_date date1
 
       page.within('[data-qa-selector="op-datepicker-modal"]') do
         click_on 'Save'
       end
-
-      expect(page).to have_no_text "A non-working day for this date exists already. " \
-                                   "There can only be one non-working day created for " \
-                                   "each unique date."
 
       expect(page).to have_selector('.fc-list-event-title', text: 'My holiday')
 
@@ -219,16 +215,12 @@ describe 'Working Days', js: true do
         fill_in 'name', with: 'Another important day'
       end
 
-      date2 = Time.zone.today.next_week.next_occurring(:tuesday) + 1.week
+      date2 = Time.zone.today.next_week.next_occurring(:tuesday)
       datepicker.set_date date2
 
       page.within('[data-qa-selector="op-datepicker-modal"]') do
         click_on 'Save'
       end
-
-      expect(page).to have_no_text "A non-working day for this date exists already. " \
-                                   "There can only be one non-working day created for " \
-                                   "each unique date."
 
       click_on 'Apply changes'
       click_on 'Save and reschedule'

--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+
+  # Change `Date.beginning_of_week` in the context of the specs
+  # according to the current locale.
+  #
+  # See also: https://github.com/opf/openproject/pull/12066
+  #
+  config.append_before do
+    case I18n.locale
+    when :en
+      Date.beginning_of_week = :sunday
+    when :de, :fr
+      Date.beginning_of_week = :monday
+    else
+      Rails.logger.warn "First day of week not defined for locale #{I18n.locale} in spec/support/i18n.rb."
+    end
+  end
+end

--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -1,11 +1,24 @@
 RSpec.configure do |config|
-
   # Change `Date.beginning_of_week` in the context of the specs
   # according to the current locale.
   #
+  # Usage:
+  #
+  #    context "with Date.beginning_of_week based on I18n.locale", beginning_of_week: :locale
+  #    context "with Date.beginning_of_week set on :sunday", beginning_of_week: :sunday
+  #
   # See also: https://github.com/opf/openproject/pull/12066
   #
-  config.append_before do
+  config.append_before do |example|
+    beginning_of_week = example.metadata[:beginning_of_week]
+    if beginning_of_week == :locale
+      set_beginning_of_week_based_on_locale
+    elsif beginning_of_week.present? and beginning_of_week.is_a? Symbol
+      Date.beginning_of_week = beginning_of_week
+    end
+  end
+
+  def set_beginning_of_week_based_on_locale
     case I18n.locale
     when :en
       Date.beginning_of_week = :sunday


### PR DESCRIPTION
## Specs failing on Sunday

This pull request fixes a couple of specs that have failed on Sundays:

```
Failed examples:

rspec ./spec/features/admin/working_days_spec.rb:189 # Working Days non-working days can add non-working days
```

<img width="1912" alt="Bildschirm­foto 2023-02-12 um 13 54 27" src="https://user-images.githubusercontent.com/1679688/218315263-af64e2db-e654-487c-b1de-110711904e64.png">

```
Failed examples:

rspec ./modules/team_planner/spec/features/team_planner_error_handling_spec.rb:68 # Team planner error handling with full permissions cannot change the wp because of required fields not being set
rspec ./modules/team_planner/spec/features/team_planner_error_handling_spec.rb:83 # Team planner error handling with full permissions cannot change the wp because of conflicting modifications
```

<img width="1912" alt="Bildschirm­foto 2023-02-12 um 14 51 47" src="https://user-images.githubusercontent.com/1679688/218315725-8cbd8b4c-b81d-4608-9b8c-3e7379e151f7.png">

## Background

OpenProject has a setting to define the beginning of the week (`:sunday`, `:monday`, …). It defaults to the beginning of the week in the used locale, i.e. `:sunday` for the `:en` locale and `:monday` for the `:de` locale.

Disregarding the OpenProject setting and the locale, the `Date#beginning_of_week` method used in the specs considers `:monday` to be the beginning of the week per default. This discrepancy causes some specs to fail on some days of the week and to succeed on other days.

## Debugging

In order to experiment with these specs, use `Timecop` to simulate the spec running on another day:

```ruby
before do
  Timecop.travel 3.days.ago
end
```

## Setting `beginning_of_week` based on locale

We could set `Date.beginning_of_week` based on the current `I18n.locale` in a `before` block for each spec.

However, many appear to have their own workarounds and would be broken by this change. Investigating all of these specs is out of scope of this pull request.

## This pull request

In order to fix a specific set of specs that fail on some days of the week, this pull request provides the switch `beginning_of_week`:

```ruby
describe "some feature", beginning_of_week: :locale` do
end
```
