### PR TITLE
Use correctly prefixed warnings

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -4,7 +4,7 @@
   &--header
     display: flex
     justify-content: space-between
-    align-items: start
+    align-items: flex-start
     flex-direction: column
     width: 280px
     margin: $spot-spacing-1 $spot-spacing-1 0 $spot-spacing-1
@@ -45,7 +45,7 @@
 
     &-help
       display: flex
-      align-items: end
+      align-items: flex-end
       justify-content: center
       background-color: $spot-color-basic-gray-6
       border: 1px solid $spot-color-basic-gray-4

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.sass
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.sass
@@ -26,7 +26,7 @@
 
   &--buttons
     display: flex
-    justify-content: end
+    justify-content: flex-end
     align-items: center
 
   &--info-button
@@ -42,4 +42,4 @@
     padding: $spot-spacing-0_5 $spot-spacing-0_5
     cursor: pointer
     display: flex
-    justify-content: end
+    justify-content: flex-end

--- a/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
@@ -15,7 +15,7 @@
     flex-direction: column-reverse
 
     @media (max-width: 680px)
-      justify-content: end
+      justify-content: flex-end
 
     @media (max-height: 480px)
       // reorder elements to be displayed in row on very small heights

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -35,7 +35,7 @@
 
 .widget-box--blocks--upsale-buttons
   display: flex
-  justify-content: end
+  justify-content: flex-end
   align-items: center
 
   .button

--- a/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
@@ -57,7 +57,7 @@
     .button-box
       grid-area: button
       display: flex
-      justify-content: end
+      justify-content: flex-end
 
     &-button
       margin: $spot-spacing-0_75 0 0

--- a/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_relations.sass
@@ -74,7 +74,7 @@
     &-actions
       grid-area: actions
       display: flex
-      justify-content: end
+      justify-content: flex-end
 
     &-id
       @include text-shortener()

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -52,7 +52,7 @@
   // not supported in all browsers
   [class^="__hl_"],
   [class*=" __hl_"]
-    color-adjust: exact
+    print-color-adjust: exact
     -webkit-print-color-adjust: exact
 
   // Sizes from user agent stylesheet


### PR DESCRIPTION
```

./node_modules/@angular-devkit/build-angular/src/tools/babel/webpack-loader.js??ruleSet[1].rules[2].use[0]!./node_modules/source-map-loader/dist/cjs.js??ruleSet[1].rules[3]!./node_modules/dragula/dist/dragula.min.js:11:93-94 - Warning: Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

./src/styles.scss - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(13397:5) from "autoprefixer" plugin: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.

Code:
  color-adjust: exact


./src/styles.scss - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(15846:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  justify-content: end


./src/styles.scss - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(18053:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  justify-content: end


./src/styles.scss - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(18181:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  justify-content: end


./src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass?ngResource - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(14:3) from "autoprefixer" plugin: start value has mixed support, consider using flex-start instead

Code:
  align-items: start


./src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass?ngResource - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(59:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  align-items: end


./src/app/shared/components/enterprise-banner/enterprise-banner.component.sass?ngResource - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(29:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  justify-content: end


./src/app/shared/components/enterprise-banner/enterprise-banner.component.sass?ngResource - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
(45:3) from "autoprefixer" plugin: end value has mixed support, consider using flex-end instead

Code:
  justify-content: end

```