### PR TITLE
Removing references to Enterprise for multi-select custom fields

### DIFF
--- a/docs/system-admin-guide/custom-fields/README.md
+++ b/docs/system-admin-guide/custom-fields/README.md
@@ -63,16 +63,13 @@ With these additional settings, you have absolute freedom which custom fields ar
 
 
 
-## Create a multi-select custom field (Enterprise add-on)
+## Create a multi-select custom field
 
 For work package custom fields of type **List** and **User** you may also select **multi-select custom fields** to select more than one value at once.
-Please note that this add-on is only available in the [Enterprise on-premises](https://www.openproject.org/enterprise-edition/) and [Enterprise cloud](https://www.openproject.org/hosting/).
 
-To create a multi-select custom field follow the same steps as you would when [creating a standard custom field](#add-a-new-custom-field). Select format *List* or format *User* and check the option *Allow multi-select*.
+To create a multi-select custom field follow the same steps as you would when [creating a standard custom field](#add-a-new-custom-field). Select format *List* or *User* and check the option *Allow multi-select*.
 
 ![Sys-admin-multi-select-custom-field](Sys-admin-multi-select-custom-field.png)
-
-
 
 When using multi-select custom fields, you can add as many options as required. The cross icon next to an option will remove it from the selection. The check mark will save your changes.
 

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -242,7 +242,7 @@ module OpenProject
                 href: 'https://www.openproject.org/docs/system-admin-guide/custom-fields/custom-fields-projects/'
               },
               custom_field_multiselect: {
-                href: 'https://www.openproject.org/docs/system-admin-guide/custom-fields/#create-a-multi-select-custom-field-enterprise-add-on'
+                href: 'https://www.openproject.org/docs/system-admin-guide/custom-fields/#create-a-multi-select-custom-field'
               },
               status_read_only: {
                 href: 'https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-status/#create-a-new-work-package-status'


### PR DESCRIPTION
I've deleted the references to multi-select being an Enterprise add-on in the Custom fields section as this will be released to community in 13.0 (OP#47851).

@as-op does the index menu on the right side update automatically with the headers (I removed the Enterprise add-on part of it) or do we need to do something else here?