### PR TITLE
Fix/move name validation of query

### DIFF
--- a/app/contracts/queries/base_contract.rb
+++ b/app/contracts/queries/base_contract.rb
@@ -62,6 +62,10 @@ module Queries
     validate :user_allowed_to_make_public
     validate :timestamps_are_parsable
 
+    validates :name,
+              presence: true,
+              length: { maximum: 255 }
+
     def validate_project
       errors.add :project, :error_not_found if project_id.present? && !project_visible?
     end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -39,7 +39,7 @@ class JournalsController < ApplicationController
   include SortHelper
 
   def index
-    retrieve_query
+    @query = retrieve_query(@project)
     sort_init 'id', 'desc'
     sort_update(@query.sortable_key_by_column_name)
 

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -145,7 +145,7 @@ class WorkPackagesController < ApplicationController
   end
 
   def load_and_validate_query
-    @query ||= retrieve_query
+    @query ||= retrieve_query(@project)
 
     unless @query.valid?
       # Ensure outputting an html response

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -27,17 +27,17 @@
 #++
 
 module QueriesHelper
-  def retrieve_query
-    @query = if params[:query_id].present?
-               Query.where(project: @project).find(params[:query_id])
-             else
-               Query.new_default(project: @project)
-             end
+  def retrieve_query(project)
+    query = if params[:query_id].present?
+              Query.where(project:).find(params[:query_id])
+            else
+              Query.new_default(project:)
+            end
 
     ::API::V3::UpdateQueryFromV3ParamsService
-      .new(@query, current_user)
+      .new(query, current_user)
       .call(params.permit!.to_h)
 
-    @query
+    query
   end
 end

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -31,8 +31,7 @@ module QueriesHelper
     @query = if params[:query_id].present?
                Query.where(project: @project).find(params[:query_id])
              else
-               Query.new_default(name: '_',
-                                 project: @project)
+               Query.new_default(project: @project)
              end
 
     ::API::V3::UpdateQueryFromV3ParamsService

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -42,10 +42,6 @@ class Query < ApplicationRecord
   serialize :column_names, Array
   serialize :sort_criteria, Array
 
-  validates :name,
-            presence: true,
-            length: { maximum: 255 }
-
   validates :include_subprojects,
             inclusion: [true, false]
 

--- a/app/services/api/v3/work_package_collection_from_query_params_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_params_service.rb
@@ -35,7 +35,7 @@ module API
       end
 
       def call(params = {})
-        query = Query.new_default(name: '_', project: params[:project])
+        query = Query.new_default(project: params[:project])
 
         WorkPackageCollectionFromQueryService
           .new(query, current_user, scope:)

--- a/db/migrate/20230531093004_remove_default_from_query_name.rb
+++ b/db/migrate/20230531093004_remove_default_from_query_name.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromQueryName < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :queries, :name, to: nil, from: ''
+  end
+end

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -87,8 +87,7 @@ module API
             end
 
             get do
-              @query = Query.new_default(name: 'default',
-                                         user: current_user)
+              @query = Query.new_default(user: current_user)
 
               authorize_by_policy(:show)
 

--- a/lib/api/v3/queries/queries_by_project_api.rb
+++ b/lib/api/v3/queries/queries_by_project_api.rb
@@ -42,8 +42,7 @@ module API
 
           namespace :default do
             get do
-              query = Query.new_default(name: 'default',
-                                        user: current_user,
+              query = Query.new_default(user: current_user,
                                         project: @project)
 
               query_representer_response(query, params)

--- a/modules/backlogs/spec/models/work_package_export_spec.rb
+++ b/modules/backlogs/spec/models/work_package_export_spec.rb
@@ -30,7 +30,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:project) { create(:project) }
-  let(:query) { Query.new_default(name: '_', project:) }
+  let(:query) { Query.new_default(project:) }
 
   subject { described_class.new query }
 

--- a/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
+++ b/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
@@ -67,7 +67,7 @@ module API
                     raise API::Errors::NotFound.new
                   end
 
-                  query = Query.new_default(name: '_', project:)
+                  query = Query.new_default(project:)
                   updated_query = ::API::V3::UpdateQueryFromV3ParamsService.new(query, User.current).call(params)
 
                   exporter = ::OpenProject::Bim::BcfXml::Exporter.new(updated_query.result)

--- a/spec/contracts/queries/shared_contract_examples.rb
+++ b/spec/contracts/queries/shared_contract_examples.rb
@@ -31,8 +31,12 @@ require 'contracts/shared/model_contract_shared_context'
 
 shared_context 'with queries contract' do
   let(:project) { build_stubbed(:project) }
+  let(:name) { 'Some query name' }
+  let(:public) { false }
+  let(:user) { current_user }
+  let(:permissions) { %i[view_queries save_queries] }
   let(:query) do
-    build_stubbed(:query, project:, public:, user:)
+    build_stubbed(:query, project:, public:, user:, name:)
   end
 
   let(:current_user) do
@@ -48,5 +52,21 @@ shared_context 'with queries contract' do
   before do
     # Assume project is always visible
     allow(contract).to receive(:project_visible?).and_return true
+  end
+
+  describe 'validation' do
+    it_behaves_like 'contract is valid'
+
+    context 'if the name is nil' do
+      let(:name) { nil }
+
+      it_behaves_like 'contract is invalid', name: :blank
+    end
+
+    context 'if the name is empty' do
+      let(:name) { '' }
+
+      it_behaves_like 'contract is invalid', name: :blank
+    end
   end
 end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -521,12 +521,6 @@ describe Query,
   end
 
   describe '#valid?' do
-    it 'is not valid without a name' do
-      query.name = ''
-      expect(query.save).to be_falsey
-      expect(query.errors[:name].first).to include(I18n.t('activerecord.errors.messages.blank'))
-    end
-
     context 'with a missing value and an operator that requires values' do
       before do
         query.add_filter('due_date', 't-', [''])

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -41,7 +41,7 @@ describe WorkPackage::Exports::CSV, 'integration' do
            member_with_permissions: %i(view_work_packages))
   end
   let(:query) do
-    Query.new_default(name: '_').tap do |query|
+    Query.new_default.tap do |query|
       query.column_names = %i(subject assigned_to updated_at estimated_hours)
     end
   end

--- a/spec/services/api/v3/work_package_collection_from_query_params_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_params_service_spec.rb
@@ -77,7 +77,7 @@ describe API::V3::WorkPackageCollectionFromQueryParamsService,
     before do
       allow(Query)
         .to receive(:new_default)
-        .with(name: '_', project:)
+        .with(project:)
         .and_return(query)
     end
 

--- a/spec/services/principals/replace_references_service_call_integration_spec.rb
+++ b/spec/services/principals/replace_references_service_call_integration_spec.rb
@@ -495,7 +495,8 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
                       :user_id do
         let(:attributes) do
           {
-            include_subprojects: true
+            include_subprojects: true,
+            name: "'abc'"
           }
         end
       end


### PR DESCRIPTION
Moves the `name` validation from the Query model to its contract. That way, queries can be constructed for the sake of filtering without having to set a name. When persisting, the same validation as before is active.

This should avoid working around the validation (occurrences in `dev` removed in this PR) as was necessary in e.g. #12727