### PR TITLE
bug/47864 boards + team planner add existing autocompleter should respect the current project filter include projects

### DIFF
--- a/app/models/queries/work_packages/filter/id_filter.rb
+++ b/app/models/queries/work_packages/filter/id_filter.rb
@@ -29,4 +29,8 @@
 class Queries::WorkPackages::Filter::IdFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   include ::Queries::WorkPackages::Filter::FilterForWpMixin
+
+  def visible_scope
+    WorkPackage.visible
+  end
 end

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -88,11 +88,16 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
       filters.merge(currentFilters, 'subprojectId');
     }
 
+    const params = {
+      sortBy: '[["updatedAt","desc"]]',
+      offset: '1',
+      pageSize: '10',
+    };
     return this
       .apiV3Service
       .withOptionalProject(this.CurrentProject.id)
       .work_packages
-      .filtered(filters)
+      .filtered(filters, params)
       .get()
       .pipe(
         map((collection) => collection.elements),

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -80,10 +80,11 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
     if (results && results.elements.length > 0) {
       filters.add('id', '!', results.elements.map((wp:WorkPackageResource) => wp.id!));
     }
-    // Add the subproject filter, if any
+    // Add the project filter, if any
     const query = this.querySpace.query.value;
     if (query?.filters) {
       const currentFilters = this.urlParamsHelper.buildV3GetFilters(query.filters);
+      filters.merge(currentFilters, 'project');
       filters.merge(currentFilters, 'subprojectId');
     }
 

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -75,7 +75,7 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
     const filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
     const results = this.querySpace.results.value;
 
-    filters.add('subjectOrId', '**', [searchString]);
+    filters.add('typeahead', '**', [searchString]);
 
     if (results && results.elements.length > 0) {
       filters.add('id', '!', results.elements.map((wp:WorkPackageResource) => wp.id!));

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
@@ -37,7 +37,6 @@ import { StateService } from '@uirouter/core';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { teamPlannerEventRemoved } from 'core-app/features/team-planner/team-planner/planner/team-planner.actions';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
-import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
 import { OpWorkPackagesCalendarService } from 'core-app/features/calendar/op-work-packages-calendar.service';
 
 @Component({
@@ -185,7 +184,10 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
       .apiV3Service
       .withOptionalProject(this.currentProject.id)
       .work_packages
-      .filtered(filters, { pageSize: '-1' })
+      .filtered(filters, {
+        pageSize: '-1',
+        sortBy: '[["updatedAt","desc"]]',
+      })
       .get()
       .pipe(
         map((collection) => collection.elements),


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/47864

- Use typeahead filter for adding existing cards to board
- Respect project filter in autocompleter while adding existing cards to board
- Prioritize latest updated WPs for autocompleter while adding existing cards to board
- WP ID filter should allow IDs outside from current project and its subprojects, e.g. when combined with project filter
