### PR TITLE
Change icons to spot-icon part 4

### DIFF
--- a/app/components/components/on_off_status_component.html.erb
+++ b/app/components/components/on_off_status_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="on-off-status-cell">
   <% if enabled? %>
   <span class="on-off-status -enabled">
-    <%= helpers.op_icon 'icon-yes' %>
+    <%= helpers.spot_icon 'yes' %>
     <%= model[:on_text] %>
   </span>
       <p>
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
       </p>
   <% else %>
   <span class="on-off-status -disabled">
-    <%= helpers.op_icon 'icon-not-supported' %>
+    <%= helpers.spot_icon 'not-supported' %>
     <%= model[:off_text] %>
   </span>
       <p><%= model[:off_description] %></p>

--- a/app/components/custom_actions/row_component.rb
+++ b/app/components/custom_actions/row_component.rb
@@ -53,7 +53,7 @@ module CustomActions
 
     def edit_link
       link_to(
-        helpers.op_icon('icon icon-edit'),
+        helpers.spot_icon('edit'),
         helpers.edit_custom_action_path(action),
         title: t(:button_edit)
       )
@@ -61,7 +61,7 @@ module CustomActions
 
     def delete_link
       link_to(
-        helpers.op_icon('icon icon-delete'),
+        helpers.spot_icon('delete'),
         helpers.custom_action_path(action),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) },

--- a/app/components/custom_actions/table_component.rb
+++ b/app/components/custom_actions/table_component.rb
@@ -47,7 +47,7 @@ module CustomActions
               aria: { label: t('custom_actions.new') },
               class: 'wp-inline-create--add-link',
               title: t('custom_actions.new') do
-        helpers.op_icon('icon icon-add')
+        helpers.spot_icon('add')
       end
     end
   end

--- a/app/components/enumerations/row_component.rb
+++ b/app/components/enumerations/row_component.rb
@@ -62,7 +62,7 @@ module Enumerations
 
     def delete_link
       helpers.link_to(
-        helpers.op_icon('icon icon-delete'),
+        helpers.spot_icon('delete'),
         helpers.enumeration_path(enumeration),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) },

--- a/app/components/enumerations/table_component.rb
+++ b/app/components/enumerations/table_component.rb
@@ -61,7 +61,7 @@ module Enumerations
               class: 'wp-inline-create--add-link',
               data: { 'qa-selector': "create-enumeration-#{rows.name.underscore.dasherize}" },
               title: t(:label_enumeration_new) do
-        helpers.op_icon('icon icon-add')
+        helpers.spot_icon('add')
       end
     end
   end

--- a/app/components/members/row_component.rb
+++ b/app/components/members/row_component.rb
@@ -57,9 +57,9 @@ module Members
       link = mail_to(principal.mail)
 
       if member.principal.invited?
-        i = content_tag "i", "", title: t("text_user_invited"), class: "icon icon-mail1"
+        aria = content_tag "span", t("text_user_invited"), class: "hidden-for-sighted"
 
-        link + i
+        link + aria + spot_icon('mail1')
       else
         link
       end
@@ -125,7 +125,7 @@ module Members
 
     def edit_link
       link_to(
-        helpers.op_icon('icon icon-edit'),
+        helpers.spot_icon('edit'),
         '#',
         class: "toggle-membership-button #{toggle_item_class_name}",
         'data-action': 'members-form#toggleMembershipEdit',
@@ -145,7 +145,7 @@ module Members
     def delete_link
       if model.deletable?
         link_to(
-          helpers.op_icon('icon icon-delete'),
+          helpers.spot_icon('delete'),
           { controller: '/members', action: 'destroy', id: model, page: params[:page] },
           method: :delete,
           data: { confirm: delete_link_confirmation, disable_with: I18n.t(:label_loading) },

--- a/app/components/placeholder_users/row_component.rb
+++ b/app/components/placeholder_users/row_component.rb
@@ -47,10 +47,10 @@ module PlaceholderUsers
     def delete_link
       if helpers.can_delete_placeholder_user?(placeholder_user, User.current)
         link_to deletion_info_placeholder_user_path(placeholder_user) do
-          helpers.tooltip_tag I18n.t('placeholder_users.delete_tooltip'), icon: 'icon-delete'
+          helpers.tooltip_tag I18n.t('placeholder_users.delete_tooltip'), icon: 'delete'
         end
       else
-        helpers.tooltip_tag I18n.t('placeholder_users.right_to_manage_members_missing'), icon: 'icon-help2'
+        helpers.tooltip_tag I18n.t('placeholder_users.right_to_manage_members_missing'), icon: 'help2'
       end
     end
 

--- a/app/components/projects/row_component.html.erb
+++ b/app/components/projects/row_component.html.erb
@@ -43,7 +43,9 @@ See COPYRIGHT and LICENSE files for more details.
     <% if items.any?  %>
       <ul class="project-actions">
         <li aria-haspopup="true" title="<%= I18n.t(:label_open_menu) %>" class="drop-down">
-          <a class="icon icon-show-more-horizontal context-menu--icon" title="<%= t(:label_open_menu) %>" href></a>
+          <a class="context-menu--icon" title="<%= t(:label_open_menu) %>" href>
+            <%= spot_icon('show-more-horizontal') %>
+          </a>
           <ul style="display:none;" class="menu-drop-down-container">
             <% items.each do |item| %>
               <li>
@@ -55,18 +57,22 @@ See COPYRIGHT and LICENSE files for more details.
       </ul>
     <% end %>
     <% unless project.description.blank? %>
-      <a class="icon collapse icon-arrow-up1 projects-table--description-toggle"
+      <a class="collapse projects-table--description-toggle"
          href
          title="<%= t('label_project_hide_details') %>"
          data-project-target="descriptionToggle"
          data-action="click->project#toggleDescription"
-         data-project-project-id-param="<%= project.id %>"></a>
-      <a class="icon expand icon-arrow-down1 projects-table--description-toggle"
+         data-project-project-id-param="<%= project.id %>">
+         <%= spot_icon('arrow-up1') %>
+      </a>
+      <a class="expand projects-table--description-toggle"
          href
          title="<%= t('label_project_show_details') %>"
          data-project-target="descriptionToggle"
          data-action="click->project#toggleDescription"
-         data-project-project-id-param="<%= project.id %>"></a>
+         data-project-project-id-param="<%= project.id %>">
+         <%= spot_icon('arrow-down1') %>
+      </a>
     <% end %>
   </td>
 </tr>

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
                   <div class="generic-table--sort-header">
                     <%= content_tag :a,
-                                    helpers.op_icon("icon-hierarchy"),
+                                    helpers.spot_icon("hierarchy"),
                                     href: href_only_when_not_sort_lft,
                                     class: "spot-link #{deactivate_class_on_lft_sort}",
                                     title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>

--- a/app/components/row_component.rb
+++ b/app/components/row_component.rb
@@ -70,7 +70,7 @@ class RowComponent < RailsComponent
 
   def checkmark(condition)
     if condition
-      helpers.op_icon 'icon icon-checkmark'
+      helpers.spot_icon 'checkmark'
     end
   end
 end

--- a/app/components/statuses/row_component.rb
+++ b/app/components/statuses/row_component.rb
@@ -72,7 +72,7 @@ module Statuses
 
     def delete_link
       link_to(
-        helpers.op_icon('icon icon-delete'),
+        helpers.spot_icon('delete'),
         status_path(status),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) },

--- a/app/components/statuses/table_component.rb
+++ b/app/components/statuses/table_component.rb
@@ -47,7 +47,7 @@ module Statuses
               aria: { label: t(:label_work_package_status_new) },
               class: 'wp-inline-create--add-link',
               title: t(:label_work_package_status_new) do
-        helpers.op_icon('icon icon-add')
+        helpers.spot_icon('add')
       end
     end
 

--- a/app/components/versions/row_component.rb
+++ b/app/components/versions/row_component.rb
@@ -97,20 +97,18 @@ module Versions
     def edit_link
       return unless version.project == table.project
 
-      helpers.link_to_if_authorized '',
+      helpers.link_to_if_authorized spot_icon('edit'),
                                     { controller: '/versions', action: 'edit', id: version },
-                                    class: 'icon icon-edit',
                                     title: t(:button_edit)
     end
 
     def delete_link
       return unless version.project == table.project
 
-      helpers.link_to_if_authorized '',
+      helpers.link_to_if_authorized spot_icon('delete'),
                                     { controller: '/versions', action: 'destroy', id: version },
                                     data: { confirm: t(:text_are_you_sure) },
                                     method: :delete,
-                                    class: 'icon icon-delete',
                                     title: t(:button_delete)
     end
 

--- a/app/helpers/tooltip_helper.rb
+++ b/app/helpers/tooltip_helper.rb
@@ -36,11 +36,11 @@ module TooltipHelper
   # @param placement [string] placement (top, left, right, bottom)
   # @param span_classes [string] Additional classes on the span
   # @param icon [string] icon class
-  def tooltip_tag(text, placement: 'left', icon: 'icon-help', span_classes: nil)
+  def tooltip_tag(text, placement: 'left', icon: 'help', span_classes: nil)
     content_tag :span,
                 class: "tooltip--#{placement} #{span_classes}",
                 data: { tooltip: text } do
-      op_icon "icon #{icon}"
+      spot_icon icon
     end
   end
 end

--- a/frontend/doc/PLUGINS.md
+++ b/frontend/doc/PLUGINS.md
@@ -65,7 +65,7 @@ export function initializeCostsPlugin() {
             pluginContext.hooks.workPackageSingleContextMenu(function(params:any) {
                 return {
                     key: 'log_costs',
-                    icon: 'icon-projects',
+                    icon: 'projects',
                     indexBy: function(actions:any) {
                         var index = _.findIndex(actions, {key: 'log_time'});
                         return index !== -1 ? index + 1 : actions.length;

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -1,12 +1,13 @@
 <div class="top-menu-search">
   <button
     *ngIf="expanded"
+    type="button"
     (click)="toggleMobileSearch()"
     class="top-menu-search--back-button"
-    href="#"
-    title="{{text.close_search}}"
+    [attr.title]="text.close_search"
+    [attr.aria-label]="text.close_search"
   >
-    <i class="icon-arrow-left1" aria-hidden="true"></i>
+    <span class="spot-icon spot-icon_arrow-left1"></span>
   </button>
 
   <op-autocompleter
@@ -87,7 +88,8 @@
     #btn
     id="top-menu-search-button"
     class="top-menu-search--button search-form-normal"
-    title="{{text.search}}"
+    [attr.title]="text.search"
+    [attr.aria-label]="text.search"
     [class.-input-focused]="expanded"
     (click)="handleClick($event)"
 

--- a/frontend/src/app/core/setup/globals/components/admin/backup.component.html
+++ b/frontend/src/app/core/setup/globals/components/admin/backup.component.html
@@ -13,8 +13,8 @@
     </div>
 
     <button name="button" type="submit" class="button">
-      <i class="button--icon icon-save"></i>
-      <span class="button--text">{{ text.downloadBackup }}</span>
+      <span class="spot-icon spot-icon_save"></span>
+      <span>{{ text.downloadBackup }}</span>
     </button>
   </section>
 </form>
@@ -31,7 +31,7 @@
       </p>
 
       <p class="danger-zone--warning">
-        <span class="icon icon-error"></span>
+        <span class="spot-icon spot-icon_error"></span>
         <span>{{ text.note }}</span>
       </p>
       <div>
@@ -70,8 +70,8 @@
           [disabled]="backupToken.length === 0"
           (click)="triggerBackup($event)"
         >
-          <i class="button--icon icon-export"></i>
-          <span class="button--text">{{ text.requestBackup }}</span>
+          <span class="spot-icon spot-icon_export"></span>
+          <span>{{ text.requestBackup }}</span>
         </button>
       </div>
     </section>

--- a/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
@@ -48,7 +48,7 @@ export function wpOnboardingTourSteps():OnboardingStep[] {
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       bottom: '-64',
       onNext() {
-        jQuery('#wp-view-context-menu .icon-view-timeline')[0].click();
+        jQuery('#wp-view-context-menu .spot-icon_view-timeline')[0].click();
       },
     },
     {

--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
@@ -17,12 +17,14 @@
       </ngx-gallery>
     </div>
 
-    <a *ngIf="viewerVisible && createAllowed"
-       [title]="text.add_viewpoint"
-       class="button"
-       (click)="saveViewpoint(workPackage)">
-      <op-icon icon-classes="button--icon icon-add"></op-icon>
-      <span class="button--text"> {{text.viewpoint}} </span>
-    </a>
+    <button
+      type="button"
+      *ngIf="viewerVisible && createAllowed"
+      class="button"
+      (click)="saveViewpoint(workPackage)"
+    >
+      <span class="spot-icon spot-icon_add"></span>
+      <span>{{ text.viewpoint }}</span>
+    </button>
   </div>
 </ng-container>

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/bcf-view.service.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/bcf-view.service.ts
@@ -52,11 +52,11 @@ export class BcfViewService extends WorkPackageQueryStateService<BcfViewState> {
   };
 
   public icon:{ [key:string]:string } = {
-    cards: 'icon-view-card',
-    viewer: 'icon-view-model',
-    splitTable: 'icon-view-split-viewer-table',
-    splitCards: 'icon-view-split2',
-    table: 'icon-view-list',
+    cards: 'view-card',
+    viewer: 'view-model',
+    splitTable: 'view-split-viewer-table',
+    splitCards: 'view-split2',
+    table: 'view-list',
   };
 
   constructor(

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
@@ -42,13 +42,16 @@ import { WpTableExportModalComponent } from 'core-app/shared/components/modals/e
 
 @Component({
   template: `
-    <a [title]="text.export_hover"
-       class="button export-bcf-button"
-       [attr.href]="exportLink"
-       (click)="showDelayedExport($event)">
-      <op-icon icon-classes="button--icon icon-export"></op-icon>
-      <span class="button--text"> {{text.export}} </span>
-    </a>
+    <button
+      type="button"
+      [attr.title]="text.export_hover"
+      class="button export-bcf-button"
+      [attr.href]="exportLink"
+      (click)="showDelayedExport($event)"
+    >
+      <span class="spot-icon spot-icon_export"></span>
+      <span> {{text.export}} </span>
+    </button>
   `,
   selector: 'bcf-export-button',
 })

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
@@ -41,7 +41,7 @@ import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-
     >
       <span class="spot-icon spot-icon_import"></span>
       <span>{{text.import}}</span>
-    </a>
+    </button>
   `,
   selector: 'bcf-import-button',
 })

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
@@ -33,11 +33,14 @@ import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-
 
 @Component({
   template: `
-    <a [title]="text.import_hover"
+    <button
+      type="button"
+      [title]="text.import_hover"
       (click)="handleClick()"
-      class="button import-bcf-button">
-      <op-icon icon-classes="button--icon icon-import"></op-icon>
-      <span class="button--text"> {{text.import}} </span>
+      class="button import-bcf-button"
+    >
+      <span class="spot-icon spot-icon_import"></span>
+      <span>{{text.import}}</span>
     </a>
   `,
   selector: 'bcf-import-button',

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -32,11 +32,14 @@ import { StateService } from '@uirouter/core';
 
 @Component({
   template: `
-    <a [title]="text.refresh_hover"
-       class="button refresh-button"
-       (click)="refresh()">
-      <op-icon icon-classes="button--icon icon-workflow"></op-icon>
-    </a>
+    <button
+      type="button"
+      [attr.aria-label]="text.refresh_hover"
+      class="button refresh-button"
+      (click)="refresh()"
+    >
+      <span class="spot-icon spot-icon_workflow"></span>
+    </button>
   `,
   selector: 'op-refresh-button',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
@@ -32,13 +32,13 @@ import { IfcModelsDataService } from 'core-app/features/bim/ifc_models/pages/vie
 
 @Component({
   template: `
-    <a *ngIf="manageAllowed"
-       class="button"
-       [href]="manageIFCPath">
-      <op-icon icon-classes="button--icon icon-settings2"></op-icon>
-      <span class="button--text"
-            [textContent]="text.manage"
-            aria-hidden="true"></span>
+    <a
+      *ngIf="manageAllowed"
+      class="button"
+      [href]="manageIFCPath"
+    >
+      <span class="spot-icon spot-icon_settings2"></span>
+      <span [textContent]="text.manage"></span>
     </a>
 
   `,

--- a/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-button.component.ts
@@ -33,15 +33,16 @@ import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bc
 @Component({
   template: `
     <ng-container *ngIf="(view$ | async) as current">
-      <button class="button"
-              id="bcf-view-toggle-button"
-              opBcfViewDropdown>
-        <op-icon icon-classes="button--icon {{bcfView.icon[current]}}"></op-icon>
+      <button
+        class="button"
+        id="bcf-view-toggle-button"
+        opBcfViewDropdown
+      >
+        <span class="spot-icon spot-icon_{{bcfView.icon[current]}}"></span>
         <span class="button--text"
-              aria-hidden="true"
               [textContent]="bcfView.text[current]">
         </span>
-        <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+        <span class="spot-icon spot-icon_dropdown"></span>
       </button>
     </ng-container>
   `,

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
@@ -32,11 +32,12 @@
               <button
                 class="op-select-footer--label"
                 type="button"
-                (click)="onNewActionCreated()">
-                  <span class="icon-context">
-                    <op-icon icon-classes="icon-plus icon-context"></op-icon>
-                    {{text.button_create}} {{ngSelectComponent.ngSelectInstance.searchTerm}}
-                  </span>
+                (click)="onNewActionCreated()"
+              >
+                <span class="spot-icon spot-icon_plus"></span>
+                <span>
+                  {{text.button_create}} {{ngSelectComponent.ngSelectInstance.searchTerm}}
+                </span>
               </button>
 
             </ng-template>

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.html
@@ -36,12 +36,15 @@
     <div class="op-board-list--query-container drop-zone"
          [ngClass]="{ '-with-create-button': board.isAction || showAddButton }">
       <div class="op-board-list--button-container">
-        <button [title]="text.addCard"
-                *ngIf="showAddButton"
-                data-qa-selector="op-board-list--card-dropdown-add-button"
-                class="op-board-list--add-button op-board-list--card-dropdown-button button"
-                op-addCardDropdown>
-          <op-icon icon-classes="icon-small icon-add"></op-icon>
+        <button
+          [attr.title]="text.addCard"
+          [attr.aria-label]="text.addCard"
+          *ngIf="showAddButton"
+          data-qa-selector="op-board-list--card-dropdown-add-button"
+          class="op-board-list--add-button op-board-list--card-dropdown-button button"
+          op-addCardDropdown
+        >
+          <span class="spot-icon spot-icon_1 spot-icon_add"></span>
         </button>
       </div>
 

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -16,9 +16,11 @@
          vsDragScroll
          [cdkDragData]="boardWidget"
          [vsDragScrollContainer]="_container">
-      <span *ngIf="board.editable"
-            class="boards-list-item-handle icon icon-drag-handle"
-            cdkDragHandle></span>
+      <span
+        *ngIf="board.editable"
+        class="boards-list-item-handle spot-icon spot-icon_drag-handle"
+        cdkDragHandle
+      ></span>
       <board-list [resource]="boardWidget"
                   [board]="board"
                   (onRemove)="removeList(board, boardWidget)"
@@ -28,17 +30,20 @@
     <span *ngIf="showHiddenListWarning"
           class="boards-list--tooltip tooltip--right"
           [attr.data-tooltip]="text.hiddenListWarning">
-      <i class="icon icon-attention"></i>
+      <span class="spot-icon spot-icon_attention"></span>
     </span>
 
-    <div class="boards-list--add-item -no-text-select"
-         *ngIf="board.editable"
-         (click)="addList(board)">
+    <button
+      class="boards-list--add-item -no-text-select"
+      *ngIf="board.editable"
+      (click)="addList(board)"
+      type="button"
+    >
       <div class="boards-list--add-item-text">
-        <op-icon icon-classes="icon-add icon-context"></op-icon>
+        <span class="spot-icon spot-icon_add"></span>
         <span [textContent]="text.addList"></span>
       </div>
-    </div>
+    </button>
   </div>
 
   <op-enterprise-banner

--- a/frontend/src/app/features/boards/board/toolbar-menu/boards-menu-button.component.ts
+++ b/frontend/src/app/features/boards/board/toolbar-menu/boards-menu-button.component.ts
@@ -5,11 +5,14 @@ import { Observable } from 'rxjs';
 
 @Component({
   template: `
-    <button title="{{ text.button_more }}"
-            class="button last board--settings-dropdown toolbar-icon"
-            boardsToolbarMenu
-            [boardsToolbarMenu-resource]="board$ | async">
-      <op-icon icon-classes="button--icon icon-show-more"></op-icon>
+    <button
+      [attr.title]="text.button_more"
+      [attr.aria-label]="text.button_more"
+      class="button -icon-only last board--settings-dropdown toolbar-icon"
+      boardsToolbarMenu
+      [boardsToolbarMenu-resource]="board$ | async"
+    >
+      <span class="spot-icon spot-icon_show-more"></span>
     </button>
   `,
 })

--- a/frontend/src/app/features/boards/index-page/boards-index-page.component.html
+++ b/frontend/src/app/features/boards/index-page/boards-index-page.component.html
@@ -6,15 +6,15 @@
     <ul class="toolbar-items">
       <li *ngIf="canAdd"
           class="toolbar-item">
-        <a class="button -alt-highlight"
-           [title]="text.create_new_board"
-           (click)="newBoard()">
-          <op-icon icon-classes="button--icon icon-add">
-          </op-icon>
-          <span class="button--text"
-                [textContent]="text.board">
-          </span>
-        </a>
+        <button
+          class="button -alt-highlight"
+          [title]="text.create_new_board"
+          (click)="newBoard()"
+          type="button"
+        >
+          <span class="spot-icon spot-icon_add"></span>
+          <span [textContent]="text.board"></span>
+        </button>
       </li>
     </ul>
   </div>
@@ -69,7 +69,7 @@
         <tr *ngIf="boards.length === 0" id="empty-row-notification">
           <td colspan="4">
             <span>
-              <op-icon icon-classes="icon-info1 icon-context"></op-icon>
+              <span class="spot-icon spot-icon_info1"></span>
               <span>
                 <strong [textContent]="text.noResults"></strong>
               </span>
@@ -94,12 +94,14 @@
             <op-date-time [dateTimeValue]="board.createdAt"></op-date-time>
           </td>
           <td class="buttons">
-            <button class="spot-link"
-                    type="button"
-                    (click)="destroyBoard(board)"
-                    [title]="text.delete"
-                    >
-              <op-icon icon-classes="icon icon-delete"></op-icon>
+            <button
+              class="spot-link"
+              type="button"
+              (click)="destroyBoard(board)"
+              [attr.title]="text.delete"
+              [attr.aria-label]="text.delete"
+            >
+              <span class="spot-icon spot-icon_delete"></span>
             </button>
           </td>
         </tr>

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.template.html
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.template.html
@@ -7,14 +7,12 @@
   <button
     *ngIf="memoizedCreateAllowed"
     class="button te-calendar--create-button"
-    [attr.aria-label]="text.logTime"
     (click)="addEventToday()"
   >
-    <op-icon icon-classes="button--icon icon-log_time"></op-icon>
+    <span class="spot-icon spot-icon_log-time"></span>
     <span
       class="button--text"
       [textContent]="text.logTime"
-      aria-hidden="true"
     ></span>
   </button>
 

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -51,21 +51,23 @@
       ></span>
 
       <div class="op-ian-item--buttons">
-        <i
+        <button
           *ngIf="!notification.readIAN"
           data-qa-selector="mark-as-read-button"
-          class="op-ian-item--button icon-mark-read"
-          [title]="text.mark_as_read"
+          class="op-ian-item--button"
+          type="button"
+          [attr.title]="text.mark_as_read"
+          [attr.aria-label]="text.mark_as_read"
           (click)="markAsRead($event, aggregatedNotifications)"
           tabindex="0"
         >
-        </i>
-        <i
-          class="op-ian-item--button op-ian-item--button_shown-on-focus icon-info1"
+          <span class="spot-icon spot-icon_mark-read"></span>
+        </button>
+        <span
+          class="op-ian-item--button op-ian-item--button_shown-on-focus spot-icon spot-icon_info1"
           (keydown.enter)="showDetails()"
           tabindex="0"
-        >
-        </i>
+        ></span>
       </div>
     </div>
 
@@ -115,8 +117,7 @@
 
       <span class="op-ian-item--reason-count"></span>
       <div class="op-ian-item--buttons">
-        <i class="op-ian-item--button icon-mark-read">
-        </i>
+        <span class="op-ian-item--button spot-icon spot-icon_mark-read"></span>
       </div>
     </div>
   </ng-template>

--- a/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
+++ b/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
@@ -12,7 +12,7 @@
     <div class="loading-indicator--location"
          data-indicator-name="modal">
       <div class="status-icon-wrapper" *ngIf="!isLoading && statusIcon">
-        <span [ngClass]="statusIcon" class="icon-big"></span>
+        <span class="spot-icon spot-icon_2 spot-icon_{{ statusIcon }}"></span>
       </div>
     </div>
     <div>

--- a/frontend/src/app/features/job-status/job-status-modal/job-status.modal.ts
+++ b/frontend/src/app/features/job-status/job-status-modal/job-status.modal.ts
@@ -126,11 +126,9 @@ export class JobStatusModalComponent extends OpModalComponent implements OnInit 
       case 'cancelled':
       case 'failure':
       case 'error':
-        return 'icon-error';
-        break;
+        return 'error';
       case 'success':
-        return 'icon-checkmark';
-        break;
+        return 'checkmark';
       default:
         return null;
     }
@@ -222,10 +220,10 @@ export class JobStatusModalComponent extends OpModalComponent implements OnInit 
 
   private handleError(error:HttpErrorResponse) {
     if (error?.status === 404) {
-      this.statusIcon = 'icon-help';
+      this.statusIcon = 'help';
       this.message = this.I18n.t('js.job_status.generic_messages.not_found');
     } else {
-      this.statusIcon = 'icon-error';
+      this.statusIcon = 'error';
       this.message = error?.message || this.I18n.t('js.error.internal');
       this.toastService.addError(this.message);
     }

--- a/frontend/src/app/features/reporting/reporting-page/functionality/reporting_engine/group_bys.js
+++ b/frontend/src/app/features/reporting/reporting-page/functionality/reporting_engine/group_bys.js
@@ -72,7 +72,7 @@ Reporting.GroupBys = (function($){
     remove_link.attr('href', '');
 
     remove_icon = $('<span><span>');
-    remove_icon.attr('class', 'icon-context icon-close icon4');
+    remove_icon.attr('class', 'spot-icon spot-icon_close');
 
     remove_link.attr('title', I18n.t("js.reporting_engine.label_remove") + ' ' + group_by.find('label').html());
     remove_icon.attr('alt', I18n.t("js.reporting_engine.label_remove") + ' ' + group_by.find('label').html());

--- a/frontend/src/app/features/work-packages/components/filters/filter-container/filter-container.directive.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-container/filter-container.directive.html
@@ -1,11 +1,12 @@
 <button
   class="button -small advanced-filters--toggle"
+  type="button"
   (click)="wpFiltersService.toggleVisibility()"
   [class.-active]="visible$ | async"
   *ngIf="showFilterButton"
 >
-  <i class="button--icon icon-filter"></i>
-  <span class="button--text" [textContent]="filterButtonText"></span>
+  <span class="spot-icon spot-icon_filter"></span>
+  <span [textContent]="filterButtonText"></span>
 </button>
 
 <div

--- a/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
@@ -75,6 +75,7 @@ export class FilterProjectComponent extends UntilDestroyedMixin implements OnIni
   }
 
   async onChange(val:HalResource[]|IProjectAutocompleteItem[]):Promise<void> {
+    console.log(val);
     if (val === this.filter.values || val === undefined) {
       return;
     }

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
@@ -40,20 +40,22 @@
         type="button"
         *ngIf="userCanQuote"
         class="spot-link"
-        [title]="text.quote_comment"
+        [attr.title]="text.quote_comment"
+        [attr.aria-label]="text.quote_comment"
         (click)="quoteComment()"
       >
-        <op-icon icon-classes="action-icon icon-quote"></op-icon>
+        <span class="spot-icon spot-icon_quote"></span>
       </button>
       <button
         *ngIf="userCanEdit"
         type="button"
         class="spot-link"
         [ngClass]="'edit-activity--' + activityNo"
-        [title]="text.edit_comment"
+        [attr.title]="text.edit_comment"
+        [attr.aria-label]="text.edit_comment"
         (click)="activate()"
       >
-        <op-icon icon-classes="action-icon icon-edit"></op-icon>
+        <span class="spot-icon spot-icon_edit"></span>
       </button>
     </div>
   </div>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -49,7 +49,7 @@ export interface TimelineButtonText extends ButtonControllerText {
 export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit {
   public buttonId = 'work-packages-timeline-toggle-button';
 
-  public iconClass = 'icon-view-timeline';
+  public iconClass = 'view-timeline';
 
   private activateLabel:string;
 

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
@@ -28,10 +28,10 @@ export class GroupHeaderBuilder {
 
     if (group.collapsed) {
       text = this.text.expand;
-      togglerIconClass = 'icon-plus';
+      togglerIconClass = 'plus';
     } else {
       text = this.text.collapse;
-      togglerIconClass = 'icon-minus2';
+      togglerIconClass = 'minus2';
     }
 
     row.classList.add(rowGroupClassName, groupClassNameFor(group));
@@ -40,9 +40,9 @@ export class GroupHeaderBuilder {
     row.dataset.groupIdentifier = group.identifier;
     row.innerHTML = `
       <td colspan="${colspan}" class="-no-highlighting">
-        <div class="expander icon-context ${togglerIconClass}">
-          <span class="hidden-for-sighted">${_.escape(text)}</span>
-        </div>
+        <span class="expander spot-icon spot-icon_${togglerIconClass}">
+        </span>
+        <span class="hidden-for-sighted">${_.escape(text)}</span>
         <div class="group--value" data-qa-selector="op-group--value">
           ${_.escape(groupName(group))}
           <span class="count">

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/inline-create-row-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/inline-create-row-builder.ts
@@ -83,9 +83,11 @@ export class InlineCreateRowBuilder extends SingleRowBuilder {
 
     td.innerHTML = `
     <a
-       href="#"
-       class="${inlineCreateCancelClassName} icon icon-cancel"
-       aria-label="${this.text.cancelButton}">
+      href="#"
+      class="${inlineCreateCancelClassName}"
+      aria-label="${this.text.cancelButton}"
+    >
+      <span class="spot-icon spot-icon_cancel"></span>
     </a>
    `;
 

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
@@ -16,9 +16,10 @@
         <li class="toolbar-item hidden-for-mobile">
           <button id="create-wp-menu-button"
                   [attr.title]="text.button_settings"
+                  [attr.aria-label]="text.button_settings"
                   class="button -icon-only last work-packages-settings-button toolbar-icon"
                   wpCreateSettingsMenu>
-            <i class="button--icon icon-show-more"></i>
+            <span class="spot-icon spot-icon_show-more"></span>
           </button>
         </li>
       </ul>

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-new-split-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-new-split-view.html
@@ -10,10 +10,14 @@
       <div class="work-packages--new-details-header">
         <wp-type-status [workPackage]="newWorkPackage"></wp-type-status>
         <div class="wp--details--switch-fullscreen-wrapper">
-          <a (click)="switchToFullscreen()"
-             class="work-packages-show-view-button wp--details--switch-fullscreen ">
-            <span class="icon-context icon-to-fullscreen"></span>
-          </a>
+          <!-- TODO: this button needs an aria-label! -->
+          <button
+            type="button"
+            (click)="switchToFullscreen()"
+            class="work-packages-show-view-button wp--details--switch-fullscreen"
+          >
+            <span class="spot-icon spot-icon_to-fullscreen"></span>
+          </button>
         </div>
       </div>
       <wp-single-view [workPackage]="newWorkPackage"

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
@@ -12,11 +12,12 @@
     </div>
     <div class="wp-relations-controls-section relation-row">
       <button
-          type="button"
-          class="spot-link wp-create-relation--cancel"
-          (click)="cancel()"
+        type="button"
+        class="spot-link wp-create-relation--cancel"
+        (click)="cancel()"
+        [attr.aria-label]="text.abort"
       >
-        <op-icon icon-classes="icon-remove icon-no-color" [icon-title]="text.abort"></op-icon>
+        <span class="spot-icon spot-icon_remove"></span>
       </button>
     </div>
   </div>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -73,26 +73,22 @@
         type="button"
         class="spot-link wp-relations--description-btn"
         [ngClass]="{'-visible': showDescriptionInfo }"
-        [title]="text.description_label"
+        [attr.title]="text.description_label"
+        [attr.aria-label]="text.toggleDescription"
         (click)="userInputs.showRelationInfo = !userInputs.showRelationInfo"
       >
-        <op-icon
-          icon-classes="icon-info1 icon-no-color -padded wp-relations--icon wp-relations--description-icon"
-          [icon-title]="text.toggleDescription"
-        ></op-icon>
+        <span class="spot-icon spot-icon_info1 wp-relations--icon wp-relations--description-icon"></span>
       </button>
       <button
         *ngIf="!!relation.delete"
         type="button"
         class="spot-link relation-row--remove-btn"
         [ngClass]="{'-visible': showDescriptionInfo }"
-        [title]="text.removeButton"
+        [attr.title]="text.removeButton"
+        [attr.aria-label]="text.removeButton"
         (click)="removeRelation()"
       >
-        <op-icon
-          icon-classes="icon-remove icon-no-color -padded wp-relations--icon"
-          [icon-title]="text.removeButton"
-        ></op-icon>
+        <span class="spot-icon spot-icon_remove wp-relations--icon"></span>
       </button>
     </div>
   </div>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -48,8 +48,9 @@
           type="button"
           class="spot-link wp-create-relation--cancel"
           (click)="toggleRelationsCreateForm()"
+          [attr.aria-label]="text.abort"
         >
-          <op-icon icon-classes="icon-remove icon-no-color -padded" [icon-title]="text.abort"></op-icon>
+          <span class="spot-icon spot-icon_remove"></span>
         </button>
       </div>
     </div>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -13,9 +13,10 @@
       #wpRelationGroupByToggler
       id="wp-relation-group-by-toggle"
       type="button"
-      class="button -small -transparent -with-icon icon-group-by icon-small hide-when-print"
+      class="button -small -transparent  hide-when-print"
       (click)="toggleButton()"
     >
+      <span class="spot-icon spot-icon_1 spot-icon_group-by"></span>
       <span [textContent]="togglerText"></span>
     </button>
   </div>

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-tab.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-tab.html
@@ -18,10 +18,12 @@
             <button
               *ngIf="first && showToggler"
               type="button"
-              class="activity-comments--toggler button -small -transparent -with-icon icon-filter icon-small hide-when-print"
-              [textContent]="togglerText"
+              class="activity-comments--toggler button -small -transparent hide-when-print"
               (click)="toggleComments()"
-            ></button>
+            >
+              <span class="spot-icon spot-icon_1 spot-icon_filter"></span>
+              <span [textContent]="togglerText"></span>
+            </button>
           </h3>
 
           <activity-entry

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.html
@@ -10,9 +10,10 @@
   <button
     type="button"
     class="spot-link form--selected-value--remover"
-    [title]="text.remove"
+    [attr.title]="text.remove"
+    [attr.aria-label]="text.remove"
     (click)="remove()"
   >
-    <op-icon icon-classes="icon-remove"></op-icon>
+    <span class="spot-icon spot-icon_remove"></span>
   </button>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -167,7 +167,7 @@ export class WorkPackageContextMenuHelperService {
     if (this.wpViewIndent.canOutdent(workPackage)) {
       actions.push({
         key: 'hierarchy-outdent',
-        icon: 'icon-paragraph-left',
+        icon: 'paragraph-left',
         text: I18n.t('js.relation_buttons.hierarchy_outdent'),
       });
     }
@@ -176,7 +176,7 @@ export class WorkPackageContextMenuHelperService {
     if (this.wpViewIndent.canIndent(workPackage)) {
       actions.push({
         key: 'hierarchy-indent',
-        icon: 'icon-paragraph-right',
+        icon: 'paragraph-right',
         text: I18n.t('js.relation_buttons.hierarchy_indent'),
       });
     }

--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
@@ -6,12 +6,19 @@
       *ngIf="displayHierarchyIcon"
       (click)="toggleHierarchy($event)"
       [attr.title]="text.toggleHierarchy"
+<<<<<<< HEAD
       [attr.aria-label]="text.toggleHierarchy"
       tabindex="-1"
       aria-hidden="true"
       [attr.data-qa-hierarchy-type]="hierarchyType"
     >
       <span class="spot-icon spot-icon_{{ hierarchyType }}"></span>
+=======
+      tabindex="-1"
+      aria-hidden="true"
+    >
+      <span class="spot-icon spot-icon_{{ hierarchyIcon }}"></span>
+>>>>>>> 2f871dff07 (Change all icons to spot-icon in wp-table)
     </span>
 
     <!--suppress XmlDuplicatedId -->

--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
@@ -6,19 +6,12 @@
       *ngIf="displayHierarchyIcon"
       (click)="toggleHierarchy($event)"
       [attr.title]="text.toggleHierarchy"
-<<<<<<< HEAD
       [attr.aria-label]="text.toggleHierarchy"
       tabindex="-1"
       aria-hidden="true"
       [attr.data-qa-hierarchy-type]="hierarchyType"
     >
       <span class="spot-icon spot-icon_{{ hierarchyType }}"></span>
-=======
-      tabindex="-1"
-      aria-hidden="true"
-    >
-      <span class="spot-icon spot-icon_{{ hierarchyIcon }}"></span>
->>>>>>> 2f871dff07 (Change all icons to spot-icon in wp-table)
     </span>
 
     <!--suppress XmlDuplicatedId -->

--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
@@ -6,6 +6,7 @@
       *ngIf="displayHierarchyIcon"
       (click)="toggleHierarchy($event)"
       [attr.title]="text.toggleHierarchy"
+      [attr.aria-label]="text.toggleHierarchy"
       tabindex="-1"
       aria-hidden="true"
       [attr.data-qa-hierarchy-type]="hierarchyType"
@@ -63,6 +64,7 @@
     <span
       *ngIf="baselineIncompatible"
       [attr.title]="text.baselineIncompatible"
+      [attr.aria-label]="text.baselineIncompatible"
       class="spot-icon spot-icon_1_25 spot-icon_warning"
     ></span>
 

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.html
@@ -7,20 +7,22 @@
       <button
         type="button"
         class="spot-link work-packages--details-fullscreen-icon"
-        [title]="text.details.goToFullScreen"
+        [attr.title]="text.details.goToFullScreen"
+        [attr.aria-label]="text.details.goToFullScreen"
         (click)="switchToFullscreen()"
       >
-        <op-icon icon-classes="icon-context icon-no-color icon-to-fullscreen"></op-icon>
+        <span class="spot-icon spot-icon_to-fullscreen"></span>
       </button>
     </li>
     <li class="tab-icon">
       <button
         type="button"
         class="spot-link work-packages--details-close-icon"
-        [title]="text.details.close"
+        [attr.title]="text.details.close"
+        [attr.aria-label]="text.details.close"
         (click)="close()"
       >
-        <op-icon icon-classes="icon-context icon-no-color icon-close"></op-icon>
+        <span class="spot-icon spot-icon_close"></span>
       </button>
     </li>
   </ng-container>

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -43,7 +43,7 @@
         </li>
         <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
           <button
-            class="button -icon-only dropdown-relative toolbar-icon"
+            class="button dropdown-relative toolbar-icon"
             [attr.title]="text.fullView.buttonMore"
             wpSingleContextMenu
             [wpSingleContextMenu-workPackage]="workPackage"

--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
@@ -4,7 +4,7 @@
   [title]="text.manually_scheduled"
   [subtitle]="text.click_on_show_relations_to_open_gantt"
   [actionButton]="text.show_relations_button"
-  actionButtonClasses="icon-view-timeline"
+  actionButtonIcon="view-timeline"
   (buttonClicked)="openGantt($event)"
 ></op-modal-banner>
 <op-modal-banner
@@ -13,7 +13,7 @@
   [title]="text.automatically_scheduled_parent"
   [subtitle]="text.click_on_show_relations_to_open_gantt"
   [actionButton]="text.show_relations_button"
-  actionButtonClasses="icon-view-timeline"
+  actionButtonIcon="view-timeline"
   (buttonClicked)="openGantt($event)"
 ></op-modal-banner>
 <ng-container *ngIf="!scheduleManually && !isParent">
@@ -23,7 +23,7 @@
     [title]="text.start_date_limited_by_relations"
     [subtitle]="text.click_on_show_relations_to_open_gantt"
     [actionButton]="text.show_relations_button"
-    actionButtonClasses="icon-view-timeline"
+  actionButtonIcon="view-timeline"
     (buttonClicked)="openGantt($event)"
   ></op-modal-banner>
 
@@ -33,7 +33,7 @@
     [title]="text.changing_dates_affects_follow_relations"
     [subtitle]="text.click_on_show_relations_to_open_gantt"
     [actionButton]="text.show_relations_button"
-    actionButtonClasses="icon-view-timeline"
+    actionButtonIcon="view-timeline"
     (buttonClicked)="openGantt($event)"
   ></op-modal-banner>
 </ng-container>

--- a/frontend/src/app/shared/components/fields/edit/field-controls/edit-field-controls.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-controls/edit-field-controls.component.html
@@ -1,21 +1,21 @@
 <div class="inplace-edit--dashboard">
   <div class="inplace-edit--controls">
     <button
-        type="button"
-        class="inplace-edit--control inplace-edit--control--save"
-        [disabled]="(field.required && field.isEmpty()) || undefined"
-        [title]="saveTitle"
-        (click)="save()"
+      type="button"
+      class="inplace-edit--control inplace-edit--control--save"
+      [disabled]="(field.required && field.isEmpty()) || undefined"
+      [attr.aria-label]="saveTitle"
+      (click)="save()"
     >
-      <op-icon icon-classes="icon-checkmark icon-no-color" [icon-title]="saveTitle"></op-icon>
+      <span class="spot-icon spot-icon_checkmark"></span>
     </button>
     <button
-        type="button"
-        class="inplace-edit--control inplace-edit--control--cancel"
-        [title]="cancelTitle"
-        (click)="cancel()"
+      type="button"
+      class="inplace-edit--control inplace-edit--control--cancel"
+      [attr.aria-label]="cancelTitle"
+      (click)="cancel()"
     >
-      <op-icon icon-classes="icon-close icon-no-color" [icon-title]="cancelTitle"></op-icon>
+      <span class="spot-icon spot-icon_close"></span>
     </button>
 </div>
 </div>

--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
@@ -9,13 +9,15 @@
           <zen-mode-toggle-button></zen-mode-toggle-button>
         </li>
         <li class="toolbar-item">
-          <button class="button"
-                  *ngIf="addWidget.isAllowed"
-                  [title]="addWidget.addText"
-                  (click)="areas.toggleHelpMode()"
-                  [ngClass]="{'-active': areas.inHelpMode}">
-            <op-icon icon-classes="button--icon icon-add">
-            </op-icon>
+          <button
+            class="button"
+            *ngIf="addWidget.isAllowed"
+            [attr.title]="addWidget.addText"
+            [attr.aria-label]="addWidget.addText"
+            (click)="areas.toggleHelpMode()"
+            [ngClass]="{'-active': areas.inHelpMode}"
+          >
+            <span class="spot-icon spot-icon_add"></span>
           </button>
         </li>
       </ul>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -90,18 +90,27 @@
             <em [textContent]="item.sum"></em>
           </td>
           <td class="buttons">
-            <a *ngIf="item.entry && item.entry.updateImmediately"
-               (click)="editTimeEntry(item.entry)"
-               [title]="text.edit"
-               attr.data-qa-selector="edit-time-entry-{{ item.entry.id }}"
+            <button
+              type="button"
+              class="spot-link"
+              *ngIf="item.entry && item.entry.updateImmediately"
+              (click)="editTimeEntry(item.entry)"
+              [attr.title]="text.edit"
+              [attr.aria-label]="text.edit"
+              attr.data-qa-selector="edit-time-entry-{{ item.entry.id }}"
             >
-              <op-icon icon-classes="icon-context icon-edit"></op-icon>
-            </a>
-            <a *ngIf="item.entry && item.entry.delete"
-               (click)="deleteIfConfirmed($event, item.entry)"
-               [title]="text.delete" >
-              <op-icon icon-classes="icon-context icon-delete"></op-icon>
-            </a>
+              <span class="spot-icon spot-icon_edit"></span>
+            </button>
+            <button
+              type="button"
+              class="spot-link"
+              *ngIf="item.entry && item.entry.delete"
+              (click)="deleteIfConfirmed($event, item.entry)"
+              [attr.title]="text.delete"
+              [attr.aria-label]="text.delete"
+            >
+              <span class="spot-icon spot-icon_delete"></span>
+            </button>
           </td>
         </tr>
       </tbody>

--- a/frontend/src/app/shared/components/hide-section/hide-section-link/hide-section-link.component.html
+++ b/frontend/src/app/shared/components/hide-section/hide-section-link/hide-section-link.component.html
@@ -1,8 +1,9 @@
 <button
-    type="button"
-    class="spot-link"
-    [title]="text.remove"
-    (click)="hideSection()"
+  type="button"
+  class="spot-link"
+  [attr.title]="text.remove"
+  [attr.aria-label]="text.remove"
+  (click)="hideSection()"
 >
-  <op-icon icon-classes="icon-close icon-small"></op-icon>
+  <span class="spot-icon spot-icon_1 spot-icon_close"></span>
 </button>

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -31,7 +31,7 @@
     type="button"
     (click)="buttonClicked.emit($event)"
   >
-    <op-icon icon-classes="button--icon {{ actionButtonClasses }}"></op-icon>
-    <span class="button--text" [textContent]="actionButton"></span>
+    <span class="spot-icon spot-icon_{{ actionButtonIcon }}"></span>
+    <span [textContent]="actionButton"></span>
   </button>
 </div>

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.ts
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.ts
@@ -49,7 +49,7 @@ export class OpModalBannerComponent {
 
   @Input() actionButton?:string;
 
-  @Input() actionButtonClasses?:string;
+  @Input() actionButtonIcon?:string;
 
   @Output() buttonClicked = new EventEmitter<MouseEvent>();
 }

--- a/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
+++ b/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
@@ -20,7 +20,7 @@
           (click)="triggerByLink(option.url, $event)"
           id="export-{{ option.identifier }}"
         >
-          <op-icon icon-classes="icon-export-{{ option.identifier }} icon-big"></op-icon>
+          <span class="spot-icon spot-icon_2 spot-icon_export-{{ option.identifier }}"></span>
           <span class="op-export-options--option-label" [textContent]="option.label"></span>
         </a>
       </li>
@@ -32,7 +32,7 @@
         type="button"
         class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
         (click)="closeMe()"
-        >
+      >
         {{ text.cancelButton }}
      </button>
     </div>

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
@@ -116,7 +116,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         // Sort ascending
         hidden: !this.wpTableSortBy.isSortable(c),
         linkText: this.I18n.t('js.work_packages.query.sort_descending'),
-        icon: 'icon-sort-descending',
+        icon: 'sort-descending',
         onClick: (evt:any) => {
           if (this.wpTableSortBy.isManualSortingMode) {
             this.confirmDialog.confirm({
@@ -135,7 +135,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         // Sort descending
         hidden: !this.wpTableSortBy.isSortable(c),
         linkText: this.I18n.t('js.work_packages.query.sort_ascending'),
-        icon: 'icon-sort-ascending',
+        icon: 'sort-ascending',
         onClick: (evt:any) => {
           if (this.wpTableSortBy.isManualSortingMode) {
             this.confirmDialog.confirm({
@@ -154,7 +154,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         // Group by
         hidden: !this.wpTableGroupBy.isGroupable(c) || this.wpTableGroupBy.isCurrentlyGroupedBy(c),
         linkText: this.I18n.t('js.work_packages.query.group'),
-        icon: 'icon-group-by',
+        icon: 'group-by',
         onClick: () => {
           if (this.wpTableHierarchies.isEnabled) {
             this.wpTableHierarchies.setEnabled(false);
@@ -167,7 +167,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         // Move left
         hidden: this.wpTableColumns.isFirst(c),
         linkText: this.I18n.t('js.work_packages.query.move_column_left'),
-        icon: 'icon-column-left',
+        icon: 'column-left',
         onClick: () => {
           this.wpTableColumns.shift(c, -1);
           return true;
@@ -177,7 +177,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         // Move right
         hidden: this.wpTableColumns.isLast(c),
         linkText: this.I18n.t('js.work_packages.query.move_column_right'),
-        icon: 'icon-column-right',
+        icon: 'column-right',
         onClick: () => {
           this.wpTableColumns.shift(c, 1);
           return true;
@@ -186,7 +186,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
       {
         // Hide column
         linkText: this.I18n.t('js.work_packages.query.hide_column'),
-        icon: 'icon-delete',
+        icon: 'delete',
         onClick: () => {
           const focusColumn = this.wpTableColumns.previous(c) || this.wpTableColumns.next(c);
           this.wpTableColumns.removeColumn(c);
@@ -202,7 +202,7 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
       {
         // Insert columns
         linkText: this.I18n.t('js.work_packages.query.insert_columns'),
-        icon: 'icon-columns',
+        icon: 'columns',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
             WpTableConfigurationModalComponent,

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -166,7 +166,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         disabled: false,
         linkText: this.I18n.t('js.toolbar.settings.configure_view'),
         hidden: this.hideTableOptions,
-        icon: 'icon-settings',
+        icon: 'settings',
         onClick: ($event:JQuery.TriggeredEvent) => {
           this.opContextMenu.close();
           this.opModalService.show(WpTableConfigurationModalComponent, this.injector);
@@ -178,7 +178,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Insert columns
         linkText: this.I18n.t('js.work_packages.query.insert_columns'),
         hidden: this.hideTableOptions,
-        icon: 'icon-columns',
+        icon: 'columns',
         class: 'hidden-for-mobile',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
@@ -193,7 +193,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Sort by
         linkText: this.I18n.t('js.toolbar.settings.sort_by'),
         hidden: this.hideTableOptions,
-        icon: 'icon-sort-by',
+        icon: 'sort-by',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
             WpTableConfigurationModalComponent,
@@ -207,7 +207,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Group by
         linkText: this.I18n.t('js.toolbar.settings.group_by'),
         hidden: this.hideTableOptions,
-        icon: 'icon-group-by',
+        icon: 'group-by',
         class: 'hidden-for-mobile',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
@@ -222,7 +222,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Rename query shortcut
         disabled: !this.query.id || this.authorisationService.cannot('query', 'updateImmediately'),
         linkText: this.I18n.t('js.toolbar.settings.page_settings'),
-        icon: 'icon-edit',
+        icon: 'edit',
         onClick: ($event:JQuery.TriggeredEvent) => {
           if (this.allowQueryAction($event, 'update')) {
             jQuery(`${selectableTitleIdentifier}`).trigger(triggerEditingEvent);
@@ -235,7 +235,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Query save modal
         disabled: this.authorisationService.cannot('query', 'updateImmediately'),
         linkText: this.I18n.t('js.toolbar.settings.save'),
-        icon: 'icon-save',
+        icon: 'save',
         onClick: ($event:JQuery.TriggeredEvent) => {
           const { query } = this;
           if (!isPersistedResource(query) && this.allowQueryAction($event, 'updateImmediately')) {
@@ -251,7 +251,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Query save as modal
         disabled: this.form ? !this.form.$links.create_new : this.authorisationService.cannot('query', 'updateImmediately'),
         linkText: this.I18n.t('js.toolbar.settings.save_as'),
-        icon: 'icon-save',
+        icon: 'save',
         onClick: ($event:JQuery.TriggeredEvent) => {
           if (this.allowFormAction($event, 'create_new')) {
             this.opModalService.show(SaveQueryModalComponent, this.injector);
@@ -264,7 +264,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Delete query
         disabled: this.authorisationService.cannot('query', 'delete'),
         linkText: this.I18n.t('js.toolbar.settings.delete'),
-        icon: 'icon-delete',
+        icon: 'delete',
         onClick: ($event:JQuery.TriggeredEvent) => {
           if (this.allowQueryAction($event, 'delete')
             && window.confirm(this.I18n.t('js.text_query_destroy_confirmation'))) {
@@ -279,7 +279,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         disabled: this.authorisationService.cannot('work_packages', 'representations'),
         linkText: this.I18n.t('js.toolbar.settings.export'),
         hidden: this.hideTableOptions,
-        icon: 'icon-export',
+        icon: 'export',
         onClick: ($event:JQuery.TriggeredEvent) => {
           if (this.allowWorkPackageAction($event, 'representations')) {
             this.opModalService.show(WpTableExportModalComponent, this.injector);
@@ -292,7 +292,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         // Sharing modal
         disabled: this.authorisationService.cannot('query', 'unstar') && this.authorisationService.cannot('query', 'star'),
         linkText: this.I18n.t('js.toolbar.settings.visibility_settings'),
-        icon: 'icon-watched',
+        icon: 'watched',
         onClick: ($event:JQuery.TriggeredEvent) => {
           if (this.allowQueryAction($event, 'unstar') || this.allowQueryAction($event, 'star')) {
             this.opModalService.show(QuerySharingModalComponent, this.injector);
@@ -310,7 +310,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
         hidden: !this.query.results.customFields || this.hideTableOptions,
         href: this.query.results.customFields && this.query.results.customFields.href,
         linkText: this.query.results.customFields && this.query.results.customFields.name,
-        icon: 'icon-custom-fields',
+        icon: 'custom-fields',
         onClick: () => false,
       },
       {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
@@ -83,7 +83,7 @@ export class WorkPackageCreateSettingsMenuDirective extends OpContextMenuTrigger
     if (queryCustomFields) {
       this.items.push({
         href: queryCustomFields.href,
-        icon: 'icon-custom-fields',
+        icon: 'custom-fields',
         linkText: queryCustomFields.name,
         onClick: () => false,
       });
@@ -92,7 +92,7 @@ export class WorkPackageCreateSettingsMenuDirective extends OpContextMenuTrigger
     if (configureFormLink) {
       this.items.push({
         href: configureFormLink.href,
-        icon: 'icon-settings3',
+        icon: 'settings3',
         linkText: configureFormLink.name,
         onClick: () => false,
       });

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-group-toggle-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-group-toggle-dropdown-menu.directive.ts
@@ -60,7 +60,7 @@ export class WorkPackageGroupToggleDropdownMenuDirective extends OpContextMenuTr
       {
         disabled: this.wpViewCollapsedGroups.allGroupsAreCollapsed,
         linkText: this.I18n.t('js.button_collapse_all'),
-        icon: 'icon-minus2',
+        icon: 'minus2',
         onClick: (evt:JQuery.TriggeredEvent) => {
           this.wpViewCollapsedGroups.setAllGroupsCollapseStateTo(true);
 
@@ -70,7 +70,7 @@ export class WorkPackageGroupToggleDropdownMenuDirective extends OpContextMenuTr
       {
         disabled: this.wpViewCollapsedGroups.allGroupsAreExpanded,
         linkText: this.I18n.t('js.button_expand_all'),
-        icon: 'icon-plus',
+        icon: 'plus',
         onClick: (evt:JQuery.TriggeredEvent) => {
           this.wpViewCollapsedGroups.setAllGroupsCollapseStateTo(false);
 

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -99,7 +99,7 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
     this.items = statuses.map((status:HalResource) => ({
       disabled: false,
       linkText: status.name,
-      postIcon: status.isReadonly ? 'icon-locked' : null,
+      postIcon: status.isReadonly ? 'locked' : null,
       postIconTitle: this.I18n.t('js.work_packages.message_work_package_read_only'),
       class: Highlighting.inlineClass('status', status.id!),
       onClick: () => {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -79,7 +79,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           // Card View
           linkText: this.I18n.t('js.views.card'),
           title: this.I18n.t('js.button_show_cards'),
-          icon: 'icon-view-card',
+          icon: 'view-card',
           onClick: (evt:any) => {
             this.isOpen = false;
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayCardRepresentation);
@@ -99,7 +99,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           // List View
           linkText: this.I18n.t('js.views.list'),
           title: this.I18n.t('js.button_show_table'),
-          icon: 'icon-view-list',
+          icon: 'view-list',
           onClick: (evt:any) => {
             this.isOpen = false;
             this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
@@ -118,7 +118,7 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
           // List View with enabled Gantt
           linkText: this.I18n.t('js.views.timeline'),
           title: this.I18n.t('js.button_show_gantt'),
-          icon: 'icon-view-timeline',
+          icon: 'view-timeline',
           onClick: (evt:any) => {
             this.isOpen = false;
             if (!this.wpTableTimeline.isVisible) {

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
@@ -18,11 +18,10 @@
           [attr.title]="item.title || undefined"
           (click)="handleClick(item, $event)"
         >
-          <op-icon *ngIf="item.icon" icon-classes="icon-action-menu {{ item.icon }}"></op-icon>
+          <span *ngIf="item.icon" class="spot-icon spot-icon_{{ item.icon }}"></span>
           <span [textContent]="item.linkText"></span>
-          <op-icon *ngIf="item.postIcon"
-                   [icon-title]="item.postIconTitle || ''"
-                   icon-classes="icon-action-menu-post {{ item.postIcon }}"></op-icon>
+          <span *ngIf="item.postIcon" class="spot-icon spot-icon_{{ item.postIcon }} icon-action-menu-post"></span>
+          <span *ngIf="item.postIconTitle" [textContent]="item.postIconTitle" class="hidden-for-sighted"></span>
         </a>
         <button
           *ngIf="!item.href"
@@ -34,11 +33,10 @@
           [attr.title]="item.title || undefined"
           (click)="handleClick(item, $event)"
         >
-          <op-icon *ngIf="item.icon" icon-classes="icon-action-menu {{ item.icon }}"></op-icon>
+          <span *ngIf="item.icon" class="spot-icon spot-icon_{{ item.icon }}"></span>
           <span [textContent]="item.linkText"></span>
-          <op-icon *ngIf="item.postIcon"
-                   [icon-title]="item.postIconTitle || ''"
-                   icon-classes="icon-action-menu-post {{ item.postIcon }}"></op-icon>
+          <span *ngIf="item.postIcon" class="spot-icon spot-icon_{{ item.postIcon }} icon-action-menu-post"></span>
+          <span *ngIf="item.postIconTitle" [textContent]="item.postIconTitle" class="hidden-for-sighted"></span>
         </button>
       </li>
     </ng-container>

--- a/frontend/src/app/shared/components/table-pagination/table-pagination.component.html
+++ b/frontend/src/app/shared/components/table-pagination/table-pagination.component.html
@@ -82,7 +82,7 @@
 
       <li class="op-pagination--info"
           *ngIf="infoText">
-        <op-icon icon-classes="icon-info1 icon-context"></op-icon>
+        <span class="spot-icon spot-icon_info1"></span>
         <span [textContent]="infoText">
 
         </span>

--- a/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
@@ -29,7 +29,7 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
       class="spot-link"
     >
       <span class="spot-icon spot-icon_edit"></span>
-    </a>
+    </button>
     <button
       type="button"
       (click)="deleteTimeEntry()"
@@ -37,7 +37,7 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
       class="spot-link"
     >
       <span class="spot-icon spot-icon_delete"></span>
-    </a>
+    </button>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [

--- a/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
@@ -22,15 +22,21 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
 @Component({
   selector: triggerActionsEntryComponentSelector,
   template: `
-    <a (click)="editTimeEntry()"
-       [title]="text.edit"
-       class="no-decoration-on-hover">
-      <op-icon icon-classes="icon-context icon-edit"></op-icon>
+    <button
+      type="button"
+      (click)="editTimeEntry()"
+      [attr.aria-label]="text.edit"
+      class="spot-link"
+    >
+      <span class="spot-icon spot-icon_edit"></span>
     </a>
-    <a (click)="deleteTimeEntry()"
-       [title]="text.delete"
-       class="no-decoration-on-hover">
-      <op-icon icon-classes="icon-context icon-delete"></op-icon>
+    <button
+      type="button"
+      (click)="deleteTimeEntry()"
+      [attr.aria-label]="text.delete"
+      class="spot-link"
+    >
+      <span class="spot-icon spot-icon_delete"></span>
     </a>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/shared/components/toaster/upload-progress.component.ts
+++ b/frontend/src/app/shared/components/toaster/upload-progress.component.ts
@@ -56,8 +56,8 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
       <progress max="100" value="0" #progressBar></progress>
       <p #progressPercentage>0%</p>
       <span class="upload-completed" *ngIf="completed || error">
-      <op-icon icon-classes="icon-close" *ngIf="error"></op-icon>
-      <op-icon icon-classes="icon-checkmark" *ngIf="completed"></op-icon>
+      <span class="spot-icon spot-icon_inline spot-icon_1_25 spot-icon_close" *ngIf="error"></span>
+      <span class="spot-icon spot-icon_inline spot-icon_1_25 spot-icon_checkmark" *ngIf="completed"></span>
     </span>
     </li>
   `,

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -94,14 +94,6 @@
   cursor: pointer
   color: white
 
-.clear-button
-  border: 0
-  background: transparent
-  margin: 0
-  padding: 0
-  cursor: pointer
-  text-transform: inherit
-
 .group-edit-handler
   width: 100%
   text-align: left

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -131,7 +131,7 @@ module OpenProject
 
     def project_link_name(project, show_icon)
       if show_icon && User.current.member_of?(project)
-        icon_wrapper('icon-context icon-star', I18n.t(:description_my_project).html_safe + '&nbsp;'.html_safe) + project.name
+        spot_icon('star') + I18n.t(:description_my_project).html_safe + '&nbsp;'.html_safe + project.name
       else
         project.name
       end

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -42,8 +42,8 @@ module OpenProject::TextFormatting
 
       def add_header_link(node, id)
         link = content_tag(:a,
-                           '',
-                           class: 'op-uc-link_permalink icon-link',
+                           spot_icon('link'),
+                           class: 'op-uc-link_permalink',
                            'aria-hidden': true,
                            href: "##{id}")
         node['id'] = id

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -49,7 +49,7 @@ module Redmine::MenuManager::TopMenu::HelpMenu
                                   title: I18n.t(:label_help),
                                   class: 'op-app-menu--item-action',
                                   aria: { haspopup: 'true' } do
-      spot_icon('help1', size: '1_5')
+      spot_icon('help2', size: '1_5')
     end
 
     render_menu_dropdown(

--- a/modules/avatars/frontend/module/avatar-upload-form/avatar-upload-form.html
+++ b/modules/avatars/frontend/module/avatar-upload-form/avatar-upload-form.html
@@ -24,9 +24,12 @@
     <img [src]="avatarPreviewUrl" class="avatars--local-avatar-preview" />
 </fieldset>
 
-<button type="submit"
-        (click)="uploadAvatar($event)"
-        [attr.disabled]="!avatarFile || busy || undefined"
-        [textContent]="text.button_update"
-        class="button -highlight -with-icon icon-checkmark">
+<button
+  type="submit"
+  (click)="uploadAvatar($event)"
+  [attr.disabled]="!avatarFile || busy || undefined"
+  class="button -highlight"
+>
+  <span class="spot-icon spot-icon_checkmark"></span>
+  <span [textContent]="text.button_update"></span>
 </button>

--- a/modules/bim/app/components/bim/ifc_models/row_component.rb
+++ b/modules/bim/app/components/bim/ifc_models/row_component.rb
@@ -14,7 +14,7 @@ module Bim
 
       def default?
         if model.is_default?
-          helpers.op_icon 'icon icon-checkmark'
+          helpers.spot_icon 'checkmark'
         end
       end
 
@@ -65,26 +65,23 @@ module Bim
       end
 
       def delete_link
-        link_to '',
+        link_to helpers.spot_icon('delete'),
                 bcf_project_ifc_model_path(model.project, model),
-                class: 'icon icon-delete',
                 data: { confirm: I18n.t(:text_are_you_sure) },
                 title: I18n.t(:button_delete),
                 method: :delete
       end
 
       def download_link
-        link_to '',
+        link_to helpers.spot_icon('download'),
                 API::V3::Utilities::PathHelper::ApiV3Path.attachment_content(model.ifc_attachment&.id),
-                class: 'icon icon-download',
                 title: I18n.t(:button_download),
                 download: true
       end
 
       def edit_link
-        link_to '',
+        link_to helpers.spot_icon('edit'),
                 edit_bcf_project_ifc_model_path(model.project, model),
-                class: 'icon icon-edit',
                 accesskey: helpers.accesskey(:edit),
                 title: I18n.t(:button_edit)
       end

--- a/modules/bim/app/components/bim/ifc_models/table_component.rb
+++ b/modules/bim/app/components/bim/ifc_models/table_component.rb
@@ -15,7 +15,7 @@ module Bim
         link_to(new_bcf_project_ifc_model_path,
                 class: 'wp-inline-create--add-link',
                 title: I18n.t('ifc_models.label_new_ifc_model')) do
-          helpers.op_icon('icon icon-add')
+          helpers.spot_icon('add')
         end
       end
 

--- a/modules/bim/app/views/bim/bcf/issues/_import_errors.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/_import_errors.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <span>
-    <%= op_icon 'icon-context icon-warning' %>
+    <%= spot_icon('warning') %>
     <strong><%= error_message %></strong>
   </span>
 </p>

--- a/modules/bim/app/views/bim/bcf/issues/index.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/index.html.erb
@@ -8,7 +8,7 @@
       <%= link_to({ action: 'upload' },
                 title: I18n.t(:label_import),
                 class: 'button import-bcf-button') do %>
-        <%= op_icon('button--icon icon-import') %>
+        <%= spot_icon('import') %>
         <span class="button--text"><%= t(:label_import) %></span>
       <% end %>
     </li>
@@ -17,7 +17,7 @@
       <%= link_to(project_work_packages_with_query_path(@project, query, format: :bcf),
                 title: t('bcf.bcf_xml.export'),
                 class: 'button export-bcf-button') do %>
-        <%= op_icon('button--icon icon-export') %>
+        <%= spot_icon('export') %>
         <span class="button--text"><%= t('bcf.bcf_xml.export') %></span>
       <% end %>
     </li>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_no_default_notice.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_no_default_notice.html.erb
@@ -7,7 +7,7 @@
     </ul>
     <% unless current_page?(bcf_project_ifc_models_path(project)) %>
       <%= link_to(bcf_project_ifc_models_path(project), class: 'button', accesskey: accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %> <%= t('ifc_models.label_edit_defaults') %>
+        <%= spot_icon('edit') %> <%= t('ifc_models.label_edit_defaults') %>
       <% end %>
     <% end %>
   </div>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/edit.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/edit.html.erb
@@ -32,5 +32,5 @@ See COPYRIGHT and LICENSE files for more details.
 <%= labelled_tabular_form_for @ifc_model, url: bcf_project_ifc_model_path(@project, @ifc_model), method: 'PATCH' do |f| -%>
   <%= error_messages_for_contract @ifc_model, @errors %>
   <%= render partial: 'form', locals: { f: f } %>
-  <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: "-highlight" %>
 <% end %>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/index.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/index.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
                   { class: 'button -alt-highlight',
                     aria: { label: t(:'ifc_models.label_new_ifc_model') },
                     title: t(:'ifc_models.label_new_ifc_model') } do %>
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot_icon('add') %>
         <span class="button--text"><%= ::Bim::IfcModels::IfcModel.model_name.human %></span>
       <% end %>
     </li>
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
                   { class: 'button',
                     aria: { label: t('ifc_models.label_show_defaults') },
                     title: t('ifc_models.label_show_defaults') } do %>
-        <%= op_icon('button--icon icon-watched') %>
+        <%= spot_icon('watched') %>
         <span class="button--text"><%= t('ifc_models.label_show_defaults') %></span>
       <% end %>
     </li>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/new.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/new.html.erb
@@ -31,5 +31,5 @@ See COPYRIGHT and LICENSE files for more details.
 <%= labelled_tabular_form_for @ifc_model, url: bcf_project_ifc_models_path(@project), html: { multipart: true } do |f| -%>
   <%= error_messages_for_contract @ifc_model, @errors %>
   <%= render :partial => 'form', locals: { f: f } %>
-  <%= styled_button_tag t(:button_create), class: "-highlight -with-icon icon-checkmark" %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_create), class: "-highlight" %>
 <% end %>

--- a/modules/bim/app/views/bim/ifc_models/ifc_viewer/_unconverted_notice.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_viewer/_unconverted_notice.html.erb
@@ -1,5 +1,12 @@
 <div class="op-toast -info">
-  <a href="#" title="close" class="op-toast--close icon-context icon-close"></a>
+  <button
+    type="button"
+    title="close"
+    aria-label="close"
+    class="op-toast--close"
+  >
+    <span class="spot-icon spot-icon_close"></span>
+  </button>
   <div class="op-toast--content">
     <p><%= t('ifc_models.processing_notice.processing_default') %></p>
     <ul>

--- a/modules/budgets/app/views/budgets/_edit.html.erb
+++ b/modules/budgets/app/views/budgets/_edit.html.erb
@@ -35,6 +35,6 @@ See COPYRIGHT and LICENSE files for more details.
                                         :class => 'form'} do |f| %>
     <%= render :partial => 'form', :locals => {:f => f} %>
   <div class="generic-table--action-buttons">
-      <%= styled_button_tag t(:button_submit), class: '-with-icon icon-checkmark -highlight', id: 'budget-table--submit-button'%>
+      <%= styled_button_tag spot_icon('checkmark') + t(:button_submit), class: '-highlight', id: 'budget-table--submit-button'%>
   </div>
 <% end %>

--- a/modules/budgets/app/views/budgets/index.html.erb
+++ b/modules/budgets/app/views/budgets/index.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:budgets, :new) %>
     <li class="toolbar-item">
       <a href="<%= new_projects_budget_path(@project) %>" aria-label="<%= I18n.t(:button_add_budget) %>" id="add-budget-button" title="<%= I18n.t(:button_add_budget) %>" class="button -alt-highlight">
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot_icon('add') %>
         <span class="button--text"><%= t(:label_budget) %></span>
       </a>
     </li>

--- a/modules/budgets/app/views/budgets/items/_budget_override_cost_form.html.erb
+++ b/modules/budgets/app/views/budgets/items/_budget_override_cost_form.html.erb
@@ -1,7 +1,9 @@
 <section class="costs--edit-form" hidden>
   <div class="form--field">
     <div class="form--field-container">
-      <div class="costs--edit-planned-costs-cancel-btn form--field-affix -transparent icon icon-close"></div>
+      <div class="costs--edit-planned-costs-cancel-btn form--field-affix -transparent">
+        <%= spot_icon('close') %>
+      </div>
       <div class="form--text-field-container">
         <%= text_field_tag(
               field_name,

--- a/modules/budgets/app/views/budgets/items/_labor_budget_item.html.erb
+++ b/modules/budgets/app/views/budgets/items/_labor_budget_item.html.erb
@@ -89,7 +89,8 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
 
         <% cost_value = labor_budget_item.amount || labor_budget_item.calculated_costs(@budget.fixed_date, @budget.project_id) %>
-        <a id="<%= "#{id_prefix}_costs" %>" class="costs--edit-planned-costs-btn icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
+        <a id="<%= "#{id_prefix}_costs" %>" class="costs--edit-planned-costs-btn" title="<%= t(:help_click_to_edit) %>">
+          <%= spot_icon('edit') %>
           <% if labor_budget_item.costs_visible_by?(User.current) %>
             <%= number_to_currency(cost_value) %>
           <% end %>
@@ -104,7 +105,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <td class="delete form--td budget-table--fields buttons">
       <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>" href="#">
-        <%= op_icon('icon-context icon-delete') %>
+        <%= spot_icon('delete') %>
         <span class="hidden-for-sighted"><%= t(:button_delete) %></span>
       </a>
     </td>

--- a/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
+++ b/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
@@ -91,7 +91,8 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
 
         <% cost_value = material_budget_item.amount || material_budget_item.calculated_costs(@budget.fixed_date) %>
-        <a id="<%= id_prefix %>_costs" class="costs--edit-planned-costs-btn icon-context icon-edit" role="button" title="<%= t(:help_click_to_edit) %>">
+        <a id="<%= id_prefix %>_costs" class="costs--edit-planned-costs-btn" role="button" title="<%= t(:help_click_to_edit) %>">
+          <%= spot_icon('edit') %>
           <%= number_to_currency(cost_value) %>
         </a>
         </a>
@@ -105,7 +106,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <td class="delete form--td budget-table--fields buttons">
       <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>">
-        <%= op_icon('icon-context icon-delete') %>
+        <%= spot_icon('delete') %>
         <span class="hidden-for-sighted"><%= t(:button_delete) %></span>
       </a>
     </td>

--- a/modules/budgets/app/views/budgets/new.html.erb
+++ b/modules/budgets/app/views/budgets/new.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
                               :as => :budget,
                               :html => {:multipart => true, :id => 'budget_form'} do |f| %>
     <%= render :partial => 'form', :locals => {:f => f} %>
-    <%= styled_button_tag t(:button_create), class: '-with-icon icon-checkmark' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_create) %>
     <%= styled_button_tag t(:button_create_and_continue), :name => 'continue',
           class: 'button -highlight'%>
 <% end %>

--- a/modules/budgets/app/views/budgets/show.html.erb
+++ b/modules/budgets/app/views/budgets/show.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:budgets, :edit) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'budgets', action: 'edit',  id: @budget }, class: 'button', accesskey: accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %>
+        <%= spot_icon('edit') %>
         <span class="button--text"><%= t(:button_update) %></span>
       <% end %>
     </li>
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:budgets, :copy) %>
     <li class="toolbar-item hidden-for-mobile">
       <%= link_to({ controller: 'budgets', action: 'copy', id: @budget }, class: 'button') do %>
-        <%= op_icon('button--icon icon-copy') %>
+        <%= spot_icon('copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>
       <% end %>
     </li>
@@ -48,7 +48,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:budgets, :destroy) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'budgets', action: 'destroy', id: @budget }, class: 'button', method: :delete) do %>
-        <%= op_icon('button--icon icon-delete') %>
+        <%= spot_icon('delete') %>
         <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>
     </li>

--- a/modules/budgets/app/views/budgets/subform/_labor_budget_subform.html.erb
+++ b/modules/budgets/app/views/budgets/subform/_labor_budget_subform.html.erb
@@ -103,7 +103,7 @@ end -%>
     </div>
     <div class="wp-inline-create-button">
       <a href="#" class="budget-add-row wp-inline-create--add-link" role="link" title="<%= t(:button_add_budget_item) %>">
-        <%= op_icon('icon icon-add') %>
+        <%= spot_icon('add') %>
       </a>
     </div>
   </fieldset>

--- a/modules/budgets/app/views/budgets/subform/_material_budget_subform.html.erb
+++ b/modules/budgets/app/views/budgets/subform/_material_budget_subform.html.erb
@@ -111,7 +111,7 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
       <div class="wp-inline-create-button">
         <a class="budget-add-row wp-inline-create--add-link" role="button" title="<%= t(:button_add_budget_item) %>">
-          <%= op_icon('icon icon-add') %>
+          <%= spot_icon('add') %>
         </a>
       </div>
     </fieldset>

--- a/modules/calendar/app/components/calendar/row_component.rb
+++ b/modules/calendar/app/components/calendar/row_component.rb
@@ -49,10 +49,9 @@ module Calendar
     def delete_link
       if table.current_user.allowed_to?(:manage_calendars, project)
         link_to(
-          '',
+          spot_icon('delete'),
           project_calendar_path(project, query.id),
           method: :delete,
-          class: 'icon icon-delete',
           data: {
             confirm: I18n.t(:text_are_you_sure),
             'qa-selector': "calendar-remove-#{query.id}"

--- a/modules/calendar/app/views/calendar/calendars/index.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/index.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
       <%= link_to new_project_calendars_path(@project),
                   class: 'button -alt-highlight',
                   title: t('js.calendar.create_new') do %>
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot_icon('add') %>
         <span class="button--text"><%= t(:label_calendar) %></span>
       <% end %>
     </li>

--- a/modules/costs/app/views/cost_types/_list.html.erb
+++ b/modules/costs/app/views/cost_types/_list.html.erb
@@ -102,11 +102,12 @@ See COPYRIGHT and LICENSE files for more details.
                 </span>
                 <button type="submit"
                         class="button submit_cost_type">
-                  <%= icon_wrapper('icon icon-save', I18n.t(:caption_save_rate)) %>
+                  <%= spot_icon('save') %>
+                  <span><%= I18n.t(:caption_save_rate) %></span>
                 </button>
               <% end %>
             </td>
-            <%= content_tag :td, cost_type.is_default? ? icon_wrapper('icon icon-checkmark', I18n.t(:general_text_Yes)) : "" %>
+            <%= content_tag :td, cost_type.is_default? ? spot_icon('checkmark') + I18n.t(:general_text_Yes) : "" %>
             <td class="buttons">
               <%= form_for cost_type, url:    cost_type_path(cost_type),
                                       method: :delete,
@@ -115,7 +116,8 @@ See COPYRIGHT and LICENSE files for more details.
                                                 title: t(:button_lock) } do |f| %>
                 <button type="submit"
                         class="button--link submit_cost_type">
-                  <%= icon_wrapper('icon icon-locked', I18n.t(:button_lock)) %>
+                  <%= spot_icon('locked') %>
+                  <span><%= I18n.t(:button_lock) %></span>
                 </button>
               <% end %>
             </td>

--- a/modules/costs/app/views/cost_types/_list_deleted.html.erb
+++ b/modules/costs/app/views/cost_types/_list_deleted.html.erb
@@ -84,7 +84,8 @@ See COPYRIGHT and LICENSE files for more details.
                                                   class: 'restore_cost_type' } do |f| %>
                     <button type="submit"
                             class="button--link submit_cost_type">
-                      <%= icon_wrapper('icon icon-unlocked', I18n.t(:button_unlock)) %>
+                      <%= spot_icon('unlocked') %>
+                      <span><%= I18n.t(:button_unlock) %></span>
                     </button>
                   <% end %>
                 </td>

--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -74,8 +74,12 @@ See COPYRIGHT and LICENSE files for more details.
       </span>
     </td>
     <td class="buttons">
-      <a href="#" class="delete-row-button no-decoration-on-hover">
-        <%= op_icon('icon-context icon-delete', title: t(:button_delete)) %>
+      <a
+        href="#"
+        class="delete-row-button no-decoration-on-hover"
+        aria-label="<%= t(:button_delete) %>"
+      >
+        <%= spot_icon('delete') %>
       </a>
     </td>
   </tr>

--- a/modules/costs/app/views/cost_types/edit.html.erb
+++ b/modules/costs/app/views/cost_types/edit.html.erb
@@ -112,9 +112,9 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="wp-inline-create-button">
     <label class="hidden-for-sighted" for="add_rate_date" %>"><%= t(:description_date_for_new_rate) %></label>
     <a id="add_rate_date" href="#" class="add-row-button wp-inline-create--add-link" title="<%= t(:button_add_rate) %>">
-      <%= op_icon('icon icon-add') %>
+      <%= spot_icon('add') %>
     </a>
   </div>
-  <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save) %>
 <% end %>
 </costs-subform>

--- a/modules/costs/app/views/cost_types/index.html.erb
+++ b/modules/costs/app/views/cost_types/index.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= toolbar title: CostType.model_name.human(count: 2) do %>
   <li class="toolbar-item">
     <a href="<%= new_cost_type_path %>" aria-label="<%= t(:button_add_cost_type) %>" title="<%= t(:button_add_cost_type) %>" class="button -alt-highlight">
-      <%= op_icon('button--icon icon-add') %>
+      <%= spot_icon('add') %>
       <span class="button--text"><%= CostType.model_name.human %></span>
     </a>
   </li>
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
       </li>
       <li class="simple-filters--controls">
         <%= submit_tag t(:button_apply), class: 'button -highlight -small' %>
-        <%= link_to t(:button_clear), cost_types_path, class: 'button -small -with-icon icon-undo' %>
+        <%= link_to spot_icon('undo') + t(:button_clear), cost_types_path, class: 'button -small' %>
       </li>
     </ul>
   </fieldset>

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -116,9 +116,10 @@ See COPYRIGHT and LICENSE files for more details.
     <span class="form--field-container">
       <a href="#"
          id="cost_entry_costs"
-         class="costs--edit-planned-costs-btn icon-context icon-edit"
+         class="costs--edit-planned-costs-btn"
          role="button"
          title="<%= t(:help_click_to_edit) %>">
+            <%= spot_icon('edit') %>
             <%= number_to_currency(@cost_entry.real_costs) %>
         </a>
       <%= render partial: '/budgets/items/budget_override_cost_form',
@@ -150,5 +151,5 @@ See COPYRIGHT and LICENSE files for more details.
     <%= f.text_field :comments, size: 100, container_class: '-wide' %>
   </div>
 
-  <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save) %>
 <% end %>

--- a/modules/costs/app/views/hourly_rates/_list_default.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_default.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <div class="user-rate-history-list">
 <div class="contextual">
-  <%= link_to t(:button_update), edit_hourly_rate_path(@user), :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
+  <%= link_to spot_icon('edit') + t(:button_update), edit_hourly_rate_path(@user), :accesskey => accesskey(:edit) %>
 </div>
 <h3><%= User.human_attribute_name(:default_rates) %></h3>
 <% if @rates_default.blank? %>
@@ -79,7 +79,7 @@ See COPYRIGHT and LICENSE files for more details.
           <tr>
             <td style="padding-right: 1em;"><%= rate.valid_from %></td>
             <td class="currency"><%= number_to_currency(rate.rate) %></td>
-            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-checkmark',I18n.t(:general_text_Yes)) : "" %></td>
+            <td><%= rate == current_rate ? spot_icon('checkmark') + I18n.t(:general_text_Yes) : "" %></td>
           </tr>
         <%- end -%>
         </tbody>

--- a/modules/costs/app/views/hourly_rates/_list_project.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_project.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="user-rate-history-list">
 <div class="contextual">
   <% if project && User.current.allowed_to?({:controller => '/hourly_rates', :action => 'edit'}, project) %>
-    <%= link_to t(:button_update), {:controller => '/hourly_rates', :action => 'edit', :project_id => project, :id => @user}, :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
+    <%= link_to spot_icon('edit') + t(:button_update), {:controller => '/hourly_rates', :action => 'edit', :project_id => project, :id => @user}, :accesskey => accesskey(:edit) %>
   <% end %>
 </div>
 <h3><%=h project.name %><%= (" - " + number_to_currency(current_rate.rate)) if current_rate %></h3>
@@ -91,7 +91,7 @@ See COPYRIGHT and LICENSE files for more details.
           <tr>
             <td style="padding-right: 1em;"><%= rate.valid_from %></td>
             <td class="currency"><%= number_to_currency(rate.rate) %></td>
-            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-checkmark',I18n.t(:general_text_Yes)) : "" %></td>
+            <td><%= rate == current_rate ? spot_icon('checkmark') + I18n.t(:general_text_Yes) : "" %></td>
           </tr>
         <%- end -%>
         </tbody>

--- a/modules/costs/app/views/hourly_rates/_rate.html.erb
+++ b/modules/costs/app/views/hourly_rates/_rate.html.erb
@@ -63,8 +63,12 @@ See COPYRIGHT and LICENSE files for more details.
       </span>
     </td>
     <td class="buttons">
-      <a href="#" class="delete-row-button no-decoration-on-hover">
-        <%= op_icon('icon-context icon-delete', title: t(:button_delete)) %>
+      <a
+        href="#"
+        class="delete-row-button no-decoration-on-hover"
+        aria-label="<%= t(:button_delete) %>"
+      >
+        <%= spot_icon('delete') %>
       </a>
     </td>
   </tr>

--- a/modules/costs/app/views/hourly_rates/edit.html.erb
+++ b/modules/costs/app/views/hourly_rates/edit.html.erb
@@ -87,12 +87,12 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
   <div class="wp-inline-create-button">
     <a href="#" class="add-row-button wp-inline-create--add-link">
-      <%= op_icon('icon icon-add') %>
-        <%= t(:button_add_rate) %>
+      <%= spot_icon('add') %>
+      <%= t(:button_add_rate) %>
     </a>
   </div>
   <div class="generic-table--action-buttons">
-    <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_save) %>
   </div>
 <% end %>
 </costs-subform>

--- a/modules/costs/app/views/projects/settings/time_entry_activities/_activities.html.erb
+++ b/modules/costs/app/views/projects/settings/time_entry_activities/_activities.html.erb
@@ -45,5 +45,5 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <div class="generic-table--action-buttons">
-  <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: '-highlight' %>
 </div>

--- a/modules/costs/frontend/module/main.ts
+++ b/modules/costs/frontend/module/main.ts
@@ -37,7 +37,7 @@ export function initializeCostsPlugin(injector:Injector) {
 
     pluginContext.hooks.workPackageSingleContextMenu((params:any) => ({
       key: 'log_costs',
-      icon: 'icon-projects',
+      icon: 'projects',
       indexBy(actions:any) {
         const index = _.findIndex(actions, { key: 'log_time' });
         return index !== -1 ? index + 1 : actions.length;
@@ -48,7 +48,7 @@ export function initializeCostsPlugin(injector:Injector) {
 
     pluginContext.hooks.workPackageTableContextMenu((params:any) => ({
       key: 'log_costs',
-      icon: 'icon-projects',
+      icon: 'projects',
       link: 'logCosts',
       indexBy(actions:any) {
         const index = _.findIndex(actions, { link: 'logTime' });

--- a/modules/documents/app/views/documents/edit.html.erb
+++ b/modules/documents/app/views/documents/edit.html.erb
@@ -31,5 +31,5 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= labelled_tabular_form_for @document, url: document_path(@document), method: 'PATCH' do |f| -%>
   <%= render partial: "documents/form", locals: { f: f } %>
-  <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: "-highlight" %>
 <% end %>

--- a/modules/documents/app/views/documents/index.html.erb
+++ b/modules/documents/app/views/documents/index.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
                   { class: 'button -alt-highlight',
                     aria: {label: t(:label_document_new)},
                     title: t(:label_document_new)}) do %>
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot_icon('add') %>
         <span class="button--text"><%= t('activerecord.models.document') %></span>
       <% end %>
     </li>

--- a/modules/documents/app/views/documents/new.html.erb
+++ b/modules/documents/app/views/documents/new.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= labelled_tabular_form_for @document, url: project_documents_path(@project), html: { multipart: true } do |f| -%>
   <%= render :partial => 'documents/form', locals: { f: f } %>
-  <%= styled_button_tag t(:button_create), class: "-highlight -with-icon icon-checkmark" %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_create), class: "-highlight" %>
 <% end %>
 
 

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:documents, :edit) %>
     <li class="toolbar-item">
       <%= link_to({controller: '/documents', action: 'edit', id: @document}, class: 'button', accesskey: accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %>
+        <%= spot_icon('edit') %>
         <span class="button--text"><%= t(:button_edit) %></span>
       <% end %>
     </li>
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:documents, :destroy) %>
     <li class="toolbar-item">
       <%= link_to({controller: '/documents', action: 'destroy', id: @document}, class: 'button', data: { confirm: t(:text_are_you_sure) }, method: :delete) do %>
-        <%= op_icon('button--icon icon-delete') %>
+        <%= spot_icon('delete') %>
         <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>
     </li>

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/destroy_info.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/destroy_info.html.erb
@@ -10,7 +10,7 @@
     <p>
     </p>
     <p class="danger-zone--warning">
-      <span class="icon icon-info2"></span>
+      <span class="spot-icon spot-icon_info2"></span>
       <%= t('ldap_groups.synchronized_filters.destroy.confirmation', name: @filter.name, groups_count: @filter.groups.count) %>
     </p>
 
@@ -55,7 +55,7 @@
     <div class="danger-zone--verification">
       <input type="text"></input>
       <%= styled_button_tag title: t(:button_delete), class: '-highlight', disabled: true do
-        concat content_tag :i, '', class: 'button--icon icon-delete'
+        concat spot_icon('delete')
         concat content_tag :span, t(:button_delete), class: 'button--text'
       end %>
       <%= link_to t(:button_cancel),

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/edit.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/edit.html.erb
@@ -10,8 +10,8 @@
   <%= render partial: 'form', locals: { f: f } %>
 
   <p>
-    <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
-    <%= link_to t(:button_cancel), { action: :show }, class: 'button -with-icon icon-cancel' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: '-highlight' %>
+    <%= link_to spot_icon('cancel') + t(:button_cancel), { action: :show }, class: 'button' %>
   </p>
 <% end %>
 

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/new.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/new.html.erb
@@ -10,8 +10,8 @@
   <%= render partial: 'form', locals: { f: f } %>
 
   <p>
-    <%= styled_button_tag t(:button_create), class: '-highlight -with-icon icon-checkmark' %>
-    <%= link_to t(:button_cancel), ldap_groups_synchronized_groups_path, class: 'button -with-icon icon-cancel' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_create), class: '-highlight' %>
+    <%= link_to spot_icon('cancel') + t(:button_cancel), ldap_groups_synchronized_groups_path, class: 'button' %>
   </p>
 <% end %>
 

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/show.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/show.html.erb
@@ -6,14 +6,14 @@
   <li class="toolbar-item">
     <%= link_to({ action: :edit },
                 class: 'button') do %>
-      <%= op_icon('button--icon icon-edit') %>
+      <%= spot_icon('edit') %>
       <span class="button--text"><%= t(:button_edit) %></span>
     <% end %>
   </li>
   <li class="toolbar-item">
     <%= link_to({ action: :destroy_info },
                 class: 'button -danger') do %>
-      <%= op_icon('button--icon icon-delete') %>
+      <%= spot_icon('delete') %>
       <span class="button--text"><%= t(:button_delete) %></span>
     <% end %>
   </li>

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/destroy_info.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/destroy_info.html.erb
@@ -10,7 +10,7 @@
     <p>
     </p>
     <p class="danger-zone--warning">
-      <span class="icon icon-info2"></span>
+      <span class="spot-icon spot-icon_info2"></span>
       <%= t('ldap_groups.synchronized_groups.destroy.confirmation', name: @group.dn, users_count: @group.users.count)%>
     </p>
     <p>
@@ -22,13 +22,13 @@
     <div class="danger-zone--verification">
       <input type="text"></input>
       <%= styled_button_tag title: t(:button_delete), class: '-highlight', disabled: true do
-        concat content_tag :i, '', class: 'button--icon icon-delete'
+        concat spot_icon('delete')
         concat content_tag :span, t(:button_delete), class: 'button--text'
       end %>
-      <%= link_to t(:button_cancel),
+      <%= link_to spot_icon('cancel') + t(:button_cancel),
                   { action: :index },
                   title: t(:button_cancel),
-                  class: 'button -with-icon icon-cancel' %>
+                  class: 'button' %>
     </div>
   </section>
 <% end %>

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
@@ -6,7 +6,7 @@
                 { class: 'button',
                   aria: {label: t('ldap_groups.synchronized_filters.singular')},
                   title: t('ldap_groups.synchronized_filters.add_new')} do %>
-      <%= op_icon('button--icon icon-add') %>
+      <%= spot_icon('add') %>
       <span class="button--text"><%= t('ldap_groups.synchronized_filters.singular') %></span>
     <% end %>
   </li>
@@ -16,7 +16,7 @@
                 { class: 'button',
                   aria: {label: t('ldap_groups.synchronized_groups.singular')},
                   title: t('ldap_groups.synchronized_groups.add_new')} do %>
-      <%= op_icon('button--icon icon-add') %>
+      <%= spot_icon('add') %>
       <span class="button--text"><%= t('ldap_groups.synchronized_groups.singular') %></span>
     <% end %>
   </li>

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/new.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/new.html.erb
@@ -56,8 +56,8 @@
   </fieldset>
 
   <p>
-    <%= styled_button_tag t(:button_create), class: '-highlight -with-icon icon-checkmark' %>
-    <%= link_to t(:button_cancel), url_for(action: :index), class: 'button -with-icon icon-cancel' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_create), class: '-highlight' %>
+    <%= link_to spot_icon('cancel') + t(:button_cancel), url_for(action: :index), class: 'button' %>
   </p>
 <% end %>
 

--- a/modules/meeting/app/views/meeting_contents/diff.html.erb
+++ b/modules/meeting/app/views/meeting_contents/diff.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(@content_type.pluralize, :history) %>
     <li class="toolbar-item">
       <%= link_to({controller: "/#{@content_type.pluralize}", action: 'history', meeting_id: @meeting }, class: 'button') do %>
-        <%= op_icon('button--icon icon-wiki') %>
+        <%= spot_icon('wiki') %>
         <span class="button--text"><%= t(:label_history) %></span>
       <% end %>
     </li>

--- a/modules/meeting/app/views/meetings/edit.html.erb
+++ b/modules/meeting/app/views/meetings/edit.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= toolbar title: "#{t(:label_meeting)} ##{@meeting.id}" %>
 <%= labelled_tabular_form_for @meeting, :url => {:controller => '/meetings', :action => 'update'}, :html => {:id => 'meeting-form', :method => :put} do |f| -%>
   <%= render :partial => 'form', :locals => {:f => f} %>
-<%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
-<%= link_to t(:button_cancel), { :action => 'show', :id => @meeting },
-      class: 'button -with-icon icon-cancel' %>
+<%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: '-highlight -with-icon' %>
+<%= link_to spot_icon('cancel') + t(:button_cancel), { :action => 'show', :id => @meeting },
+      class: 'button -with-icon' %>
 <% end if @project %>

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
          title="<%= I18n.t(:label_meeting_new) %>"
          arial-label="<%= I18n.t(:label_meeting_new) %>"
          class="button -alt-highlight">
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot_icon('add') %>
         <span class="button--text"><%= t(:label_meeting) %></span>
       </a>
     </li>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:meetings, :edit) %>
     <li class="toolbar-item">
       <%= link_to({:controller => '/meetings', :action => 'edit', :id => @meeting}, class: 'button',:accesskey => accesskey(:edit)) do%>
-        <%= op_icon('button--icon icon-edit') %>
+        <%= spot_icon('edit') %>
         <span class="button--text"><%= t(:button_edit) %></span>
       <% end %>
     </li>
@@ -49,7 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if authorize_for(:meetings, :copy) %>
     <li class="toolbar-item hidden-for-mobile">
       <%= link_to({:controller => '/meetings', :action => 'copy', :id => @meeting}, class: 'button') do %>
-        <%= op_icon('button--icon icon-copy') %>
+        <%= spot_icon('copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>
       <% end %>
     </li>
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
                   class: 'button',
                   method: :delete,
                   data: { confirm: t(:text_are_you_sure) }) do %>
-        <%= op_icon('button--icon icon-delete') %>
+        <%= spot_icon('delete') %>
         <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>
     </li>

--- a/modules/storages/app/components/storages/admin/row_component.rb
+++ b/modules/storages/app/components/storages/admin/row_component.rb
@@ -55,9 +55,8 @@ module Storages::Admin
     end
 
     def delete_link
-      link_to '',
+      link_to spot_icon('delete'),
               admin_settings_storage_path(storage),
-              class: 'icon icon-delete',
               data: { confirm: I18n.t('storages.delete_warning.storage') },
               title: I18n.t(:button_delete),
               method: :delete

--- a/modules/storages/app/components/storages/admin/table_component.rb
+++ b/modules/storages/app/components/storages/admin/table_component.rb
@@ -54,7 +54,7 @@ module Storages::Admin
       link_to(new_admin_settings_storage_path,
               class: 'wp-inline-create--add-link',
               title: I18n.t('storages.label_new_storage')) do
-        helpers.op_icon('icon icon-add')
+        helpers.spot_icon('add')
       end
     end
 

--- a/modules/storages/app/components/storages/projects_storages/row_component.rb
+++ b/modules/storages/app/components/storages/projects_storages/row_component.rb
@@ -56,16 +56,14 @@ module Storages::ProjectsStorages
     end
 
     def edit_link
-      link_to '',
+      link_to spot_icon('edit'),
               edit_project_settings_projects_storage_path(project_id: project_storage.project, id: project_storage),
-              class: 'icon icon-edit',
               title: I18n.t(:button_edit)
     end
 
     def delete_link
-      link_to '',
+      link_to spot_icon('delete'),
               project_settings_projects_storage_path(project_id: project_storage.project, id: project_storage),
-              class: 'icon icon-delete',
               data: { confirm: I18n.t('storages.delete_warning.project_storage') },
               title: I18n.t(:button_delete),
               method: :delete

--- a/modules/storages/app/components/storages/projects_storages/table_component.rb
+++ b/modules/storages/app/components/storages/projects_storages/table_component.rb
@@ -50,7 +50,7 @@ module Storages::ProjectsStorages
       link_to(new_project_settings_projects_storage_path,
               class: 'wp-inline-create--add-link',
               title: I18n.t('storages.label_new_storage')) do
-        helpers.op_icon('icon icon-add')
+        helpers.spot_icon('add')
       end
     end
 

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -7,7 +7,7 @@
 
 <%= labelled_tabular_form_for @object, url: admin_settings_storage_path(@object), as: :storages_storage do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>
-  <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
+  <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: "-highlight" %>
 <% end %>
 
 <% if @object.oauth_application %>
@@ -28,11 +28,11 @@
       </div>
     </div>
 
-    <%= link_to(t("storages.buttons.replace_openproject_oauth"),
+    <%= link_to(spot_icon('reload') + t("storages.buttons.replace_openproject_oauth"),
                 replace_oauth_application_admin_settings_storage_path(@object),
                 method: :delete,
                 data: { confirm: t(:'storages.confirm_replace_oauth_application') },
-                class: 'button -with-icon icon-reload') %>
+                class: 'button') %>
   </fieldset>
 <% end %>
 
@@ -53,11 +53,11 @@
         </div>
       </div>
     </div>
-    <%= link_to(t("storages.buttons.replace_provider_type_oauth", provider_type: t("storages.provider_types.#{@object.short_provider_type}.name")),
+    <%= link_to(spot_icon('reload') + t("storages.buttons.replace_provider_type_oauth", provider_type: t("storages.provider_types.#{@object.short_provider_type}.name")),
                 new_admin_settings_storage_oauth_client_path(@object),
                 data: { confirm: t(:'storages.confirm_replace_oauth_client') },
-                class: 'button -with-icon icon-reload') %>
+                class: 'button') %>
   <% else %>
-    <%= link_to(t("js.label_create"), new_admin_settings_storage_oauth_client_path(@object), class: 'button -with-icon icon-add') %>
+    <%= link_to(spot_icon('add') + t("js.label_create"), new_admin_settings_storage_oauth_client_path(@object), class: 'button') %>
   <% end %>
 </fieldset>

--- a/modules/storages/app/views/storages/admin/storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/index.html.erb
@@ -7,7 +7,7 @@
                 { class: 'button -alt-highlight',
                   aria: { label: t('storages.label_new_storage') },
                   title: t('storages.label_new_storage') } do %>
-      <%= op_icon('button--icon icon-add') %>
+      <%= spot_icon('add') %>
       <span class="button--text"><%= ::Storages::Storage.model_name.human %></span>
     <% end %>
   </li>

--- a/modules/storages/app/views/storages/admin/storages/new.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/new.html.erb
@@ -6,9 +6,9 @@
 <%= labelled_tabular_form_for @object, url: admin_settings_storages_path(@object), as: :storages_storage do |f| -%>
   <%= render partial: 'form', locals: { f: f } %>
   <% if @object.oauth_client %>
-    <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_save), class: "-highlight" %>
   <% else %>
-    <%= styled_button_tag t("storages.buttons.save_and_continue_setup"), class: "-highlight -with-icon icon-checkmark" %>
+    <%= styled_button_tag spot_icon('checkmark') + t("storages.buttons.save_and_continue_setup"), class: "-highlight" %>
   <% end %>
-  <%= link_to t(:button_cancel), admin_settings_storages_path, class: 'button -with-icon icon-close' %>
+  <%= link_to spot_icon('close') + t(:button_cancel), admin_settings_storages_path, class: 'button' %>
 <% end %>

--- a/modules/storages/app/views/storages/admin/storages/new_oauth_client.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/new_oauth_client.html.erb
@@ -37,9 +37,9 @@
   </fieldset>
 
   <% if @storage.oauth_client %>
-    <%= styled_button_tag t(:button_replace), class: "-highlight -with-icon icon-checkmark" %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_replace), class: "-highlight" %>
   <% else %>
-    <%= styled_button_tag t("storages.buttons.save_and_complete_setup"), class: "-highlight -with-icon icon-checkmark" %>
+    <%= styled_button_tag spot_icon('checkmark') + t("storages.buttons.save_and_complete_setup"), class: "-highlight" %>
   <% end %>
 <% end %>
 

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
   <li class="toolbar-item">
     <%= link_to edit_admin_settings_storage_path(@object),
                 class: 'button' do %>
-      <%= op_icon('button--icon icon-edit') %>
+      <%= spot_icon('edit') %>
       <span class="button--text"><%= t(:button_edit) %></span>
     <% end %>
   </li>
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
                 method: :delete,
                 data: { confirm: I18n.t('storages.delete_warning.storage') },
                 class: 'button -danger' do %>
-      <%= op_icon('button--icon icon-delete') %>
+      <%= spot_icon('delete') %>
       <span class="button--text"><%= t(:button_delete) %></span>
     <% end %>
   </li>

--- a/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
@@ -46,7 +46,7 @@
           </copy-to-clipboard>
           <button class="client-id-copy-button button -without-button-styling"
                   title="<%= t(:label_copy_to_clipboard) %>">
-            <%= op_icon('icon-copy') %>
+            <%= spot_icon('copy') %>
             <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
           </button>
         </div>
@@ -75,7 +75,7 @@
           </copy-to-clipboard>
           <button class="secret-copy-button button -without-button-styling"
                   title="<%= t(:label_copy_to_clipboard) %>">
-            <%= op_icon('icon-copy') %>
+            <%= spot_icon('copy') %>
             <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
           </button>
         </div>
@@ -84,8 +84,8 @@
   </fieldset>
 
   <% if @object.oauth_client %>
-    <%= link_to t("storages.buttons.done_continue_setup"), admin_settings_storage_path(@object), class: "-highlight -with-icon icon-checkmark button" %>
+    <%= link_to spot_icon('checkmark') + t("storages.buttons.done_continue_setup"), admin_settings_storage_path(@object), class: "-highlight button" %>
   <% else %>
-    <%= link_to t("storages.buttons.done_continue_setup"), new_admin_settings_storage_oauth_client_path(@object), class: "-highlight -with-icon icon-checkmark button" %>
+    <%= link_to spot_icon('checkmark') + t("storages.buttons.done_continue_setup"), new_admin_settings_storage_oauth_client_path(@object), class: "-highlight button" %>
   <% end %>
 <% end %>

--- a/modules/storages/app/views/storages/project_settings/index.html.erb
+++ b/modules/storages/app/views/storages/project_settings/index.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
                   { class: 'button -alt-highlight',
                     aria: { label: t(:'storages.label_new_storage') },
                     title: t(:'ifc_models.label_new_storage') } do %>
-        <%= op_icon('button--icon icon-add') %>
+        <%= spot-icon('add') %>
         <span class="button--text"><%= ::Storages::Storage.model_name.human %></span>
       <% end %>
     </li>

--- a/modules/two_factor_authentication/app/components/two_factor_authentication/devices/row_component.rb
+++ b/modules/two_factor_authentication/app/components/two_factor_authentication/devices/row_component.rb
@@ -17,7 +17,7 @@ module ::TwoFactorAuthentication
 
       def default
         if device.default
-          helpers.op_icon 'icon-yes'
+          helpers.spot_icon 'yes'
         else
           '-'
         end
@@ -25,13 +25,13 @@ module ::TwoFactorAuthentication
 
       def confirmed
         if device.active
-          helpers.op_icon 'icon-yes'
+          helpers.spot_icon 'yes'
         elsif table.self_table?
           link_to t('two_factor_authentication.devices.confirm_now'),
                   { controller: table.target_controller, action: :confirm, device_id: device.id }
 
         else
-          helpers.op_icon 'icon-no'
+          helpers.spot_icon 'no'
         end
       end
 

--- a/modules/two_factor_authentication/app/components/two_factor_authentication/devices/table_component.rb
+++ b/modules/two_factor_authentication/app/components/two_factor_authentication/devices/table_component.rb
@@ -33,7 +33,7 @@ module ::TwoFactorAuthentication
           link_to({ controller: target_controller, action: :new },
                   class: 'budget-add-row wp-inline-create--add-link',
                   title: I18n.t('two_factor_authentication.devices.add_new')) do
-            helpers.op_icon('icon icon-add')
+            helpers.spot_icon('add')
           end
         end
       end

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/backup_codes/show.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/backup_codes/show.html.erb
@@ -35,7 +35,7 @@
                   class: "button hide-when-print",
                   download: 'backup-codes.txt',
                   href: "data:text/plain;charset=utf-8,#{CGI.escape(@backup_codes.join("\n"))}" do %>
-    <%= op_icon 'button--icon icon-save' %>
+    <%= spot_icon 'save' %>
     <span class="button--text"><%= t(:button_download) %></span>
   <% end %>
   <button
@@ -43,7 +43,7 @@
     class="button hide-when-print"
     data-action="two-factor-authentication#print"
   >
-    <%= op_icon 'button--icon icon-print' %>
+    <%= spot_icon 'print' %>
     <span class="button--text"><%= t(:button_print) %></span>
   </button>
 </div>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
@@ -32,7 +32,7 @@
           { class: 'button -alt-highlight',
             aria: {label: t('two_factor_authentication.label_device')},
             title: t('two_factor_authentication.devices.add_new')} do %>
-      <%= op_icon('button--icon icon-add') %>
+      <%= spot_icon('add') %>
       <span class="button--text"><%= t('two_factor_authentication.label_device') %></span>
     <% end %>
   </li>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new.html.erb
@@ -13,7 +13,7 @@
   <%= render partial: "two_factor_authentication/two_factor_devices/form", locals: { f: f, device_type: @device_type, device: @device, user: @user } %>
 
   <p>
-    <%= styled_button_tag t(:button_continue), class: '-highlight -with-icon icon-checkmark' %>
-    <%= link_to t(:button_cancel), index_path, class: 'button -with-icon icon-cancel' %>
+    <%= styled_button_tag spot_icon('checkmark') + t(:button_continue), class: '-highlight' %>
+    <%= link_to spot_icon('cancel') + t(:button_cancel), index_path, class: 'button' %>
   </p>
 <% end %>

--- a/modules/two_factor_authentication/app/views/users/_two_factor_authentication_admin.html.erb
+++ b/modules/two_factor_authentication/app/views/users/_two_factor_authentication_admin.html.erb
@@ -40,7 +40,7 @@
                       method: :post,
                       data: { confirm: t('two_factor_authentication.admin.delete_all_are_you_sure') },
                       class: "button -danger" do %>
-            <%= op_icon 'button--icon icon-delete' %>
+            <%= spot_icon('delete') %>
             <span class="button--text"><%= t 'two_factor_authentication.admin.button_delete_all_devices' %></span>
           <% end %>
         </li>
@@ -48,7 +48,7 @@
       <% if ::OpenProject::TwoFactorAuthentication::TokenStrategyManager.admin_register_sms_strategy.present? %>
       <li class="toolbar-item">
         <%= link_to new_user_2fa_device_path(@user, type: :sms), class: 'button -alt-highlight' do %>
-            <%= op_icon 'button--icon icon-add' %>
+            <%= spot_icon('add') %>
             <span class="button--text"><%= t 'two_factor_authentication.admin.button_register_mobile_phone_for_user' %></span>
         <% end %>
       </li>

--- a/modules/xls_export/app/views/hooks/xls_report/_view_cost_report_toolbar.html.erb
+++ b/modules/xls_export/app/views/hooks/xls_report/_view_cost_report_toolbar.html.erb
@@ -1,10 +1,10 @@
 <% if User.current.allowed_to? :export_work_packages, @project, global: @project.nil? %>
   <li class="toolbar-item">
-    <%= link_to(t(:export_to_excel),
+    <%= link_to(spot_icon('export-xls-descr') + t(:export_to_excel),
                 { controller: "cost_reports" ,
                   action: :index,
                   format: 'xls',
                   project_id: @project },
-                class: "button icon-export-xls-descr") %>
+                class: "button") %>
   </li>
 <% end %>


### PR DESCRIPTION
op-icon was changed to spot-icon in the following places:

* BCF WP Attribute group
* BCF View
* BCF Export & Import
* BCF refresh button
* BCF view toggle
* Board add list modal
* Board list
* Boards toolbar menu
* Boards index page
* Calendar
* WP user activity
* WP relations
* WP Watcher entries
* WP Tabs
* Datepicker banner
* Field controls edit
* Grid page
* Time entries list
* hide section link
* Modal banners
* WP table export modal
* Context menus
* Table pagination
* Time entries edit trigger actions entry
* Upload progress toaster
* Job status modal
* Global search input
* Backup page in admin pages
* Work package onboarding tour
* In app notification entry
* Reporting page
* WP Filter container
* Wp fast table grouped header
* WP full view & split view
* WP inline create
* WP relations group
* Wp Activity tab
* on/off status
* custom actions row & table
* enumerations row & table
* members row
* placeholder users row
* projects row & table
* statuses row & table
* versions row
* tooltip
* user content link
* avatar upload
* ifc model row & table
* ifc model CRUD
* bcf issues
* budget CRUD
* calendar row & index
* cost types CRUD
* hourly rates CRUD
* time entry activities
* documents CRUD
* LDAP groups & filters CRUD
* meetings CRUD
* storages & project storages row & table
* storages CRUD
* 2FA row & table
* 2FA CRUD
* Cost report toolbar

Also updates the icon of the help menu in the app header from help1 to help2

Part of https://community.openproject.org/work_packages/47363/activity