### PR TITLE
[48239] Baseline time zone label not vertically centered

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -23,7 +23,7 @@
 
     &-help
       display: flex
-      align-items: center
+      align-items: end
       justify-content: center
       background-color: $spot-color-basic-gray-6
       border: 1px solid $spot-color-basic-gray-3


### PR DESCRIPTION
https://community.openproject.org/work_packages/48239/activity