### PR TITLE
Make upload specs less flaky

### DIFF
--- a/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
+++ b/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
@@ -37,6 +37,7 @@ describe 'Upload attachment to budget', js: true do
   let(:attachments) { Components::Attachments.new }
   let(:image_fixture) { UploadedFile.load_from('spec/fixtures/files/image.png') }
   let(:editor) { Components::WysiwygEditor.new }
+  let(:attachments_list) { Components::AttachmentsList.new }
 
   before do
     login_as(user)
@@ -54,13 +55,13 @@ describe 'Upload attachment to budget', js: true do
     # adding an image
     editor.drag_attachment image_fixture.path, 'Image uploaded on creation'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    editor.attachments_list.expect_attached('image.png')
 
     click_on 'Create'
 
     expect(page).to have_selector('#content img', count: 1)
     expect(page).to have_content('Image uploaded on creation')
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    attachments_list.expect_attached('image.png')
 
     within '.toolbar-items' do
       click_on "Update"
@@ -68,14 +69,14 @@ describe 'Upload attachment to budget', js: true do
 
     editor.drag_attachment image_fixture.path, 'Image uploaded the second time'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    editor.attachments_list.expect_attached('image.png', count: 2)
 
     click_on 'Submit'
 
     expect(page).to have_selector('#content img', count: 2)
     expect(page).to have_content('Image uploaded on creation')
     expect(page).to have_content('Image uploaded the second time')
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    attachments_list.expect_attached('image.png', count: 2)
   end
 
   it 'can upload an image to new and existing budgets via drag & drop on attachment list' do
@@ -89,33 +90,26 @@ describe 'Upload attachment to budget', js: true do
     editor.set_markdown "Some content because it's required"
 
     # adding an image
-    find("[data-qa-selector='op-attachments--drop-box']").drop(image_fixture.path)
+    editor.attachments_list.drop(image_fixture)
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    editor.attachments_list.expect_attached('image.png')
 
     click_on 'Create'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    attachments_list.expect_attached('image.png')
 
     within '.toolbar-items' do
       click_on "Update"
     end
 
-    # Wait for page load
-    expect(page).to have_selector('[data-qa-selector="op-attachments"]')
-    script = <<~JS
-      const event = new DragEvent('dragenter');
-      document.body.dispatchEvent(event);
-    JS
-    page.execute_script(script)
-
     # adding an image
-    find("[data-qa-selector='op-attachments--drop-box']").drop(image_fixture.path)
+    editor.attachments_list.drag_enter
+    editor.attachments_list.drop(image_fixture)
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    editor.attachments_list.expect_attached('image.png', count: 2)
 
     click_on 'Submit'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    attachments_list.expect_attached('image.png', count: 2)
   end
 end

--- a/modules/meeting/spec/features/meetings_attachments_spec.rb
+++ b/modules/meeting/spec/features/meetings_attachments_spec.rb
@@ -24,6 +24,7 @@ describe 'Add an attachment to a meeting (agenda)', js: true do
   let(:attachments) { Components::Attachments.new }
   let(:image_fixture) { UploadedFile.load_from('spec/fixtures/files/image.png') }
   let(:editor) { Components::WysiwygEditor.new }
+  let(:attachments_list) { Components::AttachmentsList.new }
 
   before do
     login_as(dev)
@@ -56,24 +57,22 @@ describe 'Add an attachment to a meeting (agenda)', js: true do
 
   describe 'attachment dropzone' do
     it 'can upload an image via attaching and drag & drop' do
-      # called the same for all Wysiwyg dditors no matter if for work packages
-      # or not
-      container = page.find('[data-qa-selector="op-attachments"]')
-      scroll_to_element(container)
+      editor.wait_until_loaded
+      attachments_list.wait_until_visible
 
       ##
       # Attach file manually
-      expect(page).not_to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]')
+      editor.attachments_list.expect_empty
       attachments.attach_file_on_input(image_fixture.path)
-      expect(page).not_to have_selector('op-toasters-upload-progress')
-      expect(page).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', wait: 5)
+      editor.wait_until_upload_progress_toaster_cleared
+      editor.attachments_list.expect_attached('image.png')
 
       ##
       # and via drag & drop
-      attachments.drag_and_drop_file(container, image_fixture.path)
-      expect(page).not_to have_selector('op-toasters-upload-progress')
-      expect(page)
-        .to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', count: 2, wait: 5)
+      editor.attachments_list.drag_enter
+      editor.attachments_list.drop(image_fixture)
+      editor.wait_until_upload_progress_toaster_cleared
+      editor.attachments_list.expect_attached('image.png', count: 2)
     end
   end
 end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -57,7 +57,7 @@ describe 'Attribute help texts', js: true do
         editor.set_markdown('My attribute help text')
         editor.drag_attachment image_fixture.path, 'Image uploaded on creation'
 
-        expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+        editor.attachments_list.expect_attached('image.png')
         click_button 'Save'
 
         expect(instance.help_text).to include 'My attribute help text'
@@ -81,7 +81,7 @@ describe 'Attribute help texts', js: true do
         # Add an image
         # adding an image
         editor.drag_attachment image_fixture.path, 'Image uploaded on creation'
-        expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+        editor.attachments_list.expect_attached('image.png')
         click_button 'Save'
 
         # Should now show on index for editing

--- a/spec/features/forums/attachment_upload_spec.rb
+++ b/spec/features/forums/attachment_upload_spec.rb
@@ -116,6 +116,7 @@ describe 'Upload attachment to forum message', js: true do
       click_on "Edit"
     end
 
+    page.find("[data-qa-selector='op-attachments']") # wait for attachments element to be displayed before starting drag and drop
     script = <<~JS
       const event = new DragEvent('dragenter');
       document.body.dispatchEvent(event);

--- a/spec/features/wiki/attachment_upload_spec.rb
+++ b/spec/features/wiki/attachment_upload_spec.rb
@@ -39,6 +39,7 @@ describe 'Upload attachment to wiki page', js: true do
   let(:attachments) { Components::Attachments.new }
   let(:image_fixture) { UploadedFile.load_from('spec/fixtures/files/image.png') }
   let(:editor) { Components::WysiwygEditor.new }
+  let(:attachments_list) { Components::AttachmentsList.new }
   let(:wiki_page_content) { project.wiki.pages.first.content.text }
 
   before do
@@ -51,15 +52,15 @@ describe 'Upload attachment to wiki page', js: true do
     # adding an image
     editor.drag_attachment image_fixture.path, 'Image uploaded the first time'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
-    expect(page).not_to have_selector('op-toasters-upload-progress')
+    editor.attachments_list.expect_attached('image.png')
+    editor.wait_until_upload_progress_toaster_cleared
 
     click_on 'Save'
 
     expect(page).to have_text("Successful creation")
     expect(page).to have_selector('#content img', count: 1)
     expect(page).to have_content('Image uploaded the first time')
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    attachments_list.expect_attached('image.png')
 
     # required sleep otherwise clicking on the Edit button doesn't do anything
     SeleniumHubWaiter.wait
@@ -69,12 +70,12 @@ describe 'Upload attachment to wiki page', js: true do
     end
 
     # Replace the image with a named attachment URL (Regression #28381)
-    expect(page).to have_selector('.ck-editor__editable', wait: 5)
+    editor.wait_until_loaded
     editor.set_markdown "\n\nSome text\n![my-first-image](image.png)\n\nText that prevents the two images colliding"
 
     editor.drag_attachment image_fixture.path, 'Image uploaded the second time'
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    editor.attachments_list.expect_attached('image.png', count: 2)
 
     editor.in_editor do |container, _|
       # Expect URL is mapped to the correct URL
@@ -92,7 +93,7 @@ describe 'Upload attachment to wiki page', js: true do
     expect(page).to have_selector('#content img', count: 2)
     # First figcaption is lost by having replaced the markdown
     expect(page).to have_content('Image uploaded the second time')
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    attachments_list.expect_attached('image.png', count: 2)
 
     # Both images rendered referring to the api endpoint
     expect(page).to have_selector('img[src^="/api/v3/attachments/"]', count: 2)
@@ -106,18 +107,18 @@ describe 'Upload attachment to wiki page', js: true do
   it 'can upload an image to new and existing wiki page via drag & drop on attachments' do
     visit project_wiki_path(project, 'test')
 
-    expect(page).not_to have_selector('[data-qa-selector="op-attachment-list-item"]')
+    editor.attachments_list.expect_empty
 
     # adding an image
-    find("[data-qa-selector='op-attachments--drop-box']").drop(image_fixture.path)
+    editor.attachments_list.drop(image_fixture.path)
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
-    expect(page).not_to have_selector('op-toasters-upload-progress')
+    editor.attachments_list.expect_attached('image.png')
+    editor.wait_until_upload_progress_toaster_cleared
 
     click_on 'Save'
 
     expect(page).to have_text("Successful creation")
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+    attachments_list.expect_attached('image.png')
 
     # required sleep otherwise clicking on the Edit button doesn't do anything
     SeleniumHubWaiter.wait
@@ -126,22 +127,15 @@ describe 'Upload attachment to wiki page', js: true do
       click_on "Edit"
     end
 
-    expect(page).to have_selector('.ck-editor__editable', wait: 5)
-
-    script = <<~JS
-      const event = new DragEvent('dragenter');
-      document.body.dispatchEvent(event);
-    JS
-    page.execute_script(script)
-
     # adding an image
-    find("[data-qa-selector='op-attachments--drop-box']").drop(image_fixture.path)
+    editor.attachments_list.drag_enter
+    editor.attachments_list.drop(image_fixture)
 
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
-    expect(page).not_to have_selector('op-toasters-upload-progress')
+    editor.attachments_list.expect_attached('image.png', count: 2)
+    editor.wait_until_upload_progress_toaster_cleared
 
     click_on 'Save'
     expect(page).to have_text("Successful update")
-    expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png', count: 2)
+    attachments_list.expect_attached('image.png', count: 2)
   end
 end

--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -123,7 +123,7 @@ describe 'Upload attachment to work package', js: true do
         attachments.drag_and_drop_file(target, image_fixture.path)
 
         sleep 2
-        expect(page).not_to have_selector('op-toasters-upload-progress')
+        editor.wait_until_upload_progress_toaster_cleared
 
         editor.in_editor do |_container, editable|
           expect(editable).to have_selector('img[src*="/api/v3/attachments/"]', wait: 20)
@@ -191,7 +191,7 @@ describe 'Upload attachment to work package', js: true do
           attachments.drag_and_drop_file(target, image_fixture.path)
 
           sleep 2
-          expect(page).not_to have_selector('op-toasters-upload-progress')
+          editor.wait_until_upload_progress_toaster_cleared
 
           editor.in_editor do |_container, editable|
             expect(editable).to have_selector('img[src*="/api/v3/attachments/"]', wait: 20)
@@ -253,7 +253,7 @@ describe 'Upload attachment to work package', js: true do
                                      page.find('[data-qa-tab-id="files"]')
 
       expect(page).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', wait: 10)
-      expect(page).not_to have_selector('op-toasters-upload-progress')
+      editor.wait_until_upload_progress_toaster_cleared
       wp_page.expect_tab 'Files'
     end
 
@@ -276,13 +276,13 @@ describe 'Upload attachment to work package', js: true do
       # Attach file manually
       expect(page).not_to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]')
       attachments.attach_file_on_input(image_fixture.path)
-      expect(page).not_to have_selector('op-toasters-upload-progress')
+      editor.wait_until_upload_progress_toaster_cleared
       expect(page).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', wait: 5)
 
       ##
       # and via drag & drop
       attachments.drag_and_drop_file(container, image_fixture.path)
-      expect(page).not_to have_selector('op-toasters-upload-progress')
+      editor.wait_until_upload_progress_toaster_cleared
       expect(page)
         .to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', count: 2, wait: 5)
     end

--- a/spec/support/components/attachments_list.rb
+++ b/spec/support/components/attachments_list.rb
@@ -1,0 +1,49 @@
+# Handles attachments list generally found under the wysiwyg editor.
+module Components
+  class AttachmentsList
+    include Capybara::DSL
+    include Capybara::RSpecMatchers
+    include RSpec::Matchers
+
+    attr_reader :context_selector
+
+    def initialize(context = '#content')
+      @context_selector = context
+    end
+
+    # Simulates start dragging a file into the window by sending a "dragenter" event.
+    def drag_enter
+      wait_until_visible # element must be visible before any drag and drop
+      page.execute_script <<~JS
+        const event = new DragEvent('dragenter');
+        document.body.dispatchEvent(event);
+      JS
+    end
+
+    # Drops a file into the attachments list drop box.
+    def drop(file)
+      path = file.to_s
+      drop_box_element.drop(path)
+    end
+
+    def expect_empty
+      expect(page).not_to have_selector("#{context_selector} [data-qa-selector='op-attachment-list-item']")
+    end
+
+    def expect_attached(name, count: 1)
+      expect(page).to have_selector("#{context_selector} [data-qa-selector='op-attachment-list-item']", text: name, count:)
+    end
+
+    def wait_until_visible
+      element.tap { scroll_to_element(_1) }
+    end
+
+    def element
+      page.find("#{context_selector} [data-qa-selector='op-attachments']")
+    end
+
+    def drop_box_element
+      find("#{context_selector} [data-qa-selector='op-attachments--drop-box']")
+    end
+  end
+end

--- a/spec/support/uploaded_file.rb
+++ b/spec/support/uploaded_file.rb
@@ -21,7 +21,7 @@ class UploadedFile
     full_path = Rails.root.join(path)
     shared_path = DownloadList::SHARED_PATH.join(File.basename(full_path))
     # with remote drivers, files to upload must be in the shared downloads folder
-    FileUtils.cp(full_path, shared_path, verbose: true)
+    FileUtils.cp(full_path, shared_path)
     new(shared_path)
   end
 end


### PR DESCRIPTION
The flaky test fixed in 59eb308cbb (the first one of this PR) was failing because the test was not waiting for the attachments element to be displayed. In some other similar tests, the code was waiting for it, and one test ever scrolled to that element.

If code was properly factored, the above test would never have been flaky in the first place.

This PR is an attempt to factor the interactions with the attachments list so that the next test written using it will be reliable by default.
