### PR TITLE
allow to limit self registration for openid connect providers

### DIFF
--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -104,13 +104,17 @@ module Users
     # Try to register a user with an existsing omniauth connection
     # bypassing regular account registration restrictions
     def register_omniauth_user
-      return if user.identity_url.blank?
+      return if skip_omniauth_user?
 
       user.activate
 
       with_saved_user_result(success_message: I18n.t(:notice_account_registered_and_logged_in)) do
         Rails.logger.info { "User #{user.login} was successfully activated after arriving from omniauth." }
       end
+    end
+
+    def skip_omniauth_user?
+      user.identity_url.blank?
     end
 
     def register_by_email_activation

--- a/docs/installation-and-operations/misc/custom-openid-connect-providers/README.md
+++ b/docs/installation-and-operations/misc/custom-openid-connect-providers/README.md
@@ -145,6 +145,23 @@ OpenProject OIDC integration supports [back-channel logouts](https://openid.net/
 
 On the identity provider side, you need to set `https://<OpenProject host>/auth/<provider>/backchannel-logout`. `<provider>` is the identifier of the OIDC configuration as provided above. 
 
+
+
+#### Respecting self-registration
+
+You can configure OpenProject to restrict which users can register on the system with the [authentication self-registration setting](../authentication-settings)
+
+ By default, users returning from a SAML idP will be automatically created. If you'd like for the SAML integration to respect the configured self-registration option, please use setting `limit_self_registration`:
+
+```ruby
+options = { 
+  # ... other options
+  limit_self_registration: true
+}
+```
+
+
+
 ### Claims
 
 You can also request [claims](https://openid.net/specs/openid-connect-core-1_0-final.html#Claims) for both the id_token and userinfo endpoint.

--- a/docs/system-admin-guide/authentication/authentication-settings/README.md
+++ b/docs/system-admin-guide/authentication/authentication-settings/README.md
@@ -23,6 +23,8 @@ You can adapt the following under the authentication settings:
 
    c) **Automatic account activation** means that a newly registered user will automatically be active.
 
+   **Note:** By default, self-registration is only applied to internal users (logging in with username and password). If you have an identity provider such as LDAP, SAML or OpenID Connect, use the respective settings in their configuration to control which users are applicable for automatic user creation.
+
 3. Define if the **email address should be used as login** name.
 
 4. Define after how many days the **activation email sent to new users will expire**. Afterwards, you will have the possibility to [re-send the activation email](../../users-permissions/users/#resend-user-invitation-via-email) via the user settings.

--- a/docs/system-admin-guide/authentication/openid-providers/README.md
+++ b/docs/system-admin-guide/authentication/openid-providers/README.md
@@ -29,10 +29,9 @@ You can configure the following options.
 2. Optionally enter a **display name**.
 3. Enter the **Identifier**.
 4. Enter the **Secret**.
-5. Press the blue **create** button.
-
-
-
+5. Optionally, if you want to honor the system-wide self-registration setting, enable "Limit self registration".
+When checked, users will be created according to the [self-registration setting](../authentication-settings).
+6. Press the blue **create** button.
 
 
 ## Google Workspace

--- a/docs/system-admin-guide/authentication/saml/README.md
+++ b/docs/system-admin-guide/authentication/saml/README.md
@@ -233,13 +233,13 @@ Be sure to choose the correct indentation and base key. The items below the `sam
 
 In this section, we detail some of the required and optional configuration options for SAML.
 
-**Mandatory: Response signature verification**
+#### 2.1 Mandatory: Response signature verification
 
 SAML responses by identity providers are required to be signed. You can configure this by either specifying the response's certificate fingerprint in `idp_cert_fingerprint` , or by passing the entire PEM-encoded certificate string in `idp_cert` (beware of newlines and formatting the cert, [c.f. the idP certificate options in omniauth-saml](https://github.com/omniauth/omniauth-saml#options))
 
 
 
-**Mandatory: Attribute mapping**
+#### 2.2 Mandatory: Attribute mapping
 
 Use the key `attribute_statements` to provide mappings for attributes returned by the SAML identity provider's response to OpenProject internal attributes. 
 
@@ -291,7 +291,9 @@ default:
         last_name: ['sn']
 ```
 
-**Optional: Setting the attribute format**
+
+
+#### 2.3 Optional: Setting the attribute format
 
 By default, the attributes above will be requested with the format `urn:oasis:names:tc:SAML:2.0:attrname-format:basic`.
 That means the response should contain attribute names 'mail', etc. as configured above.
@@ -327,7 +329,9 @@ default:
         last_name: ['urn:oid:2.5.4.4']
 ```
 
-**Optional: Request signature and Assertion Encryption**
+
+
+#### 2.4 Optional: Request signature and Assertion Encryption
 
 Your identity provider may optionally encrypt the assertion response, however note that with the required use of TLS transport security, in many cases this is not necessary. You may wish to use Assertion Encryption if TLS is terminated before the OpenProject application server (e.g., on the load balancer level).
 
@@ -368,8 +372,24 @@ default:
         digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256'
 ```
 
-
 With request signing enabled, the certificate will be added to the identity provider to validate the signature of the service provider's request.
+
+
+
+#### 2.5. Optional: Restrict who can automatically self-register
+
+You can configure OpenProject to restrict which users can register on the system with the [authentication self-registration setting](../authentication-settings)
+
+ By default, users returning from a SAML idP will be automatically created. If you'd like for the SAML integration to respect the configured self-registration option, please use this setting:
+
+```yml
+default:
+  # <-- other configuration -->
+    mysaml1:
+      # <-- other configuration -->
+      limit_self_registration: true
+```
+
 
 
 ### 3: Restarting the server

--- a/modules/auth_plugins/lib/open_project/auth_plugins/patches.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins/patches.rb
@@ -26,22 +26,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'open_project/plugins'
-
-module OpenProject::AuthPlugins
-  class Engine < ::Rails::Engine
-    engine_name :openproject_auth_plugins
-
-    include OpenProject::Plugins::ActsAsOpEngine
-
-    register 'openproject-auth_plugins',
-             author_url: 'https://www.openproject.org',
-             bundled: true
-
-    patch_with_namespace :Users, :RegisterUserService
-
-    config.to_prepare do
-      OpenProject::AuthPlugins::Hooks
-    end
-  end
+module OpenProject::AuthPlugins::Patches
 end

--- a/modules/auth_plugins/lib/open_project/auth_plugins/patches/register_user_service_patch.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins/patches/register_user_service_patch.rb
@@ -26,22 +26,20 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'open_project/plugins'
+module OpenProject::AuthPlugins::Patches::RegisterUserServicePatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
 
-module OpenProject::AuthPlugins
-  class Engine < ::Rails::Engine
-    engine_name :openproject_auth_plugins
+  module InstanceMethods
+    def skip_omniauth_user?
+      super || limit_self_registration?(user)
+    end
 
-    include OpenProject::Plugins::ActsAsOpEngine
+    def limit_self_registration?(user)
+      provider = user.authentication_provider.downcase
 
-    register 'openproject-auth_plugins',
-             author_url: 'https://www.openproject.org',
-             bundled: true
-
-    patch_with_namespace :Users, :RegisterUserService
-
-    config.to_prepare do
-      OpenProject::AuthPlugins::Hooks
+      OpenProject::Plugins::AuthPlugin.limit_self_registration? provider:
     end
   end
 end

--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -92,6 +92,15 @@ module OpenProject::Plugins
       [camelization, name].compact.first.underscore.to_sym
     end
 
+    ##
+    # Indicates whether or not self registration should be limited for the provider
+    # with the given name.
+    #
+    # @param provider [String] Name of the provider
+    def self.limit_self_registration?(provider:)
+      Hash(find_provider_by_name(provider))[:limit_self_registration]
+    end
+
     def self.warn_unavailable(name)
       RequestStore.fetch("warn_unavailable_auth_#{name}") do
         Rails.logger.warn { "OmniAuth SSO strategy #{name} is only available for Enterprise Editions." }

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -62,11 +62,11 @@ module OpenIDConnect
     end
 
     def create_params
-      params.require(:openid_connect_provider).permit(:name, :display_name, :identifier, :secret)
+      params.require(:openid_connect_provider).permit(:name, :display_name, :identifier, :secret, :limit_self_registration)
     end
 
     def update_params
-      params.require(:openid_connect_provider).permit(:display_name, :identifier, :secret)
+      params.require(:openid_connect_provider).permit(:display_name, :identifier, :secret, :limit_self_registration)
     end
 
     def find_provider

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -21,14 +21,27 @@ module OpenIDConnect
     delegate :scope, to: :omniauth_provider, allow_nil: true
     delegate :to_h, to: :omniauth_provider, allow_nil: false
 
+    ##
+    # Controls whether or not self registration shall be limited for this provider.
+    #
+    # See also:
+    #   - OpenProject::Plugins::AuthPlugin.limit_self_registration?
+    #   - OpenProject::AuthPlugins::Patches::RegisterUserServicePatch
+    attr_reader :limit_self_registration
+
     def initialize(omniauth_provider)
       @omniauth_provider = omniauth_provider
       @errors = ActiveModel::Errors.new(self)
       @display_name = omniauth_provider.to_h[:display_name]
+      @limit_self_registration = initial_value_for_limit_self_registration
     end
 
     def self.initialize_with(params)
-      new(NewProvider.new(params))
+      do_limit = params[:limit_self_registration]
+
+      new(NewProvider.new(params.except(:limit_self_registration))).tap do |p|
+        p.limit_self_registration = String(do_limit).to_bool unless do_limit.nil?
+      end
     end
 
     def new_record?
@@ -39,6 +52,24 @@ module OpenIDConnect
       omniauth_provider.is_a?(OmniAuth::OpenIDConnect::Provider)
     end
 
+    def limit_self_registration?
+      @limit_self_registration
+    end
+
+    def limit_self_registration=(value)
+      @limit_self_registration = value
+    end
+
+    def to_h
+      return {} if omniauth_provider.nil?
+
+      omniauth_provider.to_h.merge(limit_self_registration: limit_self_registration?)
+    end
+
+    def limit_self_registration_default
+      name == "google" # limit by default only for Google since anyone can sign in
+    end
+
     def id
       return nil unless persisted?
 
@@ -46,33 +77,64 @@ module OpenIDConnect
     end
 
     def valid?
-      @errors.add(:name, :invalid) unless ALLOWED_TYPES.include?(name)
+      @errors.add(:name, :invalid) unless type_allowed?(name)
       @errors.add(:identifier, :blank) if identifier.blank?
       @errors.add(:secret, :blank) if secret.blank?
       @errors.none?
     end
 
+    ##
+    # Checks if the provider with the given name is of an allowed type.
+    #
+    # Types can be followed by a period and arbitrary names to add several
+    # providers of the same type. E.g. 'azure', 'azure.dep1', 'azure.dep2'.
+    def type_allowed?(name)
+      ALLOWED_TYPES.any? { |allowed| name =~ /\A#{allowed}(\..+)?\Z/ }
+    end
+
     def save
       return false unless valid?
 
-      config = Setting.plugin_openproject_openid_connect || Hash.new
-      config["providers"] ||= Hash.new
-      config["providers"][name] = omniauth_provider.to_h.stringify_keys
-      Setting.plugin_openproject_openid_connect = config
+      Setting.plugin_openproject_openid_connect = setting_with_provider
+
       true
     end
 
     def destroy
-      config = Setting.plugin_openproject_openid_connect
-      config["providers"] ||= {}
-      config["providers"].delete(name)
-      Setting.plugin_openproject_openid_connect = config
+      Setting.plugin_openproject_openid_connect = setting_without_provider
+
       true
+    end
+
+    def setting_with_provider
+      setting.deep_merge "providers" => { name => to_h.stringify_keys }
+    end
+
+    def setting_without_provider
+      setting.tap do |s|
+        s["providers"].delete name
+      end
+    end
+
+    def setting
+      Hash(Setting.plugin_openproject_openid_connect).tap do |h|
+        h["providers"] ||= Hash.new
+      end
     end
 
     # https://api.rubyonrails.org/classes/ActiveModel/Errors.html
     def read_attribute_for_validation(attr)
       send(attr)
+    end
+
+    private
+
+    def initial_value_for_limit_self_registration
+      if omniauth_provider.configuration&.has_key? :limit_self_registration
+        omniauth_provider.configuration[:limit_self_registration]
+      else
+        limit_self_registration_default
+      end
     end
   end
 end

--- a/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
@@ -22,4 +22,11 @@
   <div class="form--field -required">
     <%= f.text_field :secret, required: true, container_class: '-middle' %>
   </div>
+
+  <div class="form--field">
+    <%= f.check_box :limit_self_registration, required: false, container_class: '-middle' %>
+    <div class="form--field-instructions">
+      <%= I18n.t('openid_connect.setting_instructions.limit_self_registration') %>
+    </div>
+  </div>
 </fieldset>

--- a/modules/openid_connect/config/locales/de.yml
+++ b/modules/openid_connect/config/locales/de.yml
@@ -10,6 +10,7 @@ de:
         identifier: Identifier
         secret: Secret
         scope: Scope
+        limit_self_registration: Selbstregistrierung einschränken
   openid_connect:
     menu_title: OpenID-Provider
     providers:
@@ -20,3 +21,7 @@ de:
       singular: OpenID-Provider
       upsale:
         description: Use existing OpenID credentials with OpenProject for easier access and interoperability with a range of other providers.
+    setting_instructions:
+      limit_self_registration: >
+        Wenn diese Option aktiv ist, können sich neue Nutzer mit diesem OpenID-Provider nur registrieren,
+        wenn die Selbstregistrierungs-Einstellung es erlaubt.

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
         identifier: Identifier
         secret: Secret
         scope: Scope
+        limit_self_registration: Limit self registration
   openid_connect:
     menu_title: OpenID providers
     providers:
@@ -18,3 +19,6 @@ en:
       no_results_table: No providers have been defined yet.
       plural: OpenID providers
       singular: OpenID provider
+    setting_instructions:
+      limit_self_registration: >
+        If enabled users can only register using this provider if the self registration setting allows for it.

--- a/modules/openid_connect/spec/controllers/providers_controller_spec.rb
+++ b/modules/openid_connect/spec/controllers/providers_controller_spec.rb
@@ -204,11 +204,13 @@ describe OpenIDConnect::ProvidersController do
     end
 
     describe '#update' do
-      context 'when found', with_settings: {
-        plugin_openproject_openid_connect: {
-          "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
-        }
-      } do
+      context 'when found' do
+        before do
+          Setting.plugin_openproject_openid_connect = {
+            "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
+          }
+        end
+
         it 'successfully updates the provider configuration' do
           put :update, params: { id: "azure", openid_connect_provider: valid_params.merge(secret: "NEWSECRET") }
           expect(response).to be_redirect
@@ -220,11 +222,13 @@ describe OpenIDConnect::ProvidersController do
     end
 
     describe '#destroy' do
-      context 'when found', with_settings: {
-        plugin_openproject_openid_connect: {
-          "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
-        }
-      } do
+      context 'when found' do
+        before do
+          Setting.plugin_openproject_openid_connect = {
+            "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
+          }
+        end
+
         it 'removes the provider' do
           delete :destroy, params: { id: "azure" }
           expect(response).to be_redirect

--- a/modules/openid_connect/spec/models/provider_spec.rb
+++ b/modules/openid_connect/spec/models/provider_spec.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenIDConnect::Provider do
+  let(:provider) do
+    described_class.initialize_with name: "azure", identifier: "id", secret: "secret"
+  end
+
+  def auth_plugin
+    OpenProject::Plugins::AuthPlugin
+  end
+
+  describe 'limit_self_registration' do
+    before do
+      # required so that the auth plugin sees any providers (ee feature)
+      allow(EnterpriseToken).to receive(:show_banners?).and_return false
+    end
+
+    context 'with no limited providers' do
+      it "shows the provider as unlimited" do
+        expect(auth_plugin).not_to be_limit_self_registration provider: provider.name
+      end
+
+      context 'when set to true' do
+        before do
+          provider.limit_self_registration = true
+        end
+
+        it "saving the provider makes it limited" do
+          provider.save
+
+          expect(auth_plugin).to be_limit_self_registration provider: provider.name
+        end
+      end
+
+      context 'when set to false' do
+        before do
+          provider.limit_self_registration = false
+        end
+
+        it "saving the provider does nothing" do
+          provider.save
+
+          expect(auth_plugin).not_to be_limit_self_registration provider: provider.name
+        end
+      end
+    end
+
+    context(
+      'with a limited provider',
+      with_settings: {
+        plugin_openproject_openid_connect: {
+          "providers" => {
+            "azure" => {
+              "name" => "azure",
+              "identifier" => "id",
+              "secret" => "secret",
+              "limit_self_registration" => true
+            }
+          }
+        }
+      }
+    ) do
+      it "shows the provider as limited" do
+        expect(auth_plugin).to be_limit_self_registration provider: provider.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
WP [#47622](https://community.openproject.org/projects/openproject/work_packages/47622/activity)

This PR simply adds a new checkbox to the OpenID Connect provider configuration.

![image](https://user-images.githubusercontent.com/158871/233096133-b0f88bbb-bf50-41c3-8a1c-12ff7e4f16cd.png)

This is activated by default for Google only. With this checkbox checked users can only register if the self registration setting allows it. Otherwise the setting will be ignored. This is the desired behaviour for AzureAD and most other providers. 