### PR TITLE
Remove truncation of work package subject in title 

### DIFF
--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -178,7 +178,7 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
     this.authorisationService.initModelAuth('work_package', this.workPackage.$links);
 
     // Push the current title
-    this.titleService.setFirstPart(this.workPackage.subjectWithType(20));
+    this.titleService.setFirstPart(this.workPackage.subjectWithType(-1));
 
     // Preselect this work package for future list operations
     this.showStaticPagePath = this.PathHelper.workPackagePath(this.workPackageId);


### PR DESCRIPTION
This was added in https://github.com/opf/openproject/pull/6308 but never specified to be truncated. The truncation happens so early that searching for the title becomes harder.

https://community.openproject.org/wp/47876