### PR TITLE
allow direct uploads outside of Amazon S3

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -731,12 +731,14 @@ module Settings
       remote_storage_upload_host: {
         format: :string,
         default: nil,
-        writable: false
+        writable: false,
+        description: 'Host the frontend uses to upload files to, which has to be added to the CSP.'
       },
       remote_storage_download_host: {
         format: :string,
         default: nil,
-        writable: false
+        writable: false,
+        description: 'Host the frontend uses to download files, which has to be added to the CSP.'
       },
       report_incoming_email_errors: {
         description: 'Respond to incoming mails with error details',

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -728,6 +728,16 @@ module Settings
         },
         writable: false
       },
+      remote_storage_upload_host: {
+        format: :string,
+        default: nil,
+        writable: false
+      },
+      remote_storage_download_host: {
+        format: :string,
+        default: nil,
+        writable: false
+      },
       report_incoming_email_errors: {
         description: 'Respond to incoming mails with error details',
         default: true

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -338,7 +338,7 @@ rake attachments:copy_to[file]
 
 ### direct uploads
 
-> **NOTE**: This only works for S3 right now. When using fog with another provider this configuration will be `false`. The same goes for when no fog storage is configured, or when the `use_iam_profile` option is used in the fog credentials when using S3.
+> **NOTE**: This only works for AWS S3 or S3-compatible storages<sup>\*</sup>. When using fog with another provider this configuration will be `false`. The same goes for when no fog storage is configured, or when the `use_iam_profile` option is used in the fog credentials when using S3.
 
 When using fog attachments uploaded in the frontend will be posted directly to the cloud rather than going through the OpenProject servers. This allows large attachments to be uploaded without the need to increase the `client_max_body_size` for the proxy in front of OpenProject. Also it prevents web processes from being blocked through long uploads.
 
@@ -348,6 +348,15 @@ If, for what ever reason, this is undesirable, you can disable this option. In t
 
 ```yaml
 OPENPROJECT_DIRECT__UPLOADS="false"
+```
+
+\* If not using AWS S3, you will have to explicitly configure `remote_storage_upload_host` and `remote_storage_download_host`.
+
+Here is what it would look like if we were to configure the default for AWS S3:
+
+```yaml
+OPENPROJECT_REMOTE__STORAGE__UPLOAD__HOST=mybucket.s3.amazonaws.com
+OPENPROJECT_REMOTE__STORAGE__DOWNLOAD__HOST=mybucket.s3.eu-west.amazonaws.com"
 ```
 
 ### fog download url expires in

--- a/lib_static/open_project/configuration/helpers.rb
+++ b/lib_static/open_project/configuration/helpers.rb
@@ -52,14 +52,21 @@ module OpenProject
       # Do not allow direct uploads when using IAM-profile-based authorization rather
       # than access-key-based ones since carrierwave_direct does not support that.
       #
-      # We also don't support direct uploads for S3-compatible object storage services
-      # as we haven't tested it with any of them and it doesn't work anyway as far
-      # as we know.
-      #
-      # Note: If we do want to support other services than AWS we would also have
-      # to make `remote_storage_upload_host` and `remote_storage_download_host` configurable.
+      # We do support direct uploads for S3-compatible object storage services
+      # only if remote storage upload and download hosts were configured explicitly.
+      # Since these only have to be configured if you want to use direct uploads,
+      # we assume what ever provider you use does support this if you do.
       def direct_uploads_supported?
-        remote_storage? && remote_storage_aws? && !use_iam_profile? && fog_credentials[:host].blank?
+        remote_storage? && remote_storage_aws? && !use_iam_profile? &&
+          (using_amazon_s3? || using_custom_remote_storage_hosts?)
+      end
+
+      def using_amazon_s3?
+        fog_credentials[:host].blank?
+      end
+
+      def using_custom_remote_storage_hosts?
+        self['remote_storage_upload_host'].present? && self['remote_storage_download_host'].present?
       end
 
       def direct_uploads?
@@ -88,15 +95,15 @@ module OpenProject
       end
 
       def remote_storage_upload_host
-        if remote_storage_aws?
-          "#{fog_directory}.s3.amazonaws.com"
-        end
+        self['remote_storage_upload_host'].presence ||
+          (remote_storage_aws? && "#{fog_directory}.s3.amazonaws.com") ||
+          nil
       end
 
       def remote_storage_download_host
-        if remote_storage_aws?
-          "#{fog_directory}.s3.#{fog_credentials[:region]}.amazonaws.com"
-        end
+        self['remote_storage_download_host'].presence ||
+          (remote_storage_aws? && "#{fog_directory}.s3.#{fog_credentials[:region]}.amazonaws.com") ||
+          nil
       end
 
       def remote_storage_hosts


### PR DESCRIPTION
This PR changes no existing functionality. It merely allows also configuring direct attachment uploads to S3 compatible object storages other than Amazon's S3 itself.