### PR TITLE
Refactor collections services to resource services with single access

### DIFF
--- a/frontend/src/app/core/apiv3/endpoints/days/api-v3-days-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/days/api-v3-days-paths.ts
@@ -46,8 +46,8 @@ export class ApiV3DaysPaths extends ApiV3ResourceCollection<IDay, ApiV3DayPaths>
   // Static paths
 
   // /api/v3/days/week
-  public readonly week = new ApiV3GettableResource(this.apiRoot, this.path, 'week', this);
+  public readonly week = new ApiV3ResourceCollection<IDay, ApiV3DayPaths>(this.apiRoot, this.path, 'week');
 
   // /api/v3/days/nonWorkingDays
-  public readonly nonWorkingDays = new ApiV3GettableResource(this.apiRoot, this.path, 'non_working', this);
+  public readonly nonWorkingDays = new ApiV3ResourceCollection<IDay, ApiV3DayPaths>(this.apiRoot, this.path, 'non_working');
 }

--- a/frontend/src/app/core/apiv3/paths/apiv3-resource.ts
+++ b/frontend/src/app/core/apiv3/paths/apiv3-resource.ts
@@ -78,10 +78,12 @@ export class ApiV3ResourceCollection<V, T extends ApiV3GettableResource<V>> exte
 
   @InjectField() halResourceService:HalResourceService;
 
-  constructor(protected apiRoot:ApiV3Service,
+  constructor(
+    protected apiRoot:ApiV3Service,
     protected basePath:string,
     segment:string,
-    protected resource?:Constructor<T>) {
+    protected resource?:Constructor<T>,
+  ) {
     super(basePath, segment, resource);
   }
 

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -92,7 +92,7 @@ export class CurrentUserService {
 
           return { filters, pageSize: -1 };
         }),
-        switchMap((params) => this.capabilitiesService.require(params)),
+        switchMap((params) => this.capabilitiesService.requireCollection(params)),
       );
   }
 

--- a/frontend/src/app/core/days/weekday.service.ts
+++ b/frontend/src/app/core/days/weekday.service.ts
@@ -73,7 +73,7 @@ export class WeekdayService {
 
     return this
       .weekdaysService
-      .require()
+      .requireCollection()
       .pipe(
         take(1),
         tap((weekdays) => {

--- a/frontend/src/app/core/state/attachments/attachments.service.ts
+++ b/frontend/src/app/core/state/attachments/attachments.service.ts
@@ -46,21 +46,23 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { AttachmentsStore } from 'core-app/core/state/attachments/attachments.store';
 import { IAttachment } from 'core-app/core/state/attachments/attachment.model';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
-import { insertCollectionIntoState, removeEntityFromCollectionAndState } from 'core-app/core/state/collection-store';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  IUploadFile,
+  OpUploadService,
+} from 'core-app/core/upload/upload.service';
+import { removeEntityFromCollectionAndState } from 'core-app/core/state/resource-store';
+import {
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import isNewResource, { HAL_NEW_RESOURCE_ID } from 'core-app/features/hal/helpers/is-new-resource';
 import waitForUploadsFinished from 'core-app/core/upload/wait-for-uploads-finished';
 import isNotNull from 'core-app/core/state/is-not-null';
 
 @Injectable()
-export class AttachmentsResourceService extends ResourceCollectionService<IAttachment> {
+export class AttachmentsResourceService extends ResourceStoreService<IAttachment> {
   @InjectField() I18n:I18nService;
 
   @InjectField() uploadService:OpUploadService;
@@ -68,37 +70,6 @@ export class AttachmentsResourceService extends ResourceCollectionService<IAttac
   @InjectField() configurationService:ConfigurationService;
 
   @InjectField() toastService:ToastService;
-
-  /**
-   * This method ensures that a specific collection is fetched, if not available.
-   *
-   * @param key The collection key, of the required collection.
-   */
-  requireCollection(key:string):void {
-    if (this.store.getValue().collections[key]) {
-      return;
-    }
-
-    this.fetchAttachments(key).subscribe();
-  }
-
-  /**
-   * Fetches attachments by the attachment collection self link.
-   * This link is used as key to store the result collection in the resource store.
-   *
-   * @param attachmentsSelfLink The self link of the attachment collection from the parent resource.
-   */
-  fetchAttachments(attachmentsSelfLink:string):Observable<IHALCollection<IAttachment>> {
-    return this.http
-      .get<IHALCollection<IAttachment>>(attachmentsSelfLink)
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, attachmentsSelfLink)),
-        catchError((error:HttpErrorResponse) => {
-          this.toastService.addError(error);
-          throw new Error(error.message);
-        }),
-      );
-  }
 
   /**
    * Sends deletion request and updates the store collection of attachments.
@@ -227,7 +198,7 @@ export class AttachmentsResourceService extends ResourceCollectionService<IAttac
     return attachments?.href || null;
   }
 
-  protected createStore():CollectionStore<IAttachment> {
+  protected createStore():ResourceStore<IAttachment> {
     return new AttachmentsStore();
   }
 

--- a/frontend/src/app/core/state/attachments/attachments.store.ts
+++ b/frontend/src/app/core/state/attachments/attachments.store.ts
@@ -28,13 +28,13 @@
 
 import { EntityStore, StoreConfig } from '@datorama/akita';
 import { IAttachment } from 'core-app/core/state/attachments/attachment.model';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 
-export interface AttachmentsState extends CollectionState<IAttachment> {}
+export interface AttachmentsState extends ResourceState<IAttachment> {}
 
 @StoreConfig({ name: 'attachments' })
 export class AttachmentsStore extends EntityStore<AttachmentsState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.spec.ts
@@ -220,7 +220,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require(params)
+        .requireCollection(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });
@@ -234,7 +234,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require(params)
+        .requireCollection(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });
@@ -244,7 +244,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require(params)
+        .requireCollection(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(2);
         });
@@ -254,7 +254,7 @@ describe('Capabilities service', () => {
       };
 
       service
-        .require(params)
+        .requireCollection(params)
         .subscribe((caps) => {
           expect(caps.length).toEqual(1);
         });

--- a/frontend/src/app/core/state/capabilities/capabilities.service.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.ts
@@ -2,44 +2,22 @@ import { Injectable } from '@angular/core';
 import {
   catchError,
   map,
-  switchMap,
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { collectionKey } from 'core-app/core/state/collection-store';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
 import { CapabilitiesStore } from 'core-app/core/state/capabilities/capabilities.store';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @Injectable()
-export class CapabilitiesResourceService extends ResourceCollectionService<ICapability> {
+export class CapabilitiesResourceService extends ResourceStoreService<ICapability> {
   @InjectField() toastService:ToastService;
-
-  /**
-   * Require the available capabilities for the given filter params
-   * Returns a cached set if it was loaded already.
-   *
-   * @param params List params to require
-   * @private
-   */
-  public require$(params:ApiV3ListParameters):Observable<ICapability[]> {
-    const key = collectionKey(params);
-    if (this.collectionExists(key) || this.collectionLoading(key)) {
-      return this.loadedCollection(key);
-    }
-
-    return this
-      .fetchCapabilities(params)
-      .pipe(
-        switchMap(() => this.loadedCollection(key)),
-      );
-  }
 
   /**
    * Returns the loaded capabilities for a context
@@ -64,14 +42,11 @@ export class CapabilitiesResourceService extends ResourceCollectionService<ICapa
       );
   }
 
-  protected createStore():CollectionStore<ICapability> {
+  protected createStore():ResourceStore<ICapability> {
     return new CapabilitiesStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .capabilities
-      .path;
+    return this.apiV3Service.capabilities.path;
   }
 }

--- a/frontend/src/app/core/state/capabilities/capabilities.store.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.store.ts
@@ -1,13 +1,13 @@
 import { EntityStore, StoreConfig } from '@datorama/akita';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
 
-export interface CapabilitiesState extends CollectionState<ICapability> {
+export interface CapabilitiesState extends ResourceState<ICapability> {
 }
 
 @StoreConfig({ name: 'capabilities' })
 export class CapabilitiesStore extends EntityStore<CapabilitiesState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/days/day.service.ts
+++ b/frontend/src/app/core/state/days/day.service.ts
@@ -1,31 +1,19 @@
 import { Injectable } from '@angular/core';
 import {
-  finalize,
   map,
   take,
-  tap,
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import {
-  ApiV3ListFilter,
-  ApiV3ListParameters,
-} from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import {
-  collectionKey,
-  insertCollectionIntoState,
-  removeCollectionLoading,
-  setCollectionLoading,
-} from 'core-app/core/state/collection-store';
+import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { DayStore } from 'core-app/core/state/days/day.store';
 import { IDay } from 'core-app/core/state/days/day.model';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 
 @Injectable()
-export class DayResourceService extends ResourceCollectionService<IDay> {
+export class DayResourceService extends ResourceStoreService<IDay> {
   protected basePath():string {
     return this
       .apiV3Service
@@ -54,7 +42,7 @@ export class DayResourceService extends ResourceCollectionService<IDay> {
       ['date', '<>d', [from, to]],
     ];
 
-    return this.require({ filters });
+    return this.requireCollection({ filters });
   }
 
   requireNonWorkingYears$(start:Date|string, end:Date|string):Observable<IDay[]> {
@@ -65,24 +53,10 @@ export class DayResourceService extends ResourceCollectionService<IDay> {
       ['date', '<>d', [from, to]],
     ];
 
-    return this.require({ filters });
+    return this.requireCollection({ filters });
   }
 
-  fetchCollection(params:ApiV3ListParameters):Observable<IHALCollection<IDay>> {
-    const collectionURL = collectionKey(params);
-
-    setCollectionLoading(this.store, collectionURL);
-
-    return this
-      .http
-      .get<IHALCollection<IDay>>(this.basePath() + collectionURL)
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        finalize(() => removeCollectionLoading(this.store, collectionURL)),
-      );
-  }
-
-  protected createStore():CollectionStore<IDay> {
+  protected createStore():ResourceStore<IDay> {
     return new DayStore();
   }
 }

--- a/frontend/src/app/core/state/days/day.store.ts
+++ b/frontend/src/app/core/state/days/day.store.ts
@@ -3,17 +3,17 @@ import {
   StoreConfig,
 } from '@datorama/akita';
 import {
-  CollectionState,
-  createInitialCollectionState,
-} from 'core-app/core/state/collection-store';
+  ResourceState,
+  createInitialResourceState,
+} from 'core-app/core/state/resource-store';
 import { IDay } from 'core-app/core/state/days/day.model';
 
-export interface DayState extends CollectionState<IDay> {
+export interface DayState extends ResourceState<IDay> {
 }
 
 @StoreConfig({ name: 'days' })
 export class DayStore extends EntityStore<DayState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/days/weekday.service.ts
+++ b/frontend/src/app/core/state/days/weekday.service.ts
@@ -12,17 +12,17 @@ import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import {
   extendCollectionElementsWithId,
   insertCollectionIntoState,
-} from 'core-app/core/state/collection-store';
+} from 'core-app/core/state/resource-store';
 import { WeekdayStore } from 'core-app/core/state/days/weekday.store';
 import { IWeekday } from 'core-app/core/state/days/weekday.model';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 
 @Injectable()
-export class WeekdayResourceService extends ResourceCollectionService<IWeekday> {
-  require():Observable<IWeekday[]> {
+export class WeekdayResourceService extends ResourceStoreService<IWeekday> {
+  requireCollection():Observable<IWeekday[]> {
     return this
       .query
       .selectHasCache()
@@ -44,15 +44,11 @@ export class WeekdayResourceService extends ResourceCollectionService<IWeekday> 
       );
   }
 
-  protected createStore():CollectionStore<IWeekday> {
+  protected createStore():ResourceStore<IWeekday> {
     return new WeekdayStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .days
-      .week
-      .path;
+    return this.apiV3Service.days.week.path;
   }
 }

--- a/frontend/src/app/core/state/days/weekday.store.ts
+++ b/frontend/src/app/core/state/days/weekday.store.ts
@@ -3,17 +3,17 @@ import {
   StoreConfig,
 } from '@datorama/akita';
 import {
-  CollectionState,
-  createInitialCollectionState,
-} from 'core-app/core/state/collection-store';
+  ResourceState,
+  createInitialResourceState,
+} from 'core-app/core/state/resource-store';
 import { IWeekday } from 'core-app/core/state/days/weekday.model';
 
-export interface WeekdayState extends CollectionState<IWeekday> {
+export interface WeekdayState extends ResourceState<IWeekday> {
 }
 
 @StoreConfig({ name: 'weekdays' })
 export class WeekdayStore extends EntityStore<WeekdayState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/file-links/file-links.service.ts
+++ b/frontend/src/app/core/state/file-links/file-links.service.ts
@@ -29,7 +29,11 @@
 import { applyTransaction } from '@datorama/akita';
 import { Injectable } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
-import { from, Observable, of } from 'rxjs';
+import {
+  from,
+  Observable,
+  of,
+} from 'rxjs';
 import {
   groupBy,
   mergeMap,
@@ -38,17 +42,26 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import { IFileLink, IFileLinkOriginData } from 'core-app/core/state/file-links/file-link.model';
+import {
+  IFileLink,
+  IFileLinkOriginData,
+} from 'core-app/core/state/file-links/file-link.model';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { FileLinksStore } from 'core-app/core/state/file-links/file-links.store';
-import { insertCollectionIntoState, removeEntityFromCollectionAndState } from 'core-app/core/state/collection-store';
-import { CollectionStore, ResourceCollectionService } from 'core-app/core/state/resource-collection.service';
+import {
+  insertCollectionIntoState,
+  removeEntityFromCollectionAndState,
+} from 'core-app/core/state/resource-store';
+import {
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { IHalResourceLink } from 'core-app/core/state/hal-resource';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
 @Injectable()
-export class FileLinksResourceService extends ResourceCollectionService<IFileLink> {
-  protected createStore():CollectionStore<IFileLink> {
+export class FileLinksResourceService extends ResourceStoreService<IFileLink> {
+  protected createStore():ResourceStore<IFileLink> {
     return new FileLinksStore();
   }
 

--- a/frontend/src/app/core/state/file-links/file-links.store.ts
+++ b/frontend/src/app/core/state/file-links/file-links.store.ts
@@ -26,15 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 import { EntityStore, StoreConfig } from '@datorama/akita';
 import { IFileLink } from 'core-app/core/state/file-links/file-link.model';
 
-export interface FileLinksState extends CollectionState<IFileLink> {}
+export interface FileLinksState extends ResourceState<IFileLink> {}
 
 @StoreConfig({ name: 'file_links' })
 export class FileLinksStore extends EntityStore<FileLinksState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
@@ -36,16 +36,22 @@ import {
   markNotificationsAsReadByFilters,
   notificationsMarkedRead,
 } from 'core-app/core/state/in-app-notifications/in-app-notifications.actions';
-import { EffectCallback, EffectHandler } from 'core-app/core/state/effects/effect-handler.decorator';
+import {
+  EffectCallback,
+  EffectHandler,
+} from 'core-app/core/state/effects/effect-handler.decorator';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { InAppNotificationsStore } from 'core-app/core/state/in-app-notifications/in-app-notifications.store';
-import { CollectionStore, ResourceCollectionService } from 'core-app/core/state/resource-collection.service';
+import {
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
-export class InAppNotificationsResourceService extends ResourceCollectionService<INotification> {
+export class InAppNotificationsResourceService extends ResourceStoreService<INotification> {
   @InjectField() actions$:ActionsService;
 
   update(id:ID, inAppNotification:Partial<INotification>):void {
@@ -87,14 +93,11 @@ export class InAppNotificationsResourceService extends ResourceCollectionService
       });
   }
 
-  protected createStore():CollectionStore<INotification> {
+  protected createStore():ResourceStore<INotification> {
     return new InAppNotificationsStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .notifications
-      .path;
+    return this.apiV3Service.notifications.path;
   }
 }

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notifications.store.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notifications.store.ts
@@ -1,13 +1,13 @@
 import { EntityStore, StoreConfig } from '@datorama/akita';
 import { INotification } from './in-app-notification.model';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 
-export interface InAppNotificationsState extends CollectionState<INotification> {
+export interface InAppNotificationsState extends ResourceState<INotification> {
 }
 
 @StoreConfig({ name: 'in-app-notifications' })
 export class InAppNotificationsStore extends EntityStore<InAppNotificationsState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/principals/principals.service.ts
+++ b/frontend/src/app/core/state/principals/principals.service.ts
@@ -1,74 +1,27 @@
 import { Injectable } from '@angular/core';
-import {
-  catchError,
-  tap,
-} from 'rxjs/operators';
-import { Observable } from 'rxjs';
-import { applyTransaction } from '@datorama/akita';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import {
-  collectionKey,
-  insertCollectionIntoState,
-} from 'core-app/core/state/collection-store';
 import { EffectHandler } from 'core-app/core/state/effects/effect-handler.decorator';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { PrincipalsStore } from './principals.store';
 import { IPrincipal } from './principal.model';
-import { IUser } from 'core-app/core/state/principals/user.model';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
-export class PrincipalsResourceService extends ResourceCollectionService<IPrincipal> {
+export class PrincipalsResourceService extends ResourceStoreService<IPrincipal> {
   @InjectField() actions$:ActionsService;
 
   @InjectField() toastService:ToastService;
 
-  fetchUser(id:string|number):Observable<IUser> {
-    return this.http
-      .get<IUser>(this.apiV3Service.users.id(id).path)
-      .pipe(
-        tap((data) => {
-          applyTransaction(() => {
-            this.store.upsertMany([data]);
-          });
-        }),
-        catchError((error) => {
-          this.toastService.addError(error);
-          throw error;
-        }),
-      );
-  }
-
-  fetchPrincipals(params:ApiV3ListParameters):Observable<IHALCollection<IPrincipal>> {
-    const collectionURL = collectionKey(params);
-
-    return this
-      .http
-      .get<IHALCollection<IPrincipal>>(this.basePath() + collectionURL)
-      .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        catchError((error) => {
-          this.toastService.addError(error);
-          throw error;
-        }),
-      );
-  }
-
-  protected createStore():CollectionStore<IPrincipal> {
+  protected createStore():ResourceStore<IPrincipal> {
     return new PrincipalsStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .principals
-      .path;
+    return this.apiV3Service.principals.path;
   }
 }

--- a/frontend/src/app/core/state/principals/principals.store.ts
+++ b/frontend/src/app/core/state/principals/principals.store.ts
@@ -1,13 +1,13 @@
 import { EntityStore, StoreConfig } from '@datorama/akita';
 import { IPrincipal } from './principal.model';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 
-export interface PrincipalsState extends CollectionState<IPrincipal> {
+export interface PrincipalsState extends ResourceState<IPrincipal> {
 }
 
 @StoreConfig({ name: 'principals' })
 export class PrincipalsStore extends EntityStore<PrincipalsState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/projects/projects.service.ts
+++ b/frontend/src/app/core/state/projects/projects.service.ts
@@ -31,13 +31,13 @@ import { tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { IProject } from './project.model';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { ProjectsStore } from 'core-app/core/state/projects/projects.store';
 
 @Injectable()
-export class ProjectsResourceService extends ResourceCollectionService<IProject> {
+export class ProjectsResourceService extends ResourceStoreService<IProject> {
   update(link:string):Observable<IProject> {
     return this.http.get<IProject>(link)
       .pipe(
@@ -47,14 +47,11 @@ export class ProjectsResourceService extends ResourceCollectionService<IProject>
       );
   }
 
-  protected createStore():CollectionStore<IProject> {
+  protected createStore():ResourceStore<IProject> {
     return new ProjectsStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .projects
-      .path;
+    return this.apiV3Service.projects.path;
   }
 }

--- a/frontend/src/app/core/state/projects/projects.store.ts
+++ b/frontend/src/app/core/state/projects/projects.store.ts
@@ -1,13 +1,13 @@
 import { EntityStore, StoreConfig } from '@datorama/akita';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 import { IProject } from './project.model';
 
-export interface ProjectsState extends CollectionState<IProject> {
+export interface ProjectsState extends ResourceState<IProject> {
 }
 
 @StoreConfig({ name: 'projects' })
 export class ProjectsStore extends EntityStore<ProjectsState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/resource-store.service.ts
+++ b/frontend/src/app/core/state/resource-store.service.ts
@@ -37,6 +37,7 @@ import {
   filter,
   finalize,
   map,
+  shareReplay,
   switchMap,
   tap,
 } from 'rxjs/operators';
@@ -288,6 +289,7 @@ export abstract class ResourceStoreService<T extends { id:ID }> {
 
           throw error;
         }),
+        shareReplay(1),
       );
   }
 
@@ -316,6 +318,7 @@ export abstract class ResourceStoreService<T extends { id:ID }> {
 
           throw error;
         }),
+        shareReplay(1),
       );
   }
 

--- a/frontend/src/app/core/state/resource-store.service.ts
+++ b/frontend/src/app/core/state/resource-store.service.ts
@@ -41,16 +41,18 @@ import {
   tap,
 } from 'rxjs/operators';
 import {
-  collectionKey,
   CollectionResponse,
-  CollectionState,
   insertCollectionIntoState,
-  removeCollectionLoading,
-  setCollectionLoading,
-} from 'core-app/core/state/collection-store';
+  removeResourceLoading,
+  ResourceState,
+  setResourceLoading,
+} from 'core-app/core/state/resource-store';
 import { omit } from 'lodash';
 import isDefinedEntity from 'core-app/core/state/is-defined-entity';
-import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
+import {
+  ApiV3ListParameters,
+  listParamsString,
+} from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import {
   HttpClient,
@@ -62,16 +64,19 @@ import {
 } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
+import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
-export type CollectionStore<T> = EntityStore<CollectionState<T>>;
+export type ResourceStore<T> = EntityStore<ResourceState<T>>;
 
-export interface ResourceCollectionLoadOptions {
+export interface ResourceStoreLoadOptions {
   handleErrors:boolean;
 }
 
+export type ResourceKeyInput = ApiV3ListParameters|string;
+
 @Injectable()
-export abstract class ResourceCollectionService<T extends { id:ID }> {
-  protected store:CollectionStore<T> = this.createStore();
+export abstract class ResourceStoreService<T extends { id:ID }> {
+  protected store:ResourceStore<T> = this.createStore();
 
   protected query = new QueryEntity(this.store);
 
@@ -87,30 +92,47 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
    * Require the results for the given filter params
    * Returns a cached set if it was loaded already.
    *
-   * @param params List params to require
+   * @param input List params to require, or href of the resource
    * @private
    */
-  public require(params:ApiV3ListParameters):Observable<T[]> {
-    const key = collectionKey(params);
-    if (this.collectionExists(key) || this.collectionLoading(key)) {
-      return this.loadedCollection(key);
+  public requireCollection(input:ResourceKeyInput):Observable<T[]> {
+    const href = this.buildResourceLink(input);
+    if (this.collectionExists(href) || this.resourceLoading(href)) {
+      return this.loadedCollection(href);
     }
 
     return this
-      .fetchCollection(params)
+      .fetchCollection(href)
       .pipe(
-        switchMap(() => this.loadedCollection(key)),
+        switchMap(() => this.loadedCollection(href)),
       );
+  }
+
+  /**
+   * Require a single entity to be loaded.
+   * Returnes the cached entity if it was loaded already
+   *
+   * @param href {string}
+   */
+  public requireEntity(href:string):Observable<T> {
+    const id = idFromLink(href);
+    if (this.query.hasEntity(id) || this.resourceLoading(href)) {
+      return this.lookup(id);
+    }
+
+    return this.fetchEntity(href);
   }
 
   /**
    * Retrieve a collection from the store
    *
-   * @param key The collection key to fetch
+   * @param input List params to require, or href of the resource
    */
-  collection(key:string):Observable<T[]> {
+  collection(input:ResourceKeyInput):Observable<T[]> {
+    const href = this.buildResourceLink(input);
+
     return this
-      .collectionState(key)
+      .collectionState(href)
       .pipe(
         switchMap((collection) => this.query.selectMany(collection?.ids || [])),
       );
@@ -118,11 +140,13 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
 
   /**
    * Return a collection observable that triggers only when the collection is loaded.
-   * @param key
+   * @param input List params to require, or href of the resource
    */
-  loadedCollection(key:string):Observable<T[]> {
+  loadedCollection(input:ResourceKeyInput):Observable<T[]> {
+    const href = this.buildResourceLink(input);
+
     return this
-      .collectionState(key)
+      .collectionState(href)
       .pipe(
         filter((collection) => !!collection),
         switchMap((collection:CollectionResponse) => this.query.selectMany(collection.ids)),
@@ -131,14 +155,16 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
 
   /**
    * Return a collection observable that triggers only when the collection is loaded.
-   * @param key
+   * @param input List params to require, or href of the resource
    */
-  collectionState(key:string):Observable<CollectionResponse|undefined> {
+  collectionState(input:ResourceKeyInput):Observable<CollectionResponse|undefined> {
+    const href = this.buildResourceLink(input);
+
     return this
       .query
       .select()
       .pipe(
-        map((state) => state.collections[key]),
+        map((state) => state.collections[href]),
       );
   }
 
@@ -172,36 +198,44 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
 
   /**
    * Checks, if the store already has a collection given the key
+   *
+   * @param input List params to require, or href of the resource
    */
-  collectionExists(input:string|ApiV3ListParameters):boolean {
-    const key = typeof input === 'string' ? input : collectionKey(input);
+  collectionExists(input:ResourceKeyInput):boolean {
+    const href = this.buildResourceLink(input);
+
     return !!this
       .query
       .getValue()
-      .collections[key];
+      .collections[href];
   }
 
   /**
    * Checks, if the store already has a collection given the key
+   *
+   * @param input List params to require, or href of the resource
    */
-  collectionLoading(input:string|ApiV3ListParameters):boolean {
-    const key = typeof input === 'string' ? input : collectionKey(input);
+  resourceLoading(input:ResourceKeyInput):boolean {
+    const href = this.buildResourceLink(input);
+
     return this
       .query
       .getValue()
-      .loadingCollections[key] === true;
+      .loadingResources[href] === true;
   }
 
   /**
    * Clear a collection key
-   * @param key Collection key to clear
+   * @param input List params to require, or href of the resource
    */
-  clear(key:string):void {
+  clear(input:ResourceKeyInput):void {
+    const href = this.buildResourceLink(input);
+
     this
       .store
       .update(
         ({ collections }) => ({
-          collections: omit(collections, key),
+          collections: omit(collections, href),
         }),
       );
   }
@@ -219,7 +253,7 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
   /**
    * Fetch a given collection, returning only its results
    */
-  fetchResults(params:ApiV3ListParameters|string):Observable<T[]> {
+  fetchResults(params:ResourceKeyInput):Observable<T[]> {
     return this
       .fetchCollection(params)
       .pipe(
@@ -230,26 +264,26 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
   /**
    * Fetch a given collection, ensuring it is being flagged as loaded
    *
-   * @param params {ApiV3ListParameters|string} collection key or list params to build collection key from
-   * @param options {ResourceCollectionLoadOptions} Handle collection loading errors within the resource service
+   * @param params {ResourceKeyInput} collection key or list params to build collection key from
+   * @param options {ResourceStoreLoadOptions} Handle collection loading errors within the resource service
    */
   fetchCollection(
-    params:ApiV3ListParameters|string,
-    options:ResourceCollectionLoadOptions = { handleErrors: true },
+    params:ResourceKeyInput,
+    options:ResourceStoreLoadOptions = { handleErrors: true },
   ):Observable<IHALCollection<T>> {
-    const key = typeof params === 'string' ? params : collectionKey(params);
+    const href = this.buildResourceLink(params);
 
-    setCollectionLoading(this.store, key);
+    setResourceLoading(this.store, href);
 
     return this
       .http
-      .get<IHALCollection<T>>(this.basePath() + key)
+      .get<IHALCollection<T>>(href)
       .pipe(
-        tap((collection) => insertCollectionIntoState(this.store, collection, key)),
-        finalize(() => removeCollectionLoading(this.store, key)),
+        tap((collection) => insertCollectionIntoState(this.store, collection, href)),
+        finalize(() => removeResourceLoading(this.store, href)),
         catchError((error:unknown) => {
           if (options.handleErrors) {
-            this.handleCollectionLoadingError(error as HttpErrorResponse, key);
+            this.handleResourceLoadingError(error as HttpErrorResponse, href);
           }
 
           throw error;
@@ -258,10 +292,46 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
   }
 
   /**
+   * Fetch a single entity, ensuring it is being flagged as loaded
+   *
+   * @param href {string} of the resource to load
+   * @param options {ResourceStoreLoadOptions} Handle loading errors within the resource service
+   */
+  fetchEntity(
+    href:string,
+    options:ResourceStoreLoadOptions = { handleErrors: true },
+  ):Observable<T> {
+    setResourceLoading(this.store, href);
+
+    return this
+      .http
+      .get<T>(href)
+      .pipe(
+        tap((entity) => this.store.add(entity)),
+        finalize(() => removeResourceLoading(this.store, href)),
+        catchError((error:unknown) => {
+          if (options.handleErrors) {
+            this.handleResourceLoadingError(error as HttpErrorResponse, href);
+          }
+
+          throw error;
+        }),
+      );
+  }
+
+  protected buildResourceLink(input:ResourceKeyInput):string {
+    if (typeof input === 'string') {
+      return input;
+    }
+
+    return this.basePath() + listParamsString(input);
+  }
+
+  /**
    * Create a new instance of this resource service's underlying store.
    * @protected
    */
-  protected abstract createStore():CollectionStore<T>;
+  protected abstract createStore():ResourceStore<T>;
 
   /**
    * Base path for this collection
@@ -272,10 +342,10 @@ export abstract class ResourceCollectionService<T extends { id:ID }> {
   /**
    * By default, add a toast error in case of loading errors
    * @param error
-   * @param _collectionKey
+   * @param _path
    * @protected
    */
-  protected handleCollectionLoadingError(error:HttpErrorResponse, _collectionKey:string):void {
+  protected handleResourceLoadingError(error:HttpErrorResponse, _path:string):void {
     this.toastService.addError(error);
   }
 }

--- a/frontend/src/app/core/state/resource-store.ts
+++ b/frontend/src/app/core/state/resource-store.ts
@@ -17,12 +17,12 @@ export interface CollectionResponse {
   ids:ID[];
 }
 
-export interface CollectionState<T> extends EntityState<T> {
+export interface ResourceState<T> extends EntityState<T> {
   /** Loaded notification collections */
   collections:Record<string, CollectionResponse>;
 
-  /** Loading collections */
-  loadingCollections:Record<string, boolean>;
+  /** Loading resources, collections or singular entities */
+  loadingResources:Record<string, boolean>;
 }
 
 export interface CollectionItem {
@@ -36,58 +36,48 @@ export function mapHALCollectionToIDCollection<T extends CollectionItem>(collect
 }
 
 /**
- * Initialize the collection part of the entity store
+ * Initialize the resource part of the entity store
  */
-export function createInitialCollectionState<T>():CollectionState<T> {
+export function createInitialResourceState<T>():ResourceState<T> {
   return {
     collections: {},
-    loadingCollections: {},
+    loadingResources: {},
   };
 }
 
 /**
- * Returns the collection key for the given APIv3 parameters
- *
- * @param params list params
- */
-export function collectionKey(params:ApiV3ListParameters):string {
-  return listParamsString(params);
-}
-
-/**
- * Mark a collection key as being loaded
+ * Mark a resource path as being loaded
  *
  * @param store An entity store for the collection
- * @param collectionUrl The key to insert the collection at
- * @param loading The loading state
+ * @param url The resource path to mark as loading
  */
-export function setCollectionLoading<T extends { id:ID }>(
-  store:EntityStore<CollectionState<T>>,
-  collectionUrl:string,
+export function setResourceLoading<T extends { id:ID }>(
+  store:EntityStore<ResourceState<T>>,
+  url:string,
 ):void {
-  store.update(({ loadingCollections }) => (
+  store.update(({ loadingResources }) => (
     {
-      loadingCollections: {
-        ...loadingCollections,
-        [collectionUrl]: true,
+      loadingResources: {
+        ...loadingResources,
+        [url]: true,
       },
     }
   ));
 }
 
 /**
- * Mark a collection key as no longer loading
+ * Mark a resource path as no longer loading
  *
  * @param store An entity store for the collection
- * @param collectionUrl The key to insert the collection at
+ * @param url The resource path to unmark as loading
  */
-export function removeCollectionLoading<T extends { id:ID }>(
-  store:EntityStore<CollectionState<T>>,
-  collectionUrl:string,
+export function removeResourceLoading<T extends { id:ID }>(
+  store:EntityStore<ResourceState<T>>,
+  url:string,
 ):void {
-  store.update(({ loadingCollections }) => (
+  store.update(({ loadingResources }) => (
     {
-      loadingCollections: filter(loadingCollections, (_, key) => key !== collectionUrl),
+      loadingResources: filter(loadingResources, (_, key) => key !== url),
     }
   ));
 }
@@ -100,7 +90,7 @@ export function removeCollectionLoading<T extends { id:ID }>(
  * @param collectionUrl The key to insert the collection at
  */
 export function insertCollectionIntoState<T extends { id:ID }>(
-  store:EntityStore<CollectionState<T>>,
+  store:EntityStore<ResourceState<T>>,
   collection:IHALCollection<T>,
   collectionUrl:string,
 ):void {
@@ -129,7 +119,7 @@ export function insertCollectionIntoState<T extends { id:ID }>(
 }
 
 export function removeEntityFromCollectionAndState<T extends { id:ID }>(
-  store:EntityStore<CollectionState<T>>,
+  store:EntityStore<ResourceState<T>>,
   entityId:ID,
   collectionUrl:string,
 ):void {

--- a/frontend/src/app/core/state/storages/storages.service.ts
+++ b/frontend/src/app/core/state/storages/storages.service.ts
@@ -28,19 +28,22 @@
 
 import { Injectable } from '@angular/core';
 import { tap } from 'rxjs/operators';
-import { forkJoin, Observable } from 'rxjs';
+import {
+  forkJoin,
+  Observable,
+} from 'rxjs';
 import { IStorage } from 'core-app/core/state/storages/storage.model';
 import { StoragesStore } from 'core-app/core/state/storages/storages.store';
-import { insertCollectionIntoState } from 'core-app/core/state/collection-store';
+import { insertCollectionIntoState } from 'core-app/core/state/resource-store';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { IHalResourceLink } from 'core-app/core/state/hal-resource';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 
 @Injectable()
-export class StoragesResourceService extends ResourceCollectionService<IStorage> {
+export class StoragesResourceService extends ResourceStoreService<IStorage> {
   updateCollection(key:string, storageLinks:IHalResourceLink[]):Observable<IStorage[]> {
     return forkJoin(storageLinks.map((link) => this.http.get<IStorage>(link.href)))
       .pipe(
@@ -51,7 +54,7 @@ export class StoragesResourceService extends ResourceCollectionService<IStorage>
       );
   }
 
-  protected createStore():CollectionStore<IStorage> {
+  protected createStore():ResourceStore<IStorage> {
     return new StoragesStore();
   }
 

--- a/frontend/src/app/core/state/storages/storages.store.ts
+++ b/frontend/src/app/core/state/storages/storages.store.ts
@@ -27,14 +27,14 @@
 //++
 
 import { EntityStore, StoreConfig } from '@datorama/akita';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 import { IStorage } from 'core-app/core/state/storages/storage.model';
 
-export interface StoragesState extends CollectionState<IStorage> {}
+export interface StoragesState extends ResourceState<IStorage> {}
 
 @StoreConfig({ name: 'storages' })
 export class StoragesStore extends EntityStore<StoragesState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/core/state/views/views.service.ts
+++ b/frontend/src/app/core/state/views/views.service.ts
@@ -4,24 +4,21 @@ import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { ViewsStore } from 'core-app/core/state/views/views.store';
 import { IView } from 'core-app/core/state/views/view.model';
 import {
-  CollectionStore,
-  ResourceCollectionService,
-} from 'core-app/core/state/resource-collection.service';
+  ResourceStore,
+  ResourceStoreService,
+} from 'core-app/core/state/resource-store.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @EffectHandler
 @Injectable()
-export class ViewsResourceService extends ResourceCollectionService<IView> {
+export class ViewsResourceService extends ResourceStoreService<IView> {
   @InjectField() actions$:ActionsService;
 
-  protected createStore():CollectionStore<IView> {
+  protected createStore():ResourceStore<IView> {
     return new ViewsStore();
   }
 
   protected basePath():string {
-    return this
-      .apiV3Service
-      .views
-      .path;
+    return this.apiV3Service.views.path;
   }
 }

--- a/frontend/src/app/core/state/views/views.store.ts
+++ b/frontend/src/app/core/state/views/views.store.ts
@@ -1,13 +1,13 @@
 import { EntityStore, StoreConfig } from '@datorama/akita';
-import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ResourceState, createInitialResourceState } from 'core-app/core/state/resource-store';
 import { IView } from './view.model';
 
-export interface ViewsState extends CollectionState<IView> {
+export interface ViewsState extends ResourceState<IView> {
 }
 
 @StoreConfig({ name: 'views' })
 export class ViewsStore extends EntityStore<ViewsState> {
   constructor() {
-    super(createInitialCollectionState());
+    super(createInitialResourceState());
   }
 }

--- a/frontend/src/app/features/in-app-notifications/center/menu/state/ian-menu.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/state/ian-menu.service.ts
@@ -26,7 +26,6 @@ import {
   map,
   switchMap,
 } from 'rxjs/operators';
-import { collectionKey } from 'core-app/core/state/collection-store';
 import { combineLatest } from 'rxjs';
 
 @Injectable()
@@ -43,10 +42,7 @@ export class IanMenuService {
   projectsForNotifications$ = this
     .projectsFilter$
     .pipe(
-      switchMap((filterParams) => {
-        const key = collectionKey(filterParams);
-        return this.projectsResourceService.collection(key);
-      }),
+      switchMap((filterParams) => this.projectsResourceService.collection(filterParams)),
     );
 
   notificationsByProject$ = combineLatest([

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -66,7 +66,7 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import {
   InAppNotificationsResourceService,
 } from 'core-app/core/state/in-app-notifications/in-app-notifications.service';
-import { mapHALCollectionToIDCollection } from 'core-app/core/state/collection-store';
+import { mapHALCollectionToIDCollection } from 'core-app/core/state/resource-store';
 import { INotificationPageQueryParameters } from 'core-app/features/in-app-notifications/in-app-notifications.routes';
 import {
   IAN_FACET_FILTERS,

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.store.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.store.ts
@@ -1,5 +1,5 @@
 import { Store, StoreConfig } from '@datorama/akita';
-import { CollectionResponse } from 'core-app/core/state/collection-store';
+import { CollectionResponse } from 'core-app/core/state/resource-store';
 import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { NOTIFICATIONS_MAX_SIZE } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { INotificationPageQueryParameters } from 'core-app/features/in-app-notifications/in-app-notifications.routes';

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -419,7 +419,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     this.params$
       .pipe(this.untilDestroyed())
       .subscribe((params) => {
-        this.principalsResourceService.fetchPrincipals(params).subscribe();
+        this.principalsResourceService.requireCollection(params).subscribe();
       });
 
     combineLatest([

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
@@ -22,7 +22,6 @@ import {
   EffectHandler,
 } from 'core-app/core/state/effects/effect-handler.decorator';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
-import { collectionKey } from 'core-app/core/state/collection-store';
 import { Query } from '@datorama/akita';
 
 @EffectHandler
@@ -39,7 +38,7 @@ export class WpSingleViewService {
     .select((state) => state.notifications.filters)
     .pipe(
       filter((filters) => filters.length > 0),
-      switchMap((filters) => this.resourceService.collection(collectionKey({ filters }))),
+      switchMap((filters) => this.resourceService.collection({ filters })),
     );
 
   selectNotificationsCount$ = this
@@ -92,10 +91,9 @@ export class WpSingleViewService {
   }
 
   markAllAsRead():void {
-    const key = collectionKey({ filters: this.store.getValue().notifications.filters });
     this
       .resourceService
-      .collection(key)
+      .collection({ filters: this.store.getValue().notifications.filters })
       .pipe(
         take(1),
       )

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -185,7 +185,7 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
 
     // Fetch attachments of current work package
     const attachments = this.workPackage.attachments as unknown&{ href:string };
-    this.attachmentsResourceService.fetchAttachments(attachments.href).subscribe();
+    this.attachmentsResourceService.fetchCollection(attachments.href).subscribe();
 
     if (this.workPackage.$links.fileLinks) {
       this.fileLinkResourceService

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
@@ -103,15 +103,10 @@ export class OpAttachmentListItemComponent extends UntilDestroyedMixin implement
   ngOnInit():void {
     this.fileIcon = getIconForMimeType(this.attachment.contentType);
 
-    const authorId = idFromLink(this.attachment._links.author.href);
-
-    if (!this.principalsResourceService.exists(authorId)) {
-      this.principalsResourceService.fetchUser(authorId).subscribe();
-    }
+    const href = this.attachment._links.author.href;
+    this.author$ = this.principalsResourceService.requireEntity(href);
 
     this.timestampText = this.timezoneService.parseDatetime(this.attachment.createdAt).fromNow();
-
-    this.author$ = this.principalsResourceService.lookup(authorId).pipe(first());
 
     combineLatest([
       this.author$,

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -152,7 +152,7 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
 
     // ensure collection is loaded to the store
     if (!isNewResource(this.resource)) {
-      this.attachmentsResourceService.requireCollection(this.attachmentsSelfLink);
+      this.attachmentsResourceService.requireCollection(this.attachmentsSelfLink).subscribe();
     }
 
     const compareCreatedAtTimestamps = (a:IAttachment, b:IAttachment):number => {


### PR DESCRIPTION
Refactors collection services into resource services, providing access to both collections and entities through their href.

By that, fixes https://community.openproject.org/work_packages/47518/activity by providing a way to require entities without loading them twice.