### PR TITLE
Fix N+1 performance issue on storage api get

### DIFF
--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -180,12 +180,12 @@ module API::V3::Storages
 
     private
 
-    def storage_projects_ids(model)
-      model.projects.filter { |project| user_allowed_to_manage?(project) }.map(&:id)
+    def storage_projects_ids(storage)
+      storage.projects.filter { |project| user_allowed_to_manage?(project) }.map(&:id)
     end
 
-    def user_allowed_to_manage?(model)
-      current_user.allowed_to?(:manage_file_links, model.project)
+    def user_allowed_to_manage?(project)
+      current_user.allowed_to?(:manage_file_links, project)
     end
 
     def authorization_state

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -181,11 +181,9 @@ module API::V3::Storages
     private
 
     def storage_projects_ids(storage)
-      storage.projects.filter { |project| user_allowed_to_manage?(project) }.map(&:id)
-    end
-
-    def user_allowed_to_manage?(project)
-      current_user.allowed_to?(:manage_file_links, project)
+      storage.projects
+        .merge(Project.allowed_to(current_user, :manage_file_links))
+        .pluck(:id)
     end
 
     def authorization_state

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -91,33 +91,33 @@ describe API::V3::Storages::StorageRepresenter, 'rendering' do
         # rubocop:disable RSpec/ExampleLength
         it 'contains upload information for each of these projects' do
           project_linked_with_upload_permission =
-            create(:project).tap do |project|
+            create(:project, name: 'project linked, user member with upload permission').tap do |project|
               create(:project_storage, project:, storage:, creator: user)
               create(:member, user:, project:, roles: [uploader_role])
             end
           another_project_linked_with_upload_permission =
-            create(:project).tap do |project|
+            create(:project, name: 'another project linked, user member with upload permission').tap do |project|
               create(:project_storage, project:, storage:, creator: user)
               create(:member, user:, project:, roles: [uploader_role])
             end
-          _project_linked_without_any_permissions =
-            create(:project).tap do |project|
-              create(:project_storage, project:, storage:, creator: user)
-              create(:member, user:, project:, roles: [no_permissions_role])
-            end
-          _project_linked_not_member =
-            create(:project).tap do |project|
-              create(:project_storage, project:, storage:, creator: user)
-            end
-          _project_linked_another_user_member =
-            create(:project).tap do |project|
-              create(:project_storage, project:, storage:, creator: user)
-              create(:member, user: another_user, project:, roles: [uploader_role])
-            end
-          _project_not_linked_with_upload_permission =
-            create(:project).tap do |project|
-              create(:member, user:, project:, roles: [uploader_role])
-            end
+          create(:project, name: 'project linked, no permissions').tap do |project|
+            create(:project_storage, project:, storage:, creator: user)
+            create(:member, user:, project:, roles: [no_permissions_role])
+          end
+          create(:project, name: 'project linked, user not member').tap do |project|
+            create(:project_storage, project:, storage:, creator: user)
+          end
+          create(:project, active: false, name: 'archived project linked, user member with upload permission').tap do |project|
+            create(:project_storage, project:, storage:, creator: user)
+            create(:member, user:, project:, roles: [uploader_role])
+          end
+          create(:project, name: 'project linked, another user is member with upload permission').tap do |project|
+            create(:project_storage, project:, storage:, creator: user)
+            create(:member, user: another_user, project:, roles: [uploader_role])
+          end
+          create(:project, name: 'project not linked, with upload permission').tap do |project|
+            create(:member, user:, project:, roles: [uploader_role])
+          end
 
           expect(generated).to have_json_size(2).at_path('_links/prepareUpload')
 


### PR DESCRIPTION
According to [AppSignal on community](https://appsignal.com/openproject-gmbh/sites/62b06dacd2a5e41321946fcf/performance?query=), [GET::API::V3::Storages::StoragesAPI#/storages/:storage_id/](https://appsignal.com/openproject-gmbh/sites/62b06dacd2a5e41321946fcf/performance/incidents/411) endpoint is the one having most impact with a mean time of 385 ms.

When observing the event timeline of the AppSignal samples for this endpoint, a pattern repeats: selecting roles, permissions, and modules multiple times.

It is a N+1 issue where the roles and permissions will be checked for each project the storage is connected to in order to return the `prepareUpload` array in the json response.

It's fixed using `Project.allowed_to(user, permission)`, and basic test coverage for it was added.