### PR TITLE
[46162] Date picker on Mobile does not take the full screen

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -33,6 +33,7 @@
       top: unset !important
       right: $spot-spacing-1
       width: calc(100vw - (2 * #{$spot-spacing-1}))
+      max-height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
 
     @media #{$spot-mq-drop-modal-in-context}
       position: absolute

--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -33,7 +33,6 @@
       top: unset !important
       right: $spot-spacing-1
       width: calc(100vw - (2 * #{$spot-spacing-1}))
-      height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
 
     @media #{$spot-mq-drop-modal-in-context}
       position: absolute


### PR DESCRIPTION
First the height is set to auto which I think is correct and sets the height of drop modal body based on the heights of its children, then a few lines after it there is a calculation for the height that I'm not sure where will be used but I think that this calculation should be used for max-height of body. 

https://community.openproject.org/work_packages/46162/activity