### PR TITLE
[46492] Don't use implicitly build boolean custom_values for change detection

### DIFF
--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -62,7 +62,7 @@ class CustomValue < ApplicationRecord
   end
 
   def default?
-    value == custom_field.default_value
+    custom_field.cast_value(value) == custom_field.default_value
   end
 
   protected

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -146,5 +146,16 @@ describe WorkPackage, 'acts_as_customizable' do
         expect(model_instance.custom_field_changes).to be_empty
       end
     end
+
+    context 'with a bool custom_field having a default value' do
+      before do
+        custom_field.update! field_format: 'bool', default_value: '0'
+        model_instance.custom_values.destroy_all
+      end
+
+      it 'returns no changes' do
+        expect(model_instance.custom_field_changes).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/46492

In the continuity of #11897: detecting if the changed value is the custom field default value need casting for boolean custom fields. Without casting, the value would be `"f"` and the default value `false`.