### PR TITLE
[#48390] Fix time zone dependency of the `today` query operator

### DIFF
--- a/app/models/queries/operators/date_range_clauses.rb
+++ b/app/models/queries/operators/date_range_clauses.rb
@@ -32,10 +32,10 @@ module Queries::Operators
     # the end of the day of yesterday + from until the end of today + to.
     def relative_date_range_clause(table, field, from, to)
       if from
-        from_date = Date.today + from
+        from_date = Date.current + from
       end
       if to
-        to_date = Date.today + to
+        to_date = Date.current + to
       end
       date_range_clause(table, field, from_date, to_date)
     end


### PR DESCRIPTION
`Date.current` ensures that the comparison against the timestamp is performed in UTC, which prevents causing two different "todays", compared to using `Date.today` which uses the host's time zone.

The `projects_index_spec` already captures the failing behavior without the fix and demonstrates a successful
run with this fix applied regardless of the time of day or host machine that runs it.

Example:
The host machine's time is 23:00 May 29th
The Rails server's time (UTC) is 01:00 May 30th

If you just created a record and you're attempting to filter it with a **created_on today** filter, then
May 30th(`created_at` timestamp's date) != May 29th(`Date.today`'s return value)
so your record wouldn't be returned in the query when it should have been.

See: https://community.openproject.org/work_packages/48390