### PR TITLE
mark the link of members in the group representer uncacheable

### DIFF
--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -205,6 +205,7 @@ module API
                                  skip_render: ->(*) { false },
                                  skip_link: skip_render,
                                  link_title_attribute: :name,
+                                 uncacheable_link: false,
                                  getter: associated_resources_default_getter(name, representer),
                                  setter: associated_resources_default_setter(name, v3_path),
                                  link: associated_resources_default_link(name,
@@ -216,6 +217,7 @@ module API
                     getter:,
                     setter:,
                     link:,
+                    uncacheable_link:,
                     skip_render:)
         end
 

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -54,7 +54,8 @@ module API
 
         associated_resources :users,
                              as: :members,
-                             skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }
+                             skip_render: -> { !current_user.allowed_to_globally?(:manage_members) },
+                             uncacheable_link: true
       end
     end
   end

--- a/spec/lib/api/v3/groups/group_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_representer_spec.rb
@@ -84,6 +84,18 @@ describe API::V3::Groups::GroupRepresenter, 'rendering' do
 
         it_behaves_like 'has no link'
       end
+
+      context 'when first having the necessary permissions and then not (caching)' do
+        before do
+          representer.to_json
+
+          allow(current_user)
+            .to receive(:allowed_to_globally?)
+                  .and_return false
+        end
+
+        it_behaves_like 'has no link'
+      end
     end
 
     describe 'updateImmediately' do


### PR DESCRIPTION
That link should be guarded by a permission check but that permission check short circuited if the cache is used.

Ideally, the `skip_render` would be transformed into a `cache_if` like it is present on the links. That way, the result would still be cached only to be removed in case the user lacks permission.

I refrained from doing so in this bugfix.

https://community.openproject.org/wp/42303