### PR TITLE
Fix undefined method ancestors_relations used in Task

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -106,13 +106,9 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
       if is_story?
         Story.find(id)
       elsif is_task?
-        # Make sure to get the closest ancestor that is a Story
-        ancestors_relations
-          .includes(:from)
-          .where(from: { type_id: Story.types })
-          .order(hierarchy: :asc)
+        ancestors
+          .where(type_id: Story.types)
           .first
-          .from
       end
     end
 

--- a/modules/backlogs/spec/models/work_package_spec.rb
+++ b/modules/backlogs/spec/models/work_package_spec.rb
@@ -26,28 +26,72 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require_relative '../spec_helper'
 
 describe WorkPackage do
   describe '#backlogs_types' do
     it 'returns all the ids of types that are configures to be considered backlogs types' do
       allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ 'story_types' => [1], 'task_type' => 2 })
 
-      expect(WorkPackage.backlogs_types).to match_array([1, 2])
+      expect(described_class.backlogs_types).to match_array([1, 2])
     end
 
     it 'returns an empty array if nothing is defined' do
       allow(Setting).to receive(:plugin_openproject_backlogs).and_return({})
 
-      expect(WorkPackage.backlogs_types).to eq([])
+      expect(described_class.backlogs_types).to eq([])
     end
 
     it 'reflects changes to the configuration' do
       allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ 'story_types' => [1], 'task_type' => 2 })
-      expect(WorkPackage.backlogs_types).to match_array([1, 2])
+      expect(described_class.backlogs_types).to match_array([1, 2])
 
       allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ 'story_types' => [3], 'task_type' => 4 })
-      expect(WorkPackage.backlogs_types).to match_array([3, 4])
+      expect(described_class.backlogs_types).to match_array([3, 4])
+    end
+  end
+
+  describe '#story' do
+    shared_let(:project) { create(:project) }
+    shared_let(:status) { create(:status) }
+    shared_let(:story_type) { create(:type, name: 'Story') }
+    shared_let(:task_type) { create(:type, name: 'Task') }
+
+    before do
+      allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ 'story_types' => [story_type.id],
+                                                                           'task_type' => task_type.id })
+    end
+
+    context 'for a WorkPackage' do
+      let(:work_package) { build_stubbed(:work_package) }
+
+      it 'returns nil' do
+        expect(work_package.story).to be_nil
+      end
+    end
+
+    context 'for a Story' do
+      let(:story) { create(:story, project:, status:, type: story_type) }
+
+      it 'returns self' do
+        expect(story.story).to eq(story)
+      end
+    end
+
+    context 'for a Task' do
+      let(:parent_parent_story) { create(:story, project:, status:, type: story_type) }
+      let(:parent_story) { create(:story, parent: parent_parent_story, project:, status:, type: story_type) }
+      let(:task) { create(:task, parent: parent_story, project:, status:, type: task_type) }
+
+      it 'returns the closest WorkPackage ancestor being a Story' do
+        expect(task.story).to eq(described_class.find(parent_story.id))
+
+        # transform the parent_story into a task
+        parent_story.update(type: task_type)
+
+        # the returned story is now the grand parent
+        expect(task.story).to eq(described_class.find(parent_parent_story.id))
+      end
     end
   end
 end


### PR DESCRIPTION
Noticed with AppSignal error https://appsignal.com/openproject-gmbh/sites/63237184d2a5e463ef717e6e/exceptions/incidents/708
Occurs ~10 times per day.

This method was removed in PR #10349 when moving wp hierarchy to closure_tree. The relation used to be created by typed_dag gem in config/initializers/typed_dag.rb.