### PR TITLE
Restore some authentication settings in admin

### DIFF
--- a/app/components/settings/text_setting_component.html.erb
+++ b/app/components/settings/text_setting_component.html.erb
@@ -62,6 +62,7 @@ See COPYRIGHT and LICENSE files for more details.
       styled_text_area_tag(
         "settings[#{name}][#{current_language.to_s}]",
         Setting.send(name)[current_language.to_s],
+        disabled: !Setting.send(:"#{name}_writable?"),
         label: false,
         id: "settings-#{name}",
         class: 'wiki-edit',

--- a/app/models/permitted_params/allowed_settings.rb
+++ b/app/models/permitted_params/allowed_settings.rb
@@ -23,9 +23,7 @@ class PermittedParams
       keys = Settings::Definition.all.keys
 
       restrictions.select(&:applicable?).each do |restriction|
-        restricted_keys = restriction.restricted_keys
-
-        keys.delete_if { |key| restricted_keys.include? key }
+        keys -= restriction.restricted_keys
       end
 
       keys
@@ -56,7 +54,7 @@ class PermittedParams
 
       add_restriction!(
         keys: %i(registration_footer),
-        condition: -> { OpenProject::Configuration.registration_footer.present? }
+        condition: -> { !Setting.registration_footer_writable? }
       )
     end
 

--- a/app/views/admin/settings/authentication_settings/show.html.erb
+++ b/app/views/admin/settings/authentication_settings/show.html.erb
@@ -46,18 +46,16 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="form--field">
         <%= setting_check_box :email_login, title: I18n.t("tooltip.setting_email_login") %>
       </div>
+
+      <%= render Settings::NumericSettingComponent.new("invitation_expiration_days", unit: "days") %>
     </fieldset>
 
-    <% if OpenProject::Configuration.registration_footer.blank? %>
-      <%= render Settings::NumericSettingComponent.new("invitation_expiration_days", unit: "days") %>
-
-      <fieldset class="form--fieldset">
-        <fieldset id="registration_footer" class="form--fieldset">
-          <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
-          <%= render Settings::TextSettingComponent.new(I18n.locale, name: "registration_footer") %>
-        </fieldset>
+    <fieldset class="form--fieldset">
+      <fieldset id="registration_footer" class="form--fieldset">
+        <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
+        <%= render Settings::TextSettingComponent.new(I18n.locale, name: "registration_footer") %>
       </fieldset>
-    <% end %>
+    </fieldset>
 
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= I18n.t(:passwords, scope: [:settings]) %></legend>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -730,8 +730,7 @@ module Settings
       registration_footer: {
         default: {
           'en' => ''
-        },
-        writable: false
+        }
       },
       remote_storage_upload_host: {
         format: :string,

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -73,6 +73,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   public initialContent:string;
 
+  public readOnly = false;
+
   public resource?:HalResource;
 
   public context:ICKEditorContext;
@@ -120,6 +122,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
       .removeAttr('required')
       .hide();
     this.initialContent = this.wrappedTextArea.val() as string;
+    this.readOnly = !!this.wrappedTextArea.attr('disabled');
 
     this.$attachmentsElement = this.formElement.find('#attachments_fields');
     this.context = {
@@ -127,7 +130,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
       resource: this.resource,
       previewContext: this.previewContext,
     };
-    if (!this.macros) {
+    if (!this.macros || this.readOnly) {
       this.context.macros = 'none';
     }
   }
@@ -145,6 +148,9 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     // Have a hacky way to access the editor from outside of angular.
     // This is e.g. employed to set the text from outside to reuse the same editor for different languages.
     this.$element.data('editor', editor);
+    if (this.readOnly) {
+      editor.enableReadOnlyMode('wrapped-text-area-disabled');
+    }
 
     if (this.resource && this.resource.attachments) {
       this.setupAttachmentAddedCallback(editor);

--- a/spec/controllers/admin/settings/authentication_controller_spec.rb
+++ b/spec/controllers/admin/settings/authentication_controller_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Admin::Settings::AuthenticationSettingsController do
   describe 'PATCH #update' do
     render_views
 
-    current_user { create(:admin) }
+    shared_let(:admin) { create(:admin) }
+    current_user { admin }
 
     describe 'registration_footer' do
       let(:old_settings) do
@@ -61,17 +62,9 @@ RSpec.describe Admin::Settings::AuthenticationSettingsController do
         }
       end
 
-      around do |example|
-        original_settings = {}
+      before do
         old_settings.each_key do |key|
-          original_settings[key] = Setting[key]
           Setting[key] = old_settings[key]
-        end
-        example.run
-      ensure
-        # restore settings
-        old_settings.each_key do |key|
-          Setting[key] = original_settings[key]
         end
       end
 

--- a/spec/controllers/admin/settings/authentication_controller_spec.rb
+++ b/spec/controllers/admin/settings/authentication_controller_spec.rb
@@ -36,4 +36,73 @@ RSpec.describe Admin::Settings::AuthenticationSettingsController do
 
     it_behaves_like 'a controller action with require_admin'
   end
+
+  describe 'PATCH #update' do
+    render_views
+
+    current_user { create(:admin) }
+
+    describe 'registration_footer' do
+      let(:old_settings) do
+        {
+          registration_footer: {
+            'de' => 'Old German registration footer',
+            'en' => 'Old English registration footer'
+          }
+        }
+      end
+
+      let(:new_settings) do
+        {
+          registration_footer: {
+            'de' => 'New German registration footer',
+            'en' => 'New English registration footer'
+          }
+        }
+      end
+
+      around do |example|
+        original_settings = {}
+        old_settings.each_key do |key|
+          original_settings[key] = Setting[key]
+          Setting[key] = old_settings[key]
+        end
+        example.run
+      ensure
+        # restore settings
+        old_settings.each_key do |key|
+          Setting[key] = original_settings[key]
+        end
+      end
+
+      describe 'when writable' do
+        before do
+          patch 'update', params: { settings: new_settings }
+        end
+
+        it 'is successful' do
+          expect(response).to redirect_to(admin_settings_authentication_path)
+        end
+
+        it 'changes the registration_footer' do
+          expect(Setting.registration_footer).to eq new_settings[:registration_footer]
+        end
+      end
+
+      describe 'when non-writable (set via env var)' do
+        before do
+          allow(Setting).to receive(:registration_footer_writable?).and_return(false)
+          patch 'update', params: { settings: new_settings }
+        end
+
+        it 'is successful' do
+          expect(response).to redirect_to(admin_settings_authentication_path)
+        end
+
+        it 'does not change the registration_footer' do
+          expect(Setting.registration_footer).to eq old_settings[:registration_footer]
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/settings/authentication_controller_spec.rb
+++ b/spec/controllers/admin/settings/authentication_controller_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe Admin::Settings::AuthenticationSettingsController do
   end
 
   describe 'PATCH #update' do
-    render_views
-
     shared_let(:admin) { create(:admin) }
     current_user { admin }
 

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -734,7 +734,7 @@ RSpec.describe PermittedParams do
       it_behaves_like 'allows params'
     end
 
-    describe 'with password login disabld' do
+    describe 'with password login disabled' do
       include_context 'prepare params comparison'
 
       before do
@@ -765,11 +765,11 @@ RSpec.describe PermittedParams do
       it { expect(subject).to eq(permitted_hash) }
     end
 
-    describe 'with no registration footer configured' do
+    describe 'with writable registration footer' do
       before do
-        allow(OpenProject::Configuration)
-          .to receive(:registration_footer)
-                .and_return({})
+        allow(Setting)
+          .to receive(:registration_footer_writable?)
+                .and_return(true)
       end
 
       let(:hash) do
@@ -783,13 +783,13 @@ RSpec.describe PermittedParams do
       it_behaves_like 'allows params'
     end
 
-    describe 'with a registration footer configured' do
+    describe 'with a non-writable registration footer (set via env var or config file)' do
       include_context 'prepare params comparison'
 
       before do
-        allow(OpenProject::Configuration)
-          .to receive(:registration_footer)
-                .and_return("en" => "configured footer")
+        allow(Setting)
+          .to receive(:registration_footer_writable?)
+                .and_return(false)
       end
 
       let(:hash) do
@@ -800,11 +800,11 @@ RSpec.describe PermittedParams do
         }
       end
 
-      let(:permitted_hash) do
+      let(:expected_permitted_hash) do
         {}
       end
 
-      it { expect(subject).to eq(permitted_hash) }
+      it { expect(subject).to eq(expected_permitted_hash) }
     end
   end
 

--- a/spec/views/admin/settings/authentication/show.html.erb_spec.rb
+++ b/spec/views/admin/settings/authentication/show.html.erb_spec.rb
@@ -58,29 +58,4 @@ RSpec.describe 'admin/settings/authentication_settings/show' do
       expect(rendered).not_to have_text I18n.t('settings.brute_force_prevention')
     end
   end
-
-  context 'with no registration_footer configured' do
-    before do
-      allow(OpenProject::Configuration).to receive(:registration_footer).and_return({})
-      render
-    end
-
-    it 'shows the registration footer textfield' do
-      expect(rendered).to have_text I18n.t(:setting_registration_footer)
-    end
-  end
-
-  context 'with registration_footer configured' do
-    before do
-      allow(OpenProject::Configuration)
-        .to receive(:registration_footer)
-        .and_return("en" => "You approve.")
-
-      render
-    end
-
-    it 'does not show the registration footer textfield' do
-      expect(rendered).not_to have_text I18n.t(:setting_registration_footer)
-    end
-  end
 end


### PR DESCRIPTION
Also makes ckEditorAugmentedTextarea read-only if the wrapped text area is disabled.

As for the invitation_expiration_days setting, commit 269f9416ddc and commit 286d862c38 got intertwined with merge commit eb63698a3dd, and resulted in hiding the setting when
`OpenProject::Configuration.registration_footer` is set.

As for the registration_footer setting, PR #6321 intent was to prevent modifying it if it was already set via env var or configuration file. When `OpenProject::Configuration` and `Settings` were merged, this code was not updated. With the default value being non-blank, it lead to hiding the setting from the administration pages.

This commit restores both settings.