### PR TITLE
Fix accent button hover color (#12311)

### DIFF
--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
     --main-menu-border-width: 1px;
     <% end %>
     <% if design_color.variable == "alternative-color" %>
-    --button--alt-highlight-background-hover-color: <%= design_color.darken 0.82 %>;
+    --button--alt-highlight-background-hover-color: <%= design_color.darken 0.18 %>;
     <% end %>
     <% if design_color.variable == "primary-color" %>
       --primary-color--minor1: <%= design_color.lighten 0.3 %>;


### PR DESCRIPTION
Cherry pick of a fix that was merged into `dev`. I believe we should fix it in `release/12.5`, too.

> When switching the color calculations in the backend, a slight logic
> error was made. The new algorithm is inverted from the old one,
> and thus needs to darken "by 18%" instead of darkening "to 82%".
> 
> This commit switches the numbers so hovered buttons are not almost
> fully black.