### PR TITLE
[#47599] Changes project archive process to only archive active subprojects

### DIFF
--- a/app/contracts/projects/archive_contract.rb
+++ b/app/contracts/projects/archive_contract.rb
@@ -61,8 +61,10 @@ module Projects
       return if errors.present?
 
       subprojects = model.descendants
-      return if subprojects.empty?
-      return if user.allowed_to?(:archive_project, subprojects)
+      # Only active projects are allowed to be archived.
+      active_subprojects = subprojects.select {|p| p.active?}
+      return if active_subprojects.empty?
+      return if user.allowed_to?(:archive_project, active_subprojects)
 
       errors.add :base, :archive_permission_missing_on_subprojects
     end

--- a/app/contracts/projects/archive_contract.rb
+++ b/app/contracts/projects/archive_contract.rb
@@ -60,9 +60,7 @@ module Projects
       # prevent adding another error if there is already one present
       return if errors.present?
 
-      subprojects = model.descendants
-      # Only active projects are allowed to be archived.
-      active_subprojects = subprojects.select(&:active?)
+      active_subprojects = model.active_subprojects
       return if active_subprojects.empty?
       return if user.allowed_to?(:archive_project, active_subprojects)
 

--- a/app/contracts/projects/archive_contract.rb
+++ b/app/contracts/projects/archive_contract.rb
@@ -62,7 +62,7 @@ module Projects
 
       subprojects = model.descendants
       # Only active projects are allowed to be archived.
-      active_subprojects = subprojects.select {|p| p.active?}
+      active_subprojects = subprojects.select(&:active?)
       return if active_subprojects.empty?
       return if user.allowed_to?(:archive_project, active_subprojects)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -342,6 +342,11 @@ class Project < ApplicationRecord
     parents | descendants # Set union
   end
 
+  # Returns an array of active subprojects.
+  def active_subprojects
+    project.descendants.select(&:active)
+  end
+
   class << self
     # builds up a project hierarchy helper structure for use with #project_tree_from_hierarchy
     #

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -344,7 +344,7 @@ class Project < ApplicationRecord
 
   # Returns an array of active subprojects.
   def active_subprojects
-    project.descendants.select(&:active)
+    project.descendants.where(active: true)
   end
 
   class << self

--- a/app/services/projects/archive_service.rb
+++ b/app/services/projects/archive_service.rb
@@ -39,8 +39,8 @@ module Projects
     private
 
     def persist(service_call)
-      archive_project(model) and model.children.each do |child|
-        archive_project(child)
+      archive_project(model) and model.active_subprojects.each do |subproject|
+        archive_project(subproject)
       end
 
       service_call
@@ -48,8 +48,7 @@ module Projects
 
     def archive_project(project)
       # We do not care for validations but want the timestamps to be updated
-      # for the changed models.
-      project.update_attribute(:active, false) if project.active?
+      project.update_attribute(:active, false)
     end
   end
 end

--- a/app/services/projects/archive_service.rb
+++ b/app/services/projects/archive_service.rb
@@ -48,7 +48,8 @@ module Projects
 
     def archive_project(project)
       # We do not care for validations but want the timestamps to be updated
-      project.update_attribute(:active, false)
+      # for the changed models.
+      project.update_attribute(:active, false) if project.active?
     end
   end
 end

--- a/spec/contracts/projects/archive_contract_spec.rb
+++ b/spec/contracts/projects/archive_contract_spec.rb
@@ -72,6 +72,24 @@ describe Projects::ArchiveContract do
 
         include_examples 'contract is valid'
       end
+
+      context 'when some of subprojects are archived but not all' do
+        before do
+          subproject1.update_column(:active, false)
+          create(:member, user: current_user, project: subproject2, roles: [archivist_role])
+        end
+
+        include_examples 'contract is valid'
+      end
+
+      context 'when all of subprojects are archived' do
+        before do
+          subproject1.update_column(:active, false)
+          subproject2.update_column(:active, false)
+        end
+
+        include_examples 'contract is valid'
+      end
     end
 
     include_examples 'contract is valid for active admins and invalid for regular users'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -358,6 +358,27 @@ describe Project do
     end
   end
 
+  describe '#active_subprojects' do
+    subject { root_project.active_subprojects }
+
+    shared_let(:root_project) { create(:project) }
+    shared_let(:parent_project) { create(:project, parent: root_project) }
+    shared_let(:child_project1) { create(:project, parent: parent_project) }
+
+    context 'with an archived subproject' do
+      before do
+        child_project1.active = false
+        child_project1.save
+      end
+
+      it { is_expected.to eq [parent_project] }
+    end
+
+    context 'with all active subprojects' do
+      it { is_expected.to eq [parent_project, child_project1] }
+    end
+  end
+
   describe '#rolled_up_types' do
     let!(:parent) do
       create(:project, types: [parent_type]).tap do |p|

--- a/spec/services/projects/archive_service_spec.rb
+++ b/spec/services/projects/archive_service_spec.rb
@@ -34,14 +34,14 @@ describe Projects::ArchiveService do
   let(:subproject2) { create(:project) }
   let(:subproject3) { create(:project) }
   let(:user) { create(:admin) }
-  let(:instance) { described_class.new(user: user, model: project) }
+  let(:instance) { described_class.new(user:, model: project) }
 
   context 'with project without any subprojects' do
-    it 'should archive the project' do
-      expect(project.reload.archived?).to be_falsey
+    it 'archives the project' do
+      expect(project.reload).not_to be_archived
 
       expect(instance.call).to be_truthy
-      expect(project.reload.archived?).to be_truthy
+      expect(project.reload).to be_archived
     end
   end
 
@@ -52,30 +52,30 @@ describe Projects::ArchiveService do
     end
 
     shared_examples 'when archiving a project' do
-      it 'should archive the project' do
+      it 'archives the project' do
         # Baseline verification.
-        expect(project.reload.archived?).to be_falsey
+        expect(project.reload).not_to be_archived
 
         # Action.
         expect(instance.call).to be_truthy
 
         # Endline verification.
-        expect(project.reload.archived?).to be_truthy
+        expect(project.reload).to be_archived
       end
 
-      it 'should archive all the subprojects' do
+      it 'archives all the subprojects' do
         # Baseline verification.
-        expect(subproject1.reload.archived?).to be_falsey
-        expect(subproject2.reload.archived?).to be_falsey
-        expect(subproject3.reload.archived?).to be_falsey
+        expect(subproject1.reload).not_to be_archived
+        expect(subproject2.reload).not_to be_archived
+        expect(subproject3.reload).not_to be_archived
 
         # Action.
         expect(instance.call).to be_truthy
 
         # Endline verification.
-        expect(subproject1.reload.archived?).to be_truthy
-        expect(subproject2.reload.archived?).to be_truthy
-        expect(subproject3.reload.archived?).to be_truthy
+        expect(subproject1.reload).to be_archived
+        expect(subproject2.reload).to be_archived
+        expect(subproject3.reload).to be_archived
       end
     end
 
@@ -92,7 +92,6 @@ describe Projects::ArchiveService do
 
       include_examples 'when archiving a project'
     end
-
   end
 
   context 'with project having an archived subproject' do
@@ -104,8 +103,8 @@ describe Projects::ArchiveService do
     end
 
     context 'while archiving the project' do
-      it 'should not change timestamp of the already archived subproject' do
-        expect(subproject1.reload.archived?).to be_truthy
+      it 'does not change timestamp of the already archived subproject' do
+        expect(subproject1.reload).to be_archived
         before_timestamp = subproject1.updated_at
 
         expect(instance.call).to be_truthy
@@ -114,8 +113,8 @@ describe Projects::ArchiveService do
         expect(before_timestamp).to eq(after_timestamp)
       end
 
-      it 'should change timestamp of the active subproject' do
-        expect(subproject2.reload.archived?).to be_falsey
+      it 'changes timestamp of the active subproject' do
+        expect(subproject2.reload).not_to be_archived
         before_timestamp = subproject2.updated_at
 
         expect(instance.call).to be_truthy

--- a/spec/services/projects/archive_service_spec.rb
+++ b/spec/services/projects/archive_service_spec.rb
@@ -29,7 +29,6 @@
 require 'spec_helper'
 
 describe Projects::ArchiveService do
-
   let(:project) { create(:project) }
   let(:subproject1) { create(:project) }
   let(:subproject2) { create(:project) }
@@ -54,19 +53,26 @@ describe Projects::ArchiveService do
 
     shared_examples 'when archiving a project' do
       it 'should archive the project' do
+        # Baseline verification.
         expect(project.reload.archived?).to be_falsey
 
+        # Action.
         expect(instance.call).to be_truthy
+
+        # Endline verification.
         expect(project.reload.archived?).to be_truthy
       end
 
       it 'should archive all the subprojects' do
+        # Baseline verification.
         expect(subproject1.reload.archived?).to be_falsey
         expect(subproject2.reload.archived?).to be_falsey
         expect(subproject3.reload.archived?).to be_falsey
 
+        # Action.
         expect(instance.call).to be_truthy
 
+        # Endline verification.
         expect(subproject1.reload.archived?).to be_truthy
         expect(subproject2.reload.archived?).to be_truthy
         expect(subproject3.reload.archived?).to be_truthy
@@ -117,9 +123,6 @@ describe Projects::ArchiveService do
         after_timestamp = subproject2.reload.updated_at
         expect(before_timestamp).not_to eq(after_timestamp)
       end
-
     end
   end
-
-
 end

--- a/spec/services/projects/archive_service_spec.rb
+++ b/spec/services/projects/archive_service_spec.rb
@@ -1,0 +1,125 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Projects::ArchiveService do
+
+  let(:project) { create(:project) }
+  let(:subproject1) { create(:project) }
+  let(:subproject2) { create(:project) }
+  let(:subproject3) { create(:project) }
+  let(:user) { create(:admin) }
+  let(:instance) { described_class.new(user: user, model: project) }
+
+  context 'with project without any subprojects' do
+    it 'should archive the project' do
+      expect(project.reload.archived?).to be_falsey
+
+      expect(instance.call).to be_truthy
+      expect(project.reload.archived?).to be_truthy
+    end
+  end
+
+  context 'with project having subprojects' do
+    before do
+      project.update(children: [subproject1, subproject2, subproject3])
+      project.reload
+    end
+
+    shared_examples 'when archiving a project' do
+      it 'should archive the project' do
+        expect(project.reload.archived?).to be_falsey
+
+        expect(instance.call).to be_truthy
+        expect(project.reload.archived?).to be_truthy
+      end
+
+      it 'should archive all the subprojects' do
+        expect(subproject1.reload.archived?).to be_falsey
+        expect(subproject2.reload.archived?).to be_falsey
+        expect(subproject3.reload.archived?).to be_falsey
+
+        expect(instance.call).to be_truthy
+
+        expect(subproject1.reload.archived?).to be_truthy
+        expect(subproject2.reload.archived?).to be_truthy
+        expect(subproject3.reload.archived?).to be_truthy
+      end
+    end
+
+    include_examples 'when archiving a project'
+
+    context 'with deep nesting' do
+      before do
+        project.update(children: [subproject1])
+        subproject1.update(children: [subproject2])
+        subproject2.update(children: [subproject3])
+        project.reload
+        subproject1.reload
+      end
+
+      include_examples 'when archiving a project'
+    end
+
+  end
+
+  context 'with project having an archived subproject' do
+    let(:subproject1) { create(:project, active: false) }
+
+    before do
+      project.update(children: [subproject1, subproject2, subproject3])
+      project.reload
+    end
+
+    context 'while archiving the project' do
+      it 'should not change timestamp of the already archived subproject' do
+        expect(subproject1.reload.archived?).to be_truthy
+        before_timestamp = subproject1.updated_at
+
+        expect(instance.call).to be_truthy
+
+        after_timestamp = subproject1.reload.updated_at
+        expect(before_timestamp).to eq(after_timestamp)
+      end
+
+      it 'should change timestamp of the active subproject' do
+        expect(subproject2.reload.archived?).to be_falsey
+        before_timestamp = subproject2.updated_at
+
+        expect(instance.call).to be_truthy
+
+        after_timestamp = subproject2.reload.updated_at
+        expect(before_timestamp).not_to eq(after_timestamp)
+      end
+
+    end
+  end
+
+
+end


### PR DESCRIPTION
## Description:

This PR fixes https://community.openproject.org/projects/openproject/work_packages/47599

Currently, archiving a project requires rights to archive the project and subprojects ([ref](https://github.com/opf/openproject/blob/ee61b6d2b3ce9d19ad0a0a08feaf5a123869ec4a/app/contracts/projects/archive_contract.rb#L65)). Also, users are not allowed to take actions on an archive/active=false project. ([ref](https://github.com/opf/openproject/blob/ee61b6d2b3ce9d19ad0a0a08feaf5a123869ec4a/app/services/authorization/user_allowed_service.rb#L82))

Through this PR  we are changing the contracts to allow archiving of a project when the users have the rights to archive the project and **active** subprojects.

## Proof of the changes:
[scrnli_14_04_2023_06-32-17.webm](https://user-images.githubusercontent.com/16653571/231914728-73f38f37-6867-420b-958f-ec70e05711b1.webm)
