### PR TITLE
Set host name as well as Capybara root options

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,10 +5,12 @@ require 'capybara-screenshot/rspec'
 require 'rack_session_access/capybara'
 require 'action_dispatch'
 
-RSpec.shared_context 'with default_url_options set' do
+RSpec.shared_context 'with default_url_options and host name set to Capybara test server' do
   before do
     @original_host = default_url_options[:host]
     @original_port = default_url_options[:port]
+    @original_host_setting = Setting.host_name
+    Setting.host_name = "#{Capybara.server_host}:#{Capybara.server_port}"
     default_url_options[:host] = Capybara.server_host
     default_url_options[:port] = Capybara.server_port
   end
@@ -16,6 +18,7 @@ RSpec.shared_context 'with default_url_options set' do
   after do
     default_url_options[:host] = @original_host # rubocop:disable RSpec/InstanceVariable
     default_url_options[:port] = @original_port # rubocop:disable RSpec/InstanceVariable
+    Setting.host_name = @original_host_setting
   end
 end
 
@@ -39,7 +42,7 @@ RSpec.configure do |config|
   end
 
   # Set the default options
-  config.include_context 'with default_url_options set', type: :feature
+  config.include_context 'with default_url_options and host name set to Capybara test server', type: :feature
 
   # Make it possible to match on value attribute.
   #

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,19 +6,18 @@ require 'rack_session_access/capybara'
 require 'action_dispatch'
 
 RSpec.shared_context 'with default_url_options and host name set to Capybara test server' do
-  before do
-    @original_host = default_url_options[:host]
-    @original_port = default_url_options[:port]
-    @original_host_setting = Setting.host_name
-    Setting.host_name = "#{Capybara.server_host}:#{Capybara.server_port}"
+  around do |example|
+    original_host = default_url_options[:host]
+    original_port = default_url_options[:port]
+    original_host_setting = Setting.host_name
     default_url_options[:host] = Capybara.server_host
     default_url_options[:port] = Capybara.server_port
-  end
-
-  after do
-    default_url_options[:host] = @original_host # rubocop:disable RSpec/InstanceVariable
-    default_url_options[:port] = @original_port # rubocop:disable RSpec/InstanceVariable
-    Setting.host_name = @original_host_setting
+    Setting.host_name = "#{Capybara.server_host}:#{Capybara.server_port}"
+    example.run
+  ensure
+    default_url_options[:host] = original_host
+    default_url_options[:port] = original_port
+    Setting.host_name = original_host_setting
   end
 end
 


### PR DESCRIPTION
The default host name is wrong and will prevent Rails url_helpers from using `url_for foo, only_path: false` due to a leading to the wrong host.
