### PR TITLE
optimize activating a type for multiple projects

### DIFF
--- a/app/models/custom_fields_project.rb
+++ b/app/models/custom_fields_project.rb
@@ -1,0 +1,33 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+# Join table between to store the work package custom fields active in a project.
+class CustomFieldsProject < ApplicationRecord
+  belongs_to :project
+  belongs_to :custom_field
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -79,11 +79,13 @@ class Project < ApplicationRecord
   has_many :changesets, through: :repository
   has_one :wiki, dependent: :destroy
   # Custom field for the project's work_packages
-  has_and_belongs_to_many :work_package_custom_fields,
-                          -> { order("#{CustomField.table_name}.position") },
-                          class_name: 'WorkPackageCustomField',
-                          join_table: "#{table_name_prefix}custom_fields_projects#{table_name_suffix}",
-                          association_foreign_key: 'custom_field_id'
+  has_many :custom_fields_projects,
+           dependent: :destroy
+  has_many :work_package_custom_fields,
+           -> { order("#{CustomField.table_name}.position") },
+           through: :custom_fields_projects,
+           class_name: 'WorkPackageCustomField',
+           source: :custom_field
   has_one :status, class_name: 'Projects::Status', dependent: :destroy
   has_many :budgets, dependent: :destroy
   has_many :notification_settings, dependent: :destroy

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -164,7 +164,8 @@ class BaseTypeService
   def set_active_custom_fields
     new_cf_ids_to_add = active_custom_field_ids - type.custom_field_ids
     type.custom_field_ids = active_custom_field_ids
-    set_active_custom_fields_for_projects(type.projects, new_cf_ids_to_add)
+    set_active_custom_fields_for_projects(type.projects,
+                                          new_cf_ids_to_add)
   end
 
   def active_custom_field_ids
@@ -183,7 +184,14 @@ class BaseTypeService
   end
 
   def set_active_custom_fields_for_projects(projects, custom_field_ids)
-    projects.each { |p| p.work_package_custom_field_ids |= custom_field_ids }
+    values = projects
+               .to_a
+               .product(custom_field_ids)
+               .map { |p, cf_ids| { project_id: p.id, custom_field_id: cf_ids } }
+
+    return if values.empty?
+
+    CustomFieldsProject.insert_all(values)
   end
 
   def set_active_custom_fields_for_project_ids(project_ids)

--- a/db/migrate/20230309104056_unique_index_on_custom_fields_projects.rb
+++ b/db/migrate/20230309104056_unique_index_on_custom_fields_projects.rb
@@ -1,0 +1,47 @@
+class UniqueIndexOnCustomFieldsProjects < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |direction|
+      direction.up { remove_duplicates }
+    end
+
+    remove_index :custom_fields_projects,
+                 %i[custom_field_id project_id]
+
+    add_index :custom_fields_projects,
+              %i[custom_field_id project_id],
+              unique: true
+  end
+
+  private
+
+  # Selects all distinct tuples of (project_id, custom_field_id), then removes the whole content
+  # of custom_fields_projects to then add the distinct tuples again.
+  def remove_duplicates
+    execute <<~SQL.squish
+      WITH selection AS (
+        SELECT
+          project_id,
+          custom_field_id
+        FROM
+          custom_fields_projects
+        GROUP BY
+          (project_id, custom_field_id)
+      ),
+      deletion AS (
+        DELETE FROM
+          custom_fields_projects
+      ),
+      insertion AS (
+        INSERT INTO
+          custom_fields_projects
+        SELECT
+          project_id,
+          custom_field_id
+        FROM
+          selection
+      )
+
+      SELECT 1
+    SQL
+  end
+end


### PR DESCRIPTION
Instead of individual insert statements for adding the custom fields associated to a type for the projects the type is activated in, now one statement is employed.

To avoid duplicates, a unique index is added to the join table. Since there might already be duplicates in the table, that was the case in my test database, the table is cleaned up before setting the unique index.

Since `insert_all` requires a proper model and does not work on a habtm association, the join table linking projects and custom fields has now a proper model.

The join table for the linking of projects and types is still filled up by individual INSERT statements. That could still be improved. However, when testing the impact of that was not so bad. This is probably because it will increase linearly as compared to the projects-custom_fields table where the impact is n*m.

https://community.openproject.org/wp/46118 