### PR TITLE
Ignore builtin users in cleanup

### DIFF
--- a/spec/support/rspec_cleanup.rb
+++ b/spec/support/rspec_cleanup.rb
@@ -17,11 +17,11 @@ RSpec.configure do |config|
   # We don't want this to be reported on CI as it breaks the build
   unless ENV['CI']
     config.append_after(:suite) do
-      [User, Project, WorkPackage].each do |cls|
+      [User.not_builtin, Project, WorkPackage].each do |cls|
         next if cls.count == 0
 
         raise <<-EOS
-          Your specs left a #{cls} in the DB
+          Your specs left #{cls.count} #{cls.model_name.plural} in the DB
           Did you use before(:all) instead of before
           or forget to kill the instances in a after(:all)?
         EOS


### PR DESCRIPTION
With database_cleaner no longer running after each spec [1], implicitly created builtin users will not be cleaned up. As they are unique and reused, this is safe to ignore

[1] https://github.com/opf/openproject/pull/11443