### PR TITLE
Reduce flakiness on `mobile_date_filter_spec`

### DIFF
--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe 'mobile date filter work packages', js: true do
       end_field.set Date.current.strftime('%m/%d/%Y')
 
       loading_indicator_saveguard
+
+      wp_cards.expect_work_package_count 1
       wp_cards.expect_work_package_listed work_package_with_due_date
       wp_cards.expect_work_package_not_listed work_package_without_due_date
 
@@ -86,6 +88,8 @@ RSpec.describe 'mobile date filter work packages', js: true do
       date_field.set Date.current.strftime('%m/%d/%Y')
 
       loading_indicator_saveguard
+
+      wp_cards.expect_work_package_count 1
       wp_cards.expect_work_package_listed work_package_with_due_date
       wp_cards.expect_work_package_not_listed work_package_without_due_date
 

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -36,6 +36,10 @@ module Pages
       super()
     end
 
+    def expect_work_package_count(count)
+      expect(page).to have_selector('wp-single-card', count:, wait: 20)
+    end
+
     def expect_work_package_listed(*work_packages)
       work_packages.each do |wp|
         expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp.id}']", wait: 10)


### PR DESCRIPTION
By asserting the count of the work package cards that should be present first, we can fail-fast and ensure that the following
expectations of which work packages should be present are not time/speed dependent, making them more stable and hopefully reducing flakiness.