### PR TITLE
WP Fields [2]: Two columns with label-on-top on thin fields

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.sass
@@ -13,10 +13,11 @@
   width: calc(100% + #{$spot-spacing-3})
 
   &--attribute
-    flex-basis: calc(100% - #{$spot-spacing-3})
-    flex-grow: 0
+    flex-basis: 20rem
+    flex-grow: 1
     flex-shrink: 0
     margin: 0 $spot-spacing-1_5
+    max-width: 100%
 
     @media screen and (min-width: 92rem), print
       flex-basis: calc(50% - #{$spot-spacing-3})

--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -36,6 +36,7 @@
     @extend .form--label
     display: flex
     flex-basis: 170px
+    flex-grow: 1
     padding: 0.375rem 0
     font-weight: bold
     > wp-replacement-label
@@ -47,10 +48,12 @@
 
   &--value-container
     display: flex
-    flex: 1 0 65%
+    flex-basis: 65%
+    flex-grow: 1000000
+    flex-shrink: 0
+    align-self: center
     margin-bottom: 0.1875rem
     padding: 0.375rem 0
-    align-self: center
     height: 100%
 
     p

--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -30,52 +30,51 @@
   display: flex
   flex-wrap: wrap
   font-size: 0.875rem
-
-.attributes-key-value--key
-  @extend .form--label
-  display: flex
-  flex: 1 0 35%
-  max-width: 35%
   margin-bottom: 0.1875rem
-  padding: 0.375rem 0
-  font-weight: bold
-  // Ensure that the text is shortened while the help icon will be displayed
-  // The flex and max-width of wp-replacement-label and attribute-help-text
-  // are tuned to:
-  // * have the label be displayed in total if there is enough place (safari
-  //   tends to sometimes fall back to ellipsis too early, e.g. for 'Category')
-  // * Have the label grow to the full width if necessary and only apply ellipsis
-  //   after that.
-  // * have the attribute-help-text positioned as far to the left as possible so to be
-  //   right after the label.
-  // It is unclear why in `flex: 100 0 auto` the 100 seems to be doing the trick (MAGIC NUMBER).
-  // It does not work with e.g. 1000 or 10
-  > wp-replacement-label
-    @include text-shortener
-    padding-right: $spot-spacing-0_5
-    flex: 1 1 auto
-    max-width: 100%
-  > attribute-help-text
-    flex: 100 0 auto
 
-.attributes-key-value--value-container
-  display: flex
-  flex: 1 0 65%
-  max-width: 65%
-  margin-bottom: 0.1875rem
-  padding: 0.375rem 0
-  align-self: center
-  height: 100%
+  &--key
+    @extend .form--label
+    display: flex
+    flex-basis: 170px
+    padding: 0.375rem 0
+    font-weight: bold
+    // Ensure that the text is shortened while the help icon will be displayed
+    // The flex and max-width of wp-replacement-label and attribute-help-text
+    // are tuned to:
+    // * have the label be displayed in total if there is enough place (safari
+    //   tends to sometimes fall back to ellipsis too early, e.g. for 'Category')
+    // * Have the label grow to the full width if necessary and only apply ellipsis
+    //   after that.
+    // * have the attribute-help-text positioned as far to the left as possible so to be
+    //   right after the label.
+    // It is unclear why in `flex: 100 0 auto` the 100 seems to be doing the trick (MAGIC NUMBER).
+    // It does not work with e.g. 1000 or 10
+    > wp-replacement-label
+      @include text-shortener
+      padding-right: $spot-spacing-0_5
+      flex: 1 1 auto
+      max-width: 100%
+    > attribute-help-text
+      flex: 100 0 auto
 
-  p
-    font-size: $form-label-fontsize
-    word-wrap: break-word
+  &--value-container
+    display: flex
+    flex: 1 0 65%
+    max-width: 65%
+    margin-bottom: 0.1875rem
+    padding: 0.375rem 0
+    align-self: center
+    height: 100%
 
-  &.not-editable
-    padding: 6px
+    p
+      font-size: $form-label-fontsize
+      word-wrap: break-word
 
-.attributes-key-value--value
-  @include grid-visible-overflow
+    &.not-editable
+      padding: 6px
+
+  &--value
+    @include grid-visible-overflow
 
 // Alternative implementation to the one above.
 // It's main advantage is that it can act on the whole of the key/value-pairs.

--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -38,19 +38,7 @@
     flex-basis: 170px
     padding: 0.375rem 0
     font-weight: bold
-    // Ensure that the text is shortened while the help icon will be displayed
-    // The flex and max-width of wp-replacement-label and attribute-help-text
-    // are tuned to:
-    // * have the label be displayed in total if there is enough place (safari
-    //   tends to sometimes fall back to ellipsis too early, e.g. for 'Category')
-    // * Have the label grow to the full width if necessary and only apply ellipsis
-    //   after that.
-    // * have the attribute-help-text positioned as far to the left as possible so to be
-    //   right after the label.
-    // It is unclear why in `flex: 100 0 auto` the 100 seems to be doing the trick (MAGIC NUMBER).
-    // It does not work with e.g. 1000 or 10
     > wp-replacement-label
-      @include text-shortener
       padding-right: $spot-spacing-0_5
       flex: 1 1 auto
       max-width: 100%
@@ -60,7 +48,6 @@
   &--value-container
     display: flex
     flex: 1 0 65%
-    max-width: 65%
     margin-bottom: 0.1875rem
     padding: 0.375rem 0
     align-self: center

--- a/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
+++ b/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
@@ -115,34 +115,6 @@ i
     padding: 0
     margin: 0
 
-// Increase label width
-.router--work-packages-full-view .attributes-group,
-.router--work-packages-full-create .attributes-group
-  // We have to find a middle way between
-  // (a) avoiding label wrap and
-  // (b) ugly content wrap (e.g. in the label)
-  // These values are what matches best at the moment. So be careful when changing them.
-  .attributes-key-value--key
-    flex: 1 0 45%
-    max-width: 45%
-  .attributes-key-value--value-container
-    position: relative
-    flex: 1 0 55%
-    max-width: 55%
-
-  // For attributes that span both columns, make sure the label is not way too wide 
-  .wp-attribute-group--attribute_span-all
-    @media screen and (min-width: 92rem), print
-      // These weird calculations are made to account for the side-margins that make
-      // up the flex-basis calculations of the single-column items. 
-      .attributes-key-value--key
-        flex: 1 0 calc((100% - 3rem) * 0.225)
-        max-width: calc((100% - 3rem) * 0.225)
-      .attributes-key-value--value-container
-        flex: 1 0 calc((100% - 3rem) * 0.775)
-        max-width: calc((100% - 3rem) * 0.775)
-
-
 // -------------------- Info row --------------------
 .work-packages--info-row
   font-size: 12px

--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -76,16 +76,8 @@
     .toolbar-container
       padding-right: 0
 
-    .attributes-key-value--key,
-    .attributes-key-value--value-container
-      margin-bottom: 20px
-
       .inplace-editing--container
         border: none
-
-    .attributes-key-value--key
-      flex-basis: 30% !important
-      padding: 0 !important
 
     .work-packages--panel-inner > .attributes-group:first-child
       .attributes-group--header


### PR DESCRIPTION
This is one of two possible variants of column layouting for work package fields, where all field labels behave the same. Because we cannot rely on breakpoints for layouting, the layouting instead relies on the widths of the containers themselves.

Closes https://community.openproject.org/projects/14/work_packages/47680/activity

Alternative Pullpreview is @ #12545
Alternative Pullpreview is @ #12549