### PR TITLE
fix refreshing the page after cancelling the process in confirmation modal specified in [41226] Instance-wide public holidays (non-working days)

### DIFF
--- a/app/helpers/confirmation_dialog_helper.rb
+++ b/app/helpers/confirmation_dialog_helper.rb
@@ -35,6 +35,7 @@ module ConfirmationDialogHelper
     text: nil,
     danger_zone: false,
     show_list_data: false,
+    refresh_on_cancel: false,
     list_title: nil,
     warning_text: nil,
     button_continue: nil,
@@ -57,6 +58,7 @@ module ConfirmationDialogHelper
         warningText: warning_text,
         passedData: passed_data,
         showListData: show_list_data,
+        refreshOnCancel: refresh_on_cancel,
         icon: {
           continue: icon_continue
         }.compact

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
@@ -48,7 +48,7 @@
         type="button"
         class="button spot-modal--cancel-button spot-action-bar--action"
         data-qa-selector="confirmation-modal--cancel"
-        (click)="closeMe($event)"
+        (click)="close($event)"
       >
         <span *ngIf="icon.cancel as clazz" class="spot-icon spot-icon_{{clazz}}"></span>
         <span>{{text.button_cancel}}</span>

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.ts
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.ts
@@ -54,6 +54,7 @@ export interface ConfirmDialogOptions {
   showClose?:boolean;
   closeByDocument?:boolean;
   showListData?:boolean;
+  refreshOnCancel?:boolean;
   listTitle?:string;
   warningText?:string;
   passedData?:string[];
@@ -70,6 +71,8 @@ export class ConfirmDialogModalComponent extends OpModalComponent {
   public showClose:boolean;
 
   public showListData:boolean;
+
+  public refreshOnCancel:boolean;
 
   public listTitle:string;
 
@@ -98,15 +101,18 @@ export class ConfirmDialogModalComponent extends OpModalComponent {
 
   public dangerHighlighting:boolean;
 
-  constructor(readonly elementRef:ElementRef,
+  constructor(
+    readonly elementRef:ElementRef,
     @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
     readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService) {
+    readonly I18n:I18nService,
+  ) {
     super(locals, cdRef, elementRef);
     this.options = (locals.options || {}) as ConfirmDialogOptions;
 
     this.dangerHighlighting = _.defaultTo(this.options.dangerHighlighting, false);
     this.showListData = _.defaultTo(this.options.showListData, false);
+    this.refreshOnCancel = _.defaultTo(this.options.refreshOnCancel, false);
     this.listTitle = _.defaultTo(this.options.listTitle, '');
     this.warningText = _.defaultTo(this.options.warningText, '');
     this.passedData = _.defaultTo(this.options.passedData, []);
@@ -120,5 +126,12 @@ export class ConfirmDialogModalComponent extends OpModalComponent {
   public confirmAndClose(evt:Event):void {
     this.confirmed = true;
     this.closeMe(evt);
+  }
+
+  public close(evt:Event):void {
+    this.closeMe(evt);
+    if (this.refreshOnCancel) {
+      window.location.reload();
+    }
   }
 }

--- a/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
+++ b/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
@@ -145,6 +145,7 @@ export class OpNonWorkingDaysListComponent implements OnInit {
           },
           dangerHighlighting: true,
           divideContent: true,
+          refreshOnCancel: true,
           showListData: this.removedNonWorkingDays.length > 0,
           warningText: this.text.warning,
           passedData: this.removedNonWorkingDays,


### PR DESCRIPTION
Make it possible in confirmation dialog to refresh the page if the user presses cancel button.

fixing: https://community.openproject.org/projects/openproject/work_packages/41226/activity#activity-46