### PR TITLE
 [#48259] Fix missing wiki details

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -54,6 +54,8 @@ class WikiPage < ApplicationRecord
 
   acts_as_journalized
 
+  register_journal_formatted_fields(:wiki_diff, 'text')
+
   attr_accessor :redirect_existing_links
 
   validates :title, presence: true

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -81,6 +81,13 @@ describe 'Wiki activities' do
     expect(page)
       .to have_link('Wiki: My page')
 
+    within("li.op-activity-list--item", match: :first) do
+      expect(page)
+        .to have_selector('li', text: "Text changed (Details)")
+      expect(page)
+        .to have_link('Details')
+    end
+
     # Click on the second wiki activity item
     find(:xpath, "(//a[text()='Wiki: My page'])[1]").click
 


### PR DESCRIPTION
Fixes https://community.openproject.org/work_packages/48259

The line was removed when wiki_content was removed but as the tests didn't check the detail being displayed explicitly it was not caught earlier. I have reinstated the custom journal formatter in wiki_page this time and also updated the spec file to check for this case in the future.