### PR TITLE
Can use space-separated string for array settings

### DIFF
--- a/lib_static/open_project/configuration/helpers.rb
+++ b/lib_static/open_project/configuration/helpers.rb
@@ -135,14 +135,6 @@ module OpenProject
         menus.to_h
       end
 
-      def disabled_modules
-        array self['disabled_modules']
-      end
-
-      def blacklisted_routes
-        array self['blacklisted_routes']
-      end
-
       ##
       # Whether we're running a bim edition
       def bim?
@@ -199,7 +191,7 @@ module OpenProject
       # In the latter case the string will be split and the values returned as an array.
       def array(value)
         if value.is_a?(String) && value =~ / /
-          value.split ' '
+          value.split
         else
           Array(value)
         end


### PR DESCRIPTION
Doing `OPENPROJECT_DISABLED__MODULES="repository wiki"` is the same as doing `OPENPROJECT_DISABLED__MODULES="['repository', 'wiki']"`.