### PR TITLE
[46373] Display whole activity title

### DIFF
--- a/app/components/activities/item_component.html.erb
+++ b/app/components/activities/item_component.html.erb
@@ -1,6 +1,6 @@
 <li class="op-activity-list--item">
   <div class="op-activity-list--item-title">
-    <%= link_to format_activity_title(@event.event_title), @event.event_path %>
+    <%= link_to @event.event_title.squish, @event.event_path %>
     <%= project_suffix %>
   </div>
   <%=

--- a/app/components/activities/item_component.rb
+++ b/app/components/activities/item_component.rb
@@ -66,10 +66,6 @@ class Activities::ItemComponent < ViewComponent::Base
         .filter_map { |detail| @event.journal.render_detail(detail, activity_page: @activity_page) }
   end
 
-  def format_activity_title(text)
-    helpers.truncate_single_line(text, length: 100)
-  end
-
   def comment
     return unless work_package_activity?
 

--- a/spec/components/activities/item_component_spec.rb
+++ b/spec/components/activities/item_component_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe Activities::ItemComponent, type: :component do
     expect(page).to have_css('.op-activity-list--item-title', text: 'Project: Project <b>name</b> with HTML)')
   end
 
+  it 'does not truncate the title' do
+    event.event_title = 'Hello, World!' * 20
+    render_inline(described_class.new(event:))
+
+    expect(page).to have_css('.op-activity-list--item-title', text: event.event_title)
+  end
+
+  it 'removes line breaks and tabs from the title and replaces them with spaces' do
+    event.event_title = "This \t should\n\rbe\n all\ncleaned"
+    render_inline(described_class.new(event:))
+
+    expect(page).to have_css('.op-activity-list--item-title', text: 'This should be all cleaned')
+  end
+
   context 'for Project activities' do
     let(:journal) { build_stubbed(:project_journal) }
 


### PR DESCRIPTION
https://community.openproject.org/wp/46373

Stop truncating activity title at 100 characters like it used to be.