### PR TITLE
[46237] Datepicker: Update colours of mini calendar so non-working days are visible in all modes

### DIFF
--- a/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
+++ b/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
@@ -106,8 +106,7 @@ export function onDayCreate(
 ):void {
   if (ignoreNonWorkingDays && isNonWorkingDay) {
     dayElem.classList.add('flatpickr-non-working-day_enabled');
-  }
-  if (isNonWorkingDay) {
+  } else if (!ignoreNonWorkingDays && isNonWorkingDay) {
     dayElem.classList.add('flatpickr-non-working-day');
   }
 

--- a/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
+++ b/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
@@ -104,7 +104,10 @@ export function onDayCreate(
   isNonWorkingDay:boolean,
   isDayDisabled:boolean,
 ):void {
-  if (!ignoreNonWorkingDays && isNonWorkingDay) {
+  if (ignoreNonWorkingDays && isNonWorkingDay) {
+    dayElem.classList.add('flatpickr-non-working-day_enabled');
+  }
+  if (isNonWorkingDay) {
     dayElem.classList.add('flatpickr-non-working-day');
   }
 

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -30,7 +30,7 @@ $datepicker--border-radius: 5px
 
 @mixin disabled-day
   background: $spot-color-basic-white
-  color: $spot-color-basic-gray-4
+  color: $spot-color-basic-gray-3
   pointer-events: none
   cursor: not-allowed
 
@@ -45,7 +45,7 @@ $datepicker--border-radius: 5px
 
 @mixin non-working-day_enabled
   background: $spot-color-basic-gray-6
-  color: #000000
+  color: $spot-color-basic-black
   border-radius: 0
   pointer-events: auto
 
@@ -150,7 +150,7 @@ $datepicker--border-radius: 5px
 
         &.inRange
           background: var(--primary-color--lighten-80)
-          color: $spot-color-basic-black
+          color: var(--primary-color)
           border-color: var(--primary-color--lighten-80)
           border-radius: 0
 
@@ -159,11 +159,11 @@ $datepicker--border-radius: 5px
 
           &.flatpickr-non-working-day
             background: $spot-color-basic-gray-6
-            color: $spot-color-basic-gray-4
+            color: $spot-color-basic-gray-3
   
           &.flatpickr-non-working-day_enabled
             background: $spot-color-basic-gray-6
-            color: #000000
+            color: $spot-color-basic-black
   
             &.inRange
               color: $spot-color-basic-gray-5
@@ -183,7 +183,9 @@ $datepicker--border-radius: 5px
             color: $spot-color-basic-gray-3
 
           &.today
-            color: $spot-color-basic-gray-4
+            color: $spot-color-basic-gray-3
+            background: $spot-color-indication-current-date
+            border-color: $spot-color-indication-current-date
 
 .flatpickr-calendar.flatpickr-container-suppress-hover
   .flatpickr-day

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -44,6 +44,9 @@ $datepicker--border-radius: 5px
   pointer-events: none
 
 @mixin non-working-day_enabled
+  background: $spot-color-basic-gray-6
+  color: #000000
+  border-radius: 0
   pointer-events: auto
 
 .flatpickr-current-month
@@ -157,7 +160,11 @@ $datepicker--border-radius: 5px
           &.flatpickr-non-working-day
             background: $spot-color-basic-gray-6
             color: $spot-color-basic-gray-4
-
+  
+          &.flatpickr-non-working-day_enabled
+            background: $spot-color-basic-gray-6
+            color: #000000
+  
             &.inRange
               color: $spot-color-basic-gray-5
               background: $spot-color-basic-gray-6

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -43,6 +43,9 @@ $datepicker--border-radius: 5px
   border-radius: 0
   pointer-events: none
 
+@mixin non-working-day_enabled
+  pointer-events: auto
+
 .flatpickr-current-month
   display: flex !important
 
@@ -56,6 +59,8 @@ $datepicker--border-radius: 5px
     @include disabled-day
   &.flatpickr-non-working-day
     @include non-working-day
+  &.flatpickr-non-working-day_enabled
+    @include non-working-day_enabled
 
 .flatpickr-calendar.inline
   box-shadow: none !important
@@ -113,6 +118,9 @@ $datepicker--border-radius: 5px
         &.flatpickr-non-working-day
           @include non-working-day
 
+        &.flatpickr-non-working-day_enabled
+          @include non-working-day_enabled
+  
           &.inRange
             color: $spot-color-basic-gray-2
 


### PR DESCRIPTION
- [x] Show non working daysin date picker, even when the "Working days only" switch is set to OFF.
- [x] Distinguish between a "clickbale" (enabled) non-working day and a "non-clickable" (disabled) non working day.

https://community.openproject.org/work_packages/46237/activity