### PR TITLE
Fix wrong spacing in Firefox when using line breaks in tables

### DIFF
--- a/frontend/src/global_styles/content/user-content/_mixins.sass
+++ b/frontend/src/global_styles/content/user-content/_mixins.sass
@@ -1,7 +1,10 @@
 @mixin user-content-children 
   > * + *
     margin-top: 0.8rem
-  
+
+  > br
+    margin-top: 0
+
   > .op-uc-h1 + *,
   > .op-uc-h2 + *,
   > .op-uc-h3 + *,


### PR DESCRIPTION
Exclude br from margin-top in user content-mixin because this results in wrong spacing in Firefox and all other browsers ignore margins on br. 

See [#48027](https://community.openproject.org/projects/openproject/work_packages/details/48027) for details