### PR TITLE
Bug/45701 notifications not sent for new work packages when creating project from template

### DIFF
--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -92,12 +92,6 @@ module BaseServices
     protected
 
     ##
-    # Disabling sending regular notifications
-    def service_context(*, &)
-      in_context(model, send_notifications: false, &)
-    end
-
-    ##
     # Should the dependency be skipped for this service run?
     def skip_dependency?(_params, _dependency_cls)
       false

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -139,9 +139,8 @@ module Projects::Copy
         # We don't support copying budgets right now
         budget_id: nil,
 
-        # We fetch the value from the global registry to persist it in the job which
-        # will trigger a delayed job for potentially sending the journal notifications.
-        send_notifications: ActionMailer::Base.perform_deliveries
+        # We persist the setting in the job which will trigger a delayed job for potentially sending the journal notifications.
+        send_notifications: params[:send_notifications]
       }
     end
 

--- a/app/services/shared/service_state.rb
+++ b/app/services/shared/service_state.rb
@@ -25,7 +25,6 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require "ostruct"
 
 ##
 # Service state object to be passed around services
@@ -34,7 +33,7 @@ require "ostruct"
 # Borrows heavily from interactor gem's context class at
 # https://github.com/collectiveidea/interactor
 module Shared
-  class ServiceState < OpenStruct
+  class ServiceState < Hashie::Mash
     ##
     # Builds the context object unless
     # it's already an instance of this context.

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -154,7 +154,7 @@ class CopyProjectJob < ApplicationJob
   end
 
   def copy_project_params
-    params = { target_project_params: }
+    params = { target_project_params:, send_notifications: send_mails }
     params[:only] = associations_to_copy if associations_to_copy.present?
 
     params

--- a/lib/api/v3/projects/copy/parse_copy_params_service.rb
+++ b/lib/api/v3/projects/copy/parse_copy_params_service.rb
@@ -41,7 +41,7 @@ module API
               target_project_params: attributes,
               attributes_only: true,
               only: meta[:only],
-              send_notifications: meta[:send_notifications] != false
+              send_notifications: meta[:send_notifications] == true
             }
           end
         end

--- a/lib/api/v3/projects/copy/project_copy_meta_representer.rb
+++ b/lib/api/v3/projects/copy/project_copy_meta_representer.rb
@@ -51,8 +51,8 @@ module API
           property :send_notifications,
                    exec_context: :decorator,
                    getter: ->(*) do
-                     # Default to true
-                     represented.send_notifications != false
+                     # Default to false
+                     represented.send_notifications || false
                    end,
                    setter: ->(fragment:, **) do
                      represented.send_notifications = fragment

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -151,10 +151,6 @@ describe 'Projects copy',
       editor = Components::WysiwygEditor.new "[data-qa-field-name='customField#{project_custom_field.id}']"
       editor.expect_value 'some text cf'
 
-      # Deactivate sending of mails during copying
-      click_on 'Copy options'
-      uncheck 'Send email notifications during the project copy'
-
       click_button 'Save'
 
       expect(page).to have_text 'The job has been queued and will be processed shortly.'

--- a/spec/lib/api/v3/projects/copy/project_copy_payload_representer_spec.rb
+++ b/spec/lib/api/v3/projects/copy/project_copy_payload_representer_spec.rb
@@ -42,18 +42,18 @@ describe API::V3::Projects::Copy::ProjectCopyPayloadRepresenter do
 
     subject { representer.to_json }
 
-    it 'has a _meta property with the copy properties set to true by default' do
+    it 'has a _meta property with the copy properties set to true by default but sendNotifications false by default' do
       expect(subject).to have_json_path '_meta'
-
-      expect(subject)
-        .to be_json_eql(true.to_json)
-              .at_path("_meta/sendNotifications")
 
       Projects::CopyService.copyable_dependencies.each do |dep|
         expect(subject)
           .to be_json_eql(true.to_json)
                 .at_path("_meta/copy#{dep[:identifier].camelize}")
       end
+
+      expect(subject)
+        .to be_json_eql(false.to_json)
+              .at_path("_meta/sendNotifications")
     end
 
     context 'with the meta property containing which associations to copy' do

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -197,7 +197,7 @@ describe API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
 
       it 'returns it as false' do
         expect(response.body)
-          .to be_json_eql(true.to_json)
+          .to be_json_eql(false.to_json)
                 .at_path("_embedded/payload/_meta/sendNotifications")
       end
     end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -29,16 +29,16 @@
 require 'spec_helper'
 
 describe Projects::CopyService, 'integration', type: :model do
-  shared_let(:status_locked) { create :status, is_readonly: true }
-  shared_let(:source) { create :project, enabled_module_names: %w[wiki work_package_tracking] }
-  shared_let(:source_wp) { create :work_package, project: source, subject: 'source wp' }
+  shared_let(:status_locked) { create(:status, is_readonly: true) }
+  shared_let(:source) { create(:project, enabled_module_names: %w[wiki work_package_tracking]) }
+  shared_let(:source_wp) { create(:work_package, project: source, subject: 'source wp') }
   shared_let(:source_wp_locked) do
-    create :work_package, project: source, subject: 'source wp locked', status: status_locked
+    create(:work_package, project: source, subject: 'source wp locked', status: status_locked)
   end
-  shared_let(:source_query) { create :query, project: source, name: 'My query' }
-  shared_let(:source_view) { create :view_work_packages_table, query: source_query }
-  shared_let(:source_category) { create :category, project: source, name: 'Stock management' }
-  shared_let(:source_version) { create :version, project: source, name: 'Version A' }
+  shared_let(:source_query) { create(:query, project: source, name: 'My query') }
+  shared_let(:source_view) { create(:view_work_packages_table, query: source_query) }
+  shared_let(:source_category) { create(:category, project: source, name: 'Stock management') }
+  shared_let(:source_version) { create(:version, project: source, name: 'Version A') }
   shared_let(:source_wiki_page) { create(:wiki_page_with_content, wiki: source.wiki) }
   shared_let(:source_child_wiki_page) { create(:wiki_page_with_content, wiki: source.wiki, parent: source_wiki_page) }
   shared_let(:source_forum) { create(:forum, project: source) }
@@ -57,11 +57,12 @@ describe Projects::CopyService, 'integration', type: :model do
     { name: 'Some name', identifier: 'some-identifier' }
   end
   let(:params) do
-    { target_project_params:, only: only_args }
+    { target_project_params:, only: only_args, send_notifications: }
   end
-  let(:role) { create :role, permissions: %i[copy_projects view_work_packages work_package_assigned] }
+  let(:send_notifications) { true }
+  let(:role) { create(:role, permissions: %i[copy_projects view_work_packages work_package_assigned]) }
 
-  shared_let(:new_project_role) { create :role, permissions: %i[] }
+  shared_let(:new_project_role) { create(:role, permissions: %i[]) }
 
   before do
     with_enterprise_token(:readonly_work_packages)
@@ -203,10 +204,10 @@ describe Projects::CopyService, 'integration', type: :model do
     context 'with group memberships' do
       let(:only_args) { %w[members] }
 
-      let!(:user) { create :user }
+      let!(:user) { create(:user) }
       let!(:another_role) { create(:role) }
       let!(:group) do
-        create :group, members: [user]
+        create(:group, members: [user])
       end
 
       it 'will copy them as well' do
@@ -469,7 +470,7 @@ describe Projects::CopyService, 'integration', type: :model do
         end
 
         context 'if one work package is a cross project reference' do
-          let(:other_project) { create :project }
+          let(:other_project) { create(:project) }
           let(:only_args) { %w[work_packages queries] }
 
           before do


### PR DESCRIPTION
Enables sending of notifications for individual models (e.g. work packages) when copying. If the option to send notifications is checked, e.g. the assignee of a copied work package will receive a notification. 

Because this change potentially leads to a lot of notifications being created, the default for sending is changed to `false`. The user has to actively decide to want notifications being sent.

https://community.openproject.org/wp/45701 