### PR TITLE
Implement models instead of hashes as journal changes

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -30,8 +30,6 @@ class Journal < ApplicationRecord
   self.table_name = "journals"
   self.ignored_columns += ["activity_type"]
 
-  WorkingDayUpdate = Struct.new(:working_days, :non_working_days, keyword_init: true)
-
   include ::JournalChanges
   include ::JournalFormatter
   include ::Acts::Journalized::FormatHooks

--- a/app/models/journal/caused_by_progress_mode_changed_to_status_based.rb
+++ b/app/models/journal/caused_by_progress_mode_changed_to_status_based.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+class Journal::CausedByProgressModeChangedToStatusBased < CauseOfChange::Base
+  def initialize
+    super("progress_mode_changed_to_status_based")
+  end
+end

--- a/app/models/journal/caused_by_status_p_complete_changed.rb
+++ b/app/models/journal/caused_by_status_p_complete_changed.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+class Journal::CausedByStatusPCompleteChanged < CauseOfChange::Base
+  def initialize(status_name:, status_id:, status_p_complete_change:)
+    additional = {
+      "status_name" => status_name,
+      "status_id" => status_id,
+      "status_p_complete_change" => status_p_complete_change
+    }
+
+    super("status_p_complete_changed", additional)
+  end
+end

--- a/app/models/journal/caused_by_system_update.rb
+++ b/app/models/journal/caused_by_system_update.rb
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2012-2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,19 +25,12 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
-class AddFileLinkJournalsToExistingContainers < ActiveRecord::Migration[7.0]
-  def up
-    system_user = SystemUser.first
-    containers = Storages::FileLink.includes(:container).map(&:container).uniq.compact
-
-    containers.each do |container|
-      next unless container.class.journaled?
-
-      Journals::CreateService.new(container, system_user)
-                             .call(cause: Jounal::CausedBySystemUpdate.new(feature: 'file_links_journal'))
-    end
+#
+class Journal::CausedBySystemUpdate < CauseOfChange::Base
+  def initialize(feature:)
+    additional = {
+      "feature" => feature
+    }
+    super('system_update', additional)
   end
-
-  def down; end
 end

--- a/app/models/journal/caused_by_system_update.rb
+++ b/app/models/journal/caused_by_system_update.rb
@@ -31,6 +31,6 @@ class Journal::CausedBySystemUpdate < CauseOfChange::Base
     additional = {
       "feature" => feature
     }
-    super('system_update', additional)
+    super("system_update", additional)
   end
 end

--- a/app/models/journal/caused_by_work_package_child_change.rb
+++ b/app/models/journal/caused_by_work_package_child_change.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+class Journal::CausedByWorkPackageChildChange < CauseOfChange::Base
+  def initialize(work_package)
+    additional = {
+      "work_package_id" => work_package.id
+    }
+    super('work_package_children_changed_times', additional)
+  end
+end

--- a/app/models/journal/caused_by_work_package_child_change.rb
+++ b/app/models/journal/caused_by_work_package_child_change.rb
@@ -31,6 +31,6 @@ class Journal::CausedByWorkPackageChildChange < CauseOfChange::Base
     additional = {
       "work_package_id" => work_package.id
     }
-    super('work_package_children_changed_times', additional)
+    super("work_package_children_changed_times", additional)
   end
 end

--- a/app/models/journal/caused_by_work_package_parent_change.rb
+++ b/app/models/journal/caused_by_work_package_parent_change.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Journal::CausedByWorkPackageParentChange < CauseOfChange::Base
+  def initialize(work_package)
+    additional = {
+      "work_package_id" => work_package.id
+    }
+    super('work_package_parent_changed_times', additional)
+  end
+end

--- a/app/models/journal/caused_by_work_package_parent_change.rb
+++ b/app/models/journal/caused_by_work_package_parent_change.rb
@@ -31,6 +31,6 @@ class Journal::CausedByWorkPackageParentChange < CauseOfChange::Base
     additional = {
       "work_package_id" => work_package.id
     }
-    super('work_package_parent_changed_times', additional)
+    super("work_package_parent_changed_times", additional)
   end
 end

--- a/app/models/journal/caused_by_work_package_predecessor_change.rb
+++ b/app/models/journal/caused_by_work_package_predecessor_change.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Journal::CausedByWorkPackagePredecessorChange < CauseOfChange::Base
+  def initialize(work_package)
+    additional = {
+      "work_package_id" => work_package.id
+    }
+    super('work_package_predecessor_changed_times', additional)
+  end
+end

--- a/app/models/journal/caused_by_work_package_predecessor_change.rb
+++ b/app/models/journal/caused_by_work_package_predecessor_change.rb
@@ -31,6 +31,6 @@ class Journal::CausedByWorkPackagePredecessorChange < CauseOfChange::Base
     additional = {
       "work_package_id" => work_package.id
     }
-    super('work_package_predecessor_changed_times', additional)
+    super("work_package_predecessor_changed_times", additional)
   end
 end

--- a/app/models/journal/caused_by_work_package_related_change.rb
+++ b/app/models/journal/caused_by_work_package_related_change.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Journal::CausedByWorkPackageRelatedChange < CauseOfChange::Base
+  def initialize(work_package:)
+    additional = {
+      "work_package_id" => work_package.id
+    }
+    super('work_package_related_changed_times', additional)
+  end
+end

--- a/app/models/journal/caused_by_work_package_related_change.rb
+++ b/app/models/journal/caused_by_work_package_related_change.rb
@@ -31,6 +31,6 @@ class Journal::CausedByWorkPackageRelatedChange < CauseOfChange::Base
     additional = {
       "work_package_id" => work_package.id
     }
-    super('work_package_related_changed_times', additional)
+    super("work_package_related_changed_times", additional)
   end
 end

--- a/app/models/journal/caused_by_working_day_changes.rb
+++ b/app/models/journal/caused_by_working_day_changes.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Journal::CausedByWorkingDayChanges < CauseOfChange::Base
+  def initialize(working_days:, non_working_days:)
+    additional = {
+      "changed_days" => {
+        "working_days" => working_days,
+        "non_working_days" => non_working_days.transform_keys(&:iso8601)
+      }
+    }
+    super('working_days_changed', additional)
+  end
+end

--- a/app/models/journal/caused_by_working_day_changes.rb
+++ b/app/models/journal/caused_by_working_day_changes.rb
@@ -34,6 +34,6 @@ class Journal::CausedByWorkingDayChanges < CauseOfChange::Base
         "non_working_days" => non_working_days.transform_keys(&:iso8601)
       }
     }
-    super('working_days_changed', additional)
+    super("working_days_changed", additional)
   end
 end

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -870,7 +870,7 @@ module Journals
 
     def cause_sql(cause)
       # Using the same encoder mechanism that ActiveRecord uses for json/jsonb columns
-      ActiveSupport::JSON.encode(cause&.to_h || {})
+      ActiveSupport::JSON.encode(cause || {})
     end
 
     # Because we added the journal via bare metal sql, rails does not yet
@@ -906,7 +906,7 @@ module Journals
     end
 
     def same_cause?(predecessor, cause)
-      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause.to_h
+      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -48,13 +48,9 @@ module Journals
       self.journable = journable
     end
 
-    def call(notes: "", cause: {})
-      # JSON columns read from the database always have string keys. As we do not know what is passed in here,
-      # and we want to compare it to values read from the DB, we need to stringify the keys here as well
-      normalized_cause = cause.deep_stringify_keys
-
+    def call(notes: "", cause: CauseOfChange::NoCause.new)
       Journal.transaction do
-        journal = create_journal(notes, normalized_cause)
+        journal = create_journal(notes, cause)
 
         if journal
           reload_journals
@@ -270,28 +266,28 @@ module Journals
 
     def cleanup_predecessor_attachable(predecessor)
       cleanup_predecessor(predecessor,
-                          'attachable_journals',
+                          "attachable_journals",
                           :journal_id,
                           :id)
     end
 
     def cleanup_predecessor_customizable(predecessor)
       cleanup_predecessor(predecessor,
-                          'customizable_journals',
+                          "customizable_journals",
                           :journal_id,
                           :id)
     end
 
     def cleanup_predecessor_storable(predecessor)
       cleanup_predecessor(predecessor,
-                          'storages_file_links_journals',
+                          "storages_file_links_journals",
                           :journal_id,
                           :id)
     end
 
     def cleanup_predecessor_agenda_itemable(predecessor)
       cleanup_predecessor(predecessor,
-                          'meeting_agenda_item_journals',
+                          "meeting_agenda_item_journals",
                           :journal_id,
                           :id)
     end
@@ -817,7 +813,7 @@ module Journals
         SQL
       end
 
-      data_changes.join(' OR ')
+      data_changes.join(" OR ")
     end
 
     def only_on_changed_or_forced_condition_sql(predecessor, notes, cause)
@@ -835,17 +831,17 @@ module Journals
 
     def data_sink_columns
       text_columns = text_column_names
-      (journable.journaled_columns_names - text_columns + text_columns).join(', ')
+      (journable.journaled_columns_names - text_columns + text_columns).join(", ")
     end
 
     def data_source_columns
       text_columns = text_column_names
       normalized_text_columns = text_columns.map { |column| normalize_newlines_sql(column) }
-      (journable.journaled_columns_names - text_columns + normalized_text_columns).join(', ')
+      (journable.journaled_columns_names - text_columns + normalized_text_columns).join(", ")
     end
 
     def journable_data_sql_addition
-      journable.class.aaj_options[:data_sql]&.call(journable) || ''
+      journable.class.aaj_options[:data_sql]&.call(journable) || ""
     end
 
     def text_column_names
@@ -874,7 +870,7 @@ module Journals
 
     def cause_sql(cause)
       # Using the same encoder mechanism that ActiveRecord uses for json/jsonb columns
-      ActiveSupport::JSON.encode(cause || {})
+      ActiveSupport::JSON.encode(cause&.to_h || {})
     end
 
     # Because we added the journal via bare metal sql, rails does not yet
@@ -910,7 +906,7 @@ module Journals
     end
 
     def same_cause?(predecessor, cause)
-      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause
+      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause.to_h
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -30,11 +30,11 @@ class WorkPackages::UpdateService < BaseServices::Update
   include ::WorkPackages::Shared::UpdateAncestors
   include Attachments::ReplaceAttachments
 
-  attr_accessor :cause_of_update
+  attr_accessor :cause_of_rescheduling
 
-  def initialize(user:, model:, contract_class: nil, contract_options: {}, cause_of_update: nil)
+  def initialize(user:, model:, contract_class: nil, contract_options: {}, cause_of_rescheduling: nil)
     super(user:, model:, contract_class:, contract_options:)
-    self.cause_of_update = cause_of_update || model
+    self.cause_of_rescheduling = cause_of_rescheduling || model
   end
 
   private
@@ -135,7 +135,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
   def reschedule(work_package, work_packages)
     WorkPackages::SetScheduleService
-      .new(user:, work_package: work_packages, initiated_by: cause_of_update)
+      .new(user:, work_package: work_packages, initiated_by: cause_of_rescheduling)
       .call(work_package.saved_changes.keys.map(&:to_sym))
   end
 

--- a/app/workers/work_packages/apply_statuses_p_complete_job.rb
+++ b/app/workers/work_packages/apply_statuses_p_complete_job.rb
@@ -75,13 +75,17 @@ class WorkPackages::ApplyStatusesPCompleteJob < ApplicationJob
 
     case cause_type
     when "progress_mode_changed_to_status_based"
-      { type: cause_type }
+      Journal::CausedByProgressModeChangedToStatusBased.new
     when "status_p_complete_changed"
       raise ArgumentError, "status_name must be provided" if status_name.blank?
       raise ArgumentError, "status_id must be provided" if status_id.nil?
       raise ArgumentError, "change must be provided" if change.nil?
 
-      { type: cause_type, status_name:, status_id:, status_p_complete_change: change }
+      Journal::CausedByStatusPCompleteChanged.new(
+        status_name:,
+        status_id:,
+        status_p_complete_change: change
+      )
     else
       raise "Unable to handle cause type #{cause_type.inspect}"
     end

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -38,9 +38,9 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     user = User.find(user_id)
 
     User.execute_as user do
-      wd_update = Journal::WorkingDayUpdate.new(
+      wd_update = Journal::CausedByWorkingDayChanges.new(
         working_days: changed_days(previous_working_days),
-        non_working_days: changed_non_working_dates(previous_non_working_days).transform_keys(&:iso8601)
+        non_working_days: changed_non_working_dates(previous_non_working_days)
       )
 
       updated_work_package_ids = collect_id_for_each(applicable_work_package(previous_working_days,
@@ -56,14 +56,9 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
 
   private
 
-  def apply_change_to_work_package(user, work_package, changed_working_days)
-    cause = {
-      "type" => "working_days_changed",
-      "changed_days" => changed_working_days.to_h
-    }
-
+  def apply_change_to_work_package(user, work_package, cause)
     WorkPackages::UpdateService
-      .new(user:, model: work_package, contract_class: EmptyContract, cause_of_update: changed_working_days)
+      .new(user:, model: work_package, contract_class: EmptyContract, cause_of_rescheduling: cause)
       .call(duration: work_package.duration, journal_cause: cause) # trigger a recomputation of start and due date
       .all_results
   end

--- a/app/workers/work_packages/update_progress_job.rb
+++ b/app/workers/work_packages/update_progress_job.rb
@@ -246,7 +246,7 @@ class WorkPackages::UpdateProgressJob < ApplicationJob
     WorkPackage.where(id: updated_work_package_ids).find_each do |work_package|
       Journals::CreateService
         .new(work_package, system_user)
-        .call(cause: { type: "system_update", feature: "progress_calculation_changed" })
+        .call(cause: Journal::CausedBySystemUpdate.new(feature: "progress_calculation_changed"))
     end
   end
 

--- a/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
+++ b/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
@@ -37,7 +37,7 @@ class AddFileLinkJournalsToExistingContainers < ActiveRecord::Migration[7.0]
       next unless container.class.journaled?
 
       Journals::CreateService.new(container, system_user)
-                             .call(cause: Jounal::CausedBySystemUpdate.new(feature: 'file_links_journal'))
+                             .call(cause: Jounal::CausedBySystemUpdate.new(feature: "file_links_journal"))
     end
   end
 

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -73,7 +73,7 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user: User.current, notes: '', cause: CauseOfChange::NoCause.new)
+    def add_journal(user: User.current, notes: "", cause: CauseOfChange::NoCause.new)
       self.journal_user ||= user
       self.journal_notes ||= notes
       self.journal_cause ||= cause
@@ -83,7 +83,7 @@ module Acts::Journalized
 
     def with_ensured_journal_attributes
       self.journal_user ||= User.current
-      self.journal_notes ||= ''
+      self.journal_notes ||= ""
       self.journal_cause ||= CauseOfChange::NoCause.new
 
       yield

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -73,7 +73,7 @@ module Acts::Journalized
       end
     end
 
-    def add_journal(user: User.current, notes: '', cause: {})
+    def add_journal(user: User.current, notes: '', cause: CauseOfChange::NoCause.new)
       self.journal_user ||= user
       self.journal_notes ||= notes
       self.journal_cause ||= cause
@@ -84,7 +84,7 @@ module Acts::Journalized
     def with_ensured_journal_attributes
       self.journal_user ||= User.current
       self.journal_notes ||= ''
-      self.journal_cause ||= {}
+      self.journal_cause ||= CauseOfChange::NoCause.new
 
       yield
     ensure

--- a/lib_static/plugins/acts_as_journalized/lib/cause_of_change.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/cause_of_change.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2012-2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -45,51 +45,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-require 'journal_changes'
-require 'journal_formatter'
-require 'cause_of_change'
+require_relative 'cause_of_change/base'
+require_relative 'cause_of_change/no_cause'
 
-module Acts
-end
-
-Dir[File.expand_path('acts/journalized/*.rb', __dir__)].sort.each { |f| require f }
-
-module Acts
-  module Journalized
-    def self.included(base)
-      base.extend ClassMethods
-      base.extend Journalized
-    end
-
-    module ClassMethods
-      def plural_name
-        name.underscore.pluralize
-      end
-
-      # This call will start journaling the model.
-      def acts_as_journalized(options = {})
-        return if journaled?
-
-        include_aaj_modules
-
-        prepare_journaled_options(options)
-
-        has_many :journals, -> {
-          order("#{Journal.table_name}.version ASC")
-        }, **has_many_journals_options
-      end
-
-      private
-
-      def include_aaj_modules
-        include Options
-        include Creation
-        include Reversion
-        include Permissions
-        include SaveHooks
-        include FormatHooks
-        include DataClass
-      end
-    end
-  end
+module CauseOfChange
 end

--- a/lib_static/plugins/acts_as_journalized/lib/cause_of_change/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/cause_of_change/base.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CauseOfChange
+  class Base
+    attr_reader :type, :additional_attributes
+
+    def initialize(type, additional_attributes = {})
+      @type = type
+      @additional_attributes = additional_attributes
+    end
+
+    def to_h
+      { "type" => type }.merge(additional_attributes).deep_stringify_keys
+    end
+
+    def blank?
+      false
+    end
+
+    def ==(other)
+      if other.is_a?(Hash)
+        to_h == other
+      else
+        other.class == self.class &&
+         type == other.type &&
+         additional_attributes == other.additional_attributes
+      end
+    end
+  end
+end

--- a/lib_static/plugins/acts_as_journalized/lib/cause_of_change/base.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/cause_of_change/base.rb
@@ -35,7 +35,7 @@ module CauseOfChange
       @additional_attributes = additional_attributes
     end
 
-    def to_h
+    def to_hash
       { "type" => type }.merge(additional_attributes).deep_stringify_keys
     end
 
@@ -44,13 +44,7 @@ module CauseOfChange
     end
 
     def ==(other)
-      if other.is_a?(Hash)
-        to_h == other
-      else
-        other.class == self.class &&
-         type == other.type &&
-         additional_attributes == other.additional_attributes
-      end
+      to_hash == other.to_hash
     end
   end
 end

--- a/lib_static/plugins/acts_as_journalized/lib/cause_of_change/no_cause.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/cause_of_change/no_cause.rb
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CauseOfChange
+  class NoCause < Base
+    def initialize
+      super(nil)
+    end
+
+    def blank?
+      true
+    end
+
+    def to_h
+      {}
+    end
+  end
+end

--- a/lib_static/plugins/acts_as_journalized/lib/cause_of_change/no_cause.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/cause_of_change/no_cause.rb
@@ -36,7 +36,7 @@ module CauseOfChange
       true
     end
 
-    def to_h
+    def to_hash
       {}
     end
   end

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -141,11 +141,12 @@ RSpec.describe WorkPackages::SetScheduleService do
           .to be_present,
               "Expected work package ##{wp.id} '#{wp.subject}' to be rescheduled"
 
-        expect(result.journal_cause['work_package_id'])
+        expect(result.journal_cause.additional_attributes["work_package_id"])
           .to eql(initiating_work_package.id),
-              "Expected work package change to ##{wp.id} to have been caused by ##{initiating_work_package.id}."
+              "Expected work package change to ##{wp.id} to have been caused by ##{initiating_work_package.id}, but " \
+              "it was caused by ##{result.journal_cause.additional_attributes[:work_package_id]}."
 
-        expect(result.journal_cause['type'])
+        expect(result.journal_cause.type)
         .to eql("work_package_related_changed_times"),
             "Expected work package change to ##{wp.id} to have been caused because ##{expected_cause_type}."
 


### PR DESCRIPTION
Instead of passing hashes around, we have well defined models for causes, that can be instantiated and passed around. This also solves that we had to introduce the "helper" struct we needed to introduce for the working day update