### PR TITLE
Change icons to spot-icon part 2

### DIFF
--- a/frontend/src/app/features/admin/types/attribute-group.component.html
+++ b/frontend/src/app/features/admin/types/attribute-group.component.html
@@ -1,26 +1,41 @@
 <div class="type-form-conf-group">
   <div class="group-head">
-    <span class="group-handle icon-drag-handle"></span>
+    <span class="spot-icon spot-icon_1_25 spot-icon_drag-handle group-handle"></span>
     <op-group-edit-in-place
-        [name]="group.name"
-        (onValueChange)="rename($event)"
-        class="group-name">
-    </op-group-edit-in-place>
-    <span class="delete-group icon-small icon-close" (click)="deleteGroup.emit()"></span>
+      [name]="group.name"
+      (onValueChange)="rename($event)"
+      class="group-name"
+    ></op-group-edit-in-place>
+    <button
+      class="clear-button delete-group"
+      type="button"
+      (click)="deleteGroup.emit()"
+    >
+      <span class="spot-icon spot-icon_1_25 spot-icon_close"></span>
+    </button>
   </div>
   <div class="attributes" dragula="attributes" [(dragulaModel)]="group.attributes">
-    <div *ngFor="let attribute of group.attributes"
-         class="type-form-conf-attribute"
-         [attr.data-key]="attribute.key">
-      <span class="attribute-handle icon-drag-handle"></span>
+    <div
+      *ngFor="let attribute of group.attributes"
+      class="type-form-conf-attribute"
+      [attr.data-key]="attribute.key"
+    >
+      <span class="spot-icon spot-icon_1 spot-icon_drag-handle attribute-handle"></span>
       <span class="attribute-name">
         {{ attribute.translation }}
-        <span class="attribute-cf-label"
-              *ngIf="attribute.is_cf"
-              [textContent]="text.custom_field">
-          </span>
+        <span
+          class="attribute-cf-label"
+          *ngIf="attribute.is_cf"
+          [textContent]="text.custom_field"
+        ></span>
       </span>
-      <span class="delete-attribute icon-small icon-close" (click)="removeFromGroup(attribute)"></span>
+      <button
+        class="clear-button delete-attribute"
+        type="button"
+        (click)="removeFromGroup(attribute)"
+      >
+        <span class="spot-icon spot-icon_1 spot-icon_close"></span>
+      </button>
     </div>
   </div>
 </div> <!-- END attribute group -->

--- a/frontend/src/app/features/admin/types/group-edit-in-place.html
+++ b/frontend/src/app/features/admin/types/group-edit-in-place.html
@@ -1,16 +1,19 @@
-<div *ngIf="!editing"
-      (click)="startEditing()"
-      [textContent]="name"
-      class="group-edit-handler">
-</div>
+<button
+  *ngIf="!editing"
+  type="button"
+  (click)="startEditing()"
+  [textContent]="name"
+  class="clear-button group-edit-handler"
+></button>
 <input
-    #nameInput
-    *ngIf="editing"
-    class="group-edit-in-place--input"
-    type="text"
-    opAutofocus
-    [(ngModel)]="editedName"
-    [attr.placeholder]="placeholder"
-    (blur)="saveEdition($event)"
-    (keydown.escape)="reset()"
-    (keydown.enter)="saveEdition($event)">
+  #nameInput
+  *ngIf="editing"
+  class="group-edit-in-place--input"
+  type="text"
+  opAutofocus
+  [(ngModel)]="editedName"
+  [attr.placeholder]="placeholder"
+  (blur)="saveEdition($event)"
+  (keydown.escape)="reset()"
+  (keydown.enter)="saveEdition($event)"
+>

--- a/frontend/src/app/features/admin/types/query-group.component.html
+++ b/frontend/src/app/features/admin/types/query-group.component.html
@@ -10,8 +10,8 @@
     </div>
     <div class="type-form-query">
         <span class="type-form-query-group--edit-button" (click)="editQuery.emit()">
-          <op-icon icon-classes="button--icon icon-edit"></op-icon>
-            {{ text.edit_query }}
+          <span class="spot-icon spot-icon_edit"></span>
+          <span>{{ text.edit_query }}</span>
         </span>
     </div>
 </div> <!-- END query group -->

--- a/frontend/src/app/features/admin/types/query-group.component.html
+++ b/frontend/src/app/features/admin/types/query-group.component.html
@@ -1,17 +1,27 @@
 <div class="type-form-conf-group type-form-query-group">
-    <div class="group-head">
-        <span class="group-handle icon-drag-handle"></span>
-        <op-group-edit-in-place
-                [name]="group.name"
-                (onValueChange)="rename($event)"
-                class="group-name">
-        </op-group-edit-in-place>
-        <span class="delete-group icon-small icon-close" (click)="deleteGroup.emit()"></span>
-    </div>
-    <div class="type-form-query">
-        <span class="type-form-query-group--edit-button" (click)="editQuery.emit()">
-          <span class="spot-icon spot-icon_edit"></span>
-          <span>{{ text.edit_query }}</span>
-        </span>
-    </div>
+  <div class="group-head">
+    <span class="spot-icon spot-icon_1_25 spot-icon_drag-handle group-handle"></span>
+    <op-group-edit-in-place
+      [name]="group.name"
+      (onValueChange)="rename($event)"
+      class="group-name"
+    ></op-group-edit-in-place>
+    <button
+      class="delete-group clear-button"
+      type="button"
+      (click)="deleteGroup.emit()"
+    >
+      <span class="spot-icon spot-icon_1 spot-icon_close"></span>
+    </button>
+  </div>
+  <div class="type-form-query">
+    <button
+      class="clear-button type-form-query-group--edit-button"
+      type="button"
+      (click)="editQuery.emit()"
+    >
+      <span class="spot-icon spot-icon_1_25 spot-icon_edit spot-icon_inline"></span>
+      <span>{{ text.edit_query }}</span>
+    </button>
+  </div>
 </div> <!-- END query group -->

--- a/frontend/src/app/features/admin/types/type-form-configuration.html
+++ b/frontend/src/app/features/admin/types/type-form-configuration.html
@@ -72,10 +72,12 @@
         <span class="advice" [textContent]="text.drag_to_activate"></span>
       </div>
       <div class="attributes" dragula="attributes" [(dragulaModel)]="inactives">
-        <div *ngFor="let inactive_attribute of inactives"
-             class="type-form-conf-attribute"
-             [attr.data-key]="inactive_attribute.key">
-          <span class="attribute-handle icon-drag-handle"></span>
+        <div
+          *ngFor="let inactive_attribute of inactives"
+          class="type-form-conf-attribute"
+          [attr.data-key]="inactive_attribute.key"
+        >
+          <span class="attribute-handle spot-icon spot-icon_1 spot-icon_drag-handle"></span>
           <span class="attribute-name">
               {{ inactive_attribute.translation }}
             <span *ngIf="inactive_attribute.is_cf"

--- a/frontend/src/app/features/admin/types/type-form-configuration.html
+++ b/frontend/src/app/features/admin/types/type-form-configuration.html
@@ -2,20 +2,25 @@
   <div class="toolbar toolbar_empty-title">
     <ul class="toolbar-items">
       <li class="toolbar-item">
-        <button type="button -alt-highlight"
-                class="form-configuration--reset button"
-                (click)="resetToDefault($event)">
-          <op-icon icon-classes="button--icon icon-undo"></op-icon>
+        <button
+          type="button -alt-highlight"
+          class="form-configuration--reset button"
+          (click)="resetToDefault($event)"
+        >
+          <span class="spot-icon spot-icon_undo"></span>
           <span class="button--text" [textContent]="text.reset"></span>
         </button>
       </li>
       <li
         *ngIf="!typeBanner.eeShowBanners"
         class="toolbar-item drop-down">
-        <a class="form-configuration--add-group button -alt-highlight" aria-haspopup="true">
-          <op-icon icon-classes="button--icon icon-add"></op-icon>
+        <a
+          class="form-configuration--add-group button -alt-highlight"
+          aria-haspopup="true"
+        >
+          <span class="spot-icon spot-icon_add"></span>
           <span class="button--text" [textContent]="text.label_group"></span>
-          <op-icon icon-classes="button--dropdown-indicator"></op-icon>
+          <span class="spot-icon spot-icon_dropdown"></span>
         </a>
         <ul class="menu-drop-down-container">
           <li>

--- a/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.html
+++ b/frontend/src/app/features/invite-user-modal/button/invite-user-button.component.html
@@ -4,9 +4,7 @@
   (click)="onAddNewClick($event)"
   *ngIf="canInviteUsersToProject$ | async"
 >
-  <span class="icon-context">
-    <op-icon icon-classes="icon-user-plus icon-context"></op-icon>
-    {{text.button}}
-  </span>
+  <span class="spot-icon spot-icon_user-plus"></span>
+  {{text.button}}
 </button>
 

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
@@ -42,14 +42,14 @@
   <ng-template ng-tag-tmp>
     <!--Invite a new user by email-->
     <div *ngIf="canInviteByEmail$ | async">
-      <span class="spot-icon spot-icon_mail1"></span>
+      <span class="spot-icon spot-icon_inline spot-icon_1_25 spot-icon_mail1"></span>
       <b>{{ text.inviteNewUser }}</b>
       {{ input }}
     </div>
 
     <!--Create a new placeholder by name-->
     <div *ngIf="canCreateNewPlaceholder$ | async">
-      <span class="spot-icon spot-icon_add"></span>
+      <span class="spot-icon spot-icon_inline spot-icon_1_25 spot-icon_add"></span>
       <b>{{ text.createNewPlaceholder }}</b>
       {{ input }}
     </div>

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
@@ -42,14 +42,14 @@
   <ng-template ng-tag-tmp>
     <!--Invite a new user by email-->
     <div *ngIf="canInviteByEmail$ | async">
-      <op-icon icon-classes="icon-mail1 icon-context"></op-icon>
+      <span class="spot-icon spot-icon_mail1"></span>
       <b>{{ text.inviteNewUser }}</b>
       {{ input }}
     </div>
 
     <!--Create a new placeholder by name-->
     <div *ngIf="canCreateNewPlaceholder$ | async">
-      <op-icon icon-classes="icon-add icon-context"></op-icon>
+      <span class="spot-icon spot-icon_add"></span>
       <b>{{ text.createNewPlaceholder }}</b>
       {{ input }}
     </div>

--- a/frontend/src/app/features/invite-user-modal/principal/principal.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal.component.html
@@ -112,8 +112,8 @@
         class="button button_no-margin spot-action-bar--action"
         (click)="back.emit()"
       >
-        <op-icon icon-classes="button--icon icon-arrow-left1"></op-icon>
-        {{ text.principal.backButton }}
+        <span class="spot-icon spot-icon_arrow-left1"></span>
+        <span>{{ text.principal.backButton }}</span>
       </button>
     </div>
 

--- a/frontend/src/app/features/invite-user-modal/summary/summary.component.html
+++ b/frontend/src/app/features/invite-user-modal/summary/summary.component.html
@@ -35,9 +35,9 @@
         type="button"
         class="button button_no-margin spot-action-bar--action"
         (click)="back.emit()"
-        >
-        <op-icon icon-classes="button--icon icon-arrow-left1"></op-icon>
-        {{ text.backButton }}
+      >
+        <span class="spot-icon spot-icon_arrow-left1"></span>
+        <span>{{ text.backButton }}</span>
       </button>
     </div>
 

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -41,7 +41,7 @@
         [textContent]="currentViewTitle"
         aria-hidden="true"
       ></span>
-      <span class="spot-icon spot-icon_1_25 spot-icon_pulldown hidden-for-mobile"></span>
+      <span class="spot-icon spot-icon_dropdown hidden-for-mobile"></span>
     </button>
   </ng-container>
 

--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.html
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.html
@@ -4,39 +4,35 @@
     <ng-container *ngIf="!showAbove" [ngTemplateOutlet]="template"></ng-container>
 
     <div
-        class="work-package--details--long-field work-packages--activity--add-comment hide-when-print"
-        [ngClass]="{'work-packages--activity--add-comment_top': showAbove} "
-        #commentContainer
-        *ngIf="canAddComment"
+      class="work-package--details--long-field work-packages--activity--add-comment hide-when-print"
+      [ngClass]="{'work-packages--activity--add-comment_top': showAbove} "
+      #commentContainer
+      *ngIf="canAddComment"
     >
       <div class="inline-edit--container inplace-edit">
         <edit-form-portal
-            *ngIf="active"
-            [schemaInput]="schema"
-            [changeInput]="change"
-            [editFieldHandler]="handler"
-        >
-        </edit-form-portal>
+          *ngIf="active"
+          [schemaInput]="schema"
+          [changeInput]="change"
+          [editFieldHandler]="handler"
+        ></edit-form-portal>
         <div
-            *ngIf="!active"
-            (dragover)="startDragOverActivation($event)"
-            (dragenter)="startDragOverActivation($event)"
+          *ngIf="!active"
+          (dragover)="startDragOverActivation($event)"
+          (dragenter)="startDragOverActivation($event)"
         >
           <button
-              class="work-package-comment inline-edit--display-field"
-              [title]="text.editTitle"
-              (click)="activate()"
+            class="work-package-comment inline-edit--display-field"
+            [title]="text.editTitle"
+            (click)="activate()"
           >
             <span
-                class="work-package-comment--text"
-                [textContent]="text.placeholder"
-            >
-            </span>
+              class="work-package-comment--text"
+              [textContent]="text.placeholder"
+            ></span>
 
-            <op-icon
-                class="work-package-comment--icon"
-                icon-classes="icon-edit" [icon-title]="text.editTitle"
-            ></op-icon>
+            <span class="spot-icon spot-icon_edit"></span>
+            <span class="hidden-for-sighted" [textContent]="text.editTitle"></span>
           </button>
         </div>
       </div>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-button.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-button.template.html
@@ -1,10 +1,12 @@
-<button class="button {{ buttonClass }}"
-        type="button"
-        [class.-active]="isActive"
-        [disabled]="disabled || (!isToggle() && isActive)"
-        [attr.id]="buttonId"
-        [attr.title]="label"
-        [attr.accesskey]="accessKey"
-        (click)="performAction($event)">
-  <op-icon icon-classes="{{ iconClass }} button--icon"></op-icon>
+<button
+  class="button {{ buttonClass }}"
+  type="button"
+  [class.-active]="isActive"
+  [disabled]="disabled || (!isToggle() && isActive)"
+  [attr.id]="buttonId"
+  [attr.title]="label"
+  [attr.accesskey]="accessKey"
+  (click)="performAction($event)"
+>
+  <span class="spot-icon spot-icon_{{ icon }}"></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-button.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-button.template.html
@@ -1,5 +1,5 @@
 <button
-  class="button {{ buttonClass }}"
+  class="button -icon-only {{ buttonClass }}"
   type="button"
   [class.-active]="isActive"
   [disabled]="disabled || (!isToggle() && isActive)"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -13,6 +13,6 @@
     <span class="button--text"
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>
-    <span class="spot-icon spot-icon_1 spot-icon_pulldown"></span>
+    <span class="spot-icon spot-icon_dropdown"></span>
   </button>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
@@ -54,7 +54,7 @@ export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageBu
 
   public buttonClass = 'toolbar-icon';
 
-  public iconClass = 'icon-info2';
+  public icon = 'info2';
 
   public activateLabel:string;
 

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
@@ -1,13 +1,13 @@
 <button
+  type="button"
   (click)="markAllBelongingNotificationsAsRead()"
   [attr.title]="text.mark_as_read"
-  class="button">
-
-  <op-icon icon-classes="button--icon icon-mark-read"></op-icon>
+  class="button"
+>
+  <span class="spot-icon spot-icon_mark-read"></span>
   <span
     *ngIf="showWithText"
     class="button--text"
     [textContent]="text.mark_as_read"
-  >
-  </span>
+  ></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component.ts
@@ -46,7 +46,7 @@ export class ZenModeButtonComponent extends AbstractWorkPackageButtonComponent {
 
   public buttonClass = 'toolbar-icon';
 
-  public iconClass = 'icon-zen-mode';
+  public icon = 'zen-mode';
 
   static inZenMode = false;
 

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
@@ -1,7 +1,8 @@
 <div class="work-packages--details-toolbar">
-  <wp-watcher-button [workPackage]="workPackage"
-                     [showText]="true">
-  </wp-watcher-button>
+  <wp-watcher-button
+    [workPackage]="workPackage"
+    [showText]="true"
+  ></wp-watcher-button>
 
   <op-work-package-mark-notification-button
     *ngIf="displayNotificationsButton"
@@ -10,12 +11,14 @@
     data-qa-selector="mark-notification-read-button"
   ></op-work-package-mark-notification-button>
 
-  <button class="button dropdown-relative"
-          [attr.accesskey]="7"
+  <button
+    class="button dropdown-relative"
+    [attr.accesskey]="7"
 
-          wpSingleContextMenu
-          [wpSingleContextMenu-workPackage]="workPackage">
+    wpSingleContextMenu
+    [wpSingleContextMenu-workPackage]="workPackage"
+  >
     <span class="button--text" [textContent]="text.button_more"></span>
-    <op-icon icon-classes="button--dropdown-indicator"></op-icon>
+    <span class="spot-icon spot-icon_dropdown"></span>
   </button>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
@@ -16,7 +16,7 @@
         <li class="toolbar-item hidden-for-mobile">
           <button id="create-wp-menu-button"
                   [attr.title]="text.button_settings"
-                  class="button last work-packages-settings-button toolbar-icon"
+                  class="button -icon-only last work-packages-settings-button toolbar-icon"
                   wpCreateSettingsMenu>
             <i class="button--icon icon-show-more"></i>
           </button>

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
@@ -112,13 +112,13 @@ export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin imple
       this.buttonText = this.I18n.t('js.label_unwatch');
       this.buttonClass = '-active';
       this.buttonId = 'unwatch-button';
-      this.watchIconClass = 'icon-watched';
+      this.watchIconClass = 'spot-icon_watched';
     } else {
       this.buttonTitle = this.I18n.t('js.label_watch_work_package');
       this.buttonText = this.I18n.t('js.label_watch');
       this.buttonClass = '';
       this.buttonId = 'watch-button';
-      this.watchIconClass = 'icon-unwatched';
+      this.watchIconClass = 'spot-icon_unwatched';
     }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
@@ -112,13 +112,13 @@ export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin imple
       this.buttonText = this.I18n.t('js.label_unwatch');
       this.buttonClass = '-active';
       this.buttonId = 'unwatch-button';
-      this.watchIconClass = 'spot-icon_watched';
+      this.watchIconClass = 'watched';
     } else {
       this.buttonTitle = this.I18n.t('js.label_watch_work_package');
       this.buttonText = this.I18n.t('js.label_watch');
       this.buttonClass = '';
       this.buttonId = 'watch-button';
-      this.watchIconClass = 'spot-icon_unwatched';
+      this.watchIconClass = 'unwatched';
     }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
@@ -9,6 +9,6 @@
   [id]="buttonId"
 >
 
-  <span class="spot-icon {{watchIconClass}}"></span>
+  <span class="spot-icon spot-icon_{{ watchIconClass }}"></span>
   <span class="button--text" *ngIf="showText" [textContent]="buttonText"></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
@@ -1,11 +1,14 @@
-<button *ngIf="displayWatchButton"
-        (click)="toggleWatch()"
-        [attr.title]="buttonTitle"
-        [disabled]="disabled"
-        [ngClass]="buttonClass"
-        class="button toolbar-icon"
-        [id]="buttonId">
+<button
+  *ngIf="displayWatchButton"
+  type="button"
+  (click)="toggleWatch()"
+  [attr.title]="buttonTitle"
+  [disabled]="disabled"
+  [ngClass]="buttonClass"
+  class="button toolbar-icon"
+  [id]="buttonId"
+>
 
-  <op-icon icon-classes="button--icon {{watchIconClass}}"></op-icon>
+  <span class="spot-icon {{watchIconClass}}"></span>
   <span class="button--text" *ngIf="showText" [textContent]="buttonText"></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
@@ -1,6 +1,6 @@
 <button
   *ngIf="displayWatchButton"
-  type="button"
+  type="button -icon-only"
   (click)="toggleWatch()"
   [attr.title]="buttonTitle"
   [disabled]="disabled"

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -41,11 +41,13 @@
           </zen-mode-toggle-button>
         </li>
         <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
-          <button class="button dropdown-relative toolbar-icon"
-                  [attr.title]="text.fullView.buttonMore"
-                  wpSingleContextMenu
-                  [wpSingleContextMenu-workPackage]="workPackage">
-            <op-icon icon-classes="button--icon icon-show-more"></op-icon>
+          <button
+            class="button dropdown-relative toolbar-icon"
+            [attr.title]="text.fullView.buttonMore"
+            wpSingleContextMenu
+            [wpSingleContextMenu-workPackage]="workPackage"
+          >
+            <span class="spot-icon spot-icon_show-more"></span>
           </button>
         </li>
       </ul>

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -43,7 +43,7 @@
         </li>
         <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
           <button
-            class="button dropdown-relative toolbar-icon"
+            class="button -icon-only dropdown-relative toolbar-icon"
             [attr.title]="text.fullView.buttonMore"
             wpSingleContextMenu
             [wpSingleContextMenu-workPackage]="workPackage"

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -1,8 +1,9 @@
-<div edit-form
-     [resource]="workPackage"
-     *ngIf="workPackage"
-     class="work-packages--show-view">
-
+<div
+  edit-form
+  [resource]="workPackage"
+  *ngIf="workPackage"
+  class="work-packages--show-view"
+>
   <wp-breadcrumb [workPackage]="workPackage"></wp-breadcrumb>
 
   <div class="toolbar-container">
@@ -26,9 +27,10 @@
           </wp-create-button>
         </li>
         <li class="toolbar-item" *ngIf="displayWatchButton">
-          <wp-watcher-button [workPackage]="workPackage"
-                             [showText]="false">
-          </wp-watcher-button>
+          <wp-watcher-button
+            [workPackage]="workPackage"
+            [showText]="false"
+          ></wp-watcher-button>
         </li>
         <li class="toolbar-item" *ngIf="(displayNotificationsButton$ | async)">
           <op-work-package-mark-notification-button
@@ -37,8 +39,7 @@
           ></op-work-package-mark-notification-button>
         </li>
         <li class="toolbar-item hidden-for-mobile">
-          <zen-mode-toggle-button>
-          </zen-mode-toggle-button>
+          <zen-mode-toggle-button></zen-mode-toggle-button>
         </li>
         <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
           <button
@@ -62,17 +63,25 @@
     </div>
     <div class="work-packages-full-view--split-right work-packages-tab-view--overflow">
       <div class="work-packages--panel-inner">
-        <span class="hidden-for-sighted" tabindex="-1" opAutofocus [textContent]="focusAnchorLabel"></span>
+        <span
+          class="hidden-for-sighted"
+          tabindex="-1"
+          opAutofocus
+          [textContent]="focusAnchorLabel"
+        ></span>
         <op-wp-tabs [workPackage]="workPackage" [view]="'full'"></op-wp-tabs>
-        <div class="tabcontent"
-             data-notification-selector='notification-scroll-container'
-             ui-view>
-        </div>
+        <div
+          class="tabcontent"
+          data-notification-selector='notification-scroll-container'
+          ui-view
+        ></div>
       </div>
 
       <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
-        <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
-                    [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
+        <wp-resizer
+          [elementClass]="'work-packages-full-view--split-right'"
+          [localStorageKey]="'openProject-fullViewFlexBasis'"
+        ></wp-resizer>
       </div>
     </div>
   </div>

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
@@ -1,5 +1,5 @@
 <form
-  *ngIf="form && handleSubmit"
+  *ngIf="form && handleSubmit && fields.length"
   data-qa="op-form--container"
   class="op-form"
   [formGroup]="form"
@@ -34,7 +34,7 @@
 <formly-form
   data-qa="op-form--container"
   class="op-form--fieldset"
-  *ngIf="form && !handleSubmit"
+  *ngIf="form && !handleSubmit && fields.length"
   [form]="form"
   [model]="innerModel"
   [fields]="fields"

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.sass
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.sass
@@ -1,0 +1,3 @@
+.op-dynamic-form
+  &:empty
+    display: none

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
@@ -2,11 +2,13 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostBinding,
   Input,
   OnChanges,
   Output,
   SimpleChanges,
   ViewChild,
+  ViewEncapsulation,
 } from '@angular/core';
 import { FormlyForm } from '@ngx-formly/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -126,13 +128,16 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 @Component({
   selector: 'op-dynamic-form',
   templateUrl: './dynamic-form.component.html',
-  styleUrls: ['./dynamic-form.component.scss'],
+  styleUrls: ['./dynamic-form.component.sass'],
+  encapsulation: ViewEncapsulation.None,
   providers: [
     DynamicFormService,
     DynamicFieldsService,
   ],
 })
 export class DynamicFormComponent extends UntilDestroyedMixin implements OnChanges {
+  @HostBinding('class.op-dynamic-form') className = true;
+
   /** Backend form URL (e.g. https://community.openproject.org/api/v3/projects/dev-large/form) */
   @Input() formUrl?:string;
 

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
@@ -8,7 +8,7 @@
     <img [src]="image.enterprise_edition" class="hidden-for-mobile op-enterprise-banner--image">
     <div class="op-toast--content">
       <div class="op-enterprise-banner--header">
-        <span class="spot-icon spot-icon_enterprise-addons spot-icon_inline"></span>
+        <span class="spot-icon spot-icon_enterprise-addons"></span>
         <span [textContent]="text.enterpriseFeature" class="op-enterprise-banner--title"></span>
         <button
           *ngIf="collapsible"
@@ -35,15 +35,17 @@
           *ngIf="moreInfoLink"
           [attr.href]="moreInfoLink"
           class="op-enterprise-banner--info-button"
-          target=”_blank”>
-          <span class="spot-icon spot-icon_external-link"></span> 
+          target=”_blank”
+        >
+          <span class="spot-icon spot-icon_inline spot-icon_external-link"></span>
           {{ text.more_info_text }}
         </a>
 
         <a
           [href]="pricingUrl"
           target=”_blank”
-          class="button -highlight">
+          class="button -highlight"
+        >
           <span class="spot-icon spot-icon_enterprise-addons"></span>
           {{ text.upgrade }}
         </a>

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.sass
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.sass
@@ -21,19 +21,19 @@
   &--image
     width: 115px
     height: 75px
-    padding-right: 20px
+    padding-right: $spot-spacing_1_5
     margin: auto
 
   &--buttons
     display: flex
     justify-content: end
+    align-items: center
 
   &--info-button
-    padding-top: $spot-spacing-1_25
-    padding-right: $spot-spacing-1_5
+    margin-right: $spot-spacing-1
 
     .spot-icon:before
-      padding-right: 0.875rem
+      padding-right: $spot-spacing-0_5
 
   &--collapsible-button
     background: transparent

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -50,6 +50,10 @@ a.button
     &::before
       padding: 0 var(--button--text-icon-spacing) 0 0
 
+  &.-icon-only
+    width: 34px
+    padding: 0
+
   &.-danger
     background: var(--content-form-danger-zone-bg-color)
     color: var(--content-form-danger-zone-font-color)

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -12,12 +12,8 @@
       cursor: -webkit-grab
       cursor: grab
       color: var(--font-color-on-primary-dark)
-      font-size: 12px
     op-group-edit-in-place
       display: inline-block
-    .delete-group:before
-      vertical-align: bottom
-      color: var(--font-color-on-primary-dark)
   .attributes
     min-height: 29px
 
@@ -33,16 +29,12 @@
       background: white
       color: #222222
 
-  .delete-group,
-  .delete-attribute
-    cursor: pointer
-    
   &.-error
     background: var(--content-form-error-color)
     .group-name
       border-color: var(--content-form-error-color)
     .group-handle,
-    .delete-group:before
+    .delete-group
       color: var(--font-color-on-primary)
 
 
@@ -71,7 +63,6 @@
     cursor: -webkit-grab
     cursor: grab
     color: var(--body-font-color)
-    font-size: 12px
   .delete-attribute:before
     color: var(--body-font-color)
 
@@ -87,7 +78,7 @@
 .group-head,
 .type-form-conf-attribute
   display: flex
-  align-items: baseline
+  align-items: center
   justify-content: space-between
   .icon-drag-handle
     flex-basis: 15px
@@ -103,4 +94,13 @@
   cursor: pointer
   color: white
 
-// Ensure dropdown is shown
+.clear-button
+  border: 0
+  background: transparent
+  margin: 0
+  padding: 0
+  cursor: pointer
+
+.group-edit-handler
+  width: 100%
+  text-align: left

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -100,6 +100,7 @@
   margin: 0
   padding: 0
   cursor: pointer
+  text-transform: inherit
 
 .group-edit-handler
   width: 100%

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -78,7 +78,7 @@ describe 'form configuration', js: true do
         # Wait for page reload
         sleep 1
 
-        expect(page).not_to have_selector('.group-head', text: 'WHATEVER')
+        expect(page).not_to have_selector('.group-edit-handler', text: 'WHATEVER')
         form.expect_group('details', 'Details')
         form.expect_attribute(key: :assignee)
       end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -21,13 +21,11 @@ describe 'Watcher tab', js: true, selenium: true do
   def expect_button_is_watching
     title = I18n.t('js.label_unwatch_work_package')
     expect(page).to have_selector("#unwatch-button[title='#{title}']", wait: 10)
-    expect(page).to have_selector('#unwatch-button .button--icon.icon-watched', wait: 10)
   end
 
   def expect_button_is_not_watching
     title = I18n.t('js.label_watch_work_package')
     expect(page).to have_selector("#watch-button[title='#{title}']")
-    expect(page).to have_selector('#watch-button .button--icon.icon-unwatched')
   end
 
   shared_examples 'watch and unwatch with button' do


### PR DESCRIPTION
Switch icons to spot-icon in the following places:

* admin pages WP type form configuration
* invite user modal
* work package comment add
* work package details toolbar (split screen on the bottom, watch/unwatch, "more", mark as read)
* work package full view toolbar (on the top, with zen mode, watch/unwatch, "more"

There are also some a11y changes in here especially in the wp type form configuration. A lot of click event listeners were set on `span` or `div` instead of a `button`.

On top, there's small style changes & fixes; 
* a dynamic form without fields would still render with margins, causing weird spacings. It will now be hidden
* WP Type form configuration icons are different sizes to align with the hierarchical nature, and some spacings have improved

Part of https://community.openproject.org/work_packages/47363/activity