### PR TITLE
docker dev setup bin compose fixes

### DIFF
--- a/bin/compose
+++ b/bin/compose
@@ -57,12 +57,24 @@ elif [[ "$1" = "setup" ]]; then
 elif [[ "$1" = "reset" ]]; then
   $DOCKER_COMPOSE -f $COMPOSE_FILE down && docker volume rm `docker volume ls -q | grep ${PWD##*/}_`
 elif [[ "$1" = "rspec" ]]; then
-  if ! docker ps | grep ${PWD##*/}_backend-test_1 > /dev/null; then
+  function get-container-name() {
+    name=`docker-compose ps backend-test | tail -n1 | cut -d ' ' -f1`
+
+    if [ "$name" = 'NAME' ]; then
+      return 1;
+    else
+      echo "$name"
+    fi
+  }
+
+  if ! get-container-name > /dev/null; then
     echo "Test backend not running yet. Starting it..."
 
     $DOCKER_COMPOSE -f $COMPOSE_FILE up -d backend-test
 
-    while ! docker logs --since 1m ${PWD##*/}_backend-test_1 | grep "Ready for tests" > /dev/null; do
+    container=`get-container-name`
+
+    while ! docker logs --since 1m $container 2>&1 | grep "Ready for tests" &> /dev/null; do
       sleep 1
       printf "."
     done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ x-op-backend: &backend
     OPENPROJECT_RAILS__CACHE__STORE: file_store
     OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"
     DATABASE_URL: postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@${DB_HOST:-db}:${DB_PORT:-5432}/${DB_DATABASE:-openproject}
-    OPENPROJECT_EDITION: $OPENPROJECT_EDITION
+    OPENPROJECT_EDITION: ${OPENPROJECT_EDITION:-standard}
   volumes:
     - ".:/home/dev/openproject"
     - "opdata:/var/openproject/assets"


### PR DESCRIPTION
Fixes `bin/compose` so that https://www.openproject.org/docs/development/development-environment-docker/#tests works as documented again. Apparently at some point the container name pattern in compose changed from using underscores to dashes. So I generalised the code to be able to deal with any sort of container name which I should've done to begin with.

Also sets a default value for `OPENPROJECT_EDITION` in `docker-compose.yml` so no `.env` file has to be created to get the quickstart running.