### PR TITLE
optimize calculating assignables for multiple projects

### DIFF
--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -86,7 +86,7 @@ class WorkPackages::BulkController < ApplicationController
   def setup_edit
     @available_statuses = @projects.map { |p| Workflow.available_statuses(p) }.inject(&:&)
     @custom_fields = @projects.map(&:all_work_package_custom_fields).inject(&:&)
-    @assignables = @responsibles = possible_assignees
+    @assignables = @responsibles = Principal.possible_assignee(@projects)
     @types = @projects.map(&:types).inject(&:&)
   end
 
@@ -99,12 +99,6 @@ class WorkPackages::BulkController < ApplicationController
     rescue ::ActiveRecord::RecordNotFound
       # raised by #reload if work package no longer exists
       # nothing to do, work package was already deleted (eg. by a parent)
-    end
-  end
-
-  def possible_assignees
-    @projects.inject(Principal.all) do |scope, project|
-      scope.where(id: Principal.possible_assignee(project))
     end
   end
 

--- a/app/models/principals/scopes/possible_assignee.rb
+++ b/app/models/principals/scopes/possible_assignee.rb
@@ -40,13 +40,18 @@ module Principals::Scopes
       # * Group
       # User instances need to be non locked (status).
       # Only principals with a role marked as assignable in the project are returned.
-      # @project [Project] The project for which eligible candidates are to be searched
+      # If more than one project is given, the principals need to be assignable in all of the projects (intersection).
+      # @project [Project, [Project]] The project for which eligible candidates are to be searched
       # @return [ActiveRecord::Relation] A scope of eligible candidates
       def possible_assignee(project)
-        not_locked
-          .includes(:members)
-          .references(:members)
-          .merge(Member.assignable.of(project))
+        where(
+          id: Member
+              .assignable
+              .of(project)
+              .group('user_id')
+              .having(["COUNT(DISTINCT(project_id, user_id)) = ?", Array(project).count])
+              .select('user_id')
+        )
       end
     end
   end

--- a/spec/models/principals/scopes/possible_assignee_spec.rb
+++ b/spec/models/principals/scopes/possible_assignee_spec.rb
@@ -110,5 +110,21 @@ describe Principals::Scopes::PossibleAssignee do
           .to be_empty
       end
     end
+
+    context 'when asking for multiple projects' do
+      subject { Principal.possible_assignee([project, other_project]) }
+
+      before do
+        create(:member,
+               principal: member_user,
+               project: other_project,
+               roles: [role])
+      end
+
+      it 'returns users assignable in all of the provided projects (intersection)' do
+        expect(subject)
+          .to match_array([member_user])
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of having a where subquery for each project, the number of memberships which grant assignability (DISTINCT) need to be equal or higher to the number of projects.

https://community.openproject.org/wp/46284