### PR TITLE
Allow members help-text to be added

### DIFF
--- a/app/models/attribute_help_text/project.rb
+++ b/app/models/attribute_help_text/project.rb
@@ -39,6 +39,8 @@ class AttributeHelpText::Project < AttributeHelpText
       attributes[field.attribute_name] = field.name
     end
 
+    attributes['members'] = I18n.t(:label_member_plural)
+
     attributes
   end
 

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -56,7 +56,15 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
       <div class="grid-content medium-8 small-12 -flex -with-button">
         <div class="form--field">
-          <%= styled_label_tag :member_role_ids, t(:label_role_search) %>
+          <%= styled_label_tag :member_role_ids do %>
+            <%= content_tag :span, t(:label_role_search) %>
+            <%= angular_component_tag 'attribute-help-text',
+                                      inputs: {
+                                        attribute: 'members',
+                                        attributeScope: 'Project'
+                                      }
+            %>
+          <% end %>
           <div class="form--field-container">
             <div class="form--select-container -auto">
               <% options = roles.collect { |obj| [obj.name, obj.id] } %>

--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.html
@@ -2,6 +2,10 @@
     [name]="widgetName"
     [editable]="isEditable">
 
+  <attribute-help-text slot="prepend"
+                       attribute="members"
+                       [attributeScope]="'Project'"></attribute-help-text>
+
   <widget-menu
       slot="menu"
       [resource]="resource">


### PR DESCRIPTION
Shown at:
  - Members widget in overview
  - Members role selection

https://community.openproject.org/wp/46816