### PR TITLE
Allow basic datepicker to show, but click on nwd

### DIFF
--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -167,7 +167,7 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, A
         onDayCreate: (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
           onDayCreate(
             dayElem,
-            false,
+            true,
             this.datePickerInstance?.weekdaysService.isNonWorkingDay(dayElem.dateObj),
             !!this.minimalDate && dayElem.dateObj <= this.minimalDate,
           );

--- a/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
+++ b/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
@@ -104,8 +104,12 @@ export function onDayCreate(
   isNonWorkingDay:boolean,
   isDayDisabled:boolean,
 ):void {
-  if (!ignoreNonWorkingDays && isNonWorkingDay) {
+  if (isNonWorkingDay) {
     dayElem.classList.add('flatpickr-non-working-day');
+
+    if (!ignoreNonWorkingDays) {
+      dayElem.classList.add('flatpickr-non-working-day-disabled');
+    }
   }
 
   if (isDayDisabled) {

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -41,6 +41,8 @@ $datepicker--border-radius: 5px
   background: $spot-color-basic-gray-6
   color: $spot-color-basic-gray-3
   border-radius: 0
+
+@mixin non-working-day-disabled
   pointer-events: none
 
 .flatpickr-current-month
@@ -51,11 +53,20 @@ $datepicker--border-radius: 5px
   left: 65%
 
 
-.flatpickr-day
-  &.flatpickr-disabled
-    @include disabled-day
-  &.flatpickr-non-working-day
-    @include non-working-day
+.flatpickr-calendar
+  .flatpickr-day
+    color: $spot-color-basic-black
+    margin: 0
+    border-radius: $datepicker--border-radius
+    box-shadow: none !important
+
+    &.flatpickr-disabled
+      @include disabled-day
+    &.flatpickr-non-working-day
+      @include non-working-day
+    &.flatpickr-non-working-day-disabled
+      @include non-working-day-disabled
+
 
 .flatpickr-calendar.inline
   box-shadow: none !important
@@ -103,9 +114,6 @@ $datepicker--border-radius: 5px
         color: $spot-color-basic-black
         height: 30px
         line-height: 28px
-        margin: 0
-        border-radius: $datepicker--border-radius
-        box-shadow: none !important
 
         &:hover
           border-radius: 0


### PR DESCRIPTION
The merged basic date picker does show all non working days, but as before suppresses all clicks.