### PR TITLE
Use native input for mobile on basic datepickers

### DIFF
--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
@@ -1,4 +1,5 @@
 <input
+  *ngIf="!mobile"
   #input
   type="text"
   class="spot-input op-basic-range-datepicker--input"
@@ -7,10 +8,44 @@
   [attr.data-value]="value"
   [id]="id"
   [name]="name"
-  [attr.name]="name"
   [required]="required"
   [disabled]="disabled"
   [ngModel]="stringValue"
   (ngModelChange)="changeValueFromInputDebounced($event)"
   (focus)="showDatePicker()"
 />
+<ng-container *ngIf="mobile">
+  <input
+    type="date"
+    class="spot-input"
+    data-qa-selector="op-basic-range-date-picker-start"
+    [ngClass]="inputClassNames"
+    id="{{ id }}-start"
+    name="{{ name }}-start"
+    [required]="required"
+    [disabled]="disabled"
+    [ngModel]="value[0] || ''"
+    (ngModelChange)="changeValueFromInputDebounced([$event, value[1] || ''])"
+  />
+  <span class="op-basic-range-datepicker--spacer" [textContent]="text.spacer"></span>
+  <input
+    type="date"
+    class="spot-input"
+    data-qa-selector="op-basic-range-date-picker-end"
+    [ngClass]="inputClassNames"
+    id="{{ id }}-end"
+    name="{{ name }}-end"
+    [required]="required"
+    [disabled]="disabled"
+    [ngModel]="value[1] || ''"
+    (ngModelChange)="changeValueFromInputDebounced([value[0] || '', $event])"
+  />
+  <input
+    type="hidden"
+    data-qa-selector="op-basic-range-date-picker--value"
+    [attr.data-value]="stringValue"
+    [id]="id"
+    [name]="name"
+    [ngModel]="stringValue"
+  />
+</ng-container>

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.sass
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.sass
@@ -1,6 +1,7 @@
 .op-basic-range-datepicker
   &_mobile
     display: flex
+    flex-direction: column
     align-items: center
   &--input
     min-width: 12rem

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.sass
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.sass
@@ -1,3 +1,8 @@
 .op-basic-range-datepicker
+  &_mobile
+    display: flex
+    align-items: center
   &--input
     min-width: 12rem
+  &--spacer
+    padding: 0 0.5rem

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -37,6 +37,7 @@ import {
   HostBinding,
   Injector,
   Input,
+  OnInit,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -46,14 +47,17 @@ import {
   ControlValueAccessor,
   NG_VALUE_ACCESSOR,
 } from '@angular/forms';
-import { onDayCreate } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
+import {
+  onDayCreate,
+  validDate,
+} from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DatePicker } from '../datepicker';
 import flatpickr from 'flatpickr';
 import { DayElement } from 'flatpickr/dist/types/instance';
 import { populateInputsFromDataset } from '../../dataset-inputs';
 import { debounce } from 'lodash';
-import { SpotDropModalTeleportationService } from 'core-app/spot/components/drop-modal/drop-modal-teleportation.service';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 export const rangeSeparator = '-';
 
@@ -76,12 +80,12 @@ export const opBasicRangeDatePickerSelector = 'op-basic-range-date-picker';
     },
   ],
 })
-export class OpBasicRangeDatePickerComponent implements ControlValueAccessor, AfterViewInit {
+export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAccessor, AfterViewInit {
   @HostBinding('class.op-basic-range-datepicker') className = true;
 
-  @Output('valueChange') valueChange = new EventEmitter();
+  @HostBinding('class.op-basic-range-datepicker_mobile') mobile = false;
 
-  public stringValue = '';
+  @Output('valueChange') valueChange = new EventEmitter();
 
   private _value:string[] = [];
 
@@ -108,12 +112,15 @@ export class OpBasicRangeDatePickerComponent implements ControlValueAccessor, Af
 
   @ViewChild('input') input:ElementRef;
 
+  stringValue = '';
+
+  datePickerInstance:DatePicker;
+
   text = {
     date: this.I18n.t('js.work_packages.properties.date'),
     placeholder: this.I18n.t('js.placeholders.default'),
+    spacer: this.I18n.t('js.filter.value_spacer'),
   };
-
-  public datePickerInstance:DatePicker;
 
   constructor(
     readonly I18n:I18nService,
@@ -121,24 +128,36 @@ export class OpBasicRangeDatePickerComponent implements ControlValueAccessor, Af
     readonly injector:Injector,
     readonly cdRef:ChangeDetectorRef,
     readonly elementRef:ElementRef,
-    readonly spotDropModalTeleportationService:SpotDropModalTeleportationService,
+    readonly deviceService:DeviceService,
   ) {
     populateInputsFromDataset(this);
   }
 
+  ngOnInit() {
+    this.mobile = this.deviceService.isMobile;
+  }
+
   ngAfterViewInit():void {
-    this.initializeDatePicker();
+    if (!this.mobile) {
+      this.initializeDatePicker();
+    }
   }
 
   changeValueFromInputDebounced = debounce(this.changeValueFromInput.bind(this), 16);
 
-  changeValueFromInput(value:string) {
-    const newDates = this.resolveDateStringToArray(value);
-    this.valueChange.emit(newDates);
+  changeValueFromInput(value:string|string[]) {
+    const newDates = (typeof value === 'string') ? this.resolveDateStringToArray(value) : value;
+
     this.onChange(newDates);
     this.onTouched(newDates);
     this.writeValue(newDates);
     this.cdRef.detectChanges();
+
+    if (newDates.find((el) => !validDate(el))) {
+      return;
+    }
+
+    this.valueChange.emit(newDates);
   }
 
   showDatePicker():void {

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
@@ -1,4 +1,5 @@
 <input
+  *ngIf="!mobile"
   #input
   type="text"
   class="spot-input"
@@ -9,7 +10,22 @@
   [attr.name]="name"
   [required]="required"
   [disabled]="disabled"
-  (input)="changeValueFromInput($event)"
+  (input)="changeValueFromInput($event.target.value)"
   (focus)="showDatePicker()"
   [attr.data-remote-field-key]="remoteFieldKey"
 />
+
+<ng-container *ngIf="mobile">
+  <input
+    type="date"
+    class="spot-input"
+    [ngClass]="inputClassNames"
+    [attr.data-value]="value"
+    [id]="id"
+    [name]="name"
+    [required]="required"
+    [disabled]="disabled"
+    [ngModel]="value"
+    (ngModelChange)="changeValueFromInput($event)"
+  />
+</ng-container>

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -37,6 +37,7 @@ import {
   Injector,
   Input,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -56,6 +57,7 @@ import flatpickr from 'flatpickr';
 import { DayElement } from 'flatpickr/dist/types/instance';
 import { populateInputsFromDataset } from '../../dataset-inputs';
 import { SpotDropModalTeleportationService } from 'core-app/spot/components/drop-modal/drop-modal-teleportation.service';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 export const opBasicSingleDatePickerSelector = 'op-basic-single-date-picker';
 
@@ -73,7 +75,7 @@ export const opBasicSingleDatePickerSelector = 'op-basic-single-date-picker';
     },
   ],
 })
-export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
   @Output() valueChange = new EventEmitter();
 
   @Output() picked = new EventEmitter();
@@ -104,6 +106,8 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, A
 
   @ViewChild('input') input:ElementRef;
 
+  mobile = false;
+
   text = {
     date: this.I18n.t('js.work_packages.properties.date'),
     placeholder: this.I18n.t('js.placeholders.default'),
@@ -117,32 +121,32 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, A
     readonly injector:Injector,
     readonly cdRef:ChangeDetectorRef,
     readonly elementRef:ElementRef,
-    readonly spotDropModalTeleportationService:SpotDropModalTeleportationService,
+    readonly deviceService:DeviceService,
   ) {
     populateInputsFromDataset(this);
   }
 
+  ngOnInit() {
+    this.mobile = this.deviceService.isMobile;
+  }
+
   ngAfterViewInit():void {
-    this.initializeDatePicker();
+    if (!this.mobile) {
+      this.initializeDatePicker();
+    }
   }
 
   ngOnDestroy():void {
     this.datePickerInstance?.destroy();
   }
 
-  changeValueFromInput($event:KeyboardEvent) {
-    const value = ($event.target as HTMLInputElement).value;
+  changeValueFromInput(value:string) {
     if (validDate(value)) {
-      const dateString = this.timezoneService.formattedISODate(value);
-      this.datePickerInstance.setDates(dateString);
-      this.valueChange.emit(dateString);
-      this.onTouched(dateString);
-      this.onChange(dateString);
-      this.writeValue(dateString);
-    } else if (value === '') {
-      this.datePickerInstance.setDates('');
-      this.onTouched('');
-      this.onChange('');
+      this.onTouched(value);
+      this.onChange(value);
+      this.writeValue(value);
+      this.datePickerInstance?.setDates(value);
+      this.valueChange.emit(value);
     }
   }
 

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -37,6 +37,7 @@ import {
   Injector,
   Input,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -56,6 +57,7 @@ import flatpickr from 'flatpickr';
 import { DayElement } from 'flatpickr/dist/types/instance';
 import { populateInputsFromDataset } from '../../dataset-inputs';
 import { SpotDropModalTeleportationService } from 'core-app/spot/components/drop-modal/drop-modal-teleportation.service';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 export const opBasicSingleDatePickerSelector = 'op-basic-single-date-picker';
 
@@ -73,7 +75,7 @@ export const opBasicSingleDatePickerSelector = 'op-basic-single-date-picker';
     },
   ],
 })
-export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
   @Output() valueChange = new EventEmitter();
 
   @Output() picked = new EventEmitter();
@@ -104,6 +106,8 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, A
 
   @ViewChild('input') input:ElementRef;
 
+  mobile = false;
+
   text = {
     date: this.I18n.t('js.work_packages.properties.date'),
     placeholder: this.I18n.t('js.placeholders.default'),
@@ -117,32 +121,33 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, A
     readonly injector:Injector,
     readonly cdRef:ChangeDetectorRef,
     readonly elementRef:ElementRef,
-    readonly spotDropModalTeleportationService:SpotDropModalTeleportationService,
+    readonly deviceService:DeviceService,
   ) {
     populateInputsFromDataset(this);
   }
 
+  ngOnInit() {
+    this.mobile = this.deviceService.isMobile;
+  }
+
   ngAfterViewInit():void {
-    this.initializeDatePicker();
+    if (!this.mobile) {
+      this.initializeDatePicker();
+    }
   }
 
   ngOnDestroy():void {
     this.datePickerInstance?.destroy();
   }
 
-  changeValueFromInput($event:KeyboardEvent) {
-    const value = ($event.target as HTMLInputElement).value;
+  changeValueFromInput(value:string) {
+    this.onTouched(value);
+    this.onChange(value);
+    this.writeValue(value);
+
     if (validDate(value)) {
-      const dateString = this.timezoneService.formattedISODate(value);
-      this.datePickerInstance.setDates(dateString);
-      this.valueChange.emit(dateString);
-      this.onTouched(dateString);
-      this.onChange(dateString);
-      this.writeValue(dateString);
-    } else if (value === '') {
-      this.datePickerInstance.setDates('');
-      this.onTouched('');
-      this.onChange('');
+      this.datePickerInstance?.setDates(value);
+      this.valueChange.emit(value);
     }
   }
 

--- a/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
@@ -111,24 +111,9 @@ describe 'Switching work package view',
   end
 
   context 'switching to mobile card view' do
-    let!(:height_before) do
-      page.driver.browser.manage.window.size.height
-    end
-    let!(:width_before) do
-      page.driver.browser.manage.window.size.width
-    end
-
-    after do
-      page.driver.browser.manage.window.resize_to(width_before, height_before)
-    end
+    include_context 'with mobile screen size'
 
     it 'can switch the representation automatically on mobile after a refresh' do
-      # Change browser size to mobile
-      page.driver.browser.manage.window.resize_to(679, 1080)
-
-      # Expect the representation to switch to card on mobile
-      page.driver.browser.navigate.refresh
-
       # It shows the elements as cards
       cards.expect_work_package_listed wp_1, wp_2
 

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -1,0 +1,568 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe 'filter work packages', js: true do
+  let(:user) { create(:admin) }
+  let(:watcher) { create(:user) }
+  let(:project) { create(:project, members: { watcher => role }) }
+  let(:role) { create(:existing_role, permissions: [:view_work_packages]) }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:filters) { Components::WorkPackages::Filters.new }
+
+  current_user { user }
+
+  context 'by watchers' do
+    let(:work_package_with_watcher) do
+      wp = build(:work_package, project:)
+      wp.add_watcher watcher
+      wp.save!
+
+      wp
+    end
+    let(:work_package_without_watcher) { create(:work_package, project:) }
+
+    before do
+      work_package_with_watcher
+      work_package_without_watcher
+
+      wp_table.visit!
+    end
+
+    # Regression test for bug #24114 (broken watcher filter)
+    it 'onlies filter work packages by watcher' do
+      filters.open
+      loading_indicator_saveguard
+
+      filters.add_filter_by 'Watcher', 'is (OR)', watcher.name
+      loading_indicator_saveguard
+
+      wp_table.expect_work_package_listed work_package_with_watcher
+      wp_table.ensure_work_package_not_listed! work_package_without_watcher
+    end
+  end
+
+  context 'by version in project' do
+    let(:version) { create(:version, project:) }
+    let(:work_package_with_version) do
+      create(:work_package, project:, subject: 'With version', version:)
+    end
+    let(:work_package_without_version) { create(:work_package, subject: 'Without version', project:) }
+
+    before do
+      work_package_with_version
+      work_package_without_version
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving, retrieving and altering the saved filter' do
+      filters.open
+
+      filters.add_filter_by('Version', 'is (OR)', version.name)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_version
+      wp_table.ensure_work_package_not_listed! work_package_without_version
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'version'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_version, work_package_without_version
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_version
+      wp_table.ensure_work_package_not_listed! work_package_without_version
+
+      filters.open
+
+      filters.expect_filter_by('Version', 'is (OR)', version.name)
+
+      filters.set_operator 'Version', 'is not'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_without_version
+      wp_table.ensure_work_package_not_listed! work_package_with_version
+    end
+  end
+
+  context 'when filtering by status in project' do
+    let(:status) { create(:status, name: 'Open status') }
+    let(:closed_status) { create(:closed_status, name: 'Closed status') }
+    let(:work_package_with_status) do
+      create(:work_package, project:, subject: 'With open status', status:)
+    end
+    let(:work_package_without_status) { create(:work_package, subject: 'With closed status', project:, status: closed_status) }
+
+    before do
+      work_package_with_status
+      work_package_without_status
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering and matching the selected value' do
+      filters.open
+
+      filters.remove_filter :status
+      filters.expect_no_filter_by :status
+      filters.add_filter_by('Status', 'is (OR)', status.name)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_status
+      wp_table.ensure_work_package_not_listed! work_package_without_status
+
+      filters.open_autocompleter :status
+
+      expect(page).to have_selector('.ng-option', text: closed_status.name)
+      expect(page).not_to have_selector('.ng-option', text: status.name)
+    end
+  end
+
+  context 'by finish date outside of a project' do
+    let(:work_package_with_due_date) { create(:work_package, project:, due_date: Date.current) }
+    let(:work_package_without_due_date) { create(:work_package, project:, due_date: 5.days.from_now) }
+    let(:wp_table) { Pages::WorkPackagesTable.new }
+
+    before do
+      work_package_with_due_date
+      work_package_without_due_date
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving and altering the saved filter' do
+      filters.open
+
+      filters.add_filter_by('Finish date',
+                            'between',
+                            [1.day.ago.strftime('%Y-%m-%d'), Date.current.strftime('%Y-%m-%d')],
+                            'dueDate')
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_due_date
+      wp_table.ensure_work_package_not_listed! work_package_without_due_date
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'dueDate'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_due_date, work_package_without_due_date
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_due_date
+      wp_table.ensure_work_package_not_listed! work_package_without_due_date
+
+      filters.open
+
+      filters.expect_filter_by('Finish date',
+                               'between',
+                               [1.day.ago.strftime('%Y-%m-%d'), Date.current.strftime('%Y-%m-%d')],
+                               'dueDate')
+
+      filters.set_filter 'Finish date', 'in more than', '1', 'dueDate'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_without_due_date
+      wp_table.ensure_work_package_not_listed! work_package_with_due_date
+    end
+  end
+
+  context 'by list cf inside a project' do
+    let(:type) do
+      type = create(:type)
+
+      project.types << type
+
+      type
+    end
+
+    let(:work_package_with_list_value) do
+      wp = create(:work_package, project:, type:)
+      wp.send(list_cf.attribute_setter, list_cf.custom_options.first.id)
+      wp.save!
+      wp
+    end
+
+    let(:work_package_with_anti_list_value) do
+      wp = create(:work_package, project:, type:)
+      wp.send(list_cf.attribute_setter, list_cf.custom_options.last.id)
+      wp.save!
+      wp
+    end
+
+    let(:list_cf) do
+      cf = create(:list_wp_custom_field)
+
+      project.work_package_custom_fields << cf
+      type.custom_fields << cf
+
+      cf
+    end
+
+    before do
+      list_cf
+      work_package_with_list_value
+      work_package_with_anti_list_value
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving the saved filter' do
+      # Wait for form to load
+      filters.expect_loaded
+
+      filters.open
+      filters.add_filter_by(list_cf.name,
+                            'is not',
+                            list_cf.custom_options.last.value,
+                            list_cf.attribute_name(:camel_case))
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_list_value
+      wp_table.ensure_work_package_not_listed! work_package_with_anti_list_value
+
+      # Do not display already selected values in the autocompleter (Regression #46249)
+      filters.open_autocompleter list_cf.attribute_name(:camel_case)
+
+      expect(page).not_to have_selector('.ng-option', text: list_cf.custom_options.last.value)
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter list_cf.attribute_name(:camel_case)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_list_value, work_package_with_anti_list_value
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_with_list_value
+      wp_table.ensure_work_package_not_listed! work_package_with_anti_list_value
+
+      filters.open
+
+      filters.expect_filter_by(list_cf.name,
+                               'is not',
+                               list_cf.custom_options.last.value,
+                               "customField#{list_cf.id}")
+    end
+  end
+
+  context 'by string cf inside a project with url-query relevant chars' do
+    let(:type) do
+      type = create(:type)
+
+      project.types << type
+
+      type
+    end
+
+    let(:work_package_plus) do
+      wp = create(:work_package, project:, type:)
+      wp.send(string_cf.attribute_setter, 'G+H')
+      wp.save!
+      wp
+    end
+
+    let(:work_package_and) do
+      wp = create(:work_package, project:, type:)
+      wp.send(string_cf.attribute_setter, 'A&B')
+      wp.save!
+      wp
+    end
+
+    let(:string_cf) do
+      cf = create(:string_wp_custom_field)
+
+      project.work_package_custom_fields << cf
+      type.custom_fields << cf
+
+      cf
+    end
+
+    before do
+      string_cf
+      work_package_plus
+      work_package_and
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving the saved filter' do
+      # Wait for form to load
+      filters.expect_loaded
+
+      filters.open
+      filters.add_filter_by(string_cf.name,
+                            'is',
+                            ['G+H'],
+                            string_cf.attribute_name(:camel_case))
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_plus
+      wp_table.ensure_work_package_not_listed! work_package_and
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter string_cf.attribute_name(:camel_case)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_plus, work_package_and
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_plus
+      wp_table.ensure_work_package_not_listed! work_package_and
+
+      filters.open
+
+      filters.expect_filter_by(string_cf.name,
+                               'is',
+                               ['G+H'],
+                               "customField#{string_cf.id}")
+
+      filters.set_filter(string_cf,
+                         'is',
+                         ['A&B'],
+                         string_cf.attribute_name(:camel_case))
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed work_package_and
+      wp_table.ensure_work_package_not_listed! work_package_plus
+    end
+  end
+
+  context 'by attachment content' do
+    let(:attachment_a) { build(:attachment, filename: 'attachment-first.pdf') }
+    let(:attachment_b) { build(:attachment, filename: 'attachment-second.pdf') }
+    let(:wp_with_attachment_a) do
+      create(:work_package, subject: 'WP attachment A', project:, attachments: [attachment_a])
+    end
+    let(:wp_with_attachment_b) do
+      create(:work_package, subject: 'WP attachment B', project:, attachments: [attachment_b])
+    end
+    let(:wp_without_attachment) { create(:work_package, subject: 'WP no attachment', project:) }
+    let(:wp_table) { Pages::WorkPackagesTable.new }
+
+    before do
+      allow_any_instance_of(Plaintext::Resolver).to receive(:text).and_return('I am the first text $1.99.')
+      wp_with_attachment_a
+      ExtractFulltextJob.perform_now(attachment_a.id)
+      allow_any_instance_of(Plaintext::Resolver).to receive(:text).and_return('I am the second text.')
+      wp_with_attachment_b
+      ExtractFulltextJob.perform_now(attachment_b.id)
+      wp_without_attachment
+    end
+
+    context 'with full text search capabilities' do
+      before do
+        skip("Database does not support full text search.") unless OpenProject::Database::allows_tsv?
+      end
+
+      it 'allows filtering and retrieving and altering the saved filter' do
+        wp_table.visit!
+        wp_table.expect_work_package_listed wp_with_attachment_a, wp_with_attachment_b
+
+        filters.open
+
+        # content contains with multiple hits
+        filters.add_filter_by('Attachment content',
+                              'contains',
+                              ['text'],
+                              'attachmentContent')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_a, wp_with_attachment_b
+        wp_table.ensure_work_package_not_listed! wp_without_attachment
+
+        # content contains single hit with numbers
+        filters.remove_filter 'attachmentContent'
+
+        filters.add_filter_by('Attachment content',
+                              'contains',
+                              ['first 1.99'],
+                              'attachmentContent')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_a
+        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
+
+        filters.remove_filter 'attachmentContent'
+
+        # content does not contain
+        filters.add_filter_by('Attachment content',
+                              'doesn\'t contain',
+                              ['first'],
+                              'attachmentContent')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_b, wp_without_attachment
+        wp_table.ensure_work_package_not_listed! wp_with_attachment_a
+
+        filters.remove_filter 'attachmentContent'
+
+        # ignores special characters
+        filters.add_filter_by('Attachment content',
+                              'contains',
+                              ['! first:* \')'],
+                              'attachmentContent')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_a
+        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
+
+        filters.remove_filter 'attachmentContent'
+
+        # file name contains
+        filters.add_filter_by('Attachment file name',
+                              'contains',
+                              ['first'],
+                              'attachmentFileName')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_a
+        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
+
+        filters.remove_filter 'attachmentFileName'
+
+        # file name does not contain
+        filters.add_filter_by('Attachment file name',
+                              'doesn\'t contain',
+                              ['first'],
+                              'attachmentFileName')
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_with_attachment_b
+        wp_table.ensure_work_package_not_listed! wp_with_attachment_a
+      end
+    end
+  end
+
+  context 'DB does not offer TSVector support' do
+    before do
+      allow(OpenProject::Database).to receive(:allows_tsv?).and_return(false)
+    end
+
+    it "does not offer attachment filters" do
+      expect(page).not_to have_select 'add_filter_select', with_options: ['Attachment content', 'Attachment file name']
+    end
+  end
+
+  describe 'specific filters' do
+    describe 'filters on date by created_at (Regression #28459)' do
+      let!(:wp_updated_today) do
+        create(:work_package, subject: 'Created today', project:, created_at: Time.current.change(hour: 12))
+      end
+      let!(:wp_updated_5d_ago) do
+        create(:work_package, subject: 'Created 5d ago', project:, created_at: 5.days.ago)
+      end
+
+      it do
+        wp_table.visit!
+        loading_indicator_saveguard
+        wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+        filters.open
+
+        filters.add_filter_by 'Created on',
+                              'on',
+                              [Date.current.iso8601],
+                              'createdAt'
+
+        loading_indicator_saveguard
+
+        wp_table.expect_work_package_listed wp_updated_today
+        wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+      end
+    end
+  end
+
+  describe 'keep the filter attribute order (Regression #33136)' do
+    let(:version1) { create(:version, project:, name: 'Version 1', id: 1) }
+    let(:version2) { create(:version, project:, name: 'Version 2', id: 2) }
+
+    it do
+      wp_table.visit!
+      loading_indicator_saveguard
+
+      filters.open
+      filters.add_filter_by 'Version', 'is (OR)', [version2.name, version1.name]
+      loading_indicator_saveguard
+
+      sleep(3)
+
+      filters.expect_filter_by 'Version', 'is (OR)', [version1.name]
+      filters.expect_filter_by 'Version', 'is (OR)', [version2.name]
+
+      # Order should stay unchanged
+      filters.expect_filter_order('Version', [version2.name, version1.name])
+    end
+  end
+
+  describe 'add parent WP filter' do
+    let(:wp_parent) { create(:work_package, project:, subject: 'project') }
+    let(:wp_child1) { create(:work_package, project:, subject: 'child 1', parent: wp_parent) }
+    let(:wp_child2) { create(:work_package, project:, subject: 'child 2', parent: wp_parent) }
+    let(:wp_default) { create(:work_package, project:, subject: 'default') }
+
+    it do
+      wp_parent
+      wp_child1
+      wp_child2
+      wp_default
+      wp_table.visit!
+      loading_indicator_saveguard
+      filters.expect_loaded
+      filters.open
+      filters.add_filter_by 'Parent', 'is (OR)', [wp_parent.subject]
+      loading_indicator_saveguard
+
+      # It should show the children of the selected parent
+      wp_table.expect_work_package_listed wp_child1, wp_child2
+      wp_table.ensure_work_package_not_listed! wp_default
+    end
+  end
+end

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -28,541 +28,73 @@
 
 require 'spec_helper'
 
-describe 'filter work packages', js: true do
-  let(:user) { create(:admin) }
-  let(:watcher) { create(:user) }
-  let(:project) { create(:project, members: { watcher => role }) }
-  let(:role) { create(:existing_role, permissions: [:view_work_packages]) }
-  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
-  let(:filters) { Components::WorkPackages::Filters.new }
+describe 'mobile date filter work packages', js: true do
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project) }
+  shared_let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  shared_let(:wp_cards) { Pages::WorkPackageCards.new(project) }
+  shared_let(:filters) { Components::WorkPackages::Filters.new }
+  shared_let(:work_package_with_due_date) { create(:work_package, project:, due_date: Date.current) }
+  shared_let(:work_package_without_due_date) { create(:work_package, project:, due_date: 5.days.from_now) }
 
   current_user { user }
 
-  context 'by watchers' do
-    let(:work_package_with_watcher) do
-      wp = build(:work_package, project:)
-      wp.add_watcher watcher
-      wp.save!
+  include_context 'with mobile screen size'
 
-      wp
-    end
-    let(:work_package_without_watcher) { create(:work_package, project:) }
-
-    before do
-      work_package_with_watcher
-      work_package_without_watcher
-
-      wp_table.visit!
-    end
-
-    # Regression test for bug #24114 (broken watcher filter)
-    it 'onlies filter work packages by watcher' do
-      filters.open
-      loading_indicator_saveguard
-
-      filters.add_filter_by 'Watcher', 'is (OR)', watcher.name
-      loading_indicator_saveguard
-
-      wp_table.expect_work_package_listed work_package_with_watcher
-      wp_table.ensure_work_package_not_listed! work_package_without_watcher
-    end
+  before do
+    wp_table.visit!
   end
 
-  context 'by version in project' do
-    let(:version) { create(:version, project:) }
-    let(:work_package_with_version) do
-      create(:work_package, project:, subject: 'With version', version:)
-    end
-    let(:work_package_without_version) { create(:work_package, subject: 'Without version', project:) }
-
-    before do
-      work_package_with_version
-      work_package_without_version
-
-      wp_table.visit!
-    end
-
-    it 'allows filtering, saving, retrieving and altering the saved filter' do
-      filters.open
-
-      filters.add_filter_by('Version', 'is (OR)', version.name)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_version
-      wp_table.ensure_work_package_not_listed! work_package_without_version
-
-      wp_table.save_as('Some query name')
-
-      filters.remove_filter 'version'
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_version, work_package_without_version
-
-      last_query = Query.last
-
-      wp_table.visit_query(last_query)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_version
-      wp_table.ensure_work_package_not_listed! work_package_without_version
-
-      filters.open
-
-      filters.expect_filter_by('Version', 'is (OR)', version.name)
-
-      filters.set_operator 'Version', 'is not'
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_without_version
-      wp_table.ensure_work_package_not_listed! work_package_with_version
-    end
-  end
-
-  context 'when filtering by status in project' do
-    let(:status) { create(:status, name: 'Open status') }
-    let(:closed_status) { create(:closed_status, name: 'Closed status') }
-    let(:work_package_with_status) do
-      create(:work_package, project:, subject: 'With open status', status:)
-    end
-    let(:work_package_without_status) { create(:work_package, subject: 'With closed status', project:, status: closed_status) }
-
-    before do
-      work_package_with_status
-      work_package_without_status
-
-      wp_table.visit!
-    end
-
-    it 'allows filtering and matching the selected value' do
-      filters.open
-
-      filters.remove_filter :status
-      filters.expect_no_filter_by :status
-      filters.add_filter_by('Status', 'is (OR)', status.name)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_status
-      wp_table.ensure_work_package_not_listed! work_package_without_status
-
-      filters.open_autocompleter :status
-
-      expect(page).to have_selector('.ng-option', text: closed_status.name)
-      expect(page).not_to have_selector('.ng-option', text: status.name)
-    end
-  end
-
-  context 'by finish date outside of a project' do
-    let(:work_package_with_due_date) { create(:work_package, project:, due_date: Date.current) }
-    let(:work_package_without_due_date) { create(:work_package, project:, due_date: 5.days.from_now) }
-    let(:wp_table) { Pages::WorkPackagesTable.new }
-
-    before do
-      work_package_with_due_date
-      work_package_without_due_date
-
-      wp_table.visit!
-    end
-
+  context 'when filtering between finish date' do
     it 'allows filtering, saving and retrieving and altering the saved filter' do
       filters.open
+      filters.add_filter('Finish date')
+      filters.set_operator('Finish date', 'between', 'dueDate')
 
-      filters.add_filter_by('Finish date',
-                            'between',
-                            [1.day.ago.strftime('%Y-%m-%d'), Date.current.strftime('%Y-%m-%d')],
-                            'dueDate')
+      start_field = find('[data-qa-selector="op-basic-range-date-picker-start"]')
+      end_field = find('[data-qa-selector="op-basic-range-date-picker-end"]')
+
+      start_field.native.clear
+      end_field.native.clear
+
+      start_field.set 1.day.ago.strftime('%m/%d/%Y')
+      end_field.set Date.current.strftime('%m/%d/%Y')
 
       loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_due_date
-      wp_table.ensure_work_package_not_listed! work_package_without_due_date
+      wp_cards.expect_work_package_listed work_package_with_due_date
+      wp_cards.expect_work_package_not_listed work_package_without_due_date
 
       wp_table.save_as('Some query name')
-
-      filters.remove_filter 'dueDate'
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_due_date, work_package_without_due_date
+      wp_table.expect_and_dismiss_toaster(message: 'Successful creation.')
 
       last_query = Query.last
-
-      wp_table.visit_query(last_query)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_due_date
-      wp_table.ensure_work_package_not_listed! work_package_without_due_date
-
-      filters.open
-
-      filters.expect_filter_by('Finish date',
-                               'between',
-                               [1.day.ago.strftime('%Y-%m-%d'), Date.current.strftime('%Y-%m-%d')],
-                               'dueDate')
-
-      filters.set_filter 'Finish date', 'in more than', '1', 'dueDate'
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_without_due_date
-      wp_table.ensure_work_package_not_listed! work_package_with_due_date
+      date_filter = last_query.filters.last
+      expect(date_filter.values).to eq [1.day.ago.to_date.iso8601, Date.current.iso8601]
     end
   end
 
-  context 'by list cf inside a project' do
-    let(:type) do
-      type = create(:type)
-
-      project.types << type
-
-      type
-    end
-
-    let(:work_package_with_list_value) do
-      wp = create(:work_package, project:, type:)
-      wp.send(list_cf.attribute_setter, list_cf.custom_options.first.id)
-      wp.save!
-      wp
-    end
-
-    let(:work_package_with_anti_list_value) do
-      wp = create(:work_package, project:, type:)
-      wp.send(list_cf.attribute_setter, list_cf.custom_options.last.id)
-      wp.save!
-      wp
-    end
-
-    let(:list_cf) do
-      cf = create(:list_wp_custom_field)
-
-      project.work_package_custom_fields << cf
-      type.custom_fields << cf
-
-      cf
-    end
-
-    before do
-      list_cf
-      work_package_with_list_value
-      work_package_with_anti_list_value
-
-      wp_table.visit!
-    end
-
-    it 'allows filtering, saving and retrieving the saved filter' do
-      # Wait for form to load
-      filters.expect_loaded
-
+  context 'when filtering on finish date' do
+    it 'allows filtering, saving and retrieving and altering the saved filter' do
       filters.open
-      filters.add_filter_by(list_cf.name,
-                            'is not',
-                            list_cf.custom_options.last.value,
-                            list_cf.attribute_name(:camel_case))
+      filters.add_filter('Finish date')
+      filters.set_operator('Finish date', 'on', 'dueDate')
+
+      date_field = find_field 'values-dueDate'
+      expect(date_field['type']).to eq 'date'
+
+      date_field.native.clear
+      date_field.set Date.current.strftime('%m/%d/%Y')
 
       loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_list_value
-      wp_table.ensure_work_package_not_listed! work_package_with_anti_list_value
-
-      # Do not display already selected values in the autocompleter (Regression #46249)
-      filters.open_autocompleter list_cf.attribute_name(:camel_case)
-
-      expect(page).not_to have_selector('.ng-option', text: list_cf.custom_options.last.value)
+      wp_cards.expect_work_package_listed work_package_with_due_date
+      wp_cards.expect_work_package_not_listed work_package_without_due_date
 
       wp_table.save_as('Some query name')
-
-      filters.remove_filter list_cf.attribute_name(:camel_case)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_list_value, work_package_with_anti_list_value
+      wp_table.expect_and_dismiss_toaster(message: 'Successful creation.')
 
       last_query = Query.last
-
-      wp_table.visit_query(last_query)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_with_list_value
-      wp_table.ensure_work_package_not_listed! work_package_with_anti_list_value
-
-      filters.open
-
-      filters.expect_filter_by(list_cf.name,
-                               'is not',
-                               list_cf.custom_options.last.value,
-                               "customField#{list_cf.id}")
-    end
-  end
-
-  context 'by string cf inside a project with url-query relevant chars' do
-    let(:type) do
-      type = create(:type)
-
-      project.types << type
-
-      type
-    end
-
-    let(:work_package_plus) do
-      wp = create(:work_package, project:, type:)
-      wp.send(string_cf.attribute_setter, 'G+H')
-      wp.save!
-      wp
-    end
-
-    let(:work_package_and) do
-      wp = create(:work_package, project:, type:)
-      wp.send(string_cf.attribute_setter, 'A&B')
-      wp.save!
-      wp
-    end
-
-    let(:string_cf) do
-      cf = create(:string_wp_custom_field)
-
-      project.work_package_custom_fields << cf
-      type.custom_fields << cf
-
-      cf
-    end
-
-    before do
-      string_cf
-      work_package_plus
-      work_package_and
-
-      wp_table.visit!
-    end
-
-    it 'allows filtering, saving and retrieving the saved filter' do
-      # Wait for form to load
-      filters.expect_loaded
-
-      filters.open
-      filters.add_filter_by(string_cf.name,
-                            'is',
-                            ['G+H'],
-                            string_cf.attribute_name(:camel_case))
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_plus
-      wp_table.ensure_work_package_not_listed! work_package_and
-
-      wp_table.save_as('Some query name')
-
-      filters.remove_filter string_cf.attribute_name(:camel_case)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_plus, work_package_and
-
-      last_query = Query.last
-
-      wp_table.visit_query(last_query)
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_plus
-      wp_table.ensure_work_package_not_listed! work_package_and
-
-      filters.open
-
-      filters.expect_filter_by(string_cf.name,
-                               'is',
-                               ['G+H'],
-                               "customField#{string_cf.id}")
-
-      filters.set_filter(string_cf,
-                         'is',
-                         ['A&B'],
-                         string_cf.attribute_name(:camel_case))
-
-      loading_indicator_saveguard
-      wp_table.expect_work_package_listed work_package_and
-      wp_table.ensure_work_package_not_listed! work_package_plus
-    end
-  end
-
-  context 'by attachment content' do
-    let(:attachment_a) { build(:attachment, filename: 'attachment-first.pdf') }
-    let(:attachment_b) { build(:attachment, filename: 'attachment-second.pdf') }
-    let(:wp_with_attachment_a) do
-      create(:work_package, subject: 'WP attachment A', project:, attachments: [attachment_a])
-    end
-    let(:wp_with_attachment_b) do
-      create(:work_package, subject: 'WP attachment B', project:, attachments: [attachment_b])
-    end
-    let(:wp_without_attachment) { create(:work_package, subject: 'WP no attachment', project:) }
-    let(:wp_table) { Pages::WorkPackagesTable.new }
-
-    before do
-      allow_any_instance_of(Plaintext::Resolver).to receive(:text).and_return('I am the first text $1.99.')
-      wp_with_attachment_a
-      ExtractFulltextJob.perform_now(attachment_a.id)
-      allow_any_instance_of(Plaintext::Resolver).to receive(:text).and_return('I am the second text.')
-      wp_with_attachment_b
-      ExtractFulltextJob.perform_now(attachment_b.id)
-      wp_without_attachment
-    end
-
-    context 'with full text search capabilities' do
-      before do
-        skip("Database does not support full text search.") unless OpenProject::Database::allows_tsv?
-      end
-
-      it 'allows filtering and retrieving and altering the saved filter' do
-        wp_table.visit!
-        wp_table.expect_work_package_listed wp_with_attachment_a, wp_with_attachment_b
-
-        filters.open
-
-        # content contains with multiple hits
-        filters.add_filter_by('Attachment content',
-                              'contains',
-                              ['text'],
-                              'attachmentContent')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a, wp_with_attachment_b
-        wp_table.ensure_work_package_not_listed! wp_without_attachment
-
-        # content contains single hit with numbers
-        filters.remove_filter 'attachmentContent'
-
-        filters.add_filter_by('Attachment content',
-                              'contains',
-                              ['first 1.99'],
-                              'attachmentContent')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter 'attachmentContent'
-
-        # content does not contain
-        filters.add_filter_by('Attachment content',
-                              'doesn\'t contain',
-                              ['first'],
-                              'attachmentContent')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_b, wp_without_attachment
-        wp_table.ensure_work_package_not_listed! wp_with_attachment_a
-
-        filters.remove_filter 'attachmentContent'
-
-        # ignores special characters
-        filters.add_filter_by('Attachment content',
-                              'contains',
-                              ['! first:* \')'],
-                              'attachmentContent')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter 'attachmentContent'
-
-        # file name contains
-        filters.add_filter_by('Attachment file name',
-                              'contains',
-                              ['first'],
-                              'attachmentFileName')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_a
-        wp_table.ensure_work_package_not_listed! wp_without_attachment, wp_with_attachment_b
-
-        filters.remove_filter 'attachmentFileName'
-
-        # file name does not contain
-        filters.add_filter_by('Attachment file name',
-                              'doesn\'t contain',
-                              ['first'],
-                              'attachmentFileName')
-
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_with_attachment_b
-        wp_table.ensure_work_package_not_listed! wp_with_attachment_a
-      end
-    end
-  end
-
-  context 'DB does not offer TSVector support' do
-    before do
-      allow(OpenProject::Database).to receive(:allows_tsv?).and_return(false)
-    end
-
-    it "does not offer attachment filters" do
-      expect(page).not_to have_select 'add_filter_select', with_options: ['Attachment content', 'Attachment file name']
-    end
-  end
-
-  describe 'specific filters' do
-    describe 'filters on date by created_at (Regression #28459)' do
-      let!(:wp_updated_today) do
-        create(:work_package, subject: 'Created today', project:, created_at: Time.current.change(hour: 12))
-      end
-      let!(:wp_updated_5d_ago) do
-        create(:work_package, subject: 'Created 5d ago', project:, created_at: 5.days.ago)
-      end
-
-      it do
-        wp_table.visit!
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
-
-        filters.open
-
-        filters.add_filter_by 'Created on',
-                              'on',
-                              [Date.current.iso8601],
-                              'createdAt'
-
-        loading_indicator_saveguard
-
-        wp_table.expect_work_package_listed wp_updated_today
-        wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
-      end
-    end
-  end
-
-  describe 'keep the filter attribute order (Regression #33136)' do
-    let(:version1) { create(:version, project:, name: 'Version 1', id: 1) }
-    let(:version2) { create(:version, project:, name: 'Version 2', id: 2) }
-
-    it do
-      wp_table.visit!
-      loading_indicator_saveguard
-
-      filters.open
-      filters.add_filter_by 'Version', 'is (OR)', [version2.name, version1.name]
-      loading_indicator_saveguard
-
-      sleep(3)
-
-      filters.expect_filter_by 'Version', 'is (OR)', [version1.name]
-      filters.expect_filter_by 'Version', 'is (OR)', [version2.name]
-
-      # Order should stay unchanged
-      filters.expect_filter_order('Version', [version2.name, version1.name])
-    end
-  end
-
-  describe 'add parent WP filter' do
-    let(:wp_parent) { create(:work_package, project:, subject: 'project') }
-    let(:wp_child1) { create(:work_package, project:, subject: 'child 1', parent: wp_parent) }
-    let(:wp_child2) { create(:work_package, project:, subject: 'child 2', parent: wp_parent) }
-    let(:wp_default) { create(:work_package, project:, subject: 'default') }
-
-    it do
-      wp_parent
-      wp_child1
-      wp_child2
-      wp_default
-      wp_table.visit!
-      loading_indicator_saveguard
-      filters.expect_loaded
-      filters.open
-      filters.add_filter_by 'Parent', 'is (OR)', [wp_parent.subject]
-      loading_indicator_saveguard
-
-      # It should show the children of the selected parent
-      wp_table.expect_work_package_listed wp_child1, wp_child2
-      wp_table.ensure_work_package_not_listed! wp_default
+      date_filter = last_query.filters.last
+      expect(date_filter.values).to eq [Date.current.iso8601]
     end
   end
 end

--- a/spec/support/shared/with_mobile_screen.rb
+++ b/spec/support/shared/with_mobile_screen.rb
@@ -24,23 +24,23 @@
 #
 #  See COPYRIGHT and LICENSE files for more details.
 
-RSpec.configure do |config|
-  config.around :example, :with_screen_size do |example|
-    width_before = page.driver.browser.manage.window.size.width
-    height_before = page.driver.browser.manage.window.size.height
+shared_context 'with mobile screen size' do |width, height|
+  let!(:height_before) do
+    page.driver.browser.manage.window.size.height
+  end
+  let!(:width_before) do
+    page.driver.browser.manage.window.size.width
+  end
 
-    width, height = example.metadata[:with_screen_size]
+  before do
+    # Change browser size
+    page.driver.browser.manage.window.resize_to(width || 500, height || 1000)
 
-    begin
-      # Change browser size
-      page.driver.browser.manage.window.resize_to(width, height)
+    # Refresh the page
+    page.driver.browser.navigate.refresh
+  end
 
-      # Refresh the page
-      page.driver.browser.navigate.refresh
-
-      example.run
-    ensure
-      page.driver.browser.manage.window.resize_to(width_before, height_before)
-    end
+  after do
+    page.driver.browser.manage.window.resize_to(width_before, height_before)
   end
 end

--- a/spec/support/shared/with_mobile_screen.rb
+++ b/spec/support/shared/with_mobile_screen.rb
@@ -1,0 +1,46 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+RSpec.configure do |config|
+  config.around :example, :with_screen_size do |example|
+    width_before = page.driver.browser.manage.window.size.width
+    height_before = page.driver.browser.manage.window.size.height
+
+    width, height = example.metadata[:with_screen_size]
+
+    begin
+      # Change browser size
+      page.driver.browser.manage.window.resize_to(width, height)
+
+      # Refresh the page
+      page.driver.browser.navigate.refresh
+
+      example.run
+    ensure
+      page.driver.browser.manage.window.resize_to(width_before, height_before)
+    end
+  end
+end


### PR DESCRIPTION
- On mobile:
  - [x] Turn basic range into two native date fields
  - [x] Turn basic single into single date field
- [x] Add specs on mobile screens

https://community.openproject.org/wp/46814