### PR TITLE
Add more inclusive language to 2FA settings

### DIFF
--- a/modules/two_factor_authentication/config/locales/en.yml
+++ b/modules/two_factor_authentication/config/locales/en.yml
@@ -70,8 +70,8 @@ en:
       delete_all_are_you_sure: 'Are you sure you want to delete all 2FA devices for this user?'
       button_delete_all_devices: 'Delete registered 2FA devices'
       button_register_mobile_phone_for_user: 'Register mobile phone'
-      text_2fa_enabled: 'Upon every login, this user will be requested to enter a OTP token from his default 2FA device.'
-      text_2fa_disabled: "The user did not set up a 2FA device through his 'My account page'"
+      text_2fa_enabled: 'Upon every login, this user will be requested to enter a OTP token from their default 2FA device.'
+      text_2fa_disabled: "The user did not set up a 2FA device through their 'My account page'"
     upsale:
       title: 'Two-factor authentication'
       description: 'Strenghten the security of your OpenProject instance by offering (or enforcing) two-factor authentification to all project members.'


### PR DESCRIPTION
In admin for 2FA it would display a message saying "his" when it should be "their"