### PR TITLE
Fix deserialization issue with Settings

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1100,12 +1100,11 @@ module Settings
     end
 
     def override_value(other_value)
-      coerced_value = coerce(other_value)
-      if valid_for?(coerced_value)
-        self.value = coerced_value
+      self.value = coerce(other_value)
+      if valid_for?(value)
         self.writable = false
       else
-        raise ArgumentError, "Value for #{name} must be one of #{allowed.join(', ')} but is #{coerced_value}"
+        raise ArgumentError, "Value for #{name} must be one of #{allowed.join(', ')} but is #{value}"
       end
     end
 

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -154,6 +154,12 @@ RSpec.describe Settings::Definition, :settings_reset do
         expect(all[:rest_api_enabled].value).to be false
       end
 
+      it 'overriding symbol configuration having allowed values from ENV will cast the value before validation check' do
+        stub_const('ENV', { 'OPENPROJECT_RAILS__CACHE__STORE' => 'memcache' })
+        reset(:rails_cache_store)
+        expect(all[:rails_cache_store].value).to eq :memcache
+      end
+
       it 'overriding datetime configuration from ENV will cast the value' do
         stub_const('ENV', { 'OPENPROJECT_CONSENT__TIME' => '2222-01-01' })
         reset(:consent_time)


### PR DESCRIPTION
It was preventing deployments as Setting.rails_cache_store was set via an env variable but failed to validate as the allowed values were symbols and the value was a string. As it was not converted to symbol before the validity check, it was not valid and the application could not start.