### PR TITLE
Do not change project when moving cards in Kanban board

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
@@ -239,7 +239,8 @@ export abstract class BoardActionService {
       ));
     }
 
-    new WorkPackageFilterValues(this.injector, query.filters)
+    const except = ['project'];
+    new WorkPackageFilterValues(this.injector, query.filters, except)
       .applyDefaultsFromFilters(changeset);
   }
 

--- a/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
@@ -54,7 +54,7 @@ export class FilterProjectComponent extends UntilDestroyedMixin implements OnIni
 
   @Input() public filter:QueryFilterInstanceResource;
 
-  @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
+  @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this), 0);
 
   additionalProjectApiFilters:ApiV3ListFilter[] = [];
 

--- a/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
@@ -33,11 +33,14 @@ export class WorkPackageFilterValues {
       if (this.excluded.indexOf(filter.id) !== -1) {
         return;
       }
+      const operator = filter.operator.id as FilterOperator;
 
       // Special case due to the introduction of the project include dropdown
       // If we are in a project, we want the create wp to be part of that project.
       // Only for embedded tables, there might be different filter values necessary.
       if (filter.id === 'project') {
+        if (operator !== '=') return;
+
         const projectFilter = _.find(filter.values, (resource:HalResource|string) => {
           return ((resource instanceof HalResource) ? resource.href : resource) === this.currentProject.apiv3Path;
         });
@@ -52,7 +55,6 @@ export class WorkPackageFilterValues {
       }
 
       // Look for a handler with the filter's operator
-      const operator = filter.operator.id as FilterOperator;
       const handler = this.handlers[operator];
 
       // Apply the filter if there is any

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -47,6 +47,10 @@ module Pages
       @board
     end
 
+    def filters
+      Components::WorkPackages::Filters.new
+    end
+
     def free?
       @board.options['type'] == 'free'
     end
@@ -167,6 +171,14 @@ module Pages
       target = page.find list_selector(to)
 
       drag_n_drop_element(from: source, to: target)
+    end
+
+    def wait_for_lists_reload
+      # wait for reload of lists to start and finish
+      # Not sure if that's the most reliable way to do it, but there is nothing visible
+      # about the PATCH request being sent and executed successfully after moving a card.
+      expect(page).to have_selector('.loading-indicator', wait: 5)
+      expect(page).not_to have_selector('.loading-indicator')
     end
 
     def add_list(option: nil, query: option)

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -8,6 +8,9 @@ module Components::Autocompleter
       # Wait for dropdown to open
       ng_find_dropdown(element, results_selector:) if wait_dropdown_open
 
+      # Wait for autocompleter options to be loaded (data fetching is debounced by 250ms after creation or typing)
+      expect(element).not_to have_selector('.ng-spinner-loader')
+
       # Insert the text to find
       within(element) do
         ng_enter_query(element, query)


### PR DESCRIPTION
https://community.openproject.org/wp/44895

The values to apply when moving cards were taken from filters, and if the project filter was present, it would set the project.