### PR TITLE
[45794] Incorrect width of the "Add" buttons in the sidebar (Calendar, Boards)

### DIFF
--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -11,7 +11,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="canCreateBoards$ | async"
-    class="button -alt-highlight"
+    class="button -alt-highlight -expand"
     (click)="showNewBoardModal()"
     [title]="text.create_new_board"
     data-qa-selector="sidebar--create-board-button"

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
@@ -11,7 +11,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="(canCreateCalendar$ | async)"
-    class="button -alt-highlight"
+    class="button -alt-highlight -expand"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
     [title]="text.create_new_calendar"


### PR DESCRIPTION
Add missing class '-expand' to the add buttons of calendar and board modules.

https://community.openproject.org/projects/openproject/work_packages/45794/activity