### PR TITLE
do no allow taking over builtin users via omniauth

### DIFF
--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -162,7 +162,7 @@ module Authentication
     def remap_existing_user
       return unless Setting.oauth_allow_remapping_of_existing_users?
 
-      User.find_by_login(user_attributes[:login])
+      User.not_builtin.find_by(login: user_attributes[:login])
     end
 
     ##


### PR DESCRIPTION
With a wrong omniauth (say, SAML) configuration returning an empty (`""`) login it was possible to take over the anonymous or even the system user by accident. This PR prevents that by only allowing not builtin users to be taken over.