### PR TITLE
fix migration by not using class code

### DIFF
--- a/modules/overviews/db/migrate/20190826083604_my_project_page_to_grid.rb
+++ b/modules/overviews/db/migrate/20190826083604_my_project_page_to_grid.rb
@@ -192,8 +192,16 @@ class MyProjectPageToGrid < ActiveRecord::Migration[5.2]
     Attachment.where(container_type: 'MyProjectsOverview', container_id: id)
   end
 
+  def new_default_query(attributes = nil)
+    Query.new(attributes).tap do |query|
+      query.add_default_filter
+      query.set_default_sort
+      query.show_hierarchies = true
+    end
+  end
+
   def query(grid, identifier)
-    query = Query.new_default name: '_',
+    query = new_default_query name: '_',
                               is_public: true,
                               hidden: true,
                               project: grid.project,


### PR DESCRIPTION
which has changed since the migration was written

This is why it's best avoided to use any AR model or other code that may change in migrations.

WP [#48122](https://community.openproject.org/projects/openproject/work_packages/48122/activity)