### PR TITLE
Add missing foreign keys.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -79,13 +79,10 @@ class Project < ApplicationRecord
   has_many :changesets, through: :repository
   has_one :wiki, dependent: :destroy
   # Custom field for the project's work_packages
-  has_many :custom_fields_projects,
-           dependent: :destroy
-  has_many :work_package_custom_fields,
-           -> { order("#{CustomField.table_name}.position") },
-           through: :custom_fields_projects,
-           class_name: 'WorkPackageCustomField',
-           source: :custom_field
+  has_and_belongs_to_many :work_package_custom_fields,
+                          -> { order("#{CustomField.table_name}.position") },
+                          join_table: :custom_fields_projects,
+                          association_foreign_key: 'custom_field_id'
   has_one :status, class_name: 'Projects::Status', dependent: :destroy
   has_many :budgets, dependent: :destroy
   has_many :notification_settings, dependent: :destroy
@@ -319,7 +316,7 @@ class Project < ApplicationRecord
   end
 
   def enabled_module_names=(module_names)
-    if module_names&.is_a?(Array)
+    if module_names.is_a?(Array)
       module_names = module_names.map(&:to_s).compact_blank
       self.enabled_modules = module_names.map do |name|
         enabled_modules.detect do |mod|

--- a/app/workers/projects/delete_project_job.rb
+++ b/app/workers/projects/delete_project_job.rb
@@ -39,12 +39,12 @@ module Projects
       service_call = ::Projects::DeleteService.new(user:, model: project).call
 
       if service_call.failure?
-        Rails.logger.error "Failed to delete project #{project} in background job: " \
-                           "#{service_call.message}"
+        OpenProject.logger.error("Failed to delete project #{project} in background job: " \
+                                 "#{service_call.message}")
       end
     rescue StandardError => e
-      Rails.logger.error('Encountered an error when trying to delete project ' \
-                         "'#{project}' : #{e.message} #{e.backtrace.join("\n")}")
+      OpenProject.logger.error('Encountered an error when trying to delete project ' \
+                               "'#{project}' : #{e.message} #{e.backtrace.join("\n")}")
     end
   end
 end

--- a/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
+++ b/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
@@ -1,0 +1,34 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddForeignKeysToWorkPackages < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :work_packages, :types, on_delete: :cascade, on_update: :cascade
+    add_foreign_key :work_packages, :statuses, on_delete: :cascade, on_update: :cascade
+  end
+end

--- a/db/migrate/20230315103437_add_foreign_keys_to_workflows.rb
+++ b/db/migrate/20230315103437_add_foreign_keys_to_workflows.rb
@@ -1,0 +1,35 @@
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddForeignKeysToWorkflows < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :workflows, :types, on_delete: :cascade, on_update: :cascade
+    add_foreign_key :workflows, :statuses, column: 'old_status_id', on_delete: :cascade, on_update: :cascade
+    add_foreign_key :workflows, :statuses, column: 'new_status_id', on_delete: :cascade, on_update: :cascade
+    add_foreign_key :workflows, :roles, on_delete: :cascade, on_update: :cascade
+  end
+end

--- a/db/migrate/20230315183431_add_foreign_keys_to_projects_types.rb
+++ b/db/migrate/20230315183431_add_foreign_keys_to_projects_types.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddForeignKeysToProjectsTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :projects_types, :types, on_delete: :cascade, on_update: :cascade
+    add_foreign_key :projects_types, :projects, on_delete: :cascade, on_update: :cascade
+  end
+end

--- a/db/migrate/20230315184533_add_foreign_keys_to_custom_fields_projects.rb
+++ b/db/migrate/20230315184533_add_foreign_keys_to_custom_fields_projects.rb
@@ -1,0 +1,34 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddForeignKeysToCustomFieldsProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :custom_fields_projects, :custom_fields, on_delete: :cascade, on_update: :cascade
+    add_foreign_key :custom_fields_projects, :projects, on_delete: :cascade, on_update: :cascade
+  end
+end

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -30,7 +30,7 @@ require 'contracts/work_packages/shared_base_contract'
 
 describe WorkPackages::UpdateContract do
   let(:work_package_project) do
-    build_stubbed(:project, public: false).tap do |p|
+    create(:project, public: false).tap do |p|
       allow(Project)
         .to receive(:find)
         .with(p.id)
@@ -56,7 +56,7 @@ describe WorkPackages::UpdateContract do
     end
   end
   let(:user) { build_stubbed(:user) }
-  let(:type) { build_stubbed(:type) }
+  let(:type) { create(:type) }
   let(:status) { build_stubbed(:status) }
   let(:permissions) { %i[view_work_packages edit_work_packages assign_versions] }
 

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -60,7 +60,9 @@ describe API::V3::WorkPackages::EagerLoading::Checksum do
     end
 
     it 'produces a different checksum on changes to the status id' do
-      WorkPackage.where(id: work_package.id).update_all(status_id: 0)
+      new_status = create(:status)
+
+      WorkPackage.where(id: work_package.id).update_all(status_id: new_status.id)
 
       expect(new_checksum)
         .not_to eql orig_checksum
@@ -130,7 +132,8 @@ describe API::V3::WorkPackages::EagerLoading::Checksum do
     end
 
     it 'produces a different checksum on changes to the type id' do
-      WorkPackage.where(id: work_package.id).update_all(type_id: 0)
+      new_type = create(:type)
+      WorkPackage.where(id: work_package.id).update_all(type_id: new_type.id)
 
       expect(new_checksum)
         .not_to eql orig_checksum

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Query do
   let(:query) { build(:query) }
-  let(:project) { build_stubbed(:project) }
+  let(:project) { create(:project) }
   let(:relation_columns_allowed) { true }
   let(:conditional_highlighting_allowed) { true }
 
@@ -233,7 +233,7 @@ describe Query do
     end
 
     context 'results caching' do
-      let(:project2) { build_stubbed(:project) }
+      let(:project2) { create(:project) }
 
       it 'does not call the db twice' do
         query.project = project

--- a/spec/services/update_type_service_spec.rb
+++ b/spec/services/update_type_service_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 require 'services/shared_type_service'
 
 describe UpdateTypeService do
-  let(:type) { build_stubbed(:type) }
+  let(:type) { create(:type) }
   let(:user) { build_stubbed(:admin) }
 
   let(:instance) { described_class.new(type, user) }


### PR DESCRIPTION
 OP#41000
 OP#41001
 OP#41002
 OP#41003
 OP#41004
- [Add foreign keys to increase ref integrety.](https://github.com/opf/openproject/commit/e625c03f930512c261b4462275858012bbff2d70)|
- [Fix issue with DeleteProjectJob logger.](https://github.com/opf/openproject/commit/ce37b51311e30b798bb1ea1874ebd6335b35ddcb) 
  - `Delayed::Worker.logger` is set to nil in `config/initializers/delayed_job_config.rb:30`. Hence `Rails.logger` is used.
  - Simplify code a by reducing its size.
- [Fix projects.work_package_custom_fields association.](https://github.com/opf/openproject/commit/95dc447baa371454b0d79eab8cbc06bcf20e77f3)
  `Project#destroy` method was broken due to absence of a primary key in custom_fields_projects table, but has_may association requires it.
  
  ![failed_project_destroy_call](https://user-images.githubusercontent.com/11717656/225424205-c632a192-598c-4486-bece-21bfc35b2dc5.png)
   The solution is to switch to set `has_and_belongs_to_many` association without using intermediate `has_many` association. Then the `Project#destroy` works fine and `work_package_custom_fields` works as expected:
   
  ![association_query](https://user-images.githubusercontent.com/11717656/225424717-08c6e4e3-0eca-4770-bb86-a79a55ce3ae2.png)
