### PR TITLE
Fix height in single modal date picker

### DIFF
--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.sass
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.sass
@@ -1,0 +1,3 @@
+@media screen and (max-width: 679px)
+  .spot-drop-modal--body
+    height: auto !important

--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
@@ -64,7 +64,7 @@ export const opModalSingleDatePickerSelector = 'op-modal-single-date-picker';
 @Component({
   selector: opModalSingleDatePickerSelector,
   templateUrl: './modal-single-date-picker.component.html',
-  styleUrls: ['../styles/datepicker.modal.sass'],
+  styleUrls: ['../styles/datepicker.modal.sass', './modal-single-date-picker.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   providers: [

--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -33,7 +33,7 @@
       top: unset !important
       right: $spot-spacing-1
       width: calc(100vw - (2 * #{$spot-spacing-1}))
-      max-height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
+      height: calc(#{var(--app-height)} - (#{$spot-spacing-3_5} + #{$spot-spacing-1}))
 
     @media #{$spot-mq-drop-modal-in-context}
       position: absolute


### PR DESCRIPTION
Revert the changes I made to the height of drop modal body, since it should span over the full screen for example in project select modal. I just added the rule for mobile mode in single modal date picker that uses drop modal.