### PR TITLE
Fix buggy issues in baseline

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
@@ -10,7 +10,7 @@
   <a
     *ngIf="eeShowBanners"
     [attr.href]="text.moreInfoLink"
-    class="op-baseline--info-button"
+    class="op-baseline--info-button spot-body-small"
     target=”_blank”>
     {{ text.more_info_text }}
     <span class="spot-icon spot-icon_external-link"></span> 

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
@@ -48,7 +48,7 @@
       </select>
 
     </div>
-    <span slot="description">  {{ mappedSelectedDate }} </span>
+    <span slot="description" *ngIf="mappedSelectedDate">  {{ mappedSelectedDate }} </span>
   </spot-form-field>
 
   <spot-form-field

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -42,14 +42,13 @@
     
     &-input
       width: 65%
-      border: 1px solid $spot-color-basic-gray-3
 
     &-help
       display: flex
       align-items: end
       justify-content: center
       background-color: $spot-color-basic-gray-6
-      border: 1px solid $spot-color-basic-gray-3
+      border: 1px solid $spot-color-basic-gray-4
       border-left: none !important
       padding: $spot-spacing-0_5 $spot-spacing-0_25
       line-height: unset

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -28,7 +28,7 @@
   &--body
     flex-shrink: 1
     flex-basis: 100%
-    overflow: hidden
+    overflow: auto
     margin-top: 0 !important
 
     @media screen and #{$spot-mq-drop-modal-in-context}

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -6,7 +6,7 @@
     justify-content: space-between
     align-items: start
     flex-direction: column
-    width: 265px
+    width: 280px
     margin: $spot-spacing-1 $spot-spacing-1 0 $spot-spacing-1
     color: $spot-color-basic-gray-2
 


### PR DESCRIPTION
- [x] Remove extra space at the bottom of inputs when there is no description.
- [x] Change border color of time inputs in baseline modal.
- [x] Make modal body scrollable when the view height is small.
- [x] Chanege 'More information' button font-size.