### PR TITLE
Revert between datepickers to use two basic fields again

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
+++ b/frontend/src/app/features/work-packages/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
@@ -45,7 +45,7 @@ export abstract class AbstractDateTimeValueController extends UntilDestroyedMixi
   }
 
   ngOnInit() {
-    _.remove(this.filter.values as string[], (value) => !this.timezoneService.isValidISODateTime(value));
+    _.remove(this.filter.values as string[], (value) => !(value === '' || this.timezoneService.isValidISODateTime(value)));
   }
 
   public abstract get lowerBoundary():Moment|null;

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
@@ -1,5 +1,5 @@
 <op-basic-single-date-picker
-  (valueChange)="begin = isoDateParser($event)"
+  (valueChange)="parseBegin($event)"
   [value]="isoDateFormatter(begin)"
   [opAutofocus]="shouldFocus"
   required="true"
@@ -12,7 +12,7 @@
 </span>
 
 <op-basic-single-date-picker
-  (valueChange)="end = isoDateParser($event)"
+  (valueChange)="parseEnd($event)"
   [value]="isoDateFormatter(end)"
   [id]="'values-' + filter.id + '-end'"
   [name]="'v[' + filter.id + ']-end'"

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.html
@@ -1,13 +1,23 @@
-<op-basic-range-date-picker
-  [id]="'values-' + filter.id"
-  [name]="'v[' + filter.id + ']'"
-  class="advanced-filters--date-field"
-
-  [value]="value"
-  (valueChange)="value = $event"
+<op-basic-single-date-picker
+  (valueChange)="begin = isoDateParser($event)"
+  [value]="isoDateFormatter(begin)"
   [opAutofocus]="shouldFocus"
-></op-basic-range-date-picker>
+  required="true"
+  [id]="'values-' + filter.id + '-begin'"
+  [name]="'v[' + filter.id + ']-begin'"
+  classes="advanced-filters--date-field"
+></op-basic-single-date-picker>
 
+<span class="advanced-filters--affix" [textContent]="text.spacer">
+</span>
+
+<op-basic-single-date-picker
+  (valueChange)="end = isoDateParser($event)"
+  [value]="isoDateFormatter(end)"
+  [id]="'values-' + filter.id + '-end'"
+  [name]="'v[' + filter.id + ']-end'"
+  classes="advanced-filters--date-field"
+></op-basic-single-date-picker>
 
 <span
   class="advanced-filters--tooltip-trigger -multiline"

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -26,11 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { Moment } from 'moment';
 import {
-  HostBinding,
   Component,
+  HostBinding,
   Input,
   OnInit,
   Output,

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -71,21 +71,21 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
     super(I18n, timezoneService);
   }
 
-  public get begin():HalResource|string {
-    return this.filter.values[0];
+  public get begin():string {
+    return (this.filter.values[0] || '') as string;
   }
 
-  public set begin(val) {
+  public set begin(val:string) {
     this.filter.values[0] = val || '';
     this.filterChanged.emit(this.filter);
   }
 
-  public get end() {
-    return this.filter.values[1];
+  public get end():string {
+    return (this.filter.values[1] || '') as string;
   }
 
-  public set end(val) {
-    this.filter.values[1] = val || '';
+  public set end(val:string) {
+    this.filter.values = [this.begin, val || ''] as string[];
     this.filterChanged.emit(this.filter);
   }
 

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -41,6 +41,7 @@ import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { AbstractDateTimeValueController } from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller';
+import { validDate } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
 
 @Component({
   selector: 'op-filter-date-times-value',
@@ -100,5 +101,33 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
       return this.timezoneService.parseDatetime(this.end.toString());
     }
     return null;
+  }
+
+  public parseBegin(date:string|null) {
+    if (date && validDate(date)) {
+      const parsed = this
+        .timezoneService
+        .parseISODatetime(date)
+        .utc()
+        .startOf('day');
+
+      this.begin = this.timezoneService.formattedISODateTime(parsed);
+    }
+  }
+
+  public parseEnd(date:string|null) {
+    if (date && validDate(date)) {
+      const parsed = this
+        .timezoneService
+        .parseISODatetime(date)
+        .utc()
+        .endOf('day');
+
+      this.end = this.timezoneService.formattedISODateTime(parsed);
+    }
+  }
+
+  public formatter(data:string[]):string[] {
+    return data.map((date) => this.isoDateFormatter(date));
   }
 }

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -103,7 +103,13 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
   }
 
   public parseBegin(date:string|null) {
-    if (date && validDate(date)) {
+    if (date === null || !validDate(date)) {
+      return;
+    }
+
+    if (date === '') {
+      this.begin = date;
+    } else {
       const parsed = this
         .timezoneService
         .parseISODatetime(date)
@@ -115,7 +121,13 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
   }
 
   public parseEnd(date:string|null) {
-    if (date && validDate(date)) {
+    if (date === null || !validDate(date)) {
+      return;
+    }
+
+    if (date === '') {
+      this.end = date;
+    } else {
       const parsed = this
         .timezoneService
         .parseISODatetime(date)

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -70,21 +70,22 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
     super(I18n, timezoneService);
   }
 
-  public get value():string[] {
-    return (this.filter.values as string[]) || [];
-  }
-
-  public set value(val:string[]) {
-    this.filter.values = val;
-    this.filterChanged.emit(this.filter);
-  }
-
   public get begin():HalResource|string {
     return this.filter.values[0];
   }
 
+  public set begin(val) {
+    this.filter.values[0] = val || '';
+    this.filterChanged.emit(this.filter);
+  }
+
   public get end() {
     return this.filter.values[1];
+  }
+
+  public set end(val) {
+    this.filter.values[1] = val || '';
+    this.filterChanged.emit(this.filter);
   }
 
   public get lowerBoundary():Moment|null {

--- a/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
@@ -26,8 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { Component, HostBinding, Input, Output } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  Output,
+} from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import * as moment from 'moment';
@@ -59,35 +63,36 @@ export class FilterDatesValueComponent extends UntilDestroyedMixin {
 
   constructor(
     readonly timezoneService:TimezoneService,
-    readonly I18n:I18nService) {
+    readonly I18n:I18nService,
+  ) {
     super();
   }
 
-  public get value():(HalResource[]|string[]) {
-    return this.filter.values || [];
+  public get value():string[] {
+    return (this.filter.values || []) as string[];
   }
 
-  public set value(val:(HalResource[]|string[])) {
+  public set value(val:string[]) {
     this.filter.values = val;
     this.filterChanged.emit(this.filter);
   }
 
-  public get begin():any {
-    return this.filter.values[0];
+  public get begin():string {
+    return (this.filter.values[0] || '') as string;
   }
 
-  public get end():HalResource|string {
-    return this.filter.values[1];
+  public get end():string {
+    return (this.filter.values[1] || '') as string;
   }
 
-  public parser(data:any) {
+  public parser(data:string):string|null {
     if (moment(data, 'YYYY-MM-DD', true).isValid()) {
       return data;
     }
     return null;
   }
 
-  public formatter(data:any) {
+  public formatter(data:string):string|null {
     if (moment(data, 'YYYY-MM-DD', true).isValid()) {
       const d = this.timezoneService.parseDate(data);
       return this.timezoneService.formattedISODate(d);

--- a/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
@@ -27,12 +27,7 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import {
-  Component,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, HostBinding, Input, Output } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import * as moment from 'moment';
@@ -64,8 +59,7 @@ export class FilterDatesValueComponent extends UntilDestroyedMixin {
 
   constructor(
     readonly timezoneService:TimezoneService,
-    readonly I18n:I18nService,
-  ) {
+    readonly I18n:I18nService) {
     super();
   }
 
@@ -76,5 +70,28 @@ export class FilterDatesValueComponent extends UntilDestroyedMixin {
   public set value(val:(HalResource[]|string[])) {
     this.filter.values = val;
     this.filterChanged.emit(this.filter);
+  }
+
+  public get begin():any {
+    return this.filter.values[0];
+  }
+
+  public get end():HalResource|string {
+    return this.filter.values[1];
+  }
+
+  public parser(data:any) {
+    if (moment(data, 'YYYY-MM-DD', true).isValid()) {
+      return data;
+    }
+    return null;
+  }
+
+  public formatter(data:any) {
+    if (moment(data, 'YYYY-MM-DD', true).isValid()) {
+      const d = this.timezoneService.parseDate(data);
+      return this.timezoneService.formattedISODate(d);
+    }
+    return null;
   }
 }

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -141,11 +141,10 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
   }
 
   changeValueFromInput(value:string) {
-    this.onTouched(value);
-    this.onChange(value);
-    this.writeValue(value);
-
     if (validDate(value)) {
+      this.onTouched(value);
+      this.onChange(value);
+      this.writeValue(value);
       this.datePickerInstance?.setDates(value);
       this.valueChange.emit(value);
     }

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -497,16 +497,14 @@ describe 'filter work packages', js: true do
              subject: 'Created today',
              project:,
              created_at: Time.current.change(hour: 12),
-             updated_at: Time.current.change(hour: 12),
-             )
+             updated_at: Time.current.change(hour: 12))
     end
     shared_let(:wp_updated_5d_ago) do
       create(:work_package,
              subject: 'Created 5d ago',
              project:,
              created_at: 5.days.ago,
-             updated_at: 5.days.ago,
-             )
+             updated_at: 5.days.ago)
     end
 
     it 'filters on date by created_at (Regression #28459)' do
@@ -614,7 +612,7 @@ describe 'filter work packages', js: true do
 
       filters.add_filter_by 'Updated',
                             'between',
-                            [6.day.ago.to_date.iso8601],
+                            [6.days.ago.to_date.iso8601],
                             'updatedAt'
 
       loading_indicator_saveguard
@@ -665,7 +663,7 @@ describe 'filter work packages', js: true do
 
       filters.add_filter_by 'Updated',
                             'between',
-                            [nil, 6.day.ago.to_date.iso8601],
+                            [nil, 6.days.ago.to_date.iso8601],
                             'updatedAt'
 
       loading_indicator_saveguard

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -674,13 +674,13 @@ describe 'filter work packages', js: true do
       last_query = Query.last
       date_filter = last_query.filters.last
       expect(date_filter.values)
-        .to eq [nil, 1.day.ago.utc.beginning_of_day.iso8601]
+        .to eq ['', 1.day.ago.utc.end_of_day.iso8601]
 
       wp_table.visit_query(last_query)
 
       loading_indicator_saveguard
-      wp_table.expect_work_package_listed wp_updated_today
-      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+      wp_table.expect_work_package_listed wp_updated_5d_ago
+      wp_table.ensure_work_package_not_listed! wp_updated_today
 
       filters.open
 

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -29,10 +29,10 @@
 require 'spec_helper'
 
 describe 'filter work packages', js: true do
-  let(:user) { create(:admin) }
-  let(:watcher) { create(:user) }
-  let(:project) { create(:project, members: { watcher => role }) }
-  let(:role) { create(:existing_role, permissions: [:view_work_packages]) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:watcher) { create(:user) }
+  shared_let(:role) { create(:existing_role, permissions: [:view_work_packages]) }
+  shared_let(:project) { create(:project, members: { watcher => role }) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   let(:filters) { Components::WorkPackages::Filters.new }
 
@@ -491,32 +491,203 @@ describe 'filter work packages', js: true do
     end
   end
 
-  describe 'specific filters' do
-    describe 'filters on date by created_at (Regression #28459)' do
-      let!(:wp_updated_today) do
-        create(:work_package, subject: 'Created today', project:, created_at: Time.current.change(hour: 12))
-      end
-      let!(:wp_updated_5d_ago) do
-        create(:work_package, subject: 'Created 5d ago', project:, created_at: 5.days.ago)
-      end
+  describe 'datetime filters' do
+    shared_let(:wp_updated_today) do
+      create(:work_package,
+             subject: 'Created today',
+             project:,
+             created_at: Time.current.change(hour: 12),
+             updated_at: Time.current.change(hour: 12),
+             )
+    end
+    shared_let(:wp_updated_5d_ago) do
+      create(:work_package,
+             subject: 'Created 5d ago',
+             project:,
+             created_at: 5.days.ago,
+             updated_at: 5.days.ago,
+             )
+    end
 
-      it do
-        wp_table.visit!
-        loading_indicator_saveguard
-        wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+    it 'filters on date by created_at (Regression #28459)' do
+      wp_table.visit!
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
 
-        filters.open
+      filters.open
 
-        filters.add_filter_by 'Created on',
-                              'on',
-                              [Date.current.iso8601],
-                              'createdAt'
+      filters.add_filter_by 'Created on',
+                            'on',
+                            [Date.current.iso8601],
+                            'createdAt'
 
-        loading_indicator_saveguard
+      loading_indicator_saveguard
 
-        wp_table.expect_work_package_listed wp_updated_today
-        wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
-      end
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+    end
+
+    it 'filters on date by updated_at' do
+      wp_table.visit!
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.open
+
+      filters.add_filter_by 'Updated',
+                            'on',
+                            [Date.current.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+    end
+
+    it 'filters between date by updated_at' do
+      wp_table.visit!
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.open
+
+      filters.add_filter_by 'Updated',
+                            'between',
+                            [1.day.ago.to_date.iso8601, Date.current.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      last_query = Query.last
+      date_filter = last_query.filters.last
+      expect(date_filter.values)
+        .to eq [1.day.ago.utc.beginning_of_day.iso8601, Time.current.utc.end_of_day.iso8601]
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      filters.open
+
+      filters.expect_filter_by 'Updated on',
+                               'between',
+                               [1.day.ago.to_date.iso8601, Date.current.iso8601],
+                               'updatedAt'
+    end
+
+    it 'filters between date by updated_at (lower boundary only)' do
+      wp_table.visit!
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.open
+
+      filters.add_filter_by 'Updated',
+                            'between',
+                            [1.day.ago.to_date.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.add_filter_by 'Updated',
+                            'between',
+                            [6.day.ago.to_date.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      last_query = Query.last
+      date_filter = last_query.filters.last
+      expect(date_filter.values)
+        .to eq [1.day.ago.utc.beginning_of_day.iso8601]
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      filters.open
+
+      filters.expect_filter_by 'Updated on',
+                               'between',
+                               [1.day.ago.to_date.iso8601, ''],
+                               'updatedAt'
+    end
+
+    it 'filters between date by updated_at (upper boundary only)' do
+      wp_table.visit!
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.open
+
+      filters.add_filter_by 'Updated',
+                            'between',
+                            [nil, 1.day.ago.to_date.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+
+      wp_table.expect_work_package_listed wp_updated_5d_ago
+      wp_table.ensure_work_package_not_listed! wp_updated_today
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today, wp_updated_5d_ago
+
+      filters.add_filter_by 'Updated',
+                            'between',
+                            [nil, 6.day.ago.to_date.iso8601],
+                            'updatedAt'
+
+      loading_indicator_saveguard
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago, wp_updated_today
+
+      last_query = Query.last
+      date_filter = last_query.filters.last
+      expect(date_filter.values)
+        .to eq [nil, 1.day.ago.utc.beginning_of_day.iso8601]
+
+      wp_table.visit_query(last_query)
+
+      loading_indicator_saveguard
+      wp_table.expect_work_package_listed wp_updated_today
+      wp_table.ensure_work_package_not_listed! wp_updated_5d_ago
+
+      filters.open
+
+      filters.expect_filter_by 'Updated on',
+                               'between',
+                               ['', 1.day.ago.to_date.iso8601],
+                               'updatedAt'
     end
   end
 

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -226,10 +226,10 @@ module Components
         retry_block do
           # wait for filter to be present
           filter_element = page.find("#filter_#{id}")
-          if operator == 'between'
-            insert_two_single_dates(id, value)
-          elsif filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
+          if filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
             insert_date_range(filter_element, value)
+          elsif operator == 'between'
+            insert_two_single_dates(id, value)
           elsif filter_element.has_selector?(".ng-select-container", wait: false)
             insert_autocomplete_item(filter_element, value)
           else

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -123,7 +123,7 @@ module Components
 
         set_operator(name, operator, selector)
 
-        set_value(id, value) unless value.nil?
+        set_value(id, value, operator) unless value.nil?
 
         close_autocompleter(id)
       end
@@ -222,28 +222,51 @@ module Components
         '.work-packages--filters-optional-container'
       end
 
-      def set_value(id, value)
+      def set_value(id, value, operator)
         retry_block do
           # wait for filter to be present
           filter_element = page.find("#filter_#{id}")
-          if filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
-            date_input = filter_element.find("[data-qa-selector='op-basic-range-date-picker']")
-            ensure_value_is_input_correctly date_input, value: Array(value).join(' - ')
+          if operator == 'between'
+            insert_two_single_dates(id, value)
+          elsif filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
+            insert_date_range(filter_element, value)
           elsif filter_element.has_selector?(".ng-select-container", wait: false)
-            Array(value).each do |val|
-              select_autocomplete filter_element.find("op-autocompleter"),
-                                  query: val,
-                                  results_selector: '.ng-dropdown-panel-items'
-            end
+            insert_autocomplete_item(filter_element, value)
           else
-            within_values(id) do
-              page.all('input').each_with_index do |input, index|
-                # Wait a bit to insert the values
-                ensure_value_is_input_correctly input, value: value[index]
-              end
-            end
+            insert_plain_value(id, value)
           end
         end
+      end
+
+      def insert_autocomplete_item(filter_element, value)
+        Array(value).each do |val|
+          select_autocomplete filter_element.find("op-autocompleter"),
+                              query: val,
+                              results_selector: '.ng-dropdown-panel-items'
+        end
+      end
+
+      def insert_plain_value(id, value)
+        within_values(id) do
+          page.all('input').each_with_index do |input, index|
+            # Wait a bit to insert the values
+            ensure_value_is_input_correctly input, value: value[index]
+          end
+        end
+      end
+
+      def insert_two_single_dates(id, value)
+        fill_in("values-#{id}-begin", with: value[0]) if value[0]
+        sleep 1
+        loading_indicator_saveguard
+        fill_in("values-#{id}-end", with: value[1]) if value[1]
+        sleep 1
+        loading_indicator_saveguard
+      end
+
+      def insert_date_range(filter_element, value)
+        date_input = filter_element.find("[data-qa-selector='op-basic-range-date-picker']")
+        ensure_value_is_input_correctly date_input, value: Array(value).join(' - ')
       end
 
       def autocomplete_dropdown_value(id:, value:, present: true)

--- a/spec/support/shared/selenium_workarounds.rb
+++ b/spec/support/shared/selenium_workarounds.rb
@@ -43,6 +43,6 @@ module SeleniumWorkarounds
       break if correctly_set
     end
 
-    raise "Found value #{found_value}, but expected #{value}." unless correctly_set
+    raise "Found value #{input.value}, but expected #{value}." unless correctly_set
   end
 end


### PR DESCRIPTION
Followup for https://github.com/opf/openproject/pull/12296

But also fixes:

- Convert timezones to utc
- Make lower boundary start at beginning of day
- Make upper boundary end at end of day

https://community.openproject.org/wp/46865