### PR TITLE
Fix alignment of text in project tables

### DIFF
--- a/frontend/src/global_styles/content/_project_status.sass
+++ b/frontend/src/global_styles/content/_project_status.sass
@@ -70,6 +70,7 @@
 .project-status--name
   text-transform: uppercase
   font-weight: bold
+
   &.-not-set
     color: var(--project-status-gray)
   &.-off-track

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -167,13 +167,21 @@ table.generic-table
       td:not(.-no-ellipsis)
         @include text-shortener
 
+    .project td
+      > span,
+      > a
+        // Because of the way table-cell display works,
+        // the easiest way to properly center-align inline
+        // elements is to just push them down a pixel.
+        position: relative
+        top: 1px
+
     td
       max-width: 300px
       text-align: left
       line-height: 1.6
       padding-top: 0.5rem
       padding-bottom: 0.5rem
-      vertical-align: top
 
       &.form--td
         vertical-align: middle


### PR DESCRIPTION
Text in table cells was spaced too high up. Icons generally looked correct. Changing the paddings for the cells was out of the question, because that would misalign items that fill the full height.

This commit pushes down `a` and `span` elements inside table cells by one pixel. This is rather hacky, but it makes sure we don't have to completely redo the way positioning works in table cells in general.

Closes https://community.openproject.org/work_packages/45946/activity