### PR TITLE
Refactor the Components::WorkPackages::Filters

### DIFF
--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -217,8 +217,8 @@ module Components
           # wait for filter to be present
           filter_element = page.find("#filter_#{id}")
           if filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
-            input = filter_element.find("[data-qa-selector='op-basic-range-date-picker']")
-            ensure_value_is_input_correctly input, value: Array(value).join(' - ')
+            date_input = filter_element.find("[data-qa-selector='op-basic-range-date-picker']")
+            ensure_value_is_input_correctly date_input, value: Array(value).join(' - ')
           elsif filter_element.has_selector?(".ng-select-container", wait: false)
             Array(value).each do |val|
               select_autocomplete filter_element.find("op-autocompleter"),

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -157,27 +157,11 @@ module Components
       end
 
       def expect_autocomplete_value(id, value)
-        # wait for filter to be present
-        filter_element = page.find("#filter_#{id}")
-        if page.has_selector?("#filter_#{id} .ng-select-container")
-          Array(value).each do |val|
-            dropdown = search_autocomplete filter_element.find("op-autocompleter"),
-                                           query: val,
-                                           results_selector: '.ng-dropdown-panel-items'
-            expect(dropdown).to have_selector('.ng-option', text: val)
-          end
-        end
+        autocomplete_dropdown_value(id:, value:)
       end
 
       def expect_missing_autocomplete_value(id, value)
-        if page.has_selector?("#filter_#{id} .ng-select-container")
-          Array(value).each do |val|
-            dropdown = search_autocomplete page.find("#filter_#{id} op-autocompleter"),
-                                           query: val,
-                                           results_selector: '.ng-dropdown-panel-items'
-            expect(dropdown).not_to have_selector('.ng-option', text: val)
-          end
-        end
+        autocomplete_dropdown_value(id:, value:, present: false)
       end
 
       def expect_no_filter_by(name, selector = nil)
@@ -248,6 +232,19 @@ module Components
                 ensure_value_is_input_correctly input, value: value[index]
               end
             end
+          end
+        end
+      end
+
+      def autocomplete_dropdown_value(id:, value:, present: true)
+        filter_element = page.find("#filter_#{id}")
+
+        if filter_element.has_selector?(".ng-select-container", wait: false)
+          Array(value).each do |val|
+            dropdown = search_autocomplete filter_element.find("op-autocompleter"),
+                                           query: val,
+                                           results_selector: '.ng-dropdown-panel-items'
+            expect(dropdown).to have_conditional_selector(present, '.ng-option', text: val)
           end
         end
       end

--- a/spec/support/matchers/has_conditional_selector.rb
+++ b/spec/support/matchers/has_conditional_selector.rb
@@ -27,16 +27,31 @@
 #++
 
 # Extending Capybara to allow a flagged check for has_selector to avoid
-# lots of if/else
+# lots of if/else. Extension is available for both the `Capybara::Session`
+# and `Capybara::Node::Matchers`, thus the matcher can be used on both on the
+# `page` or any element (Capybara::Node::Element).
+#   - expect(page).to have_conditional_selector(...)
+#   - expect(input).to have_conditional_selector(...)
+
+module Capybara
+  module Node
+    module Matchers
+      def has_conditional_selector?(condition, *args, **kw_args)
+        if condition
+          has_selector? *args, **kw_args
+        else
+          has_no_selector? *args, **kw_args
+        end
+      end
+    end
+  end
+end
 
 module Capybara
   class Session
-    def has_conditional_selector?(condition, *args, **kw_args)
-      if condition
-        has_selector? *args, **kw_args
-      else
-        has_no_selector? *args, **kw_args
-      end
+    def has_conditional_selector?(...)
+      @touched = true
+      current_scope.has_conditional_selector?(...)
     end
   end
 end


### PR DESCRIPTION
Improve the `expect_autocomplete_value` and `expect_missing_autocomplete_value` methods. This is a leftover improvement from the [OP#46249](https://community.openproject.org/work_packages/46249).