### PR TITLE
Retry download of nodejs package

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -8,7 +8,9 @@ ENV USER=dev
 RUN useradd -d /home/$USER -m $USER -s /bin/bash
 WORKDIR /home/$USER
 
-RUN curl -s https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar xzf - -C /usr/local --strip-components=1
+RUN curl --retry 10 --output /tmp/node.tar.gz --silent --show-error https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \
+  && tar xzf /tmp/node.tar.gz --directory /usr/local --strip-components=1 \
+  && rm -f /tmp/node.tar.gz
 
 RUN wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list


### PR DESCRIPTION
This should avoid the error 'gzip: stdin: unexpected end of file' and 'tar: Unexpected EOF in archive' encountered from time to time in CI.