### PR TITLE
Fix datetime filter not using startof/endof day

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
@@ -3,8 +3,8 @@
   [name]="'v[' + filter.id + ']'"
   class="advanced-filters--date-field"
 
-  [value]="value"
-  (valueChange)="value = $event"
+  (valueChange)="value = parser($event)"
+  [value]="formatter(value)"
   [opAutofocus]="shouldFocus"
 ></op-basic-range-date-picker>
 

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -100,4 +100,20 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
     }
     return null;
   }
+
+  public parser(data:string[]):string[] {
+    if (data.length === 2) {
+      let [start, end] = data.map((el) => this.timezoneService.parseISODatetime(el));
+      start = start.startOf('day');
+      end = end.endOf('day');
+
+      return [start, end].map((el) => this.timezoneService.formattedISODateTime(el));
+    }
+
+    return data.map((date) => this.isoDateParser(date));
+  }
+
+  public formatter(data:string[]):string[] {
+    return data.map((date) => this.isoDateFormatter(date));
+  }
 }

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -143,7 +143,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
     }
   }
 
-  changeValueFromInputDebounced = debounce(this.changeValueFromInput.bind(this), 16);
+  changeValueFromInputDebounced = debounce(this.changeValueFromInput.bind(this), 250);
 
   changeValueFromInput(value:string|string[]) {
     const newDates = (typeof value === 'string') ? this.resolveDateStringToArray(value) : value;

--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
@@ -197,7 +197,7 @@ export class OpModalSingleDatePickerComponent implements ControlValueAccessor, O
     this.cdRef.detectChanges();
   }
 
-  changeValueFromInputDebounced = debounce(this.changeValueFromInput.bind(this), 16);
+  changeValueFromInputDebounced = debounce(this.changeValueFromInput.bind(this), 250);
 
   changeValueFromInput(value:string) {
     this.valueChange.emit(value);

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -497,16 +497,14 @@ describe 'filter work packages', js: true do
              subject: 'Created today',
              project:,
              created_at: Time.current.change(hour: 12),
-             updated_at: Time.current.change(hour: 12),
-             )
+             updated_at: Time.current.change(hour: 12))
     end
     shared_let(:wp_updated_5d_ago) do
       create(:work_package,
              subject: 'Created 5d ago',
              project:,
              created_at: 5.days.ago,
-             updated_at: 5.days.ago,
-      )
+             updated_at: 5.days.ago)
     end
 
     it 'filters on date by created_at (Regression #28459)' do
@@ -552,15 +550,40 @@ describe 'filter work packages', js: true do
 
       filters.open
 
-      filters.add_filter_by 'Updated',
+      filters.add_filter_by 'Updated on',
                             'between',
-                            [1.day.ago.iso8601, Date.current.iso8601],
+                            [1.day.ago.to_date.iso8601, Date.current.iso8601],
                             'updatedAt'
 
       loading_indicator_saveguard
 
       wp_table.expect_work_package_listed wp_updated_today
       wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      last_query = Query.last
+      date_filter = last_query.filters.last
+      expect(date_filter.values)
+        .to eq [1.day.ago.utc.beginning_of_day.iso8601, Time.current.utc.end_of_day.iso8601]
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      filters.open
+
+      filters.expect_filter_by 'Updated on',
+                               'between',
+                               [1.day.ago.to_date.iso8601, Date.current.iso8601],
+                               'updatedAt'
     end
   end
 

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -46,6 +46,7 @@ describe 'mobile date filter work packages',
     target.native.clear
     page.execute_script('arguments[0].value = arguments[1];', target.native, value)
     page.execute_script('arguments[0].dispatchEvent(new Event("input"));', target.native) if fire_change
+    sleep 1
   end
 
   before do
@@ -61,12 +62,9 @@ describe 'mobile date filter work packages',
       start_field = find('[data-qa-selector="op-basic-range-date-picker-start"]')
       end_field = find('[data-qa-selector="op-basic-range-date-picker-end"]')
 
-      native_input(start_field, 1.day.ago.to_date.iso8601, fire_change: false)
+      native_input(start_field, 1.day.ago.to_date.iso8601)
+      loading_indicator_saveguard
       native_input(end_field, Date.current.iso8601)
-
-
-      # wait for debounce
-      sleep 1
 
       loading_indicator_saveguard
       wp_cards.expect_work_package_listed work_package_with_due_date

--- a/spec/support/shared/selenium_workarounds.rb
+++ b/spec/support/shared/selenium_workarounds.rb
@@ -43,6 +43,6 @@ module SeleniumWorkarounds
       break if correctly_set
     end
 
-    raise "Found value #{found_value}, but expected #{value}." unless correctly_set
+    raise "Found value #{input.value}, but expected #{value}." unless correctly_set
   end
 end


### PR DESCRIPTION
The datetime filter always sends <date>Z00:00:00 for both start and end values. This is obviously incorrect, as it will exclude, say work packages created today with "Created At = <Today's date>" , since the upper boundary is TodayZ:00:00:00


https://community.openproject.org/work_packages/46865