### PR TITLE
ensure order of columns when inserting from select

### DIFF
--- a/db/migrate/20230309104056_unique_index_on_custom_fields_projects.rb
+++ b/db/migrate/20230309104056_unique_index_on_custom_fields_projects.rb
@@ -62,6 +62,10 @@ class UniqueIndexOnCustomFieldsProjects < ActiveRecord::Migration[7.0]
       insertion AS (
         INSERT INTO
           custom_fields_projects
+          (
+            project_id,
+            custom_field_id
+          )
         SELECT
           project_id,
           custom_field_id


### PR DESCRIPTION
Ensure the insert columns match the columns in the select when reinserting the custom_fields_projects in the migration adding a unique constraint on the table.