### PR TITLE
Adjust foreign keys migrations.

### DIFF
--- a/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
+++ b/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
@@ -27,8 +27,15 @@
 #++
 
 class AddForeignKeysToWorkPackages < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    WorkPackage.where.not(type: Type.all).destroy_all
     add_foreign_key :work_packages, :types, on_delete: :cascade, on_update: :cascade
+    WorkPackage.where.not(type: Status.all).destroy_all
     add_foreign_key :work_packages, :statuses, on_delete: :cascade, on_update: :cascade
+  end
+
+  def down
+    remove_foreign_key :work_packages, :types
+    remove_foreign_key :work_packages, :statuses
   end
 end

--- a/db/migrate/20230315103437_add_foreign_keys_to_workflows.rb
+++ b/db/migrate/20230315103437_add_foreign_keys_to_workflows.rb
@@ -26,10 +26,20 @@
 #++
 
 class AddForeignKeysToWorkflows < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    Workflow.where.not(type: Type.all).destroy_all
     add_foreign_key :workflows, :types, on_delete: :cascade, on_update: :cascade
+    Workflow.where.not(old_status_id: Status.all).or(Workflow.where.not(new_status_id: Status.all)).destroy_all
     add_foreign_key :workflows, :statuses, column: 'old_status_id', on_delete: :cascade, on_update: :cascade
     add_foreign_key :workflows, :statuses, column: 'new_status_id', on_delete: :cascade, on_update: :cascade
+    Workflow.where.not(type: Role.all).destroy_all
     add_foreign_key :workflows, :roles, on_delete: :cascade, on_update: :cascade
+  end
+
+  def down
+    remove_foreign_key :workflows, :types
+    remove_foreign_key :workflows, :statuses
+    remove_foreign_key :workflows, :statuses
+    remove_foreign_key :workflows, :roles
   end
 end

--- a/db/migrate/20230315183431_add_foreign_keys_to_projects_types.rb
+++ b/db/migrate/20230315183431_add_foreign_keys_to_projects_types.rb
@@ -25,8 +25,18 @@
 #++
 
 class AddForeignKeysToProjectsTypes < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    execute <<~SQL.squish
+      DELETE FROM projects_types
+        WHERE type_id NOT IN (SELECT id FROM types) OR
+              project_id NOT IN (SELECT id FROM projects)
+    SQL
     add_foreign_key :projects_types, :types, on_delete: :cascade, on_update: :cascade
     add_foreign_key :projects_types, :projects, on_delete: :cascade, on_update: :cascade
+  end
+
+  def down
+    remove_foreign_key :projects_types, :types
+    remove_foreign_key :projects_types, :projects
   end
 end

--- a/db/migrate/20230315184533_add_foreign_keys_to_custom_fields_projects.rb
+++ b/db/migrate/20230315184533_add_foreign_keys_to_custom_fields_projects.rb
@@ -27,8 +27,18 @@
 #++
 
 class AddForeignKeysToCustomFieldsProjects < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    execute <<~SQL.squish
+      DELETE FROM custom_fields_projects
+        WHERE custom_field_id NOT IN (SELECT id FROM custom_fields) OR
+              project_id NOT IN (SELECT id FROM projects)
+    SQL
     add_foreign_key :custom_fields_projects, :custom_fields, on_delete: :cascade, on_update: :cascade
     add_foreign_key :custom_fields_projects, :projects, on_delete: :cascade, on_update: :cascade
+  end
+
+  def down
+    remove_foreign_key :custom_fields_projects, :custom_fields
+    remove_foreign_key :custom_fields_projects, :projects
   end
 end


### PR DESCRIPTION
OP#41000
OP#41001
OP#41002
OP#41003
OP#41004
Adjust foreign keys migrations to delete inconsistent data related to the following foreign key constraint to be added to the database.
The output of local migrating process with generated queries.
```bash
[ba1ash@p14:~/prj/openproject]$ docker compose exec backend bundle exec rails db:migrate
Starting with bootsnap.
[fog][WARNING] Unrecognized arguments: share_point_tenant_id, share_point_client_id, share_point_client_secret, share_point_tenant_name, share_point_site, share_point_locale
   (0.5ms)  SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  ↳ config/initializers/enforce_isolation_level.rb:47:in `set_connection_isolation_level'
  Setting Maximum (0.9ms)  SELECT MAX("settings"."updated_at") FROM "settings"
  ↳ app/models/setting.rb:316:in `settings_updated_at'
  ActiveRecord::SchemaMigration Pluck (0.9ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
  ↳ app/models/journable/timestamps.rb:74:in `block in <module:Timestamps>'
   (0.2ms)  SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  ↳ config/initializers/enforce_isolation_level.rb:47:in `set_connection_isolation_level'
  ActiveRecord::SchemaMigration Pluck (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
  ↳ lib_static/open_project/database.rb:73:in `migrations_pending?'
Running via Spring preloader in process 966
   (0.1ms)  SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  ↳ config/initializers/enforce_isolation_level.rb:47:in `set_connection_isolation_level'
   (0.2ms)  SELECT 1;
  ↳ lib/tasks/database.rake:46:in `block (3 levels) in <main>'
   (0.2ms)  SHOW server_version_num;
  ↳ lib_static/open_project/database.rb:177:in `numeric_version'
   (0.2ms)  SHOW server_version_num;
  ↳ lib_static/open_project/database.rb:177:in `numeric_version'
   (0.1ms)  SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  ↳ config/initializers/enforce_isolation_level.rb:47:in `set_connection_isolation_level'
   (0.2ms)  SELECT pg_try_advisory_lock(2193071229178148760)
  ActiveRecord::SchemaMigration Pluck (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Migrating to AddUpdateDeleteCascadeToWorkPackagesProjectId (20230314093106)
== 20230314093106 AddUpdateDeleteCascadeToWorkPackagesProjectId: migrating ====
-- remove_foreign_key(:work_packages, :projects)
  TRANSACTION (0.2ms)  BEGIN
   (1.1ms)  ALTER TABLE "work_packages" DROP CONSTRAINT "fk_rails_931ad309e8"
   -> 0.0066s
-- add_foreign_key(:work_packages, :projects, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.8ms)  ALTER TABLE "work_packages" ADD CONSTRAINT "fk_rails_931ad309e8"
FOREIGN KEY ("project_id")
  REFERENCES "projects" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0030s
== 20230314093106 AddUpdateDeleteCascadeToWorkPackagesProjectId: migrated (0.0099s)

  ActiveRecord::SchemaMigration Create (0.6ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20230314093106"]]
  TRANSACTION (6.6ms)  COMMIT
Migrating to AddForeignKeysToWorkPackages (20230314165213)
== 20230314165213 AddForeignKeysToWorkPackages: migrating =====================
  TRANSACTION (0.2ms)  BEGIN
  WorkPackage Load (0.7ms)  SELECT "work_packages".* FROM "work_packages" WHERE "work_packages"."type_id" NOT IN (SELECT "types"."id" FROM "types" ORDER BY position ASC)
-- add_foreign_key(:work_packages, :types, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.0ms)  ALTER TABLE "work_packages" ADD CONSTRAINT "fk_rails_f2a8977aa1"
FOREIGN KEY ("type_id")
  REFERENCES "types" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0019s
  WorkPackage Load (0.6ms)  SELECT "work_packages".* FROM "work_packages" WHERE "work_packages"."type_id" NOT IN (SELECT "statuses"."id" FROM "statuses" ORDER BY "statuses"."position" ASC)
-- add_foreign_key(:work_packages, :statuses, {:on_delete=>:cascade, :on_update=>:cascade})
   (0.8ms)  ALTER TABLE "work_packages" ADD CONSTRAINT "fk_rails_5edb6f06e6"
FOREIGN KEY ("status_id")
  REFERENCES "statuses" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0016s
== 20230314165213 AddForeignKeysToWorkPackages: migrated (0.0256s) ============

  ActiveRecord::SchemaMigration Create (0.2ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20230314165213"]]
  TRANSACTION (0.7ms)  COMMIT
Migrating to AddForeignKeysToWorkflows (20230315103437)
== 20230315103437 AddForeignKeysToWorkflows: migrating ========================
  TRANSACTION (0.2ms)  BEGIN
  Workflow Load (0.9ms)  SELECT "workflows".* FROM "workflows" WHERE "workflows"."type_id" NOT IN (SELECT "types"."id" FROM "types" ORDER BY position ASC)
-- add_foreign_key(:workflows, :types, {:on_delete=>:cascade, :on_update=>:cascade})
   (0.9ms)  ALTER TABLE "workflows" ADD CONSTRAINT "fk_rails_2a8f410364"
FOREIGN KEY ("type_id")
  REFERENCES "types" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0018s
  Workflow Load (0.9ms)  SELECT "workflows".* FROM "workflows" WHERE ("workflows"."old_status_id" NOT IN (SELECT "statuses"."id" FROM "statuses" ORDER BY "statuses"."position" ASC) OR "workflows"."new_status_id" NOT IN (SELECT "statuses"."id" FROM "statuses" ORDER BY "statuses"."position" ASC))
-- add_foreign_key(:workflows, :statuses, {:column=>"old_status_id", :on_delete=>:cascade, :on_update=>:cascade})
   (1.1ms)  ALTER TABLE "workflows" ADD CONSTRAINT "fk_rails_b4628cffdf"
FOREIGN KEY ("old_status_id")
  REFERENCES "statuses" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0033s
-- add_foreign_key(:workflows, :statuses, {:column=>"new_status_id", :on_delete=>:cascade, :on_update=>:cascade})
   (1.2ms)  ALTER TABLE "workflows" ADD CONSTRAINT "fk_rails_66af376b7e"
FOREIGN KEY ("new_status_id")
  REFERENCES "statuses" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0021s
  Workflow Load (0.7ms)  SELECT "workflows".* FROM "workflows" WHERE "workflows"."type_id" NOT IN (SELECT "roles"."id" FROM "roles")
  Workflow Destroy (0.5ms)  DELETE FROM "workflows" WHERE "workflows"."id" = $1  [["id", 973]]
  Workflow Destroy (0.3ms)  DELETE FROM "workflows" WHERE "workflows"."id" = $1  [["id", 974]]
  Workflow Destroy (0.2ms)  DELETE FROM "workflows" WHERE "workflows"."id" = $1  [["id", 975]]
-- add_foreign_key(:workflows, :roles, {:on_delete=>:cascade, :on_update=>:cascade})
   (2.1ms)  ALTER TABLE "workflows" ADD CONSTRAINT "fk_rails_0c5f149c21"
FOREIGN KEY ("role_id")
  REFERENCES "roles" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0047s
== 20230315103437 AddForeignKeysToWorkflows: migrated (0.5421s) ===============

  ActiveRecord::SchemaMigration Create (0.6ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20230315103437"]]
  TRANSACTION (7.2ms)  COMMIT
Migrating to AddForeignKeysToProjectsTypes (20230315183431)
== 20230315183431 AddForeignKeysToProjectsTypes: migrating ====================
-- execute("DELETE FROM projects_types WHERE type_id NOT IN (SELECT id FROM types) OR project_id NOT IN (SELECT id FROM projects)")
  TRANSACTION (0.3ms)  BEGIN
   (1.2ms)  DELETE FROM projects_types WHERE type_id NOT IN (SELECT id FROM types) OR project_id NOT IN (SELECT id FROM projects)
   -> 0.0051s
-- add_foreign_key(:projects_types, :types, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.5ms)  ALTER TABLE "projects_types" ADD CONSTRAINT "fk_rails_da213a0c8b"
FOREIGN KEY ("type_id")
  REFERENCES "types" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0032s
-- add_foreign_key(:projects_types, :projects, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.6ms)  ALTER TABLE "projects_types" ADD CONSTRAINT "fk_rails_7c3935a107"
FOREIGN KEY ("project_id")
  REFERENCES "projects" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0033s
== 20230315183431 AddForeignKeysToProjectsTypes: migrated (0.0123s) ===========

  ActiveRecord::SchemaMigration Create (0.6ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20230315183431"]]
  TRANSACTION (1.4ms)  COMMIT
Migrating to AddForeignKeysToCustomFieldsProjects (20230315184533)
== 20230315184533 AddForeignKeysToCustomFieldsProjects: migrating =============
-- execute("DELETE FROM custom_fields_projects WHERE custom_field_id NOT IN (SELECT id FROM custom_fields) OR project_id NOT IN (SELECT id FROM projects)")
  TRANSACTION (0.3ms)  BEGIN
   (1.3ms)  DELETE FROM custom_fields_projects WHERE custom_field_id NOT IN (SELECT id FROM custom_fields) OR project_id NOT IN (SELECT id FROM projects)
   -> 0.0049s
-- add_foreign_key(:custom_fields_projects, :custom_fields, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.6ms)  ALTER TABLE "custom_fields_projects" ADD CONSTRAINT "fk_rails_e51cefe60d"
FOREIGN KEY ("custom_field_id")
  REFERENCES "custom_fields" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0031s
-- add_foreign_key(:custom_fields_projects, :projects, {:on_delete=>:cascade, :on_update=>:cascade})
   (1.9ms)  ALTER TABLE "custom_fields_projects" ADD CONSTRAINT "fk_rails_12fb30588e"
FOREIGN KEY ("project_id")
  REFERENCES "projects" ("id")
 ON DELETE CASCADE ON UPDATE CASCADE
   -> 0.0038s
== 20230315184533 AddForeignKeysToCustomFieldsProjects: migrated (0.0126s) ====

  ActiveRecord::SchemaMigration Create (0.5ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20230315184533"]]
  TRANSACTION (0.9ms)  COMMIT
  ActiveRecord::InternalMetadata Load (0.8ms)  SELECT "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 LIMIT $2  [["key", "environment"], ["LIMIT", 1]]
   (0.6ms)  SELECT pg_advisory_unlock(2193071229178148760)
   (0.3ms)  SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  ↳ config/initializers/enforce_isolation_level.rb:47:in `set_connection_isolation_level'
  ActiveRecord::SchemaMigration Pluck (1.5ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
```