### PR TITLE
Feature/48249 implement global index page for team planners

### DIFF
--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -30,7 +30,7 @@
 
 module Meetings
   class RowComponent < ::RowComponent
-    def project
+    def project_id
       helpers.link_to_project model.project, {}, {}, false
     end
 

--- a/modules/meeting/app/components/meetings/table_component.rb
+++ b/modules/meeting/app/components/meetings/table_component.rb
@@ -32,7 +32,7 @@ module Meetings
   class TableComponent < ::TableComponent
     options :current_project # used to determine if displaying the projects column
 
-    sortable_columns :title, :start_time, :duration, :location
+    sortable_columns :title, :project_id, :start_time, :duration, :location
 
     def initial_sort
       %i[start_time asc]
@@ -45,7 +45,7 @@ module Meetings
     def headers
       @headers ||= [
         [:title, { caption: Meeting.human_attribute_name(:title) }],
-        current_project.blank? ? [:project, { caption: Meeting.human_attribute_name(:project) }] : nil,
+        current_project.blank? ? [:project_id, { caption: Meeting.human_attribute_name(:project) }] : nil,
         [:start_time, { caption: Meeting.human_attribute_name(:start_time) }],
         [:duration, { caption: Meeting.human_attribute_name(:duration) }],
         [:location, { caption: Meeting.human_attribute_name(:location) }]

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -64,7 +64,7 @@ module OpenProject::Meeting
            icon: 'meetings'
 
       menu :top_menu,
-           :meetings, { controller: '/meetings', project_id: nil, action: 'index' },
+           :meetings, { controller: '/meetings', action: 'index', project_id: nil },
            context: :modules,
            caption: :label_meeting_plural,
            if: Proc.new {

--- a/modules/team_planner/app/components/team_planner_overview/row_component.rb
+++ b/modules/team_planner/app/components/team_planner_overview/row_component.rb
@@ -1,0 +1,49 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TeamPlannerOverview
+  class RowComponent < ::RowComponent
+    def query
+      model
+    end
+
+    delegate :project, to: :query
+
+    def name
+      link_to query.name, project_team_planner_path(project, query.id)
+    end
+
+    def project_id
+      helpers.link_to_project model.project, {}, {}, false
+    end
+
+    def created_at
+      helpers.format_time(query.created_at)
+    end
+  end
+end

--- a/modules/team_planner/app/components/team_planner_overview/table_component.rb
+++ b/modules/team_planner/app/components/team_planner_overview/table_component.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TeamPlannerOverview
+  class TableComponent < ::TableComponent
+    options :current_user
+    columns :name, :project_id, :created_at
+    sortable_columns :name, :project_id, :created_at
+
+    def initial_sort
+      %w[name asc]
+    end
+
+    def sortable?
+      true
+    end
+
+    def paginated?
+      true
+    end
+
+    def headers
+      [
+        [:name, { caption: I18n.t(:label_name) }],
+        [:project_id, { caption: Query.human_attribute_name(:project) }],
+        [:created_at, { caption: Query.human_attribute_name(:created_at) }]
+      ]
+    end
+  end
+end

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -2,13 +2,18 @@ module ::TeamPlanner
   class TeamPlannerController < BaseController
     include EnterpriseTrialHelper
     before_action :find_optional_project
-    before_action :authorize
+    before_action :authorize, except: %i[overview]
+    before_action :authorize_global, only: %i[overview]
     before_action :require_ee_token, except: %i[upsale]
     before_action :find_plan_view, only: %i[destroy]
 
     menu_item :team_planner_view
 
     def index
+      @views = visible_plans(@project)
+    end
+
+    def overview
       @views = visible_plans
     end
 
@@ -48,13 +53,19 @@ module ::TeamPlanner
       render_404
     end
 
-    def visible_plans
-      Query
+    def visible_plans(project = nil)
+      query = Query
         .visible(current_user)
+        .includes(:project)
         .joins(:views)
         .where('views.type' => 'team_planner')
-        .where('queries.project_id' => @project.id)
         .order('queries.name ASC')
+
+      if project
+        query = query.where('queries.project_id' => project.id)
+      end
+
+      query
     end
   end
 end

--- a/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
@@ -1,0 +1,5 @@
+<% html_title(t('team_planner.label_team_planner_plural')) -%>
+
+<%= toolbar title: t(:'team_planner.label_team_planner_plural') %>
+
+<%= render ::TeamPlannerOverview::TableComponent.new(rows: @views, current_user: current_user) %>

--- a/modules/team_planner/config/routes.rb
+++ b/modules/team_planner/config/routes.rb
@@ -1,4 +1,6 @@
 OpenProject::Application.routes.draw do
+  get :team_planners, to: 'team_planner/team_planner#overview'
+
   scope 'projects/:project_id', as: 'project' do
     resources :team_planners,
               controller: 'team_planner/team_planner',

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -53,6 +53,16 @@ module OpenProject::TeamPlanner
            partial: 'team_planner/team_planner/menu',
            last: true,
            caption: :'team_planner.label_team_planner_plural'
+
+      menu :top_menu,
+           :team_planners, { controller: '/team_planner/team_planner', action: :overview },
+           context: :modules,
+           caption: :'team_planner.label_team_planner_plural',
+           if: Proc.new {
+             OpenProject::FeatureDecisions.more_global_index_pages_active? &&
+              (User.current.logged? || !Setting.login_required?) &&
+                User.current.allowed_to_globally?(:view_team_planner)
+           }
     end
 
     add_view :TeamPlanner,


### PR DESCRIPTION
Implements https://community.openproject.org/projects/openproject/work_packages/48249

In 283d846a9e6553b1198ff08dcba1deec6e6ed284 I have noticed that in the meetings table, the projects column was not sortable, so I fixed the issue here as well