### PR TITLE
feat(onboarding): parameter to start the onboarding tour 

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
@@ -56,7 +56,8 @@ export function detectOnboardingTour():void {
     }
 
     // ------------------------------- Tutorial Homescreen page -------------------------------
-    if (currentTourPart === 'readyToStart') {
+    // start the home onboarding tour (either after the intro modal or by parameter)
+    if (currentTourPart === 'readyToStart' || url.searchParams.get('start_home_onboarding_tour')) {
       void triggerTour('homescreen');
     }
 

--- a/spec/features/onboarding/onboarding_tour_spec.rb
+++ b/spec/features/onboarding/onboarding_tour_spec.rb
@@ -63,6 +63,12 @@ describe 'onboarding tour for new users', js: true do
       expect(page).to have_text "Neueste sichtbare Projekte in dieser Instanz."
     end
 
+    it 'I can start the tour without selecting a language' do
+      visit home_path start_home_onboarding_tour: true
+      expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.welcome')), normalize_ws: true
+      expect(page).to have_selector '.enjoyhint_next_btn:not(.enjoyhint_hide)'
+    end
+
     context 'the tutorial does not start' do
       before do
         allow(Setting).to receive(:welcome_text).and_return("<a> #{project.name} </a>")


### PR DESCRIPTION
...without the language selection dialog but with `start_home_onboarding_tour` (future use e.g. by the trial creation or users with preselected language)
