### PR TITLE
Fix links with edited opSetting:base_url in them

### DIFF
--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -29,25 +29,45 @@
 require 'spec_helper'
 
 describe 'Homescreen index' do
-  let!(:user) { build_stubbed(:user) }
+  let(:admin) { create(:admin) }
+  let(:user) { build_stubbed(:user) }
   let!(:project) { create(:public_project, identifier: 'public-project') }
+  let(:general_settings_page) { Pages::Admin::SystemSettings::General.new }
 
-  before do
-    login_as user
-    visit root_url
-  end
+  describe 'with a dynamic URL in the welcome text' do
+    before do
+      Setting.welcome_text = "With [a link to the public project]({{opSetting:base_url}}/projects/public-project)"
+      Setting.welcome_on_homescreen = true
+    end
 
-  describe 'with a dynamic URL in the welcome text',
-           with_settings: {
-             welcome_text: "With [a link to the public project]({{opSetting:base_url}}/projects/public-project)",
-             welcome_on_homescreen?: true
-           } do
     it 'renders the correct link' do
+      login_as user
+      visit root_url
       expect(page)
         .to have_selector("a[href=\"#{OpenProject::Application.root_url}/projects/public-project\"]")
 
       click_link "a link to the public project"
       expect(page).to have_current_path project_path(project)
+    end
+
+    it 'can change the welcome text and still have a valid link', js: true do
+      login_as admin
+
+      general_settings_page.visit!
+
+      welcome_text_editor = general_settings_page.welcome_text_editor
+      scroll_to_element(welcome_text_editor.container)
+      welcome_text_editor.click_and_type_slowly('Hello! ')
+
+      general_settings_page.press_save_button
+      general_settings_page.expect_and_dismiss_toaster
+
+      visit root_url
+      expect(page)
+        .to have_selector("a[href=\"#{OpenProject::Application.root_url}/projects/public-project\"]")
+
+      click_link "a link to the public project"
+      expect(page).to have_current_path "#{project_path(project)}/"
     end
   end
 end

--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -67,7 +67,7 @@ describe 'Homescreen index' do
         .to have_selector("a[href=\"#{OpenProject::Application.root_url}/projects/public-project\"]")
 
       click_link "a link to the public project"
-      expect(page).to have_current_path "#{project_path(project)}/"
+      expect(page).to have_current_path /#{Regexp.escape(project_path(project))}\/?$/
     end
   end
 end

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -48,9 +48,17 @@ describe 'Switching types in work package table', js: true do
       query
     end
 
-    let(:type_field) { wp_table.edit_field(work_package, :type) }
-    let(:text_field) { wp_table.edit_field(work_package, cf_text.attribute_name(:camel_case)) }
-    let(:req_text_field) { wp_table.edit_field(work_package, cf_req_text.attribute_name(:camel_case)) }
+    def type_field
+      wp_table.edit_field(work_package, :type)
+    end
+
+    def text_field
+      wp_table.edit_field(work_package, cf_text.attribute_name(:camel_case))
+    end
+
+    def req_text_field
+      wp_table.edit_field(work_package, cf_req_text.attribute_name(:camel_case))
+    end
 
     before do
       login_as(user)

--- a/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
@@ -43,6 +43,8 @@ describe OpenProject::TextFormatting,
 
           [Link with setting]({{opSetting:base_url}}/foo/bar)
 
+          [Saved and transformed link with setting](http://localhost:3000/prefix/%7B%7BopSetting:base_url%7D%7D/foo/bar)
+
           Inline reference to invalid variable: {{opSetting:smtp_password}}
 
           Inline reference to missing variable: {{opSetting:does_not_exist}}
@@ -60,6 +62,10 @@ describe OpenProject::TextFormatting,
           <p class="op-uc-p">
             <a href="#{OpenProject::Application.root_url}/foo/bar" rel="noopener noreferrer"
                class="op-uc-link">Link with setting</a>
+          </p>
+          <p class="op-uc-p">
+            <a href="#{OpenProject::Application.root_url}/foo/bar" rel="noopener noreferrer"
+               class="op-uc-link">Saved and transformed link with setting</a>
           </p>
           <p class="op-uc-p">
             Inline reference to invalid variable: {{opSetting:smtp_password}}

--- a/spec/support/pages/admin/system_settings/general.rb
+++ b/spec/support/pages/admin/system_settings/general.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -28,56 +26,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject::TextFormatting
-  module Filters
-    class SettingMacrosFilter < HTML::Pipeline::Filter
-      ALLOWED_SETTINGS = %w[
-        host_name
-        base_url
-      ].freeze
+require 'support/pages/page'
 
-      def self.regexp
-        %r{
-        \{\{opSetting:(.+?)\}\}
-        |
-        https?://[^% ]+?/%7B%7BopSetting:(base_url)%7D%7D
-        }x
-      end
+module Pages::Admin::SystemSettings
+  class General < ::Pages::Page
+    def path
+      "/admin/settings/general"
+    end
 
-      def call
-        return html unless applicable?
+    def toast_type
+      :rails
+    end
 
-        html.gsub(self.class.regexp) do |matched_string|
-          variable = ($1.presence || $2.presence).dup
-          variable.gsub!('\\', '')
+    def welcome_text_editor
+      Components::WysiwygEditor.new welcome_text_selector
+    end
 
-          if ALLOWED_SETTINGS.include?(variable)
-            send variable
-          else
-            matched_string
-          end
-        end
-      end
+    def welcome_text_selector
+      'ckeditor-augmented-textarea[textarea-selector="#settings_welcome_text"]'
+    end
 
-      private
-
-      def host_name
-        OpenProject::StaticRouting::UrlHelpers.host
-      end
-
-      def base_url
-        url_helpers.root_url.chomp('/')
-      end
-
-      def url_helpers
-        @url_helpers ||= OpenProject::StaticRouting::StaticRouter.new.url_helpers
-      end
-
-      ##
-      # Faster inclusion check before the regex is being applied
-      def applicable?
-        html.include?('{{opSetting:') || html.include?('%7B%7BopSetting:')
-      end
+    def press_save_button
+      scroll_to(:bottom)
+      click_button('Save')
     end
   end
 end


### PR DESCRIPTION
Refs https://community.openproject.org/wp/48158

When editing formatted text, the ckeditor turns `{{opSetting::base_url}}` into an escaped version of the same link. It then looks like `http://host:port/%7B%7BopSetting:base_port%7D%7D` and does not work anymore.

The fix here is to extend the macro recognition regex to include the http://host:port/ part before with the escaped curly braces, so that substitution works. It has the nice side effect to make all previously edited links work again.