### PR TITLE
Fix timestamps allowing all oneDayAgo timestamps

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -438,8 +438,7 @@ class Query < ApplicationRecord
 
   def allowed_timestamps
     return timestamps if EnterpriseToken.allows_to?(:baseline_comparison)
-
-    timestamps.select { |t| t.oneDayAgo? || t.to_time >= Date.yesterday }
+    timestamps.select { |t| t.one_day_ago? || t.to_time >= Date.yesterday }
   end
 
   def valid_filter_subset!

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -439,7 +439,7 @@ class Query < ApplicationRecord
   def allowed_timestamps
     return timestamps if EnterpriseToken.allows_to?(:baseline_comparison)
 
-    timestamps.reject { |t| t.to_time < Date.yesterday }
+    timestamps.select { |t| t.oneDayAgo? || t.to_time >= Date.yesterday }
   end
 
   def valid_filter_subset!

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -128,6 +128,10 @@ class Timestamp
     to_s.match? TimestampParser::DATE_KEYWORD_REGEX
   end
 
+  def oneDayAgo?
+    to_s.start_with? 'oneDayAgo'
+  end
+
   def to_s
     @timestamp_string.to_s
   end

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -128,7 +128,7 @@ class Timestamp
     to_s.match? TimestampParser::DATE_KEYWORD_REGEX
   end
 
-  def oneDayAgo?
+  def one_day_ago?
     to_s.start_with? 'oneDayAgo'
   end
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -146,6 +146,12 @@ RSpec.describe Query,
         it { is_expected.to be_valid }
       end
 
+      context "when the 'oneDayAgo' with a timezone is provided" do
+        let(:timestamps) { ["oneDayAgo@00:00+09:00"] }
+
+        it { is_expected.to be_valid }
+      end
+
       context "when the shortcut value 'now' is provided" do
         let(:timestamps) { ["now"] }
 


### PR DESCRIPTION
Using a `oneDayAgo` timestamp outside EE would fail depending on the timezone used. This PR ensures that any "oneDayAgo" timestamp is valid.

https://community.openproject.org/wp/48566