### PR TITLE
Bug/46249 error on filtering of work packages

### DIFF
--- a/app/models/global_role.rb
+++ b/app/models/global_role.rb
@@ -26,4 +26,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class GlobalRole < Role; end
+class GlobalRole < Role
+  def self.givable
+    where(builtin: NON_BUILTIN)
+      .where(type: 'GlobalRole')
+      .order(Arel.sql('position'))
+  end
+end

--- a/app/models/queries/work_packages/filter/role_filter.rb
+++ b/app/models/queries/work_packages/filter/role_filter.rb
@@ -68,7 +68,7 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   private
 
   def roles
-    ::Role.givable
+    ::Role.givable.or(::GlobalRole.givable)
   end
 
   def operator_for_filtering

--- a/lib/api/v3/queries/schemas/role_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/role_filter_dependency_representer.rb
@@ -33,7 +33,9 @@ module API
         class RoleFilterDependencyRepresenter <
           FilterDependencyRepresenter
           def href_callback
-            api_v3_paths.roles
+            params = [grantable: { operator: '=', values: ['t'] }]
+            escaped = CGI.escape(::JSON.dump(params))
+            "#{api_v3_paths.roles}?filters=#{escaped}"
           end
 
           def type

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -46,8 +46,8 @@ module API
           end
           private_class_method :index
 
-          def self.show(name)
-            define_singleton_method(name) { |id| build_path(name, id) }
+          def self.show(name, path = name)
+            define_singleton_method(name) { |id| build_path(path, id) }
           end
           private_class_method :show
 
@@ -394,6 +394,9 @@ module API
 
           index :role
           show :role
+
+          index :global_role, 'roles'
+          show :global_role, 'role'
 
           def self.show_revision(project_id, identifier)
             show_revision_project_repository_path(project_id, identifier)

--- a/spec/features/work_packages/table/queries/assignees_role_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/assignees_role_filter_spec.rb
@@ -1,0 +1,89 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe "Work package filtering by assignee's role", js: true do
+  shared_let(:project) { create(:project) }
+  shared_let(:role) { create(:role, permissions: %i[view_work_packages save_queries]) }
+  shared_let(:global_role) { create(:global_role, permissions: %i[view_work_packages save_queries]) }
+  shared_let(:builtin_roles) { [create(:non_member), create(:anonymous_role)] }
+  shared_let(:non_builtin_roles) { [role, global_role] }
+
+  shared_let(:other_user) do
+    create(:user,
+           firstname: 'Other',
+           lastname: 'User',
+           member_in_project: project,
+           member_through_role: role)
+  end
+
+  shared_let(:work_package_user_assignee) do
+    create(:work_package,
+           project:,
+           assigned_to: other_user)
+  end
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:filters) { Components::WorkPackages::Filters.new }
+
+  current_user do
+    create(:user,
+           member_in_project: project,
+           member_through_role: role,
+           global_permissions: %i[view_members])
+  end
+
+  it "shows the work package matching the assigne's role to filter" do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package_user_assignee)
+
+    filters.open
+    # It does not shows builtin roles such as Anonymous and NonMember
+    filters.expect_missing_filter_value_by("Assignee's role", 'is (OR)', builtin_roles, 'assignedToRole')
+    filters.expect_filter_value_by("Assignee's role", 'is (OR)', non_builtin_roles, 'assignedToRole')
+
+    filters.add_filter_by("Assignee's role", 'is (OR)', non_builtin_roles, 'assignedToRole')
+
+    wp_table.expect_work_package_listed(work_package_user_assignee)
+    sleep 2
+
+    wp_table.save_as('Subject query')
+
+    wp_table.expect_and_dismiss_toaster(message: 'Successful creation.')
+
+    # Revisit query
+    wp_table.visit_query Query.last
+    wp_table.expect_work_package_listed(work_package_user_assignee)
+
+    filters.open
+    # Do not show the already selected roles in the autocomplete dropdown
+    filters.expect_missing_autocomplete_value('assignedToRole', non_builtin_roles)
+    filters.expect_filter_by("Assignee's role", 'is (OR)', non_builtin_roles, 'assignedToRole')
+  end
+end

--- a/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
@@ -47,7 +47,8 @@ describe API::V3::Queries::Schemas::RoleFilterDependencyRepresenter do
       describe 'values' do
         let(:path) { 'values' }
         let(:type) { '[]Role' }
-        let(:href) { api_v3_paths.roles }
+        let(:grantable_filter) { CGI.escape(JSON.dump([grantable: { operator: '=', values: ['t'] }])) }
+        let(:href) { api_v3_paths.roles + "?filters=#{grantable_filter}" }
 
         context "for operator 'Queries::Operators::Equals'" do
           let(:operator) { Queries::Operators::Equals }

--- a/spec/models/queries/work_packages/filter/role_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/role_filter_spec.rb
@@ -38,8 +38,10 @@ describe Queries::WorkPackages::Filter::RoleFilter do
 
     describe '#available?' do
       it 'is true if any givable role exists' do
-        allow(Role)
-          .to receive_message_chain(:givable, :exists?)
+        allow(Role).to receive(:givable)
+        allow(Role.givable).to receive(:or).with(GlobalRole.givable)
+        allow(Role.givable.or(GlobalRole.givable))
+          .to receive(:exists?)
           .and_return true
 
         expect(instance).to be_available
@@ -56,8 +58,10 @@ describe Queries::WorkPackages::Filter::RoleFilter do
 
     describe '#allowed_values' do
       before do
-        allow(Role)
-          .to receive(:givable)
+        allow(Role).to receive(:givable)
+        allow(Role.givable)
+          .to receive(:or)
+          .with(GlobalRole.givable)
           .and_return [role]
       end
 
@@ -78,10 +82,11 @@ describe Queries::WorkPackages::Filter::RoleFilter do
       let(:role2) { build_stubbed(:role) }
 
       before do
-        allow(Role)
-          .to receive(:givable)
+        allow(Role).to receive(:givable)
+        allow(Role.givable)
+          .to receive(:or)
+          .with(GlobalRole.givable)
           .and_return([role, role2])
-
         instance.values = [role.id.to_s, role2.id.to_s]
       end
 


### PR DESCRIPTION
See [`OP#46249 Comment#8`](https://community.openproject.org/projects/openproject/work_packages/46249#activity-8)

- Global roles now can be used as a filter.
- Builtin roles such as `Anonymous` or `NonMember` will not show up in the filter.