### PR TITLE
Fix XSS attack in news author div

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -219,7 +219,7 @@ module ApplicationHelper
     return if author.nil?
 
     I18n.t(:'js.label_added_time_by',
-           author: author.name,
+           author: html_escape(author.name),
            age: created,
            authorLink: user_path(author)).html_safe
   end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -367,7 +367,7 @@ en:
     label_add_row_before: "Add row before"
     label_add_selected_columns: "Add selected columns"
     label_added_by: "added by"
-    label_added_time_by: "Added by <a href=%{authorLink}>%{author}</a> at %{age}"
+    label_added_time_by: "Added by <a href=\"%{authorLink}\">%{author}</a> at %{age}"
     label_ago: "days ago"
     label_all: "all"
     label_all_work_packages: "all work packages"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -173,6 +173,15 @@ describe ApplicationHelper do
     end
   end
 
+  describe '.authoring_at' do
+    it 'escapes html from author name' do
+      created = '2023-06-02'
+      author = create(:user, firstname: '<b>Hello</b>', lastname: 'world')
+      expect(authoring_at(created, author))
+        .to eq("Added by <a href=\"/users/#{author.id}\">&lt;b&gt;Hello&lt;/b&gt; world</a> at 2023-06-02")
+    end
+  end
+
   describe '.all_lang_options_for_select' do
     it 'has all languages translated ("English" should appear only once)' do
       impostor_locales =


### PR DESCRIPTION
Same as #12770, ported to 12.5 release branch.

Visible in landing page latest news section, when using a name with html entities in it.