### PR TITLE
[47027] Allow any decimal value when logging time

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
@@ -35,7 +35,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 @Component({
   template: `
     <input type="number"
-           step="0.25"
+           step="any"
            class="inline-edit--field op-input"
            #input
            [attr.aria-required]="required"


### PR DESCRIPTION
Closes https://community.openproject.org/wp/47027

Having a step of 0.25 restricts the value validity. For instance 2.4 is not valid and is truncated to 2. Likewise, 7.9 would be truncated to 7.

Using `step="any"` allows to use any numeric value, and step is 1 when using up and down buttons or keys.