### PR TITLE
Fix possible unprotected redirect

### DIFF
--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -125,7 +125,7 @@ class BudgetsController < ApplicationController
 
     if call.success?
       flash[:notice] = t(:notice_successful_update)
-      redirect_to(params[:back_to] || { action: 'show', id: @budget })
+      redirect_to(@budget)
     else
       @budget = call.result
       @errors = call.errors


### PR DESCRIPTION
It has been spotted by brakeman since the upgrade to version 5.4.1.

In fact, this `back_to` parameter was introduced in https://github.com/opf/openproject/pull/8557/files#diff-25ff8b3377029a3f79253f4ba637ab2ec195658fb50ad65a64c35c7c411db057R123-R147 but never actually used, so it's better to remove it.