### PR TITLE
[#46150] introduce op-upload-service

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -36,7 +36,9 @@ import {
   HTTP_INTERCEPTORS,
   HttpClientModule,
 } from '@angular/common/http';
+import { A11yModule } from '@angular/cdk/a11y';
 import { ReactiveFormsModule } from '@angular/forms';
+
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { States } from 'core-app/core/states/states.service';
 import { OpenprojectFieldsModule } from 'core-app/shared/components/fields/openproject-fields.module';
@@ -76,7 +78,7 @@ import { PasswordConfirmationModalComponent } from 'core-app/shared/components/m
 import { WpPreviewModalComponent } from 'core-app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal';
 import { OpHeaderProjectSelectComponent } from 'core-app/shared/components/header-project-select/header-project-select.component';
 import { OpHeaderProjectSelectListComponent } from 'core-app/shared/components/header-project-select/list/header-project-select-list.component';
-
+import { OpUploadService } from 'core-app/core/upload/upload.service';
 import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
 import { MainMenuResizerComponent } from 'core-app/shared/components/resizer/resizer/main-menu-resizer.component';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
@@ -88,12 +90,11 @@ import { OpenprojectPluginsModule } from 'core-app/features/plugins/openproject-
 import { LinkedPluginsModule } from 'core-app/features/plugins/linked-plugins.module';
 import { OpenProjectInAppNotificationsModule } from 'core-app/features/in-app-notifications/in-app-notifications.module';
 import { OpenProjectBackupService } from './core/backup/op-backup.service';
-import { OpenProjectDirectFileUploadService } from './core/file-upload/op-direct-file-upload.service';
+import { OpenProjectDirectFileUploadService } from 'core-app/core/file-upload/op-direct-file-upload.service';
 import { OpenProjectStateModule } from 'core-app/core/state/openproject-state.module';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
 import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 import { TopMenuService } from 'core-app/core/top-menu/top-menu.service';
-import { A11yModule } from '@angular/cdk/a11y';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -207,6 +208,7 @@ export function initializeServices(injector:Injector) {
     },
     PaginationService,
     OpenProjectBackupService,
+    OpUploadService,
     OpenProjectFileUploadService,
     OpenProjectDirectFileUploadService,
     ConfirmDialogService,

--- a/frontend/src/app/core/upload/upload.service.ts
+++ b/frontend/src/app/core/upload/upload.service.ts
@@ -1,0 +1,138 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { HttpClient, HttpEvent } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { share } from 'rxjs/operators';
+
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
+
+export interface NextcloudUploadConfiguration {
+  type:'nextcloud';
+  overwrite:boolean;
+}
+
+export interface FogStorageUploadConfiguration {
+  type:'fog';
+  description?:string;
+  fileName:string;
+  contentType:string;
+  fileSize:string;
+}
+
+export interface LocalStorageUploadConfiguration {
+  type:'local';
+  description?:string;
+  fileName:string;
+}
+
+export type UploadConfiguration =
+  NextcloudUploadConfiguration
+  |FogStorageUploadConfiguration
+  |LocalStorageUploadConfiguration;
+
+export interface FileForUpload extends File {
+  config:UploadConfiguration;
+}
+
+@Injectable()
+export class OpUploadService {
+  constructor(private readonly http:HttpClient) {}
+
+  public upload<T>(url:string, files:FileForUpload[]):Observable<HttpEvent<T>>[] {
+    return files.map((file) => this.uploadSingle<T>(url, file));
+  }
+
+  private uploadSingle<T>(url:string, file:FileForUpload):Observable<HttpEvent<T>> {
+    let observable:Observable<HttpEvent<T>>;
+
+    switch (file.config.type) {
+      case 'nextcloud':
+        observable = this.nextcloudRequest<T>(url, file);
+        break;
+      case 'local':
+        observable = this.localRequest<T>(url, file);
+        break;
+      default:
+        throw new Error(`Cannot create request for type '${file.config.type}'.`);
+    }
+
+    return observable.pipe(share());
+  }
+
+  private nextcloudRequest<T>(url:string, file:FileForUpload):Observable<HttpEvent<T>> {
+    return this.http.request<T>(
+      'post',
+      url,
+      {
+        body: this.formData(file),
+        headers: { [EXTERNAL_REQUEST_HEADER]: 'true' },
+        observe: 'events',
+        reportProgress: true,
+        responseType: 'json',
+      },
+    );
+  }
+
+  private localRequest<T>(url:string, file:FileForUpload):Observable<HttpEvent<T>> {
+    return this.http.request(
+      'post',
+      url,
+      {
+        body: this.formData(file),
+        observe: 'events',
+        withCredentials: true,
+        responseType: 'json',
+        reportProgress: true,
+      },
+    );
+  }
+
+  private formData(file:FileForUpload):FormData {
+    const data = new FormData();
+
+    switch (file.config.type) {
+      case 'nextcloud':
+        data.append('file', file, file.name);
+        data.append('overwrite', String(file.config.overwrite));
+        break;
+      case 'local':
+        data.append('metadata', JSON.stringify({
+          description: file.config.description,
+          fileName: file.config.fileName,
+        }));
+        data.append('file', file, file.config.fileName);
+        break;
+      default:
+        console.warn('unknown upload config type');
+    }
+
+    return data;
+  }
+}

--- a/frontend/src/app/shared/components/storages/storage/upload-to-nextcloud.ts
+++ b/frontend/src/app/shared/components/storages/storage/upload-to-nextcloud.ts
@@ -1,0 +1,51 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Observable } from 'rxjs';
+import { HttpEvent } from '@angular/common/http';
+
+import { FileForUpload, OpUploadService } from 'core-app/core/upload/upload.service';
+import { IUploadLink } from 'core-app/core/state/storage-files/upload-link.model';
+
+export interface FileUploadResponse {
+  file_name:string;
+  file_id:string;
+}
+
+export default function uploadToNextcloud(
+  uploadService:OpUploadService,
+  uploadLink:IUploadLink,
+  file:File,
+):Observable<HttpEvent<FileUploadResponse>> {
+  const { href } = uploadLink._links.destination;
+
+  const upload = file as FileForUpload;
+  upload.config = { overwrite: false, type: 'nextcloud' };
+
+  return uploadService.upload<FileUploadResponse>(href, [upload])[0];
+}


### PR DESCRIPTION
- https://community.openproject.org/work_packages/46150
- use upload service for storage uploads

This is a first step to introduce `OpUploadService` and eventually get rid of `OpenProjectUploadService` and `OpenProjectDirectUploadService`. 
First step is replacing upload triggered from storage component. Second will be replacing attachment upload.

⚠️ ON HOLD ⚠️ 

Rejected. Next version proposed in #12157 