### PR TITLE
Use min-width as default min-width for tooltip content

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/tooltip.sass
+++ b/frontend/src/app/spot/styles/sass/components/tooltip.sass
@@ -17,6 +17,7 @@
 
     position: absolute
     height: auto
+    min-width: max-content
 
     box-shadow: $spot-shadow-light-low
     color: $spot-color-basic-gray-1

--- a/frontend/src/stories/Tooltip.mdx
+++ b/frontend/src/stories/Tooltip.mdx
@@ -13,7 +13,8 @@ The tooltip provides additional textual context on hover over interactive elemen
 
 This context can be used to provide additional information (hover over a "help" icon) or to signal state information (for example, if a certain item is disabled).
 
-By default, the tooltip takes 80% of the width of the container. This can be overridden if needed. 
+By default, the tooltip takes uses `min-width: max-content` to fill the content.
+This can be overridden if needed by specifying overrides on the body slot.
 
 <Canvas of={TooltipStories.InList} />
 


### PR DESCRIPTION
This slightly changes the default behavior of the tooltip width, up for discussion if this should be the default or an override.