### PR TITLE
[#48506] Add `parent` as a supported link property under `attributesByTimestamp`

### DIFF
--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -51,6 +51,7 @@ module API
           priority
           type
           version
+          parent
         ].freeze
 
         SUPPORTED_PROPERTIES = (SUPPORTED_NON_LINK_PROPERTIES + SUPPORTED_LINK_PROPERTIES).freeze
@@ -76,7 +77,7 @@ module API
 
         def rendered_properties
           @rendered_properties ||= begin
-            properties = (changed_properties_as_api_name & SUPPORTED_PROPERTIES) + ['_meta']
+            properties = changed_properties_as_api_name.intersection(SUPPORTED_PROPERTIES) + ['_meta']
 
             if represented.exists_at_timestamp?
               properties + ["links", :self]

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
       priority
       type
       version
+      parent
     ]
   end
 
@@ -61,6 +62,13 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
   let(:type) { build_stubbed(:type) }
   let(:priority) { build_stubbed(:priority) }
   let(:version) { build_stubbed(:version) }
+  let(:parent) do
+    build_stubbed(:work_package).tap do |wp|
+      allow(wp)
+        .to receive(:visible?)
+        .and_return(true)
+    end
+  end
   let(:project) { build_stubbed(:project) }
 
   let(:work_package) do
@@ -73,6 +81,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
                   type:,
                   priority:,
                   version:,
+                  parent:,
                   responsible:).tap do |wp|
       allow(wp)
         .to receive(:respond_to?)
@@ -160,6 +169,10 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'version' => {
             'href' => api_v3_paths.version(version.id),
             'title' => version.name
+          },
+          'parent' => {
+            'href' => api_v3_paths.work_package(parent.id),
+            'title' => parent.subject
           },
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
@@ -346,6 +359,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
     #              "status"=>{"href"=>"/api/v3/statuses/3", "title"=>"status 1"},
     #              "responsible"=>{"href"=>nil},
     #              "assignee"=>{"href"=>"/api/v3/users/68", "title"=>"Bob Bobbit"},
+    #              "parent"=>{"href"=>"/api/v3/work_packages/102"}
     #              "version"=>{"href"=>nil}}
     #            },
     #            {
@@ -399,6 +413,10 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'version' => {
             'href' => api_v3_paths.version(version.id),
             'title' => version.name
+          },
+          'parent' => {
+            'href' => api_v3_paths.work_package(parent.id),
+            'title' => parent.subject
           },
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1390,7 +1390,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
               .at_path("_embedded/attributesByTimestamp/1/_links/self/href")
           end
 
-          it 'has no information about whether the work package matches the query filters at the timestamp' \
+          it 'has no information about whether the work package matches the query filters at the timestamp ' \
              'because there are no filters without a query' do
             expect(subject)
               .not_to have_json_path("_embedded/attributesByTimestamp/0/_meta/matchesFilters")


### PR DESCRIPTION
## Work Package Details
See: https://community.openproject.org/work_packages/48506

## Demo
### Activity
<img width="766" alt="image" src="https://github.com/opf/openproject/assets/61627014/f038d932-5d87-470f-af30-d32cabf924ea">

### Work Package request with timestamp params
`http://localhost:3000/api/v3/work_packages/8?timestamps=2023-06-12T15:29:00-05:00,2023-06-12T15:36:00-05:00,PT0S`

### `attributesByTimestamp` contents
```json
{ 
    "attributesByTimestamp": [
          {
            "_meta": {
              "exists": true,
              "timestamp": "2023-06-12T15:29:00-05:00"
            },
            "_links": {
              "self": {
                "href": "/api/v3/work_packages/8?timestamps=2023-06-12T20%3A29%3A00Z",
                "title": "Setup conference website"
              },
              "parent": {
                "href": "/api/v3/work_packages/2",
                "title": "Organize open source conference"
              }
            }
          },
          {
            "_meta": {
              "exists": true,
              "timestamp": "2023-06-12T15:36:00-05:00"
            },
            "_links": {
              "self": {
                "href": "/api/v3/work_packages/8?timestamps=2023-06-12T20%3A36%3A00Z",
                "title": "Setup conference website"
              },
              "parent": {
                "href": "/api/v3/work_packages/29",
                "title": "Set up navigation concept for website."
              }
            }
          },
          {
            "_meta": {
              "exists": true,
              "timestamp": "PT0S"
            },
            "_links": {
              "self": {
                "href": "/api/v3/work_packages/8",
                "title": "Setup conference website"
              }
            }
          }
    ],
  }
```