### PR TITLE
remove non unrequired width

### DIFF
--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -44,7 +44,6 @@
     @include text-shortener
     flex: 0 1 auto
     padding-right: $spot-spacing-0_5
-    width: 100% // prevent text-overflow from capping too early on Safari
 
 .attributes-key-value--value-container
   display: flex


### PR DESCRIPTION
Since 12.5, the layouting of the attribute key-value list has been changed so that the width is no longer necessary.

In part, this reverts #11789.

https://community.openproject.org/wp/45561