### PR TITLE
Fix eslint action

### DIFF
--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -17,6 +17,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: opf/action-eslint@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.13'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: reviewdog/action-eslint@v1
         with:
           reporter: github-pr-check
+          workdir: 'frontend/'
+          eslint_flags: 'src/'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -139,7 +139,7 @@
         "browserslist": "^4.8.7",
         "codelyzer": "^6.0.0",
         "css-loader": "^6.7.1",
-        "eslint": "^8.31.0",
+        "eslint": "^8.34.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-plugin-change-detection-strategy": "^0.1.1",
@@ -30141,9 +30141,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
@@ -71667,9 +71667,9 @@
       }
     },
     "eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "browserslist": "^4.8.7",
     "codelyzer": "^6.0.0",
     "css-loader": "^6.7.1",
-    "eslint": "^8.31.0",
+    "eslint": "^8.34.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-change-detection-strategy": "^0.1.1",


### PR DESCRIPTION
action-eslint breaks with npmv9, so we use setup-node to fix the version used.

https://github.com/reviewdog/action-eslint/issues/152