### PR TITLE
ensure most recent dom element is used on resizing

### DIFF
--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -84,7 +84,10 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   ngOnInit() {
     // Get element
-    this.resizingElement = <HTMLElement>document.getElementsByClassName(this.elementClass)[0];
+    // We use this more complicated approach of taking the last element of the class as it allows
+    // to still work in case an element is duplicated by Angular.
+    const elements = document.getElementsByClassName(this.elementClass);
+    this.resizingElement = <HTMLElement>elements[elements.length - 1];
 
     // Get initial width from local storage and apply
     const localStorageValue = this.parseLocalStorageValue();


### PR DESCRIPTION
Some instance have custom plugins that make use of the "BrowserAnimationsModule" which seems to duplicate a DOM element. If that is the case, the code before (`document.getElementsByClassName(this.elementClass)[0]`) would still be operating on the DOM element to be replaced.

https://community.openproject.org/wp/44278