### PR TITLE
Prevent jumping months when toggling datepicker

### DIFF
--- a/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
+++ b/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
@@ -73,13 +73,30 @@ export function keepCurrentlyActiveMonth(datePicker:DatePicker, currentMonth:num
   datePicker.datepickerInstance.currentYear = currentYear;
 }
 
+export function comparableDate(date?:DateOption):number|null {
+  if (!date || typeof date === 'string') {
+    return null;
+  }
+
+  if (typeof date === 'number') {
+    return date;
+  }
+
+  return date.getTime();
+}
+
 export function setDates(dates:DateOption|DateOption[], datePicker:DatePicker, enforceDate?:Date):void {
   const { currentMonth, currentYear, selectedDates } = datePicker.datepickerInstance;
 
-  const [newStart, newEnd] = _.castArray(dates) as Date[];
+  const [newStart, newEnd] = _.castArray(dates);
   const [selectedStart, selectedEnd] = selectedDates;
 
-  if (newStart.getTime() === selectedStart.getTime() && (newEnd === selectedEnd || !!newEnd === !!selectedEnd)) {
+  // In case the new times match the current times, do not try to update
+  // the current selected months (Regression #46488)
+  if (selectedDates.length > 0
+    && comparableDate(newStart) === comparableDate(selectedStart)
+    && comparableDate(newEnd) === comparableDate(selectedEnd)
+  ) {
     return;
   }
 

--- a/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
+++ b/frontend/src/app/shared/components/datepicker/helpers/date-modal.helpers.ts
@@ -74,8 +74,15 @@ export function keepCurrentlyActiveMonth(datePicker:DatePicker, currentMonth:num
 }
 
 export function setDates(dates:DateOption|DateOption[], datePicker:DatePicker, enforceDate?:Date):void {
-  const { currentMonth } = datePicker.datepickerInstance;
-  const { currentYear } = datePicker.datepickerInstance;
+  const { currentMonth, currentYear, selectedDates } = datePicker.datepickerInstance;
+
+  const [newStart, newEnd] = _.castArray(dates) as Date[];
+  const [selectedStart, selectedEnd] = selectedDates;
+
+  if (newStart.getTime() === selectedStart.getTime() && (newEnd === selectedEnd || !!newEnd === !!selectedEnd)) {
+    return;
+  }
+
   datePicker.setDates(dates);
 
   if (enforceDate) {

--- a/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
@@ -320,12 +320,12 @@ export class OpWpMultiDateFormComponent extends UntilDestroyedMixin implements A
       this.ignoreNonWorkingDays = !!this.changeset.value('ignoreNonWorkingDays');
     }
 
-    this.initializeDatepicker();
+    this.datePickerInstance?.datepickerInstance.redraw();
     this.cdRef.detectChanges();
   }
 
   changeNonWorkingDays():void {
-    this.initializeDatepicker();
+    this.datePickerInstance?.datepickerInstance.redraw();
 
     // Resent the current start and duration so that the end date is calculated
     if (!!this.dates.start && !!this.duration) {


### PR DESCRIPTION
When toggling NWD , the datepicker should not jump when:

- No dates are selected
- Only one date is selected and nothing changes
- Two dates are selected and nothing changes

https://community.openproject.org/wp/46488