### PR TITLE
Restore suppressing of notifications in groups service

### DIFF
--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -61,10 +61,10 @@ class Journal::NotificationConfiguration
     end
 
     def log_warning(send_notifications)
-      return if active == send_notifications
+      return if active? == send_notifications
 
       message = <<~MSG
-        Ignoring setting journal notifications to '#{send_notifications}' as a parent block already set it to #{active}"
+        Ignoring setting journal notifications to '#{send_notifications}' as a parent block already set it to #{active?}"
       MSG
       Rails.logger.debug message
     end

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -77,7 +77,7 @@ module BaseServices
     end
 
     def set_attributes_params(params)
-      params
+      params.except(:send_notifications)
     end
   end
 end

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -52,7 +52,11 @@ module Groups
     def after_perform(call)
       Groups::CreateInheritedRolesService
         .new(model, current_user: user, contract_class:)
-        .call(user_ids: params[:ids], message: params[:message])
+        .call(
+          user_ids: params[:ids],
+          message: params[:message],
+          send_notifications: params.fetch(:send_notifications, true)
+        )
 
       call
     end

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -49,7 +49,7 @@ class Groups::UpdateService < ::BaseServices::Update
     if new_user_ids.any?
       db_call = ::Groups::AddUsersService
                   .new(call.result, current_user: user)
-                  .call(ids: new_user_ids)
+                  .call(ids: new_user_ids, send_notifications: params.fetch(:send_notifications, true))
 
       call.add_dependent!(db_call)
     end

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
       User.system.run_given do |system_user|
         Groups::AddUsersService
           .new(group, current_user: system_user)
-          .call(ids: members.map(&:id))
+          .call(ids: members.map(&:id), send_notifications: false)
           .on_failure { |call| raise call.message }
       end
     end

--- a/spec/services/groups/update_roles_service_integration_spec.rb
+++ b/spec/services/groups/update_roles_service_integration_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe Groups::UpdateRolesService, 'integration', type: :model do
-  subject(:service_call) { instance.call(member:, message:) }
+  subject(:service_call) { instance.call(member:, message:, send_notifications:) }
 
   let(:project) { create :project }
   let(:role) { create :role }
@@ -46,12 +46,13 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
       ::Groups::CreateInheritedRolesService
         .new(group, current_user: User.system, contract_class: EmptyContract)
-        .call(user_ids: users.map(&:id))
+        .call(user_ids: users.map(&:id), send_notifications: false)
     end
   end
   let(:users) { create_list :user, 2 }
   let(:member) { Member.find_by(principal: group) }
   let(:message) { "Some message" }
+  let(:send_notifications) { true }
 
   let(:instance) do
     described_class.new(group, current_user:)
@@ -89,6 +90,15 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
     end
   end
 
+  shared_examples_for 'sends no notification' do
+    it 'on the updated membership' do
+      service_call
+
+      expect(Notifications::GroupMemberAlteredJob)
+        .not_to have_received(:perform_later)
+    end
+  end
+
   context 'when adding a role' do
     let(:added_role) { create(:role) }
 
@@ -112,6 +122,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
     it_behaves_like 'sends notification' do
       let(:user) { users }
+    end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
     end
   end
 
@@ -154,6 +170,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
       it_behaves_like 'sends notification' do
         let(:user) { users }
       end
+
+      context 'when notifications are suppressed' do
+        let(:send_notifications) { false }
+
+        it_behaves_like 'sends no notification'
+      end
     end
 
     context 'when removing a global role' do
@@ -179,6 +201,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
       it_behaves_like 'sends notification' do
         let(:user) { users }
+      end
+
+      context 'when notifications are suppressed' do
+        let(:send_notifications) { false }
+
+        it_behaves_like 'sends no notification'
       end
     end
   end
@@ -222,6 +250,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
     it_behaves_like 'sends notification' do
       let(:user) { users.last }
     end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
+    end
   end
 
   context 'when removing a role' do
@@ -247,6 +281,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
     it_behaves_like 'sends notification' do
       let(:user) { users }
+    end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
     end
   end
 
@@ -290,6 +330,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
     it_behaves_like 'sends notification' do
       let(:user) { users.last }
     end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
+    end
   end
 
   context 'when replacing roles' do
@@ -315,6 +361,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
     it_behaves_like 'sends notification' do
       let(:user) { users }
+    end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
     end
   end
 
@@ -358,6 +410,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
     it_behaves_like 'sends notification' do
       let(:user) { users }
     end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
+    end
   end
 
   context 'when adding a role and the user has a role already granted by a different group' do
@@ -373,7 +431,7 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
         ::Groups::CreateInheritedRolesService
           .new(group, current_user: User.system, contract_class: EmptyContract)
-          .call(user_ids: users.map(&:id))
+          .call(user_ids: users.map(&:id), send_notifications: false)
       end
     end
 
@@ -398,6 +456,12 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
 
     it_behaves_like 'sends notification' do
       let(:user) { users }
+    end
+
+    context 'when notifications are suppressed' do
+      let(:send_notifications) { false }
+
+      it_behaves_like 'sends no notification'
     end
   end
 

--- a/spec/services/groups/update_service_spec.rb
+++ b/spec/services/groups/update_service_spec.rb
@@ -76,7 +76,7 @@ describe Groups::UpdateService, type: :model do
 
           expect(add_users_service)
             .to have_received(:call)
-            .with(ids: [new_group_user.user_id])
+            .with(ids: [new_group_user.user_id], send_notifications: true)
         end
       end
 
@@ -94,7 +94,7 @@ describe Groups::UpdateService, type: :model do
 
           expect(add_users_service)
             .to have_received(:call)
-            .with(ids: [new_group_user.user_id])
+            .with(ids: [new_group_user.user_id], send_notifications: true)
         end
       end
 


### PR DESCRIPTION
send_notifications was suppressed for e.g., city of cologne modifying groups through scripts

https://community.openproject.org/wp/46330