### PR TITLE
properly define js variable in jquery.flot

### DIFF
--- a/frontend/src/vendor/jquery.flot/jquery.flot.js
+++ b/frontend/src/vendor/jquery.flot/jquery.flot.js
@@ -545,7 +545,7 @@
                 ps = s.datapoints.pointsize;
                 points = s.datapoints.points;
 
-                insertSteps = s.lines.show && s.lines.steps;
+                let insertSteps = s.lines.show && s.lines.steps;
                 s.xaxis.used = s.yaxis.used = true;
                 
                 for (j = k = 0; j < data.length; ++j, k += ps) {
@@ -1004,7 +1004,7 @@
                 setRange(axis);
             });
 
-            allocatedAxes = $.grep(axes, function (axis) { return axis.reserveSpace; });
+            let allocatedAxes = $.grep(axes, function (axis) { return axis.reserveSpace; });
 
             plotOffset.left = plotOffset.right = plotOffset.top = plotOffset.bottom = 0;
             if (options.grid.show) {


### PR DESCRIPTION
Since the script is now executed in strict mode, creating a global variable implicitly is prevented.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode?retiredLocale=de#converting_mistakes_into_errors

https://community.openproject.org/wp/47079