### PR TITLE
Stub a custom non working day that is < yesterday

### DIFF
--- a/spec/contracts/queries/base_contract_spec.rb
+++ b/spec/contracts/queries/base_contract_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Queries::BaseContract do
         let(:timestamps) { "lastWorkingDay@00:00+00:00" }
 
         before do
-          allow(Day).to receive(:last_working) { Day.first }
+          allow(Day).to receive(:last_working) { Day.new(date: 7.days.ago) }
         end
 
         it_behaves_like 'contract is invalid', timestamps: :forbidden

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Query,
         let(:timestamps) { "lastWorkingDay@00:00+00:00" }
 
         before do
-          allow(Day).to receive(:last_working) { Day.first }
+          allow(Day).to receive(:last_working) { Day.new(date: 7.days.ago) }
         end
 
         it 'is invalid' do


### PR DESCRIPTION
Using `Day.first` will cause the spec to fail for e.g., today (June 1st)