### PR TITLE
add #remove_filter method to Query

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -194,6 +194,14 @@ class Query < ApplicationRecord
     filter
   end
 
+  # Removes the filter with the given name
+  # from the query without persisting the change.
+  #
+  # @param [String] name the filter to remove
+  def remove_filter(name)
+    filters.delete_if { |f| f.field.to_s == name.to_s }
+  end
+
   def normalized_name
     name.parameterize.underscore
   end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -810,6 +810,23 @@ describe Query,
     end
   end
 
+  describe '#remove_filter' do
+    context 'if the filter exists' do
+      it 'removes the filter' do
+        # Works because status_id is there by default
+        expect { query.remove_filter('status_id') }
+          .to change { query.filters.count }.by(-1)
+      end
+    end
+
+    context 'if the filter does not exist' do
+      it 'is a noop' do
+        expect { query.remove_filter('assigned_to_id') }
+          .not_to change { query.filters.count }
+      end
+    end
+  end
+
   describe 'filters and statement_filters (private method)' do
     def subproject_filter?(filter)
       filter.is_a?(Queries::WorkPackages::Filter::SubprojectFilter)


### PR DESCRIPTION
The method reduces the need to directly manipulate the `.filters` object by callers. 

I haven't been able to find that being done already in the existing codebase but it would be added by the [iCal PR](https://github.com/opf/openproject/pull/12019/files#diff-39894f7ac754fce6d0e40d8facec1575a48ff1701d3b9c42e90ba958e15cfaa7R73-R74)