### PR TITLE
[#41275] Perform default language reset on saving language settings

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -74,13 +74,6 @@ class AdminController < ApplicationController
     redirect_to admin_settings_mail_notifications_path
   end
 
-  def force_user_language
-    User.where.not(language: Setting.available_languages)
-        .update_all(language: Setting.default_language)
-
-    redirect_to admin_settings_languages_path
-  end
-
   def info
     @db_version = OpenProject::Database.version
     @checklist = [

--- a/app/services/settings/language_update_service.rb
+++ b/app/services/settings/language_update_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+class Settings::LanguageUpdateService < Settings::UpdateService
+  def after_perform(call)
+    force_user_language
+
+    call
+  end
+
+  private
+
+  def force_user_language
+    User.where.not(language: Setting.available_languages)
+        .update_all(language: Setting.default_language)
+  end
+end

--- a/app/services/settings/language_update_service.rb
+++ b/app/services/settings/language_update_service.rb
@@ -31,14 +31,14 @@
 
 class Settings::LanguageUpdateService < Settings::UpdateService
   def after_perform(call)
-    force_user_language
+    force_users_to_use_only_available_languages
 
     call
   end
 
   private
 
-  def force_user_language
+  def force_users_to_use_only_available_languages
     User.where.not(language: Setting.available_languages)
         .update_all(language: Setting.default_language)
   end

--- a/app/views/admin/settings/languages_settings/show.html.erb
+++ b/app/views/admin/settings/languages_settings/show.html.erb
@@ -67,9 +67,3 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>
-
-<div style="float:right">
-  <%= link_to t(:label_force_user_language_to_default),
-              { controller: '/admin', action: 'force_user_language' },
-              method: :post %>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,7 +325,6 @@ OpenProject::Application.routes.draw do
     collection do
       get :plugins
       get :info
-      post :force_user_language
       post :test_email
     end
   end

--- a/spec/controllers/admin/settings/languages_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/languages_settings_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require 'spec_helper'
+
+RSpec.describe Admin::Settings::LanguagesSettingsController do
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  describe 'GET #show' do
+    subject { get 'show' }
+
+    describe 'permissions' do
+      let(:fetch) { subject }
+
+      it_behaves_like 'a controller action with require_admin'
+    end
+
+    it 'renders the language settings template' do
+      subject
+
+      expect(response).to be_successful
+      expect(response).to render_template 'admin/settings/languages_settings/show', 'layouts/admin'
+    end
+  end
+
+  describe 'PATCH #update' do
+    subject { patch 'update', params: }
+
+    let(:available_languages) { %w[en fr de] }
+    let(:start_of_week) { 1 }
+    let(:first_week_of_year) { 1 }
+    let(:date_format) { Settings::Definition[:date_format].allowed.first }
+    let(:time_format) { Settings::Definition[:time_format].allowed.first }
+    let(:base_settings) do
+      { available_languages:, start_of_week:, first_week_of_year:, date_format:, time_format: }
+    end
+    let(:params) { { settings: } }
+
+    context 'with valid params' do
+      let(:settings) { base_settings }
+
+      it 'succeeds' do
+        subject
+
+        expect(response).to redirect_to action: :show
+        expect(flash[:notice]).to eq I18n.t(:notice_successful_update)
+      end
+
+      it 'sets language of users having a non-available language to the default language',
+         with_settings: { available_languages: %w[en de ja], default_language: 'de' } do
+        user_de = create(:user, language: 'de')
+        user_en = create(:user, language: 'en')
+        user_foo = create(:user, language: 'foo')
+        user_fr = create(:user, language: 'fr')
+        user_ja = create(:user, language: 'ja')
+
+        subject
+
+        expect(user_de.reload.language).to eq('de')
+        expect(user_en.reload.language).to eq('en')
+        expect(user_foo.reload.language).to eq('de')
+        expect(user_fr.reload.language).to eq('de')
+        expect(user_ja.reload.language).to eq('ja')
+      end
+    end
+
+    shared_examples 'invalid combination of start_of_week and first_week_of_year' do |missing_param:|
+      provided_param = (%i[start_of_week first_week_of_year] - [missing_param]).first
+
+      context "when setting only #{provided_param} but not #{missing_param}" do
+        let(:settings) { base_settings.except(missing_param) }
+
+        it 'redirects and sets the flash error' do
+          subject
+
+          expect(response).to redirect_to action: :show
+          expect(flash[:error])
+            .to eq(I18n.t('settings.display.first_date_of_week_and_year_set',
+                          first_week_setting_name: I18n.t(:setting_first_week_of_year),
+                          day_of_week_setting_name: I18n.t(:setting_start_of_week)))
+        end
+      end
+    end
+
+    include_examples 'invalid combination of start_of_week and first_week_of_year', missing_param: :first_week_of_year
+    include_examples 'invalid combination of start_of_week and first_week_of_year', missing_param: :start_of_week
+  end
+end

--- a/spec/controllers/admin/settings/projects_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/projects_settings_controller_spec.rb
@@ -29,26 +29,17 @@
 require 'spec_helper'
 
 RSpec.describe Admin::Settings::ProjectsSettingsController do
-  before do
-    allow(@controller).to receive(:set_localization)
-    @params = {}
+  shared_let(:user) { create(:admin) }
+  current_user { user }
 
-    @user = create(:admin)
-    allow(User).to receive(:current).and_return @user
+  before do
+    allow(controller).to receive(:set_localization)
   end
 
-  describe 'show' do
+  describe 'GET #show' do
     render_views
 
-    context 'default project modules' do
-      before do
-        @previous_projects_modules = Setting.default_projects_modules
-      end
-
-      after do
-        Setting.default_projects_modules = @previous_projects_modules
-      end
-
+    describe 'default project modules' do
       it 'contains a check box for the activity module on the projects tab' do
         get 'show', params: { tab: 'projects' }
 
@@ -57,15 +48,7 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
         expect(response.body).to have_selector "input[@name='settings[default_projects_modules][]'][@value='activity']"
       end
 
-      it 'contains a check box for the activity module on the projects tab' do
-        get 'show', params: { tab: 'projects' }
-
-        expect(response).to be_successful
-        expect(response).to render_template 'admin/settings/projects_settings/show'
-        expect(response.body).to have_selector "input[@name='settings[default_projects_modules][]'][@value='activity']"
-      end
-
-      describe 'without activated activity module' do
+      context 'without activated activity module' do
         before do
           Setting.default_projects_modules = %w[wiki]
         end
@@ -80,9 +63,9 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
         end
       end
 
-      describe 'with activity in Setting.default_projects_modules' do
+      context 'with activity in Setting.default_projects_modules' do
         before do
-          Setting.default_projects_modules = %w[activity wiki]
+          Setting.default_projects_modules = %w[activity]
         end
 
         it 'contains a checked checkbox for activity' do
@@ -97,18 +80,10 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
     end
   end
 
-  describe 'update' do
+  describe 'PATCH #update' do
     render_views
 
-    context 'default project modules' do
-      before do
-        @previous_projects_modules = Setting.default_projects_modules
-      end
-
-      after do
-        Setting.default_projects_modules = @previous_projects_modules
-      end
-
+    describe 'default project modules' do
       it 'does not store the activity in the default_projects_modules if unchecked' do
         patch 'update',
               params: {
@@ -141,17 +116,6 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
     end
 
     describe 'password settings' do
-      let(:old_settings) do
-        {
-          password_min_length: 10,
-          password_active_rules: [],
-          password_min_adhered_rules: 0,
-          password_days_valid: 365,
-          password_count_former_banned: 2,
-          lost_password: true
-        }
-      end
-
       let(:new_settings) do
         {
           password_min_length: 42,
@@ -163,26 +127,22 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
         }
       end
 
-      let(:original_settings) { Hash.new }
-
       before do
-        old_settings.keys.each do |key|
-          original_settings[key] = Setting[key]
-        end
+        old_settings = {
+          password_min_length: 10,
+          password_active_rules: [],
+          password_min_adhered_rules: 0,
+          password_days_valid: 365,
+          password_count_former_banned: 2,
+          lost_password: true
+        }
 
-        old_settings.keys.each do |key|
-          Setting[key] = old_settings[key]
-        end
-      end
-
-      after do
-        # restore settings
-        old_settings.keys.each do |key|
-          Setting[key] = original_settings[key]
+        old_settings.each do |key, value|
+          Setting[key] = value
         end
       end
 
-      describe 'PATCH #update with password login enabled' do
+      context 'with password login enabled' do
         before do
           allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
 
@@ -198,7 +158,7 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
         end
 
         it 'sets the active character classes to lowercase and uppercase' do
-          expect(Setting[:password_active_rules]).to eq ['uppercase', 'lowercase']
+          expect(Setting[:password_active_rules]).to eq %w[uppercase lowercase]
         end
 
         it 'sets the required number of classes to 7' do
@@ -218,7 +178,7 @@ RSpec.describe Admin::Settings::ProjectsSettingsController do
         end
       end
 
-      describe 'PATCH #update with password login disabled' do
+      describe 'with password login disabled' do
         before do
           allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(true)
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -126,30 +126,4 @@ RSpec.describe AdminController do
       expect(response).to render_template 'info'
     end
   end
-
-  describe 'POST #force_user_language' do
-    it 'sets language of users having a non-available language to the default language' do
-      Setting.available_languages = %w[en de ja]
-      Setting.default_language = 'de'
-      user_de = create(:user, language: 'de')
-      user_en = create(:user, language: 'en')
-      user_foo = create(:user, language: 'foo')
-      user_fr = create(:user, language: 'fr')
-      user_ja = create(:user, language: 'ja')
-
-      post :force_user_language
-
-      expect(user_de.reload.language).to eq('de')
-      expect(user_en.reload.language).to eq('en')
-      expect(user_foo.reload.language).to eq('de')
-      expect(user_fr.reload.language).to eq('de')
-      expect(user_ja.reload.language).to eq('ja')
-    end
-
-    it 'redirects to the language settings page' do
-      post :force_user_language
-
-      expect(response).to redirect_to(admin_settings_languages_path)
-    end
-  end
 end

--- a/spec/routing/admin_spec.rb
+++ b/spec/routing/admin_spec.rb
@@ -49,11 +49,6 @@ RSpec.describe 'admin routes' do
       .to route_to('admin#info')
   end
 
-  it 'connects POST /admin/force_user_language to admin#force_user_language' do
-    expect(post('/admin/force_user_language'))
-      .to route_to('admin#force_user_language')
-  end
-
   it 'connects POST /admin/test_email to admin#test_email' do
     expect(post('/admin/test_email'))
       .to route_to('admin#test_email')

--- a/spec/routing/language_settings_routing_spec.rb
+++ b/spec/routing/language_settings_routing_spec.rb
@@ -1,6 +1,8 @@
-#-- copyright
+# frozen_string_literal: true
+
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) 2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,39 +26,21 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
+#
 
-module Admin::Settings
-  class LanguagesSettingsController < ::Admin::SettingsController
-    menu_item :settings_languages
-    # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :validate_start_of_week_and_first_week_of_year_combination, only: :update
-    # rubocop:enable Rails/LexicallyScopedActionFilter
+require 'spec_helper'
 
-    def default_breadcrumb
-      t(:label_languages)
-    end
+RSpec.describe 'Language Settings routes' do
+  it do
+    expect(get('/admin/settings/languages'))
+      .to route_to(controller: 'admin/settings/languages_settings',
+                   action: 'show')
+  end
 
-    protected
-
-    def update_service
-      ::Settings::LanguageUpdateService
-    end
-
-    private
-
-    def validate_start_of_week_and_first_week_of_year_combination
-      start_of_week = settings_params[:start_of_week]
-      start_of_year = settings_params[:first_week_of_year]
-
-      if start_of_week.present? ^ start_of_year.present?
-        flash[:error] = I18n.t(
-          'settings.display.first_date_of_week_and_year_set',
-          first_week_setting_name: I18n.t(:setting_first_week_of_year),
-          day_of_week_setting_name: I18n.t(:setting_start_of_week)
-        )
-        redirect_to action: :show
-      end
-    end
+  it do
+    expect(patch('/admin/settings/languages'))
+      .to route_to(controller: 'admin/settings/languages_settings',
+                   action: 'update')
   end
 end

--- a/spec/services/settings/language_update_service_spec.rb
+++ b/spec/services/settings/language_update_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require 'spec_helper'
+require_relative 'shared/shared_call_examples'
+require_relative 'shared/shared_setup_context'
+
+RSpec.describe Settings::LanguageUpdateService do
+  include_context 'with update service setup'
+
+  before do
+    # stub forcing default language
+    allow(instance)
+      .to receive(:force_user_language)
+  end
+
+  describe '#call' do
+    subject { instance.call(params) }
+
+    include_examples 'successful call'
+
+    it 'sets language of users having a non-available language to the default language' do
+      subject
+
+      expect(instance)
+        .to have_received(:force_user_language)
+    end
+
+    context 'when the contract is not successfully validated' do
+      let(:contract_success) { false }
+
+      include_examples 'unsuccessful call'
+    end
+  end
+end

--- a/spec/services/settings/shared/shared_setup_context.rb
+++ b/spec/services/settings/shared/shared_setup_context.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require 'spec_helper'
+
+RSpec.shared_context 'with update service setup' do
+  let(:instance) do
+    described_class.new(user:)
+  end
+  let(:user) { build_stubbed(:user) }
+  let(:contract) do
+    instance_double(Settings::UpdateContract,
+                    validate: contract_success,
+                    errors: instance_double(ActiveModel::Error))
+  end
+  let(:contract_success) { true }
+  let(:setting_definition) do
+    instance_double(Settings::Definition)
+  end
+  let(:setting_name) { :a_setting_name }
+  let(:new_setting_value) { 'a_new_setting_value' }
+  let(:previous_setting_value) { 'the_previous_setting_value' }
+  let(:params) { { setting_name => new_setting_value } }
+
+  before do
+    # stub a setting definition
+    allow(Settings::Definition)
+      .to receive(:[])
+            .and_call_original
+    allow(Settings::Definition)
+      .to receive(:[])
+            .with(setting_name)
+            .and_return(setting_definition)
+    allow(Setting)
+      .to receive(:[])
+            .and_call_original
+    allow(Setting)
+      .to receive(:[]).with(setting_name)
+                      .and_return(previous_setting_value)
+    allow(Setting)
+      .to receive(:[]=)
+
+    # stub contract
+    allow(Settings::UpdateContract)
+      .to receive(:new)
+            .and_return(contract)
+  end
+end

--- a/spec/services/settings/update_service_spec.rb
+++ b/spec/services/settings/update_service_spec.rb
@@ -26,53 +26,11 @@
 
 require 'spec_helper'
 require_relative 'shared/shared_call_examples'
+require_relative 'shared/shared_setup_context'
+
 
 RSpec.describe Settings::UpdateService do
-  let(:instance) do
-    described_class.new(user:)
-  end
-  let(:user) { build_stubbed(:user) }
-  let(:contract) do
-    instance_double(Settings::UpdateContract,
-                    validate: contract_success,
-                    errors: instance_double(ActiveModel::Error))
-  end
-  let(:contract_success) { true }
-  let(:setting_definition) do
-    instance_double(Settings::Definition)
-  end
-  let(:definition_on_change) do
-    instance_double(Proc,
-                    call: nil)
-  end
-  let(:setting_name) { :a_setting_name }
-  let(:new_setting_value) { 'a_new_setting_value' }
-  let(:previous_setting_value) { 'the_previous_setting_value' }
-  let(:params) { { setting_name => new_setting_value } }
-
-  before do
-    # stub a setting definition
-    allow(Settings::Definition)
-      .to receive(:[])
-            .and_call_original
-    allow(Settings::Definition)
-      .to receive(:[])
-            .with(setting_name)
-            .and_return(setting_definition)
-    allow(Setting)
-      .to receive(:[])
-          .and_call_original
-    allow(Setting)
-      .to receive(:[]).with(setting_name)
-          .and_return(previous_setting_value)
-    allow(Setting)
-      .to receive(:[]=)
-
-    # stub contract
-    allow(Settings::UpdateContract)
-      .to receive(:new)
-          .and_return(contract)
-  end
+  include_context 'with update service setup'
 
   describe '#call' do
     subject { instance.call(params) }


### PR DESCRIPTION
See: https://community.openproject.org/work_packages/41275

Saving language settings should automatically reset the language of users with a non-available language
to the default language, and the obscure link in the bottom right corner to perform the language reset
manually will no longer be needed.