### PR TITLE
Ensure scan phase fails if brakeman segfaults

### DIFF
--- a/.github/workflows/brakeman-scan-core.yml
+++ b/.github/workflows/brakeman-scan-core.yml
@@ -33,9 +33,13 @@ jobs:
           gem install brakeman
 
       - name: Scan
-        continue-on-error: true
         run: |
-          brakeman -i config/brakeman.ignore -f sarif -o output.sarif.json .
+          brakeman \
+            --ignore-config config/brakeman.ignore \
+            --no-exit-on-warn \
+            --no-exit-on-error \
+            --format sarif \
+            --output output.sarif.json
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
brakeman segfaulted in a CI job, and it was not noticed because of `continue-on-error: true`. Using `--no-exit-on-warn` and `--no-exit-on-error` allows to remove the `continue-on-error: true` parameter.