### PR TITLE
maintenance/allow running watchexec inside docker

### DIFF
--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -30,6 +30,17 @@ RUN apt-get update -qq && \
 RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs
 
+# Install watchexec for continuous test execution.
+# Usage:
+# - Add the following line to your ~/.bashrc ("dcrw" stands for "Docker Compose Rspec Watch"):
+# dcrw() { docker compose exec backend-test watchexec --exts rb,erb -- bin/rspec --order defined --format documentation --fail-fast $1; }
+# - and then use it like this:
+# dcrw <path-to-your-spec-file>
+RUN curl -fsSL https://apt.cli.rs/pubkey.asc | tee -a /usr/share/keyrings/rust-tools.asc
+RUN curl -fsSL https://apt.cli.rs/rust-tools.list | tee /etc/apt/sources.list.d/rust-tools.list
+RUN apt update
+RUN apt install watchexec-cli
+
 COPY ./docker/dev/backend/scripts/setup /usr/sbin/setup
 COPY ./docker/dev/backend/scripts/run-app /usr/sbin/run-app
 


### PR DESCRIPTION
Make the command `watchexec` available in Docker images for dev/backend. This allows for continuously run certain specs whenever .rb/.erb files change.  

- [x] Ads a APT source for Rust tools
- [x] Installs `watchexec`
- [x] Adds a comment on how to use it.  
