### PR TITLE
fix rubocop warnings on startup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ require:
   - rubocop-rspec
   - ./lib_static/rubocop/cop/open_project/no_do_end_block_with_rspec_capybara_matcher_in_expect.rb
   - ./lib_static/rubocop/cop/open_project/use_service_result_factory_methods.rb
+  - rubocop-capybara
+  - rubocop-factory_bot
 
 inherit_mode:
   merge:
@@ -15,6 +17,9 @@ AllCops:
   NewCops: enable
   Exclude:
     - '**/node_modules/**/*'
+
+FactoryBot/SyntaxMethods:
+  Enabled: true
 
 Gemspec/RequiredRubyVersion:
   Exclude:
@@ -232,9 +237,6 @@ RSpec/ContextWording:
     - when
     - with
     - without
-
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: true
 
 Style/Alias:
   Enabled: false


### PR DESCRIPTION
* fixes the FactoryBot namespace
* explicitly requires rubocop-capybara and rubocop-factory_bot which should be used implictly already

```
Lefthook v1.4.1
RUNNING HOOK: pre-commit
eslint: (skip) no files for inspection

  EXECUTE > rubocop
.rubocop.yml: RSpec/FactoryBot/SyntaxMethods has the wrong namespace - should be FactoryBot
Inspecting 1 file
.

1 file inspected, no offenses detected

The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara
  * rubocop-factory_bot

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

Becomes   

```
Lefthook v1.4.1
RUNNING HOOK: pre-commit
eslint: (skip) no files for inspection

  EXECUTE > rubocop
Inspecting 1 file
.

1 file inspected, no offenses detected
``` 