### PR TITLE
Add crossaxis positioning fallback for drop-modal

### DIFF
--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -144,7 +144,11 @@ export class SpotDropModalComponent implements OnDestroy {
               {
                 placement: this.alignment,
                 middleware: this.allowRepositioning ? [
-                  flip(),
+                  flip({
+                    mainAxis: true,
+                    crossAxis: true,
+                    fallbackAxisSideDirection: 'start',
+                  }),
                   shift({ limiter: limitShift() }),
                 ] : [],
               },


### PR DESCRIPTION
Drop-modals could still find themselves in a position where they'd open in  a direction that scrolled the main page. This commit allows drop-modals to fall back to a different axis (e.g. left-right if top-bottom does not work).

Closes https://community.openproject.org/work_packages/46164/activity