### PR TITLE
[42287] Current rate of cost type increased by a factor of 10 when saving cost type with German language settings

### DIFF
--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
                                  index: id_or_index,
                                  inputmode: :decimal,
                                  placeholder: t(:label_example_placeholder, decimal: unitless_currency_number(1000.50)),
-                                 value: rate.rate ? rate.rate.round(2) : "",
+                                 value: rate.rate ? unitless_currency_number(rate.rate.round(2)) : "",
                                  required: templated ? false : true %>
         <span class="form-label">
           <%= Setting.plugin_costs['costs_currency'] %>


### PR DESCRIPTION
The character used as the decimal separator for some languages like German or Spanish is comma. So we need to set the value without unit while saving.

https://community.openproject.org/projects/openproject/work_packages/42287/activity