### PR TITLE
fix replacement-label width on safari

### DIFF
--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -40,10 +40,23 @@
   padding: 0.375rem 0
   font-weight: bold
   // Ensure that the text is shortened while the help icon will be displayed
+  // The flex and max-width of wp-replacement-label and attribute-help-text
+  // are tuned to:
+  // * have the label be displayed in total if there is enough place (safari
+  //   tends to sometimes fall back to ellipsis too early, e.g. for 'Category')
+  // * Have the label grow to the full width if necessary and only apply ellipsis
+  //   after that.
+  // * have the attribute-help-text positioned as far to the left as possible so to be
+  //   right after the label.
+  // It is unclear why in `flex: 100 0 auto` the 100 seems to be doing the trick (MAGIC NUMBER).
+  // It does not work with e.g. 1000 or 10
   > wp-replacement-label
     @include text-shortener
-    flex: 0 1 auto
     padding-right: $spot-spacing-0_5
+    flex: 1 1 auto
+    max-width: 100%
+  > attribute-help-text
+    flex: 100 0 auto
 
 .attributes-key-value--value-container
   display: flex


### PR DESCRIPTION
Special fix for safari to prevent preemptive ellipsis. 

https://community.openproject.org/wp/45561