### PR TITLE
Fix project-autocompleter search

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -209,9 +209,11 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
         map((projects) => buildTree(projects)),
         map((projects) => recursiveSort(projects)),
         map((projectTreeItems) => flattenProjectTree(projectTreeItems)),
-        switchMap((projects) => this.valueChange.pipe(
-          map((value) => this.disableSelectedItems(projects, value)),
-        )),
+        switchMap(
+          (projects) => merge(of([]), this.valueChange).pipe(
+            map(() => this.disableSelectedItems(projects, this.value)),
+          ),
+        ),
       );
     }
     return getPaginatedResults<IProject>(
@@ -261,11 +263,8 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
         map((projects) => recursiveSort(projects)),
         map((projectTreeItems) => flattenProjectTree(projectTreeItems)),
         switchMap(
-          (projects) => merge(
-            of([]),
-            this.valueChange,
-          ).pipe(
-            map((value) => this.disableSelectedItems(projects, value)),
+          (projects) => merge(of([]), this.valueChange).pipe(
+            map(() => this.disableSelectedItems(projects, this.value)),
           ),
         ),
       );

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -190,6 +190,10 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
     projects:IProjectAutocompleteItem[],
     value:IProjectAutocompleterData|IProjectAutocompleterData[]|null,
   ) {
+    if (!this.multiple) {
+      return projects;
+    }
+
     const normalizedValue = (value || []);
     const arrayedValue = (Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue]).map((p) => p.href || p.id);
     return projects.map((project) => {

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -74,7 +74,7 @@ module Components::Autocompleter
       text = select_text.presence || query
 
       # click the element to select it
-      target_dropdown.find('.ng-option', text:, match: :first, wait: 15).click
+      target_dropdown.find('.ng-option', text: text, match: :first, wait: 15).click
     end
   end
 end

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -74,7 +74,7 @@ module Components::Autocompleter
       text = select_text.presence || query
 
       # click the element to select it
-      target_dropdown.find('.ng-option', text: text, match: :first, wait: 15).click
+      target_dropdown.find('.ng-option', text:, match: :first, wait: 15).click
     end
   end
 end


### PR DESCRIPTION
After making sure already selected projects in the project-autocompleter could not be selected again, the search itself was broken. This commit fixes that.

Addresses https://community.openproject.org/work_packages/47074/activity#activity-11