### PR TITLE
[#36719] Invalid status saved for work packages when created from a view with status filter

### DIFF
--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -59,17 +59,5 @@ module WorkPackages
       # lock version is initialized by AR itself
       super - ['lock_version']
     end
-
-    def status_exists?
-      super && (!type_exists? || status_exists_in_type?)
-    end
-
-    def type_exists?
-      model.type_id && model.type && !type_inexistent?
-    end
-
-    def status_exists_in_type?
-      model.type.statuses.exists?(model.status_id)
-    end
   end
 end

--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -59,5 +59,17 @@ module WorkPackages
       # lock version is initialized by AR itself
       super - ['lock_version']
     end
+
+    def status_exists?
+      super && (!type_exists? || status_exists_in_type?)
+    end
+
+    def type_exists?
+      model.type_id && model.type && !type_inexistent?
+    end
+
+    def status_exists_in_type?
+      model.type.statuses.exists?(model.status_id)
+    end
   end
 end

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -320,7 +320,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   def reassign_status(available_statuses)
     return if available_statuses.include?(work_package.status) || work_package.status.is_a?(Status::InexistentStatus)
 
-    new_status = available_statuses.detect(&:is_default) || available_statuses.first
+    new_status = available_statuses.detect(&:is_default) || available_statuses.first || Status.default
     work_package.status = new_status if new_status.present?
   end
 

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -168,7 +168,14 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   end
 
   def set_default_status
+    remove_status_if_invalid
     work_package.status ||= Status.default
+  end
+
+  def remove_status_if_invalid
+    if work_package.type && !work_package.type.statuses.exists?(model.status_id)
+      work_package.status = nil
+    end
   end
 
   def set_default_priority

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -168,14 +168,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   end
 
   def set_default_status
-    remove_status_if_invalid
     work_package.status ||= Status.default
-  end
-
-  def remove_status_if_invalid
-    if work_package.type && !work_package.type.statuses.exists?(model.status_id)
-      work_package.status = nil
-    end
   end
 
   def set_default_priority
@@ -334,7 +327,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   def reassign_invalid_status_if_type_changed
     # Checks that the issue can not be moved to a type with the status unchanged
     # and the target type does not have this status
-    if work_package.type_id_changed? && !work_package.status_id_changed?
+    if work_package.type_id_changed?
       reassign_status work_package.type.statuses(include_default: true)
     end
   end

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
@@ -267,11 +267,6 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
             throw new Error('No new work package was created');
           }
 
-          // // We need to apply the defaults again (after them being applied in the form requests)
-          // // here as the initial form requests might have led to some default
-          // // values not being carried over. This can happen when custom fields not available in one type are filter values.
-          // this.defaultsFromFilters(change, defaults);
-
           return change;
         });
       });

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
@@ -267,10 +267,10 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
             throw new Error('No new work package was created');
           }
 
-          // We need to apply the defaults again (after them being applied in the form requests)
-          // here as the initial form requests might have led to some default
-          // values not being carried over. This can happen when custom fields not available in one type are filter values.
-          this.defaultsFromFilters(change, defaults);
+          // // We need to apply the defaults again (after them being applied in the form requests)
+          // // here as the initial form requests might have led to some default
+          // // values not being carried over. This can happen when custom fields not available in one type are filter values.
+          // this.defaultsFromFilters(change, defaults);
 
           return change;
         });

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe WorkPackages::CreateContract do
 
       it 'is not authorized' do
         expect(validated_contract.errors.symbols_for(:base))
-          .to match_array [:error_unauthorized]
+          .to contain_exactly(:error_unauthorized)
       end
     end
 
@@ -99,7 +99,7 @@ RSpec.describe WorkPackages::CreateContract do
 
       it 'is not authorized' do
         expect(validated_contract.errors.symbols_for(:base))
-          .to match_array [:error_unauthorized]
+          .to contain_exactly(:error_unauthorized)
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe WorkPackages::CreateContract do
 
       it 'is not authorized' do
         expect(validated_contract.errors.symbols_for(:base))
-          .to match_array [:error_unauthorized]
+          .to contain_exactly(:error_unauthorized)
       end
     end
   end
@@ -140,7 +140,41 @@ RSpec.describe WorkPackages::CreateContract do
         work_package.author = build_stubbed(:user)
 
         expect(validated_contract.errors.symbols_for(:author_id))
-          .to match_array %i[invalid error_readonly]
+          .to contain_exactly(:invalid, :error_readonly)
+      end
+    end
+  end
+
+  describe 'status' do
+    let(:status) { create(:status) }
+    let(:type) { create(:type) }
+
+    before do
+      work_package.type = type
+      work_package.status = status
+    end
+
+    context 'when a type is not present' do
+      it 'is valid' do
+        work_package.type = nil
+        expect(validated_contract.errors.symbols_for(:status))
+          .to be_empty
+      end
+    end
+
+    context 'when a type is present and the status is not part of it' do
+      it 'is invalid' do
+        expect(validated_contract.errors.symbols_for(:status))
+          .to contain_exactly(:does_not_exist)
+      end
+    end
+
+    context 'when a type is present and the status is part of it' do
+      let!(:workflow) { create(:workflow, type:, old_status: status) }
+
+      it 'is valid' do
+        expect(validated_contract.errors.symbols_for(:status))
+          .to be_empty
       end
     end
   end

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -140,41 +140,7 @@ RSpec.describe WorkPackages::CreateContract do
         work_package.author = build_stubbed(:user)
 
         expect(validated_contract.errors.symbols_for(:author_id))
-          .to contain_exactly(:invalid, :error_readonly)
-      end
-    end
-  end
-
-  describe 'status' do
-    let(:status) { create(:status) }
-    let(:type) { create(:type) }
-
-    before do
-      work_package.type = type
-      work_package.status = status
-    end
-
-    context 'when a type is not present' do
-      it 'is valid' do
-        work_package.type = nil
-        expect(validated_contract.errors.symbols_for(:status))
-          .to be_empty
-      end
-    end
-
-    context 'when a type is present and the status is not part of it' do
-      it 'is invalid' do
-        expect(validated_contract.errors.symbols_for(:status))
-          .to contain_exactly(:does_not_exist)
-      end
-    end
-
-    context 'when a type is present and the status is part of it' do
-      let!(:workflow) { create(:workflow, type:, old_status: status) }
-
-      it 'is valid' do
-        expect(validated_contract.errors.symbols_for(:status))
-          .to be_empty
+          .to match_array %i[invalid error_readonly]
       end
     end
   end

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
   shared_let(:type) { create(:type) }
   shared_let(:type2) { create(:type) }
   shared_let(:status) { create(:default_status) }
-  shared_let(:target_status) { create(:status) }
   shared_let(:priority) { create(:priority) }
   shared_let(:target_priority) { create(:priority) }
   shared_let(:project) do
@@ -358,6 +357,9 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
           let(:start_date) { Date.today }
           let(:due_date) { Date.today + 1 }
           let(:target_version) { create(:version, project: target_project) }
+          let(:target_type) { target_project.types.first }
+          let(:target_status) { create(:status, workflow_for_type: target_type) }
+
           let(:target_user) do
             user = create(:user)
 
@@ -375,7 +377,7 @@ RSpec.describe WorkPackages::MovesController, with_settings: { journal_aggregati
                    ids: [work_package.id, work_package_2.id],
                    copy: '',
                    new_project_id: target_project.id,
-                   new_type_id: target_project.types.first.id, # FIXME see #1868
+                   new_type_id: target_type.id, # FIXME see #1868
                    assigned_to_id: target_user.id,
                    responsible_id: target_user.id,
                    status_id: target_status,

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -43,5 +43,15 @@ FactoryBot.define do
     trait :readonly do
       is_readonly { true }
     end
+
+    transient do
+      workflow_for_type { nil }
+    end
+
+    callback(:after_create) do |status, evaluator|
+      if evaluator.workflow_for_type
+        create(:workflow, type: evaluator.workflow_for_type, old_status: status)
+      end
+    end
   end
 end

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -180,8 +180,7 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
   end
 
   context 'with status filter' do
-    let(:closed_status) { create(:closed_status) }
-    let!(:bug_workflow) { create(:workflow, type: type_bug, old_status: closed_status) }
+    let(:closed_status) { create(:closed_status, workflow_for_type: type_bug) }
     let(:filters) do
       [['status_id', '=', [closed_status.id]]]
     end

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
   let(:type_bug) { create(:type_bug) }
   let(:type_task) { create(:type_task) }
   let(:project) { create(:project, types: [type_task, type_bug]) }
-  let(:status) { create(:default_status) }
 
-  let!(:status) { create(:default_status) }
+  let!(:default_status) { create(:default_status) }
   let!(:priority) { create(:priority, is_default: true) }
 
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
@@ -51,7 +50,7 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
         query.add_filter(*filter)
       end
 
-      query.column_names = ['id', 'subject', 'type', 'assigned_to']
+      query.column_names = ['id', 'subject', 'type', 'assigned_to', 'status']
       query.save!
     end
   end
@@ -177,6 +176,103 @@ RSpec.describe 'Work package create uses attributes from filters', js: true, sel
       expect(wp.subject).to eq 'Split Foobar!'
       expect(wp.assigned_to_id).to eq assignee.id
       expect(wp.type_id).to eq type_bug.id
+    end
+  end
+
+  context 'with status filter' do
+    let(:closed_status) { create(:closed_status) }
+    let!(:bug_workflow) { create(:workflow, type: type_bug, old_status: closed_status) }
+    let(:filters) do
+      [['status_id', '=', [closed_status.id]]]
+    end
+
+    it 'uses the status filter in inline-create and split view' do
+      # When the chosen type ( type_task ) does not have a workflow for the status (closed_status)
+      # of the filter, it uses the default status instead (Regression #36719)
+      wp_table.click_inline_create
+
+      # Expect type set to task
+      type_field = wp_table.edit_field(nil, :type)
+      type_field.expect_state_text type_task.name.upcase
+
+      # Expect status set to status
+      status_field = wp_table.edit_field(nil, :status)
+      status_field.expect_state_text default_status.name
+
+      # Save the WP
+      subject_field = wp_table.edit_field(nil, :subject)
+      subject_field.set_value 'Foobar!'
+      subject_field.submit_by_enter
+
+      wp_table.expect_toast(
+        message: 'Successful creation. Click here to open this work package in fullscreen view.'
+      )
+      wp_table.dismiss_toaster!
+
+      wp = WorkPackage.last
+      expect(wp.subject).to eq 'Foobar!'
+      expect(wp.type_id).to eq type_task.id
+      expect(wp.status_id).to eq default_status.id
+
+      # When the chosen type (type_bug) has a workflow for the status (closed_status)
+      # of the filter, it uses that status
+
+      # Open split view create
+      split_view_create.click_create_wp_button(type_bug)
+
+      subject_field = split_view_create.edit_field :subject
+      subject_field.expect_active!
+      subject_field.set_value 'Split Foobar!'
+
+      # Type field IS NOT synced
+      type_field = split_view_create.edit_field :type
+      type_field.expect_state_text type_bug.name.upcase
+
+      # Status is synced
+      status_field = split_view_create.edit_field :status
+      status_field.expect_display_value(closed_status.name.humanize)
+
+      within '.work-packages--edit-actions' do
+        click_button 'Save'
+      end
+
+      wp_table.expect_toast(message: 'Successful creation.')
+
+      wp = WorkPackage.last
+      expect(wp.subject).to eq 'Split Foobar!'
+      expect(wp.type_id).to eq type_bug.id
+      expect(wp.status_id).to eq closed_status.id
+
+      Pages::SplitWorkPackage.new(wp, project).close
+
+      # When the chosen type (type_task) does not have a workflow for the status (closed_status)
+      # of the filter, it uses the default status instead (Regression #36719)
+
+      # Open split view create
+      split_view_create.click_create_wp_button(type_task)
+
+      subject_field = split_view_create.edit_field :subject
+      subject_field.expect_active!
+      subject_field.set_value 'Split Foobar!'
+
+      # Type field IS NOT synced
+      type_field = split_view_create.edit_field :type
+      type_field.expect_state_text type_task.name.upcase
+
+      # Status is synced
+      status_field = split_view_create.edit_field :status
+      status_field.expect_display_value(default_status.name.humanize)
+
+      within '.work-packages--edit-actions' do
+        click_button 'Save'
+      end
+
+      wp_table.expect_toast(message: 'Successful creation.')
+
+      wp = WorkPackage.last
+      expect(wp.subject).to eq 'Split Foobar!'
+      expect(wp.type_id).to eq type_task.id
+      expect(wp.status_id).to eq default_status.id
     end
   end
 end

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -116,9 +116,7 @@ RSpec.describe 'inline create work package', js: true do
 
         type_field = wp_table.edit_field(nil, :type)
         type_field.activate!
-        sleep(0.1)
-        type_field.openSelectField
-        type_field.set_value cf_type.name
+        type_field.set_select_field_value cf_type.name
 
         wp_table.expect_toast(
           type: :error,

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -539,7 +539,8 @@ RSpec.describe MailHandler do
 
     context 'when sending a mail not as a reply' do
       context 'for a given project' do
-        let!(:status) { create(:status, name: 'Resolved') }
+        let(:type) { project.types.first }
+        let!(:status) { create(:status, name: 'Resolved', workflow_for_type: type) }
         let!(:version) { create(:version, name: 'alpha', project:) }
 
         include_context 'for wp_on_given_project' do
@@ -555,7 +556,7 @@ RSpec.describe MailHandler do
 
         it 'sets the first type in the project' do
           expect(subject.type)
-            .to eql(project.types.first)
+            .to eql(type)
         end
 
         it 'sets the subject' do
@@ -923,7 +924,8 @@ RSpec.describe MailHandler do
       end
 
       context 'for wp with status' do
-        let!(:status) { create(:status, name: 'Resolved') }
+        let(:type) { project.types.first }
+        let!(:status) { create(:status, name: 'Resolved', workflow_for_type: type) }
 
         # This email contains: 'Project: onlinestore' and 'Status: Resolved'
         include_context 'for wp_on_given_project'
@@ -937,7 +939,8 @@ RSpec.describe MailHandler do
       end
 
       context 'for wp with status case insensitive' do
-        let!(:status) { create(:status, name: 'Resolved') }
+        let(:type) { project.types.first }
+        let!(:status) { create(:status, name: 'Resolved', workflow_for_type: type) }
         let!(:priority_low) { create(:priority_low, name: 'Low', is_default: true) }
         let!(:version) { create(:version, name: 'alpha', project:) }
 

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -188,9 +188,8 @@ RSpec.describe WorkPackages::SetAttributesService,
     end
 
     context 'with a valid value that is part of the type.statuses for a new work package' do
-      let(:status) { create(:status) }
       let(:type) { create(:type) }
-      let!(:workflow) { create(:workflow, type:, old_status: status) }
+      let(:status) { create(:status, workflow_for_type: type) }
       let(:call_attributes) { { status:, type: } }
       let(:expected_attributes) { { status:, type: } }
       let(:work_package) { new_work_package }

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -90,6 +90,13 @@ class EditField
     autocomplete_selector.click
   end
 
+  def set_select_field_value(value)
+    retry_block do
+      openSelectField
+      set_value value
+    end
+  end
+
   def expect_state!(open:)
     if open
       expect_active!

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -209,8 +209,12 @@ module Pages
         TextEditorField.new container, key
       # The AbstractWorkPackageCreate pages do not require a special WorkPackageStatusField,
       # because the status field on the create pages is a simple EditField.
-      when :status && !is_a?(AbstractWorkPackageCreate)
-        WorkPackageStatusField.new container
+      when :status
+        if is_a?(AbstractWorkPackageCreate)
+          EditField.new container, key
+        else
+          WorkPackageStatusField.new container
+        end
       else
         EditField.new container, key
       end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -136,7 +136,7 @@ module Pages
       container = '#work-package-activites-container'
       container += " #activity-#{number}" if number
 
-      expect(page).to have_selector(container + ' .op-user-activity--user-line', text: user.name)
+      expect(page).to have_selector("#{container} .op-user-activity--user-line", text: user.name)
     end
 
     def expect_activity_message(message)
@@ -207,7 +207,9 @@ module Pages
         DateEditField.new container, key, is_milestone: work_package&.milestone?
       when :description
         TextEditorField.new container, key
-      when :status
+      # The AbstractWorkPackageCreate pages do not require a special WorkPackageStatusField,
+      # because the status field on the create pages is a simple EditField.
+      when :status && !is_a?(AbstractWorkPackageCreate)
         WorkPackageStatusField.new container
       else
         EditField.new container, key


### PR DESCRIPTION
https://community.openproject.org/work_packages/36719

Additionally the issue is fixed in the table inline work package creation.