### PR TITLE
Fix returning cached activity for wrong work package

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/wp-linked-resource-cache.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/wp-linked-resource-cache.service.ts
@@ -28,20 +28,26 @@
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { input, InputState } from 'reactivestates';
-import { take } from 'rxjs/operators';
+import {
+  filter,
+  map,
+  take,
+} from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
-import { EntityUIStore } from '@datorama/akita';
 
-EntityUIStore;
+interface CacheInput<T> {
+  id:string;
+  value:T;
+}
 
 export abstract class WorkPackageLinkedResourceCache<T> {
   protected cacheDurationInSeconds = 120;
 
   // Cache activities for the last work package
   // to allow fast switching between work packages without refreshing.
-  protected cache:{ id:string|null, state:InputState<T> } = {
+  protected cache:{ id:string|null, state:InputState<CacheInput<T>> } = {
     id: null,
-    state: input<T>(),
+    state: input<CacheInput<T>>(),
   };
 
   /**
@@ -54,7 +60,7 @@ export abstract class WorkPackageLinkedResourceCache<T> {
    * @returns {Promise<T>}
    */
   public requireAndStream(workPackage:WorkPackageResource, force = false):Observable<T> {
-    const id = workPackage.id!;
+    const id = (workPackage.id as string|number).toString();
     const { state } = this.cache;
 
     // Clear cache if requesting different resource
@@ -63,15 +69,24 @@ export abstract class WorkPackageLinkedResourceCache<T> {
     }
 
     // Return cached value if id matches and value is present
-    if (this.isCached(id)) {
-      return of(state.value!);
+    if (this.isCached(id) && state.value) {
+      return of(state.value.value);
     }
 
-    // Ensure value is loaded only once
-    this.cache.id = id;
-    this.cache.state.putFromPromiseIfPristine(() => this.load(workPackage));
+    if (!this.isRequested(id)) {
+      // Ensure value is loaded only once
+      this.cache.id = id;
+      this.cache.state.clearAndPutFromPromise(this.load(workPackage).then((value) => ({ value, id })));
+    }
 
-    return this.cache.state.values$();
+    return this
+      .cache
+      .state
+      .values$()
+      .pipe(
+        filter((cached) => cached && cached.id === id),
+        map((cached) => cached.value),
+      );
   }
 
   public require(workPackage:WorkPackageResource, force = false):Promise<T> {
@@ -97,6 +112,16 @@ export abstract class WorkPackageLinkedResourceCache<T> {
   public isCached(workPackageId:string) {
     const { state } = this.cache;
     return this.cache.id === workPackageId && state.hasValue() && !state.isValueOlderThan(this.cacheDurationInSeconds * 1000);
+  }
+
+  /**
+   * Return whether the given work package is cached.
+   * @param {string} workPackageId
+   * @returns {boolean}
+   */
+  public isRequested(workPackageId:string) {
+    const { state } = this.cache;
+    return this.cache.id === workPackageId && state.hasActivePromiseRequest();
   }
 
   /**


### PR DESCRIPTION
When a second work package is requested while the first request promise is still active,the first will result in a value change before the value is cleared. The wrong value is transmitted in that case.

https://community.openproject.org/wp/44198