### PR TITLE
Update the Timestamp duration? logic to handle all valid duration string

### DIFF
--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -34,6 +34,8 @@ class Timestamp
   class Exception < StandardError; end
 
   class TimestampParser
+    DURATION_REGEX = /[+-]?P/ # ISO8601 "Period"
+
     DATE_KEYWORD_REGEX =
       %r{
         ^(?:#{ALLOWED_DATE_KEYWORDS.join("|")}) # match the relative date keyword
@@ -49,7 +51,7 @@ class Timestamp
       @timestamp_string = self.class.substitute_special_shortcut_values(@original_string)
 
       case @timestamp_string
-      when /[+-]?P/ # ISO8601 "Period"
+      when DURATION_REGEX
         ActiveSupport::Duration.parse(@timestamp_string).iso8601
       when DATE_KEYWORD_REGEX # Built in date keywords
         @timestamp_string
@@ -119,11 +121,11 @@ class Timestamp
   end
 
   def duration?
-    to_s.first == "P" # ISO8601 "Period"
+    to_s.match? TimestampParser::DURATION_REGEX
   end
 
   def relative_date_keyword?
-    TimestampParser::DATE_KEYWORD_REGEX.match?(to_s)
+    to_s.match? TimestampParser::DATE_KEYWORD_REGEX
   end
 
   def to_s

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -100,17 +100,26 @@ describe Timestamp do
 
       {
         'PT1H' => 'PT1H',
-        'PT0001H' => 'PT0001H',
-        'PT0009H' => 'PT0009H',
+        'PT0001H' => 'PT1H',
+        'PT0009H' => 'PT9H',
         'PT-1H' => 'PT-1H',
-        '+PT1H' => '+PT1H',
-        '-PT1H' => '-PT1H',
-        '-PT-1H' => '-PT-1H',
+        '+PT1H' => 'PT1H',
+        '-PT1H' => 'PT-1H',
+        '-PT-1H' => 'PT1H',
         '  PT1H  ' => 'PT1H',
-        '-P1M-1DT1H-02M' => '-P1M-1DT1H-02M'
+        '-P1M-1DT1H-02M' => 'P-1M1DT-1H2M'
       }.each do |input, expected|
-        it "parses #{input.inspect} into #{expected.inspect}" do
-          expect(described_class.parse(input).to_s).to eq(expected)
+        context "with the duration #{input.inspect}" do
+          subject { described_class.parse(input) }
+
+          it "keeps the original duration string intact" do
+            expect(subject).to eq(input.strip)
+          end
+
+          it "parses into #{expected.inspect}" do
+            expect(subject).to be_duration
+            expect(subject.to_duration.iso8601).to eq(expected)
+          end
         end
       end
     end


### PR DESCRIPTION
An  amendment to the PR #12686 to fix the `Timestamp#duration?` method by allowing all valid duration string.