### PR TITLE
[#31163] Add private comment activity and permission

### DIFF
--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -105,12 +105,20 @@ class WorkPackages::BulkController < ApplicationController
   def attributes_for_update
     return {} unless params.has_key? :work_package
 
-    permitted_params
+    p = permitted_params
       .update_work_package
       .tap { |attributes| attributes[:custom_field_values]&.reject! { |_k, v| v.blank? } }
       .compact_blank
       .transform_values { |v| v == 'none' ? '' : v }
       .to_h
+
+    if p[:journal_notes].present?
+      p[:journal_is_public] = params[:work_package][:is_private].nil?
+    else
+      p = p.except(:is_private) if params[:work_package][:is_private].present?
+    end
+
+    p
   end
 
   def user

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -206,8 +206,14 @@ module WorkPackagesHelper
     route[:controller] == 'work_packages' && route[:action] == 'index' && route[:state]&.match?(/^\d+/)
   end
 
-  def last_work_package_note(work_package)
-    note_journals = work_package.journals.select(&:notes?)
+  def last_work_package_note(work_package, recipient)
+    if recipient.allowed_to?(:add_private_comment, work_package.project)
+      journals = work_package.journals
+    else
+      journals = work_package.journals.where(is_public: true)
+    end
+
+    note_journals = journals.select(&:notes?)
     return t(:text_no_notes) if note_journals.empty?
 
     note_journals.last.notes

--- a/app/mailers/work_package_mailer.rb
+++ b/app/mailers/work_package_mailer.rb
@@ -57,6 +57,7 @@ class WorkPackageMailer < ApplicationMailer
       @work_package = work_package
       @watcher_changer = watcher_changer
       @action = action
+      @user = user
 
       set_work_package_headers(work_package)
       message_id work_package, user

--- a/app/models/activities/base_activity_provider.rb
+++ b/app/models/activities/base_activity_provider.rb
@@ -143,6 +143,7 @@ class Activities::BaseActivityProvider
     query = extend_event_query(query)
     query = filter_for_event_datetime(query, from, to)
     query = restrict_user(query, options)
+    query = restrict_private_comment(query, user)
     restrict_projects(query, user, options)
   end
 
@@ -235,6 +236,19 @@ class Activities::BaseActivityProvider
     perm = activity_provider_options[:permission]
 
     query.where(projects_table[:id].in(Project.allowed_to(user, perm).select(:id).arel))
+  end
+
+  def restrict_private_comment(query, user)
+    query = query.where(
+      journals_table[:is_public].eq(true).or(
+      projects_table[:id].in(
+        Project.allowed_to(user, :add_private_comment).select(:id).arel
+      ).and(
+        journals_table[:is_public].eq(false)
+      )
+    ))
+
+    query
   end
 
   attr_accessor :activity

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -243,7 +243,7 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
     newline!
 
     work_package.journals.includes(:user).order("#{Journal.table_name}.created_at ASC").each do |journal|
-      next if journal.initial?
+      next if journal.initial? || (!journal.is_public && !User.current.allowed_to?(:add_private_comment, work_package.project))
 
       pdf.font style: :bold, size: 8
       pdf.text(format_time(journal.created_at) + ' - ' + journal.user.name)

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -116,6 +116,15 @@ class Notifications::CreateFromModelService
       mail_alert_sent: strategy.supports_mail? ? false : nil
     }
 
+    user = User.find(recipient_id)
+
+    #check right for private comment
+    if model.instance_of?(Journal) && !model.is_public
+      user_not_authorized_for_private = !user.allowed_to?(:add_private_comment, project)
+
+      return ServiceResult.new(success: true) if user_not_authorized_for_private
+    end
+
     Notifications::CreateService
       .new(user: user_with_fallback)
       .call(notification_attributes)

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -36,6 +36,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.author { xml.name Setting.app_title.to_s }
   journals.each do |change|
     work_package = change.journable
+    next if !change.is_public && !User.current.allowed_to?(:add_private_comment, work_package.project)
     xml.entry do
       xml.title   "#{work_package.project.name} - #{work_package.type.name} ##{work_package.id}: #{work_package.subject}"
       xml.link    "rel" => "alternate", "href" => work_package_url(work_package)

--- a/app/views/work_package_mailer/watcher_changed.html.erb
+++ b/app/views/work_package_mailer/watcher_changed.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <hr />
 <%= render partial: 'work_package_details', locals: { work_package: @work_package } %>
 <p>
-  <%= format_text(t(:text_latest_note, note: last_work_package_note(@work_package)),
+  <%= format_text(t(:text_latest_note, note: last_work_package_note(@work_package, @user)),
                     only_path: false,
                     object: @work_package,
                     project: @work_package.project) %>

--- a/app/views/work_package_mailer/watcher_changed.text.erb
+++ b/app/views/work_package_mailer/watcher_changed.text.erb
@@ -31,4 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 ----------------------------------------
 <%= render partial: 'work_package_details', locals: { work_package: @work_package } %>
-<%= t(:text_latest_note, note: last_work_package_note(@work_package)) %>
+<%= t(:text_latest_note, note: last_work_package_note(@work_package, @user)) %>

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -181,12 +181,22 @@ See COPYRIGHT and LICENSE files for more details.
         </div>
       </div>
     </fieldset>
-    <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= Journal.human_attribute_name(:notes) %></legend>
-      <%= label_tag 'work_package_journal_notes', Journal.human_attribute_name(:notes), class: 'hidden-for-sighted' %>
-      <%= styled_text_area_tag 'work_package[journal_notes]', @notes, class: 'wiki-edit', with_text_formatting: true %>
-      <p><%= send_notification_option %></p>
-    </fieldset>
+    <% if User.current.allowed_to?(:add_private_comment, @project) || User.current.allowed_to?(:add_work_package_notes, @project) %>
+      <fieldset class="form--fieldset">
+        <legend class="form--fieldset-legend"><%= Journal.human_attribute_name(:notes) %></legend>
+        <%= label_tag 'work_package_journal_notes', Journal.human_attribute_name(:notes), class: 'hidden-for-sighted' %>
+        <%= styled_text_area_tag 'work_package[journal_notes]', 
+            @notes, 
+            class: 'wiki-edit', 
+            with_text_formatting: true,
+            data: {
+              has_private_right: User.current.allowed_to?(:add_private_comment, @project),
+              has_public_right: User.current.allowed_to?(:add_work_package_notes, @project)
+            }
+          %>
+        <p><%= send_notification_option %></p>
+      </fieldset>
+    <% end %>
   </section>
   <p><%= styled_button_tag t(:button_submit), class: '-highlight -with-icon icon-checkmark' %></p>
 <% end %>

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -177,6 +177,12 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin,
                      dependencies: :view_work_packages
 
+      wpt.permission :add_private_comment,
+                     {
+                       journals: [:new]
+                     },
+                     dependencies: :view_work_packages
+
       wpt.permission :edit_own_work_package_notes,
                      {},
                      require: :loggedin,

--- a/config/locales/crowdin/fr.yml
+++ b/config/locales/crowdin/fr.yml
@@ -2250,6 +2250,7 @@ fr:
     welcome: "Bienvenue sur %{app_title}"
     select_language: "Veuillez sélectionner votre langue"
   permission_add_work_package_notes: "Ajouter des notes"
+  permission_add_private_comment: "Voir et ajouter des notes privées"
   permission_add_work_packages: "Ajouter des lots de travaux"
   permission_add_messages: "Poster des messages"
   permission_add_project: "Créer un projet"

--- a/config/locales/crowdin/js-fr.yml
+++ b/config/locales/crowdin/js-fr.yml
@@ -134,6 +134,7 @@ fr:
       source_code: 'Basculer en mode source Markdown'
       error_saving_failed: 'L''enregistrement du document a échoué en raison de l''erreur suivante: %{error}'
       ckeditor_error: 'Une erreur s''est produite dans CKEditor'
+      private_note: 'Note privée'
       mode:
         manual: 'Basculer en mode source Markdown'
         wysiwyg: 'Basculer vers l''éditeur WYSIWYG'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2348,7 +2348,7 @@ en:
     text_getting_started_description: "Get a quick overview of project management and team collaboration with OpenProject. You can restart this video from the help menu."
     welcome: "Welcome to %{app_title}"
     select_language: "Please select your language"
-
+  permission_add_private_comment: "View and add private notes"
   permission_add_work_package_notes: "Add notes"
   permission_add_work_packages: "Add work packages"
   permission_add_messages: "Post messages"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -155,6 +155,7 @@ en:
       source_code: 'Toggle Markdown source mode'
       error_saving_failed: 'Saving the document failed with the following error: %{error}'
       ckeditor_error: 'An error occurred within CKEditor'
+      private_note: 'Private note'
       mode:
         manual: 'Switch to Markdown source'
         wysiwyg: 'Switch to WYSIWYG editor'

--- a/db/migrate/20230327023529_add_column_is_public_journal.rb
+++ b/db/migrate/20230327023529_add_column_is_public_journal.rb
@@ -26,30 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-##
-# Create journal for the given user and note.
-# Does not change the work package itself.
-
-class AddWorkPackageNoteService
-  include Contracted
-  attr_accessor :user, :work_package
-
-  def initialize(user:, work_package:)
-    self.user = user
-    self.work_package = work_package
-    self.contract_class = WorkPackages::CreateNoteContract
-  end
-
-  def call(notes, is_public: true, send_notifications: nil)
-    Journal::NotificationConfiguration.with send_notifications do
-      work_package.add_journal(user, notes, is_public)
-
-      success, errors = validate_and_yield(work_package, user) do
-        work_package.save_journals
-      end
-
-      journal = work_package.journals.last if success
-      ServiceResult.new(success:, result: journal, errors:)
-    end
+class AddColumnIsPublicJournal < ActiveRecord::Migration[7.0]
+  def change
+    add_column :journals, :is_public, :boolean, default: true, null: false
   end
 end

--- a/docs/api/apiv3/paths/work_package_activities.yml
+++ b/docs/api/apiv3/paths/work_package_activities.yml
@@ -30,6 +30,7 @@ get:
                       format: markdown
                       html: "<p>Lorem ipsum dolor sit amet.</p>"
                       raw: Lorem ipsum dolor sit amet.
+                      isPublic: true
                     createdAt: '2014-05-21T08:51:20Z'
                     updatedAt: '2014-05-21T09:14:02Z'
                     details: []
@@ -103,6 +104,15 @@ post:
     schema:
       default: true
       type: boolean
+  - description: |-
+    Indicates if the activity is public or private, it is mainly used for the comment in the work package.
+  example: false
+  in: query
+  name: isPrivate
+  required: false
+  schema:
+    default: false
+    type: boolean
   responses:
     '201':
       description: Created
@@ -156,6 +166,7 @@ post:
           example:
             comment:
               raw: I think this is awesome!
+              isPrivate: true
           properties:
             comment:
               properties:

--- a/frontend/src/app/core/state/hal-resource.ts
+++ b/frontend/src/app/core/state/hal-resource.ts
@@ -22,4 +22,5 @@ export interface IFormattable {
   format:FormattableFormat;
   raw:string;
   html:string;
+  isPublic: boolean;
 }

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -85,6 +85,8 @@ export interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
 
   addRelation(relation:any):Promise<any>|undefined;
 
+  privateComment(comment:unknown, headers?:any):Promise<any>;
+
   addWatcher(watcher:HalResource):Promise<any>;
 
   changeParent(params:any):Promise<any>;

--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment-field-handler.ts
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment-field-handler.ts
@@ -40,12 +40,13 @@ export abstract class WorkPackageCommentFieldHandler extends EditFieldHandler im
 
   public abstract get workPackage():WorkPackageResource;
 
-  public reset(withText = '') {
+  public reset(withText = '', isPrivate = false) {
     if (withText.length > 0) {
       withText += '\n';
     }
 
     this.change.setValue('comment', { raw: withText });
+    this.change.setValue('comment', { raw: withText, isPrivate: isPrivate });
   }
 
   public get schema():IFieldSchema {
@@ -63,16 +64,16 @@ export abstract class WorkPackageCommentFieldHandler extends EditFieldHandler im
   }
 
   public get commentValue() {
-    return this.change.value<{ raw:string }>('comment');
+    return this.change.value<{ raw:string, isPrivate:boolean }>('comment');
   }
 
   public handleUserCancel() {
     this.deactivate(true);
   }
 
-  public activate(withText?:string) {
+  public activate(withText?:string, isPrivate?:boolean) {
     this.active = true;
-    this.reset(withText);
+    this.reset(withText, isPrivate);
   }
 
   deactivate(focus:boolean):void {

--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.ts
@@ -102,7 +102,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
   public ngOnInit():void {
     super.ngOnInit();
 
-    this.canAddComment = !!this.workPackage.addComment;
+    this.canAddComment = !!this.workPackage.addComment || !!this.workPackage.privateComment;
     this.showAbove = this.configurationService.commentsSortedInDescendingOrder();
 
     this.commentService.draft$

--- a/frontend/src/app/features/work-packages/components/wp-activity/comment-service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-activity/comment-service.ts
@@ -50,25 +50,32 @@ export class CommentService {
   ) {
   }
 
-  public createComment(workPackage:WorkPackageResource, comment:{ raw:string }) {
-    return workPackage.addComment(
+  public createComment(workPackage:WorkPackageResource, comment:{ raw:string, isPrivate:boolean }) {
+    if (!!workPackage.addComment) {
+      return workPackage.addComment(
+        { comment },
+        { 'Content-Type': 'application/json; charset=UTF-8' },
+      ).catch((error:any) => this.errorAndReject(error, workPackage));
+    }
+
+    return workPackage.privateComment(
       { comment },
       { 'Content-Type': 'application/json; charset=UTF-8' },
     )
       .catch((error:any) => this.errorAndReject(error, workPackage));
   }
 
-  public updateComment(activity:HalResource, comment:string) {
+  public updateComment(activity:HalResource, comment:string, isPrivate: boolean) {
     const options = {
       ajax: {
         method: 'PATCH',
-        data: JSON.stringify({ comment }),
+        data: JSON.stringify({ comment, isPrivate  }),
         contentType: 'application/json; charset=utf-8',
       },
     };
 
     return activity.update(
-      { comment },
+      { comment, isPrivate },
       { 'Content-Type': 'application/json; charset=UTF-8' },
     ).then((activity:HalResource) => {
       this.toastService.addSuccess(

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
@@ -1,6 +1,7 @@
 <div
   class="op-user-activity work-package-details-activities-activity-contents"
-  *ngIf="workPackage"
+  [ngClass]="isPrivate"
+  *ngIf="workPackage && canPrivateComment"
   [attr.data-notification-selector]="hasUnreadNotification ? 'notification-activity' : null"
   (mouseenter)="focus()"
   (mouseleave)="blur()"

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.sass
@@ -21,3 +21,7 @@
   &--avatar
     flex-shrink: 0
     margin-right: 0.5rem
+
+  &--private
+    background-color: #e6e6e6
+    padding: 5px

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -57,6 +57,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   public previewContext:string;
 
+  public fieldName:string;
+
   // Which template to include
   public $element:JQuery;
 
@@ -103,6 +105,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   ngOnInit() {
     this.$element = jQuery(this.elementRef.nativeElement);
+    this.fieldName = this.textareaSelector.substring(1);
 
     // Parse the attribute explicitly since this is likely a bootstrapped element
     this.textareaSelector = this.$element.attr('textarea-selector')!;

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -1,6 +1,7 @@
 <div class="op-ckeditor--wrapper">
   <op-ckeditor
     [context]="context"
+    [fieldName]="fieldName"
     [content]="initialContent"
     (onInitialized)="setup($event)"
     (onContentChange)="markEdited()"

--- a/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.html
@@ -1,4 +1,17 @@
 <ng-container>
+  <div *ngIf="showIsPrivate">
+    <label class="form--label-with-check-box">
+      <input
+        name="work_package[is_private]"
+        [disabled]="isDisabled"
+        slot="input"
+        type="checkbox"
+        [ngModel]="isPrivate"
+        (change)="onChange($event)"
+      />
+      {{ text.privateNote }}
+    </label>
+  </div>
   <div *ngIf="error" class="op-toast -error">
     <div class="op-toast--content">
       <p>

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
@@ -2,6 +2,8 @@
   <div class="op-ckeditor--wrapper op-ckeditor-element">
     <op-ckeditor [context]="ckEditorContext"
                  [content]="initialContent"
+                 [fieldName]="field.name"
+                 [isPrivate]="isPrivate"
                  (onContentChange)="onContentChange($event)"
                  (onInitializationFailed)="initializationError = true"
                  (onInitialized)="onCkeditorSetup($event)"

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.ts
@@ -105,6 +105,7 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
     return this.editor
       .getTransformedContent()
       .then((val) => {
+        this.isPrivate = this.editor.isPrivate;
         this.rawValue = val;
       });
   }
@@ -115,6 +116,13 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
     if (this.rawValue !== value) {
       this.rawValue = value;
     }
+  }
+  
+  public get isPrivate():boolean {
+    if (this.value && Object.keys(this.value).includes("isPrivate")) {
+      return this.value.isPrivate;
+    }
+    return true;
   }
 
   public handleUserSubmit():boolean {
@@ -151,7 +159,11 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   }
 
   public set rawValue(val:string) {
-    this.value = { raw: val };
+    this.value = { raw: val, isPrivate: this.isPrivate };
+  }
+
+  public set isPrivate(val:boolean) {
+    this.value['isPrivate'] = val;
   }
 
   public isEmpty():boolean {

--- a/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
@@ -46,7 +46,7 @@
 
 .comments-number
   position: absolute
-  right: 0
+  right: 5px
   top: 10px
   display: grid
   align-items: center
@@ -136,5 +136,6 @@ ul.work-package-details-activities-messages
 
 .work-packages--activity
   &--add-comment
+    margin-top: 10px
     &_top
       margin-bottom: 20px

--- a/frontend/src/typings/open-project.typings.d.ts
+++ b/frontend/src/typings/open-project.typings.d.ts
@@ -60,6 +60,7 @@ declare namespace api {
       format?:string;
       raw:string;
       html?:string;
+      isPrivate?:boolean;
     }
   }
 }

--- a/lib/api/decorators/formattable.rb
+++ b/lib/api/decorators/formattable.rb
@@ -58,6 +58,13 @@ module API
                getter: ->(*) { to_html },
                writable: false,
                render_nil: true
+      property :is_public,
+               exec_context: :decorator,
+               getter: ->(*) {
+                @object.respond_to?(:is_public) && @object.is_public
+               },
+               writable: false,
+               render_nil: true
 
       def to_html
         format_text(raw_text, format: @format, object: @object)

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -53,7 +53,10 @@ module API
                                                                api_name: 'Activity',
                                                                instance_generator: ->(*) { @activity },
                                                                params_modifier: ->(*) {
-                                                                 { notes: declared_params[:comment] }
+                                                                { 
+                                                                  notes: declared_params[:comment], 
+                                                                  is_public: !params[:isPrivate] 
+                                                                 }
                                                                })
                                                           .mount
           end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -69,7 +69,9 @@ module API
 
         property :details,
                  exec_context: :decorator,
-                 getter: ->(*) { formatted_details(represented) },
+                 getter: ->(*) do
+                  formatted_details(represented).select { |v| v[:raw] != "" }
+                 end,
                  render_nil: true
 
         property :version, render_nil: true

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -289,6 +289,15 @@ module API
           }
         end
 
+        link :privateComment, uncacheable: true do
+          next if !current_user_allowed_to(:add_private_comment, context: represented.project)
+          {
+            href: api_v3_paths.work_package_activities(represented.id),
+            method: :post,
+            title: 'Add private comment'
+          }
+        end
+
         link :previewMarkup do
           {
             href: api_v3_paths.render_markup(link: api_v3_paths.work_package(represented.id)),

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -53,7 +53,7 @@ module Acts::Journalized
       base.class_eval do
         after_save :save_journals
 
-        attr_accessor :journal_notes, :journal_user
+        attr_accessor :journal_notes, :journal_user, :journal_is_public
       end
     end
 
@@ -61,7 +61,7 @@ module Acts::Journalized
       with_ensured_journal_attributes do
         create_call = Journals::CreateService
                       .new(self, @journal_user)
-                      .call(notes: @journal_notes)
+                      .call(notes: @journal_notes, is_public: @journal_is_public)
 
         if create_call.success? && create_call.result
           OpenProject::Notifications.send(OpenProject::Events::JOURNAL_CREATED,
@@ -73,8 +73,9 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user = User.current, notes = '')
+    def add_journal(user = User.current, notes = '', is_public = true)
       self.journal_user ||= user
+      self.journal_is_public ||= is_public
       self.journal_notes ||= notes
     end
 
@@ -88,6 +89,7 @@ module Acts::Journalized
     ensure
       self.journal_user = nil
       self.journal_notes = nil
+      self.journal_is_public = nil
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/31163/activity

Use case

When OpenProject is used with end clients, it is necessary to hide certain confidential messages from these clients. For example, messages about the cost of a task or about internal problems.

This feature allows one to write “private notes” and define which roles are allowed to write and see them.

Description
**Configuration**

In the “Roles and permissions” tab, a new setting allow to define which roles are allowed to write and see privates notes.

**Front office**
In the front office, private notes are displayed only for allowed roles with gray backgrounds.