### PR TITLE
Fix anchor links being changed due to base href

### DIFF
--- a/frontend/src/app/core/setup/globals/global-listeners.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners.ts
@@ -38,6 +38,7 @@ import { setupServerResponse } from 'core-app/core/setup/globals/global-listener
 import { listenToSettingChanges } from 'core-app/core/setup/globals/global-listeners/settings';
 import { detectOnboardingTour } from 'core-app/core/setup/globals/onboarding/onboarding_tour_trigger';
 import { performAnchorHijacking } from './global-listeners/link-hijacking';
+import { fixFragmentAnchors } from 'core-app/core/setup/globals/global-listeners/fix-fragment-anchors';
 
 /**
  * A set of listeners that are relevant on every page to set sensible defaults
@@ -139,4 +140,7 @@ export function initializeGlobalListeners():void {
 
   // Bootstrap legacy app code
   setupServerResponse();
+
+  // Replace fragment
+  fixFragmentAnchors();
 }

--- a/frontend/src/app/core/setup/globals/global-listeners/fix-fragment-anchors.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/fix-fragment-anchors.ts
@@ -1,0 +1,18 @@
+/**
+ * Due to having a <base /> tag, links that only contains anchors break as they
+ * reference the application base url + the anchor instead of the current page.
+ */
+export function fixFragmentAnchors():void {
+  // Get current document URL without any existing fragments
+  const baseUrl = document.location.href.replace(/#.*$/, '');
+
+  Array
+    .from(document.getElementsByTagName('A'))
+    .forEach((el:HTMLAnchorElement) => {
+      const href = el.getAttribute('href') as string;
+
+      if (href && href !== '#' && href.startsWith('#')) {
+        el.setAttribute('href', baseUrl + href);
+      }
+    });
+}

--- a/spec/features/wiki/wiki_page_navigation_spec.rb
+++ b/spec/features/wiki/wiki_page_navigation_spec.rb
@@ -57,5 +57,9 @@ describe 'Wiki page navigation spec', js: true do
 
     # Expect scrolled to menu node
     expect_element_in_view page.find('.tree-menu--item.-selected', text: 'Wiki Page No. 55')
+
+    # Expect permalink being correct (Regression #46351)
+    permalink = page.all('.op-uc-link_permalink', visible: :all).first
+    expect(permalink['href']).to include "/projects/#{project.identifier}/wiki/wiki-page-no-55#wiki-page-no-55"
   end
 end


### PR DESCRIPTION
Due to having a `<base />` tag, links that only contains anchors break as they reference the application base url + the anchor instead of the current page.

https://community.openproject.org/wp/46351