### PR TITLE
Move admin controllers to subfolder/namespace

### DIFF
--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -31,9 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for_contract(role, @call.errors) if @call %>
 
-<div data-controller="admin-roles"
+<div data-controller="admin--roles"
      data-application-target="dynamic"
-     data-admin-roles-global-role-value="<%= role.is_a?(GlobalRole) %>">
+     data-admin--roles-global-role-value="<%= role.is_a?(GlobalRole) %>">
   <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-slim' %>
   </div>
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
                                  "1",
                                  role.is_a?(GlobalRole),
                                  data: {
-                                   action: 'admin-roles#toggle'
+                                   action: 'admin--roles#toggle'
                                  }) %>
       </div>
     <% else %>
@@ -56,17 +56,17 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   </div>
 
-  <div data-admin-roles-target="memberAttributes"
+  <div data-admin--roles-target="memberAttributes"
        hidden>
     <%= render partial: "member_attributes", locals: { f: f, role: role, roles: roles&.select {|r| !r.is_a?(GlobalRole)} }%>
   </div>
 
-  <div data-admin-roles-target="globalPermissions"
+  <div data-admin--roles-target="globalPermissions"
        hidden>
     <%= render partial: "permissions",
                locals: { permissions: grouped_setable_permissions(GlobalRole.new), role: role, show_global_role: true }%>
   </div>
-  <div data-admin-roles-target="memberPermissions"
+  <div data-admin--roles-target="memberPermissions"
        hidden>
     <%= render partial: "permissions",
                locals: { permissions: grouped_setable_permissions(role), role: role, show_global_role: false }%>

--- a/app/views/users/_general.html.erb
+++ b/app/views/users/_general.html.erb
@@ -47,9 +47,9 @@ See COPYRIGHT and LICENSE files for more details.
                                 autocomplete: 'off'
                               },
                               data: {
-                                controller: 'admin-users',
+                                controller: 'admin--users',
                                 'application-target': 'dynamic',
-                                'admin-users-password-auth-selected-value': @user.auth_source_id.blank?,
+                                'admin--users-password-auth-selected-value': @user.auth_source_id.blank?,
                               },
                               as: :user do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/users/form/authentication/_auth_source.html.erb
+++ b/app/views/users/form/authentication/_auth_source.html.erb
@@ -10,14 +10,14 @@
                               include_blank: t(:label_internal)
                             },
                             data: {
-                              action: 'admin-users#toggleAuthenticationFields'
+                              action: 'admin--users#toggleAuthenticationFields'
                             }
     %>
   </div>
 
   <div class="form--field"
        hidden
-       data-admin-users-target="authSourceFields">
+       data-admin--users-target="authSourceFields">
     <%= f.text_field :login, required: true, size: 25 %>
   </div>
 <% end %>

--- a/app/views/users/form/authentication/_internal_password.html.erb
+++ b/app/views/users/form/authentication/_internal_password.html.erb
@@ -2,7 +2,7 @@
 <%= content_tag :div,
                 data: {
                   controller: 'disable-when-checked',
-                  'admin-users-target': 'passwordFields'
+                  'admin--users-target': 'passwordFields'
                 },
                 hidden: !@user.change_password_allowed? do %>
   <% assign_random_password_enabled = params[:user] &&

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -38,9 +38,9 @@ See COPYRIGHT and LICENSE files for more details.
                               url: { action: "create" },
                               html: { class: nil, autocomplete: 'off' },
                               data: {
-                                controller: 'admin-users',
+                                controller: 'admin--users',
                                 'application-target': 'dynamic',
-                                'admin-users-password-auth-selected-value': @user.auth_source_id.blank?,
+                                'admin--users-password-auth-selected-value': @user.auth_source_id.blank?,
                               },
                               as: :user do |f| %>
   <%= render partial: 'simple_form', locals: { f: f, auth_sources: @auth_sources, user: @user } %>

--- a/docs/development/concepts/stimulus/README.md
+++ b/docs/development/concepts/stimulus/README.md
@@ -1,0 +1,64 @@
+---
+sidebar_navigation:
+  title: Using Stimulus
+description: An introduction of how we use Stimulus to sprinkle interactivity
+keywords: Stimulus, Ruby on Rail, Hotwire
+---
+
+
+
+# Using  Stimulus
+
+In a decision to move OpenProject towards the [Hotwire approach](https://hotwired.dev/), we introduced [Stimulus.js](https://stimulus.hotwired.dev) to replace a collection of dynamically loaded custom JavaScript files used to sprinkle some interactivity.
+
+This guide will outline how to add controllers and the conventions around it. This is _not_ a documentation of stimulus itself. Use their documentation instead: https://stimulus.hotwired.dev/
+
+
+
+## Adding controllers
+
+All controllers live under `frontend/src/stimulus/controllers/`. The naming convention is `<controller-name>.controller.ts`, meaning to dasherize the name of the controller. This makes it easier to generate names and classes using common IDEs.
+
+If you want to add a common pattern, manually register the controller under `frontend/src/stimulus/setup.ts`. Often you'll want to have a dynamically loaded controller instead though.
+
+
+
+### Dynamically loaded controllers
+
+To dynamically load a controller, it needs to live under `frontend/src/stimulus/controllers/dynamic/<controller-name>.controller.ts`.
+
+In DOM, you'll tell the application the controller is dynamically loaded using the `data-application-target="dynamic"`attribute. It tells the application controller (`frontend/src/stimulus/controllers/op-application.controller.ts`) we load on every page on body to dynamically import and load the controller named `users`.
+
+```HTML
+<div data-controller="users" data-application-target="dynamic"></div>
+```
+
+
+
+#### Namespacing dynamic controllers
+
+If you want to organize your dynamic controllers in a subfolder, use the [double dash convention](https://stimulus.hotwired.dev/handbook/installing#controller-filenames-map-to-identifiers) of stimulus. For example, adding a new admin controller `settings`, you'd do the following:
+
+1. Add the controller under `frontend/src/stimulus/controllers/dynamic/admin/settings.controller.ts`
+2. Specify the controller name with a double dash for each folder
+
+```html
+<div data-controller="admin--settings" data-application-target="dynamic"></div>
+```
+
+
+
+You need to take care to prefix all actions, values etc. with the exact same pattern, e.g., `data-admin--settings-target="foobar"`.
+
+
+
+### Requring a page controller
+
+If you have a single controller used in a partial, we have added a helper to use in a partial in order to append a controller to the `#content`tag. This is useful if your template doesn't have a single DOM root. For example, to load the dynamic `project-storage-form` controller and provide a custom value to it:
+
+```erb
+<% content_controller 'project-storage-form',
+                      dynamic: true,
+                      'project-storage-form-folder-mode-value': @project_storage.project_folder_mode %>
+```
+

--- a/frontend/src/stimulus/controllers/dynamic/admin/roles.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/roles.controller.ts
@@ -30,7 +30,7 @@
 
 import { Controller } from '@hotwired/stimulus';
 
-export default class AdminRolesController extends Controller {
+export default class RolesController extends Controller {
   static targets = [
     'memberAttributes',
     'globalPermissions',

--- a/frontend/src/stimulus/controllers/dynamic/admin/users.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/users.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 
-export default class AdminUsersController extends Controller {
+export default class UsersController extends Controller {
   static targets = [
     'passwordFields',
     'authSourceFields',

--- a/frontend/src/stimulus/controllers/op-application.controller.ts
+++ b/frontend/src/stimulus/controllers/op-application.controller.ts
@@ -8,14 +8,29 @@ export class OpApplicationController extends ApplicationController {
 
   dynamicTargetConnected(target:HTMLElement) {
     const controller = target.dataset.controller as string;
+    const path = this.derivePath(controller);
 
     if (!this.loaded.has(controller)) {
       this.loaded.add(controller);
-      void import(/* webpackChunkName: "[request]" */`./dynamic/${controller}.controller`)
+      void import(/* webpackChunkName: "[request]" */`./dynamic/${path}.controller`)
         .then((imported:{ default:ControllerConstructor }) => this.application.register(controller, imported.default))
         .catch((err:unknown) => {
           console.error('Failed to load dyanmic controller chunk %O: %O', controller, err);
         });
     }
+  }
+
+  /**
+   * Derive dynamic path from controller name.
+   *
+   * Stimlus conventions allow subdirectories to be used by double dashes.
+   * We convert these to slashes for the dynamic import.
+   *
+   * https://stimulus.hotwired.dev/handbook/installing#controller-filenames-map-to-identifiers
+   * @param controller
+   * @private
+   */
+  private derivePath(controller:string):string {
+    return controller.replace('--', '/');
   }
 }


### PR DESCRIPTION
In a discussion with @Kharonus and @wielinde we wondered if we could namespace dynamically loaded controllers or have them all within one folder.

Turns out we can using a default convention of namespacing controllers with double dashes: https://stimulus.hotwired.dev/handbook/installing#controller-filenames-map-to-identifiers

This PR does exactly this for the two admin scoped/namespaced controllers