### PR TITLE
Try to fix query_handling_spec

### DIFF
--- a/spec/support/components/work_packages/settings_menu.rb
+++ b/spec/support/components/work_packages/settings_menu.rb
@@ -52,7 +52,11 @@ module Components
 
       def open!
         click_on 'work-packages-settings-button'
-        expect_open
+        dropdown_menu
+      end
+
+      def dropdown_menu
+        page.find(selector)
       end
 
       def expect_open


### PR DESCRIPTION
./modules/team_planner/spec/features/query_handling_spec.rb:139

```

  1) Team planner query handling behaves like module specific query view management within a module allows to save, rename and delete a query
     Failure/Error: expect(page).to have_selector(selector)
       expected to find css "#settingsDropdown" but there were no matches
     Shared Example Group: "module specific query view management" called from ./modules/team_planner/spec/features/query_handling_spec.rb:139
     Shared Example Group: "module specific query view management" called from ./modules/team_planner/spec/features/query_handling_spec.rb:139
     # ./spec/support/components/work_packages/settings_menu.rb:59:in `expect_open'
     # ./spec/support/components/work_packages/settings_menu.rb:55:in `open!'
     # ./spec/support/components/work_packages/settings_menu.rb:48:in `block in open_and_choose'
     # /usr/local/bundle/gems/retriable-3.1.2/lib/retriable.rb:61:in `block in retriable'
```

It appears the click does not go through, which is why `open!` has a retry_block, but `expect_open` is not retriable

Failing job example: https://github.com/opf/openproject/actions/runs/4413401252/jobs/7733821111