### PR TITLE
[46305] Wrong text references in the non working days admin page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3185,7 +3185,7 @@ en:
     change_button: "Change working days"
     warning: >
       Changing which days of the week are considered working days or non-working days can affect the start and finish days of all work packages in all projects in this instance. <br/>
-      Please note that changes are only applied after you click on the save changes button.
+      Please note that changes are only applied after you click on the apply changes button.
     journal_note:
       changed: _**Working days** changed (%{changes})._
       days:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -281,7 +281,7 @@ en:
       working_days:
         calendar:
           empty_state_header: "Non-working days"
-          empty_state_description: 'No specific non-working days are defined for this year. Click on "Add non-working day" below to add a date.'
+          empty_state_description: 'No specific non-working days are defined for this year. Click on "+ Non-working day" below to add a date.'
           new_date: '(new)'
         add_non_working_day: "Non-working day"
         already_added_error: "A non-working day for this date exists already. There can only be one non-working day created for each unique date."


### PR DESCRIPTION
Set the correct strings for warning messages in NWDs admin setting page.

https://community.openproject.org/projects/openproject/work_packages/46305/activity