### PR TITLE
Here is a typo in DB foreign keys migrations.

### DIFF
--- a/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
+++ b/db/migrate/20230314165213_add_foreign_keys_to_work_packages.rb
@@ -30,7 +30,7 @@ class AddForeignKeysToWorkPackages < ActiveRecord::Migration[7.0]
   def up
     WorkPackage.where.not(type: Type.all).destroy_all
     add_foreign_key :work_packages, :types, on_delete: :cascade, on_update: :cascade
-    WorkPackage.where.not(type: Status.all).destroy_all
+    WorkPackage.where.not(status: Status.all).destroy_all
     add_foreign_key :work_packages, :statuses, on_delete: :cascade, on_update: :cascade
   end
 


### PR DESCRIPTION
original commit 0af3ab4a2c00c70dbc288a54ad84fb885ca8506a