### PR TITLE
mobile_date_filter_spec: Send tab to input to blur the field

### DIFF
--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'mobile date filter work packages', js: true do
 
       start_field.set 1.day.ago.strftime('%m/%d/%Y')
       end_field.set Date.current.strftime('%m/%d/%Y')
+      end_field.send_keys :tab
 
       loading_indicator_saveguard
 


### PR DESCRIPTION
Another attempt at fixing `spec/features/work_packages/table/queries/mobile_date_filter_spec.rb`