### PR TITLE
Make seed data strings translatable

### DIFF
--- a/app/seeders/admin_user_seeder.rb
+++ b/app/seeders/admin_user_seeder.rb
@@ -28,7 +28,9 @@
 class AdminUserSeeder < Seeder
   def seed_data!
     user = new_admin
-    unless user.save! validate: false
+    if user.save!(validate: false)
+      seed_data.store_reference(:openproject_admin, user)
+    else
       print_error 'Seeding admin failed:'
       user.errors.full_messages.each do |msg|
         print_error "  #{msg}"
@@ -38,6 +40,10 @@ class AdminUserSeeder < Seeder
 
   def applicable?
     User.not_builtin.admin.empty?
+  end
+
+  def lookup_existing_references
+    seed_data.store_reference(:openproject_admin, User.not_builtin.admin.first)
   end
 
   def not_applicable_message

--- a/app/seeders/basic_data/type_seeder.rb
+++ b/app/seeders/basic_data/type_seeder.rb
@@ -77,8 +77,8 @@ module BasicData
 
       type_data['form_configuration'].each do |form_config_attr|
         groups = type.default_attribute_groups
-        query = find_query_by_name(form_config_attr['query_name'])
-        query_association = "query_#{query}"
+        query = seed_data.find_reference(form_config_attr['query'])
+        query_association = "query_#{query.id}"
         groups.unshift([form_config_attr['group_name'], [query_association.to_sym]])
 
         type.attribute_groups = groups
@@ -92,10 +92,6 @@ module BasicData
     def type_data_for(type)
       types_data = seed_data.lookup('type_configuration') || []
       types_data.find { |entry| I18n.t(entry['type']) == type.name }
-    end
-
-    def find_query_by_name(name)
-      Query.find_by(name:).id
     end
   end
 end

--- a/app/seeders/demo_data/create_attachments.rb
+++ b/app/seeders/demo_data/create_attachments.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module DemoData::CreateAttachments
+  def create_attachments!(container, attributes)
+    Array(attributes['attachments']).each do |file_name|
+      attachment = container.attachments.build
+      attachment.author = user
+      attachment.file = File.new(attachment_path(file_name))
+
+      attachment.save!
+    end
+  end
+
+  def attachment_path(file_name)
+    Rails.root.join(
+      "config/locales/media/en/#{file_name}"
+    )
+  end
+end

--- a/app/seeders/demo_data/global_query_seeder.rb
+++ b/app/seeders/demo_data/global_query_seeder.rb
@@ -37,7 +37,7 @@ module DemoData
 
     def seed_global_queries
       seed_data.each('global_queries') do |config|
-        DemoData::QueryBuilder.new(config, project: nil, user:).create!
+        DemoData::QueryBuilder.new(config, project: nil, user:, seed_data:).create!
       end
     end
   end

--- a/app/seeders/demo_data/overview_seeder.rb
+++ b/app/seeders/demo_data/overview_seeder.rb
@@ -1,6 +1,7 @@
 module DemoData
   class OverviewSeeder < Seeder
-    include ::DemoData::References
+    include CreateAttachments
+    include References
 
     def seed_data!
       print_status "*** Seeding Overview"
@@ -47,22 +48,6 @@ module DemoData
       query_id_references(overview, widget_options)
 
       overview.widgets.build(widget_config.except('attachments'))
-    end
-
-    def create_attachments!(overview, attributes)
-      Array(attributes['attachments']).each do |file_name|
-        attachment = overview.attachments.build
-        attachment.author = user
-        attachment.file = File.new(attachment_path(file_name))
-
-        attachment.save!
-      end
-    end
-
-    def attachment_path(file_name)
-      Rails.root.join(
-        "config/locales/media/#{I18n.locale}/#{file_name}"
-      )
     end
 
     def find_project(project_data)

--- a/app/seeders/demo_data/overview_seeder.rb
+++ b/app/seeders/demo_data/overview_seeder.rb
@@ -83,14 +83,14 @@ module DemoData
 
     def text_with_references(overview, widget_options)
       if widget_options && widget_options['text']
-        widget_options['text'] = with_references(widget_options['text'], overview.project)
+        widget_options['text'] = with_references(widget_options['text'])
         widget_options['text'] = link_attachments(widget_options['text'], overview.attachments)
       end
     end
 
     def query_id_references(overview, widget_options)
       if widget_options && widget_options['queryId']
-        widget_options['queryId'] = with_references(widget_options['queryId'], overview.project)
+        widget_options['queryId'] = with_references(widget_options['queryId'])
       end
     end
 

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -25,77 +25,55 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
+
 module DemoData
   class ProjectSeeder < Seeder
-    # Careful: The seeding recreates the seeded project before it runs, so any changes
-    # on the seeded project will be lost.
+    attr_reader :project
+    alias_method :project_data, :seed_data
+
     def seed_data!
-      print_status ' ↳ Updating settings'
-      seed_settings
-
-      seed_data.each_data('projects') do |project_data|
-        seed_project(project_data)
-        Setting.demo_projects_available = true
-      end
-
-      print_status ' ↳ Update form configuration with global queries'
-      set_form_configuration
-    end
-
-    def seed_project(project_data)
       print_status " ↳ Creating project: #{project_data.lookup('name')}"
 
-      project = reset_project(project_data)
-      set_project_status(project, project_data)
-      set_members(project)
-      seed_news(project, project_data)
-      set_types(project, project_data)
-      seed_categories(project, project_data)
-      seed_versions(project, project_data)
-      seed_queries(project, project_data)
-      seed_project_content(project, project_data)
+      self.project = reset_project
+      set_project_status
+      set_members
+      seed_news
+      set_types
+      seed_categories
+      seed_versions
+      seed_queries
+      seed_project_content
     end
 
-    def applicable?
-      Project.count.zero?
+    # override to add additional seeders
+    def project_content_seeder_classes
+      [
+        DemoData::WikiSeeder,
+        DemoData::WorkPackageSeeder,
+        DemoData::WorkPackageBoardSeeder
+      ]
     end
 
-    def seed_settings
-      seedable_welcome_settings
-        .select { |k,| Settings::Definition[k].writable? }
-        .each do |k, v|
-        Setting[k] = v
-      end
-    end
+    private
 
-    def seedable_welcome_settings
-      welcome = seed_data.lookup('welcome')
-      return {} if welcome.blank?
+    attr_writer :project
 
-      {
-        welcome_title: welcome.lookup('title'),
-        welcome_text: welcome.lookup('text'),
-        welcome_on_homescreen: 1
-      }
-    end
-
-    def reset_project(data)
+    def reset_project
       print_status '   -Creating/Resetting project'
-      delete_project(data)
-      create_project(data)
+      delete_project
+      create_project
     end
 
-    def create_project(project_data)
-      Project.create! project_data(project_data)
+    def delete_project
+      project_to_delete = Project.find_by(identifier: project_data.lookup('identifier'))
+      project_to_delete&.destroy
     end
 
-    def delete_project(data)
-      if delete_me = find_project(data)
-        delete_me.destroy
-      end
+    def create_project
+      Project.create! project_attributes
     end
 
-    def set_project_status(project, project_data)
+    def set_project_status
       print_status '   -Setting project status.'
 
       status_code = project_data.lookup('status.code')
@@ -110,7 +88,7 @@ module DemoData
       end
     end
 
-    def set_members(project)
+    def set_members
       print_status '   -Setting members.'
 
       role = Role.find_by(name: I18n.t(:default_role_project_admin))
@@ -122,13 +100,7 @@ module DemoData
       )
     end
 
-    def set_form_configuration
-      Type.all.each do |type|
-        BasicData::TypeSeeder.new(seed_data).set_attribute_groups_for_type(type)
-      end
-    end
-
-    def set_types(project, project_data)
+    def set_types
       print_status '   -Assigning types.'
 
       project.types.clear
@@ -138,7 +110,7 @@ module DemoData
       end
     end
 
-    def seed_categories(project, project_data)
+    def seed_categories
       print_status '   -Creating categories'
 
       Array(project_data.lookup('categories')).each do |cat_name|
@@ -146,7 +118,7 @@ module DemoData
       end
     end
 
-    def seed_news(project, project_data)
+    def seed_news
       print_status '   -Creating news.'
 
       project_data.each('news') do |news|
@@ -158,7 +130,7 @@ module DemoData
       end
     end
 
-    def seed_queries(project, project_data)
+    def seed_queries
       print_status '   -Creating queries.'
 
       Array(project_data.lookup('queries')).each do |config|
@@ -166,7 +138,7 @@ module DemoData
       end
     end
 
-    def seed_versions(project, project_data)
+    def seed_versions
       print_status '   -Creating versions.'
 
       project_data.each('versions') do |attributes|
@@ -174,7 +146,7 @@ module DemoData
       end
     end
 
-    def seed_project_content(project, project_data)
+    def seed_project_content
       project_content_seeder_classes.each do |seeder_class|
         print_status "   -#{seeder_class.name.demodulize}"
 
@@ -183,41 +155,16 @@ module DemoData
       end
     end
 
-    # override to add additional seeders
-    def project_content_seeder_classes
-      [
-        DemoData::WikiSeeder,
-        DemoData::WorkPackageSeeder,
-        DemoData::WorkPackageBoardSeeder
-      ]
+    def project_attributes
+      parent = Project.find_by(identifier: project_data.lookup('parent'))
+      {
+        name: project_data.lookup('name'),
+        identifier: project_data.lookup('identifier'),
+        description: project_data.lookup('description'),
+        enabled_module_names: project_data.lookup('modules'),
+        types: Type.all,
+        parent:
+      }
     end
-
-    module Data
-      module_function
-
-      def project_data(project_data)
-        {
-          name: project_data.lookup('name'),
-          identifier: project_data.lookup('identifier'),
-          description: project_data.lookup('description'),
-          enabled_module_names: project_data.lookup('modules'),
-          types: Type.all,
-          parent: parent_project(project_data)
-        }
-      end
-
-      def parent_project(project_data)
-        identifier = project_data.lookup('parent')
-        return nil if identifier.blank?
-
-        Project.find_by(identifier:)
-      end
-
-      def find_project(data)
-        Project.find_by(identifier: data.lookup('identifier'))
-      end
-    end
-
-    include Data
   end
 end

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -134,7 +134,7 @@ module DemoData
       print_status '   -Creating queries.'
 
       Array(project_data.lookup('queries')).each do |config|
-        QueryBuilder.new(config, project:, user:).create!
+        QueryBuilder.new(config, project:, user:, seed_data:).create!
       end
     end
 
@@ -142,7 +142,7 @@ module DemoData
       print_status '   -Creating versions.'
 
       project_data.each('versions') do |attributes|
-        VersionBuilder.new(attributes, project:, user:).create!
+        VersionBuilder.new(attributes, project:, user:, seed_data:).create!
       end
     end
 

--- a/app/seeders/demo_data/projects_seeder.rb
+++ b/app/seeders/demo_data/projects_seeder.rb
@@ -1,0 +1,80 @@
+#-- copyright
+
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+module DemoData
+  class ProjectsSeeder < Seeder
+    # Careful: The seeding recreates the seeded project before it runs, so any changes
+    # on the seeded project will be lost.
+    # On the other hand, it won't be applied if there are already existing projects.
+    def seed_data!
+      print_status ' ↳ Updating settings'
+      seed_settings
+
+      seed_data.each_data('projects') do |project_data|
+        seed_project(project_data)
+        Setting.demo_projects_available = true
+      end
+
+      print_status ' ↳ Update form configuration with global queries'
+      set_form_configuration
+    end
+
+    def applicable?
+      Project.count.zero?
+    end
+
+    def seed_settings
+      seedable_welcome_settings
+        .select { |k,| Settings::Definition[k].writable? }
+        .each do |k, v|
+        Setting[k] = v
+      end
+    end
+
+    def seed_project(project_data)
+      project_seeder = ProjectSeeder.new(project_data)
+      project_seeder.seed!
+    end
+
+    def set_form_configuration
+      Type.all.each do |type|
+        BasicData::TypeSeeder.new(seed_data).set_attribute_groups_for_type(type)
+      end
+    end
+
+    def seedable_welcome_settings
+      welcome = seed_data.lookup('welcome')
+      return {} if welcome.blank?
+
+      {
+        welcome_title: welcome.lookup('title'),
+        welcome_text: welcome.lookup('text'),
+        welcome_on_homescreen: 1
+      }
+    end
+  end
+end

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -36,20 +36,12 @@ module DemoData
     end
 
     def create!
-      return unless valid?
-
       create_query.tap do |query|
         seed_data.store_reference(config['reference'], query)
       end
     end
 
     private
-
-    ##
-    # Don't seed queries specific to the backlogs plugin.
-    def valid?
-      backlogs_present? || !columns.include?("story_points")
-    end
 
     def base_attributes
       {
@@ -182,12 +174,6 @@ module DemoData
           values: [assignee.id.to_s]
         }
       end
-    end
-
-    def backlogs_present?
-      @backlogs_present = defined? OpenProject::Backlogs if @backlogs_present.nil?
-
-      @backlogs_present
     end
   end
 end

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -172,17 +172,11 @@ module DemoData
     end
 
     def set_assignee_filter!(filters)
-      users = Array(config[:assignee])
-                .map(&:split)
-                .inject(User.user.none) do |scope, (firstname, lastname)|
-                  scope.or(User.user.where(firstname:, lastname:))
-                end
-                .pluck(:id)
-
-      if users.any?
+      assignee = seed_data.find_reference(config[:assignee])
+      if assignee
         filters[:assigned_to_id] = {
           operator: "=",
-          values: users.map(&:to_s)
+          values: [assignee.id.to_s]
         }
       end
     end

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -133,7 +133,7 @@ module DemoData
       set_version_filter! filters
       set_type_filter! filters
       set_parent_filter! filters
-      set_assignee_filter! filters
+      set_assigned_to_filter! filters
 
       filters
     end
@@ -174,8 +174,8 @@ module DemoData
       end
     end
 
-    def set_assignee_filter!(filters)
-      assignee = seed_data.find_reference(config[:assignee])
+    def set_assigned_to_filter!(filters)
+      assignee = seed_data.find_reference(config[:assigned_to])
       if assignee
         filters[:assigned_to_id] = {
           operator: "=",

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -26,13 +26,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 module DemoData
   class QueryBuilder < ::Seeder
-    attr_reader :config, :project, :user
+    attr_reader :config, :project, :user, :seed_data
 
-    def initialize(config, project:, user:)
+    def initialize(config, project:, user:, seed_data:)
       super()
       @config = config.with_indifferent_access
       @project = project
       @user = user
+      @seed_data = seed_data
     end
 
     def create!
@@ -139,10 +140,11 @@ module DemoData
     end
 
     def set_version_filter!(filters)
-      if version = config[:version].presence
+      version = seed_data.find_reference(config[:version])
+      if version
         filters[:version_id] = {
           operator: "=",
-          values: [Version.find_by(name: version).id]
+          values: [version.id]
         }
       end
     end

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -29,15 +29,18 @@ module DemoData
     attr_reader :config, :project, :user, :seed_data
 
     def initialize(config, project:, user:, seed_data:)
-      super()
+      super(seed_data)
       @config = config.with_indifferent_access
       @project = project
       @user = user
-      @seed_data = seed_data
     end
 
     def create!
-      create_query if valid?
+      return unless valid?
+
+      create_query.tap do |query|
+        seed_data.store_reference(config['reference'], query)
+      end
     end
 
     private

--- a/app/seeders/demo_data/references.rb
+++ b/app/seeders/demo_data/references.rb
@@ -44,20 +44,6 @@ module DemoData
     end
 
     ##
-    # Replaces occurrences of `##child:n` with a link to the given
-    # work package's nth child using the standard OpenProject work package
-    # link syntax `##<id>`.
-    def link_children(str, work_package)
-      return str unless str.present? && str.include?("##child:")
-
-      str.gsub(/##child:\d+/) do |match|
-        index = match.split(":").last.to_i - 1
-
-        "##" + work_package.children[index].id.to_s
-      end
-    end
-
-    ##
     # Links attachments from the given set of attachments, referenced via name.
     # For instance:
     #

--- a/app/seeders/demo_data/references.rb
+++ b/app/seeders/demo_data/references.rb
@@ -86,8 +86,6 @@ module DemoData
     end
 
     def link_sprints(str)
-      return str unless defined? OpenProject::Backlogs
-
       link_references(str, tag: 'sprint')
     end
 

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -28,12 +28,13 @@ module DemoData
   class VersionBuilder
     include ::DemoData::References
 
-    attr_reader :config, :project, :user
+    attr_reader :config, :project, :user, :seed_data
 
-    def initialize(config, project:, user:)
+    def initialize(config, project:, user:, seed_data:)
       @config = config
       @project = project
       @user = user
+      @seed_data = seed_data
     end
 
     def create!
@@ -59,13 +60,16 @@ module DemoData
         sharing: config['sharing'],
         project:
       )
+      seed_data.store_reference(config['reference'], version)
 
-      set_wiki! version, config['wiki'] if config['wiki']
+      set_wiki! version, config['wiki']
 
       version
     end
 
     def set_wiki!(version, config)
+      return unless config
+
       version.wiki_page_title = config['title']
       page = WikiPage.create! wiki: version.project.wiki, title: version.wiki_page_title
 

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -73,7 +73,7 @@ module DemoData
       version.wiki_page_title = config['title']
       page = WikiPage.create! wiki: version.project.wiki, title: version.wiki_page_title
 
-      content = with_references config['content'], project
+      content = with_references config['content']
       Journal::NotificationConfiguration.with false do
         WikiContent.create! page:, author: user, text: content
       end

--- a/app/seeders/demo_data/work_package_board_seeder.rb
+++ b/app/seeders/demo_data/work_package_board_seeder.rb
@@ -27,14 +27,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 module DemoData
   class WorkPackageBoardSeeder < Seeder
-    attr_reader :project, :project_data
+    attr_reader :project
+    alias_method :project_data, :seed_data
 
     include ::DemoData::References
 
     def initialize(project, project_data)
-      super()
+      super(project_data)
       @project = project
-      @project_data = project_data
     end
 
     def seed_data!
@@ -101,7 +101,8 @@ module DemoData
     end
 
     def seed_kanban_board_queries
-      status_names = ['New', 'In progress', 'Closed', 'Rejected']
+      status_keys = %i[default_status_new default_status_in_progress default_status_closed default_status_rejected]
+      status_names = status_keys.map { I18n.t(_1) }
       statuses = Status.where(name: status_names).to_a
 
       if statuses.size < status_names.size
@@ -150,7 +151,7 @@ module DemoData
     end
 
     def seed_basic_board_queries
-      wps = if project.name === 'Scrum project'
+      wps = if project.identifier === 'your-scrum-project'
               scrum_query_work_packages
             else
               basic_query_work_packages
@@ -184,21 +185,21 @@ module DemoData
 
     def scrum_query_work_packages
       [
-        [WorkPackage.find_by(subject: 'New website').id,
-         WorkPackage.find_by(subject: 'SSL certificate').id,
-         WorkPackage.find_by(subject: 'Choose a content management system').id],
-        [WorkPackage.find_by(subject: 'New login screen').id],
-        [WorkPackage.find_by(subject: 'Set-up Staging environment').id],
-        [WorkPackage.find_by(subject: 'Wrong hover color').id]
+        [seed_data.find_reference(:new_website).id,
+         seed_data.find_reference(:ssl_certificate).id,
+         seed_data.find_reference(:choose_content_management_system).id],
+        [seed_data.find_reference(:new_login_screen).id],
+        [seed_data.find_reference(:set_up_staging_environment).id],
+        [seed_data.find_reference(:wrong_hover_color).id]
       ]
     end
 
     def basic_query_work_packages
       [
-        [WorkPackage.find_by(subject: 'Setup conference website').id,
-         WorkPackage.find_by(subject: 'Upload presentations to website').id],
-        [WorkPackage.find_by(subject: 'Invite attendees to conference').id],
-        [WorkPackage.find_by(subject: 'Set date and location of conference').id],
+        [seed_data.find_reference(:setup_conference_website).id,
+         seed_data.find_reference(:upload_presentations_to_website).id],
+        [seed_data.find_reference(:invite_attendees_to_conference).id],
+        [seed_data.find_reference(:set_date_and_location_of_conference).id],
         []
       ]
     end
@@ -228,8 +229,8 @@ module DemoData
     end
 
     def seed_parent_child_board_queries
-      parents = [WorkPackage.find_by(subject: 'Organize open source conference'),
-                 WorkPackage.find_by(subject: 'Follow-up tasks')]
+      parents = [seed_data.find_reference(:organize_open_source_conference),
+                 seed_data.find_reference(:follow_up_tasks)]
 
       parents.map do |parent|
         Query.new_default(project:, user:).tap do |query|

--- a/app/seeders/demo_data/work_package_board_seeder.rb
+++ b/app/seeders/demo_data/work_package_board_seeder.rb
@@ -101,15 +101,12 @@ module DemoData
     end
 
     def seed_kanban_board_queries
-      status_keys = %i[default_status_new default_status_in_progress default_status_closed default_status_rejected]
-      status_names = status_keys.map { I18n.t(_1) }
-      statuses = Status.where(name: status_names).to_a
-
-      if statuses.size < status_names.size
-        raise StandardError.new "Not all statuses needed for seeding a KANBAN board are present. Check that they get seeded."
-      end
-
-      statuses.to_a.map do |status|
+      statuses(
+        'default_status_new',
+        'default_status_in_progress',
+        'default_status_closed',
+        'default_status_rejected'
+      ).map do |status|
         Query.new_default(project:, user:).tap do |query|
           # Make it public so that new members can see it too
           query.public = true
@@ -124,6 +121,17 @@ module DemoData
           query.save!
         end
       end
+    end
+
+    def statuses(*status_i18n_keys)
+      status_names = status_i18n_keys.map { I18n.t(_1) }
+      statuses = Status.where(name: status_names).to_a
+
+      if statuses.size < status_names.size
+        raise StandardError, "Not all statuses needed for seeding a board are present. Check that they got seeded."
+      end
+
+      statuses.to_a
     end
 
     def seed_basic_board(board_data)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -77,7 +77,7 @@ module DemoData
 
       description = work_package.description
       description = link_attachments description, work_package.attachments
-      description = with_references description, project
+      description = with_references description
 
       work_package.update(description:)
 
@@ -113,15 +113,8 @@ module DemoData
       attributes['work_package'] = work_package
     end
 
-    def find_work_package(subject_or_reference)
-      case subject_or_reference
-      when String
-        subject = subject_or_reference
-        WorkPackage.find_by(subject:)
-      when Symbol
-        reference = subject_or_reference
-        seed_data.find_reference(reference)
-      end
+    def find_work_package(reference)
+      seed_data.find_reference(reference)
     end
 
     def find_principal(reference)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -149,10 +149,8 @@ module DemoData
     end
 
     def set_backlogs_attributes!(wp_attr, attributes)
-      if defined? OpenProject::Backlogs
-        wp_attr[:position] = attributes['position'].to_i if attributes['position'].present?
-        wp_attr[:story_points] = attributes['story_points'].to_i if attributes['story_points'].present?
-      end
+      wp_attr[:position] = attributes['position'].presence&.to_i
+      wp_attr[:story_points] = attributes['story_points'].presence&.to_i
     end
 
     def create_attachments!(work_package, attributes)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -148,8 +148,9 @@ module DemoData
     end
 
     def set_version!(wp_attr, attributes)
-      if attributes['version']
-        wp_attr[:version] = Version.find_by!(name: attributes['version'])
+      version = seed_data.find_reference(attributes['version'])
+      if version
+        wp_attr[:version] = version
       end
     end
 

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -26,10 +26,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 module DemoData
   class WorkPackageSeeder < Seeder
+    include CreateAttachments
+    include References
+
     attr_reader :project, :statuses, :repository, :types
     alias_method :project_data, :seed_data
-
-    include ::DemoData::References
 
     def initialize(project, project_data)
       super(project_data)
@@ -151,16 +152,6 @@ module DemoData
     def set_backlogs_attributes!(wp_attr, attributes)
       wp_attr[:position] = attributes['position'].presence&.to_i
       wp_attr[:story_points] = attributes['story_points'].presence&.to_i
-    end
-
-    def create_attachments!(work_package, attributes)
-      Array(attributes['attachments']).each do |file_name|
-        attachment = work_package.attachments.build
-        attachment.author = work_package.author
-        attachment.file = File.new("config/locales/media/en/#{file_name}")
-
-        attachment.save!
-      end
     end
 
     def set_work_package_relations

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -67,7 +67,6 @@ module DemoData
       wp_attr = base_work_package_attributes attributes
 
       set_version! wp_attr, attributes
-      set_accountable! wp_attr, attributes
       set_time_tracking_attributes! wp_attr, attributes
       set_backlogs_attributes! wp_attr, attributes
 
@@ -146,12 +145,6 @@ module DemoData
       version = seed_data.find_reference(attributes['version'])
       if version
         wp_attr[:version] = version
-      end
-    end
-
-    def set_accountable!(wp_attr, attributes)
-      if attributes['accountable']
-        wp_attr[:responsible] = find_principal(attributes['accountable'])
       end
     end
 

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -77,7 +77,6 @@ module DemoData
 
       description = work_package.description
       description = link_attachments description, work_package.attachments
-      description = link_children description, work_package
       description = with_references description, project
 
       work_package.update(description:)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -126,12 +126,8 @@ module DemoData
       end
     end
 
-    def find_principal(lastname)
-      if lastname.present?
-        Principal.find_by!(lastname:)
-      else
-        user
-      end
+    def find_principal(reference)
+      seed_data.find_reference(reference) || user
     end
 
     def find_priority(attributes)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -100,7 +100,7 @@ module DemoData
       {
         project:,
         author: user,
-        assigned_to: find_principal(attributes['assignee']),
+        assigned_to: find_principal(attributes['assigned_to']),
         subject: attributes['subject'],
         description: attributes['description'],
         status: find_status(attributes),
@@ -126,13 +126,12 @@ module DemoData
       end
     end
 
-    def find_principal(name)
-      if name
-        group_assignee = Group.find_by(lastname: name)
-        return group_assignee unless group_assignee.nil?
+    def find_principal(lastname)
+      if lastname.present?
+        Principal.find_by!(lastname:)
+      else
+        user
       end
-
-      user
     end
 
     def find_priority(attributes)

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -29,7 +29,7 @@ class DemoDataSeeder < CompositeSeeder
     [
       DemoData::GroupSeeder,
       DemoData::GlobalQuerySeeder,
-      DemoData::ProjectSeeder,
+      DemoData::ProjectsSeeder,
       DemoData::OverviewSeeder
     ]
   end

--- a/app/seeders/seed_data.rb
+++ b/app/seeders/seed_data.rb
@@ -36,6 +36,9 @@ class SeedData
 
   def store_reference(reference, record)
     return if reference.nil?
+    if registry.key?(reference)
+      raise ArgumentError, "an object with reference #{reference.inspect} is already registered"
+    end
 
     registry[reference] = record
   end

--- a/app/seeders/seed_data.rb
+++ b/app/seeders/seed_data.rb
@@ -29,14 +29,25 @@
 #++
 
 class SeedData
-  def initialize(data)
+  def initialize(data, registry = nil)
     @data = data
+    @registry = registry || {}
+  end
+
+  def store_reference(reference, record)
+    return if reference.nil?
+
+    registry[reference] = record
+  end
+
+  def find_reference(reference)
+    registry.fetch(reference) { raise ArgumentError, "Nothing registered with reference #{reference.inspect}" }
   end
 
   def lookup(path)
     case sub_data = fetch(path)
     when Hash
-      SeedData.new(sub_data)
+      SeedData.new(sub_data, registry)
     else
       sub_data
     end
@@ -58,11 +69,13 @@ class SeedData
     return if sub_data.nil?
 
     sub_data.each_value do |item_data|
-      yield SeedData.new(item_data)
+      yield SeedData.new(item_data, registry)
     end
   end
 
   private
+
+  attr_reader :registry
 
   def fetch(path)
     keys = path.to_s.split('.')

--- a/app/seeders/seed_data.rb
+++ b/app/seeders/seed_data.rb
@@ -30,7 +30,7 @@
 
 class SeedData
   def initialize(data)
-    @data = data.deep_stringify_keys
+    @data = data
   end
 
   def lookup(path)

--- a/app/seeders/seed_data.rb
+++ b/app/seeders/seed_data.rb
@@ -41,6 +41,8 @@ class SeedData
   end
 
   def find_reference(reference)
+    return if reference.nil?
+
     registry.fetch(reference) { raise ArgumentError, "Nothing registered with reference #{reference.inspect}" }
   end
 

--- a/app/seeders/seed_data_loader.rb
+++ b/app/seeders/seed_data_loader.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class SeedDataLoader
+  class << self
+    def get_data(edition: nil)
+      edition ||= OpenProject::Configuration['edition']
+      loader = new(edition:)
+      loader.seed_data
+    end
+  end
+
+  attr_reader :edition, :locale
+
+  def initialize(edition: 'standard', locale: I18n.locale)
+    @edition = edition
+    @locale = locale
+  end
+
+  def seed_data
+    @seed_data ||= SeedData.new(translate(raw_seed_data))
+  end
+
+  def translate(hash, i18n_key = "seeds.#{edition}")
+    translate_translatable_keys(hash, i18n_key)
+    translate_nested_enumerations(hash, i18n_key)
+    hash
+  end
+
+  private
+
+  def translate_translatable_keys(hash, i18n_key)
+    translatable_keys(hash).each do |key|
+      value = hash.delete("t_#{key}")
+      hash[key] = translate_value(value, "#{i18n_key}.#{key}")
+    end
+  end
+
+  def translatable_keys(hash)
+    hash.keys
+      .filter { _1.start_with?('t_') }
+      .map { _1.gsub(/^t_/, '') }
+  end
+
+  def translate_value(value, i18n_key)
+    case value
+    when String
+      I18n.t(i18n_key, locale:, default: value)
+    when Array
+      value.map.with_index { |v, i| translate_value(v, "#{i18n_key}.#{i}") }
+    end
+  end
+
+  def translate_nested_enumerations(hash, i18n_key)
+    hash.each do |key, value|
+      case value
+      when Hash
+        translate(value, "#{i18n_key}.#{key}")
+      when Array
+        value
+          .filter { |v| v.is_a?(Hash) }
+          .each_with_index { |h, i| translate(h, "#{i18n_key}.#{key}.#{i}") }
+      end
+    end
+  end
+
+  def raw_seed_data
+    YAML.load_file(seed_file_path).deep_stringify_keys!
+  end
+
+  def seed_file_path
+    path = edition == 'bim' ? 'modules/bim/app/seeders/bim.yml' : 'app/seeders/standard.yml'
+    Rails.root.join(path)
+  end
+end

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -56,6 +56,7 @@ class Seeder
       end
     else
       Seeder.logger.debug { "   *** #{not_applicable_message}" }
+      lookup_existing_references
     end
   end
 
@@ -66,6 +67,10 @@ class Seeder
   def applicable?
     true
   end
+
+  # Called if the seeding is not applicable to have a chance to lookup
+  # existing records and set some references to them.
+  def lookup_existing_references; end
 
   def not_applicable_message
     "Skipping #{self.class.name}"

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -47,8 +47,6 @@ projects:
       code: on_track
       description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     description: This is a short summary of the goals of this demo project.
-    timeline:
-      name: Timeline
     modules:
       - work_package_tracking
       - news
@@ -306,8 +304,6 @@ projects:
       code: on_track
       description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     description: This is a short summary of the goals of this demo Scrum project.
-    timeline:
-      name: Timeline
     modules:
       - backlogs
       - news

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -105,8 +105,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        # TODO: ref wont be found with another language
-        assignee: OpenProject Admin
+        assignee: :openproject_admin
     boards:
       kanban:
         t_name: 'Kanban board'

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -321,13 +321,16 @@ projects:
         description: This is the news content.
     versions:
       - t_name: Bug Backlog
+        reference: :scrum_project__version__bug_backlog
         sharing: none
         status: open
       - t_name: Product Backlog
+        reference: :scrum_project__version__product_backlog
         sharing: none
         status: open
         start: 15
       - t_name: Sprint 1
+        reference: :scrum_project__version__sprint_1
         sharing: none
         status: open
         start: 4
@@ -355,10 +358,10 @@ projects:
 
             * Short, daily status meeting of the team.
             * Time boxed (max. 15 min).
-            * Stand-up meeting to discuss the following topics from the [Task board](##sprint:"Sprint 1").
+            * Stand-up meeting to discuss the following topics from the [Task board](##sprint:scrum_project__version__sprint_1).
                 * What do I plan to do until the next Daily Scrum?
                 * What has blocked my work (Impediments)?
-            * Scrum Master moderates and notes down [Sprint Impediments](##sprint:"Sprint 1").
+            * Scrum Master moderates and notes down [Sprint Impediments](##sprint:scrum_project__version__sprint_1).
             * Product Owner may participate may participate in order to stay informed.
 
             ### Sprint Review meeting
@@ -402,8 +405,7 @@ projects:
         timeline: true
       - t_name: Product backlog
         status: open
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         group_by: status
         sort_by: status
         columns:
@@ -416,8 +418,7 @@ projects:
           - story_points
       - t_name: Sprint 1
         status: open
-        # TODO: ref wont be found with another language
-        version: Sprint 1
+        version: :scrum_project__version__sprint_1
         hierarchy: true
         columns:
           - id
@@ -467,7 +468,7 @@ projects:
 
               1. *Invite new members to your project*: &rightarrow; Go to [Members]({{opSetting:base_url}}/projects/your-scrum-project/members) in the project navigation.
               2. *View your Product backlog and Sprint backlogs*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) in the project navigation.
-              3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select [Task Board](##sprint:"Sprint 1").
+              3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select [Task Board](##sprint:scrum_project__version__sprint_1).
               4. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
               5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:"Project plan") in the project navigation.
               6. *Create a Sprint wiki*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and open the sprint wiki from the right drop down menu in a sprint. You can edit the [wiki template]({{opSetting:base_url}}/projects/your-scrum-project/wiki/) based on your needs.
@@ -512,14 +513,13 @@ projects:
       - t_subject: New login screen
         status: :default_status_in_specification
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         position: 3
       - t_subject: Password reset does not send email
         status: :default_status_confirmed
         type: :default_type_bug
         # TODO: ref wont be found with another language
-        version: Bug Backlog
+        version: :scrum_project__version__bug_backlog
         position: 1
       - t_subject: New website
         status: :default_status_specified
@@ -530,20 +530,17 @@ projects:
           - t_subject: Newsletter registration form
             status: :default_status_in_progress
             type: :default_type_user_story
-            # TODO: ref wont be found with another language
-            version: Product Backlog
+            version: :scrum_project__version__product_backlog
             position: 6
           - t_subject: Implement product tour
             status: :default_status_in_specification
             type: :default_type_user_story
-            # TODO: ref wont be found with another language
-            version: Product Backlog
+            version: :scrum_project__version__product_backlog
             position: 4
           - t_subject: New landing page
             status: :default_status_specified
             type: :default_type_user_story
-            # TODO: ref wont be found with another language
-            version: Sprint 1
+            version: :scrum_project__version__sprint_1
             position: 2
             story_points: 3
             start: 28
@@ -552,15 +549,13 @@ projects:
               - t_subject: Create wireframes for new landing page
                 status: :default_status_in_progress
                 type: :default_type_task
-                # TODO: ref wont be found with another language
-                version: Sprint 1
+                version: :scrum_project__version__sprint_1
                 start: 28
                 duration: 1
       - t_subject: Contact form
         status: :default_status_specified
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Sprint 1
+        version: :scrum_project__version__sprint_1
         position: 5
         start: 21
         duration: 1
@@ -568,21 +563,18 @@ projects:
       - t_subject: Feature carousel
         status: :default_status_specified
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Sprint 1
+        version: :scrum_project__version__sprint_1
         position: 3
         story_points: 5
         children:
           - t_subject: Make screenshots for feature tour
             status: :default_status_closed
             type: :default_type_task
-            # TODO: ref wont be found with another language
-            version: Sprint 1
+            version: :scrum_project__version__sprint_1
       - t_subject: Wrong hover color
         status: :default_status_rejected
         type: :default_type_bug
-        # TODO: ref wont be found with another language
-        version: Sprint 1
+        version: :scrum_project__version__sprint_1
         position: 4
         story_points: 1
         start: 21
@@ -590,32 +582,28 @@ projects:
       - t_subject: SSL certificate
         status: :default_status_specified
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         position: 1
         start: 22
         duration: 1
       - t_subject: Set-up Staging environment
         status: :default_status_in_specification
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         position: 2
         start: 23
         duration: 1
       - t_subject: Choose a content management system
         status: :default_status_specified
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         position: 7
         start: 24
         duration: 1
       - t_subject: Website navigation structure
         status: :default_status_specified
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Sprint 1
+        version: :scrum_project__version__sprint_1
         position: 7
         story_points: 3
         start: 25
@@ -624,15 +612,13 @@ projects:
           - t_subject: Set up navigation concept for website.
             status: :default_status_in_specification
             type: :default_type_task
-            # TODO: ref wont be found with another language
-            version: Sprint 1
+            version: :scrum_project__version__sprint_1
             start: 25
             duration: 1
       - t_subject: Internal link structure
         status: :default_status_closed
         type: :default_type_user_story
-        # TODO: ref wont be found with another language
-        version: Product Backlog
+        version: :scrum_project__version__product_backlog
         position: 5
         start: 25
         duration: 1

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -149,7 +149,7 @@ projects:
               3. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/demo-project/work_packages/new).
               4. *Create and update a project plan*: &rightarrow; Go to [Project plan]({{opSetting:base_url}}/projects/demo-project/work_packages?query_id=##query.id:"Project plan") in the project navigation.
               5. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/demo-project/settings/modules).
-              6. *Complete your tasks in the project*: &rightarrow; Go to [Work packages &rightarrow; Tasks]({{opSetting:base_url}}/projects/demo-project/work_packages/details/##wp.id:"Set date and location of conference"/overview?query_id=##query.id:"Tasks").
+              6. *Complete your tasks in the project*: &rightarrow; Go to [Work packages &rightarrow; Tasks]({{opSetting:base_url}}/projects/demo-project/work_packages/details/##wp.id:set_date_and_location_of_conference/overview?query_id=##query.id:"Tasks").
 
               Here you will find our [User Guides](https://www.openproject.org/docs/user-guide/).
               Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).
@@ -206,6 +206,7 @@ projects:
         children:
           - start: 0
             t_subject: Set date and location of conference
+            reference: :set_date_and_location_of_conference
             description: ''
             status: default_status_in_progress
             type: default_type_task
@@ -237,8 +238,7 @@ projects:
             type: default_type_task
             duration: 1
             relations:
-              # TODO: ref wont be found with another language
-              - to: Set date and location of conference
+              - to: :set_date_and_location_of_conference
                 type: follows
             schedule_manually: false
           - start: 4
@@ -248,8 +248,7 @@ projects:
             type: default_type_task
             duration: 11
             relations:
-              # TODO: ref wont be found with another language
-              - to: Set date and location of conference
+              - to: :set_date_and_location_of_conference
                 type: follows
             schedule_manually: false
         duration: 15

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -67,6 +67,7 @@ projects:
       - Category 1 (to be changed in Project settings)
     queries:
       - t_name: Project plan
+        reference: :demo_project__query__project_plan
         status: open
         timeline: true
         sort_by: id
@@ -82,6 +83,7 @@ projects:
           - duration
           - assigned_to
       - t_name: Milestones
+        reference: :demo_project__query__milestones
         type: :default_type_milestone
         timeline: true
         columns:
@@ -93,6 +95,7 @@ projects:
           - due_date
         sort_by: id
       - t_name: Tasks
+        reference: :demo_project__query__tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -146,9 +149,9 @@ projects:
               1. *Invite new members to your project*: &rightarrow; Go to [Members]({{opSetting:base_url}}/projects/demo-project/members) in the project navigation.
               2. *View the work in your project*: &rightarrow; Go to [Work packages]({{opSetting:base_url}}/projects/demo-project/work_packages) in the project navigation.
               3. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/demo-project/work_packages/new).
-              4. *Create and update a project plan*: &rightarrow; Go to [Project plan]({{opSetting:base_url}}/projects/demo-project/work_packages?query_id=##query.id:"Project plan") in the project navigation.
+              4. *Create and update a project plan*: &rightarrow; Go to [Project plan]({{opSetting:base_url}}/projects/demo-project/work_packages?query_id=##query.id:demo_project__query__project_plan) in the project navigation.
               5. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/demo-project/settings/modules).
-              6. *Complete your tasks in the project*: &rightarrow; Go to [Work packages &rightarrow; Tasks]({{opSetting:base_url}}/projects/demo-project/work_packages/details/##wp.id:set_date_and_location_of_conference/overview?query_id=##query.id:"Tasks").
+              6. *Complete your tasks in the project*: &rightarrow; Go to [Work packages &rightarrow; Tasks]({{opSetting:base_url}}/projects/demo-project/work_packages/details/##wp.id:set_date_and_location_of_conference/overview?query_id=##query.id:demo_project__query__tasks).
 
               Here you will find our [User Guides](https://www.openproject.org/docs/user-guide/).
               Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).
@@ -183,7 +186,7 @@ projects:
           end_column: 3
           options:
             t_name: 'Milestones'
-            queryId: '##query.id:"Milestones"'
+            queryId: '##query.id:demo_project__query__milestones'
     # For all dates, the reference is the monday of the current week
     # So
     # * start: 0 references Monday
@@ -199,6 +202,7 @@ projects:
         schedule_manually: false
       - start: 0
         t_subject: Organize open source conference
+        reference: :organize_open_source_conference
         description: ''
         status: default_status_in_progress
         type: default_type_phase
@@ -232,6 +236,7 @@ projects:
             schedule_manually: false
           - start: 4
             t_subject: Invite attendees to conference
+            reference: :invite_attendees_to_conference
             description: ''
             status: default_status_new
             type: default_type_task
@@ -242,6 +247,7 @@ projects:
             schedule_manually: false
           - start: 4
             t_subject: Setup conference website
+            reference: :setup_conference_website
             description: ''
             status: default_status_new
             type: default_type_task
@@ -259,7 +265,7 @@ projects:
         type: default_type_milestone
         duration: 1
         relations:
-          - to: Organize open source conference
+          - to: :organize_open_source_conference
             type: follows
         schedule_manually: false
       - start: 21
@@ -271,6 +277,7 @@ projects:
         children:
           - start: 21
             t_subject: Upload presentations to website
+            reference: :upload_presentations_to_website
             description: ''
             status: default_status_new
             type: default_type_task
@@ -396,6 +403,7 @@ projects:
       - Category 1 (to be changed in Project settings)
     queries:
       - t_name: Project plan
+        reference: :scrum_project__query__project_plan
         status: open
         sort_by: id
         type:
@@ -469,7 +477,7 @@ projects:
               2. *View your Product backlog and Sprint backlogs*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) in the project navigation.
               3. *View your Task board*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) &rightarrow; Click on right arrow on Sprint &rightarrow; Select [Task Board](##sprint:scrum_project__version__sprint_1).
               4. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create]({{opSetting:base_url}}/projects/your-scrum-project/work_packages/new).
-              5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:"Project plan") in the project navigation.
+              5. *Create and update a project plan*: &rightarrow; Go to [Project plan](##query:scrum_project__query__project_plan) in the project navigation.
               6. *Create a Sprint wiki*: &rightarrow; Go to [Backlogs]({{opSetting:base_url}}/projects/your-scrum-project/backlogs) and open the sprint wiki from the right drop down menu in a sprint. You can edit the [wiki template]({{opSetting:base_url}}/projects/your-scrum-project/wiki/) based on your needs.
               7. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules]({{opSetting:base_url}}/projects/your-scrum-project/settings/modules).
 
@@ -506,10 +514,10 @@ projects:
           end_column: 3
           options:
             t_name: 'Project plan'
-            # TODO: ref wont be found with another language
-            queryId: '##query.id:"Project plan"'
+            queryId: '##query.id:scrum_project__query__project_plan'
     work_packages:
       - t_subject: New login screen
+        reference: :new_login_screen
         status: :default_status_in_specification
         type: :default_type_user_story
         version: :scrum_project__version__product_backlog
@@ -520,6 +528,7 @@ projects:
         version: :scrum_project__version__bug_backlog
         position: 1
       - t_subject: New website
+        reference: :new_website
         status: :default_status_specified
         type: :default_type_epic
         start: 0
@@ -570,6 +579,7 @@ projects:
             type: :default_type_task
             version: :scrum_project__version__sprint_1
       - t_subject: Wrong hover color
+        reference: :wrong_hover_color
         status: :default_status_rejected
         type: :default_type_bug
         version: :scrum_project__version__sprint_1
@@ -578,6 +588,7 @@ projects:
         start: 21
         duration: 1
       - t_subject: SSL certificate
+        reference: :ssl_certificate
         status: :default_status_specified
         type: :default_type_user_story
         version: :scrum_project__version__product_backlog
@@ -585,6 +596,7 @@ projects:
         start: 22
         duration: 1
       - t_subject: Set-up Staging environment
+        reference: :set_up_staging_environment
         status: :default_status_in_specification
         type: :default_type_user_story
         version: :scrum_project__version__product_backlog
@@ -592,6 +604,7 @@ projects:
         start: 23
         duration: 1
       - t_subject: Choose a content management system
+        reference: :choose_content_management_system
         status: :default_status_specified
         type: :default_type_user_story
         version: :scrum_project__version__product_backlog

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -27,8 +27,8 @@
 #++
 
 welcome:
-  title: "Welcome to OpenProject!"
-  text: |
+  t_title: "Welcome to OpenProject!"
+  t_text: |
     Select one of the demo projects to get started with some demo data we have prepared for you.
 
     * [Demo project]({{opSetting:base_url}}/projects/demo-project): to get an overview about classical project management.
@@ -41,12 +41,12 @@ welcome:
     You can change this welcome text [here]({{opSetting:base_url}}/admin/settings/general).
 projects:
   demo-project:
-    name: Demo project
+    t_name: Demo project
     identifier: demo-project
     status:
       code: on_track
-      description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
-    description: This is a short summary of the goals of this demo project.
+      t_description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
+    t_description: This is a short summary of the goals of this demo project.
     modules:
       - work_package_tracking
       - news
@@ -54,19 +54,19 @@ projects:
       - board_view
       - team_planner_view
     news:
-      - title: Welcome to your demo project
-        summary: >
+      - t_title: Welcome to your demo project
+        t_summary: >
           We are glad you joined.
           In this module you can communicate project news to your team members.
-        description: The actual news
+        t_description: The actual news
     types:
       - :default_type_task
       - :default_type_milestone
       - :default_type_phase
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Project plan
+      - t_name: Project plan
         status: open
         timeline: true
         sort_by: id
@@ -81,7 +81,7 @@ projects:
           - due_date
           - duration
           - assigned_to
-      - name: Milestones
+      - t_name: Milestones
         type: :default_type_milestone
         timeline: true
         columns:
@@ -92,7 +92,7 @@ projects:
           - start_date
           - due_date
         sort_by: id
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -103,18 +103,19 @@ projects:
           - priority
           - status
           - assigned_to
-      - name: Team planner
+      - t_name: Team planner
         module: team_planner
+        # TODO: ref wont be found with another language
         assignee: OpenProject Admin
     boards:
       kanban:
-        name: 'Kanban board'
+        t_name: 'Kanban board'
         filters:
           - type: default_type_task
       basic:
-        name: 'Basic board'
+        t_name: 'Basic board'
       parent_child:
-        name: 'Work breakdown structure'
+        t_name: 'Work breakdown structure'
     project-overview:
       row_count: 6
       column_count: 2
@@ -125,7 +126,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"demo_project_teaser.png")'
           attachments:
             - demo_project_teaser.png
@@ -135,8 +136,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               Discover the most important features with our [Guided Tour]({{opSetting:base_url}}/projects/demo-project/work_packages/?start_onboarding_tour=true).
@@ -175,14 +176,14 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
         - identifier: 'work_packages_table'
           start_row: 6
           end_row: 7
           start_column: 1
           end_column: 3
           options:
-            name: 'Milestones'
+            t_name: 'Milestones'
             queryId: '##query.id:"Milestones"'
     # For all dates, the reference is the monday of the current week
     # So
@@ -191,38 +192,38 @@ projects:
     # * start: -1 references the last Sunday
     work_packages:
       - start: -1
-        subject: Start of project
+        t_subject: Start of project
         description:
         status: default_status_closed
         type: default_type_milestone
         duration: 1
         schedule_manually: false
       - start: 0
-        subject: Organize open source conference
-        description:
+        t_subject: Organize open source conference
+        description: ''
         status: default_status_in_progress
         type: default_type_phase
         children:
           - start: 0
-            subject: Set date and location of conference
+            t_subject: Set date and location of conference
             description: ''
             status: default_status_in_progress
             type: default_type_task
             children:
               - start: 0
-                subject: Send invitation to speakers
+                t_subject: Send invitation to speakers
                 description: ''
                 status: default_status_in_progress
                 type: default_type_task
                 duration: 1
               - start: 0
-                subject: Contact sponsoring partners
+                t_subject: Contact sponsoring partners
                 description: ''
                 status: default_status_new
                 type: default_type_task
                 duration: 2
               - start: 0
-                subject: Create sponsorship brochure and hand-outs
+                t_subject: Create sponsorship brochure and hand-outs
                 description: ''
                 status: default_status_new
                 type: default_type_task
@@ -230,30 +231,32 @@ projects:
             duration: 4
             schedule_manually: false
           - start: 4
-            subject: Invite attendees to conference
+            t_subject: Invite attendees to conference
             description: ''
             status: default_status_new
             type: default_type_task
             duration: 1
             relations:
+              # TODO: ref wont be found with another language
               - to: Set date and location of conference
                 type: follows
             schedule_manually: false
           - start: 4
-            subject: Setup conference website
+            t_subject: Setup conference website
             description: ''
             status: default_status_new
             type: default_type_task
             duration: 11
             relations:
+              # TODO: ref wont be found with another language
               - to: Set date and location of conference
                 type: follows
             schedule_manually: false
         duration: 15
         schedule_manually: true
       - start: 15
-        subject: Conference
-        description:
+        t_subject: Conference
+        description: ''
         status: default_status_scheduled
         type: default_type_milestone
         duration: 1
@@ -262,21 +265,21 @@ projects:
             type: follows
         schedule_manually: false
       - start: 21
-        subject: Follow-up tasks
-        description:
+        t_subject: Follow-up tasks
+        description: ''
         status: default_status_to_be_scheduled
         type: default_type_phase
         children:
           - start: 21
-            subject: Upload presentations to website
+            t_subject: Upload presentations to website
             description: ''
             status: default_status_new
             type: default_type_task
             duration: 10
             schedule_manually: false
           - start: 31
-            subject: Party for conference supporters :-)
-            description: |-
+            t_subject: Party for conference supporters :-)
+            t_description: |-
               *   [ ] Beer
               *   [ ] Snacks
               *   [ ] Music
@@ -288,22 +291,23 @@ projects:
         duration: 11
         schedule_manually: false
       - start: 32
-        subject: End of project
+        t_subject: End of project
         description:
         status: default_status_new
         type: default_type_milestone
         duration: 1
         relations:
+          # TODO: ref wont be found with another language
           - to: Follow-up tasks
             type: follows
         schedule_manually: false
   scrum-project:
-    name: Scrum project
+    t_name: Scrum project
     identifier: your-scrum-project
     status:
       code: on_track
-      description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
-    description: This is a short summary of the goals of this demo Scrum project.
+      t_description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
+    t_description: This is a short summary of the goals of this demo Scrum project.
     modules:
       - backlogs
       - news
@@ -311,27 +315,27 @@ projects:
       - work_package_tracking
       - board_view
     news:
-      - title: Welcome to your Scrum demo project
-        summary: >
+      - t_title: Welcome to your Scrum demo project
+        t_summary: >
           We are glad you joined.
           In this module you can communicate project news to your team members.
         description: This is the news content.
     versions:
-      - name: Bug Backlog
+      - t_name: Bug Backlog
         sharing: none
         status: open
-      - name: Product Backlog
+      - t_name: Product Backlog
         sharing: none
         status: open
         start: 15
-      - name: Sprint 1
+      - t_name: Sprint 1
         sharing: none
         status: open
         start: 4
         duration: 7
         wiki:
-          title: Sprint 1
-          content: |
+          t_title: Sprint 1
+          t_content: |
             ### Sprint planning meeting
 
             _Please document here topics to the Sprint planning meeting_
@@ -377,7 +381,7 @@ projects:
             * Time boxed (3 h).
             * After Sprint Review, will be moderated by Scrum Master.
             * The team discusses the sprint: what went well, what needs to be improved to be more productive for the next sprint or even have more fun.
-      - name: Sprint 2
+      - t_name: Sprint 2
         sharing: none
         status: open
     types:
@@ -387,18 +391,19 @@ projects:
       - :default_type_epic
       - :default_type_user_story
       - :default_type_bug
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Project plan
+      - t_name: Project plan
         status: open
         sort_by: id
         type:
           - :default_type_milestone
           - :default_type_phase
         timeline: true
-      - name: Product backlog
+      - t_name: Product backlog
         status: open
+        # TODO: ref wont be found with another language
         version: Product Backlog
         group_by: status
         sort_by: status
@@ -410,8 +415,9 @@ projects:
           - status
           - assigned_to
           - story_points
-      - name: Sprint 1
+      - t_name: Sprint 1
         status: open
+        # TODO: ref wont be found with another language
         version: Sprint 1
         hierarchy: true
         columns:
@@ -423,15 +429,15 @@ projects:
           - assigned_to
           - done_ratio
           - story_points
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
     boards:
       kanban:
-        name: 'Kanban board'
+        t_name: 'Kanban board'
       basic:
-        name: 'Task board'
+        t_name: 'Task board'
     project-overview:
       row_count: 6
       column_count: 2
@@ -442,7 +448,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"scrum_project_teaser.png")'
           attachments:
             - scrum_project_teaser.png
@@ -452,8 +458,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               Discover the most important features with our [Guided Tour]({{opSetting:base_url}}/projects/your-scrum-project/backlogs?start_scrum_onboarding_tour=true).
@@ -493,167 +499,187 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
         - identifier: 'work_packages_table'
           start_row: 6
           end_row: 7
           start_column: 1
           end_column: 3
           options:
-            name: 'Project plan'
+            t_name: 'Project plan'
+            # TODO: ref wont be found with another language
             queryId: '##query.id:"Project plan"'
     work_packages:
-      - subject: New login screen
+      - t_subject: New login screen
         status: :default_status_in_specification
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Product Backlog
         position: 3
-      - subject: Password reset does not send email
+      - t_subject: Password reset does not send email
         status: :default_status_confirmed
         type: :default_type_bug
+        # TODO: ref wont be found with another language
         version: Bug Backlog
         position: 1
-      - subject: New website
+      - t_subject: New website
         status: :default_status_specified
         type: :default_type_epic
         start: 0
         duration: 29
         children:
-          - subject: Newsletter registration form
+          - t_subject: Newsletter registration form
             status: :default_status_in_progress
             type: :default_type_user_story
+            # TODO: ref wont be found with another language
             version: Product Backlog
             position: 6
-          - subject: Implement product tour
+          - t_subject: Implement product tour
             status: :default_status_in_specification
             type: :default_type_user_story
+            # TODO: ref wont be found with another language
             version: Product Backlog
             position: 4
-          - subject: New landing page
+          - t_subject: New landing page
             status: :default_status_specified
             type: :default_type_user_story
+            # TODO: ref wont be found with another language
             version: Sprint 1
             position: 2
             story_points: 3
             start: 28
             duration: 1
             children:
-              - subject: Create wireframes for new landing page
+              - t_subject: Create wireframes for new landing page
                 status: :default_status_in_progress
                 type: :default_type_task
+                # TODO: ref wont be found with another language
                 version: Sprint 1
                 start: 28
                 duration: 1
-      - subject: Contact form
+      - t_subject: Contact form
         status: :default_status_specified
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Sprint 1
         position: 5
         start: 21
         duration: 1
         story_points: 1
-      - subject: Feature carousel
+      - t_subject: Feature carousel
         status: :default_status_specified
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Sprint 1
         position: 3
         story_points: 5
         children:
-          - subject: Make screenshots for feature tour
+          - t_subject: Make screenshots for feature tour
             status: :default_status_closed
             type: :default_type_task
+            # TODO: ref wont be found with another language
             version: Sprint 1
-      - subject: Wrong hover color
+      - t_subject: Wrong hover color
         status: :default_status_rejected
         type: :default_type_bug
+        # TODO: ref wont be found with another language
         version: Sprint 1
         position: 4
         story_points: 1
         start: 21
         duration: 1
-      - subject: SSL certificate
+      - t_subject: SSL certificate
         status: :default_status_specified
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Product Backlog
         position: 1
         start: 22
         duration: 1
-      - subject: Set-up Staging environment
+      - t_subject: Set-up Staging environment
         status: :default_status_in_specification
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Product Backlog
         position: 2
         start: 23
         duration: 1
-      - subject: Choose a content management system
+      - t_subject: Choose a content management system
         status: :default_status_specified
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Product Backlog
         position: 7
         start: 24
         duration: 1
-      - subject: Website navigation structure
+      - t_subject: Website navigation structure
         status: :default_status_specified
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Sprint 1
         position: 7
         story_points: 3
         start: 25
         duration: 1
         children:
-          - subject: Set up navigation concept for website.
+          - t_subject: Set up navigation concept for website.
             status: :default_status_in_specification
             type: :default_type_task
+            # TODO: ref wont be found with another language
             version: Sprint 1
             start: 25
             duration: 1
-      - subject: Internal link structure
+      - t_subject: Internal link structure
         status: :default_status_closed
         type: :default_type_user_story
+        # TODO: ref wont be found with another language
         version: Product Backlog
         position: 5
         start: 25
         duration: 1
-      - subject: Develop v1.0
+      - t_subject: Develop v1.0
         status: :default_status_in_progress
         type: :default_type_phase
         start: 14
         duration: 3
-      - subject: Release v1.0
+      - t_subject: Release v1.0
         status: :default_status_new
         type: :default_type_milestone
         start: 18
         duration: 1
         relations:
+          # TODO: ref wont be found with another language
           - to: Develop v1.0
             type: follows
-      - subject: Develop v1.1
+      - t_subject: Develop v1.1
         status: :default_status_new
         type: :default_type_phase
         start: 21
         duration: 3
-      - subject: Release v1.1
+      - t_subject: Release v1.1
         status: :default_status_new
         type: :default_type_milestone
         start: 25
         duration: 1
         relations:
+          # TODO: ref wont be found with another language
           - to: Develop v1.1
             type: follows
-      - subject: Develop v2.0
+      - t_subject: Develop v2.0
         status: :default_status_new
         type: :default_type_phase
         start: 28
         duration: 3
-      - subject: Release v2.0
+      - t_subject: Release v2.0
         status: :default_status_new
         type: :default_type_milestone
         start: 32
         duration: 1
         relations:
+          # TODO: ref wont be found with another language
           - to: Develop v2.0
             type: follows
-    wiki: |
+    t_wiki: |
       ### Sprint planning meeting
 
       _Please document here topics to the Sprint planning meeting_

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -108,7 +108,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: :openproject_admin
+        assigned_to: :openproject_admin
     boards:
       kanban:
         t_name: 'Kanban board'

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -264,6 +264,7 @@ projects:
         schedule_manually: false
       - start: 21
         t_subject: Follow-up tasks
+        reference: :follow_up_tasks
         description: ''
         status: default_status_to_be_scheduled
         type: default_type_phase
@@ -295,8 +296,7 @@ projects:
         type: default_type_milestone
         duration: 1
         relations:
-          # TODO: ref wont be found with another language
-          - to: Follow-up tasks
+          - to: :follow_up_tasks
             type: follows
         schedule_manually: false
   scrum-project:
@@ -517,7 +517,6 @@ projects:
       - t_subject: Password reset does not send email
         status: :default_status_confirmed
         type: :default_type_bug
-        # TODO: ref wont be found with another language
         version: :scrum_project__version__bug_backlog
         position: 1
       - t_subject: New website
@@ -622,6 +621,7 @@ projects:
         start: 25
         duration: 1
       - t_subject: Develop v1.0
+        reference: :develop_v1_0
         status: :default_status_in_progress
         type: :default_type_phase
         start: 14
@@ -632,10 +632,10 @@ projects:
         start: 18
         duration: 1
         relations:
-          # TODO: ref wont be found with another language
-          - to: Develop v1.0
+          - to: :develop_v1_0
             type: follows
       - t_subject: Develop v1.1
+        reference: :develop_v1_1
         status: :default_status_new
         type: :default_type_phase
         start: 21
@@ -646,10 +646,10 @@ projects:
         start: 25
         duration: 1
         relations:
-          # TODO: ref wont be found with another language
-          - to: Develop v1.1
+          - to: :develop_v1_1
             type: follows
       - t_subject: Develop v2.0
+        reference: :develop_v2_0
         status: :default_status_new
         type: :default_type_phase
         start: 28
@@ -660,8 +660,7 @@ projects:
         start: 32
         duration: 1
         relations:
-          # TODO: ref wont be found with another language
-          - to: Develop v2.0
+          - to: :develop_v2_0
             type: follows
     t_wiki: |
       ### Sprint planning meeting

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -124,7 +124,7 @@ projects:
           - t_name: 'Short list'
             work_packages:
               - :invite_attendees_to_conference
-          - t_name: 'Prio list for today'
+          - t_name: 'Priority list for today'
             work_packages:
               - :set_date_and_location_of_conference
           - t_name: 'Never'
@@ -467,7 +467,7 @@ projects:
           - t_name: 'Short list'
             work_packages:
               - :new_login_screen
-          - t_name: 'Prio list for today'
+          - t_name: 'Priority list for today'
             work_packages:
               - :set_up_staging_environment
           - t_name: 'Never'

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -116,6 +116,19 @@ projects:
           - type: default_type_task
       basic:
         t_name: 'Basic board'
+        lists:
+          - t_name: 'Wish list'
+            work_packages:
+              - :setup_conference_website
+              - :upload_presentations_to_website
+          - t_name: 'Short list'
+            work_packages:
+              - :invite_attendees_to_conference
+          - t_name: 'Prio list for today'
+            work_packages:
+              - :set_date_and_location_of_conference
+          - t_name: 'Never'
+            work_packages: []
       parent_child:
         t_name: 'Work breakdown structure'
     project-overview:
@@ -445,6 +458,22 @@ projects:
         t_name: 'Kanban board'
       basic:
         t_name: 'Task board'
+        lists:
+          - t_name: 'Wish list'
+            work_packages:
+              - :new_website
+              - :ssl_certificate
+              - :choose_content_management_system
+          - t_name: 'Short list'
+            work_packages:
+              - :new_login_screen
+          - t_name: 'Prio list for today'
+            work_packages:
+              - :set_up_staging_environment
+          - t_name: 'Never'
+            work_packages:
+              - :wrong_hover_color
+
     project-overview:
       row_count: 6
       column_count: 2

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -98,7 +98,7 @@ en:
                 description: |
                   Please execute the related tasks:
 
-                  * ##child:1
+                  * ##wp:wp__create_a_new_project
                 status: :default_status_new
                 type: :default_type_task
                 priority: :default_priority_high
@@ -108,6 +108,7 @@ en:
                 assignee: 'Project Admins'
                 children:
                   - subject: Create a new project
+                    reference: :wp__create_a_new_project
                     description: |
                       Please [create a new project]({{opSetting:base_url}}/projects/new) from the project drop down menu in the left hand header navigation.
                     status: :default_status_in_progress

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -121,7 +121,6 @@ en:
                 type: :default_type_phase
                 start: 7
                 duration: 17
-                accountable: 'Project Admins'
                 relations:
                   - to: Project planning
                     type: follows

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -61,8 +61,6 @@ en:
             description: >
               **This is a demo project**. You can edit the description in
               the [Project settings -> Description]({{opSetting:base_url}}/projects/demo-project/settings).
-            timeline:
-              name: Timeline
             modules:
               - work_package_tracking
               - news

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_seeder_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_seeder_patch.rb
@@ -32,7 +32,7 @@ module OpenProject::Backlogs::Patches::ProjectSeederPatch
   end
 
   module InstanceMethods
-    def seed_versions(project, project_data)
+    def seed_versions
       super
 
       version_data = Array(project_data.lookup('versions'))

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -49,12 +49,18 @@ type_configuration:
         query: :global_query__children
 groups:
   - t_name: Architects
+    reference: :group__architects
   - t_name: BIM Coordinators
+    reference: :group__bim_coordinators
   - t_name: BIM Managers
+    reference: :group__bim_managers
   - t_name: BIM Modellers
+    reference: :group__bim_modellers
   - t_name: Lead BIM Coordinators
+    reference: :group__lead_bim_coordinators
   - t_name: MEP Engineers
   - t_name: Planners
+    reference: :group__planners
   - t_name: Structural Engineers
 welcome:
   t_title: "Welcome to OpenProject BIM edition!"
@@ -114,6 +120,7 @@ projects:
           - duration
           - assigned_to
       - t_name: Milestones
+        reference: :demo_construction_project__query__milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -215,8 +222,7 @@ projects:
           end_column: 3
           options:
             t_name: 'Milestones'
-            # TODO: ref wont be found with another language
-            queryId: '##query.id:"Milestones"'
+            queryId: '##query.id:demo_construction_project__query__milestones'
     work_packages: []
   demo-planning-constructing-project:
     t_name: (Demo) Planning & constructing
@@ -260,6 +266,7 @@ projects:
           - due_date
           - duration
       - t_name: Milestones
+        reference: :demo_planning_constructing_project__query__milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -354,7 +361,7 @@ projects:
           end_column: 3
           options:
             t_name: 'Milestones'
-            queryId: '##query.id:"Milestones"'
+            queryId: '##query.id:demo_planning_constructing_project__query__milestones'
     work_packages:
       - :start: 4
         :t_subject: Project kick off construction project
@@ -365,8 +372,7 @@ projects:
           The next step could be checking out the timetable and adjusting the appointments, by looking at the [Gantt chart]({{opSetting:base_url}}/projects/demo-construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 1
       - :start: 7
         :t_subject: Basic evaluation
@@ -391,8 +397,7 @@ projects:
               *   Derive the cost estimation and time frame
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 4
           - :start: 14
             :t_subject: Summarize the results
@@ -412,8 +417,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 4
             :relations:
               - :to: :gathering_first_project_information
@@ -425,13 +429,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 1
             :relations:
               - :to: :summarize_the_results
                 :type: follows
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 14
         :relations:
           - :to: :project_kick_off_construction_project
@@ -461,8 +464,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 10
             :relations:
               - :to: :end_of_basic_evaluation
@@ -485,13 +487,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 4
             :relations:
               - :to: :developing_first_draft
                 :type: follows
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 17
       - :start: 42
         :t_subject: Passing of preliminary planning
@@ -500,8 +501,7 @@ projects:
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 1
         :relations:
           - :to: :summarize_results
@@ -530,8 +530,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 45
             :relations:
               - :to: :passing_of_preliminary_planning
@@ -543,14 +542,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 1
             :relations:
               - :to: :finishing_design
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 46
       - :start: 98
         :t_subject: Construction phase
@@ -575,8 +572,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 31
           - :start: 130
             :t_subject: Foundation
@@ -593,8 +589,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 25
             :relations:
               - :to: :start_constructing
@@ -616,8 +611,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 46
           - :start: 164
             :t_subject: Finishing the facade
@@ -635,8 +629,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 32
           - :start: 178
             :t_subject: Installing the building service systems
@@ -653,8 +646,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 25
           - :start: 189
             :t_subject: Final touches
@@ -674,8 +666,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 18
           - :start: 208
             :t_subject: House warming party
@@ -695,8 +686,7 @@ projects:
             :relations:
               - :to: :final_touches
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 110
         :relations:
           - :to: :design_freeze
@@ -743,6 +733,7 @@ projects:
           - due_date
           - duration
       - t_name: Milestones
+        reference: :demo_bim_project__query__milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -840,8 +831,7 @@ projects:
           end_column: 3
           options:
             t_name: 'Milestones'
-            # TODO: ref wont be found with another language
-            queryId: '##query.id:"Milestones"'
+            queryId: '##query.id:demo_bim_project__query__milestones'
     work_packages:
       - :start: 14
         :t_subject: Project kick off creating BIM model
@@ -852,8 +842,7 @@ projects:
           The next step could be to check out the timetable and adjusting the appointments, by looking at the [Gantt chart]({{opSetting:base_url}}/projects/demo-bim-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Managers
+        :assigned_to: :group__bim_managers
         :duration: 1
       - :start: 15
         :t_subject: Project preparation
@@ -882,8 +871,7 @@ projects:
                   *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Planners
+            :assigned_to: :group__planners
             :duration: 14
             :relations:
               - :to: :project_kick_off_creating_bim_model
@@ -904,7 +892,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            :assigned_to: Lead BIM Coordinators
+            :assigned_to: :group__lead_bim_coordinators
             :duration: 18
             :relations:
               - :to: :gathering_project_data_and_info
@@ -916,13 +904,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: bim.default_status_resolved
             :type: default_type_milestone
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 1
             :relations:
               - :to: :creating_bim_execution_plan
                 :type: follows
-        # TODO: ref wont be found with another language
-                :assigned_to: BIM Managers
+                :assigned_to: :group__bim_managers
         :duration: 37
       - :start: 53
         :t_subject: End of preparation phase
@@ -931,8 +918,7 @@ projects:
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Managers
+        :assigned_to: :group__bim_managers
         :duration: 1
         :relations:
           - :to: :project_preparation
@@ -960,8 +946,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Modellers
+            :assigned_to: :group__bim_modellers
             :duration: 7
             :relations:
               - :to: :end_of_preparation_phase
@@ -980,8 +965,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: Lead BIM Coordinators
+            :assigned_to: :group__lead_bim_coordinators
             :duration: 2
             :relations:
               - :to: :modelling_initial_bim_model
@@ -993,14 +977,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Modellers
+            :assigned_to: :group__bim_modellers
             :duration: 1
             :relations:
               - :to: :initial_internal_model_check_and_revising
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: Architects
+        :assigned_to: :group__architects
         :duration: 11
         :relations:
           - :to: :completion_of_bim_execution_plan
@@ -1027,8 +1009,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Modellers
+            :assigned_to: :group__bim_modellers
             :duration: 1
             :relations:
               - :to: :submitting_initial_bim_model
@@ -1048,8 +1029,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Modellers
+            :assigned_to: :group__bim_modellers
             :duration: 6
             :relations:
               - :to: :referencing_external_bim_models
@@ -1068,7 +1048,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 1
             :relations:
               - :to: :modelling_of_the_bim_model
@@ -1080,14 +1060,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Modellers
+            :assigned_to: :group__bim_modellers
             :duration: 1
             :relations:
               - :to: :first_cycle_internal_model_check_and_revising
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Coordinators
+        :assigned_to: :group__bim_coordinators
         :duration: 10
         :relations:
           - :to: :submitting_initial_bim_model
@@ -1114,8 +1092,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 3
           - :start: 77
             :t_subject: Issue management, first cycle
@@ -1123,8 +1100,7 @@ projects:
             :description: ''
             :status: default_status_new
             :type: default_type_phase
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 4
           - :start: 82
             :t_subject: Finishing coordination, first cycle
@@ -1133,14 +1109,12 @@ projects:
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: Lead BIM Coordinators
+            :assigned_to: :group__lead_bim_coordinators
             :duration: 1
             :relations:
               - :to: :issue_management_first_cycle
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: Lead BIM Coordinators
+        :assigned_to: :group__lead_bim_coordinators
         :duration: 5
         :relations:
           - :to: :submitting_bim_model
@@ -1151,8 +1125,7 @@ projects:
         :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
-        # TODO: ref wont be found with another language
-        :assigned_to: Lead BIM Coordinators
+        :assigned_to: :group__lead_bim_coordinators
         :duration: 1
         :relations:
           - :to: :finishing_coordination_first_cycle
@@ -1164,8 +1137,7 @@ projects:
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
-        # TODO: ref wont be found with another language
-        :assigned_to: Lead BIM Coordinators
+        :assigned_to: :group__lead_bim_coordinators
         :duration: 1
         :relations:
           - :to: :modelling_and_coordinating_second_cycle
@@ -1176,8 +1148,7 @@ projects:
         :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
-        # TODO: ref wont be found with another language
-        :assigned_to: Lead BIM Coordinators
+        :assigned_to: :group__lead_bim_coordinators
         :duration: 1
         :relations:
           - :to: :modelling_and_coordinating_another_cycle
@@ -1189,8 +1160,7 @@ projects:
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Coordinators
+        :assigned_to: :group__bim_coordinators
         :duration: 1
         :relations:
           - :to: :modelling_and_coordinating_penultimate_cycle
@@ -1202,8 +1172,7 @@ projects:
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Coordinators
+        :assigned_to: :group__bim_coordinators
         :duration: 1
         :relations:
           - :to: :modelling_and_coordinating_last_cycle
@@ -1230,8 +1199,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 5
           - :start: 98
             :t_subject: Construct the building
@@ -1249,8 +1217,7 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 101
           - :start: 200
             :t_subject: Finish construction
@@ -1258,14 +1225,12 @@ projects:
             :description: ''
             :status: default_status_new
             :type: default_type_milestone
-            # TODO: ref wont be found with another language
-            :assigned_to: BIM Coordinators
+            :assigned_to: :group__bim_coordinators
             :duration: 1
             :relations:
               - :to: :construct_building
                 :type: follows
-        # TODO: ref wont be found with another language
-        :assigned_to: BIM Coordinators
+        :assigned_to: :group__bim_coordinators
         :duration: 112
         :relations:
           - :to: :finishing_modelling_and_coordinating
@@ -1276,8 +1241,7 @@ projects:
         :description: ''
         :status: default_status_new
         :type: default_type_phase
-        # TODO: ref wont be found with another language
-        :assigned_to: Planners
+        :assigned_to: :group__planners
         :duration: 88
       - :start: 210
         :t_subject: Handover for Facility Management
@@ -1296,8 +1260,7 @@ projects:
           *   ...
         :status: default_status_new
         :type: default_type_milestone
-        # TODO: ref wont be found with another language
-        :assigned_to: Lead BIM Coordinators
+        :assigned_to: :group__lead_bim_coordinators
         :duration: 1
         :relations:
           - :to: :finish_construction
@@ -1472,82 +1435,82 @@ projects:
     work_packages:
       - :start: 77
         :bcf_issue_uuid: fbbf9ecf-5721-4bf1-a08c-aed50dc19353
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f6271a32-acf5-49f8-a1b5-7c445f9158e5
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f210a2cd-f1f7-4691-b986-2f94117caefe
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: feb97e6e-14fd-4c62-bbad-607f2bb4ebf5
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: 00efc0da-b4d5-4933-bcb6-e01513ee2bcc
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f9e079a8-02f5-40f0-a08a-171f494ee130
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f70417a8-174a-42ae-bf1e-a0b6457d0e6f
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f55d0ec0-9a0f-4222-9926-cc5744888b02
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 4
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fc560c06-51fc-44fa-81b4-e688be189c6a
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fe2f9c1f-631b-4b37-91ea-833c4751725a
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fc5099c0-bedb-4770-a576-0429a7733517
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: 010d9884-8c93-4551-b2bc-570faffe7082
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: febee8e1-1ad2-45e5-b08d-b4be92d25ad6
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f4d71d45-5a2c-4dad-bcb1-8a4935f2ea69
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fb9705ea-b32c-46ff-bb6f-d1d049494e05
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 4
         :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fbe1d941-06ce-45f4-8ccb-ef48b8426f72
-        :assigned_to: BIM Modellers
+        :assigned_to: :group__bim_modellers
         :duration: 3
         :parent: :issue_management_first_cycle
       - :start: 98

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -27,7 +27,7 @@
 #++
 
 global_queries:
-  - name: "Embedded table: Children"
+  - t_name: "Embedded table: Children"
     parent: '{id}'
     timeline: false
     sort_by: id
@@ -44,20 +44,21 @@ global_queries:
 type_configuration:
   - type: :default_type_phase
     form_configuration:
+      # TODO: should they be translated? Or are they refs?
       - group_name: "Children"
         query_name: "Embedded table: Children"
 groups:
-  - name: Architects
-  - name: BIM Coordinators
-  - name: BIM Managers
-  - name: BIM Modellers
-  - name: Lead BIM Coordinators
-  - name: MEP Engineers
-  - name: Planners
-  - name: Structural Engineers
+  - t_name: Architects
+  - t_name: BIM Coordinators
+  - t_name: BIM Managers
+  - t_name: BIM Modellers
+  - t_name: Lead BIM Coordinators
+  - t_name: MEP Engineers
+  - t_name: Planners
+  - t_name: Structural Engineers
 welcome:
-  title: "Welcome to OpenProject BIM edition!"
-  text: |
+  t_title: "Welcome to OpenProject BIM edition!"
+  t_text: |
     Checkout the demo projects to get started with some examples.
 
     * [(Demo) Construction project]({{opSetting:base_url}}/projects/demo-construction-project): Planning, BIM process, BCF management, and constructing, all at a glance.
@@ -72,12 +73,12 @@ welcome:
     You can change this welcome text [here]({{opSetting:base_url}}/admin/settings/general).
 projects:
   demo-construction-project:
-    name: (Demo) Construction project
+    t_name: (Demo) Construction project
     identifier: demo-construction-project
     status:
       code: on_track
-      description: All tasks and the sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
-    description: This is a short summary of the goals of this demo construction project.
+      t_description: All tasks and the sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
+    t_description: This is a short summary of the goals of this demo construction project.
     modules:
       - work_package_tracking
       - news
@@ -85,19 +86,19 @@ projects:
       - board_view
       - team_planner_view
     news:
-      - title: Welcome to your demo project
-        summary: >
+      - t_title: Welcome to your demo project
+        t_summary: >
           We are glad you joined.
           In this module you can communicate project news to your team members.
-        description: The actual news
+        t_description: The actual news
     types:
       - :default_type_task
       - :default_type_milestone
       - :default_type_phase
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Project plan
+      - t_name: Project plan
         status: open
         timeline: true
         sort_by: start_date
@@ -112,7 +113,7 @@ projects:
           - due_date
           - duration
           - assigned_to
-      - name: Milestones
+      - t_name: Milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -124,7 +125,7 @@ projects:
           - start_date
           - due_date
         sort_by: start_date
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -136,12 +137,13 @@ projects:
           - type
           - status
           - assigned_to
-      - name: Team planner
+      - t_name: Team planner
         module: team_planner
+        # TODO: ref wont be found with another language
         assignee: OpenProject Admin
     boards:
       bcf:
-        name: "Simple drag'n drop workflow"
+        t_name: "Simple drag'n drop workflow"
     project-overview:
       row_count: 6
       column_count: 2
@@ -152,7 +154,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"demo_project_teaser_bim.jpg")'
           attachments:
             - demo_project_teaser_bim.jpg
@@ -162,8 +164,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               But before you jump right into it, you should know that this exemplary project is split up into two different projects:
@@ -199,31 +201,32 @@ projects:
           start_column: 2
           end_column: 3
           options:
-            name: 'Members'
+            t_name: 'Members'
         - identifier: 'work_packages_overview'
           start_row: 5
           end_row: 6
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
         - identifier: 'work_packages_table'
           start_row: 6
           end_row: 7
           start_column: 1
           end_column: 3
           options:
-            name: 'Milestones'
+            t_name: 'Milestones'
+            # TODO: ref wont be found with another language
             queryId: '##query.id:"Milestones"'
     work_packages: []
   demo-planning-constructing-project:
-    name: (Demo) Planning & constructing
+    t_name: (Demo) Planning & constructing
     identifier: demo-planning-constructing-project
     status:
       code: on_track
-      description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
+      t_description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-construction-project
-    description: This is a short summary of the goals of this demo planning and constructing project.
+    t_description: This is a short summary of the goals of this demo planning and constructing project.
     modules:
       - work_package_tracking
       - news
@@ -231,19 +234,19 @@ projects:
       - board_view
       - team_planner_view
     news:
-      - title: Welcome to your demo project
-        summary: >
+      - t_title: Welcome to your demo project
+        t_summary: >
           We are glad you joined.
           In this module you can communicate project news to your team members.
-        description: The actual news
+        t_description: The actual news
     types:
       - :default_type_task
       - :default_type_milestone
       - :default_type_phase
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Project plan
+      - t_name: Project plan
         status: open
         timeline: true
         sort_by: start_date
@@ -257,7 +260,7 @@ projects:
           - start_date
           - due_date
           - duration
-      - name: Milestones
+      - t_name: Milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -269,7 +272,7 @@ projects:
           - start_date
           - due_date
         sort_by: start_date
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -281,7 +284,7 @@ projects:
           - type
           - status
           - assigned_to
-      - name: Team planner
+      - t_name: Team planner
         module: team_planner
         assignee: OpenProject Admin
     project-overview:
@@ -294,7 +297,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"demo_project_teaser_bim.jpg")'
           attachments:
             - demo_project_teaser_bim.jpg
@@ -304,8 +307,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               Here you will find the classical roles, some workflows and work packages for your construction project.
@@ -337,43 +340,44 @@ projects:
           start_column: 2
           end_column: 3
           options:
-            name: 'Members'
+            t_name: 'Members'
         - identifier: 'work_packages_overview'
           start_row: 5
           end_row: 6
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
         - identifier: 'work_packages_table'
           start_row: 6
           end_row: 7
           start_column: 1
           end_column: 3
           options:
-            name: 'Milestones'
+            t_name: 'Milestones'
             queryId: '##query.id:"Milestones"'
     work_packages:
       - :start: 4
-        :subject: Project kick off construction project
-        :description: |-
+        :t_subject: Project kick off construction project
+        :t_description: |-
           The project kick off initializes the start of the project in your company. Everybody being part of this project should be invited to the kick off for a first briefing.
 
           The next step could be checking out the timetable and adjusting the appointments, by looking at the [Gantt chart]({{opSetting:base_url}}/projects/demo-construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 1
       - :start: 7
-        :subject: Basic evaluation
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Basic evaluation
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 7
-            :subject: Gathering first project information
-            :description: |-
+            :t_subject: Gathering first project information
+            :t_description: |-
               ## Goal
 
               *   Define tasks based on the customer needs
@@ -386,16 +390,17 @@ projects:
               *   Derive the cost estimation and time frame
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 4
           - :start: 14
-            :subject: Summarize the results
-            :description: |-
+            :t_subject: Summarize the results
+            :t_description: |-
               ## Goal
 
               *   Create a useful overview of the results
               *   Check what has been done and summarize the results
-              *   Communicate all the relevant results with the customer
+              *   Communicate all the relevant results with the customer
               *   Identify the fundamental boundary conditions of the project
 
               ## Description
@@ -405,37 +410,42 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 4
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Gathering first project information
                 :type: follows
           - :start: 21
-            :subject: End of basic evaluation
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: End of basic evaluation
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Summarize the results
                 :type: follows
         :assigned_to: Planners
         :duration: 14
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Project kick off construction project
             :type: follows
       - :start: 22
-        :subject: Preliminary planning
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Preliminary planning
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 22
-            :subject: Developing first draft
-            :description: |-
+            :t_subject: Developing first draft
+            :t_description: |-
               ## Goal
 
               *   Create a useful overview of the results
@@ -450,14 +460,16 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 10
             :relations:
+              # TODO: ref wont be found with another language
               - :to: End of basic evaluation
                 :type: follows
           - :start: 35
-            :subject: Summarize results
-            :description: |-
+            :t_subject: Summarize results
+            :t_description: |-
               ## Goal
 
               *   Create a useful overview of the results
@@ -472,34 +484,38 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 4
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Developing first draft
                 :type: follows
         :assigned_to: Planners
         :duration: 17
       - :start: 42
-        :subject: Passing of preliminary planning
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Passing of preliminary planning
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Summarize results
             :type: follows
       - :start: 44
-        :subject: Design planning
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Design planning
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 44
-            :subject: Finishing design
-            :description: |-
+            :t_subject: Finishing design
+            :t_description: |-
               ## Goal
 
               *   Design is done
@@ -513,33 +529,38 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 45
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Passing of preliminary planning
                 :type: follows
           - :start: 90
-            :subject: Design freeze
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: Design freeze
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Finishing design
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 46
       - :start: 98
-        :subject: Construction phase
+        :t_subject: Construction phase
         :description: ''
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 98
-            :subject: Start constructing
-            :description: |-
+            :t_subject: Start constructing
+            :t_description: |-
               ## Goal
 
               *   Ground breaking ceremony
@@ -553,11 +574,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 31
           - :start: 130
-            :subject: Foundation
-            :description: |-
+            :t_subject: Foundation
+            :t_description: |-
               ## Goal
 
               *   Laying of the foundation stone
@@ -570,14 +592,16 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 25
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Start constructing
                 :type: follows
           - :start: 149
-            :subject: Building construction
-            :description: |-
+            :t_subject: Building construction
+            :t_description: |-
               ## Goal
 
               *   Topping out ceremony
@@ -592,11 +616,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 46
           - :start: 164
-            :subject: Finishing the facade
-            :description: |-
+            :t_subject: Finishing the facade
+            :t_description: |-
               ## Goal
 
               *   Facade is done
@@ -610,11 +635,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 32
           - :start: 178
-            :subject: Installing the building service systems
-            :description: |-
+            :t_subject: Installing the building service systems
+            :t_description: |-
               ## Goal
 
               *   All building service systems are ready to be used
@@ -627,11 +653,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 25
           - :start: 189
-            :subject: Final touches
-            :description: |-
+            :t_subject: Final touches
+            :t_description: |-
               ## Goal
 
               *   Handover of the keys
@@ -646,11 +673,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 18
           - :start: 208
-            :subject: House warming party
-            :description: |-
+            :t_subject: House warming party
+            :t_description: |-
               ## Goal
 
               *   Have a blast!
@@ -666,19 +694,21 @@ projects:
             :relations:
               - :to: Final touches
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 110
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Design freeze
             :type: follows
   demo-bim-project:
-    name: (Demo) BIM project
+    t_name: (Demo) BIM project
     identifier: demo-bim-project
     status:
       code: on_track
-      description: All tasks and sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
+      t_description: All tasks and sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-construction-project
-    description: This is a short summary of the goals of this demo BIM project.
+    t_description: This is a short summary of the goals of this demo BIM project.
     modules:
       - work_package_tracking
       - news
@@ -686,19 +716,19 @@ projects:
       - board_view
       - team_planner_view
     news:
-      - title: Welcome to your demo project
-        summary: >
+      - t_title: Welcome to your demo project
+        t_summary: >
           We are glad you joined.
           In this module you can communicate project news to your team members.
-        description: The actual news
+        t_description: The actual news
     types:
       - :default_type_task
       - :default_type_milestone
       - :default_type_phase
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Project plan
+      - t_name: Project plan
         status: open
         timeline: true
         sort_by: start_date
@@ -712,7 +742,7 @@ projects:
           - start_date
           - due_date
           - duration
-      - name: Milestones
+      - t_name: Milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -724,7 +754,7 @@ projects:
           - start_date
           - due_date
         sort_by: start_date
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -736,7 +766,7 @@ projects:
           - type
           - status
           - assigned_to
-      - name: Team planner
+      - t_name: Team planner
         module: team_planner
         assignee: OpenProject Admin
     project-overview:
@@ -749,7 +779,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"demo_project_teaser_bim.jpg")'
           attachments:
             - demo_project_teaser_bim.jpg
@@ -759,8 +789,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               This demo project offers roles, workflows and work packages that are specialized for BIM.
@@ -795,43 +825,45 @@ projects:
           start_column: 2
           end_column: 3
           options:
-            name: 'Members'
+            t_name: 'Members'
         - identifier: 'work_packages_overview'
           start_row: 5
           end_row: 6
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
         - identifier: 'work_packages_table'
           start_row: 6
           end_row: 7
           start_column: 1
           end_column: 3
           options:
-            name: 'Milestones'
+            t_name: 'Milestones'
+            # TODO: ref wont be found with another language
             queryId: '##query.id:"Milestones"'
     work_packages:
       - :start: 14
-        :subject: Project kick off creating BIM model
-        :description: |-
+        :t_subject: Project kick off creating BIM model
+        :t_description: |-
           The project Kickoff initializes the start of the project in your company. The whole project team should be invited to the Kickoff for a first briefing.
 
           The next step could be to check out the timetable and adjusting the appointments, by looking at the [Gantt chart]({{opSetting:base_url}}/projects/demo-bim-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Managers
         :duration: 1
       - :start: 15
-        :subject: Project preparation
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Project preparation
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 15
-            :subject: Gathering the project specific data and information for the BIM model
-            :description: |-
+            :t_subject: Gathering the project specific data and information for the BIM model
+            :t_description: |-
               ## Goal
 
               *   Identify the information strategy for the customer (e.g. by using plain language questions)
@@ -847,14 +879,15 @@ projects:
                   *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Planners
             :duration: 14
             :relations:
               - :to: Project kick off creating BIM model
                 :type: follows
           - :start: 33
-            :subject: Creating the BIM execution plan
-            :description: |-
+            :t_subject: Creating the BIM execution plan
+            :t_description: |-
               # Goal
 
               *   A BIM execution plan will be defined according to the exchange requirements specifications (ERS)
@@ -873,8 +906,8 @@ projects:
               - :to: Gathering the project specific data and information for the BIM model
                 :type: follows
           - :start: 52
-            :subject: Completion of the BIM execution plan
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: Completion of the BIM execution plan
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: bim.default_status_resolved
             :type: default_type_milestone
@@ -883,29 +916,31 @@ projects:
             :relations:
               - :to: Creating the BIM execution plan
                 :type: follows
-        :assigned_to: BIM Managers
+        # TODO: ref wont be found with another language
+                :assigned_to: BIM Managers
         :duration: 37
       - :start: 53
-        :subject: End of preparation phase
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: End of preparation phase
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Managers
         :duration: 1
         :relations:
           - :to: Project preparation
             :type: follows
       - :start: 54
-        :subject: Creating initial BIM model
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Creating initial BIM model
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 54
-            :subject: Modelling initial BIM model
-            :description: |-
+            :t_subject: Modelling initial BIM model
+            :t_description: |-
               # Goal
 
               *   Modelling the initial BIM model
@@ -918,14 +953,16 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Modellers
             :duration: 7
             :relations:
+              # TODO: ref wont be found with another language
               - :to: End of preparation phase
                 :type: follows
           - :start: 62
-            :subject: Initial, internal model check and revising
-            :description: |-
+            :t_subject: Initial, internal model check and revising
+            :t_description: |-
               # Goal
 
               *   Submitting a BIM model according to the defined standards
@@ -936,37 +973,43 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: Lead BIM Coordinators
             :duration: 2
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Modelling initial BIM model
                 :type: follows
           - :start: 65
-            :subject: Submitting initial BIM model
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: Submitting initial BIM model
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Initial, internal model check and revising
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: Architects
         :duration: 11
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Completion of the BIM execution plan
             :type: follows
       - :start: 66
-        :subject: Modelling, first cycle
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Modelling, first cycle
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 66
-            :subject: Referencing external BIM models
-            :description: |-
+            :t_subject: Referencing external BIM models
+            :t_description: |-
               # Goal
 
               *   Having a foundation for developing the internal model/ offering answers
@@ -978,14 +1021,16 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Submitting initial BIM model
                 :type: follows
           - :start: 67
-            :subject: Modelling the BIM model
-            :description: |-
+            :t_subject: Modelling the BIM model
+            :t_description: |-
               # Goal
 
               *   Creating a BIM model for the project
@@ -997,14 +1042,16 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Modellers
             :duration: 6
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Referencing external BIM models
                 :type: follows
           - :start: 74
-            :subject: First Cycle, internal model check and revising
-            :description: |-
+            :t_subject: First Cycle, internal model check and revising
+            :t_description: |-
               # Goal
 
               *   Submitting a BIM model according to the defined standards
@@ -1021,31 +1068,35 @@ projects:
               - :to: Modelling the BIM model
                 :type: follows
           - :start: 76
-            :subject: Submitting BIM model
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: Submitting BIM model
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: First Cycle, internal model check and revising
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 10
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Submitting initial BIM model
             :type: follows
       - :start: 77
-        :subject: Coordination, first cycle
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Coordination, first cycle
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 77
-            :subject: Coordinate the different BIM models
-            :description: |-
+            :t_subject: Coordinate the different BIM models
+            :t_description: |-
               # Goal
 
               *   Assemble the different BIM models of the whole project team
@@ -1058,93 +1109,109 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Coordinators
             :duration: 3
           - :start: 77
-            :subject: Issue management, first cycle
+            :t_subject: Issue management, first cycle
             :description: ''
             :status: default_status_new
             :type: default_type_phase
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Coordinators
             :duration: 4
           - :start: 82
-            :subject: Finishing coordination, first cycle
-            :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+            :t_subject: Finishing coordination, first cycle
+            :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: Lead BIM Coordinators
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Issue management, first cycle
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 5
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Submitting BIM model
             :type: follows
       - :start: 83
-        :subject: Modelling & coordinating, second cycle
-        :description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
+        :t_subject: Modelling & coordinating, second cycle
+        :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
+        # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Finishing coordination, first cycle
             :type: follows
       - :start: 84
-        :subject: Modelling & coordinating, ... cycle
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Modelling & coordinating, ... cycle
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
+        # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Modelling & coordinating, second cycle
             :type: follows
       - :start: 85
-        :subject: Modelling & coordinating, (n-th minus 1) cycle
-        :description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
+        :t_subject: Modelling & coordinating, (n-th minus 1) cycle
+        :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
+        # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Modelling & coordinating, ... cycle
             :type: follows
       - :start: 86
-        :subject: Modelling & coordinating n-th cycle
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Modelling & coordinating n-th cycle
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_phase
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Modelling & coordinating, (n-th minus 1) cycle
             :type: follows
       - :start: 87
-        :subject: Finishing modelling & coordinating, n-th cycle
-        :description: This type is hierarchically a parent of the types &quot;Clash&quot;
+        :t_subject: Finishing modelling & coordinating, n-th cycle
+        :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Modelling & coordinating n-th cycle
             :type: follows
       - :start: 88
-        :subject: Use model for construction phase
+        :t_subject: Use model for construction phase
         :description: ''
         :status: default_status_new
         :type: default_type_phase
         :children:
           - :start: 88
-            :subject: Handover model for construction crew
-            :description: |-
+            :t_subject: Handover model for construction crew
+            :t_description: |-
               ## Goal
 
               *   Everyone knows the model and their tasks
@@ -1158,11 +1225,12 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Coordinators
             :duration: 5
           - :start: 98
-            :subject: Construct the building
-            :description: |-
+            :t_subject: Construct the building
+            :t_description: |-
               ## Goal
 
               *   New issues realized on construction site will be handled model based
@@ -1175,33 +1243,39 @@ projects:
               *   ...
             :status: default_status_new
             :type: default_type_task
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Coordinators
             :duration: 101
           - :start: 200
-            :subject: Finish construction
+            :t_subject: Finish construction
             :description: ''
             :status: default_status_new
             :type: default_type_milestone
+            # TODO: ref wont be found with another language
             :assigned_to: BIM Coordinators
             :duration: 1
             :relations:
+              # TODO: ref wont be found with another language
               - :to: Construct the building
                 :type: follows
+        # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 112
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Finishing modelling & coordinating, n-th cycle
             :type: follows
       - :start: 98
-        :subject: Issue management, construction phase
+        :t_subject: Issue management, construction phase
         :description: ''
         :status: default_status_new
         :type: default_type_phase
+        # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 88
       - :start: 210
-        :subject: Handover for Facility Management
-        :description: |-
+        :t_subject: Handover for Facility Management
+        :t_description: |-
           ## Goal
 
           *   The BIM model will be used for the Facility Management
@@ -1215,28 +1289,31 @@ projects:
           *   ...
         :status: default_status_new
         :type: default_type_milestone
+        # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Finish construction
             :type: follows
       - :start: 211
-        :subject: Asset Management
-        :description: Enjoy your building :)
+        :t_subject: Asset Management
+        :t_description: Enjoy your building :)
         :status: default_status_new
         :type: default_type_phase
         :duration: 1
         :relations:
+          # TODO: ref wont be found with another language
           - :to: Handover for Facility Management
             :type: follows
   demo-bcf-management-project:
-    name: (Demo) BCF management
+    t_name: (Demo) BCF management
     identifier: demo-bcf-management-project
     status:
       code: on_track
-      description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
+      t_description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-bim-project
-    description: This is a short summary of the goals of this demo BCF management project.
+    t_description: This is a short summary of the goals of this demo BCF management project.
     modules:
       - work_package_tracking
       - bim
@@ -1244,13 +1321,13 @@ projects:
       - team_planner_view
     ifc_models:
       - file: 'hospital_architecture'
-        name: 'Hospital - Architecture (cc-by-sa-3.0 Autodesk Inc.)'
+        t_name: 'Hospital - Architecture (cc-by-sa-3.0 Autodesk Inc.)'
         default: true
       - file: 'hospital_structural'
-        name: 'Hospital - Structural (cc-by-sa-3.0 Autodesk Inc.)'
+        t_name: 'Hospital - Structural (cc-by-sa-3.0 Autodesk Inc.)'
         default: true
       - file: 'hospital_mechanical'
-        name: 'Hospital - Mechanical (cc-by-sa-3.0 Autodesk Inc.)'
+        t_name: 'Hospital - Mechanical (cc-by-sa-3.0 Autodesk Inc.)'
         default: false
     types:
       - :default_type_task
@@ -1260,26 +1337,26 @@ projects:
       - 'bim.default_type_request'
       - 'bim.default_type_issue'
       - 'bim.default_type_remark'
-    categories:
+    t_categories:
       - Category 1 (to be changed in Project settings)
     queries:
-      - name: Issues
+      - t_name: Issues
         status: open
         type: 'bim.default_type_issue'
         display_representation: card
-      - name: Clashes
+      - t_name: Clashes
         status: open
         type: 'bim.default_type_clash'
         display_representation: card
-      - name: Requests
+      - t_name: Requests
         status: open
         type: 'bim.default_type_request'
         display_representation: card
-      - name: Remarks
+      - t_name: Remarks
         status: open
         type: 'bim.default_type_remark'
         display_representation: card
-      - name: Project plan
+      - t_name: Project plan
         status: open
         timeline: true
         sort_by: start_date
@@ -1293,7 +1370,7 @@ projects:
           - start_date
           - due_date
           - duration
-      - name: Milestones
+      - t_name: Milestones
         status: open
         type: :default_type_milestone
         timeline: true
@@ -1305,7 +1382,7 @@ projects:
           - start_date
           - due_date
         sort_by: start_date
-      - name: Tasks
+      - t_name: Tasks
         status: open
         type: :default_type_task
         hierarchy: true
@@ -1317,12 +1394,13 @@ projects:
           - type
           - status
           - assigned_to
-      - name: Team planner
+      - t_name: Team planner
         module: team_planner
+        # TODO: ref wont be found with another language
         assignee: OpenProject Admin
     boards:
       bcf:
-        name: "BCF issues"
+        t_name: "BCF issues"
     bcf_xml_file: "seed.bcf"
     project-overview:
       row_count: 5
@@ -1334,7 +1412,7 @@ projects:
           start_column: 1
           end_column: 3
           options:
-            name: 'Welcome'
+            t_name: 'Welcome'
             text: '![Teaser](##attachment:"demo_project_teaser_bim.jpg")'
           attachments:
             - demo_project_teaser_bim.jpg
@@ -1344,8 +1422,8 @@ projects:
           start_column: 1
           end_column: 2
           options:
-            name: 'Getting started'
-            text: |
+            t_name: 'Getting started'
+            t_text: |
               We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
               This demo project shows BCF management functionalities.
@@ -1379,128 +1457,153 @@ projects:
           start_column: 2
           end_column: 3
           options:
-            name: 'Members'
+            t_name: 'Members'
         - identifier: 'work_packages_overview'
           start_row: 5
           end_row: 6
           start_column: 1
           end_column: 3
           options:
-            name: 'Work packages'
+            t_name: 'Work packages'
     work_packages:
       - :start: 77
         :bcf_issue_uuid: fbbf9ecf-5721-4bf1-a08c-aed50dc19353
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f6271a32-acf5-49f8-a1b5-7c445f9158e5
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f210a2cd-f1f7-4691-b986-2f94117caefe
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: feb97e6e-14fd-4c62-bbad-607f2bb4ebf5
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: 00efc0da-b4d5-4933-bcb6-e01513ee2bcc
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f9e079a8-02f5-40f0-a08a-171f494ee130
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f70417a8-174a-42ae-bf1e-a0b6457d0e6f
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f55d0ec0-9a0f-4222-9926-cc5744888b02
         :assigned_to: BIM Modellers
         :duration: 4
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: fc560c06-51fc-44fa-81b4-e688be189c6a
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: fe2f9c1f-631b-4b37-91ea-833c4751725a
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: fc5099c0-bedb-4770-a576-0429a7733517
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: 010d9884-8c93-4551-b2bc-570faffe7082
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: febee8e1-1ad2-45e5-b08d-b4be92d25ad6
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: f4d71d45-5a2c-4dad-bcb1-8a4935f2ea69
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: fb9705ea-b32c-46ff-bb6f-d1d049494e05
         :assigned_to: BIM Modellers
         :duration: 4
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 77
         :bcf_issue_uuid: fbe1d941-06ce-45f4-8ccb-ef48b8426f72
         :assigned_to: BIM Modellers
         :duration: 3
+        # TODO: ref wont be found with another language
         :parent: Issue management, first cycle
       - :start: 98
         :bcf_issue_uuid: 73def76d-939d-404c-9bd0-581399f92714
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 98
         :bcf_issue_uuid: b5105e2e-add1-4d48-abb9-ce51fcea3bdd
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 98
         :bcf_issue_uuid: 99f03fde-4c74-4a8f-940a-c741738ab073
         :duration: 2
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 111
         :bcf_issue_uuid: af1de642-6d08-489b-8056-ca4c383e0617
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 114
         :bcf_issue_uuid: e6276745-3d58-4d40-80fb-6de5cb05077e
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 149
         :bcf_issue_uuid: efd7be98-1a64-4a35-ad4c-51b8881d79ed
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 152
         :bcf_issue_uuid: f689bfd4-ec09-45ca-bbe3-7d1d0f5d9933
         :duration: 21
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 178
         :bcf_issue_uuid: 3746180f-ba1e-4ea0-a0fb-6ee69ccabd85
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase
       - :start: 178
         :bcf_issue_uuid: 2adbdbb4-bb60-4250-b8af-3cd786437814
         :duration: 8
+        # TODO: ref wont be found with another language
         :parent: Issue management, construction phase

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -359,6 +359,7 @@ projects:
     work_packages:
       - :start: 4
         :t_subject: Project kick off construction project
+        :reference: :project_kick_off_construction_project
         :t_description: |-
           The project kick off initializes the start of the project in your company. Everybody being part of this project should be invited to the kick off for a first briefing.
 
@@ -377,6 +378,7 @@ projects:
         :children:
           - :start: 7
             :t_subject: Gathering first project information
+            :reference: :gathering_first_project_information
             :t_description: |-
               ## Goal
 
@@ -395,6 +397,7 @@ projects:
             :duration: 4
           - :start: 14
             :t_subject: Summarize the results
+            :reference: :summarize_the_results
             :t_description: |-
               ## Goal
 
@@ -414,11 +417,11 @@ projects:
             :assigned_to: Planners
             :duration: 4
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Gathering first project information
+              - :to: :gathering_first_project_information
                 :type: follows
           - :start: 21
             :t_subject: End of basic evaluation
+            :reference: :end_of_basic_evaluation
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
@@ -427,14 +430,12 @@ projects:
             :assigned_to: Planners
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Summarize the results
+              - :to: :summarize_the_results
                 :type: follows
         :assigned_to: Planners
         :duration: 14
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Project kick off construction project
+          - :to: :project_kick_off_construction_project
             :type: follows
       - :start: 22
         :t_subject: Preliminary planning
@@ -445,6 +446,7 @@ projects:
         :children:
           - :start: 22
             :t_subject: Developing first draft
+            :reference: :developing_first_draft
             :t_description: |-
               ## Goal
 
@@ -464,11 +466,11 @@ projects:
             :assigned_to: Planners
             :duration: 10
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: End of basic evaluation
+              - :to: :end_of_basic_evaluation
                 :type: follows
           - :start: 35
             :t_subject: Summarize results
+            :reference: :summarize_results
             :t_description: |-
               ## Goal
 
@@ -488,13 +490,13 @@ projects:
             :assigned_to: Planners
             :duration: 4
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Developing first draft
+              - :to: :developing_first_draft
                 :type: follows
         :assigned_to: Planners
         :duration: 17
       - :start: 42
         :t_subject: Passing of preliminary planning
+        :reference: :passing_of_preliminary_planning
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -503,8 +505,7 @@ projects:
         :assigned_to: Planners
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Summarize results
+          - :to: :summarize_results
             :type: follows
       - :start: 44
         :t_subject: Design planning
@@ -515,6 +516,7 @@ projects:
         :children:
           - :start: 44
             :t_subject: Finishing design
+            :reference: :finishing_design
             :t_description: |-
               ## Goal
 
@@ -533,11 +535,11 @@ projects:
             :assigned_to: Planners
             :duration: 45
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Passing of preliminary planning
+              - :to: :passing_of_preliminary_planning
                 :type: follows
           - :start: 90
             :t_subject: Design freeze
+            :reference: :design_freeze
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
@@ -546,8 +548,7 @@ projects:
             :assigned_to: Planners
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Finishing design
+              - :to: :finishing_design
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: Planners
@@ -560,6 +561,7 @@ projects:
         :children:
           - :start: 98
             :t_subject: Start constructing
+            :reference: :start_constructing
             :t_description: |-
               ## Goal
 
@@ -596,8 +598,7 @@ projects:
             :assigned_to: Planners
             :duration: 25
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Start constructing
+              - :to: :start_constructing
                 :type: follows
           - :start: 149
             :t_subject: Building construction
@@ -658,6 +659,7 @@ projects:
             :duration: 25
           - :start: 189
             :t_subject: Final touches
+            :reference: :final_touches
             :t_description: |-
               ## Goal
 
@@ -692,14 +694,13 @@ projects:
             :type: default_type_milestone
             :duration: 1
             :relations:
-              - :to: Final touches
+              - :to: :final_touches
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: Planners
         :duration: 110
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Design freeze
+          - :to: :design_freeze
             :type: follows
   demo-bim-project:
     t_name: (Demo) BIM project
@@ -845,6 +846,7 @@ projects:
     work_packages:
       - :start: 14
         :t_subject: Project kick off creating BIM model
+        :reference: :project_kick_off_creating_bim_model
         :t_description: |-
           The project Kickoff initializes the start of the project in your company. The whole project team should be invited to the Kickoff for a first briefing.
 
@@ -856,6 +858,7 @@ projects:
         :duration: 1
       - :start: 15
         :t_subject: Project preparation
+        :reference: :project_preparation
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -863,6 +866,7 @@ projects:
         :children:
           - :start: 15
             :t_subject: Gathering the project specific data and information for the BIM model
+            :reference: :gathering_project_data_and_info
             :t_description: |-
               ## Goal
 
@@ -883,10 +887,11 @@ projects:
             :assigned_to: Planners
             :duration: 14
             :relations:
-              - :to: Project kick off creating BIM model
+              - :to: :project_kick_off_creating_bim_model
                 :type: follows
           - :start: 33
             :t_subject: Creating the BIM execution plan
+            :reference: :creating_bim_execution_plan
             :t_description: |-
               # Goal
 
@@ -903,10 +908,11 @@ projects:
             :assigned_to: Lead BIM Coordinators
             :duration: 18
             :relations:
-              - :to: Gathering the project specific data and information for the BIM model
+              - :to: :gathering_project_data_and_info
                 :type: follows
           - :start: 52
             :t_subject: Completion of the BIM execution plan
+            :reference: :completion_of_bim_execution_plan
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: bim.default_status_resolved
@@ -914,13 +920,14 @@ projects:
             :assigned_to: BIM Coordinators
             :duration: 1
             :relations:
-              - :to: Creating the BIM execution plan
+              - :to: :creating_bim_execution_plan
                 :type: follows
         # TODO: ref wont be found with another language
                 :assigned_to: BIM Managers
         :duration: 37
       - :start: 53
         :t_subject: End of preparation phase
+        :reference: :end_of_preparation_phase
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -929,7 +936,7 @@ projects:
         :assigned_to: BIM Managers
         :duration: 1
         :relations:
-          - :to: Project preparation
+          - :to: :project_preparation
             :type: follows
       - :start: 54
         :t_subject: Creating initial BIM model
@@ -940,6 +947,7 @@ projects:
         :children:
           - :start: 54
             :t_subject: Modelling initial BIM model
+            :reference: :modelling_initial_bim_model
             :t_description: |-
               # Goal
 
@@ -957,11 +965,11 @@ projects:
             :assigned_to: BIM Modellers
             :duration: 7
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: End of preparation phase
+              - :to: :end_of_preparation_phase
                 :type: follows
           - :start: 62
             :t_subject: Initial, internal model check and revising
+            :reference: :initial_internal_model_check_and_revising
             :t_description: |-
               # Goal
 
@@ -977,11 +985,11 @@ projects:
             :assigned_to: Lead BIM Coordinators
             :duration: 2
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Modelling initial BIM model
+              - :to: :modelling_initial_bim_model
                 :type: follows
           - :start: 65
             :t_subject: Submitting initial BIM model
+            :reference: :submitting_initial_bim_model
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
@@ -990,15 +998,13 @@ projects:
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Initial, internal model check and revising
+              - :to: :initial_internal_model_check_and_revising
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: Architects
         :duration: 11
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Completion of the BIM execution plan
+          - :to: :completion_of_bim_execution_plan
             :type: follows
       - :start: 66
         :t_subject: Modelling, first cycle
@@ -1009,6 +1015,7 @@ projects:
         :children:
           - :start: 66
             :t_subject: Referencing external BIM models
+            :reference: :referencing_external_bim_models
             :t_description: |-
               # Goal
 
@@ -1025,11 +1032,11 @@ projects:
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Submitting initial BIM model
+              - :to: :submitting_initial_bim_model
                 :type: follows
           - :start: 67
             :t_subject: Modelling the BIM model
+            :reference: :modelling_of_the_bim_model
             :t_description: |-
               # Goal
 
@@ -1046,11 +1053,11 @@ projects:
             :assigned_to: BIM Modellers
             :duration: 6
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Referencing external BIM models
+              - :to: :referencing_external_bim_models
                 :type: follows
           - :start: 74
             :t_subject: First Cycle, internal model check and revising
+            :reference: :first_cycle_internal_model_check_and_revising
             :t_description: |-
               # Goal
 
@@ -1065,10 +1072,11 @@ projects:
             :assigned_to: BIM Coordinators
             :duration: 1
             :relations:
-              - :to: Modelling the BIM model
+              - :to: :modelling_of_the_bim_model
                 :type: follows
           - :start: 76
             :t_subject: Submitting BIM model
+            :reference: :submitting_bim_model
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
@@ -1077,15 +1085,13 @@ projects:
             :assigned_to: BIM Modellers
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: First Cycle, internal model check and revising
+              - :to: :first_cycle_internal_model_check_and_revising
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 10
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Submitting initial BIM model
+          - :to: :submitting_initial_bim_model
             :type: follows
       - :start: 77
         :t_subject: Coordination, first cycle
@@ -1114,6 +1120,7 @@ projects:
             :duration: 3
           - :start: 77
             :t_subject: Issue management, first cycle
+            :reference: :issue_management_first_cycle
             :description: ''
             :status: default_status_new
             :type: default_type_phase
@@ -1122,6 +1129,7 @@ projects:
             :duration: 4
           - :start: 82
             :t_subject: Finishing coordination, first cycle
+            :reference: :finishing_coordination_first_cycle
             :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
               and &quot;Request&quot;, thus represents a general note.
             :status: default_status_new
@@ -1130,18 +1138,17 @@ projects:
             :assigned_to: Lead BIM Coordinators
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Issue management, first cycle
+              - :to: :issue_management_first_cycle
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: Lead BIM Coordinators
         :duration: 5
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Submitting BIM model
+          - :to: :submitting_bim_model
             :type: follows
       - :start: 83
         :t_subject: Modelling & coordinating, second cycle
+        :reference: :modelling_and_coordinating_second_cycle
         :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
@@ -1149,11 +1156,11 @@ projects:
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Finishing coordination, first cycle
+          - :to: :finishing_coordination_first_cycle
             :type: follows
       - :start: 84
         :t_subject: Modelling & coordinating, ... cycle
+        :reference: :modelling_and_coordinating_another_cycle
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -1162,11 +1169,11 @@ projects:
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Modelling & coordinating, second cycle
+          - :to: :modelling_and_coordinating_second_cycle
             :type: follows
       - :start: 85
         :t_subject: Modelling & coordinating, (n-th minus 1) cycle
+        :reference: :modelling_and_coordinating_penultimate_cycle
         :t_description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
         :status: default_status_new
         :type: default_type_phase
@@ -1174,11 +1181,11 @@ projects:
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Modelling & coordinating, ... cycle
+          - :to: :modelling_and_coordinating_another_cycle
             :type: follows
       - :start: 86
         :t_subject: Modelling & coordinating n-th cycle
+        :reference: :modelling_and_coordinating_last_cycle
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -1187,11 +1194,11 @@ projects:
         :assigned_to: BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Modelling & coordinating, (n-th minus 1) cycle
+          - :to: :modelling_and_coordinating_penultimate_cycle
             :type: follows
       - :start: 87
         :t_subject: Finishing modelling & coordinating, n-th cycle
+        :reference: :finishing_modelling_and_coordinating
         :t_description: This type is hierarchically a parent of the types &quot;Clash&quot;
           and &quot;Request&quot;, thus represents a general note.
         :status: default_status_new
@@ -1200,8 +1207,7 @@ projects:
         :assigned_to: BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Modelling & coordinating n-th cycle
+          - :to: :modelling_and_coordinating_last_cycle
             :type: follows
       - :start: 88
         :t_subject: Use model for construction phase
@@ -1230,6 +1236,7 @@ projects:
             :duration: 5
           - :start: 98
             :t_subject: Construct the building
+            :reference: :construct_building
             :t_description: |-
               ## Goal
 
@@ -1248,6 +1255,7 @@ projects:
             :duration: 101
           - :start: 200
             :t_subject: Finish construction
+            :reference: :finish_construction
             :description: ''
             :status: default_status_new
             :type: default_type_milestone
@@ -1255,18 +1263,17 @@ projects:
             :assigned_to: BIM Coordinators
             :duration: 1
             :relations:
-              # TODO: ref wont be found with another language
-              - :to: Construct the building
+              - :to: :construct_building
                 :type: follows
         # TODO: ref wont be found with another language
         :assigned_to: BIM Coordinators
         :duration: 112
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Finishing modelling & coordinating, n-th cycle
+          - :to: :finishing_modelling_and_coordinating
             :type: follows
       - :start: 98
         :t_subject: Issue management, construction phase
+        :reference: :issue_management_construction_phase
         :description: ''
         :status: default_status_new
         :type: default_type_phase
@@ -1275,6 +1282,7 @@ projects:
         :duration: 88
       - :start: 210
         :t_subject: Handover for Facility Management
+        :reference: :handover_for_facility_management
         :t_description: |-
           ## Goal
 
@@ -1293,8 +1301,7 @@ projects:
         :assigned_to: Lead BIM Coordinators
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Finish construction
+          - :to: :finish_construction
             :type: follows
       - :start: 211
         :t_subject: Asset Management
@@ -1303,8 +1310,7 @@ projects:
         :type: default_type_phase
         :duration: 1
         :relations:
-          # TODO: ref wont be found with another language
-          - :to: Handover for Facility Management
+          - :to: :handover_for_facility_management
             :type: follows
   demo-bcf-management-project:
     t_name: (Demo) BCF management
@@ -1470,140 +1476,115 @@ projects:
         :bcf_issue_uuid: fbbf9ecf-5721-4bf1-a08c-aed50dc19353
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f6271a32-acf5-49f8-a1b5-7c445f9158e5
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f210a2cd-f1f7-4691-b986-2f94117caefe
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: feb97e6e-14fd-4c62-bbad-607f2bb4ebf5
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: 00efc0da-b4d5-4933-bcb6-e01513ee2bcc
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f9e079a8-02f5-40f0-a08a-171f494ee130
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f70417a8-174a-42ae-bf1e-a0b6457d0e6f
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f55d0ec0-9a0f-4222-9926-cc5744888b02
         :assigned_to: BIM Modellers
         :duration: 4
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fc560c06-51fc-44fa-81b4-e688be189c6a
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fe2f9c1f-631b-4b37-91ea-833c4751725a
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fc5099c0-bedb-4770-a576-0429a7733517
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: 010d9884-8c93-4551-b2bc-570faffe7082
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: febee8e1-1ad2-45e5-b08d-b4be92d25ad6
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: f4d71d45-5a2c-4dad-bcb1-8a4935f2ea69
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fb9705ea-b32c-46ff-bb6f-d1d049494e05
         :assigned_to: BIM Modellers
         :duration: 4
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 77
         :bcf_issue_uuid: fbe1d941-06ce-45f4-8ccb-ef48b8426f72
         :assigned_to: BIM Modellers
         :duration: 3
-        # TODO: ref wont be found with another language
-        :parent: Issue management, first cycle
+        :parent: :issue_management_first_cycle
       - :start: 98
         :bcf_issue_uuid: 73def76d-939d-404c-9bd0-581399f92714
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 98
         :bcf_issue_uuid: b5105e2e-add1-4d48-abb9-ce51fcea3bdd
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 98
         :bcf_issue_uuid: 99f03fde-4c74-4a8f-940a-c741738ab073
         :duration: 2
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 111
         :bcf_issue_uuid: af1de642-6d08-489b-8056-ca4c383e0617
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 114
         :bcf_issue_uuid: e6276745-3d58-4d40-80fb-6de5cb05077e
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 149
         :bcf_issue_uuid: efd7be98-1a64-4a35-ad4c-51b8881d79ed
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 152
         :bcf_issue_uuid: f689bfd4-ec09-45ca-bbe3-7d1d0f5d9933
         :duration: 21
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 178
         :bcf_issue_uuid: 3746180f-ba1e-4ea0-a0fb-6ee69ccabd85
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase
       - :start: 178
         :bcf_issue_uuid: 2adbdbb4-bb60-4250-b8af-3cd786437814
         :duration: 8
-        # TODO: ref wont be found with another language
-        :parent: Issue management, construction phase
+        :parent: :issue_management_construction_phase

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -139,8 +139,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        # TODO: ref wont be found with another language
-        assignee: OpenProject Admin
+        assignee: :openproject_admin
     boards:
       bcf:
         t_name: "Simple drag'n drop workflow"
@@ -286,7 +285,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: OpenProject Admin
+        assignee: :openproject_admin
     project-overview:
       row_count: 6
       column_count: 2
@@ -769,7 +768,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: OpenProject Admin
+        assignee: :openproject_admin
     project-overview:
       row_count: 6
       column_count: 2
@@ -1402,8 +1401,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        # TODO: ref wont be found with another language
-        assignee: OpenProject Admin
+        assignee: :openproject_admin
     boards:
       bcf:
         t_name: "BCF issues"

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -139,7 +139,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: :openproject_admin
+        assigned_to: :openproject_admin
     boards:
       bcf:
         t_name: "Simple drag'n drop workflow"
@@ -285,7 +285,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: :openproject_admin
+        assigned_to: :openproject_admin
     project-overview:
       row_count: 6
       column_count: 2
@@ -768,7 +768,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: :openproject_admin
+        assigned_to: :openproject_admin
     project-overview:
       row_count: 6
       column_count: 2
@@ -1401,7 +1401,7 @@ projects:
           - assigned_to
       - t_name: Team planner
         module: team_planner
-        assignee: :openproject_admin
+        assigned_to: :openproject_admin
     boards:
       bcf:
         t_name: "BCF issues"

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -28,6 +28,7 @@
 
 global_queries:
   - t_name: "Embedded table: Children"
+    reference: :global_query__children
     parent: '{id}'
     timeline: false
     sort_by: id
@@ -44,9 +45,8 @@ global_queries:
 type_configuration:
   - type: :default_type_phase
     form_configuration:
-      # TODO: should they be translated? Or are they refs?
-      - group_name: "Children"
-        query_name: "Embedded table: Children"
+      - t_group_name: "Children"
+        query: :global_query__children
 groups:
   - t_name: Architects
   - t_name: BIM Coordinators

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -78,8 +78,6 @@ projects:
       code: on_track
       description: All tasks and the sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
     description: This is a short summary of the goals of this demo construction project.
-    timeline:
-      name: Timeline
     modules:
       - work_package_tracking
       - news
@@ -226,8 +224,6 @@ projects:
       description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-construction-project
     description: This is a short summary of the goals of this demo planning and constructing project.
-    timeline:
-      name: Timeline
     modules:
       - work_package_tracking
       - news
@@ -683,8 +679,6 @@ projects:
       description: All tasks and sub-projects are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-construction-project
     description: This is a short summary of the goals of this demo BIM project.
-    timeline:
-      name: Timeline
     modules:
       - work_package_tracking
       - news
@@ -1243,8 +1237,6 @@ projects:
       description: All tasks are on schedule. The people involved know their tasks. The system is completely set up.
     parent: demo-bim-project
     description: This is a short summary of the goals of this demo BCF management project.
-    timeline:
-      name: Timeline
     modules:
       - work_package_tracking
       - bim

--- a/modules/bim/lib/open_project/bim/patches/work_package_board_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_board_seeder_patch.rb
@@ -42,14 +42,12 @@ module OpenProject::Bim::Patches::WorkPackageBoardSeederPatch
     end
 
     def seed_bcf_board_queries
-      status_names = ['New', 'In progress', 'Resolved', 'Closed']
-      statuses = Status.where(name: status_names).to_a
-
-      if statuses.size < status_names.size
-        raise StandardError.new "Not all statuses needed for seeding a BCF board are present. Check that they get seeded."
-      end
-
-      statuses.to_a.map do |status|
+      statuses(
+        'default_status_new',
+        'default_status_in_progress',
+        'bim.default_status_resolved',
+        'default_status_closed'
+      ).map do |status|
         Query.new_default(project:, user:).tap do |query|
           # Make it public so that new members can see it too
           query.public = true

--- a/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
@@ -27,7 +27,7 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
     def update_parent(work_package, attributes)
       return unless attributes['parent']
 
-      parent = WorkPackage.find_by(subject: attributes['parent'])
+      parent = find_work_package(attributes['parent'])
       return if parent.nil?
 
       work_package.parent = parent

--- a/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
@@ -12,7 +12,7 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
         work_package = find_bcf_issue(uuid)
         work_package.update_columns(created_at: Time.current,
                                     author_id: user.id,
-                                    assigned_to_id: find_assignee_id(attributes['assigned_to']),
+                                    assigned_to_id: find_principal(attributes['assigned_to']).id,
                                     start_date: time_tracking_attributes[:start_date],
                                     due_date: time_tracking_attributes[:due_date],
                                     duration: time_tracking_attributes[:duration],
@@ -39,12 +39,6 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
         .joins(:bcf_issue)
         .where(project_id: project.id, 'bcf_issues.uuid': uuid)
         .references(:bcf_issue).first
-    end
-
-    def find_assignee_id(name)
-      return nil if name.blank?
-
-      Principal.find_by(lastname: name).try(:id)
     end
   end
 end

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -57,6 +57,24 @@ describe RootSeeder,
       expect(Relation.follows.count).to eq 35
       expect(WorkPackage.where.not(parent: nil).count).to eq 55
     end
+
+    it 'assigns work packages to groups' do
+      count_by_assignee =
+        WorkPackage
+          .joins(:assigned_to)
+          .group("array_to_string(ARRAY[type || ':', firstname, lastname], ' ')")
+          .count
+          .transform_keys! { |key| key.squish.gsub('tr: ', '') }
+      expect(count_by_assignee).to eq(
+        "Group: Architects" => 1,
+        "Group: BIM Coordinators" => 11,
+        "Group: BIM Managers" => 2,
+        "Group: BIM Modellers" => 21,
+        "Group: Lead BIM Coordinators" => 8,
+        "Group: Planners" => 21,
+        "User: OpenProject Admin" => 12
+      )
+    end
   end
 
   describe 'demo data' do
@@ -74,24 +92,6 @@ describe RootSeeder,
     include_examples 'creates BIM demo data'
 
     include_examples 'no email deliveries'
-
-    it 'assigns work packages to groups' do
-      count_by_assignee =
-        WorkPackage
-          .joins(:assigned_to)
-          .group("array_to_string(ARRAY[type || ':', firstname, lastname], ' ')")
-          .count
-          .transform_keys!(&:squish)
-      expect(count_by_assignee).to eq(
-        "Group: Architects" => 1,
-        "Group: BIM Coordinators" => 11,
-        "Group: BIM Managers" => 2,
-        "Group: BIM Modellers" => 21,
-        "Group: Lead BIM Coordinators" => 8,
-        "Group: Planners" => 21,
-        "User: OpenProject Admin" => 12
-      )
-    end
   end
 
   describe 'demo data translated in another language' do

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -67,5 +67,23 @@ describe RootSeeder,
     expect(WorkPackage.where.not(parent: nil).count).to eq 55
   end
 
+  it 'assigns work packages to groups' do
+    count_by_assignee =
+      WorkPackage
+        .joins(:assigned_to)
+        .group("array_to_string(ARRAY[type || ':', firstname, lastname], ' ')")
+        .count
+        .transform_keys!(&:squish)
+    expect(count_by_assignee).to eq(
+      "Group: Architects" => 1,
+      "Group: BIM Coordinators" => 11,
+      "Group: BIM Managers" => 2,
+      "Group: BIM Modellers" => 21,
+      "Group: Lead BIM Coordinators" => 8,
+      "Group: Planners" => 21,
+      "User: OpenProject Admin" => 12
+    )
+  end
+
   include_examples 'no email deliveries'
 end

--- a/spec/seeders/basic_data/type_seeder_spec.rb
+++ b/spec/seeders/basic_data/type_seeder_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe BasicData::TypeSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:phase_type) { create(:type, name: I18n.t(:default_type_phase)) }
+  let(:seed_data) { SeedData.new(data_hash) }
+
+  before do
+    phase_type # create the Phase type
+  end
+
+  describe '#set_attribute_groups_for_type' do
+    let(:data_hash) { {} }
+
+    context 'without any form_configuration for the given type' do
+      it 'does not change attribute_groups' do
+        attribute_groups_before = phase_type.attribute_groups.dup
+        seeder.set_attribute_groups_for_type(phase_type)
+        attribute_groups_now = phase_type.attribute_groups
+        expect(attribute_groups_now).to eq(attribute_groups_before)
+      end
+    end
+
+    context 'with a form_configuration entry in type_configuration in seed data' do
+      let(:data_hash) do
+        YAML.load <<~SEEDING_DATA_YAML
+          type_configuration:
+          - type: :default_type_phase
+            form_configuration:
+              - group_name: "Children"
+                query: :query__children
+        SEEDING_DATA_YAML
+      end
+      let(:query) { create(:query) }
+
+      before do
+        seed_data.store_reference(:query__children, query)
+      end
+
+      it 'adds a query group in the form configuration of the type' do
+        attribute_groups_before = phase_type.attribute_groups.dup
+        seeder.set_attribute_groups_for_type(phase_type)
+        attribute_groups_now = phase_type.attribute_groups
+        expect(attribute_groups_now).not_to eq(attribute_groups_before)
+        expect(attribute_groups_now)
+          .to include(an_instance_of(Type::QueryGroup).and(having_attributes(attributes: query)))
+      end
+    end
+  end
+end

--- a/spec/seeders/demo_data/global_query_seeder_spec.rb
+++ b/spec/seeders/demo_data/global_query_seeder_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe DemoData::GlobalQuerySeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { SeedData.new(data_hash) }
+
+  before do
+    AdminUserSeeder.new(seed_data).seed!
+  end
+
+  context 'with a global_queries defined' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        global_queries:
+        - name: "Children"
+          reference: :global_query__children
+          parent: '{id}'
+          timeline: false
+          sort_by: id
+          hidden: true
+          public: false
+          columns:
+            - type
+            - id
+            - subject
+            - status
+            - assigned_to
+            - priority
+            - project
+      SEEDING_DATA_YAML
+    end
+
+    it 'creates a global query' do
+      expect { seeder.seed! }.to change { Query.global.count }.by(1)
+    end
+
+    it 'references the query in the seed data' do
+      seeder.seed!
+      created_query = Query.global.first
+      expect(seed_data.find_reference(:global_query__children)).to eq(created_query)
+    end
+  end
+end

--- a/spec/seeders/demo_data/group_seeder_spec.rb
+++ b/spec/seeders/demo_data/group_seeder_spec.rb
@@ -1,5 +1,6 @@
-#-- copyright
+# frozen_string_literal: true
 
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
 #
@@ -25,31 +26,34 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-module DemoData
-  class GroupSeeder < Seeder
-    include ::DemoData::References
+#++
 
-    def seed_data!
-      print_status '    ↳ Creating groups' do
-        seed_groups
-      end
+require 'spec_helper'
+
+RSpec.describe DemoData::GroupSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { SeedData.new(data_hash) }
+
+  context 'with a group defined' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        groups:
+        - name: Architects
+          reference: :architects
+      SEEDING_DATA_YAML
     end
 
-    def applicable?
-      Group.count.zero?
+    it 'creates the corresponding group with the given name as lastname' do
+      seeder.seed!
+      created_group = Group.last
+      expect(created_group).to have_attributes(lastname: 'Architects')
     end
 
-    private
-
-    def seed_groups
-      seed_data.each('groups') do |group_data|
-        group = create_group group_data['name']
-        seed_data.store_reference(group_data['reference'], group)
-      end
-    end
-
-    def create_group(name)
-      Group.create lastname: name
+    it 'references the group in the seed data' do
+      seeder.seed!
+      created_group = Group.last
+      expect(seed_data.find_reference(:architects)).to eq(created_group)
     end
   end
 end

--- a/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/spec/seeders/demo_data/project_seeder_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe DemoData::ProjectSeeder do
+  subject(:project_seeder) { described_class.new(seed_data) }
+
+  shared_let(:initial_seeding) do
+    [
+      # Color records needed by StatusSeeder and TypeSeeder
+      BasicData::ColorSeeder,
+      BasicData::ColorSchemeSeeder,
+
+      # Status records needed by WorkPackageSeeder
+      Standard::BasicData::StatusSeeder,
+
+      # Type records needed by WorkPackageSeeder
+      Standard::BasicData::TypeSeeder,
+
+      # IssuePriority records needed by WorkPackageSeeder
+      Standard::BasicData::PrioritySeeder,
+
+      # admin user needed by ProjectSeeder
+      AdminUserSeeder,
+
+      # project admin role needed by ProjectSeeder
+      BasicData::BuiltinRolesSeeder,
+      BasicData::RoleSeeder
+    ].each { |seeder| seeder.new.seed! }
+  end
+
+  let(:seed_data) { SeedData.new(project_data) }
+  let(:project_data) { project_data_with_a_version }
+  let(:project_data_with_a_version) do
+    {
+      'name' => 'Some project',
+      'versions' => [
+        {
+          'name' => 'The product backlog',
+          'reference' => :product_backlog,
+          'sharing' => 'none',
+          'status' => 'open'
+        }
+      ]
+    }
+  end
+
+  it 'stores references to created versions in the seed data' do
+    project_seeder.seed!
+    created_version = Version.find_by(name: 'The product backlog')
+    expect(seed_data.find_reference(:product_backlog)).to eq(created_version)
+  end
+
+  context 'for a version with a wiki' do
+    before do
+      project_data.update(
+        'modules' => %w[work_package_tracking wiki],
+        'wiki' => 'root wiki page content',
+        'versions' => [
+          {
+            'name' => 'First sprint',
+            'reference' => :first_sprint,
+            'sharing' => 'none',
+            'status' => 'open',
+            'wiki' => {
+              'title' => 'Sprint 1',
+              'content' => 'Please see the [Task board](##sprint:first_sprint).'
+            }
+          }
+        ]
+      )
+    end
+
+    it 'can self-reference the version link in the wiki' do
+      project_seeder.seed!
+      created_version = Version.find_by!(name: 'First sprint')
+      expect(created_version.wiki_page.content.text)
+        .to eq("Please see the [Task board](/projects/some-project/sprints/#{created_version.id}/taskboard).")
+    end
+  end
+
+  context 'with work packages linking to a version by its reference' do
+    let(:project_data) do
+      project_data_with_a_version.merge(
+        'work_packages' => [
+          {
+            'subject' => 'Some work package',
+            'status' => 'default_status_new',
+            'type' => 'default_type_task',
+            'version' => :product_backlog
+          }
+        ]
+      )
+    end
+
+    it 'creates the link' do
+      project_seeder.seed!
+      version = Version.find_by(name: 'The product backlog')
+      work_package = WorkPackage.find_by(subject: 'Some work package')
+      expect(work_package.version).to eq(version)
+    end
+  end
+
+  context 'with query linking to a version by its reference' do
+    let(:project_data) do
+      project_data_with_a_version.merge(
+        'queries' => [
+          {
+            'name' => 'Product Backlog query',
+            'status' => 'open',
+            'version' => :product_backlog
+          }
+        ]
+      )
+    end
+
+    it 'creates the link' do
+      project_seeder.seed!
+      version = Version.find_by(name: 'The product backlog')
+      query = Query.find_by(name: 'Product Backlog query')
+      expect(query.filters).to include(an_instance_of(Queries::WorkPackages::Filter::VersionFilter))
+      version_filter = query.filters.find { _1.is_a?(Queries::WorkPackages::Filter::VersionFilter) }
+      expect(version_filter.values).to eq([version.id.to_s])
+    end
+  end
+end

--- a/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/spec/seeders/demo_data/project_seeder_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe DemoData::ProjectSeeder do
         'queries' => [
           {
             'name' => 'Team planner',
-            'assignee' => :openproject_admin
+            'assigned_to' => :openproject_admin
           }
         ]
       }

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -310,11 +310,16 @@ describe DemoData::WorkPackageSeeder do
   end
 
   describe 'assigned_to' do
+    let(:seed_data) do
+      seed_data = SeedData.new('work_packages' => work_packages_data)
+      seed_data.store_reference(:user_bernard, a_user)
+      seed_data
+    end
     let(:a_user) { create(:user, lastname: 'Bernard') }
     let(:work_packages_data) do
       [
         work_package_data(subject: 'without assigned_to'),
-        work_package_data(subject: 'with assigned_to', assigned_to: a_user.lastname)
+        work_package_data(subject: 'with assigned_to', assigned_to: :user_bernard)
       ]
     end
 
@@ -323,7 +328,7 @@ describe DemoData::WorkPackageSeeder do
       expect(work_package.assigned_to).to eq(User.user.admin.last)
     end
 
-    it 'assigns work packages with assigned_to referencing the user lastname' do
+    it 'assigns work packages with assigned_to referencing the user' do
       work_package = WorkPackage.find_by(subject: 'with assigned_to')
       expect(work_package.assigned_to).to eq(a_user)
     end
@@ -340,7 +345,7 @@ describe DemoData::WorkPackageSeeder do
       let(:work_packages_data) do
         [
           work_package_data(bcf_issue_uuid: bcf_issue_without_assigned_to.uuid),
-          work_package_data(bcf_issue_uuid: bcf_issue_with_assigned_to.uuid, assigned_to: a_user.lastname)
+          work_package_data(bcf_issue_uuid: bcf_issue_with_assigned_to.uuid, assigned_to: :user_bernard)
         ]
       end
 

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -44,9 +44,6 @@ describe DemoData::WorkPackageSeeder do
 
       # IssuePriority records needed by WorkPackageSeeder
       Standard::BasicData::PrioritySeeder,
-
-      # User admin needed by WorkPackageSeeder
-      AdminUserSeeder
     ].each { |seeder| seeder.new.seed! }
   end
   let(:project) { create(:project) }
@@ -65,6 +62,13 @@ describe DemoData::WorkPackageSeeder do
 
   before do
     seed_data = SeedData.new('work_packages' => work_packages_data)
+
+    # Admin user needed by ProjectSeeder
+    # The AdminUserSeeder cannot be put in the initial_seeding block as it needs
+    # to add a reference to the created admin user in the seed_data for each
+    # example.
+    AdminUserSeeder.new(seed_data).seed!
+
     work_package_seeder = described_class.new(project, seed_data)
     work_package_seeder.seed!
   end

--- a/spec/seeders/root_seeder_shared_examples.rb
+++ b/spec/seeders/root_seeder_shared_examples.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_examples 'no email deliveries' do
+  it 'does not perform any email deliveries' do
+    perform_enqueued_jobs
+
+    expect(ActionMailer::Base.deliveries)
+      .to be_empty
+  end
+end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -125,6 +125,10 @@ describe RootSeeder,
     end
 
     include_examples 'creates standard demo data'
+
+    it 'has all Query.name translated' do
+      expect(Query.pluck(:name)).to all(start_with('tr: '))
+    end
   end
 
   describe 'demo data with development data' do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -73,6 +73,14 @@ describe RootSeeder,
       )
     end
 
+    it 'creates different types of queries' do
+      count_by_type = View.group(:type).count
+      expect(count_by_type).to eq(
+        "work_packages_table" => 7,
+        "team_planner" => 1
+      )
+    end
+
     include_examples 'no email deliveries'
 
     context 'when run a second time' do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -27,20 +27,12 @@
 #++
 
 require 'spec_helper'
+require_relative './root_seeder_shared_examples'
 
 describe RootSeeder,
          'standard edition',
          with_config: { edition: 'standard' },
          with_settings: { journal_aggregation_time_minutes: 0 } do
-  shared_examples 'no email deliveries' do
-    it 'does not perform any email deliveries' do
-      perform_enqueued_jobs
-
-      expect(ActionMailer::Base.deliveries)
-        .to be_empty
-    end
-  end
-
   describe 'demo data' do
     before_all do
       described_class.new.seed_data!

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -64,6 +64,15 @@ describe RootSeeder,
       expect(Boards::Grid.count { |grid| grid.options.has_key?(:filters) }).to eq 1
     end
 
+    it 'links work packages to their version' do
+      count_by_version = WorkPackage.joins(:version).group('versions.name').count
+      expect(count_by_version).to eq(
+        "Bug Backlog" => 1,
+        "Sprint 1" => 8,
+        "Product Backlog" => 7
+      )
+    end
+
     include_examples 'no email deliveries'
 
     context 'when run a second time' do

--- a/spec/seeders/seed_data_loader_spec.rb
+++ b/spec/seeders/seed_data_loader_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe SeedDataLoader do
+  let(:title_en) { 'Welcome to OpenProject' }
+  let(:text_en) { 'Learn how to plan projects efficiently.' }
+  let(:title_fr) { 'Bienvenue sur OpenProject' }
+  let(:text_fr) { 'Apprenez à planifier des projets efficacement.' }
+
+  def mock_translations(locale, translations_map)
+    translations_map.each do |key, translation|
+      allow(I18n).to receive(:t).with(key, hash_including(locale: locale.to_s)).and_return(translation)
+      allow(I18n).to receive(:t).with(key, hash_including(locale: locale.to_sym)).and_return(translation)
+    end
+  end
+
+  before do
+    allow(I18n).to receive(:t).and_call_original
+  end
+
+  describe '#translate' do
+    it 'translates keys with a "t_" prefix' do
+      loader = described_class.new(locale: 'fr')
+      mock_translations(
+        'fr',
+        'seeds.standard.welcome.title' => title_fr,
+        'seeds.standard.welcome.text' => text_fr
+      )
+      hash = {
+        'welcome' => {
+          't_title' => title_en,
+          't_text' => text_en,
+          'icon' => ':smile:'
+        }
+      }
+
+      translated = loader.translate(hash)
+      expect(translated.dig('welcome', 'title')).to eq(title_fr)
+      expect(translated.dig('welcome', 'text')).to eq(text_fr)
+      expect(translated.dig('welcome', 'icon')).to eq(':smile:')
+    end
+
+    it 'translates nothing if prefix "t_" is absent' do
+      loader = described_class.new(locale: 'fr')
+
+      hash = {
+        'welcome' => {
+          'title' => title_en,
+          'text' => text_en
+        }
+      }
+
+      translated = loader.translate(hash)
+      expect(I18n).not_to have_received(:t)
+      expect(translated.dig('welcome', 'title')).to eq(title_en)
+      expect(translated.dig('welcome', 'text')).to eq(text_en)
+    end
+
+    it 'uses the original string if no translation exists' do
+      loader = described_class.new(locale: 'fr')
+      hash = {
+        'welcome' => {
+          't_title' => title_en,
+          't_text' => text_en
+        }
+      }
+
+      translated = loader.translate(hash)
+
+      expect(I18n).to have_received(:t).at_least(:twice)
+      expect(translated.dig('welcome', 'title')).to eq(title_en)
+      expect(translated.dig('welcome', 'text')).to eq(text_en)
+    end
+
+    it 'removes the prefixed keys from the returned hash' do
+      loader = described_class.new(locale: 'fr')
+      hash = {
+        'welcome' => {
+          't_title' => title_en,
+          't_text' => text_en
+        }
+      }
+
+      translated = loader.translate(hash)
+      expect(translated['welcome']).to eq(
+        'title' => title_en,
+        'text' => text_en
+      )
+    end
+
+    context 'when the value to translate is an array' do
+      it 'translates each values using indices' do
+        loader = described_class.new(locale: 'de')
+        mock_translations(
+          'de',
+          'seeds.standard.categories.0' => 'Erste Kategorie',
+          'seeds.standard.categories.1' => 'Zweite Kategorie'
+        )
+        hash = {
+          't_categories' => [
+            'First category',
+            'Second category',
+            'Missing translations are kept as-is'
+          ]
+        }
+
+        translated = loader.translate(hash)
+        expect(translated['categories'])
+          .to eq(['Erste Kategorie', 'Zweite Kategorie', 'Missing translations are kept as-is'])
+      end
+    end
+
+    context 'when hash contains array of hashes' do
+      it 'translates keys in the nested values if they have translatable keys' do
+        loader = described_class.new(locale: 'fr')
+        mock_translations(
+          'fr',
+          'seeds.standard.queries.0.name' => 'Plan projet',
+          'seeds.standard.queries.1.name' => 'Tâches'
+        )
+
+        translated = loader.translate(
+          'queries' => [
+            { 't_name' => 'Project plan', 'open' => true },
+            { 't_name' => 'Tasks', 'open' => true },
+            { 't_name' => 'Missing translations are kept as-is', 'open' => true }
+          ]
+        )
+        expect(translated['queries']).to eq(
+          [
+            { 'name' => 'Plan projet', 'open' => true },
+            { 'name' => 'Tâches', 'open' => true },
+            { 'name' => 'Missing translations are kept as-is', 'open' => true }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/seeders/seed_data_spec.rb
+++ b/spec/seeders/seed_data_spec.rb
@@ -1,5 +1,6 @@
-#-- copyright
+# frozen_string_literal: true
 
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
 #
@@ -25,31 +26,37 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-module DemoData
-  class GroupSeeder < Seeder
-    include ::DemoData::References
+#++
 
-    def seed_data!
-      print_status '    ↳ Creating groups' do
-        seed_groups
-      end
+require 'spec_helper'
+
+RSpec.describe SeedData do
+  subject(:seed_data) { described_class.new({}) }
+
+  describe '#store_reference / find_reference' do
+    it 'acts as a key store to register object by a symbol' do
+      object = Object.new
+      seed_data.store_reference(:ref, object)
+      expect(seed_data.find_reference(:ref)).to be(object)
     end
 
-    def applicable?
-      Group.count.zero?
+    it 'stores nothing if reference is nil' do
+      object = Object.new
+      seed_data.store_reference(nil, object)
+      seed_data.store_reference(nil, object)
     end
 
-    private
-
-    def seed_groups
-      seed_data.each('groups') do |group_data|
-        group = create_group group_data['name']
-        seed_data.store_reference(group_data['reference'], group)
-      end
+    it 'returns nil if reference is nil' do
+      expect(seed_data.find_reference(nil)).to be_nil
+      object = Object.new
+      seed_data.store_reference(nil, object)
+      expect(seed_data.find_reference(nil)).to be_nil
     end
 
-    def create_group(name)
-      Group.create lastname: name
+    it 'raises an error when the reference is already used' do
+      seed_data.store_reference(:ref, Object.new)
+      expect { seed_data.store_reference(:ref, Object.new) }
+        .to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/support/root_seeder_test_helpers.rb
+++ b/spec/support/root_seeder_test_helpers.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RootSeederTestHelpers
+  def stub_language(locale)
+    locale = locale.to_s
+    with_settings(default_language: locale)
+    stub_const('ENV', { 'OPENPROJECT_SEED_LOCALE' => locale })
+  end
+
+  def with_edition(edition)
+    RSpec::Mocks.with_temporary_scope do
+      with_config(edition:)
+      yield
+    end
+  end
+end

--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -48,7 +48,12 @@ class WithConfig
   #
   # @config [Hash] Hash containing the configurations with keys as seen in `configuration.rb`.
   def before(example, config)
-    aggregate_mocked_configuration(example, config)
+    full_config = aggregate_mocked_configuration(example, config)
+    stub_config(full_config)
+  end
+
+  def stub_config(config)
+    config
       .with_indifferent_access
       .each { |k, v| stub_key(k, v) }
   end
@@ -89,7 +94,17 @@ class WithConfig
   end
 end
 
+module WithConfigMixin
+  module_function
+
+  def with_config(config)
+    WithConfig.new(self).stub_config(config)
+  end
+end
+
 RSpec.configure do |config|
+  config.include WithConfigMixin
+
   config.before do |example|
     with_config = example.metadata[:with_config]
 


### PR DESCRIPTION
https://community.openproject.org/wp/47353

The idea is to generate the translation files from the seed data files `standard.yml` and `bim.yml`, get it communicated to crowdin to have actual translations, and translate the seed data. Any text in the seed data files having a `t_` prefix in its key is a text to be translated. The corresponding i18n key is generated from its path in the seed data yaml.

* [x] Translate translatable keys when loading the seed data file.
* [x] Identify translatable seed text in `standard.yml` and `bim.yml`.
* [x] Stop looking up data by its English name. It would not work anymore with another language. Implement a reference mechanism instead.
* ~~Generate `en.seed.yml` files from the translatable keys of the seed data files and send it to crowdin as part of the crowdin GitHub action.~~ Moved to work package 48016