### PR TITLE
Adjusting documentation on agile boards in getting started guide

### DIFF
--- a/docs/getting-started/boards-introduction/README.md
+++ b/docs/getting-started/boards-introduction/README.md
@@ -6,11 +6,11 @@ description: Introduction to agile Boards in OpenProject.
 keywords: Agile Boards
 ---
 
-# Introduction to agile boards (Enterprise add-on)
+# Introduction to agile boards
 
 This document provides an initial introduction to the boards in OpenProject, i.e. how to use a Kanban board to manage your tasks in an agile way.
 
-> **Note**: The agile board is an Enterprise add-on and only available for the [OpenProject Enterprise cloud](https://www.openproject.org/hosting/) and the [Enterprise On-premises edition](https://www.openproject.org/enterprise-edition/).
+> **Note**:  The basic agile boards are included in the OpenProject Community edition.  OpenProject advanced Action boards are an Enterprise add-on and can only be used  with [Enterprise cloud](https://www.openproject.org/docs/enterprise-guide/enterprise-cloud-guide) or [Enterprise on-premises](https://www.openproject.org/docs/enterprise-guide/enterprise-on-premises-guide). An upgrade from the free Community edition is easily possible.
 
 
 


### PR DESCRIPTION
Adding a correction that basic agile boards are part of the community edition now and only advanced action boards are an enterprise add-on