### PR TITLE
allow date in attributesByTimestamp for milestones

### DIFF
--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -40,6 +40,7 @@ module API
           subject
           start_date
           due_date
+          date
         ].freeze
 
         SUPPORTED_LINK_PROPERTIES = %w[
@@ -91,9 +92,11 @@ module API
           # * does not mess with `start_date` and `due_date`
           represented
             .attributes_changed_to_baseline
-            .map do |property|
+            .flat_map do |property|
             if property.ends_with?('_id')
               API::Utilities::PropertyNameConverter.from_ar_name(property)
+            elsif %w[start_date due_date].include?(property)
+              ['date', property]
             else
               property
             end

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -284,4 +284,33 @@ describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'rendering' d
         .to be_json_eql(expected_json)
     end
   end
+
+  context 'with a milestone typed work package' do
+    let(:type) { build_stubbed(:type_milestone) }
+    # On a milestone, both dates will be the same
+    let(:start_date) { due_date }
+    let(:attributes_changed_to_baseline) { %w[start_date] }
+
+    let(:expected_json) do
+      {
+        'date' => work_package.start_date,
+        '_meta' => {
+          'matchesFilters' => true,
+          'exists' => true,
+          'timestamp' => timestamp.to_s
+        },
+        '_links' => {
+          'self' => {
+            'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
+            'title' => work_package.subject
+          }
+        }
+      }.to_json
+    end
+
+    it 'renders as expected' do
+      expect(subject)
+        .to be_json_eql(expected_json)
+    end
+  end
 end

--- a/spec/requests/api/v3/work_packages/index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/index_resource_spec.rb
@@ -741,6 +741,37 @@ describe 'API v3 Work package resource',
         end
       end
 
+      describe "for a milestone typed work package" do
+        let(:type) { create(:type_milestone) }
+        let(:original_date) { Date.current }
+        let(:current_date) { Date.current + 1.day }
+
+        let(:work_package) do
+          new_work_package = create(:work_package, due_date: current_date, start_date: current_date, project:, type:)
+          new_work_package.update_columns(created_at:)
+          new_work_package
+        end
+
+        let(:original_journal) do
+          create_journal(journable: work_package,
+                         timestamp: created_at,
+                         version: 1,
+                         attributes: { due_date: original_date, start_date: original_date, duration: 1 })
+        end
+        let(:current_journal) do
+          create_journal(journable: work_package,
+                         timestamp: 1.day.ago,
+                         version: 2,
+                         attributes: { due_date: current_date, start_date: current_date, duration: 1 })
+        end
+
+        it 'displays the original date in the attributesByTimestamp' do
+          expect(subject.body)
+            .to be_json_eql(original_date.to_json)
+                  .at_path("_embedded/elements/0/_embedded/attributesByTimestamp/0/date")
+        end
+      end
+
       context "with caching" do
         context "with relative timestamps" do
           let(:timestamps) { [Timestamp.parse("P-2D"), Timestamp.now] }


### PR DESCRIPTION
The date property wasn't part of the allowlist so for work packages with milestone types, the dates properties did not show at all. Now, whenever either start or due date changes on a milestone work package, the `date` property is displayed. It makes sense to treat those two dates separately although they should be the same for milestone typed work packages for the cases where type is changed.

https://community.openproject.org/wp/46653