### PR TITLE
[46190] Link back button of diff page to the correct page

### DIFF
--- a/app/components/activities/days_component.html.erb
+++ b/app/components/activities/days_component.html.erb
@@ -2,6 +2,9 @@
   <% events_by_day.each do |day, events| %>
     <%= content_tag(@header_tag, helpers.format_activity_day(day), class: 'op-activity-days--header') %>
 
-    <%= render(Activities::ListComponent.new(events:, display_user: @display_user)) %>
+    <%= render(Activities::ListComponent.new(events:,
+                                             display_user: @display_user,
+                                             activity_page: @activity_page))
+    %>
   <% end -%>
 </div>

--- a/app/components/activities/days_component.rb
+++ b/app/components/activities/days_component.rb
@@ -29,11 +29,12 @@
 #++
 
 class Activities::DaysComponent < ViewComponent::Base
-  def initialize(events:, display_user: true, header_tag: 'h3')
+  def initialize(events:, display_user: true, header_tag: 'h3', activity_page: nil)
     super()
     @events = events
     @display_user = display_user
     @header_tag = header_tag
+    @activity_page = activity_page
   end
 
   def events_by_day

--- a/app/components/activities/item_component.rb
+++ b/app/components/activities/item_component.rb
@@ -31,10 +31,11 @@
 class Activities::ItemComponent < ViewComponent::Base
   with_collection_parameter :event
 
-  def initialize(event:, display_user: true)
+  def initialize(event:, display_user: true, activity_page: nil)
     super()
     @event = event
     @display_user = display_user
+    @activity_page = activity_page
   end
 
   def display_belonging_project?
@@ -55,7 +56,7 @@ class Activities::ItemComponent < ViewComponent::Base
     @rendered_details ||=
       @event.journal
         .details
-        .flat_map { |detail| @event.journal.render_detail(detail) }
+        .flat_map { |detail| @event.journal.render_detail(detail, activity_page: @activity_page) }
   end
 
   def format_activity_title(text)

--- a/app/components/activities/list_component.html.erb
+++ b/app/components/activities/list_component.html.erb
@@ -1,3 +1,6 @@
 <ul class="op-activity-list">
-  <%= render(Activities::ItemComponent.with_collection(@events, display_user: @display_user)) %>
+  <%= render(Activities::ItemComponent.with_collection(@events,
+                                                       display_user: @display_user,
+                                                       activity_page: @activity_page))
+  %>
 </ul>

--- a/app/components/activities/list_component.rb
+++ b/app/components/activities/list_component.rb
@@ -29,9 +29,10 @@
 #++
 
 class Activities::ListComponent < ViewComponent::Base
-  def initialize(events:, display_user: true)
+  def initialize(events:, display_user: true, activity_page: nil)
     super()
     @events = events.sort { |x, y| y.event_datetime <=> x.event_datetime }
     @display_user = display_user
+    @activity_page = activity_page
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -117,7 +117,7 @@ class ActivitiesController < ApplicationController
   end
 
   def set_current_activity_page
-    RequestStore[:current_activity_page] = @project ? "projects/#{@project.identifier}" : 'all'
+    @activity_page = @project ? "projects/#{@project.identifier}" : 'all'
   end
 
   def set_session

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -32,7 +32,8 @@ class ActivitiesController < ApplicationController
                 :verify_activities_module_activated,
                 :determine_date_range,
                 :determine_subprojects,
-                :determine_author
+                :determine_author,
+                :set_current_activity_page
 
   after_action :set_session
 
@@ -113,6 +114,10 @@ class ActivitiesController < ApplicationController
     else
       :all
     end
+  end
+
+  def set_current_activity_page
+    RequestStore[:current_activity_page] = @project ? "projects/#{@project.identifier}" : 'all'
   end
 
   def set_session

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -67,6 +67,7 @@ class JournalsController < ApplicationController
       return render_400 message: I18n.t(:error_journal_attribute_not_present, attribute: field_param)
     end
 
+    @activity_page = params['activity_page']
     @diff = Redmine::Helpers::Diff.new(to, from)
 
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -275,7 +275,7 @@ class UsersController < ApplicationController
   end
 
   def set_current_activity_page
-    RequestStore[:current_activity_page] = "users/#{@user.id}"
+    @activity_page = "users/#{@user.id}"
   end
 
   def my_or_admin_layout

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,6 +44,7 @@ class UsersController < ApplicationController
   before_action :authorize_for_user, only: [:destroy]
   before_action :check_if_deletion_allowed, only: %i[deletion_info
                                                      destroy]
+  before_action :set_current_activity_page, only: [:show]
 
   # Password confirmation helpers and actions
   include PasswordConfirmation
@@ -271,6 +272,10 @@ class UsersController < ApplicationController
 
   def check_if_deletion_allowed
     render_404 unless Users::DeleteContract.deletion_allowed? @user, User.current
+  end
+
+  def set_current_activity_page
+    RequestStore[:current_activity_page] = "users/#{@user.id}"
   end
 
   def my_or_admin_layout

--- a/app/helpers/journals_helper.rb
+++ b/app/helpers/journals_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module JournalsHelper
+  def back_to_activity_page_url(activity_page)
+    case activity_page&.split('/')
+    in ['all']
+      activities_url
+    in ['projects', project_id]
+      project_activities_url(project_id)
+    in ['users', user_id]
+      user_url(user_id)
+    in ['work_packages', work_package_id]
+      work_package_url(work_package_id)
+    else
+      nil
+    end
+  end
+end

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
             subtitle: t(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to-1))
 %>
 
-<%= render(Activities::DaysComponent.new(events: @events))  %>
+<%= render(Activities::DaysComponent.new(events: @events, activity_page: @activity_page))  %>
 
 <% if @events.empty? %>
   <%= no_results_box %>

--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -27,11 +27,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<% html_title @journable.to_s %>
+
 <p><%= authoring @journal.created_at, @journal.user, label: :label_updated_time_by %></p>
 
 <%= render partial: 'diff',
            locals: { diff: @diff } %>
 
-<p><%= link_to(t(:button_back), polymorphic_path(@journable)) %></p>
-
-<% html_title "#{ @journable.to_s }" %>
+<% if @activity_page -%>
+  <p><%= link_to(t(:button_back), back_to_activity_page_url(@activity_page)) %></p>
+<% end -%>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,7 +80,7 @@ See COPYRIGHT and LICENSE files for more details.
       <p>
         <%=t(:label_reported_work_packages)%>: <%= @user.reported_work_package_count %>
       </p>
-      <%= render(Activities::DaysComponent.new(events: @events, display_user: false, header_tag: 'h4'))  %>
+      <%= render(Activities::DaysComponent.new(events: @events, display_user: false, header_tag: 'h4', activity_page: @activity_page))  %>
 
       <%= other_formats_links do |f| %>
         <%= f.link_to 'Atom', url: {controller: '/activities', action: 'index', id: nil, user_id: @user, key: User.current.rss_key} %>

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -35,7 +35,6 @@ module API
         resource :activities do
           get do
             self_link = api_v3_paths.work_package_activities @work_package.id
-            RequestStore[:current_activity_page] = "work_packages/#{@work_package.id}"
             journals = @work_package.journals.includes(:data,
                                                        :customizable_journals,
                                                        :attachable_journals,

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -35,6 +35,7 @@ module API
         resource :activities do
           get do
             self_link = api_v3_paths.work_package_activities @work_package.id
+            RequestStore[:current_activity_page] = "work_packages/#{@work_package.id}"
             journals = @work_package.journals.includes(:data,
                                                        :customizable_journals,
                                                        :attachable_journals,

--- a/lib/api/v3/activities/activity_property_formatters.rb
+++ b/lib/api/v3/activities/activity_property_formatters.rb
@@ -37,8 +37,9 @@ module API
         end
 
         def formatted_details(journal)
+          activity_page = "work_packages/#{journal.journable.id}"
           details = render_details(journal, html: false)
-          html_details = render_details(journal)
+          html_details = render_details(journal, activity_page:)
 
           details
             .zip(html_details)
@@ -47,10 +48,10 @@ module API
 
         private
 
-        def render_details(journal, html: true)
+        def render_details(journal, html: true, activity_page: nil)
           journal
             .details
-            .map { |d| journal.render_detail(d, html:) }
+            .map { |d| journal.render_detail(d, html:, activity_page:) }
             .compact
         end
 

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -74,7 +74,7 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
              action: 'diff',
              id: @journal.id,
              field: key.downcase,
-             activity_page: RequestStore[:current_activity_page])
+             activity_page: options[:activity_page])
       .compact
 
     if options[:html]

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -69,10 +69,13 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   end
 
   def link(key, options)
-    url_attr = default_attributes(options).merge(controller: '/journals',
-                                                 action: 'diff',
-                                                 id: @journal.id,
-                                                 field: key.downcase)
+    url_attr = default_attributes(options)
+      .merge(controller: '/journals',
+             action: 'diff',
+             id: @journal.id,
+             field: key.downcase,
+             activity_page: RequestStore[:current_activity_page])
+      .compact
 
     if options[:html]
       link_to(I18n.t(:label_details),

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -139,4 +139,41 @@ describe 'Activity page navigation' do
   context 'with subprojects NOT included by default', with_setting: { display_subprojects_work_packages: false } do
     include_examples 'subprojects checkbox state is preserved'
   end
+
+  context 'when navigating to a diff' do
+    before do
+      project_work_package.update(description: 'New work package description')
+    end
+
+    def assert_navigating_to_diff_page_and_back_comes_back_to_the_same_page(activity_page)
+      visit(activity_page)
+      activity_page_url = page.current_url
+
+      expect(page).to have_link(text: 'Details')
+      expect(page.text).to include("Description changed (Details)")
+      click_link('Details')
+
+      # on diff page, click the back button
+      expect(page).to have_link(text: 'Back')
+      click_link('Back')
+
+      expect(page.current_url).to eq(activity_page_url)
+    end
+
+    it 'Back button navigates to the previously seen activity page' do
+      [
+        activities_path,
+        project_activities_path(project),
+        user_path(user)
+      ].each do |activity_page|
+        assert_navigating_to_diff_page_and_back_comes_back_to_the_same_page(activity_page)
+      end
+    end
+
+    # work package activity page is rendered by Angular, so it needs js: true
+    it 'Back button navigates to the previously seen work package page', js: true do
+      activity_page = work_package_path(project_work_package)
+      assert_navigating_to_diff_page_and_back_comes_back_to_the_same_page(activity_page)
+    end
+  end
 end

--- a/spec/helpers/journals_helper_spec.rb
+++ b/spec/helpers/journals_helper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe JournalsHelper do
+  describe 'back_to_activity_page_url' do
+    {
+      'all' => 'http://test.host/activities',
+      'projects/some-identifier' => 'http://test.host/projects/some-identifier/activities',
+      'unsupported_gizmo' => nil,
+      'users/5' => 'http://test.host/users/5',
+      'work_packages/42' => 'http://test.host/work_packages/42',
+      nil => nil
+    }.each do |activity_page, expected_url|
+      context "when activity page is #{activity_page.inspect}" do
+        it do
+          expect(back_to_activity_page_url(activity_page)).to eq(expected_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/46190

The pages where the link to diff can be displayed are:
- /activities
- /project/{id}/activities
- /user/{id}
- work package activity view

When clicking on the "Details" link of a changed description activity, the back link on the diff page will redirect to the previous page.

From a code point of view, I was concerned with the [Unvalidated Redirects and Forwards vulnerability](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html) which was in OWASP top ten 2010. That's why I did not encode the full url in the query params, but only the useful parts to rebuild a correct url.

Also `RequestStore[:current_activity_page]` is used to pass values from the controller to the view. I'm not a big fan of it as it is global state, but it is simple enough and avoids passing this information from controller to view.