### PR TITLE
add non null constraints on data_id/type polymorphic foreign key

### DIFF
--- a/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
+++ b/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
@@ -1,0 +1,6 @@
+class NonNullDataReferenceOnJournals < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :journals, :data_id, false
+    change_column_null :journals, :data_type, false
+  end
+end

--- a/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
+++ b/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
@@ -1,5 +1,9 @@
 class NonNullDataReferenceOnJournals < ActiveRecord::Migration[7.0]
   def change
+    reversible do |direction|
+      direction.up { execute "DELETE FROM journals WHERE data_id IS NULL or data_type IS NULL" }
+    end
+
     change_column_null :journals, :data_id, false
     change_column_null :journals, :data_type, false
   end

--- a/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
+++ b/db/migrate/20230306083203_non_null_data_reference_on_journals.rb
@@ -1,10 +1,43 @@
 class NonNullDataReferenceOnJournals < ActiveRecord::Migration[7.0]
   def change
     reversible do |direction|
-      direction.up { execute "DELETE FROM journals WHERE data_id IS NULL or data_type IS NULL" }
+      direction.up do
+        change_on_delete_on_notification_fk(true)
+        cleanup_invalid_journals
+      end
+      direction.down do
+        change_on_delete_on_notification_fk(false)
+      end
     end
 
+    change_non_null_data_columns
+  end
+
+  private
+
+  def change_non_null_data_columns
     change_column_null :journals, :data_id, false
     change_column_null :journals, :data_type, false
+  end
+
+  def cleanup_invalid_journals
+    execute <<~SQL.squish
+      DELETE FROM journals
+      WHERE data_id IS NULL OR data_type IS NULL
+    SQL
+  end
+
+  def change_on_delete_on_notification_fk(cascade)
+    options = if cascade
+                { on_delete: :cascade }
+              else
+                {}
+              end
+
+    remove_foreign_key :notifications, :journals
+
+    add_foreign_key :notifications,
+                    :journals,
+                    **options
   end
 end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -55,4 +55,18 @@ describe Journal do
         .to change(Notification, :count).from(1).to(0)
     end
   end
+
+  describe '#create' do
+    context 'without a data foreign key' do
+      subject { create(:work_package_journal, data: nil) }
+
+      it 'raises an error and does not create a database record' do
+        expect { subject }
+          .to raise_error(ActiveRecord::NotNullViolation)
+
+        expect(described_class.count)
+          .to eq 0
+      end
+    end
+  end
 end

--- a/spec/services/users/replace_mentions_service_integration_spec.rb
+++ b/spec/services/users/replace_mentions_service_integration_spec.rb
@@ -342,7 +342,9 @@ describe Users::ReplaceMentionsService, 'integration' do
   end
 
   context 'for journal notes' do
-    it_behaves_like 'rewritten mention', :journal, :notes
+    it_behaves_like 'rewritten mention', :journal, :notes do
+      let(:additional_properties) { { data_id: 5, data_type: 'Foobar' } }
+    end
   end
 
   context 'for comment comments' do
@@ -357,7 +359,12 @@ describe Users::ReplaceMentionsService, 'integration' do
 
   context 'for customizable_journal value' do
     it_behaves_like 'rewritten mention', :journal_customizable_journal, :value do
-      let(:additional_properties) { { journal: create(:journal), custom_field: create(:text_wp_custom_field) } }
+      let(:additional_properties) do
+        {
+          journal: create(:journal, data_id: 5, data_type: 'Foobar'),
+          custom_field: create(:text_wp_custom_field)
+        }
+      end
     end
   end
 


### PR DESCRIPTION
An OP instance reported a lot of records where both are null. It is still unclear how this has happened. Having an explicit not null is not as good has having a proper foreign key constraint, which however cannot be modelled on polymorphic relations in SQL. And the invalid records reported by the instance should at least be prevented.

https://community.openproject.org/wp/46278