### PR TITLE
clear file mount column on custom style image deletion

### DIFF
--- a/app/models/custom_style.rb
+++ b/app/models/custom_style.rb
@@ -32,6 +32,8 @@ class CustomStyle < ApplicationRecord
     define_method "remove_#{name}" do
       image = send(name)
       image&.remove!
+
+      update_column name, nil
     end
   end
 end

--- a/spec/models/custom_style_spec.rb
+++ b/spec/models/custom_style_spec.rb
@@ -26,5 +26,42 @@ RSpec.describe CustomStyle, type: :model do
         expect(subject).to be_nil
       end
     end
+
+    shared_examples "removing an image from a custom style" do
+      let(:image) { raise "define me!" }
+      let(:custom_style) { create "custom_style_with_#{image}" }
+
+      let!(:file_path) { custom_style.send(image).file.path }
+
+      before do
+        custom_style.send "remove_#{image}"
+      end
+
+      it 'deletes the file' do
+        expect(File.exists?(file_path)).to be false
+      end
+
+      it 'clears the file mount column' do
+        expect(custom_style.reload.send(image).file).to be_nil
+      end
+    end
+
+    describe "#remove_favicon" do
+      it_behaves_like "removing an image from a custom style" do
+        let(:image) { "favicon" }
+      end
+    end
+
+    describe "#remove_touch_icon" do
+      it_behaves_like "removing an image from a custom style" do
+        let(:image) { "touch_icon" }
+      end
+    end
+
+    describe "#remove_logo" do
+      it_behaves_like "removing an image from a custom style" do
+        let(:image) { "logo" }
+      end
+    end
   end
 end


### PR DESCRIPTION
previously the file was just deleted, but the reference to it maintained

WP [#45997](https://community.openproject.org/projects/openproject/work_packages/45997/activity)