### PR TITLE
Fix Appsignal error private method called on Version

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
@@ -76,8 +76,6 @@ module OpenProject::Backlogs::Patches::VersionPatch
 
     delegate :hash, to: :id
 
-    private
-
     def rebuild_positions(scope, type_ids)
       wo_position = scope
                       .where(type_id: type_ids,


### PR DESCRIPTION
Driveby fix for [this AppSignal error](https://appsignal.com/openproject-gmbh/sites/63237334d2a5e463ef717f69/exceptions/incidents/20565/samples/timestamp/2023-06-15T07:43:35Z).