### PR TITLE
[46159] Date picker on Non-working days: not enough spacing between the date field and the calendar + arrows

### DIFF
--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -89,11 +89,6 @@ $datepicker--border-radius: 5px
     &:only-of-type
       padding: 0
 
-  .flatpickr-prev-month
-    padding-left: 0
-  .flatpickr-next-month
-    padding-right: 0
-
   .flatpickr-days
     .dayContainer
       box-shadow: none


### PR DESCRIPTION
Remove paading left and right from prev and next arrows.

https://community.openproject.org/projects/openproject/work_packages/46159/activity