### PR TITLE
[#47439] Add a proper test to prevent the oauth bug from happenning again.

### DIFF
--- a/spec/requests/openid_google_provider_callback_spec.rb
+++ b/spec/requests/openid_google_provider_callback_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'OpenID Google provider callback' do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  it 'redirects user without errors', webmock: true, with_settings: {
+    plugin_openproject_openid_connect: {
+      "providers" => { "google" => { "identifier" => "identifier", "secret" => "secret" } }
+    }
+  } do
+    with_enterprise_token :openid_providers
+    auth_hash = { "state" => "623960f1b4f1020941387659f022497f536ad3c95fa7e53b0f03bdbf36debd59f76320801ea2723df520",
+                  "code" => "4/0AVHEtk6HMPLH08Uw8OVoSaAbd2oTi7Z6wOlBsMQ99Yj3qgKhhyKAxUQBvQ2MZuRzvueOgQ",
+                  "scope" => "email profile https://www.googleapis.com/auth/userinfo.email openid https://www.googleapis.com/auth/userinfo.profile",
+                  "authuser" => "0",
+                  "prompt" => "none" }
+    uri = URI('/auth/google/callback')
+    uri.query = URI.encode_www_form([['code', auth_hash['code']],
+                                     ['state', auth_hash['state']],
+                                     ['scope', auth_hash['scope']],
+                                     ['authuser', auth_hash['authuser']],
+                                     ['prompt', auth_hash['prompt']]])
+    stub_request(:post, "https://accounts.google.com/o/oauth2/token").to_return(
+      status: 200,
+      body: {
+        "access_token" =>
+        "ya29.a0Ael9sCPGoZQiKuMHHVKiaiWV9NatII8T7ZY6XiwTcY-VtvSnmPH53BXDoWGU7OpFY7ctZjY0Qf-Cd_5HHULGoF_m-3WEgMvuO7F11nbYI7qoe95enqneFgDh__vvTxGRAGPpl_Xf7qbXVznh35-DHuvhyPAZmMwaCgYKAQISARASFQF4udJhMeehVtS01I8wd8HL6ReQDw0166",
+        "expires_in" => 3594,
+        "scope" =>
+        "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid",
+        "token_type" => "Bearer",
+        "id_token" =>
+        "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFhYWU4ZDdjOTIwNThiNWVlYTQ1Njg5NWJmODkwODQ1NzFlMzA2ZjMiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJhY2NvdW50cy5nb29nbGUuY29tIiwiYXpwIjoiNDI3NzUwNzQ4MTg2LWQ4OGozamNlYmN2bGlxMmd0a3RiZm1oc2lhNjYxZDU4LmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwiYXVkIjoiNDI3NzUwNzQ4MTg2LWQ4OGozamNlYmN2bGlxMmd0a3RiZm1oc2lhNjYxZDU4LmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTA3NDAzNTExMDM3OTIxMzU1MzA3IiwiZW1haWwiOiJiYTFhc2hwYXNoQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiVFBtc0ZHRng4cjdrb3RiZkJud0xVdyIsImlhdCI6MTY4MDYxMjE5NCwiZXhwIjoxNjgwNjE1Nzk0fQ.IDKlHDVg1d7tAqb8eRiq90T52xnwVX9huDjpdLoJpqr4xlnTrFCdalxJBBHd9Cv39g2KPuJaCU21B59yNAyJP6bl5P8e9Ky-y8wOFcgHqcG5qXcNtxCS3imASCchRTtre8yp9AQGYkTIC0Jh6lWg0trdfO-_idKBsd5naJeaeYdeZGkpQ8D4dxn_odla67BO3y2mUtyE4gEbzyq6wTXDATN4ucM4Dyp3Wdk7YpYYuFN1g-sF6NFl4YqugQ4zk-pYYtPLlPgGiqi3_hO9kYbRDhNBtfbMx568m-CyM2tiOIkb4utPR20scSiRqnY2oxOcd5g9znvJOjtanHM3KVdj5g"
+      }.to_json,
+      headers: { "content-type" => "application/json; charset=utf-8" }
+    )
+    stub_request(:get, "https://www.googleapis.com/oauth2/v3/userinfo?alt=json").to_return(
+      status: 200,
+      body: { "sub" => "107403511037921355307",
+              "name" => "Firstname Lastname",
+              "given_name" => "Firstname",
+              "family_name" => "Lastname",
+              "picture" => "https://lh3.googleusercontent.com/a/AGNmyxZtDAl-mgOOCF_DCo-WWEct-LyVp7zGhXkfKR8r=s96-c",
+              "email" => "email@dummy.com",
+              "email_verified" => true,
+              "locale" => "en-GB" }.to_json,
+      headers: { "content-type" => "application/json; charset=utf-8" }
+    )
+    allow_any_instance_of(OmniAuth::Strategies::OpenIDConnect).to receive(:session) {
+                                                                    { 'omniauth.state' => auth_hash['state'] }
+                                                                  }
+
+    response = get uri.to_s
+    expect(response.status).to eq(302)
+    expect(response.body).to eq("<html><body>You are being <a href=\"http://example.org/two_factor_authentication/request\">redirected</a>.</body></html>")
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/47439
The test case in this pull request reproduces a bug from https://community.openproject.org/projects/openproject/work_packages/47155.
The bug is actual for example for [this](https://github.com/opf/openproject/commit/15a78adef8beda81bd60580b4c103bdb43601411) version of code and has the following backtrace:
```

     TypeError:
       no implicit conversion of Hash into String
     # /usr/local/bundle/gems/openid_connect-1.1.8/lib/openid_connect/client.rb:29:in `handle_success_response'
     # /usr/local/bundle/gems/rack-oauth2-2.2.0/lib/rack/oauth2/client.rb:199:in `handle_response'
     # /usr/local/bundle/gems/rack-oauth2-2.2.0/lib/rack/oauth2/client.rb:76:in `access_token!'
     # /usr/local/bundle/bundler/gems/omniauth-openid-connect-0d2cd719e870/lib/omniauth/strategies/openid_connect.rb:183:in `access_token'
     # /usr/local/bundle/bundler/gems/omniauth-openid-connect-0d2cd719e870/lib/omniauth/strategies/openid_connect.rb:98:in `callback_phase'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:238:in `callback_call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:189:in `call!'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:169:in `call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/builder.rb:64:in `call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:425:in `call_app!'
     # /usr/local/bundle/gems/omniauth-saml-1.10.3/lib/omniauth/strategies/saml.rb:86:in `other_phase'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:190:in `call!'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:169:in `call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/builder.rb:64:in `call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:192:in `call!'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/strategy.rb:169:in `call'
     # /usr/local/bundle/bundler/gems/omniauth-fe862f986b2e/lib/omniauth/builder.rb:64:in `call'
     # /usr/local/bundle/gems/rack-attack-6.6.1/lib/rack/attack.rb:103:in `call'
     # /usr/local/bundle/gems/rack_session_access-0.2.0/lib/rack_session_access/middleware.rb:33:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/tempfile_reaper.rb:15:in `call'
     # /usr/local/bundle/gems/rack-attack-6.6.1/lib/rack/attack.rb:127:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/tempfile_reaper.rb:15:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/etag.rb:27:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/deflater.rb:44:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/conditional_get.rb:27:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/head.rb:12:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/session/abstract/id.rb:266:in `context'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/session/abstract/id.rb:260:in `call'
     # /usr/local/bundle/gems/rack-cors-2.0.1/lib/rack/cors.rb:102:in `call'
     # /usr/local/bundle/gems/railties-7.0.4.3/lib/rails/rack/logger.rb:40:in `call_app'
     # /usr/local/bundle/gems/railties-7.0.4.3/lib/rails/rack/logger.rb:25:in `block in call'
     # /usr/local/bundle/gems/railties-7.0.4.3/lib/rails/rack/logger.rb:25:in `call'
     # /usr/local/bundle/gems/request_store-1.5.1/lib/request_store/middleware.rb:19:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/method_override.rb:24:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/runtime.rb:22:in `call'
     # /usr/local/bundle/gems/rack-timeout-0.6.3/lib/rack/timeout/core.rb:148:in `block in call'
     # /usr/local/bundle/gems/rack-timeout-0.6.3/lib/rack/timeout/support/timeout.rb:19:in `timeout'
     # /usr/local/bundle/gems/rack-timeout-0.6.3/lib/rack/timeout/core.rb:147:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/lock.rb:18:in `call'
     # /usr/local/bundle/gems/rack-2.2.6.4/lib/rack/sendfile.rb:110:in `call'
     # /usr/local/bundle/gems/secure_headers-6.5.0/lib/secure_headers/middleware.rb:11:in `call'
     # /usr/local/bundle/gems/railties-7.0.4.3/lib/rails/engine.rb:530:in `call'
     # /usr/local/bundle/gems/rack-test-2.1.0/lib/rack/test.rb:360:in `process_request'
     # /usr/local/bundle/gems/rack-test-2.1.0/lib/rack/test.rb:163:in `custom_request'
     # /usr/local/bundle/gems/rack-test-2.1.0/lib/rack/test.rb:112:in `get'
     # ./spec/requests/omni_auth_spec.rb:69:in `block (2 levels) in <top (required)>'
     # ./spec/support/webmock.rb:45:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_mail.rb:15:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # /usr/local/bundle/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `load'
     # /usr/local/bundle/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `call'
     # -e:1:in `<main>'
```