### PR TITLE
Remove catastrophic exponential-time regex

### DIFF
--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -142,7 +142,7 @@ module ReportingHelper
     case key.to_sym
     when :work_package_id, :tweek, :tmonth, :week  then value.to_i
     when :spent_on                                 then value.to_date.mjd
-    else h(Sanitize.fragment(field_representation_map(key, value)))
+    else strip_tags(field_representation_map(key, value))
     end
   end
 

--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -142,7 +142,7 @@ module ReportingHelper
     case key.to_sym
     when :work_package_id, :tweek, :tmonth, :week  then value.to_i
     when :spent_on                                 then value.to_date.mjd
-    else h(field_representation_map(key, value).gsub(/<\/?[^>]*>/, ''))
+    else h(Sanitize.fragment(field_representation_map(key, value)))
     end
   end
 

--- a/modules/reporting/app/models/cost_query/sql_statement.rb
+++ b/modules/reporting/app/models/cost_query/sql_statement.rb
@@ -88,7 +88,7 @@ class CostQuery::SqlStatement < Report::SqlStatement
       query.select({
                      count: 1, id: [model, :id], display_costs: 1,
                      real_costs: switch("#{table}.overridden_costs IS NULL" => [model, :costs], else: [model, :overridden_costs]),
-                     week: iso_year_week(:spent_on, model),
+                     week: iso_year_week(field_name_for([model, :spent_on])),
                      singleton_value: 1
                    })
       # FIXME: build this subquery from a sql_statement

--- a/modules/reporting/lib/report/chainable.rb
+++ b/modules/reporting/lib/report/chainable.rb
@@ -329,7 +329,7 @@ module Report
     def with_table(fields)
       fields.map do |f|
         place_field_name = self.class.put_sql_table_names[f] || self.class.put_sql_table_names[f].nil?
-        place_field_name ? (field_name_for f, self) : f
+        place_field_name ? field_name_for([self, f]) : f
       end
     end
 

--- a/modules/reporting/lib/report/query_utils.rb
+++ b/modules/reporting/lib/report/query_utils.rb
@@ -155,10 +155,8 @@ module Report::QueryUtils
   # @param [Hash] options Condition => Result.
   # @return [String] Case statement.
   def switch(options)
-    desc = "#{__method__} #{options.inspect[1..-2]}".gsub(/(Cost|Time)Entry\([^)]*\)/, '\1Entry')
     options = options.with_indifferent_access
     else_part = options.delete :else
-    "-- #{desc}\n\t" \
     "CASE #{options.map do |k, v|
       "\n\t\tWHEN #{field_name_for k}\n\t\t" \
         "THEN #{field_name_for v}"

--- a/modules/reporting/lib/report/query_utils.rb
+++ b/modules/reporting/lib/report/query_utils.rb
@@ -123,20 +123,17 @@ module Report::QueryUtils
   #   field_name_for nil                            # => 'NULL'
   #   field_name_for 'foo'                          # => 'foo'
   #   field_name_for [Issue, 'project_id']          # => 'issues.project_id'
-  #   field_name_for [:issue, 'project_id'], :entry # => 'issues.project_id'
-  #   field_name_for 'project_id', :entry           # => 'entries.project_id'
+  #   field_name_for [:issue, 'project_id']         # => 'issues.project_id'
   #
   # @param [Array, Object] arg Object to generate field name for.
   # @param [Object, optional] default_table Table name to use if no table name is given.
   # @return [String] Field name.
-  def field_name_for(arg, default_table = nil)
+  def field_name_for(arg)
     return 'NULL' unless arg
-    return field_name_for(arg.keys.first, default_table) if arg.is_a? Hash
-    return arg if arg.is_a? String and arg =~ /\.| |\(.*\)/
-    return (table_name_for(arg.first || default_table) + '.') << arg.last.to_s if arg.is_a? Array and arg.size == 2
-    return arg.to_s unless default_table
+    return field_name_for(arg.keys.first) if arg.is_a? Hash
+    return "#{table_name_for(arg.first)}.#{arg.last}" if arg.is_a? Array and arg.size == 2
 
-    field_name_for [default_table, arg]
+    arg.to_s
   end
 
   ##
@@ -211,9 +208,7 @@ module Report::QueryUtils
     "#{safe_value}::#{type}"
   end
 
-  def iso_year_week(field, default_table = nil)
-    field_name = field_name_for(field, default_table)
-
+  def iso_year_week(field_name)
     "(EXTRACT(isoyear from #{field_name})*100 + \n\t\t" \
       "EXTRACT(week from #{field_name} - \n\t\t" \
       "(EXTRACT(dow FROM #{field_name})::int+6)%7))"


### PR DESCRIPTION
CodeQL in GitHub actions detected some ["catastrophic regexp"](https://www.regular-expressions.info/catastrophic.html) that we need to get rid of.

They can be seen on GitHub in Security > Code scanning  > [Polynomial regular expression used on uncontrolled data](https://github.com/opf/openproject/security/code-scanning?query=is%3Aopen+branch%3Adev+rule%3Arb%2Fpolynomial-redos).