### PR TITLE
[46649] Work package single date picker (eg. Milestone) should show short banners

### DIFF
--- a/frontend/src/app/shared/components/datepicker/wp-single-date-form/wp-single-date-form.component.sass
+++ b/frontend/src/app/shared/components/datepicker/wp-single-date-form/wp-single-date-form.component.sass
@@ -1,2 +1,6 @@
 .op-wp-single-date-form
   height: 100% 
+  .op-modal-banner
+    grid-template-columns: auto max-content !important
+    .spot-icon, .op-modal-banner--subtitle
+      display: none


### PR DESCRIPTION
Hide subtitle and icon in date picker banner for WP single date picker.

https://community.openproject.org/projects/openproject/work_packages/46649/activity