### PR TITLE
Drop other sessions of a user when registering the first 2FA device

### DIFF
--- a/app/services/sessions/drop_all_sessions_service.rb
+++ b/app/services/sessions/drop_all_sessions_service.rb
@@ -1,0 +1,46 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require_relative './base_service'
+
+module Sessions
+  class DropAllSessionsService < BaseService
+    class << self
+      ##
+      # Drop all sessions for the given user
+      def call(user)
+        return false unless active_record_sessions?
+
+        ::Sessions::UserSession
+          .for_user(user)
+          .delete_all
+
+        true
+      end
+    end
+  end
+end

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -132,6 +132,7 @@ module ::TwoFactorAuthentication
     def index_path
       raise NotImplementedError
     end
+
     helper_method :index_path
 
     def registration_failure_path
@@ -152,8 +153,10 @@ module ::TwoFactorAuthentication
 
     def logout_other_sessions
       if current_user == target_user
+        Rails.logger.info { "First 2FA device registered for #{target_user}, terminating other logged in sessions." }
         ::Sessions::DropOtherSessionsService.call(target_user, session)
       else
+        Rails.logger.info { "First 2FA device registered for #{target_user}, terminating logged in sessions." }
         ::Sessions::DropAllSessionsService.call(target_user)
       end
     end

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -95,6 +95,7 @@ module ::TwoFactorAuthentication
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def confirm_and_save(result)
       if result.success? && @device.confirm_registration_and_save
         flash[:notice] = t('two_factor_authentication.devices.registration_complete')
@@ -109,6 +110,7 @@ module ::TwoFactorAuthentication
         false
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def request_token_for_device(device, locals)
       transmit = token_service(device).request

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -69,24 +69,6 @@ module ::TwoFactorAuthentication
         )
       end
 
-      ##
-      # Validate the token input
-      def validate_device_token
-        service = token_service(@device)
-        result = service.verify(params[:otp])
-
-        if result.success? && @device.confirm_registration_and_save
-          flash[:notice] = t('two_factor_authentication.devices.registration_complete')
-          return redirect_to action: :index
-        elsif !result.success?
-          flash[:error] = t('two_factor_authentication.devices.registration_failed_token_invalid')
-        else
-          flash[:error] = t('two_factor_authentication.devices.registration_failed_update')
-        end
-
-        redirect_to action: :confirm, device_id: @device.id
-      end
-
       def request_token_for_device(device, locals)
         transmit = token_service(device).request
 
@@ -110,6 +92,10 @@ module ::TwoFactorAuthentication
 
       def show_local_breadcrumb
         false
+      end
+
+      def registration_success_path
+        url_for(action: :index)
       end
 
       def set_user_variables

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
@@ -23,8 +23,10 @@ module ::TwoFactorAuthentication
         @device_type = params[:key].to_sym
         @device = new_device_type! @device_type
 
+        has_default = ::TwoFactorAuthentication::Device.has_default?(target_user)
         @device.attributes = new_device_params
         if @device.confirm_registration_and_save
+          logout_other_sessions unless has_default
           Rails.logger.info "Admin ##{current_user.id} registered a new device #{@device_type} for #{@user.id}."
           redirect_to index_path
         else

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
@@ -56,36 +56,6 @@ module ::TwoFactorAuthentication
       end
 
       ##
-      # Send a confirmation and request a OTP entry from the user to activate the device
-      def confirm
-        if request.get?
-          request_device_confirmation_token
-        else
-          return unless ensure_token_parameter
-
-          validate_device_token
-        end
-      end
-
-      ##
-      # Validate the token input
-      def validate_device_token
-        service = token_service(@device)
-        result = service.verify(params[:otp])
-
-        if result.success? && @device.confirm_registration_and_save
-          flash[:notice] = t('two_factor_authentication.devices.registration_complete')
-          return redirect_to action: :index
-        elsif !result.success?
-          flash[:error] = t('two_factor_authentication.devices.registration_failed_token_invalid')
-        else
-          flash[:error] = t('two_factor_authentication.devices.registration_failed_update')
-        end
-
-        redirect_to confirm_two_factor_device_path(@device)
-      end
-
-      ##
       # Destroy the given device if its not the default
       def destroy
         if @device.default && strategy_manager.enforced?
@@ -116,6 +86,10 @@ module ::TwoFactorAuthentication
 
       def index_path
         edit_user_path(@user, tab: :two_factor_authentication)
+      end
+
+      def registration_success_path
+        index_path
       end
 
       def find_user

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
@@ -18,7 +18,7 @@ module TwoFactorAuthentication
     end
 
     def self.has_default?(user)
-      Device.where(user_id: user.id, active: true, default: true).exists?
+      Device.exists?(user_id: user.id, active: true, default: true)
     end
 
     def has_default?

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
@@ -185,7 +185,10 @@ describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesController
             expect(device.default).to be false
           end
 
-          it 'activates the device when entered correctly' do
+          it 'activates the device when entered correctly and logs out the user' do
+            allow(::Sessions::DropAllSessionsService)
+              .to receive(:call)
+
             allow_any_instance_of(TwoFactorAuthentication::TokenService)
               .to receive(:verify)
               .with('1234')
@@ -197,6 +200,9 @@ describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesController
             device.reload
             expect(device.active).to be true
             expect(device.default).to be true
+
+            expect(::Sessions::DropAllSessionsService)
+              .to have_received(:call).with(user)
           end
         end
       end

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
@@ -186,13 +186,15 @@ describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesController
           end
 
           it 'activates the device when entered correctly and logs out the user' do
-            allow(::Sessions::DropAllSessionsService)
+            allow(Sessions::DropAllSessionsService)
               .to receive(:call)
 
+            # rubocop:disable RSpec/AnyInstance
             allow_any_instance_of(TwoFactorAuthentication::TokenService)
               .to receive(:verify)
               .with('1234')
               .and_return(ServiceResult.success)
+            # rubocop:enable RSpec/AnyInstance
 
             post :confirm, params: { device_id: device.id, otp: '1234' }
             expect(response).to redirect_to stage_success_path(stage: :two_factor_authentication, secret: 'asdf')
@@ -201,7 +203,7 @@ describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesController
             expect(device.active).to be true
             expect(device.default).to be true
 
-            expect(::Sessions::DropAllSessionsService)
+            expect(Sessions::DropAllSessionsService)
               .to have_received(:call).with(user)
           end
         end

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
@@ -202,10 +202,12 @@ describe TwoFactorAuthentication::My::TwoFactorDevicesController do
               let!(:default_device) { create(:two_factor_authentication_device_totp, user:, default: true) }
 
               it 'activates the device when entered correctly' do
+                # rubocop:disable RSpec/AnyInstance
                 allow_any_instance_of(TwoFactorAuthentication::TokenService)
-                    .to receive(:verify)
-                            .with('1234')
-                            .and_return(ServiceResult.success)
+                  .to receive(:verify)
+                  .with('1234')
+                  .and_return(ServiceResult.success)
+                # rubocop:enable RSpec/AnyInstance
 
                 post :confirm, params: { device_id: device.id, otp: '1234' }
                 expect(response).to redirect_to action: :index

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
@@ -179,36 +179,42 @@ describe TwoFactorAuthentication::My::TwoFactorDevicesController do
             expect(device.default).to be false
           end
 
-          it 'activates the device when entered correctly' do
-            allow_any_instance_of(TwoFactorAuthentication::TokenService)
-              .to receive(:verify)
-              .with('1234')
-              .and_return(ServiceResult.success)
+          context 'when user has another active session' do
+            let!(:plain_session) { create(:user_session, user:) }
+            let!(:user_session) { Sessions::UserSession.find_by(session_id: plain_session.session_id) }
 
-            post :confirm, params: { device_id: device.id, otp: '1234' }
-            expect(response).to redirect_to action: :index
-            expect(flash[:notice]).to include I18n.t('two_factor_authentication.devices.registration_complete')
-            device.reload
-            expect(device.active).to be true
-            expect(device.default).to be true
-          end
-
-          context 'with another default device present' do
-            let!(:default_device) { create(:two_factor_authentication_device_totp, user:, default: true) }
-
-            it 'activates the device when entered correctly' do
+            it 'activates the device when entered correctly and clears other sessions' do
               allow_any_instance_of(TwoFactorAuthentication::TokenService)
-                  .to receive(:verify)
-                          .with('1234')
-                          .and_return(ServiceResult.success)
+                .to receive(:verify)
+                .with('1234')
+                .and_return(ServiceResult.success)
 
               post :confirm, params: { device_id: device.id, otp: '1234' }
               expect(response).to redirect_to action: :index
               expect(flash[:notice]).to include I18n.t('two_factor_authentication.devices.registration_complete')
               device.reload
               expect(device.active).to be true
-              # but does not set default
-              expect(device.default).to be false
+              expect(device.default).to be true
+              expect { user_session.reload }.to raise_error(ActiveRecord::RecordNotFound)
+            end
+
+            context 'with another default device present' do
+              let!(:default_device) { create(:two_factor_authentication_device_totp, user:, default: true) }
+
+              it 'activates the device when entered correctly' do
+                allow_any_instance_of(TwoFactorAuthentication::TokenService)
+                    .to receive(:verify)
+                            .with('1234')
+                            .and_return(ServiceResult.success)
+
+                post :confirm, params: { device_id: device.id, otp: '1234' }
+                expect(response).to redirect_to action: :index
+                expect(flash[:notice]).to include I18n.t('two_factor_authentication.devices.registration_complete')
+                device.reload
+                expect(device.active).to be true
+                # but does not set default
+                expect(device.default).to be false
+              end
             end
           end
         end

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
@@ -122,6 +122,16 @@ describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
       end
     end
 
+    describe '#confirm' do
+      it 'fails on GET' do
+        expect { get :confirm }.to raise_error(ActionController::UrlGenerationError)
+      end
+
+      it 'fails on POST' do
+        expect { post :confirm }.to raise_error(ActionController::UrlGenerationError)
+      end
+    end
+
     describe '#destroy' do
       it 'croaks on missing id' do
         delete :destroy, params: { id: user.id, device_id: '1234' }

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
@@ -23,7 +23,7 @@ describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
     allow(User).to receive(:current).and_return(logged_in_user)
     allow(OpenProject::TwoFactorAuthentication::TokenStrategyManager)
       .to receive(:add_default_strategy?)
-      .and_return false
+            .and_return false
   end
 
   describe 'accessing' do
@@ -93,14 +93,12 @@ describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
     end
 
     describe '#register' do
-      before do
-        post :register, params: { id: user.id, key: :sms, device: params }
-      end
-
       context 'with missing phone' do
         let(:params) { { identifier: 'foo' } }
 
         it 'renders action new' do
+          post :register, params: { id: user.id, key: :sms, device: params }
+
           expect(response).to be_successful
           expect(response).to render_template 'new'
           expect(assigns[:device]).to be_invalid
@@ -111,6 +109,8 @@ describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
         let(:params) { { phone_number: '+49123456789', identifier: 'foo' } }
 
         it 'redirects to result' do
+          post :register, params: { id: user.id, key: :sms, device: params }
+
           device = user.otp_devices.reload.last
           expect(response).to redirect_to edit_user_path(user.id, tab: :two_factor_authentication)
 
@@ -118,6 +118,44 @@ describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
           expect(device.phone_number).to eq '+49123456789'
           expect(device.default).to be_truthy
           expect(device.active).to be_truthy
+        end
+
+        context 'when user has active sessions' do
+          let!(:plain_session1) { create(:user_session, user:) }
+          let!(:user_session1) { Sessions::UserSession.find_by(session_id: plain_session1.session_id) }
+
+          let!(:plain_session2) { create(:user_session, user:) }
+          let!(:user_session2) { Sessions::UserSession.find_by(session_id: plain_session2.session_id) }
+
+          let!(:other_plain_session) { create(:user_session, user: other_user) }
+          let!(:other_session) { Sessions::UserSession.find_by(session_id: other_plain_session.session_id) }
+
+          it 'drops all sessions of that user' do
+            post :register, params: { id: user.id, key: :sms, device: params }
+
+            expect { user_session1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { user_session2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+            expect { other_session.reload }.not_to raise_error
+          end
+
+          context 'when user has an active device' do
+            let!(:device) { create(:two_factor_authentication_device_totp, user:, default: true) }
+
+            it 'does nothing' do
+              post :register, params: { id: user.id, key: :sms, device: params }
+
+              expect(user.otp_devices.count).to eq 2
+              expect(device.reload).to be_default
+              expect(user.otp_devices.last).to be_active
+              expect(user.otp_devices.last).not_to be_default
+
+              expect { user_session1.reload }.not_to raise_error
+              expect { user_session2.reload }.not_to raise_error
+
+              expect { other_session.reload }.not_to raise_error
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
When the user confirms their first device, all other active sessions of that user are dropped.

When an admin registers a mobile device on behalf of a user, all sessions of that user are dropped.