### PR TITLE
The Revit guide missed support for Revit 2022

### DIFF
--- a/docs/bim-guide/revit-add-in/README.md
+++ b/docs/bim-guide/revit-add-in/README.md
@@ -40,6 +40,7 @@ The **OpenProject Revit AddIn** does not have any special system requirements. A
 - 2019
 - 2020
 - 2021
+- 2022
 
 
 


### PR DESCRIPTION
The support was added back in 2021 https://community.openproject.org/projects/bcfier/work_packages/37958/activity
