### PR TITLE
Disable already selected projects in autocompleter

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -45,7 +45,7 @@ import {
 } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { merge, Observable, of } from 'rxjs';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { ID } from '@datorama/akita';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -191,7 +191,7 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
     value:IProjectAutocompleterData|IProjectAutocompleterData[]|null,
   ) {
     const normalizedValue = (value || []);
-    const arrayedValue = (Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue]).map(p => p.href || p.id);
+    const arrayedValue = (Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue]).map((p) => p.href || p.id);
     return projects.map((project) => {
       const isSelected = !!arrayedValue.find((selected) => selected === this.projectTracker(project));
       return {


### PR DESCRIPTION
Before this fix, projects that were already selected could be selected again in the `op-project-autocompleter` component. By default, ng-select will remove items from the provided list if it finds they have already been selected, but this does not work for our usecase, as it would break the tree view. Instead, this commit makes it so that the list of projects gets updated whenever the value changes, disabling selected projects.

Closes https://community.openproject.org/projects/openproject/work_packages/47074/activity?query_id=3922