### PR TITLE
[#48422] File picker breaks on project folders with octothorpe

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/file_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/file_query.rb
@@ -102,6 +102,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
                                                  file_info_data.dav_permissions)
       ServiceResult.success(result: storage_file)
     end
+
     # rubocop:enable Metrics/AbcSize
 
     def location(files_path)
@@ -111,7 +112,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
 
       idx += prefix.length - 1
 
-      files_path[idx..]
+      Util.escape_path(files_path[idx..])
     end
   end
 end


### PR DESCRIPTION
- https://community.openproject.org/work_packages/48422
- added escaped path to file query output

Known issues:
- when we get url safe paths back from nextcloud API, escaped sequences are lower case (e.g. `Fôlder` turns to `F%c3%b4lder`), while our own escaping sequence uses upper case characters (i.e. `Fôlder` turns to `F%C3%B4lder`)
- this breaks the first requests caching in frontend
  - first request to `/files` endpoint is done with parent value from us
  - breadcrumbs are created with data from nextcloud response
  - succeeding requests to `/files` are done with parent value from nextcloud
  - this leeds to the project folder loaded a second time without caching, as the cache key does not match