### PR TITLE
Call distinct on WorkPackageCustomField

### DIFF
--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -65,7 +65,10 @@ module Projects
     def set_default_active_work_package_custom_fields(provided)
       return if provided
 
-      model.work_package_custom_fields = WorkPackageCustomField.joins(:types).where(types: { id: model.type_ids })
+      model.work_package_custom_fields = WorkPackageCustomField
+        .joins(:types)
+        .where(types: { id: model.type_ids })
+        .distinct
     end
 
     def update_status(attributes)


### PR DESCRIPTION
If a custom field exists in multiple active types, this call will return duplicate custom fields

Fix for project creation error on edge:

```
  ↳ app/services/base_services/write.rb:36:in `persist'
  CustomFieldsProject Create (0.8ms)  INSERT INTO "custom_fields_projects" ("custom_field_id", "project_id") VALUES ($1, $2)  [["custom_field_id", 20], ["project_id", 675]]
  ↳ app/services/base_services/write.rb:36:in `persist'
  TRANSACTION (0.2ms)  ROLLBACK
  ↳ app/services/shared/service_context.rb:56:in `in_user_context'
I, [2023-03-10T15:37:49.569326 #86073]  INFO -- : duration=78166.38 db=203.31 view=77963.07 status=500 method=POST path=/api/v3/projects params={"name"=>"test", "description"=>{"format"=>"markdown", "raw"=>"", "html"=>""}, "public"=>false, "statusExplanation"=>{"format"=>"markdown", "raw"=>"", "html"=>""}, "customField57"=>nil, "customField80"=>nil, "customField54"=>nil, "customField55"=>nil, "customField56"=>nil, "customField50"=>false, "customField97"=>{"format"=>"markdown", "raw"=>"", "html"=>""}, "customField98"=>{"format"=>"markdown", "raw"=>"", "html"=>""}, "customField101"=>"test", "customField124"=>{"format"=>"markdown", "raw"=>"", "html"=>""}, "_links"=>{"status"=>{"href"=>nil}, "parent"=>{"href"=>nil}, "customField105"=>[], "customField46"=>{"href"=>nil}, "customField51"=>{"href"=>nil}, "customField52"=>{"href"=>nil}, "customField106"=>[], "customField108"=>[], "customField109"=>[], "customField110"=>{"href"=>nil}, "customField111"=>[], "customField126"=>{"href"=>nil}, "customField102"=>{"href"=>nil}}} host=localhost user=253
F, [2023-03-10T15:37:49.571930 #86073] FATAL -- :   
ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_custom_fields_projects_on_custom_field_id_and_project_id"
DETAIL:  Key (custom_field_id, project_id)=(20, 675) already exists.
):
  
app/services/base_services/write.rb:36:in `persist'
app/services/base_services/base_contracted.rb:64:in `block in perform'
app/models/journal/notification_configuration.rb:40:in `with'
app/services/shared/service_context.rb:67:in `block in without_context_transact
```