### PR TITLE
Fix meetings form layout, initialize the single datepicker with today

### DIFF
--- a/app/views/versions/_form.html.erb
+++ b/app/views/versions/_form.html.erb
@@ -58,23 +58,11 @@ See COPYRIGHT and LICENSE files for more details.
 </div>
 
 <div class="form--field">
-  <label
-    class="form--label"
-    for="version_start_date"
-  ><%= t(:start_date) %></label>
-  <div class="form--field-container -visible-overflow">
-    <%= f.date_picker :start_date %>
-  </div>
+  <%= f.date_picker :start_date, container_class: '-xslim' %>
 </div>
 
 <div class="form--field">
-  <label
-    class="form--label"
-    for="version_effective_date"
-  ><%= t(:effective_date) %></label>
-  <div class="form--field-container -visible-overflow">
-    <%= f.date_picker :effective_date %>
-  </div>
+  <%= f.date_picker :effective_date, container_class: '-xslim' %>
 </div>
 
 <div class="form--field">

--- a/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
@@ -224,6 +224,12 @@ export class OpSingleDatePickerComponent implements ControlValueAccessor, AfterC
   private initializeDatepicker() {
     this.datePickerInstance?.destroy();
 
+    if (!this.value) {
+      // Set the initial date to today, if no value is provided.
+      const today = parseDate(new Date()) as Date;
+      this.writeWorkingValue(this.timezoneService.formattedISODate(today));
+    }
+
     this.datePickerInstance = new DatePicker(
       this.injector,
       this.id,

--- a/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
@@ -224,11 +224,9 @@ export class OpSingleDatePickerComponent implements ControlValueAccessor, AfterC
   private initializeDatepicker() {
     this.datePickerInstance?.destroy();
 
-    if (!this.value) {
-      // Set the initial date to today, if no value is provided.
-      const today = parseDate(new Date()) as Date;
-      this.writeWorkingValue(this.timezoneService.formattedISODate(today));
-    }
+    // Initialize the working values.
+    const initialDate = parseDate(this.value || new Date()) as Date;
+    this.writeWorkingValue(this.timezoneService.formattedISODate(initialDate));
 
     this.datePickerInstance = new DatePicker(
       this.injector,

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-$form--field-types: (text-field, text-area, select, check-box, radio-button, range-field, search, file)
+$form--field-types: (text-field, text-area, select, check-box, radio-button, range-field, search, file, date-picker)
 
 %input-style
   border: var(--content-form-input-border)


### PR DESCRIPTION
See [OP#42358](https://community.openproject.org/projects/openproject/work_packages/42358/activity).

Addressing the bugs from the [comment](https://community.openproject.org/projects/openproject/work_packages/42358?query_id=3593#activity-29):

4. [X] I noticed that if we want to create a new Version, inside the old Start and Effective dates fields, there are now also Start and Finish dates with date pickers which start with January 1970
5. [X] Preserve the datepicker's selection when re-opening the datepicker with an existing date.