### PR TITLE
Skip tests whose needed CLI command is unavailable

### DIFF
--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -70,7 +70,7 @@ describe OpenProject::SCM::Adapters::Subversion do
   end
 
   describe 'invalid repository' do
-    describe '.check_availability!' do
+    describe '.check_availability!', skip_if_command_unavailable: 'svnadmin' do
       it 'is not available' do
         expect(Dir.exist?(url)).to be false
         expect(adapter).not_to be_available
@@ -130,7 +130,7 @@ describe OpenProject::SCM::Adapters::Subversion do
     include_context 'with tmpdir'
     let(:root_url) { tmpdir }
 
-    describe '.create_empty_svn' do
+    describe '.create_empty_svn', skip_if_command_unavailable: 'svnadmin' do
       context 'with valid root_url' do
         it 'creates the repository' do
           expect(Dir.exist?(root_url)).to be true
@@ -154,7 +154,7 @@ describe OpenProject::SCM::Adapters::Subversion do
       end
     end
 
-    describe '.check_availability!' do
+    describe '.check_availability!', skip_if_command_unavailable: 'svnadmin' do
       it 'is marked empty' do
         adapter.create_empty_svn
         expect { adapter.check_availability! }

--- a/spec/models/ldap_auth_source_spec.rb
+++ b/spec/models/ldap_auth_source_spec.rb
@@ -216,7 +216,7 @@ describe LdapAuthSource do
     end
   end
 
-  describe 'with live LDAP' do
+  describe 'with live LDAP', skip_if_command_unavailable: 'java' do
     before(:all) do
       ldif = Rails.root.join('spec/fixtures/ldap/users.ldif')
       @ldap_server = Ladle::Server.new(quiet: false, port: ParallelHelper.port_for_ldap.to_s, domain: 'dc=example,dc=com',
@@ -224,7 +224,7 @@ describe LdapAuthSource do
     end
 
     after(:all) do
-      @ldap_server.stop
+      @ldap_server&.stop # rubocop:disable RSpec/InstanceVariable
     end
 
     # Ldap has three users aa729, bb459, cc414

--- a/spec/support/repository_helpers.rb
+++ b/spec/support/repository_helpers.rb
@@ -35,19 +35,17 @@
 # of isolation.
 def with_filesystem_repository(vendor, command = nil, &block)
   repo_dir = Dir.mktmpdir("#{vendor}_repository")
-  fixture = File.join(Rails.root, "spec/fixtures/repositories/#{vendor}_repository.tar.gz")
+  fixture = Rails.root.join("spec/fixtures/repositories/#{vendor}_repository.tar.gz")
 
-  ['tar', command].compact.each do |cmd|
-    # Avoid `which`, as it's not POSIX
-    Open3.capture2e(cmd, '--version')
-  rescue Errno::ENOENT
-    skip "#{cmd} was not found in PATH. Skipping local repository specs"
+  before do
+    skip_if_commands_unavailable('tar', command)
   end
 
   after(:all) do
     FileUtils.remove_dir repo_dir
   end
 
+  skip_if_command_unavailable('tar')
   system "tar -xzf #{fixture} -C #{repo_dir}"
   block.call(repo_dir)
 end

--- a/spec/support/skip_if_command_unavailable.rb
+++ b/spec/support/skip_if_command_unavailable.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module SkipIfCommandUnavailableMixin
+  # Ensure given command(s) exist by running it with `--help`.
+  # If the command does not exist, the test is skipped.
+  #
+  # The test is not skipped if in continuous integration environment.
+  def skip_if_commands_unavailable(*commands)
+    return if ENV['CI']
+
+    commands.flatten.compact.each do |cmd|
+      # Avoid `which`, as it's not POSIX
+      Open3.capture2e(cmd, '--version')
+    rescue Errno::ENOENT
+      skip "Skipped because '#{cmd}' command not found in PATH"
+    end
+  end
+
+  alias :skip_if_command_unavailable :skip_if_commands_unavailable
+end
+
+RSpec.configure do |config|
+  include SkipIfCommandUnavailableMixin
+
+  config.before :all, :skip_if_command_unavailable do
+    skip_if_command_unavailable(self.class.metadata[:skip_if_command_unavailable])
+  end
+
+  config.before :all, :skip_if_commands_unavailable do
+    skip_if_command_unavailable(self.class.metadata[:skip_if_commands_unavailable])
+  end
+
+  config.before :example, :skip_if_command_unavailable do |example|
+    skip_if_command_unavailable(example.metadata[:skip_if_command_unavailable])
+  end
+
+  config.before :example, :skip_if_commands_unavailable do |example|
+    skip_if_command_unavailable(example.metadata[:skip_if_commands_unavailable])
+  end
+end


### PR DESCRIPTION
Mark a test to be skipped with `skip_if_command_unavailable: 'some_command'` or `skip_if_commands_unavailable: ['some_command', 'another_cmd']` in a group or example metadata.

Tests won't be skipped in CI environment, and will fail as expected if the needed CLI command is not available.

For instance, the `spec/models/ldap_auth_source_spec.rb` spec starts a LDAP server before running. It relies on `java` to start the ldap server. If the `java` command is not available, the tests marked with `skip_if_command_unavailable: 'java'` will be skipped.