### PR TITLE
[45980] Improve performance of querying with timestamps

### DIFF
--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -431,6 +431,27 @@ describe Journable::HistoricActiveRecordRelation do
         expect(subject).to include work_package
       end
     end
+
+    describe "using an initial scope with a include(:project)" do
+      # This is used in a work package query with timestamps.
+      let(:relation) do
+        WorkPackage
+          .includes(:project)
+          .where(projects: { id: project.id })
+      end
+
+      it "joins the projects table" do
+        sql = subject.to_sql.tr('"', '')
+        expect(sql).to include \
+          "LEFT OUTER JOIN projects ON projects.id = journables.project_id"
+        expect(sql).to include \
+          "WHERE projects.id = #{project.id}"
+      end
+
+      it "returns the requested work package" do
+        expect(subject).to include work_package
+      end
+    end
   end
 
   describe "#first" do


### PR DESCRIPTION
https://community.openproject.org/wp/45980

The performance improvement is on `/api/v3/projects/:id/work_packages` endpoint with `timestamps` parameter.

The inner queries (one per timestamp) are filtering on given project id and subprojects ids, but the projects table was only available in the outer query, leading to bad performance.

The perf got better once the projects table is joined in the inner queries. In fact, the projects table should have been automatically joined by ActiveRecord as the query is calling `includes(:project)` but as `Journable::HistoricActiveRecordRelation#eager_loading?` is overridden to return `false`, joining the eager loaded tables was not done. That's why it is being done explicitly.

The performance improvement is multiple order of magnitude: on a test database, it went from more than 2 minutes to 200 ms. The overall api endpoint query takes less than 2 seconds to complete.