### PR TITLE
set the correct border radius for selected non-working day 

### DIFF
--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -146,7 +146,7 @@ $datepicker--border-radius: 5px
         &.flatpickr-non-working-day_enabled
           @include non-working-day_enabled
 
-          &.selected
+          &.selected:not(.startRange, .endRange)
             border-radius: $datepicker--border-radius
 
         &.today


### PR DESCRIPTION
When working-days-only switch is off and a non-wrking day is selected at the beginning or end of the range, it shouldn't be rounded completely. But when there is only one day selected and that day is a non-working day, it should have border radius for all sides.