### PR TITLE
Fix parsing of negative iso8601 duration

### DIFF
--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -42,9 +42,9 @@ class Timestamp
   def self.parse(iso8601_string)
     return iso8601_string if iso8601_string.is_a?(Timestamp)
 
-    iso8601_string.strip!
+    iso8601_string = iso8601_string.strip
     iso8601_string = substitute_special_shortcut_values(iso8601_string)
-    if iso8601_string.start_with? "P" # ISO8601 "Period"
+    if iso8601_string.start_with? /[+-]?P/ # ISO8601 "Period"
       iso8601_string = ActiveSupport::Duration.parse(iso8601_string).iso8601
     elsif (time = Time.zone.parse(iso8601_string)).present?
       iso8601_string = time.iso8601

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -97,6 +97,22 @@ describe Timestamp do
         expect(subject.to_duration).to eq ActiveSupport::Duration.build(10)
         expect(subject.relative?).to be true
       end
+
+      {
+        'PT1H' => 'PT1H',
+        'PT0001H' => 'PT1H',
+        'PT0009H' => 'PT9H',
+        'PT-1H' => 'PT-1H',
+        '+PT1H' => 'PT1H',
+        '-PT1H' => 'PT-1H',
+        '-PT-1H' => 'PT1H',
+        '  PT1H  ' => 'PT1H',
+        '-P1M-1DT1H-02M' => 'P-1M1DT-1H2M'
+      }.each do |input, expected|
+        it "parses #{input.inspect} into #{expected.inspect}" do
+          expect(described_class.parse(input).to_s).to eq(expected)
+        end
+      end
     end
 
     describe "when providing a valid ISO8601 time" do


### PR DESCRIPTION
'P-1D' and '-P1D' both represent the same duration of -1 day.