### PR TITLE
Fix backlogs opening and saving datepicker after changing values

### DIFF
--- a/frontend/src/app/core/augmenting/dynamic-scripts/backlogs/editable_inplace.js
+++ b/frontend/src/app/core/augmenting/dynamic-scripts/backlogs/editable_inplace.js
@@ -31,7 +31,8 @@ RB.EditableInplace = (function ($) {
 
     displayEditor: function (editor) {
       this.$.addClass("editing");
-      editor.find(".editor").bind('keydown', this.handleKeydown);
+      editor.find(".editor:not(op-single-date-picker)").bind('keydown', this.handleKeydown);
+      editor.find("op-single-date-picker input[type=hidden]").on('change', this.saveEdits.bind(this));
     },
 
     getEditor: function () {

--- a/frontend/src/app/core/augmenting/dynamic-scripts/backlogs/model.js
+++ b/frontend/src/app/core/augmenting/dynamic-scripts/backlogs/model.js
@@ -385,6 +385,10 @@ RB.Model = (function ($) {
       } else {
         this.open();
       }
+      window.OpenProject.getPluginContext().then((pluginContext) => {
+        pluginContext.bootstrap(this.$[0]);
+      });
+
       this.refreshed();
     },
 

--- a/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
@@ -288,12 +288,12 @@
       align-items: center
       flex-direction: row-reverse
 
-    .editor
+    .editor, .spot-input
       font-size: 0.9rem
       line-height: 1.5rem
       height: 30px
       margin: 0
-      padding: 0
+      padding: 0 5px
 
       &.name
         flex-basis: 15em

--- a/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.html
@@ -92,9 +92,10 @@
 </spot-drop-modal>
 
 <input
+  #syncedInput
   [name]="name"
   [value]="value"
   [ngClass]="{ 'remote-field--input': !!remoteFieldKey }"
   [attr.data-remote-field-key]="remoteFieldKey"
-  hidden
+  type="hidden"
 >

--- a/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
@@ -279,7 +279,7 @@ export class OpSingleDatePickerComponent implements ControlValueAccessor, OnInit
   writeValue(value:string):void {
     this.writeWorkingValue(value);
     this.value = value;
-    this.syncedInput?.nativeElement.dispatchEvent(new Event('change'));
+    setTimeout(() => this.syncedInput?.nativeElement.dispatchEvent(new Event('change')));
   }
 
   onChange = (_:string):void => {};

--- a/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/single-date-picker/single-date-picker.component.ts
@@ -129,6 +129,8 @@ export class OpSingleDatePickerComponent implements ControlValueAccessor, OnInit
 
   @ViewChild('flatpickrTarget') flatpickrTarget:ElementRef;
 
+  @ViewChild('syncedInput') syncedInput:ElementRef<HTMLInputElement>;
+
   public workingValue = '';
 
   public workingDate:Date|null = null;
@@ -277,6 +279,7 @@ export class OpSingleDatePickerComponent implements ControlValueAccessor, OnInit
   writeValue(value:string):void {
     this.writeWorkingValue(value);
     this.value = value;
+    this.syncedInput?.nativeElement.dispatchEvent(new Event('change'));
   }
 
   onChange = (_:string):void => {};

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -45,6 +45,8 @@ module Pages
 
     def enter_edit_backlog_mode(backlog)
       within_backlog(backlog) do
+        return if has_selector?('.editing')
+
         find('.start_date.editable').click
       end
     end
@@ -82,8 +84,10 @@ module Pages
             find('input[name=name]').set value
           end
         when :start_date
+          enter_edit_backlog_mode(backlog)
           ::Components::Datepicker.update_field("#start_date_#{backlog.id}", value)
         when :effective_date
+          enter_edit_backlog_mode(backlog)
           ::Components::Datepicker.update_field("#effective_date_#{backlog.id}", value)
         else
           raise NotImplementedError
@@ -108,6 +112,8 @@ module Pages
 
     def save_backlog_from_edit_mode(backlog)
       within_backlog(backlog) do
+        return unless has_selector?('.editing')
+
         find('input[name=name]').native.send_key :return
 
         expect(page)


### PR DESCRIPTION
https://community.openproject.org/wp/46208

- [x] Saving the datepicker will also save the edit form of the sprint. This requires minor changes in the backlogs spec
- [x] Correctly bootstrap the datepicker after returning from the POST