### PR TITLE
bump rack-oauth2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,6 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     i18n-js (3.9.2)
@@ -677,7 +676,7 @@ GEM
       puma (>= 5.0, < 7)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (6.6.1)
@@ -686,10 +685,11 @@ GEM
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
-    rack-oauth2 (1.21.3)
+    rack-oauth2 (2.2.0)
       activesupport
       attr_required
-      httpclient
+      faraday (~> 2.0)
+      faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
     rack-protection (3.0.5)

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -203,9 +203,7 @@ module OAuthClients
       ServiceResult.success(result: rack_access_token)
     rescue Rack::OAuth2::Client::Error, Faraday::ParsingError => e
       service_result_with_error(i18n_rack_oauth2_error_message(e), e.message)
-    rescue Timeout::Error, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
-           Errno::EINVAL, Errno::ENETUNREACH, Errno::ECONNRESET, Errno::ECONNREFUSED, JSON::ParserError,
-           Faraday::ConnectionFailed => e
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
       # Reduce the number of exceptions in the list https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb
       service_result_with_error(
         "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}"

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -201,15 +201,20 @@ module OAuthClients
       rack_access_token = rack_oauth_client(options).access_token!(:body)
 
       ServiceResult.success(result: rack_access_token)
-    rescue Rack::OAuth2::Client::Error, Faraday::ParsingError => e
+    rescue Rack::OAuth2::Client::Error => e
       service_result_with_error(i18n_rack_oauth2_error_message(e), e.message)
-    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+    rescue Faraday::TimeoutError,
+           Faraday::ConnectionFailed,
+           Faraday::ParsingError,
+           Faraday::SSLError => e
       service_result_with_error(
-        "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}"
+        "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}",
+        e.message
       )
     rescue StandardError => e
       service_result_with_error(
-        "#{I18n.t('oauth_client.errors.oauth_returned_standard_error')}: #{e.class}: #{e.message.to_html}"
+        "#{I18n.t('oauth_client.errors.oauth_returned_standard_error')}: #{e.class}: #{e.message.to_html}",
+        e.message
       )
     end
 

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -204,7 +204,6 @@ module OAuthClients
     rescue Rack::OAuth2::Client::Error, Faraday::ParsingError => e
       service_result_with_error(i18n_rack_oauth2_error_message(e), e.message)
     rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
-      # Reduce the number of exceptions in the list https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb
       service_result_with_error(
         "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}"
       )

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -28,15 +28,6 @@ module OpenProject::OpenIDConnect
     class_inflection_override('openid_connect' => 'OpenIDConnect')
 
     register_auth_providers do
-      # Use OpenSSL default certificate store instead of HTTPClient's.
-      # It's outdated and it's unclear how it's managed.
-      OpenIDConnect.http_config do |config|
-        # The line does not work with new version of `rack-oauth2`(Faraday is used instead of HTTPClient).
-        # No need for this config. Proof:
-        # https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb#L175
-        # config.ssl_config.set_default_paths
-      end
-
       OmniAuth::OpenIDConnect::Providers.configure custom_options: %i[
         display_name? icon? sso? issuer?
         check_session_iframe? end_session_endpoint?

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -31,7 +31,10 @@ module OpenProject::OpenIDConnect
       # Use OpenSSL default certificate store instead of HTTPClient's.
       # It's outdated and it's unclear how it's managed.
       OpenIDConnect.http_config do |config|
-        config.ssl_config.set_default_paths
+        # The line does not work with new version of `rack-oauth2`(Faraday is used instead of HTTPClient).
+        # No need for this config. Proof:
+        # https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb#L175
+        # config.ssl_config.set_default_paths
       end
 
       OmniAuth::OpenIDConnect::Providers.configure custom_options: %i[

--- a/spec/services/oauth_clients/connection_manager_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_spec.rb
@@ -142,7 +142,7 @@ describe OAuthClients::ConnectionManager, type: :model do
   # The callback endpoint calls `code_to_token(code)` with the code
   # received and exchanges the code for a bearer+refresh token
   # using a HTTP request.
-  describe '#code_to_token' do
+  describe '#code_to_token', webmock: true do
     let(:code) { "7kRGJ...jG3KZ" }
 
     subject { instance.code_to_token(code) }
@@ -158,19 +158,19 @@ describe OAuthClients::ConnectionManager, type: :model do
           user_id: "admin"
         }.to_json
         stub_request(:any, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-          .to_return(status: 200, body: response_body)
+          .to_return(status: 200, body: response_body, headers: { "content-type" => "application/json; charset=utf-8" })
       end
 
-      it 'returns a valid ClientToken object', webmock: true do
+      it 'returns a valid ClientToken object' do
         expect(subject.success).to be_truthy
         expect(subject.result).to be_a OAuthClientToken
       end
     end
 
-    context 'with known error', webmock: true do
+    context 'with known error' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-          .to_return(status: 400, body: { error: error_message }.to_json)
+          .to_return(status: 400, body: { error: error_message }.to_json, headers: { "content-type" => "application/json; charset=utf-8" })
       end
 
       shared_examples 'OAuth2 error response' do
@@ -195,10 +195,10 @@ describe OAuthClients::ConnectionManager, type: :model do
       end
     end
 
-    context 'with known reply invalid_grant', webmock: true do
+    context 'with known reply invalid_grant' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-          .to_return(status: 400, body: { error: "invalid_grant" }.to_json)
+          .to_return(status: 400, body: { error: "invalid_grant" }.to_json, headers: { "content-type" => "application/json; charset=utf-8" })
       end
 
       it 'returns a specific error message' do
@@ -209,10 +209,10 @@ describe OAuthClients::ConnectionManager, type: :model do
       end
     end
 
-    context 'with unknown reply', webmock: true do
+    context 'with unknown reply' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-          .to_return(status: 400, body: { error: "invalid_requesttt" }.to_json)
+          .to_return(status: 400, body: { error: "invalid_requesttt" }.to_json, headers: { "content-type" => "application/json; charset=utf-8" })
       end
 
       it 'returns an unspecific error message' do
@@ -223,7 +223,7 @@ describe OAuthClients::ConnectionManager, type: :model do
       end
     end
 
-    context 'with reply including JSON syntax error', webmock: true do
+    context 'with reply including JSON syntax error' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
           .to_return(
@@ -235,13 +235,13 @@ describe OAuthClients::ConnectionManager, type: :model do
 
       it 'returns an unspecific error message' do
         expect(subject.success).to be_falsey
-        expect(subject.result).to eq 'Unknown :: some: very, invalid> <json}'
+        expect(subject.result).to eq "unexpected token at 'some: very, invalid> <json}'"
         expect(subject.errors[:base].count).to be(1)
         expect(subject.errors[:base].first).to include I18n.t('oauth_client.errors.oauth_returned_error')
       end
     end
 
-    context 'with 500 reply without body', webmock: true do
+    context 'with 500 reply without body' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
           .to_return(status: 500)
@@ -255,7 +255,7 @@ describe OAuthClients::ConnectionManager, type: :model do
       end
     end
 
-    context 'with bad HTTP response', webmock: true do
+    context 'with bad HTTP response' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token')).to_raise(Net::HTTPBadResponse)
       end
@@ -268,7 +268,7 @@ describe OAuthClients::ConnectionManager, type: :model do
       end
     end
 
-    context 'with timeout returns internal error', webmock: true do
+    context 'with timeout returns internal error' do
       before do
         stub_request(:post, File.join(host, '/index.php/apps/oauth2/api/v1/token')).to_timeout
       end
@@ -277,7 +277,7 @@ describe OAuthClients::ConnectionManager, type: :model do
         expect(subject.success).to be_falsey
         expect(subject.result).to be_nil
         expect(subject.errors[:base].count).to be(1)
-        expect(subject.errors[:base].first).to include I18n.t('oauth_client.errors.oauth_returned_standard_error')
+        expect(subject.errors[:base].first).to include I18n.t('oauth_client.errors.oauth_returned_http_error')
       end
     end
   end
@@ -312,7 +312,7 @@ describe OAuthClients::ConnectionManager, type: :model do
               user_id: "admin"
             }.to_json
             stub_request(:any, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-              .to_return(status: 200, body: response_body)
+              .to_return(status: 200, body: response_body, headers: { "content-type" => "application/json; charset=utf-8" })
           end
 
           it 'returns a valid ClientToken object', webmock: true do
@@ -335,7 +335,7 @@ describe OAuthClients::ConnectionManager, type: :model do
               user_id: "admin"
             }.to_json
             stub_request(:any, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-              .to_return(status: 200, body: response_body)
+              .to_return(status: 200, body: response_body, headers: { "content-type" => "application/json; charset=utf-8" })
           end
 
           it 'returns dependent error from model validation', webmock: true do
@@ -349,7 +349,7 @@ describe OAuthClients::ConnectionManager, type: :model do
         context 'with server error from OAuth2 provider' do
           before do
             stub_request(:any, File.join(host, '/index.php/apps/oauth2/api/v1/token'))
-              .to_return(status: 400, body: { error: "invalid_request" }.to_json)
+              .to_return(status: 400, body: { error: "invalid_request" }.to_json, headers: { "content-type" => "application/json; charset=utf-8" })
           end
 
           it 'returns a server error', webmock: true do
@@ -396,8 +396,8 @@ describe OAuthClients::ConnectionManager, type: :model do
             response_body2[:access_token] = "differ...RYvRH"
             request_url = File.join(host, '/index.php/apps/oauth2/api/v1/token')
             stub_request(:any, request_url).to_return(
-              { status: 200, body: response_body1.to_json },
-              { status: 200, body: response_body2.to_json }
+              { status: 200, body: response_body1.to_json, headers: { "content-type" => "application/json; charset=utf-8" } },
+              { status: 200, body: response_body2.to_json, headers: { "content-type" => "application/json; charset=utf-8" } }
             )
 
             result1 = nil
@@ -433,8 +433,8 @@ describe OAuthClients::ConnectionManager, type: :model do
             response_body2[:access_token] = "differ...RYvRH"
             request_url = File.join(host, '/index.php/apps/oauth2/api/v1/token')
             stub_request(:any, request_url)
-              .to_return(status: 200, body: response_body1.to_json).then
-              .to_return(status: 200, body: response_body2.to_json)
+              .to_return(status: 200, body: response_body1.to_json, headers: { "content-type" => "application/json; charset=utf-8" }).then
+              .to_return(status: 200, body: response_body2.to_json, headers: { "content-type" => "application/json; charset=utf-8" })
 
             result1 = nil
             result2 = nil


### PR DESCRIPTION
* Reduce the list of exceptions in `OAuthClients::ConnectionManager` that get rescued due to the switch to Faraday in newer version of `rack-oauth2`. And [Faraday]( https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb) has already grouped those exceptions. 
* Remove extra SSL configuration block in `OpenProject::OpenIDConnect` module, because this configuration is already covered by [Faraday](
https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb#L175) and it is doing the same as before in [HTTPClient](https://github.com/nahi/httpclient/blob/master/lib/httpclient/ssl_config.rb#L199).