### PR TITLE
Fix multi-column layout for WP edit fields

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.sass
@@ -20,6 +20,8 @@
 
     @media screen and (min-width: 92rem), print
       flex-basis: calc(50% - #{$spot-spacing-3})
+      min-width: 25rem
+      flex-grow: 1
 
     &_span-all
       flex-basis: calc(100% - #{$spot-spacing-3})


### PR DESCRIPTION
The two-column layout was not wrapping at all when on a desktop view, causing tiny input fields.

Closes https://community.openproject.org/wp/46313