### PR TITLE
fix showing bin icon in touchscreen devices specified in [41226] Instance-wide public holidays (non-working days)

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -292,6 +292,7 @@ en:
         warning: >
           The changes might take some time to take effect. You will be notified when all relevant work packages have been updated.
 
+
           Are you sure you want to continue?
     custom_actions:
       date:

--- a/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.sass
+++ b/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.sass
@@ -29,3 +29,10 @@
       cursor: default
       color: black
       text-decoration: none
+
+  .fc-list-event-title a
+    cursor: text
+
+  @media screen and (max-width: 679px)
+   .op-non-working-days-list--delete-icon
+      opacity: 1


### PR DESCRIPTION
Always show bin icon when it is a touchscreen device.

fixing 8th number in: https://community.openproject.org/work_packages/41226/activity#activity-44