### PR TITLE
[#47513] XLS export of work package with description cannot be opened

### DIFF
--- a/app/models/projects/exports/formatters/description.rb
+++ b/app/models/projects/exports/formatters/description.rb
@@ -1,0 +1,40 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module Projects::Exports
+  module Formatters
+    class Description < ::Exports::Formatters::Default
+      def self.apply?(attribute)
+        attribute.to_sym == :description
+      end
+
+      def format(project, **)
+        Rails::Html::FullSanitizer.new.sanitize(project.description)
+      end
+    end
+  end
+end

--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -1,10 +1,10 @@
 OpenProject::Application.configure do |application|
   application.config.to_prepare do
-    ::Exports::Register.register do
+    Exports::Register.register do
       list WorkPackage, WorkPackage::Exports::CSV
-      list WorkPackage, ::WorkPackage::PDFExport::WorkPackageListToPdf
+      list WorkPackage, WorkPackage::PDFExport::WorkPackageListToPdf
 
-      single WorkPackage, ::WorkPackage::PDFExport::WorkPackageToPdf
+      single WorkPackage, WorkPackage::PDFExport::WorkPackageToPdf
 
       formatter WorkPackage, WorkPackage::Exports::Formatters::Costs
       formatter WorkPackage, WorkPackage::Exports::Formatters::EstimatedHours
@@ -13,6 +13,7 @@ OpenProject::Application.configure do |application|
       list Project, Projects::Exports::CSV
       formatter Project, Exports::Formatters::CustomField
       formatter Project, Projects::Exports::Formatters::Status
+      formatter Project, Projects::Exports::Formatters::Description
     end
   end
 end

--- a/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
+++ b/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
@@ -50,7 +50,11 @@ module XlsExport::WorkPackage::Exporter
     end
 
     def row(work_package)
-      super + [work_package.description]
+      super + [sanitize(work_package.description)]
+    end
+
+    def sanitize(string)
+      Rails::Html::FullSanitizer.new.sanitize(string)
     end
   end
 

--- a/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
@@ -31,6 +31,18 @@ describe XlsExport::Project::Exporter::XLS do
                                 project.name, project.description, 'Off track', 'false']
   end
 
+  context 'with project description containing html' do
+    before do
+      project.update(description: "This is an <p>html</p> description.")
+    end
+
+    it 'performs a successful export' do
+      expect(rows.count).to eq(1)
+      expect(sheet.row(1)).to eq [project.id.to_s, project.identifier, project.name,
+                                  "This is an html description.", 'Off track', 'false']
+    end
+  end
+
   context 'with status_explanation enabled' do
     before do
       Setting.enabled_projects_columns += ["status_explanation"]

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -242,18 +242,18 @@ describe XlsExport::WorkPackage::Exporter::XLS do
 
     let(:work_package) do
       create(:work_package,
-             description: 'some arbitrary description',
+             description: "some arbitrary description \n <p>with some html</p>",
              project:,
              type: project.types.first)
     end
     let(:work_packages) { [work_package] }
     let(:column_names) { %w[id] }
 
-    it 'includes the description' do
+    it 'includes the HTML sanitized description' do
       expect(sheet.rows.size).to eq(1 + 1)
 
       expect(sheet.rows[1][1])
-        .to eql(work_package.description)
+        .to eql("some arbitrary description \n with some html")
     end
   end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/47513

As the quick solution, the work package and project descriptions are being stripped from html tags in the xls export.
Since excel supports rich text format, we can map our rich text editor formatting to excel for a better description export.