### PR TITLE
Use library for drop modal positioning, fix story

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@appsignal/plugin-breadcrumbs-console": "^1.1.24",
         "@appsignal/plugin-breadcrumbs-network": "^1.1.21",
         "@datorama/akita": "^6.2.0",
+        "@floating-ui/dom": "^1.2.1",
         "@fullcalendar/angular": "^6.0.2",
         "@fullcalendar/common": "^6.0.0-beta.1",
         "@fullcalendar/core": "^6.0.2",
@@ -4975,6 +4976,19 @@
       },
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.2.1"
       }
     },
     "node_modules/@foliojs-fork/fontkit": {
@@ -52140,6 +52154,19 @@
       "requires": {
         "@figspec/components": "^1.0.0",
         "@lit-labs/react": "^1.0.2"
+      }
+    },
+    "@floating-ui/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "requires": {
+        "@floating-ui/core": "^1.2.1"
       }
     },
     "@foliojs-fork/fontkit": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,6 +98,7 @@
     "@appsignal/plugin-breadcrumbs-console": "^1.1.24",
     "@appsignal/plugin-breadcrumbs-network": "^1.1.21",
     "@datorama/akita": "^6.2.0",
+    "@floating-ui/dom": "^1.2.1",
     "@fullcalendar/angular": "^6.0.2",
     "@fullcalendar/common": "^6.0.0-beta.1",
     "@fullcalendar/core": "^6.0.2",

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -2,7 +2,7 @@
   [opened]="dropModalOpen"
   [allowRepositioning]="false"
   (closed)="close()"
-  alignment="bottom-left"
+  alignment="bottom-start"
   class="op-project-list-modal"
 >
   <button

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.html
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.html
@@ -8,26 +8,22 @@
 <ng-template #body>
   <div
     *ngIf="opened"
-    class="spot-drop-modal--anchor"
-    [ngStyle]="anchorStyles"
+    #anchor
     [attr.id]="id"
+    [ngClass]="['spot-drop-modal--body', 'spot-container' ]"
+    (click)="onBodyClick($event)"
+    cdkTrapFocus
+    tabindex="0"
   >
-    <div
-      [ngClass]="['spot-drop-modal--body', 'spot-container', alignmentClass]"
-      (click)="onBodyClick($event)"
-      cdkTrapFocus
-      tabindex="0"
-    >
-      <ng-content select="[slot=body]"></ng-content>
+    <ng-content select="[slot=body]"></ng-content>
 
-      <button
-        class="spot-drop-modal--close-button spot-button"
-        type="button"
-        [attr.aria-label]="text.close"
-        (click)="close()"
-      >
-        <span class="spot-icon spot-icon_close"></span>
-      </button>
-    </div>
+    <button
+      class="spot-drop-modal--close-button spot-button"
+      type="button"
+      [attr.aria-label]="text.close"
+      (click)="close()"
+    >
+      <span class="spot-icon spot-icon_close"></span>
+    </button>
   </div>
 </ng-template>

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -14,24 +14,10 @@ import {
 import { KeyCodes } from 'core-app/shared/helpers/keyCodes.enum';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { findAllFocusableElementsWithin } from 'core-app/shared/helpers/focus-helpers';
-import SpotDropAlignmentOption from '../../drop-alignment-options';
 import { SpotDropModalTeleportationService } from './drop-modal-teleportation.service';
 import { filter, take } from 'rxjs/operators';
 import { debounce } from 'lodash';
-
-const findClippingParent = (el:HTMLElement):HTMLElement => {
-  const parent = el.parentElement;
-  if (!parent) {
-    return document.body;
-  }
-
-  const styles = window.getComputedStyle(parent);
-  if (styles.overflowY !== 'visible' || styles.overflowX !== 'visible') {
-    return parent;
-  }
-
-  return findClippingParent(parent);
-};
+import { autoUpdate, computePosition, flip, limitShift, Placement, shift } from '@floating-ui/dom';
 
 @Component({
   selector: 'spot-drop-modal',
@@ -50,13 +36,7 @@ export class SpotDropModalComponent implements OnDestroy {
    * The default alignment of the drop modal. There are twelve alignments in total. You can check which ones they are
    * from the `SpotDropAlignmentOption` Enum that is available in 'core-app/spot/drop-alignment-options'.
    */
-  @Input() public alignment:SpotDropAlignmentOption = SpotDropAlignmentOption.BottomLeft;
-
-  private calculatedAlignment = SpotDropAlignmentOption.BottomLeft;
-
-  get alignmentClass():string {
-    return `spot-drop-modal--body_${this.allowRepositioning ? this.calculatedAlignment : this.alignment}`;
-  }
+  @Input() public alignment:Placement = 'bottom-end';
 
   public _opened = false;
 
@@ -102,19 +82,16 @@ export class SpotDropModalComponent implements OnDestroy {
    */
   @Output() closed = new EventEmitter<void>();
 
-  public anchorStyles = {
-    top: '0',
-    left: '0',
-    width: '0',
-    height: '0',
-  };
-
   public id = `drop-modal-${Math.round(Math.random() * 10000)}`;
 
   public text = {
     close: this.i18n.t('js.spot.drop_modal.close'),
     focus_grab: this.i18n.t('js.spot.drop_modal.focus_grab'),
   };
+
+  private cleanupFloatingUI:() => void|undefined;
+
+  @ViewChild('anchor') anchor:ElementRef;
 
   @ViewChild('body') body:TemplateRef<any>;
 
@@ -129,7 +106,6 @@ export class SpotDropModalComponent implements OnDestroy {
 
   open() {
     this._opened = true;
-    this.repositionAnchor();
     this.updateAppHeight();
     this.cdRef.detectChanges();
 
@@ -144,10 +120,33 @@ export class SpotDropModalComponent implements OnDestroy {
     this.teleportationService
       .hasRenderedFiltered$
       .pipe(
-        filter((hasRendered) => hasRendered),
+        filter((hasRendered) => !!hasRendered),
         take(1),
       )
       .subscribe(() => {
+        const referenceEl = this.elementRef.nativeElement;
+        const floatingEl = this.anchor.nativeElement;
+        this.cleanupFloatingUI = autoUpdate(
+          referenceEl,
+          floatingEl,
+          async () => {
+            const { x, y } = await computePosition(
+              referenceEl,
+              floatingEl,
+              {
+                placement: this.alignment,
+                middleware: this.allowRepositioning
+                  ? [ flip(), shift({ limiter: limitShift() }) ]
+                  : [],
+              },
+            );
+
+            Object.assign(floatingEl.style, {
+              left: `${x}px`,
+              top: `${y}px`,
+            });
+          }
+        );
         /*
          * We have to set these listeners next tick, because they're so far up the tree.
          * If the open value was set because of a click listener in the trigger slot,
@@ -156,11 +155,8 @@ export class SpotDropModalComponent implements OnDestroy {
         setTimeout(() => {
           document.body.addEventListener('click', this.onGlobalClick);
           document.body.addEventListener('keydown', this.onEscape);
-          document.body.addEventListener('scroll', this.onScroll, true);
           window.addEventListener('resize', this.onResize);
           window.addEventListener('orientationchange', this.onResize);
-
-          this.recalculateAlignment();
 
           const focusCatcherContainer = document.querySelectorAll("[data-modal-focus-catcher-container='true']")[0];
           if (focusCatcherContainer) {
@@ -186,7 +182,6 @@ export class SpotDropModalComponent implements OnDestroy {
      */
     document.body.removeEventListener('click', this.onGlobalClick);
     document.body.removeEventListener('keydown', this.onEscape);
-    document.body.removeEventListener('scroll', this.onScroll);
     window.removeEventListener('resize', this.onResize);
     window.removeEventListener('orientationchange', this.onResize);
 
@@ -201,59 +196,15 @@ export class SpotDropModalComponent implements OnDestroy {
     this.teleportationService.clear();
     document.body.removeEventListener('click', this.onGlobalClick);
     document.body.removeEventListener('keydown', this.onEscape);
-    document.body.removeEventListener('scroll', this.onScroll);
     window.removeEventListener('resize', this.onResize);
     window.removeEventListener('orientationchange', this.onResize);
+    this.cleanupFloatingUI?.()
   }
 
   onBodyClick(e:MouseEvent):void {
     // We stop propagation here so that clicks inside the body do not
     // close the modal when the event reaches the document body
     e.stopPropagation();
-  }
-
-  private recalculateAlignment(): void {
-    const anchor = document.getElementById(this.id);
-    if (!anchor) { return; }
-
-    const modalBody = anchor.querySelector('.spot-drop-modal--body');
-    if (!modalBody) { return; }
-
-    const alignments = Object.values(SpotDropAlignmentOption) as SpotDropAlignmentOption[];
-    const index = alignments.indexOf(this.alignment);
-    const originalAlignmentClass = this.alignmentClass;
-
-    const possibleAlignment = [
-      ...alignments.splice(index),
-      ...alignments.splice(0, index),
-    ].find((alignment:SpotDropAlignmentOption) => {
-        modalBody.classList.remove(this.alignmentClass);
-        this.calculatedAlignment = alignment; 
-        modalBody.classList.add(this.alignmentClass);
-        const rect = modalBody.getBoundingClientRect();
-
-        const spaceOnLeft = rect.left >= 0;
-        const spaceOnRight = rect.right <= window.innerWidth;
-        const spaceOnTop = rect.top >= 0;
-        const spaceOnBottom = rect.bottom <= window.innerHeight;
-        return spaceOnLeft && spaceOnRight && spaceOnTop && spaceOnBottom;
-      });
-
-    /**
-     * We need to remove any residual classes left on the nativeElement after
-     * calculating the possibleAlignments. The final calculated alignment
-     * is applied via the `alignmentClass` function anyway.
-     */
-    modalBody.classList.remove(this.alignmentClass);
-    modalBody.classList.add(originalAlignmentClass);
-
-    if (possibleAlignment) {
-      this.calculatedAlignment = possibleAlignment;
-    } else {
-      this.calculatedAlignment = this.alignment;
-    }
-
-    this.cdRef.detectChanges();
   }
 
   private escapeCallback = (evt:KeyboardEvent) => {
@@ -266,8 +217,6 @@ export class SpotDropModalComponent implements OnDestroy {
 
   private resizeCallback():void {
     this.updateAppHeight();
-    this.repositionAnchor();
-    this.recalculateAlignment();
   }
 
   private onResize = debounce(this.resizeCallback.bind(this), 10);
@@ -276,14 +225,4 @@ export class SpotDropModalComponent implements OnDestroy {
     const doc = document.documentElement;
     doc.style.setProperty('--app-height', `${window.innerHeight}px`);
   };
-
-  private repositionAnchor():void {
-    const elementRect = (this.elementRef.nativeElement as HTMLElement).getBoundingClientRect();
-    this.anchorStyles.top = `${elementRect.top}px`;
-    this.anchorStyles.left = `${elementRect.left}px`;
-    this.anchorStyles.width = `${elementRect.width}px`;
-    this.anchorStyles.height = `${elementRect.height}px`;
-  }
-
-  private onScroll = debounce(this.repositionAnchor.bind(this), 16);
 }

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -17,7 +17,14 @@ import { findAllFocusableElementsWithin } from 'core-app/shared/helpers/focus-he
 import { SpotDropModalTeleportationService } from './drop-modal-teleportation.service';
 import { filter, take } from 'rxjs/operators';
 import { debounce } from 'lodash';
-import { autoUpdate, computePosition, flip, limitShift, Placement, shift } from '@floating-ui/dom';
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  limitShift,
+  Placement,
+  shift,
+} from '@floating-ui/dom';
 
 @Component({
   selector: 'spot-drop-modal',
@@ -124,8 +131,8 @@ export class SpotDropModalComponent implements OnDestroy {
         take(1),
       )
       .subscribe(() => {
-        const referenceEl = this.elementRef.nativeElement;
-        const floatingEl = this.anchor.nativeElement;
+        const referenceEl = this.elementRef.nativeElement as HTMLElement;
+        const floatingEl = this.anchor.nativeElement as HTMLElement;
         this.cleanupFloatingUI = autoUpdate(
           referenceEl,
           floatingEl,
@@ -136,7 +143,10 @@ export class SpotDropModalComponent implements OnDestroy {
               {
                 placement: this.alignment,
                 middleware: this.allowRepositioning
-                  ? [ flip(), shift({ limiter: limitShift() }) ]
+                  ? [
+                      flip(),
+                      shift({ limiter: limitShift() }),
+                    ]
                   : [],
               },
             );
@@ -145,7 +155,7 @@ export class SpotDropModalComponent implements OnDestroy {
               left: `${x}px`,
               top: `${y}px`,
             });
-          }
+          },
         );
         /*
          * We have to set these listeners next tick, because they're so far up the tree.
@@ -198,7 +208,7 @@ export class SpotDropModalComponent implements OnDestroy {
     document.body.removeEventListener('keydown', this.onEscape);
     window.removeEventListener('resize', this.onResize);
     window.removeEventListener('orientationchange', this.onResize);
-    this.cleanupFloatingUI?.()
+    this.cleanupFloatingUI?.();
   }
 
   onBodyClick(e:MouseEvent):void {

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -54,11 +54,11 @@ export class SpotDropModalComponent implements OnDestroy {
   @Input('opened')
   @HostBinding('class.spot-drop-modal_opened')
   set opened(value:boolean) {
-    if (this._opened === !!value) {
+    if (this._opened === value) {
       return;
     }
 
-    if (!!value) {
+    if (value) {
       this.open();
     } else {
       this.close();
@@ -122,7 +122,7 @@ export class SpotDropModalComponent implements OnDestroy {
      * template in the same tick.
      * To make it happy, we update afterwards
      */
-    this.teleportationService.activate(this.body)
+    this.teleportationService.activate(this.body);
 
     this.teleportationService
       .hasRenderedFiltered$
@@ -136,18 +136,17 @@ export class SpotDropModalComponent implements OnDestroy {
         this.cleanupFloatingUI = autoUpdate(
           referenceEl,
           floatingEl,
+          /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
           async () => {
             const { x, y } = await computePosition(
               referenceEl,
               floatingEl,
               {
                 placement: this.alignment,
-                middleware: this.allowRepositioning
-                  ? [
-                      flip(),
-                      shift({ limiter: limitShift() }),
-                    ]
-                  : [],
+                middleware: this.allowRepositioning ? [
+                  flip(),
+                  shift({ limiter: limitShift() }),
+                ] : [],
               },
             );
 
@@ -170,10 +169,10 @@ export class SpotDropModalComponent implements OnDestroy {
 
           const focusCatcherContainer = document.querySelectorAll("[data-modal-focus-catcher-container='true']")[0];
           if (focusCatcherContainer) {
-            (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0] as HTMLElement)?.focus();
+            (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0])?.focus();
           } else {
             // Index 1 because the element at index 0 is the trigger button to open the modal
-            (findAllFocusableElementsWithin(document.querySelector('.spot-drop-modal-portal')!)[1] as HTMLElement)?.focus();
+            (findAllFocusableElementsWithin(document.querySelector('.spot-drop-modal-portal')!)[1])?.focus();
           }
         });
       });
@@ -197,10 +196,10 @@ export class SpotDropModalComponent implements OnDestroy {
 
     this.teleportationService.clear();
     this.cdRef.detectChanges();
-    this.focusGrabber.nativeElement.focus();
+    (this.focusGrabber.nativeElement as HTMLElement).focus();
   }
 
-  private onGlobalClick = this.close.bind(this);
+  private onGlobalClick = this.close.bind(this) as () => void;
 
   ngOnDestroy():void {
     this.teleportationService.clear();

--- a/frontend/src/app/spot/components/drop-modal/stories/DropModal.stories.mdx
+++ b/frontend/src/app/spot/components/drop-modal/stories/DropModal.stories.mdx
@@ -28,6 +28,21 @@ export const dummy = (() => window.I18n = new I18nShim())();
 
 # Drop Modal
 
+Drop modals are in-between dropdowns and modals. In fact, on mobile they're indistinguishable from a normal spot-modal.
+The key difference however, is that they're tied to a specific context. On desktop views, the modal will open
+in-context, meaning that it will attach to the button or input field that opened the modal.
+
+## Usage
+
+To use drop-modals, make sure to also add the drop-modal portal to the base of your application HTML:
+
+```
+<spot-drop-modal-portal></spot-drop-modal-portal>
+```
+
+Even though drop-modals look like they are attached to an element, they're actually rendered in this portal to make sure
+they're not cut off my scrolling context or `overflow: visible` rules on parent elements.
+
 <Canvas>
   <Story
     name="Angular component"

--- a/frontend/src/app/spot/components/drop-modal/stories/DropModalList.component.html
+++ b/frontend/src/app/spot/components/drop-modal/stories/DropModalList.component.html
@@ -1,3 +1,5 @@
+<spot-drop-modal-portal></spot-drop-modal-portal>
+
 <spot-drop-modal
   [opened]="dropModalOpen"
   (closed)="close()"

--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -1,24 +1,16 @@
 .spot-drop-modal
   display: inline-flex
 
-  &--anchor
+  &--body
+    $border-radius: 5px
+
     position: absolute
     @include spot-z-index("drop-modal", 1)
     pointer-events: none
 
-  &--body
-    $border-radius: 5px
-
     pointer-events: all
     opacity: 1
 
-    position: fixed
-    height: auto
-    bottom: $spot-spacing-3_5
-    left: $spot-spacing-1
-    right: $spot-spacing-1
-    width: calc(100vw - (2 * #{$spot-spacing-1}))
-    height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
     box-shadow: $spot-shadow-light-mid
     background: $spot-color-basic-white
     border-radius: $border-radius
@@ -32,6 +24,17 @@
       max-height: calc(#{var(--app-height)} - (2 * #{$spot-spacing-1}))
       width: calc(100vw - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
 
+    @media #{$spot-mq-drop-modal-full-screen}
+      position: fixed
+      height: auto
+      bottom: $spot-spacing-3_5
+      // !important is needed here so `@floating-ui/dom` does not overwrite it.
+      left: $spot-spacing-1 !important
+      top: unset !important
+      right: $spot-spacing-1
+      width: calc(100vw - (2 * #{$spot-spacing-1}))
+      height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
+
     @media #{$spot-mq-drop-modal-in-context}
       position: absolute
       bottom: unset
@@ -41,58 +44,6 @@
       height: auto
       max-width: calc(100vw - (2 * #{$spot-spacing-1}))
       max-height: calc(#{var(--app-height)} - (2 * #{$spot-spacing-1}))
-
-      &_left-top
-        right: 100%
-        top: 0%
-
-      &_left-center
-        right: 100%
-        top: 50%
-        transform: translateY(-50%)
-
-      &_left-bottom
-        right: 100%
-        bottom: 0%
-
-      &_bottom-left
-        top: 100%
-        left: 0%
-
-      &_bottom-center
-        top: 100%
-        left: 50%
-        transform: translateX(-50%)
-
-      &_bottom-right
-        top: 100%
-        right: 0%
-
-      &_right-top
-        left: 100%
-        top: 0%
-
-      &_right-center
-        left: 100%
-        top: 50%
-        transform: translateY(-50%)
-
-      &_right-bottom
-        left: 100%
-        bottom: 0%
-
-      &_top-left
-        bottom: 100%
-        left: 0%
-
-      &_top-center
-        bottom: 100%
-        left: 50%
-        transform: translateX(-50%)
-
-      &_top-right
-        bottom: 100%
-        right: 0%
 
     // TODO: At some point, this needs to be a cleverer selector.
     // Though most action bars will probably be at the bottom of a drop-modal,

--- a/frontend/src/app/spot/styles/tokens/dist/tokens.json
+++ b/frontend/src/app/spot/styles/tokens/dist/tokens.json
@@ -55,6 +55,7 @@
   "spot-shadow-hard-mid": "3px 3px 10px rgba(0, 0, 0, 0.25)",
   "spot-shadow-hard-high": "5px 5px 20px rgba(0, 0, 0, 0.25)",
   "spot-mq-landscape": "'(orientation: landscape)'",
+  "spot-mq-drop-modal-full-screen": "'(max-width: 999px), (max-height: 499px)'",
   "spot-mq-drop-modal-in-context": "'(min-width: 1000px) and (min-height: 500px)'",
   "spot-mq-action-bar-change": "'(min-width: 768px)'",
   "spot-mq-mobile": "'(max-width: 679px)'",

--- a/frontend/src/app/spot/styles/tokens/dist/tokens.sass
+++ b/frontend/src/app/spot/styles/tokens/dist/tokens.sass
@@ -55,6 +55,7 @@ $spot-shadow-hard-low: 1px 1px 5px rgba(0, 0, 0, 0.25)
 $spot-shadow-hard-mid: 3px 3px 10px rgba(0, 0, 0, 0.25)
 $spot-shadow-hard-high: 5px 5px 20px rgba(0, 0, 0, 0.25)
 $spot-mq-landscape: '(orientation: landscape)'
+$spot-mq-drop-modal-full-screen: '(max-width: 999px), (max-height: 499px)'
 $spot-mq-drop-modal-in-context: '(min-width: 1000px) and (min-height: 500px)'
 $spot-mq-action-bar-change: '(min-width: 768px)'
 $spot-mq-mobile: '(max-width: 679px)'

--- a/frontend/src/app/spot/styles/tokens/media-queries.yml
+++ b/frontend/src/app/spot/styles/tokens/media-queries.yml
@@ -2,6 +2,9 @@ props:
   spot-mq-landscape:
     value: "'(orientation: landscape)'"
 
+  spot-mq-drop-modal-full-screen:
+    value: "'(max-width: 999px), (max-height: 499px)'"
+
   spot-mq-drop-modal-in-context:
     value: "'(min-width: 1000px) and (min-height: 500px)'"
 


### PR DESCRIPTION
After out-of-tree rendering was implemented for drop-modals, we had some issues surrounding positioning. By using the `@floating-ui/dom` library, we can avoid implementing this logic ourselves, and also fix an overflow scroll bug.

At the same time, this commit fixes the drop-modal story that broke.

Closes https://community.openproject.org/work_packages/46164/activity