### PR TITLE
[48367] Baseline icon not centered in the baseline column

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
@@ -50,3 +50,6 @@
     display: flex
     flex-direction: column
     padding-right: 6px
+
+  .spot-icon
+    vertical-align: middle


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/48367/activity