### PR TITLE
include schema into attributesByTimestamp

### DIFF
--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -56,6 +56,9 @@ module API
 
         SUPPORTED_PROPERTIES = (SUPPORTED_NON_LINK_PROPERTIES + SUPPORTED_LINK_PROPERTIES).freeze
 
+        STATIC_NON_LINK_PROPERTIES = %w[_meta].freeze
+        STATIC_LINK_PROPERTIES = ['links', :schema, :self].freeze
+
         def initialize(model, current_user:)
           super(model, current_user:, embed_links:, timestamps: [model.timestamp])
         end
@@ -77,10 +80,10 @@ module API
 
         def rendered_properties
           @rendered_properties ||= begin
-            properties = changed_properties_as_api_name.intersection(SUPPORTED_PROPERTIES) + ['_meta']
+            properties = changed_properties_as_api_name.intersection(SUPPORTED_PROPERTIES) + STATIC_NON_LINK_PROPERTIES
 
             if represented.exists_at_timestamp?
-              properties + ["links", :self]
+              properties + STATIC_LINK_PROPERTIES
             else
               properties
             end

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -177,6 +177,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json
@@ -211,6 +214,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json
@@ -238,6 +244,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json
@@ -268,6 +277,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json
@@ -320,6 +332,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json
@@ -344,23 +359,25 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
     #      {
     #        "attributesByTimestamp"=>
     #          [
-    #           # The part rendered by this representer
-    #           {
-    #            "_meta"=>{"exists"=>true, "timestamp"=>"2015-01-01T00:00:00Z", "matchesFilters"=>true},
-    #            "subject"=>"The original work package",
-    #            "startDate"=>nil,
-    #            "dueDate"=>nil,
-    #            "_links"=>
-    #             {"self"=>{"href"=>"/api/v3/work_packages/101?timestamps=2015-01-01T00%3A00%3A00Z",
-    #                       "title"=>"The original work package"},
-    #              "type"=>{"href"=>"/api/v3/types/63", "title"=>"None"},
-    #              "priority"=>{"href"=>"/api/v3/priorities/3", "title"=>"Priority 1"},
-    #              "project"=>{"href"=>"/api/v3/projects/85", "title"=>"My Project No. 2"},
-    #              "status"=>{"href"=>"/api/v3/statuses/3", "title"=>"status 1"},
-    #              "responsible"=>{"href"=>nil},
-    #              "assignee"=>{"href"=>"/api/v3/users/68", "title"=>"Bob Bobbit"},
-    #              "parent"=>{"href"=>"/api/v3/work_packages/102"}
-    #              "version"=>{"href"=>nil}}
+    #            # The part rendered by this representer
+    #            {
+    #             "_meta"=>{"exists"=>true, "timestamp"=>"2015-01-01T00:00:00Z", "matchesFilters"=>true},
+    #             "subject"=>"The original work package",
+    #             "startDate"=>nil,
+    #             "dueDate"=>nil,
+    #             "_links"=> {
+    #                  "self"=>{"href"=>"/api/v3/work_packages/101?timestamps=2015-01-01T00%3A00%3A00Z",
+    #                           "title"=>"The original work package"},
+    #                  "schema"=>{"href"=>"/api/v3/work_packages/schemas/85-63"},
+    #                  "type"=>{"href"=>"/api/v3/types/63", "title"=>"None"},
+    #                  "priority"=>{"href"=>"/api/v3/priorities/3", "title"=>"Priority 1"},
+    #                  "project"=>{"href"=>"/api/v3/projects/85", "title"=>"My Project No. 2"},
+    #                  "status"=>{"href"=>"/api/v3/statuses/3", "title"=>"status 1"},
+    #                  "responsible"=>{"href"=>nil},
+    #                  "assignee"=>{"href"=>"/api/v3/users/68", "title"=>"Bob Bobbit"},
+    #                  "parent"=>{"href"=>"/api/v3/work_packages/102"}
+    #                  "version"=>{"href"=>nil}
+    #               }
     #            },
     #            {
     #              "_meta"=>{"exists"=>false, "timestamp"=>"PT0S", "matchesFilters"=>false}
@@ -421,6 +438,9 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, 'render
           'self' => {
             'href' => api_v3_paths.work_package(work_package.id, timestamps: timestamp),
             'title' => work_package.subject
+          },
+          'schema' => {
+            'href' => api_v3_paths.work_package_schema(work_package.project_id, work_package.type_id)
           }
         }
       }.to_json


### PR DESCRIPTION
Include the reference to the schema valid for each attributeByTimestamp element. This is necessary as the work package schema is changed whenever the project or the type changes which might happen between those elements. 

https://community.openproject.org/wp/48567