### PR TITLE
[docker compose yml fix]: Duplicate YAML merge keys `(<<)` are now rejected from v2.17.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,7 @@ x-op-backend: &backend
   build:
     <<: *build
     target: develop
-  <<: *image
-  <<: *restart_policy
+  <<: [*image, *restart_policy]
   environment:
     LOCAL_DEV_CHECK: "${LOCAL_DEV_CHECK:?The docker-compose file for OpenProject has moved to https://github.com/opf/openproject-deploy}"
     RAILS_ENV: development


### PR DESCRIPTION
`docker compose` v2.17.2 fails with the following syntax error due to go/yaml/v3 update (underlying docker compose config yml parser).

```sh
❯ docker compose version                                                                                             
Docker Compose version v2.17.2
❯ docker compose config
yaml: unmarshal errors:
  line 40: mapping key "<<" already defined at line 39
  line 40: mapping key "<<" already defined at line 39
  line 40: mapping key "<<" already defined at line 39
```

> ["_Duplicate YAML merge keys (<<) are rejected._"](https://docs.docker.com/compose/release-notes/#upgrade-notes)

_See_
https://docs.docker.com/compose/release-notes/#upgrade-notes
https://github.com/docker/compose/issues/10411#issuecomment-1488019350
https://yaml.org/type/merge.html


🥼 _Backwards compatible with v2.16.x_

<details>

```sh
$ bin/docker-compose-v2.16.0 config
name: opf
services:
  backend:
    build:
      context: /home/opf
      dockerfile: ./docker/dev/backend/Dockerfile
      args:
        DEV_GID: "1001"
        DEV_UID: "1000"
      target: develop
    command:
    - run-app
    depends_on:
      cache:
        condition: service_started
      db:
        condition: service_started
    environment:
      DATABASE_URL: postgresql://openproject:openproject@db:5432/openproject
      LOCAL_DEV_CHECK: "1"
      OPENPROJECT_CACHE__MEMCACHE__SERVER: cache:11211
      OPENPROJECT_EDITION: standard
      OPENPROJECT_RAILS__CACHE__STORE: file_store
      OPENPROJECT_RAILS__RELATIVE__URL__ROOT: ""
      RAILS_ENV: development
    image: openproject/dev:latest
    networks:
      network: null
    ports:
    - mode: ingress
      target: 3000
      published: "3000"
      protocol: tcp
    restart: unless-stopped
    stdin_open: true
    tty: true
```

</details>