### PR TITLE
[#45745] Group timezones with same identifier

### DIFF
--- a/app/components/settings/time_zone_setting_component.rb
+++ b/app/components/settings/time_zone_setting_component.rb
@@ -72,9 +72,18 @@ module Settings
     def time_zone_entries
       UserPreferences::UpdateContract
         .assignable_time_zones
-        .map do |tz|
-        [tz.to_s, tz.tzinfo.canonical_identifier]
-      end
+        .group_by { |tz| tz.tzinfo.canonical_zone }
+        .map { |canonical_zone, included_zones| time_zone_option(canonical_zone, included_zones) }
+    end
+
+    private
+
+    def time_zone_option(canonical_zone, zones)
+      zone_names = zones.map(&:name).join(', ')
+      [
+        "(UTC#{ActiveSupport::TimeZone.seconds_to_utc_offset(canonical_zone.base_utc_offset)}) #{zone_names}",
+        canonical_zone.identifier
+      ]
     end
   end
 end

--- a/spec/components/settings/time_zone_setting_component_spec.rb
+++ b/spec/components/settings/time_zone_setting_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Settings::TimeZoneSettingComponent, type: :component do
+  subject { render_inline(described_class.new("user_default_timezone")) }
+
+  it "renders the timezones as options, grouping cities with the same identifier" do
+    subject
+
+    expect(page).to have_selector("option[value=\"America/Los_Angeles\"]",
+                                  text: "(UTC-08:00) Pacific Time (US & Canada)")
+    expect(page).to have_selector("option[value=\"Europe/Berlin\"]", text: "(UTC+01:00) Berlin, Copenhagen, Stockholm")
+    expect(page).to have_selector("option[value=\"Asia/Shanghai\"]", text: "(UTC+08:00) Beijing, Chongqing")
+  end
+end

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -114,11 +114,11 @@ describe 'my', js: true do
           expect(user.pref.time_zone).to eq 'Asia/Tokyo'
           visit my_settings_path
 
-          expect(page).to have_select 'pref_time_zone', selected: '(GMT+09:00) Tokyo'
-          select '(GMT+01:00) Paris', from: 'pref_time_zone'
+          expect(page).to have_select 'pref_time_zone', selected: '(UTC+09:00) Tokyo'
+          select '(UTC+01:00) Paris', from: 'pref_time_zone'
           click_on 'Save'
 
-          expect(page).to have_select 'pref_time_zone', selected: '(GMT+01:00) Paris'
+          expect(page).to have_select 'pref_time_zone', selected: '(UTC+01:00) Paris'
           expect(user.pref.time_zone).to eq 'Europe/Paris'
         end
       end


### PR DESCRIPTION
WP: https://community.openproject.org/notifications/details/45745/activity

---

Removes the special code that only allows selecting the canonical identifier for timezones. For zones that are linked to another (i.e. `Europe/Copenhagen` -> `Europe/Berlin`), this would cause the user selecting Copenhagen, but on the next page view, they see Berlin. Also, the old code caused several options in the select to use the same option value, always leading to a wrongly shown currently selected timezone:

![Bildschirmfoto 2023-05-25 um 08 11 14](https://github.com/opf/openproject/assets/522537/49bc4d07-6237-464d-afd6-1a5dde2884c7)
