### PR TITLE
Fix flaky `notification_center_date_alerts_spec`

### DIFF
--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
   # Find an assignable time zone with the same UTC offset as the local time zone
   def find_compatible_local_time_zone
     local_offset = Time.now.gmt_offset # rubocop:disable Rails/TimeZone
-    time_zone = UserPreferences::UpdateContract.assignable_time_zones.find { |tz| tz.utc_offset == local_offset }
-    .tap { p _1 }
+    time_zone = UserPreferences::UpdateContract.assignable_time_zones
+                                               .find { |tz| tz.now.utc_offset == local_offset }
+                                               .tap { p _1 }
     time_zone or raise "Unable to find an assignable time zone with #{local_offset} seconds offset."
   end
 
@@ -36,7 +37,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
     # we need to pretend that the journal records have been created before that time.
     # https://github.com/opf/openproject/pull/11678#issuecomment-1328011996
     #
-    work_package.journals.update_all created_at: Time.zone.now.change(hour: 0, minute: 0)
+    work_package.journals.update_all created_at: time_zone.now.change(hour: 0, minute: 0)
     work_package
   end
 


### PR DESCRIPTION
There are situations where a false assignable time_zone match would occur if
comparing `tz.utc_offset` to `local_offset` since the `utc_offset` stored in
the TZInfo object indeed matched the local_offset but when later utilizing the
returned `time_zone` object by calling `time_zone.now`, `ActiveSupport::TimeZone`
would perform a DST adjusment and potentially shift `time_zone.now` into a different
time/date than `Time.zone.now`.

Example from CI: Host is set to UTC time zone with a +0 offset. The `find_compatible_time_zone`
method would pick `London` since on paper, the offset was also +0; however, when using
`time_zone.now` the offset became +1 given the automatic Daylight Savings Time adjustment
since London does following DST. If UTC time was 23:XX, then the spec would fail.

This failed CI run demonstrates the issue/example above: https://github.com/opf/openproject/actions/runs/5182740870/jobs/9339858330