### PR TITLE
[#44828] add overrides for grid layout for relations on mobile

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -1,56 +1,71 @@
 <div
   *ngIf="workPackage && relatedWorkPackage"
   class="relation-row relation-row-{{ relatedWorkPackage.id }}"
-  opFocusWithin=".wp-relations-controls-section button"
+  opFocusWithin=".relation-row--grid-actions button"
 >
-  <div class="grid-block hierarchy-item">
-    <div class="grid-content medium-2 collapse">
+  <div
+    class="relation-row--grid"
+  >
+    <div>
       <button
         type="button"
         class="relation-row--type"
         (click)="activateRelationTypeEdit()"
         *ngIf="!userInputs.showRelationTypesForm"
       >
-        <span *ngIf="groupByWorkPackageType"
-              [textContent]="normalizedRelationType"></span>
-        <span *ngIf="!groupByWorkPackageType"
-              [ngClass]="highlightingClassForWpType()"
-              [textContent]="relatedWorkPackage.type.name"></span>
+        <span
+          *ngIf="groupByWorkPackageType"
+          [textContent]="normalizedRelationType"
+        ></span>
+        <span
+          *ngIf="!groupByWorkPackageType"
+          [ngClass]="highlightingClassForWpType()"
+          [textContent]="relatedWorkPackage.type.name"
+        ></span>
         <span class="hidden-for-sighted" [textContent]="text.updateRelation"></span>
       </button>
-      <div class="inline-edit--container inplace-edit"
-           *ngIf="userInputs.showRelationTypesForm">
-        <select class="inline-edit--field form--select"
-                [(ngModel)]="selectedRelationType"
-                (change)="saveRelationType()"
-                role="listbox"
-                opAutofocus
-                (keydown.escape)="cancelRelationTypeEditOnEscape($event)">
-          <option *ngFor="let relationType of availableRelationTypes"
-                  [textContent]="relationType.label"
-                  [ngValue]="relationType"></option>
+      <div
+        class="inline-edit--container inplace-edit"
+        *ngIf="userInputs.showRelationTypesForm"
+      >
+        <select
+          class="inline-edit--field form--select"
+          [(ngModel)]="selectedRelationType"
+          (change)="saveRelationType()"
+          role="listbox"
+          opAutofocus
+          (keydown.escape)="cancelRelationTypeEditOnEscape($event)"
+        >
+          <option
+            *ngFor="let relationType of availableRelationTypes"
+            [textContent]="relationType.label"
+            [ngValue]="relationType"
+          ></option>
         </select>
       </div>
     </div>
 
-    <div class="grid-content medium-5 collapse"
-         *ngIf="relatedWorkPackage">
-      <a uiSref="work-packages.show.tabs"
-         [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
-         class="wp-relations--subject-field"
-         [textContent]="relatedWorkPackage.subjectWithId(0)"
-         [attr.aria-label]="normalizedRelationType + ' ' + relatedWorkPackage.subjectWithId(0)">
-      </a>
-    </div>
+    <a
+      class="relation-row--grid-id"
+      uiSref="work-packages.show.tabs"
+      [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
+    >#{{relatedWorkPackage.id}}</a>
 
-    <div class="grid-content medium-3 collapse wp-relations-status-field">
-      <edit-form *ngIf="relatedWorkPackage" [resource]="relatedWorkPackage">
-        <op-editable-attribute-field [resource]="relatedWorkPackage" fieldName="status"></op-editable-attribute-field>
-      </edit-form>
-    </div>
+    <a
+      class="relation-row--grid-subject"
+      uiSref="work-packages.show.tabs"
+      [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
+      [textContent]="relatedWorkPackage.subject"
+      [attr.aria-label]="normalizedRelationType + ' ' + relatedWorkPackage.subjectWithId(0)"
+    ></a>
 
-    <div class="grid-content medium-2 collapse wp-relations-controls-section"
-         ng-class="{'-expanded': userInputs.showRelationInfo }">
+    <edit-form *ngIf="relatedWorkPackage" [resource]="relatedWorkPackage">
+      <op-editable-attribute-field [resource]="relatedWorkPackage" fieldName="status"></op-editable-attribute-field>
+    </edit-form>
+
+    <div
+      class="relation-row--grid-actions"
+    >
       <button
         type="button"
         class="spot-link wp-relations--description-btn"
@@ -58,8 +73,10 @@
         [title]="text.description_label"
         (click)="userInputs.showRelationInfo = !userInputs.showRelationInfo"
       >
-        <op-icon icon-classes="icon-info1 icon-no-color -padded wp-relations--icon wp-relations--description-icon"
-                 [icon-title]="text.toggleDescription"></op-icon>
+        <op-icon
+          icon-classes="icon-info1 icon-no-color -padded wp-relations--icon wp-relations--description-icon"
+          [icon-title]="text.toggleDescription"
+        ></op-icon>
       </button>
       <button
         *ngIf="!!relation.delete"
@@ -69,14 +86,18 @@
         [title]="text.removeButton"
         (click)="removeRelation()"
       >
-        <op-icon icon-classes="icon-remove icon-no-color -padded wp-relations--icon"
-                 [icon-title]="text.removeButton"></op-icon>
+        <op-icon
+          icon-classes="icon-remove icon-no-color -padded wp-relations--icon"
+          [icon-title]="text.removeButton"
+        ></op-icon>
       </button>
     </div>
   </div>
 
-  <div class="grid-block hierarchy-item description-container"
-       *ngIf="userInputs.showRelationInfo">
+  <div
+    *ngIf="userInputs.showRelationInfo"
+    class="grid-block hierarchy-item description-container"
+  >
     <button
       *ngIf="!userInputs.showDescriptionEditForm"
       type="button"
@@ -84,23 +105,26 @@
       [class.-placeholder]="!relation.description"
       (click)="startDescriptionEdit()"
       [textContent]="relation.description || text.placeholder.description"
+    ></button>
+    <div
+      class="wp-relation--description-wrapper textarea-wrapper"
+      *ngIf="userInputs.showDescriptionEditForm"
     >
-    </button>
-    <div class="wp-relation--description-wrapper textarea-wrapper"
-         *ngIf="userInputs.showDescriptionEditForm">
-          <textarea
-            #relationDescriptionTextarea
-            autofocus
-            class="wp-relation--description-textarea"
-            name="description"
-            (keyup)="handleDescriptionKey($event)"
-            [(ngModel)]="userInputs.newRelationText"></textarea>
-      <edit-field-controls [fieldController]="fieldController"
-                           (onSave)="saveDescription()"
-                           (onCancel)="cancelDescriptionEdit()"
-                           [saveTitle]="text.save"
-                           [cancelTitle]="text.cancel">
-      </edit-field-controls>
+      <textarea
+        #relationDescriptionTextarea
+        autofocus
+        class="wp-relation--description-textarea"
+        name="description"
+        (keyup)="handleDescriptionKey($event)"
+        [(ngModel)]="userInputs.newRelationText"
+      ></textarea>
+      <edit-field-controls
+        [fieldController]="fieldController"
+        (onSave)="saveDescription()"
+        (onCancel)="cancelDescriptionEdit()"
+        [saveTitle]="text.save"
+        [cancelTitle]="text.cancel"
+      ></edit-field-controls>
     </div>
   </div>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -10,6 +10,7 @@
       <button
         type="button"
         class="relation-row--type"
+        data-qa-selector="op-relation--row-type"
         (click)="activateRelationTypeEdit()"
         *ngIf="!userInputs.showRelationTypesForm"
       >
@@ -47,12 +48,14 @@
 
     <a
       class="relation-row--grid-id"
+      data-qa-selector="op-relation--row-id"
       uiSref="work-packages.show.tabs"
       [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
     >#{{relatedWorkPackage.id}}</a>
 
     <a
       class="relation-row--grid-subject"
+      data-qa-selector="op-relation--row-subject"
       uiSref="work-packages.show.tabs"
       [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
       [textContent]="relatedWorkPackage.subject"

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -22,7 +22,7 @@
 </div>
 
 <div
-  class="content"
+  class="relation-container"
   *ngIf="relatedWorkPackages"
 >
   <wp-relation-row

--- a/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
@@ -64,10 +64,11 @@
   &--grid
     display: grid
     align-items: center
-    grid-template: "info id subject status actions" / 10% 12.5% 45% 22.5% 10%
+    grid-template: "id info subject status actions" / 10% 12.5% 45% 22.5% 10%
+    margin-bottom: $spot-spacing-0_5
 
     @media #{$spot-mq-mobile}
-      grid-template: "info id status actions" "subject subject subject subject" / 30% 25% 30% 15%
+      grid-template: "id info status actions" "subject subject subject subject" / 25% 30% 30% 15%
 
 
     &-actions
@@ -78,10 +79,12 @@
     &-id
       @include text-shortener()
       grid-area: id
+      font-size: 0.875rem
 
     &-subject
       @include text-shortener()
       grid-area: subject
+      font-size: 0.875rem
 
 .wp-relations-hierarchy-section
   margin-top: 35px

--- a/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
@@ -61,6 +61,17 @@
   .controls-container
     text-align: right
 
+  // FIXME: This overrides of `_grid.scss` classes for relations fixes
+  // https://community.openproject.org/projects/openproject/work_packages/44828/activity#activity-17.
+  // But, the grid layout does not work for relations on mobile, nor does it really fit the needs
+  // of the relations component in general.
+  .medium-2
+    flex: 0 0 calc((100% / 12) * 2)
+  .medium-3
+    flex: 0 0 calc((100% / 12) * 3)
+  .medium-5
+    flex: 0 0 calc((100% / 12) * 5)
+
 .wp-relations-hierarchy-section
   margin-top: 35px
 

--- a/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
@@ -28,12 +28,16 @@
 
 .detail-panel-description-content
   .relation
-    clear: both //resolve the problem if inside are elements with float
+    //resolve the problem if inside are elements with float
+    clear: both
+
     h3
       cursor: pointer
+
       a
         text-decoration: none
         color: inherit
+
       i
         font-size: 0.8rem
 
@@ -43,41 +47,44 @@
 .hierarchy-item
   margin-bottom: 2px
 
+.relation-container
+  margin-bottom: $spot-spacing-1
+
 .relation-row
   line-height: 2em
-  .attribute-header
-    font-size: 0.8em
-    text-transform: uppercase
-    font-weight: bold
-  .description-section
-    border: 1px dotted lightblue
-    padding: 4px
+
   .inline-edit--container
     @include text-shortener
     // Similar to inner span's line-height
     line-height: 1.6em
+
     .inline-edit--display-field
       vertical-align: middle
-  .controls-container
-    text-align: right
 
-  // FIXME: This overrides of `_grid.scss` classes for relations fixes
-  // https://community.openproject.org/projects/openproject/work_packages/44828/activity#activity-17.
-  // But, the grid layout does not work for relations on mobile, nor does it really fit the needs
-  // of the relations component in general.
-  .medium-2
-    flex: 0 0 calc((100% / 12) * 2)
-  .medium-3
-    flex: 0 0 calc((100% / 12) * 3)
-  .medium-5
-    flex: 0 0 calc((100% / 12) * 5)
+  &--grid
+    display: grid
+    align-items: center
+    grid-template: "info id subject status actions" / 10% 12.5% 45% 22.5% 10%
+
+    @media #{$spot-mq-mobile}
+      grid-template: "info id status actions" "subject subject subject subject" / 30% 25% 30% 15%
+
+
+    &-actions
+      grid-area: actions
+      display: flex
+      justify-content: end
+
+    &-id
+      @include text-shortener()
+      grid-area: id
+
+    &-subject
+      @include text-shortener()
+      grid-area: subject
 
 .wp-relations-hierarchy-section
   margin-top: 35px
-
-.wp-relations-hierarchy-subject
-  @include text-shortener
-  display: block
 
 .wp-relations-controls-section
   text-align: right
@@ -96,6 +103,7 @@
 .wp-relations-create-button
   margin: 0.25rem 0
   line-height: 1.5
+
   .-create-button-full-width
     margin-top: 1.5em
     width: 100%

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     work_package_page.visit_tab! :relations
     expect_angular_frontend_initialized
     expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
-    expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
+    expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: original_work_package.subject)
   end
 
   describe 'when source work package has an attachment' do
@@ -181,6 +181,6 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     work_package_page.visit_tab!('relations')
     expect_angular_frontend_initialized
     expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
-    expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
+    expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: original_work_package.subject)
   end
 end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -69,14 +69,14 @@ shared_examples 'work package relations tab', js: true, selenium: true do
 
       ##
       # Add child #1
-      relations.openChildrenAutocompleter
+      relations.open_children_autocompleter
 
       relations.add_existing_child(child)
       relations.expect_child(child)
 
       ##
       # Add child #2
-      relations.openChildrenAutocompleter
+      relations.open_children_autocompleter
 
       relations.add_existing_child(child2)
       relations.expect_child(child2)
@@ -240,7 +240,7 @@ shared_examples 'work package relations tab', js: true, selenium: true do
 
           ##
           # Add child
-          relations.openChildrenAutocompleter
+          relations.open_children_autocompleter
 
           relations.add_existing_child(child)
           wp_page.expect_and_dismiss_toaster(message: 'Successful update.')

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -249,7 +249,7 @@ describe 'Work package relations tab', js: true, selenium: true do
 
         # Wait for the relations table to be present
         sleep 2
-        expect(page).to have_selector('.wp-relations--subject-field')
+        expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']")
 
         scroll_to_element find('.detail-panel--relations')
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -48,7 +48,7 @@ module Components
 
       def click_relation(relatable)
         SeleniumHubWaiter.wait
-        page.find(".relation-row-#{relatable.id} .wp-relations--subject-field").click
+        page.find(".relation-row-#{relatable.id} [data-qa-selector='op-relation--row-id']").click
       end
 
       def edit_relation_type(relatable, to_type:)
@@ -63,7 +63,7 @@ module Components
       def hover_action(relatable, action)
         retry_block do
           # Focus type edit to expose buttons
-          span = page.find(".relation-row-#{relatable.id} .relation-row--type", wait: 20)
+          span = page.find(".relation-row-#{relatable.id} [data-qa-selector='op-relation--row-type']", wait: 20)
           scroll_to_element(span)
           page.driver.browser.action.move_to(span.native).perform
 
@@ -96,7 +96,7 @@ module Components
         container = find('.wp-relations-create--form', wait: 10)
 
         # Labels to expect
-        relation_label = I18n.t('js.relation_labels.' + type)
+        relation_label = I18n.t("js.relation_labels.#{type}")
 
         select relation_label, from: 'relation-type--select'
 
@@ -111,9 +111,9 @@ module Components
                                       text: relation_label.upcase,
                                       wait: 10)
 
-        expect(page).to have_selector('.relation-row--type', text: to.type.name.upcase)
+        expect(page).to have_selector("[data-qa-selector='op-relation--row-type']", text: to.type.name.upcase)
 
-        expect(page).to have_selector('.wp-relations--subject-field', text: to.subject)
+        expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: to.subject)
 
         ## Test if relation exist
         work_package.reload
@@ -123,15 +123,15 @@ module Components
       end
 
       def expect_relation(relatable)
-        expect(relations_group).to have_selector('.wp-relations--subject-field', text: relatable.subject)
+        expect(relations_group).to have_selector("[data-qa-selector='op-relation--row-subject']", text: relatable.subject)
       end
 
       def expect_relation_by_text(text)
-        expect(relations_group).to have_selector('.wp-relations--subject-field', text:)
+        expect(relations_group).to have_selector("[data-qa-selector='op-relation--row-subject']", text:)
       end
 
       def expect_no_relation(relatable)
-        expect(page).not_to have_selector('.wp-relations--subject-field', text: relatable.subject)
+        expect(page).not_to have_selector("[data-qa-selector='op-relation--row-subject']", text: relatable.subject)
       end
 
       def add_parent(query, work_package)
@@ -172,7 +172,7 @@ module Components
         subject.update subject_text
       end
 
-      def openChildrenAutocompleter
+      def open_children_autocompleter
         retry_block do
           next if page.has_selector?('.wp-relations--children .ng-input input')
 


### PR DESCRIPTION
- https://community.openproject.org/work_packages/44828

@opf/frontend 
This is a real crap, I'm currently trying to fix styles, that are very global. The grid styles defined in `_grid.scss` are considered to collapse to a normal flexbox on mobile resolutions, but this is not what QA and users expect from the relations tab apparently.

My idea: Write this hack into the `_relations.sass`. And don't touch relations component any further, until we really have some UI/UX how this component really should behave on desktop and mobile resolutions. Opinions? Counter arguments? 

One possible solution for now could be refactoring the relations component into a table, which is horizontally scrollable, like the other entries inside the relations tab. But I cannot really grasp, how much impediments are to be expected.

Update:
We discussed and added the ACs for this bug to the [work package](https://community.openproject.org/work_packages/44828)