### PR TITLE
[48215] Inconsistent drop down button behaviour in work packages toolbar

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
@@ -15,8 +15,7 @@
   <span class="spot-icon spot-icon_baseline"></span>
     {{ text.toggle_title }}
   
-    <span *ngIf="!opened" class="spot-icon spot-icon_dropdown"></span>
-    <span *ngIf="opened" class="spot-icon spot-icon_dropdown-open"></span>
+    <span class="spot-icon spot-icon_dropdown"></span>
   </button>
 
   <ng-container slot="body">

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -14,4 +14,5 @@
     {{ buttonText }}
     <span class="badge -secondary" *ngIf="initialized" [textContent]="filterCount"></span>
   </span>
+  <span class="spot-icon spot-icon_dropdown"></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -49,7 +49,7 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
             aria-hidden="true"
             [textContent]="text[view]">
         </span>
-      <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+        <span class="spot-icon spot-icon_dropdown"></span>
     </button>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -75,11 +75,11 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
   protected open(evt:JQuery.TriggeredEvent) {
     this.isOpen = !this.isOpen;
     if (this.isOpen) {
-      this
+      void this
         .wpCreate
         .getEmptyForm(this.projectIdentifier)
         .then((form) => {
-          this.buildItems(form.schema.type.allowedValues);
+          this.buildItems(form.schema.type.allowedValues as TypeResource[]);
           this.opContextMenu.show(this, evt);
         });
     } else {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -79,6 +79,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
         .wpCreate
         .getEmptyForm(this.projectIdentifier)
         .then((form) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           this.buildItems(form.schema.type.allowedValues as TypeResource[]);
           this.opContextMenu.show(this, evt);
         });

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -102,6 +102,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
       ariaLabel: type.name,
       class: Highlighting.inlineClass('type', type.id!),
       onClick: ($event:JQuery.TriggeredEvent) => {
+        this.isOpen = false;
         if (isClickedWithModifier($event)) {
           return false;
         }

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -47,11 +47,15 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
 
   @Input('dropdownActive') active:boolean;
 
-  constructor(readonly elementRef:ElementRef,
+  public isOpen = false;
+
+  constructor(
+    readonly elementRef:ElementRef,
     readonly opContextMenu:OPContextMenuService,
     readonly browserDetector:BrowserDetector,
     readonly wpCreate:WorkPackageCreateService,
-    readonly $state:StateService) {
+    readonly $state:StateService,
+  ) {
     super(elementRef, opContextMenu);
   }
 
@@ -69,13 +73,18 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
   }
 
   protected open(evt:JQuery.TriggeredEvent) {
-    this
-      .wpCreate
-      .getEmptyForm(this.projectIdentifier)
-      .then((form) => {
-        this.buildItems(form.schema.type.allowedValues);
-        this.opContextMenu.show(this, evt);
-      });
+    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this
+        .wpCreate
+        .getEmptyForm(this.projectIdentifier)
+        .then((form) => {
+          this.buildItems(form.schema.type.allowedValues);
+          this.opContextMenu.show(this, evt);
+        });
+    } else {
+      this.opContextMenu.close();
+    }
   }
 
   public get locals():{ showAnchorRight?:boolean, contextMenuId?:string, items:OpContextMenuItem[] } {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -51,9 +51,16 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
     super(elementRef, opContextMenu);
   }
 
+  public isOpen = false;
+
   protected open(evt:JQuery.TriggeredEvent) {
-    this.buildItems();
-    this.opContextMenu.show(this, evt);
+    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.buildItems();
+      this.opContextMenu.show(this, evt);
+    } else {
+      this.opContextMenu.close();
+    }
   }
 
   public get locals() {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -81,6 +81,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           title: this.I18n.t('js.button_show_cards'),
           icon: 'icon-view-card',
           onClick: (evt:any) => {
+            this.isOpen = false;
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayCardRepresentation);
             if (this.wpTableTimeline.isVisible) {
               // Necessary for the timeline buttons to disappear
@@ -100,6 +101,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           title: this.I18n.t('js.button_show_table'),
           icon: 'icon-view-list',
           onClick: (evt:any) => {
+            this.isOpen = false;
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
             if (this.wpTableTimeline.isVisible) {
               this.wpTableTimeline.toggle();
@@ -118,6 +120,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           title: this.I18n.t('js.button_show_gantt'),
           icon: 'icon-view-timeline',
           onClick: (evt:any) => {
+            this.isOpen = false;
             if (!this.wpTableTimeline.isVisible) {
               this.wpTableTimeline.toggle();
             }

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -19,6 +19,7 @@
       [textContent]="count"
     >
     </span>
+    <span class="spot-icon spot-icon_dropdown"></span>
   </button>
 
   <ng-container slot="body">


### PR DESCRIPTION
- [x] All buttons that trigger a dropdown or a drop-modal have a down arrow
- [x] The down arrow should not change directions on click
- [x] A second click on the button should always dismiss the dropdown/drop modal


https://community.openproject.org/work_packages/48215/activity