### PR TITLE
Fix CSP frame-src for recaptcha

### DIFF
--- a/modules/recaptcha/lib/open_project/recaptcha/engine.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha/engine.rb
@@ -35,7 +35,7 @@ module OpenProject::Recaptcha
           keys.index_with value
         else
           {
-            frame_src: %w(https://www.google.com/recaptcha/)
+            frame_src: %w[https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/]
           }
         end
       end


### PR DESCRIPTION
Fixes https://community.openproject.org/wp/44115

Using www.recaptcha.net/recaptcha/ everywhere www.google.com/recaptcha/ is used, as recommended in https://developers.google.com/recaptcha/docs/faq\#can-i-use-recaptcha-globally,

Explicitly use `frame-src` as recommended in https://developers.google.com/recaptcha/docs/faq\#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha (the nonce seems to work only for `script-src`, but not `frame-src`).