### PR TITLE
Track the cause for Journals to associate journal with the right cause

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -232,7 +232,7 @@ class Changeset < ApplicationRecord
     return if work_package.status && work_package.status.is_closed?
 
     journal_notes = I18n.t(:text_status_changed_by_changeset, value: text_tag, locale: Setting.default_language)
-    work_package.add_journal(user || User.anonymous, journal_notes)
+    work_package.add_journal(user: user || User.anonymous, notes: journal_notes)
     work_package.status = status
     if Setting.commit_fix_done_ratio.present?
       work_package.done_ratio = Setting.commit_fix_done_ratio.to_i

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -277,7 +277,7 @@ class Changeset < ApplicationRecord
 
   def assign_openproject_user_from_comitter
     self.user = repository.find_committer_user(committer)
-    add_journal(user || User.anonymous, comments)
+    add_journal(user: user || User.anonymous, notes: comments)
   end
 
   # TODO: refactor to a standard helper method

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -30,6 +30,8 @@ class Journal < ApplicationRecord
   self.table_name = 'journals'
   self.ignored_columns += ['activity_type']
 
+  WorkingDayUpdate = Struct.new(:working_days, :non_working_days, keyword_init: true)
+
   include ::JournalChanges
   include ::JournalFormatter
   include ::Acts::Journalized::FormatHooks
@@ -52,11 +54,12 @@ class Journal < ApplicationRecord
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related
   # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB
   # hash without that prefix
-  store_accessor :cause, %i[type work_package_id], prefix: true
+  store_accessor :cause, %i[type work_package_id changed_days], prefix: true
   VALID_CAUSE_TYPES = %w[
     work_package_predecessor_changed_times
     work_package_successor_changed_times
     work_package_parent_changed_times
+    working_days_changed
   ].freeze
 
   # Make sure each journaled model instance only has unique version ids

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -53,7 +53,11 @@ class Journal < ApplicationRecord
   # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB
   # hash without that prefix
   store_accessor :cause, %i[type work_package_id], prefix: true
-  VALID_CAUSE_TYPES = %w[work_package_predecessor_changed_times work_package_successor_changed_times].freeze
+  VALID_CAUSE_TYPES = %w[
+    work_package_predecessor_changed_times
+    work_package_successor_changed_times
+    work_package_parent_changed_times
+  ].freeze
 
   # Make sure each journaled model instance only has unique version ids
   validates :version, uniqueness: { scope: %i[journable_id journable_type] }

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -60,6 +60,7 @@ class Journal < ApplicationRecord
     work_package_predecessor_changed_times
     work_package_parent_changed_times
     work_package_children_changed_times
+    work_package_related_changed_times
     working_days_changed
   ].freeze
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -50,6 +50,7 @@ class Journal < ApplicationRecord
   register_journal_formatter :time_entry_hours, OpenProject::JournalFormatter::TimeEntryHours
   register_journal_formatter :wiki_diff, OpenProject::JournalFormatter::WikiDiff
   register_journal_formatter :time_entry_named_association, OpenProject::JournalFormatter::TimeEntryNamedAssociation
+  register_journal_formatter :cause, OpenProject::JournalFormatter::Cause
 
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related
   # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -58,8 +58,8 @@ class Journal < ApplicationRecord
   store_accessor :cause, %i[type work_package_id changed_days], prefix: true
   VALID_CAUSE_TYPES = %w[
     work_package_predecessor_changed_times
-    work_package_successor_changed_times
     work_package_parent_changed_times
+    work_package_children_changed_times
     working_days_changed
   ].freeze
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -49,8 +49,15 @@ class Journal < ApplicationRecord
   register_journal_formatter :wiki_diff, OpenProject::JournalFormatter::WikiDiff
   register_journal_formatter :time_entry_named_association, OpenProject::JournalFormatter::TimeEntryNamedAssociation
 
+  # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related
+  # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB
+  # hash without that prefix
+  store_accessor :cause, %i[type work_package_id], prefix: true
+  VALID_CAUSE_TYPES = %w[work_package_predecessor_changed_times work_package_successor_changed_times].freeze
+
   # Make sure each journaled model instance only has unique version ids
   validates :version, uniqueness: { scope: %i[journable_id journable_type] }
+  validates :cause_type, inclusion: { in: VALID_CAUSE_TYPES, allow_blank: true }
 
   belongs_to :user
   belongs_to :journable, polymorphic: true
@@ -125,6 +132,10 @@ class Journal < ApplicationRecord
 
   def noop?
     (!notes || notes&.empty?) && get_changes.empty?
+  end
+
+  def has_cause?
+    cause_type.present?
   end
 
   private

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -85,6 +85,7 @@ module WorkPackage::Journalized
     register_journal_formatted_fields(:attachment, /attachments_?\d+/)
     register_journal_formatted_fields(:custom_field, /custom_fields_\d+/)
     register_journal_formatted_fields(:ignore_non_working_days, 'ignore_non_working_days')
+    register_journal_formatted_fields(:cause, 'cause')
 
     # Joined
     register_journal_formatted_fields :named_association, :parent_id, :project_id,

--- a/app/services/add_work_package_note_service.rb
+++ b/app/services/add_work_package_note_service.rb
@@ -42,7 +42,7 @@ class AddWorkPackageNoteService
 
   def call(notes, send_notifications: nil)
     Journal::NotificationConfiguration.with send_notifications do
-      work_package.add_journal(user, notes)
+      work_package.add_journal(user:, notes:)
 
       success, errors = validate_and_yield(work_package, user) do
         work_package.save_journals

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -634,7 +634,7 @@ module Journals
     end
 
     def same_cause?(predecessor, cause)
-      predecessor.cause == cause
+      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -48,7 +48,9 @@ module Journals
       self.journable = journable
     end
 
-    def call(notes: '')
+    def call(notes: '', cause: nil)
+      Rails.logger.info("Journalin with cause #{cause}")
+
       Journal.transaction do
         journal = create_journal(notes)
 

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -634,7 +634,8 @@ module Journals
     end
 
     def same_cause?(predecessor, cause)
-      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause
+      # TODO: change to a better solution that does not need deep_stringify_keys
+      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause.deep_stringify_keys
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -49,8 +49,6 @@ module Journals
     end
 
     def call(notes: '', cause: {})
-      Rails.logger.info("Journalin with cause #{cause}")
-
       Journal.transaction do
         journal = create_journal(notes, cause)
 

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -193,7 +193,8 @@ class WorkPackages::SetScheduleService
     type_mapping = {
       parent: 'work_package_parent_changed_times',
       children: 'work_package_children_changed_times',
-      predecessor: 'work_package_predecessor_changed_times'
+      predecessor: 'work_package_predecessor_changed_times',
+      related: 'work_package_related_changed_times'
     }
 
     work_package.journal_cause = {

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -37,11 +37,11 @@ class WorkPackages::SetScheduleService
   def call(changed_attributes = %i(start_date due_date))
     altered = []
 
-    if (%i(parent parent_id) & changed_attributes).any?
+    if %i(parent parent_id).intersect?(changed_attributes)
       altered += schedule_by_parent
     end
 
-    if (%i(start_date due_date parent parent_id) & changed_attributes).any?
+    if %i(start_date due_date parent parent_id).intersect?(changed_attributes)
       altered += schedule_following
     end
 

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -181,6 +181,7 @@ class WorkPackages::SetScheduleService
 
   def assign_cause_for_journaling(work_package, relation)
     return {} if initiated_by.nil?
+    return {} unless work_package.changes.keys.intersect?(%w(start_date due_date duration))
 
     if initiated_by.is_a?(WorkPackage)
       assign_cause_initiated_by_work_package(work_package, relation)
@@ -189,16 +190,19 @@ class WorkPackages::SetScheduleService
     end
   end
 
-  def assign_cause_initiated_by_work_package(work_package, relation)
-    type_mapping = {
-      parent: 'work_package_parent_changed_times',
-      children: 'work_package_children_changed_times',
-      predecessor: 'work_package_predecessor_changed_times',
-      related: 'work_package_related_changed_times'
-    }
+  def assign_cause_initiated_by_work_package(work_package, _relation)
+    # For now we only track a generic cause, and not a specialized reason depending on the relation
+    #
+    # type_mapping = {
+    #   parent: 'work_package_parent_changed_times',
+    #   children: 'work_package_children_changed_times',
+    #   predecessor: 'work_package_predecessor_changed_times',
+    #   related: 'work_package_related_changed_times'
+    # }
+    # work_package.journal_cause = { "type" => type_mapping[relation], "work_package_id" => initiated_by.id }
 
     work_package.journal_cause = {
-      "type" => type_mapping[relation],
+      "type" => "work_package_related_changed_times",
       "work_package_id" => initiated_by.id
     }
   end

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -197,15 +197,15 @@ class WorkPackages::SetScheduleService
     }
 
     work_package.journal_cause = {
-      type: type_mapping[relation],
-      work_package_id: initiated_by.id
+      "type" => type_mapping[relation],
+      "work_package_id" => initiated_by.id
     }
   end
 
   def assign_cause_initiated_by_changed_working_days(work_package)
     work_package.journal_cause = {
-      type: 'working_days_changed',
-      changed_days: initiated_by.to_h
+      "type" => 'working_days_changed',
+      "changed_days" => initiated_by.to_h
     }
   end
 end

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -124,7 +124,7 @@ class WorkPackages::SetScheduleService
   # descendants
   def reschedule_by_descendants(scheduled, dependency)
     set_dates(scheduled, dependency.start_date, dependency.due_date)
-    assign_cause_for_journaling(scheduled, :predecessor)
+    assign_cause_for_journaling(scheduled, :children)
   end
 
   # Calculates the dates of a work package based on its follows relations.
@@ -150,7 +150,7 @@ class WorkPackages::SetScheduleService
     new_start_date = [scheduled.start_date, dependency.soonest_start_date].compact.max
     new_due_date = determine_due_date(scheduled, new_start_date)
     set_dates(scheduled, new_start_date, new_due_date)
-    assign_cause_for_journaling(scheduled, :successor)
+    assign_cause_for_journaling(scheduled, :predecessor)
   end
 
   def determine_due_date(work_package, start_date)
@@ -192,7 +192,7 @@ class WorkPackages::SetScheduleService
   def assign_cause_initiated_by_work_package(work_package, relation)
     type_mapping = {
       parent: 'work_package_parent_changed_times',
-      successor: 'work_package_successor_changed_times',
+      children: 'work_package_children_changed_times',
       predecessor: 'work_package_predecessor_changed_times'
     }
 

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -27,11 +27,12 @@
 #++
 
 class WorkPackages::SetScheduleService
-  attr_accessor :user, :work_packages
+  attr_accessor :user, :work_packages, :initiating_work_package
 
-  def initialize(user:, work_package:)
+  def initialize(user:, work_package:, initiating_work_package: nil)
     self.user = user
     self.work_packages = Array(work_package)
+    self.initiating_work_package = initiating_work_package
   end
 
   def call(changed_attributes = %i(start_date due_date))

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -180,12 +180,12 @@ class WorkPackages::SetScheduleService
   end
 
   def assign_cause_for_journaling(work_package, relation)
-    return if initiated_by.nil?
+    return {} if initiated_by.nil?
 
     if initiated_by.is_a?(WorkPackage)
       assign_cause_initiated_by_work_package(work_package, relation)
-    elsif initiated_by.is_a?(NonWorkingDay)
-      assign_cause_initiated_by_non_working_day(work_package, relation)
+    elsif initiated_by.is_a?(Journal::WorkingDayUpdate)
+      assign_cause_initiated_by_changed_working_days(work_package)
     end
   end
 
@@ -202,5 +202,10 @@ class WorkPackages::SetScheduleService
     }
   end
 
-  def assign_cause_initiated_by_non_working_day(work_package, relation); end
+  def assign_cause_initiated_by_changed_working_days(work_package)
+    work_package.journal_cause = {
+      type: 'working_days_changed',
+      changed_days: initiated_by.to_h
+    }
+  end
 end

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -121,7 +121,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
   def reschedule(work_package, work_packages)
     WorkPackages::SetScheduleService
-      .new(user:, work_package: work_packages, initiating_work_package: work_package)
+      .new(user:, work_package: work_packages, initiated_by: work_package)
       .call(work_package.saved_changes.keys.map(&:to_sym))
   end
 

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -121,8 +121,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
   def reschedule(work_package, work_packages)
     WorkPackages::SetScheduleService
-      .new(user:,
-           work_package: work_packages)
+      .new(user:, work_package: work_packages, initiating_work_package: work_package)
       .call(work_package.saved_changes.keys.map(&:to_sym))
   end
 

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -30,6 +30,13 @@ class WorkPackages::UpdateService < BaseServices::Update
   include ::WorkPackages::Shared::UpdateAncestors
   include Attachments::ReplaceAttachments
 
+  attr_accessor :cause_of_update
+
+  def initialize(user:, model:, contract_class: nil, contract_options: {}, cause_of_update: nil)
+    super(user:, model:, contract_class:, contract_options:)
+    self.cause_of_update = cause_of_update || self
+  end
+
   private
 
   def after_perform(service_call)
@@ -121,7 +128,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
   def reschedule(work_package, work_packages)
     WorkPackages::SetScheduleService
-      .new(user:, work_package: work_packages, initiated_by: work_package)
+      .new(user:, work_package: work_packages, initiated_by: cause_of_update)
       .call(work_package.saved_changes.keys.map(&:to_sym))
   end
 

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -34,7 +34,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
   def initialize(user:, model:, contract_class: nil, contract_options: {}, cause_of_update: nil)
     super(user:, model:, contract_class:, contract_options:)
-    self.cause_of_update = cause_of_update || self
+    self.cause_of_update = cause_of_update || model
   end
 
   private
@@ -127,6 +127,7 @@ class WorkPackages::UpdateService < BaseServices::Update
   end
 
   def reschedule(work_package, work_packages)
+    puts "*" * 200, cause_of_update, "#" * 200
     WorkPackages::SetScheduleService
       .new(user:, work_package: work_packages, initiated_by: cause_of_update)
       .call(work_package.saved_changes.keys.map(&:to_sym))

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -127,7 +127,6 @@ class WorkPackages::UpdateService < BaseServices::Update
   end
 
   def reschedule(work_package, work_packages)
-    puts "*" * 200, cause_of_update, "#" * 200
     WorkPackages::SetScheduleService
       .new(user:, work_package: work_packages, initiated_by: cause_of_update)
       .call(work_package.saved_changes.keys.map(&:to_sym))

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -34,30 +34,39 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     user = User.find(user_id)
 
     User.execute_as user do
+      wd_update = Journal::WorkingDayUpdate.new(
+        working_days: changed_days(previous_working_days),
+        non_working_days: changed_non_working_dates(previous_non_working_days)
+      )
+
       updated_work_package_ids = collect_id_for_each(applicable_work_package(previous_working_days,
                                                                              previous_non_working_days)) do |work_package|
-        apply_change_to_work_package(user, work_package)
-      end
-      updated_work_package_ids += collect_id_for_each(applicable_predecessor(updated_work_package_ids)) do |predecessor|
-        apply_change_to_predecessor(user, predecessor)
+        apply_change_to_work_package(user, work_package, wd_update)
       end
 
-      set_journal_notice(updated_work_package_ids, previous_working_days, previous_non_working_days)
+      applicable_predecessor(updated_work_package_ids).each do |predecessor|
+        apply_change_to_predecessor(user, predecessor, wd_update)
+      end
     end
   end
 
   private
 
-  def apply_change_to_work_package(user, work_package)
+  def apply_change_to_work_package(user, work_package, changed_working_days)
+    cause = {
+      type: "working_days_changed",
+      changed_days: changed_working_days.to_h
+    }
+
     WorkPackages::UpdateService
       .new(user:, model: work_package, contract_class: EmptyContract)
-      .call(duration: work_package.duration) # trigger a recomputation of start and due date
+      .call(duration: work_package.duration, journal_cause: cause) # trigger a recomputation of start and due date
       .all_results
   end
 
-  def apply_change_to_predecessor(user, predecessor)
+  def apply_change_to_predecessor(user, predecessor, initiated_by)
     schedule_result = WorkPackages::SetScheduleService
-                        .new(user:, work_package: predecessor)
+                        .new(user:, work_package: predecessor, initiated_by:)
                         .call
 
     # The SetScheduleService does not save. It has to be done by the caller.
@@ -100,38 +109,6 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     WorkPackage
       .where(id: Relation.follows_with_delay.select(:to_id))
       .where.not(id: excluded)
-  end
-
-  def set_journal_notice(updated_work_package_ids, previous_working_days, previous_non_working_days)
-    day_changes = changed_days(previous_working_days)
-    date_changes = changed_non_working_dates(previous_non_working_days)
-    journal_note = journal_notice_text(day_changes, date_changes)
-
-    WorkPackage
-      .where(id: updated_work_package_ids.uniq)
-      .in_batches
-      .each_record do |work_package|
-      work_package.journal_notes = journal_note
-      work_package.save
-    end
-  end
-
-  def journal_notice_text(day_changes, date_changes)
-    I18n.with_locale(Setting.default_language) do
-      day_changes_messages = day_changes.collect { |day, working| working_day_change_message(day, working) }
-      date_changes_messages = date_changes.collect { |date, working| working_date_change_message(date, working) }
-      I18n.t(:'working_days.journal_note.changed',
-             changes: (day_changes_messages + date_changes_messages).join(', '))
-    end
-  end
-
-  def working_day_change_message(day, working)
-    I18n.t(:"working_days.journal_note.days.#{working ? :working : :non_working}",
-           day: WeekDay.find_by!(day:).name)
-  end
-
-  def working_date_change_message(date, working)
-    I18n.t(:"working_days.journal_note.dates.#{working ? :working : :non_working}", date:)
   end
 
   def collect_id_for_each(scope)

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -59,7 +59,7 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     }
 
     WorkPackages::UpdateService
-      .new(user:, model: work_package, contract_class: EmptyContract)
+      .new(user:, model: work_package, contract_class: EmptyContract, cause_of_update: changed_working_days)
       .call(duration: work_package.duration, journal_cause: cause) # trigger a recomputation of start and due date
       .all_results
   end

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -36,7 +36,7 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     User.execute_as user do
       wd_update = Journal::WorkingDayUpdate.new(
         working_days: changed_days(previous_working_days),
-        non_working_days: changed_non_working_dates(previous_non_working_days)
+        non_working_days: changed_non_working_dates(previous_non_working_days).transform_keys(&:iso8601)
       )
 
       updated_work_package_ids = collect_id_for_each(applicable_work_package(previous_working_days,
@@ -54,8 +54,8 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
 
   def apply_change_to_work_package(user, work_package, changed_working_days)
     cause = {
-      type: "working_days_changed",
-      changed_days: changed_working_days.to_h
+      "type" => "working_days_changed",
+      "changed_days" => changed_working_days.to_h
     }
 
     WorkPackages::UpdateService

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1482,6 +1482,7 @@ en:
       work_package_predecessor_changed_times: by changes to predecessor %{link}
       work_package_parent_changed_times: by changes to parent %{link}
       work_package_children_changed_times: by changes to child %{link}
+      work_package_related_changed_times: by changes to related %{link}
       unaccessable_work_package_changed: by changes to a related work package
       working_days_changed:
         changed: "by changes to working days (%{changes})"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1484,7 +1484,7 @@ en:
       work_package_children_changed_times: by changes to child %{link}
       unaccessable_work_package_changed: by changes to a related work package
       working_days_changed:
-        changed: "by changes to working days (%{changes})."
+        changed: "by changes to working days (%{changes})"
         days:
           working: "%{day} is now working"
           non_working: "%{day} is now non-working"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1475,6 +1475,23 @@ en:
   journals:
     changes_retracted: "The changes were retracted."
 
+    caused_changes:
+      dates_changed: "Dates changed"
+
+    cause_descriptions:
+      work_package_predecessor_changed_times: by changes to predecessor %{link}
+      work_package_parent_changed_times: by changes to parent %{link}
+      work_package_children_changed_times: by changes to child %{link}
+      unaccessable_work_package_changed: by changes to a related work package
+      working_days_changed:
+        changed: "by changes to working days (%{changes})."
+        days:
+          working: "%{day} is now working"
+          non_working: "%{day} is now non-working"
+        dates:
+          working: "%{date} is now working"
+          non_working: "%{date} is now non-working"
+
   links:
     configuration_guide: 'Configuration guide'
     get_in_touch: "You have questions? Get in touch with us."

--- a/db/migrate/20230606083221_add_cause_to_journal.rb
+++ b/db/migrate/20230606083221_add_cause_to_journal.rb
@@ -1,0 +1,5 @@
+class AddCauseToJournal < ActiveRecord::Migration[7.0]
+  def change
+    add_column :journals, :cause, :jsonb, default: {}
+  end
+end

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -91,7 +91,8 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
   end
 
   def working_date_change_message(date, working)
-    I18n.t("journals.cause_descriptions.working_days_changed.dates.#{working ? :working : :non_working}", date:)
+    I18n.t("journals.cause_descriptions.working_days_changed.dates.#{working ? :working : :non_working}",
+           date: I18n.l(Date.parse(date)))
   end
 
   # we need to tell the url_helper that there is not controller to get url_options

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
+  include ApplicationHelper
+  include OpenProject::StaticRouting::UrlHelpers
+  include OpenProject::ObjectLinking
+
+  def render(_key, values, _options = { html: true })
+    content_tag(:pre, values.last)
+  end
+end

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -32,10 +32,14 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
   include OpenProject::StaticRouting::UrlHelpers
   include OpenProject::ObjectLinking
 
-  def render(_key, values, _options = { html: true })
+  def render(_key, values, options = { html: true })
     cause = values.last
 
-    "#{content_tag(:strong, cause_type_translation(cause['type']))} #{cause_description(cause)}"
+    if options[:html]
+      "#{content_tag(:strong, cause_type_translation(cause['type']))} #{cause_description(cause, true)}"
+    else
+      "#{cause_type_translation(cause['type'])} #{cause_description(cause, false)}"
+    end
   end
 
   private
@@ -47,22 +51,22 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
     I18n.t('journals.caused_changes.dates_changed')
   end
 
-  def cause_description(cause)
+  def cause_description(cause, html)
     case cause['type']
     when 'working_days_changed'
       working_days_changed_message(cause['changed_days'])
     else
-      related_work_package_changed_message(cause)
+      related_work_package_changed_message(cause, html)
     end
   end
 
-  def related_work_package_changed_message(cause)
+  def related_work_package_changed_message(cause, html)
     related_work_package = WorkPackage.includes(:project).visible(User.current).find_by(id: cause['work_package_id'])
 
     if related_work_package
       I18n.t(
         "journals.cause_descriptions.#{cause['type']}",
-        link: link_to_work_package(related_work_package)
+        link: html ? link_to_work_package(related_work_package) : "##{related_work_package.id}"
       )
 
     else

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -57,7 +57,7 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
   end
 
   def related_work_package_changed_message(cause)
-    related_work_package = nil # WorkPackage.includes(:project).visible(User.current).find_by(id: cause['work_package_id'])
+    related_work_package = WorkPackage.includes(:project).visible(User.current).find_by(id: cause['work_package_id'])
 
     if related_work_package
       I18n.t(

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -66,7 +66,7 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
     if related_work_package
       I18n.t(
         "journals.cause_descriptions.#{cause['type']}",
-        link: html ? link_to_work_package(related_work_package) : "##{related_work_package.id}"
+        link: html ? link_to_work_package(related_work_package, all_link: true) : "##{related_work_package.id}"
       )
 
     else
@@ -76,7 +76,7 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
 
   def working_days_changed_message(changed_dates)
     day_changes_messages = changed_dates['working_days'].collect do |day, working|
-      working_day_change_message(day, working)
+      working_day_change_message(day.to_i, working)
     end
     date_changes_messages = changed_dates['non_working_days'].collect do |date, working|
       working_date_change_message(date, working)

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -73,7 +73,7 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user: User.current, notes: '', cause: nil)
+    def add_journal(user: User.current, notes: '', cause: {})
       self.journal_user ||= user
       self.journal_notes ||= notes
       self.journal_cause ||= cause
@@ -84,6 +84,7 @@ module Acts::Journalized
     def with_ensured_journal_attributes
       self.journal_user ||= User.current
       self.journal_notes ||= ''
+      self.journal_cause ||= {}
 
       yield
     ensure

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -73,7 +73,7 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user = User.current, notes = '')
+    def add_journal(user: User.current, notes: '')
       self.journal_user ||= user
       self.journal_notes ||= notes
     end

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -53,7 +53,7 @@ module Acts::Journalized
       base.class_eval do
         after_save :save_journals
 
-        attr_accessor :journal_notes, :journal_user
+        attr_accessor :journal_notes, :journal_user, :journal_cause
       end
     end
 
@@ -61,7 +61,7 @@ module Acts::Journalized
       with_ensured_journal_attributes do
         create_call = Journals::CreateService
                       .new(self, @journal_user)
-                      .call(notes: @journal_notes)
+                      .call(notes: @journal_notes, cause: @journal_cause)
 
         if create_call.success? && create_call.result
           OpenProject::Notifications.send(OpenProject::Events::JOURNAL_CREATED,
@@ -73,9 +73,10 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user: User.current, notes: '')
+    def add_journal(user: User.current, notes: '', cause: nil)
       self.journal_user ||= user
       self.journal_notes ||= notes
+      self.journal_cause ||= cause
     end
 
     private
@@ -88,6 +89,7 @@ module Acts::Journalized
     ensure
       self.journal_user = nil
       self.journal_notes = nil
+      self.journal_cause = nil
     end
   end
 end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -31,7 +31,7 @@ module JournalChanges
     return @changes if @changes
     return {} if data.nil?
 
-    @changes = cause.present? ? { cause: [nil, cause] } : {}
+    @changes = (cause.present? ? { cause: [nil, cause] } : {}).with_indifferent_access
 
     if predecessor.nil?
       @changes.merge!(initial_journal_data_changes)

--- a/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -31,14 +31,18 @@ module JournalChanges
     return @changes if @changes
     return {} if data.nil?
 
-    @changes = if predecessor.nil?
-                 initial_journal_data_changes
-               else
-                 subsequent_journal_data_changes
-               end
+    @changes = cause.present? ? { cause: [nil, cause] } : {}
+
+    if predecessor.nil?
+      @changes.merge!(initial_journal_data_changes)
+    else
+      @changes.merge!(subsequent_journal_data_changes)
+    end
 
     @changes.merge!(get_association_changes(predecessor, 'attachable', 'attachments', :attachment_id, :filename))
     @changes.merge!(get_association_changes(predecessor, 'customizable', 'custom_fields', :custom_field_id, :value))
+
+    @changes
   end
 
   private

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -123,7 +123,9 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
       wp_page = Pages::FullWorkPackage.new(earliest_work_package)
       wp_page.visit!
 
-      wp_page.expect_comment(text: "Working days changed (Monday is now non-working, Friday is now non-working).")
+      wp_page.expect_activity_message(
+        "Dates changed by changes to working days (Monday is now non-working, Friday is now non-working)"
+      )
     end
 
     it 'shows error when non working days are all unset' do
@@ -139,7 +141,8 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
         dialog.confirm
       end
 
-      expect(page).to have_selector('.flash.error', text: 'At least one day of the week must be defined as a working day.')
+      expect(page).to have_selector('.flash.error',
+                                    text: 'At least one day of the week must be defined as a working day.')
       # Restore the checkboxes to their valid state
       expect(page).to have_checked_field 'Monday'
       expect(page).to have_checked_field 'Tuesday'

--- a/spec/features/notifications/reminder_mail_spec.rb
+++ b/spec/features/notifications/reminder_mail_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Reminder email sending", js: true, with_cuprite: true do
             </mention>
       NOTE
 
-      work_package.add_journal(other_user, note)
+      work_package.add_journal(user: other_user, notes: note)
       work_package.save!
 
       watched_work_package.subject = 'New watched work package subject'

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Immediate reminder settings",
               </mention>
         NOTE
 
-        work_package.add_journal(current_user, note)
+        work_package.add_journal(user: current_user, notes: note)
         work_package.save!
       end
 

--- a/spec/lib/journal_formatter/cause_spec.rb
+++ b/spec/lib/journal_formatter/cause_spec.rb
@@ -1,0 +1,261 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe OpenProject::JournalFormatter::Cause do
+  include ApplicationHelper
+  include WorkPackagesHelper
+  include ActionView::Helpers::UrlHelper
+  include Rails.application.routes.url_helpers
+
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:instance) { described_class.new(build(:work_package_journal)) }
+  let(:link) do
+    link_to_work_package(work_package, all_link: true)
+  end
+
+  # we need to tell the url_helper that there is not controller to get url_options so that we can call link_to
+  let(:controller) { nil }
+
+  subject { instance.render("cause", [nil, cause], html:) }
+
+  context 'when the change was caused by a change to the parent' do
+    let(:cause) do
+      {
+        "type" => "work_package_parent_changed_times",
+        "work_package_id" => work_package.id
+      }
+    end
+
+    context 'when rendering HTML variant' do
+      let(:html) { true }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_parent_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+
+    context 'when rendering raw variant' do
+      let(:html) { false }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        let(:link) { "##{work_package.id}" }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_parent_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+  end
+
+  context 'when the change was caused by a change to a predecessor' do
+    let(:cause) do
+      {
+        "type" => "work_package_predecessor_changed_times",
+        "work_package_id" => work_package.id
+      }
+    end
+
+    context 'when rendering HTML variant' do
+      let(:html) { true }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_predecessor_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+
+    context 'when rendering raw variant' do
+      let(:html) { false }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        let(:link) { "##{work_package.id}" }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_predecessor_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+  end
+
+  context 'when the change was caused by a change to a child' do
+    let(:cause) do
+      {
+        "type" => "work_package_children_changed_times",
+        "work_package_id" => work_package.id
+      }
+    end
+
+    context 'when rendering HTML variant' do
+      let(:html) { true }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_children_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+
+    context 'when rendering raw variant' do
+      let(:html) { false }
+
+      context 'when the user is able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+
+        let(:link) { "##{work_package.id}" }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.work_package_children_changed_times', link:)}"
+        end
+      end
+
+      context 'when the user is not able to access the related work package' do
+        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+
+        it do
+          expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                                "#{I18n.t('journals.cause_descriptions.unaccessable_work_package_changed')}"
+        end
+      end
+    end
+  end
+
+  context 'when the change was caused by working day changes' do
+    let(:cause) do
+      {
+        "type" => 'working_days_changed',
+        "changed_days" => {
+          "working_days" => {
+            "2" => false,
+            "6" => true
+
+          },
+          "non_working_days" => {
+            "2023-01-01" => true,
+            "2023-12-24" => false
+          }
+        }
+      }
+    end
+
+    context 'when rendering HTML variant' do
+      let(:html) { true }
+
+      it do
+        changes = [
+          I18n.t("journals.cause_descriptions.working_days_changed.days.non_working", day: WeekDay.find_by!(day: 2).name),
+          I18n.t("journals.cause_descriptions.working_days_changed.days.working", day: WeekDay.find_by!(day: 6).name),
+          I18n.t("journals.cause_descriptions.working_days_changed.dates.working", date: I18n.l(Date.new(2023, 1, 1))),
+          I18n.t("journals.cause_descriptions.working_days_changed.dates.non_working", date: I18n.l(Date.new(2023, 12, 24)))
+        ].join(", ")
+        expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
+                              "#{I18n.t('journals.cause_descriptions.working_days_changed.changed', changes:)}"
+      end
+    end
+
+    context 'when rendering raw variant' do
+      let(:html) { false }
+
+      it do
+        changes = [
+          I18n.t("journals.cause_descriptions.working_days_changed.days.non_working", day: WeekDay.find_by!(day: 2).name),
+          I18n.t("journals.cause_descriptions.working_days_changed.days.working", day: WeekDay.find_by!(day: 6).name),
+          I18n.t("journals.cause_descriptions.working_days_changed.dates.working", date: I18n.l(Date.new(2023, 1, 1))),
+          I18n.t("journals.cause_descriptions.working_days_changed.dates.non_working", date: I18n.l(Date.new(2023, 12, 24)))
+        ].join(", ")
+        expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
+                              "#{I18n.t('journals.cause_descriptions.working_days_changed.changed', changes:)}"
+      end
+    end
+  end
+end

--- a/spec/lib/journal_formatter/cause_spec.rb
+++ b/spec/lib/journal_formatter/cause_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
   include ActionView::Helpers::UrlHelper
   include Rails.application.routes.url_helpers
 
-  let(:work_package) { build_stubbed(:work_package) }
+  let(:work_package) { create(:work_package) }
   let(:instance) { described_class.new(build(:work_package_journal)) }
   let(:link) do
     link_to_work_package(work_package, all_link: true)
@@ -57,7 +57,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { true }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -66,7 +68,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -79,7 +83,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { false }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         let(:link) { "##{work_package.id}" }
 
@@ -90,7 +96,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
@@ -112,7 +120,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { true }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -121,7 +131,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -134,7 +146,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { false }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         let(:link) { "##{work_package.id}" }
 
@@ -145,7 +159,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \
@@ -167,7 +183,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { true }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -176,7 +194,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.dates_changed')}</strong> " \
@@ -189,7 +209,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       let(:html) { false }
 
       context 'when the user is able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(work_package) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+        end
 
         let(:link) { "##{work_package.id}" }
 
@@ -200,7 +222,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
 
       context 'when the user is not able to access the related work package' do
-        before { allow(WorkPackage).to receive_message_chain(:includes, :visible, :find_by).and_return(nil) }
+        before do
+          allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.none)
+        end
 
         it do
           expect(subject).to eq "#{I18n.t('journals.caused_changes.dates_changed')} " \

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -60,22 +60,22 @@ RSpec.describe WorkPackage do
 
       it 'notes the changes to subject' do
         expect(work_package.last_journal.details[:subject])
-          .to match_array [nil, work_package.subject]
+          .to contain_exactly(nil, work_package.subject)
       end
 
       it 'notes the changes to project' do
         expect(work_package.last_journal.details[:project_id])
-          .to match_array [nil, work_package.project_id]
+          .to contain_exactly(nil, work_package.project_id)
       end
 
       it 'notes the description' do
         expect(work_package.last_journal.details[:description])
-          .to match_array [nil, work_package.description]
+          .to contain_exactly(nil, work_package.description)
       end
 
       it 'notes the scheduling mode' do
         expect(work_package.last_journal.details[:schedule_manually])
-          .to match_array [nil, false]
+          .to contain_exactly(nil, false)
       end
 
       it 'has the timestamp of the work package update time for created_at' do

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe WorkPackage do
 
     context 'for only journal notes adding' do
       before do
-        work_package.add_journal(User.current, 'some notes')
+        work_package.add_journal(user: User.current, notes: 'some notes')
         work_package.save
       end
 
@@ -428,7 +428,7 @@ RSpec.describe WorkPackage do
 
     context 'for mixed journal notes and attribute adding' do
       before do
-        work_package.add_journal(User.current, 'some notes')
+        work_package.add_journal(user: User.current, notes: 'some notes')
         work_package.subject = 'blubs'
         work_package.save
       end
@@ -494,7 +494,7 @@ RSpec.describe WorkPackage do
             let(:second_notes) { 'Another comment, unrelated to the first one.' }
 
             before do
-              work_package.add_journal(new_author, second_notes)
+              work_package.add_journal(user: new_author, notes: second_notes)
               work_package.save!
             end
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe WorkPackage do
       end
 
       it 'stores the note with the existing journal entry' do
-        expect { subject }.to change { work_package.last_journal.notes }.from('').to('some noes')
+        expect { subject }.to change { work_package.last_journal.notes }.from('').to('some notes')
       end
     end
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe WorkPackage do
       end
 
       it 'has the timestamp of the work package update time for created_at' do
-        expect(work_package.last_journal.updated_at).to eql(work_package.updated_at)
+        expect(work_package.last_journal.updated_at).to eql(work_package.reload.updated_at)
       end
 
       it 'does create a new journal entry' do

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -415,10 +415,8 @@ RSpec.describe WorkPackage do
     end
 
     context 'for only journal notes adding' do
-      let(:note_text) { 'some notes' }
-
       subject do
-        work_package.add_journal(user: User.current, notes: note_text)
+        work_package.add_journal(user: User.current, notes: 'some notes')
         work_package.save
       end
 
@@ -432,15 +430,13 @@ RSpec.describe WorkPackage do
       end
 
       it 'stores the note with the existing journal entry' do
-        expect { subject }.to change { work_package.last_journal.notes }.from('').to(note_text)
+        expect { subject }.to change { work_package.last_journal.notes }.from('').to('some notes')
       end
     end
 
     context 'for mixed journal notes and attribute adding' do
-      let(:note_text) { 'some notes' }
-
       subject do
-        work_package.add_journal(user: User.current, notes: note_text)
+        work_package.add_journal(user: User.current, notes: 'some notes')
         work_package.subject = 'blubs'
         work_package.save
       end
@@ -455,7 +451,7 @@ RSpec.describe WorkPackage do
       end
 
       it 'stores the note with the existing journal entry' do
-        expect { subject }.to change { work_package.last_journal.notes }.from('').to(note_text)
+        expect { subject }.to change { work_package.last_journal.notes }.from('').to('some noes')
       end
     end
 

--- a/spec/services/attachments/delete_service_integration_spec.rb
+++ b/spec/services/attachments/delete_service_integration_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Attachments::DeleteService, 'integration', with_settings: { journ
         before do
           # Force to have a journal for the attachment
           attachment
-          container.add_journal(user)
+          container.add_journal(user:)
           container.save!
 
           call
@@ -86,7 +86,7 @@ RSpec.describe Attachments::DeleteService, 'integration', with_settings: { journ
         before do
           # Force to have a journal for the attachment
           attachment
-          container.add_journal(user, 'Some notes')
+          container.add_journal(user:, notes: 'Some notes')
           container.save!
 
           # have an invalid work package

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Notifications::CreateFromModelService,
   let(:resource) { work_package }
   let(:journal) { work_package.journals.first }
   let(:journal_2_with_notes) do
-    work_package.add_journal author, 'something I have to say'
+    work_package.add_journal user: author, notes: 'something I have to say'
     work_package.save(validate: false)
     work_package.journals.last
   end
@@ -1108,7 +1108,7 @@ RSpec.describe Notifications::CreateFromModelService,
             end
 
             expect(call.all_results)
-              .to match_array([notification_group_recipient, notification_other_recipient])
+              .to contain_exactly(notification_group_recipient, notification_other_recipient)
           end
         end
       end
@@ -1117,7 +1117,7 @@ RSpec.describe Notifications::CreateFromModelService,
     describe 'in the journal notes' do
       let(:journal) { journal_2_with_notes }
       let(:journal_2_with_notes) do
-        work_package.add_journal author, note
+        work_package.add_journal user: author, notes: note
         work_package.save(validate: false)
         work_package.journals.last
       end

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe WorkPackages::SetScheduleService do
           .to be_present,
               "Expected work package ##{wp.id} '#{wp.subject}' to be rescheduled"
 
-        expect(result.journal_cause[:work_package_id])
+        expect(result.journal_cause['work_package_id'])
           .to eql(initiating_work_package.id),
               "Expected work package ##{wp.id} to have been caused by ##{initiating_work_package.id} " \
               "for the journal entry"

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe WorkPackages::SetScheduleService do
   let(:work_package_start_date) { nil }
   let(:initiating_work_package) { work_package }
   let(:instance) do
-    described_class.new(user:, work_package:, initiating_work_package:)
+    described_class.new(user:, work_package:, initiated_by: initiating_work_package)
   end
   let!(:following) { [] }
 

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe WorkPackages::SetScheduleService do
   end
   let(:work_package_due_date) { Time.zone.today }
   let(:work_package_start_date) { nil }
+  let(:initiating_work_package) { work_package }
   let(:instance) do
-    described_class.new(user:, work_package:)
+    described_class.new(user:, work_package:, initiating_work_package:)
   end
   let!(:following) { [] }
 
@@ -139,6 +140,11 @@ RSpec.describe WorkPackages::SetScheduleService do
           .to be_present,
               "Expected work package ##{wp.id} '#{wp.subject}' to be rescheduled"
 
+        expect(result.journal_cause[:work_package_id])
+          .to eql(initiating_work_package.id),
+              "Expected work package ##{wp.id} to have been caused by ##{initiating_work_package.id} " \
+              "for the journal entry"
+
         expect(result.start_date)
           .to eql(start_date),
               "Expected work package ##{wp.id} '#{wp.subject}' " \
@@ -175,7 +181,7 @@ RSpec.describe WorkPackages::SetScheduleService do
 
     it 'does not change any other work packages' do
       expect(subject.all_results)
-        .to match_array [work_package]
+        .to contain_exactly(work_package)
     end
   end
 

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe WorkPackages::SetScheduleService do
 
     it 'updates the following work packages' do
       expected.each do |wp, (start_date, due_date)|
+        expected_cause_type = "work_package_related_changed_times"
         result = subject.all_results.find { |result_wp| result_wp.id == wp.id }
         expect(result)
           .to be_present,
@@ -142,8 +143,11 @@ RSpec.describe WorkPackages::SetScheduleService do
 
         expect(result.journal_cause['work_package_id'])
           .to eql(initiating_work_package.id),
-              "Expected work package ##{wp.id} to have been caused by ##{initiating_work_package.id} " \
-              "for the journal entry"
+              "Expected work package change to ##{wp.id} to have been caused by ##{initiating_work_package.id}."
+
+        expect(result.journal_cause['type'])
+        .to eql("work_package_related_changed_times"),
+            "Expected work package change to ##{wp.id} to have been caused because ##{expected_cause_type}."
 
         expect(result.start_date)
           .to eql(start_date),
@@ -182,6 +186,12 @@ RSpec.describe WorkPackages::SetScheduleService do
     it 'does not change any other work packages' do
       expect(subject.all_results)
         .to contain_exactly(work_package)
+    end
+
+    it 'does not assign a journal cause' do
+      subject.all_results.each do |work_package|
+        expect(work_package.journal_cause).to be_blank
+      end
     end
   end
 

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -42,24 +42,22 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
   let!(:previous_working_days) { work_week }
   let!(:previous_non_working_days) { [] }
 
-  shared_examples_for 'journal updates with note' do
+  shared_examples_for 'journal updates with cause' do
     let(:changed_work_packages) { [] }
     let(:unchanged_work_packages) { [] }
-    let(:journal_notice) { raise 'need to specify note' }
+    let(:changed_days) { raise 'need to specify note' }
 
     it 'adds journal entries to changed work packages' do
       subject
 
       changed_work_packages.each do |work_package|
-        expect(work_package.journals.count)
-          .to eq 2
-        expect(work_package.journals.last.notes)
-          .to include(journal_notice)
+        # expect(work_package.journals.count).to eq 2
+        expect(work_package.journals.last.cause_type).to eq('working_days_changed')
+        expect(work_package.journals.last.cause_changed_days).to eq(changed_days)
       end
 
       unchanged_work_packages.each do |work_package|
-        expect(work_package.journals.count)
-          .to eq 1
+        expect(work_package.journals.count).to eq 1
       end
     end
   end
@@ -95,7 +93,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package,
              work_package_on_start,
@@ -103,7 +101,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
              wp_start_only,
              wp_due_only]
           end
-          let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
+          let(:changed_days) do
+            {
+              "working_days" => { "3" => false },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -126,11 +129,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
+          let(:changed_days) do
+            {
+              "working_days" => { "3" => false },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -152,11 +160,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) { "**Working days** changed (Saturday is now working)." }
+          let(:changed_days) do
+            {
+              "working_days" => { "6" => true },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -180,11 +193,17 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor, follower]
           end
-          let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
+
+          let(:changed_days) do
+            {
+              "working_days" => { "3" => false },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -208,14 +227,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [follower]
           end
           let(:unchanged_work_packages) do
             [predecessor]
           end
-          let(:journal_notice) { "**Working days** changed (Wednesday is now non-working)." }
+          let(:changed_days) do
+            {
+              "working_days" => { "3" => false },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -239,7 +263,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -268,7 +292,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -297,14 +321,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor]
           end
           let(:unchanged_work_packages) do
             [follower]
           end
-          let(:journal_notice) { "**Working days** changed (Wednesday is now working)." }
+          let(:changed_days) do
+            {
+              "working_days" => { "3" => true },
+              "non_working_days" => {}
+            }
+          end
         end
       end
 
@@ -329,7 +358,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -354,7 +383,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -376,7 +405,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(work_package.duration).to eq(3)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -408,10 +437,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
+
+          let(:changed_days) do
+            {
+              "working_days" => { "2" => false, "3" => false, "5" => false },
+              "non_working_days" => {}
+            }
+          end
+
           let(:journal_notice) do
             "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
           end
@@ -451,12 +488,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
+          let(:changed_days) do
+            {
+              "working_days" => { "2" => false, "3" => false, "5" => false },
+              "non_working_days" => {}
+            }
           end
         end
       end
@@ -486,15 +526,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(WorkPackage.pluck(:lock_version)).to all(be <= 1)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp3]
           end
           let(:unchanged_work_packages) do
             [wp2]
           end
-          let(:journal_notice) do
-            "**Working days** changed (Tuesday is now working, Wednesday is now working, Friday is now working)."
+          let(:changed_days) do
+            {
+              "working_days" => { "2" => true, "3" => true, "5" => true },
+              "non_working_days" => {}
+            }
           end
         end
       end
@@ -524,37 +567,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (Tuesday is now non-working, Wednesday is now non-working, Friday is now non-working)."
-          end
-        end
-      end
-
-      context 'when having a non english default language', with_settings: { default_language: :fr } do
-        let_schedule(<<~CHART)
-          days          | fssMTWTFSS |
-          work_package  | X▓▓XX   ░░ |
-        CHART
-
-        before do
-          set_working_week_days('saturday')
-        end
-
-        # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
-          let(:changed_work_packages) do
-            [work_package]
-          end
-          let(:journal_notice) do
-            I18n.with_locale(:fr) do
-              I18n.t(:'working_days.journal_note.changed',
-                     changes: I18n.t(:'working_days.journal_note.days.working',
-                                     day: I18n.t('date.day_names')[6]))
-            end
+          let(:changed_days) do
+            {
+              "working_days" => { "2" => false, "3" => false, "5" => false },
+              "non_working_days" => {}
+            }
           end
         end
       end
@@ -570,12 +591,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         end
 
         # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) do
-            "**Working days** changed (Sunday is now working)."
+          let(:changed_days) do
+            {
+              "working_days" => { "7" => true },
+              "non_working_days" => {}
+            }
           end
         end
       end
@@ -612,7 +636,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package,
              work_package_on_start,
@@ -620,8 +644,12 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
              wp_start_only,
              wp_due_only]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)."
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
           end
         end
       end
@@ -645,12 +673,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)."
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
           end
         end
       end
@@ -673,13 +705,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
 
-          let(:journal_notice) do
-            "**Working days** changed (#{monday.next_occurring(:saturday)} is now working)."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { monday.next_occurring(:saturday).iso8601 => true }
+            }
           end
         end
       end
@@ -704,11 +739,17 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor, follower]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)." }
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
+          end
         end
       end
 
@@ -732,14 +773,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [follower]
           end
           let(:unchanged_work_packages) do
             [predecessor]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)." }
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
+          end
         end
       end
 
@@ -763,7 +809,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -797,7 +843,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -830,14 +876,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor]
           end
           let(:unchanged_work_packages) do
             [follower]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now working)." }
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => true }
+            }
+          end
         end
       end
 
@@ -866,7 +917,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -891,7 +942,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -913,7 +964,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(work_package.duration).to eq(3)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -955,12 +1006,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1006,12 +1061,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1053,15 +1111,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(WorkPackage.pluck(:lock_version)).to all(be <= 1)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp3]
           end
           let(:unchanged_work_packages) do
             [wp2]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now working" }.join(', ')})."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([true].cycle).to_h
+            }
           end
         end
       end
@@ -1101,43 +1162,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
-          end
-        end
-      end
 
-      context 'when having a non english default language', with_settings: { default_language: :fr } do
-        let_schedule(<<~CHART)
-          days          | fssMTWTFSS |
-          work_package  | X▓▓XX   ░░ |
-        CHART
-
-        let(:non_working_days) do
-          [monday.next_occurring(:saturday), next_monday.next_occurring(:saturday)]
-        end
-
-        before do
-          # Make 'saturday' a working day
-          set_working_days(*non_working_days)
-        end
-
-        # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
-          let(:changed_work_packages) do
-            [work_package]
-          end
-          let(:journal_notice) do
-            I18n.with_locale(:fr) do
-              I18n.t(:'working_days.journal_note.changed',
-                     changes: non_working_days.map do |date|
-                       I18n.t(:'working_days.journal_note.dates.working', date:)
-                     end.join(", "))
-            end
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1158,15 +1192,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         end
 
         # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) do
-            I18n.t(:'working_days.journal_note.changed',
-                   changes: non_working_days.map do |date|
-                     I18n.t(:'working_days.journal_note.dates.working', date:)
-                   end.join(", "))
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([true].cycle).to_h
+            }
           end
         end
       end
@@ -1203,7 +1237,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package,
              work_package_on_start,
@@ -1211,8 +1245,11 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
              wp_start_only,
              wp_due_only]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
           end
         end
       end
@@ -1236,12 +1273,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
           end
         end
       end
@@ -1267,13 +1307,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
 
-          let(:journal_notice) do
-            "**Working days** changed (Saturday is now working, #{monday.next_occurring(:saturday)} is now working)."
+          let(:changed_days) do
+            {
+              "working_days" => { "6" => true },
+              "non_working_days" => { monday.next_occurring(:saturday).iso8601 => true }
+            }
           end
         end
       end
@@ -1298,11 +1341,17 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor, follower]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)." }
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
+          end
         end
       end
 
@@ -1326,14 +1375,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [follower]
           end
           let(:unchanged_work_packages) do
             [predecessor]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now non-working)." }
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => false }
+            }
+          end
         end
       end
 
@@ -1357,7 +1411,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -1391,7 +1445,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -1424,14 +1478,19 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [predecessor]
           end
           let(:unchanged_work_packages) do
             [follower]
           end
-          let(:journal_notice) { "**Working days** changed (#{next_monday.next_occurring(:wednesday)} is now working)." }
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => { next_monday.next_occurring(:wednesday).iso8601 => true }
+            }
+          end
         end
       end
 
@@ -1460,7 +1519,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [predecessor, follower]
           end
@@ -1485,7 +1544,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -1507,7 +1566,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(work_package.duration).to eq(3)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:unchanged_work_packages) do
             [work_package]
           end
@@ -1549,12 +1608,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
+
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1600,12 +1663,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1647,15 +1713,18 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           expect(WorkPackage.pluck(:lock_version)).to all(be <= 1)
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp3]
           end
           let(:unchanged_work_packages) do
             [wp2]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now working" }.join(', ')})."
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([true].cycle).to_h
+            }
           end
         end
       end
@@ -1695,51 +1764,15 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
           CHART
         end
 
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [wp1, wp2, wp3]
           end
-          let(:journal_notice) do
-            "**Working days** changed (#{non_working_days.map { |day| "#{day} is now non-working" }.join(', ')})."
-          end
-        end
-      end
-
-      context 'when having a non english default language', with_settings: { default_language: :fr } do
-        let_schedule(<<~CHART)
-          days          | fssMTWTFSS |
-          work_package  | X▓▓XX   ░░ |
-        CHART
-
-        let(:non_working_days) do
-          [monday.next_occurring(:saturday), next_monday.next_occurring(:saturday)]
-        end
-        let!(:previous_non_working_days) { week_with_saturday_and_sunday_as_non_working_day }
-
-        before do
-          # Make 'saturday' a working day
-          set_working_days(*non_working_days)
-          set_working_week_days('saturday')
-        end
-
-        # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
-          let(:changed_work_packages) do
-            [work_package]
-          end
-          let(:journal_notice) do
-            I18n.with_locale(:fr) do
-              I18n.t(:'working_days.journal_note.changed',
-                     changes: (
-                       [
-                         I18n.t(:'working_days.journal_note.days.working',
-                                day: I18n.t('date.day_names')[6])
-                       ] +
-                       non_working_days.map do |date|
-                         I18n.t(:'working_days.journal_note.dates.working', date:)
-                       end
-                     ).join(", "))
-            end
+          let(:changed_days) do
+            {
+              "working_days" => {},
+              "non_working_days" => non_working_days.map(&:iso8601).zip([false].cycle).to_h
+            }
           end
         end
       end
@@ -1763,21 +1796,16 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
         end
 
         # Not interested in the scheduling changes in this spec
-        it_behaves_like 'journal updates with note' do
+        it_behaves_like 'journal updates with cause' do
           let(:changed_work_packages) do
             [work_package]
           end
-          let(:journal_notice) do
-            I18n.t(:'working_days.journal_note.changed',
-                   changes: (
-                     [
-                       I18n.t(:'working_days.journal_note.days.working',
-                              day: I18n.t('date.day_names')[0])
-                     ] +
-                     non_working_days.map do |date|
-                       I18n.t(:'working_days.journal_note.dates.working', date:)
-                     end
-                   ).join(", "))
+
+          let(:changed_days) do
+            {
+              "working_days" => { "7" => true },
+              "non_working_days" => non_working_days.map(&:iso8601).zip([true].cycle).to_h
+            }
           end
         end
       end

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe WorkPackages::ApplyWorkingDaysChangeJob do
       subject
 
       changed_work_packages.each do |work_package|
-        # expect(work_package.journals.count).to eq 2
+        expect(work_package.journals.count).to eq 2
         expect(work_package.journals.last.cause_type).to eq('working_days_changed')
         expect(work_package.journals.last.cause_changed_days).to eq(changed_days)
       end


### PR DESCRIPTION
Implements https://community.openproject.org/work_packages/46481

- [x] Add database migration to add the `cause` field
- [x] Add the `store_accessor`s to access JSON fields
- [x] `CreateService`: Add the cause to the SQL query
- [x] `CreateSerivce`: Change logic for aggregation of journals when a cause is involved
- [x] Implement cause for changing Working/NonWorking days 
- [x] Add the cause to the journals when changing data in Scheduling
- [x] Write tests for everything
- [x] Add i18n for displaying the cause types properly
- [x] Add cause to the API representation of journals