### PR TITLE
[#48116] Baseline: Handle work package no longer visible

### DIFF
--- a/frontend/src/app/core/schemas/schema-cache.service.ts
+++ b/frontend/src/app/core/schemas/schema-cache.service.ts
@@ -28,20 +28,33 @@
 import { State } from '@openproject/reactivestates';
 import { Injectable } from '@angular/core';
 import { StateCacheService } from 'core-app/core/apiv3/cache/state-cache.service';
-import { Observable } from 'rxjs';
+import {
+  firstValueFrom,
+  Observable,
+} from 'rxjs';
 import { take } from 'rxjs/operators';
 import { States } from 'core-app/core/states/states.service';
-import { ISchemaProxy, SchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
+import {
+  ISchemaProxy,
+  SchemaProxy,
+} from 'core-app/features/hal/schemas/schema-proxy';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { WorkPackageSchemaProxy } from 'core-app/features/hal/schemas/work-package-schema-proxy';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 
+export const fallbackSchemaId = '__fallback';
+
 @Injectable()
 export class SchemaCacheService extends StateCacheService<SchemaResource> {
-  constructor(readonly states:States,
-    readonly halResourceService:HalResourceService) {
+  fallbackSchema = this.halResourceService.createHalResourceOfClass<SchemaResource>(SchemaResource, {}, true);
+
+  constructor(
+    readonly states:States,
+    readonly halResourceService:HalResourceService,
+  ) {
     super(states.schemas);
+    this.putValue(fallbackSchemaId, this.fallbackSchema);
   }
 
   public state(id:string|HalResource):State<SchemaResource> {
@@ -56,27 +69,18 @@ export class SchemaCacheService extends StateCacheService<SchemaResource> {
    * @return The schema for the HalResource
    */
   of(resource:HalResource):ISchemaProxy {
-    const schema = this.state(resource).value;
-
-    if (!schema) {
-      throw new Error(`Schema for resource ${resource} was expected to be loaded but isn't.`);
-    }
+    const schema = this.state(resource).value as SchemaResource;
 
     if (resource._type === 'WorkPackage') {
       return WorkPackageSchemaProxy.create(schema, resource);
     }
+
     return SchemaProxy.create(schema, resource);
   }
 
-  public getSchemaHref(resource:HalResource):string {
+  public getSchemaHref(resource:HalResource):string|undefined {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    const href = resource.$links.schema?.href as string|undefined;
-
-    if (!href) {
-      throw new Error(`Resource ${resource.toString()} has no schema to load.`);
-    }
-
-    return href;
+    return resource.$links.schema?.href as string|undefined;
   }
 
   /**
@@ -84,15 +88,9 @@ export class SchemaCacheService extends StateCacheService<SchemaResource> {
    * @param resource The resource with a schema property or a string to the schema href.
    * @return A promise with the loaded schema.
    */
-  ensureLoaded<T = SchemaResource>(resource:HalResource|string):Promise<T> {
+  ensureLoaded(resource:HalResource|string):Promise<SchemaResource> {
     const href = resource instanceof HalResource ? this.getSchemaHref(resource) : resource;
-
-    return this
-      .requireAndStream(href)
-      .pipe(
-        take(1),
-      )
-      .toPromise() as unknown as Promise<T>;
+    return firstValueFrom(this.requireAndStream(href || fallbackSchemaId));
   }
 
   /**
@@ -143,8 +141,9 @@ export class SchemaCacheService extends StateCacheService<SchemaResource> {
 
   private stateKey(id:string|HalResource):string {
     if (id instanceof HalResource) {
-      return this.getSchemaHref(id);
+      return this.getSchemaHref(id) || fallbackSchemaId;
     }
+
     return id;
   }
 }

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -490,7 +490,7 @@ export class TimeEntryCalendarComponent {
 
     const { entry } = event.event.extendedProps;
 
-    const schema:TimeEntrySchema = await this.schemaCache.ensureLoaded(entry);
+    const schema = await this.schemaCache.ensureLoaded(entry as TimeEntryResource) as TimeEntrySchema;
 
     jQuery(event.el).tooltip({
       content: this.tooltipContentString(event.event.extendedProps.entry, schema),

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -52,8 +52,6 @@ import { IWorkPackageTimestamp } from 'core-app/features/hal/resources/work-pack
 
 export interface WorkPackageResourceEmbedded {
   activities:CollectionResource;
-  // eslint-disable-next-line no-use-before-define
-  ancestors:WorkPackageResource[];
   assignee:HalResource|any;
   attachments:AttachmentCollectionResource;
   fileLinks?:CollectionResource;
@@ -137,7 +135,7 @@ export class WorkPackageBaseResource extends HalResource {
   public attachments:AttachmentCollectionResource;
 
   // eslint-disable-next-line no-use-before-define
-  public ancestors:WorkPackageResource[];
+  private ancestors?:this[];
 
   public attributesByTimestamp?:IWorkPackageTimestamp[];
 
@@ -158,10 +156,17 @@ export class WorkPackageBaseResource extends HalResource {
   readonly attachmentsBackend = true;
 
   /**
+   * Returns the list of ancestors, if any
+   */
+  public getAncestors():this[] {
+    return this.ancestors || [];
+  }
+
+  /**
    * Return the ids of all its ancestors, if any
    */
   public get ancestorIds():string[] {
-    return this.ancestors.map((el:HalResource) => (el.id as string|number).toString());
+    return this.getAncestors().map((el:HalResource) => (el.id as string|number).toString());
   }
 
   /**

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.component.ts
@@ -50,7 +50,7 @@ export class WorkPackageBreadcrumbComponent {
   public inputActive = false;
 
   public get hierarchyCount() {
-    return this.workPackage.ancestors.length;
+    return this.workPackage.getAncestors().length;
   }
 
   public get hierarchyLabel() {

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
@@ -11,7 +11,7 @@
       <li class="op-wp-breadcrumb--list-item">
         <span>{{ hierarchyLabel }}: </span>
       </li>
-      <ng-container *ngFor="let ancestor of workPackage.ancestors; let first = first ; let last = last">
+      <ng-container *ngFor="let ancestor of workPackage.getAncestors(); let first = first ; let last = last">
         <li
           *ngIf="!last"
           class="op-wp-breadcrumb--list-item op-wp-breadcrumb--list-item_ellipsed"

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/cell-builder.ts
@@ -77,7 +77,7 @@ export class CellBuilder {
     attribute:string,
   ):void {
     const base = (workPackage.attributesByTimestamp as IWorkPackageTimestamp[])[0];
-    base.$links.schema = workPackage.$links.schema;
+    base.$links.schema = base.$links.schema || workPackage.$links.schema;
     const span = this.fieldRenderer.render(base, attribute, null);
     span.classList.add('op-table-baseline--field', 'op-table-baseline--old-field');
     container.classList.add('op-table-baseline--container');

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -52,7 +52,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
     this.hierarchies = this.wpTableHierarchies.current;
 
     _.each(this.workPackageTable.originalRowIndex, (row) => {
-      row.object.ancestors.forEach((ancestor:WorkPackageResource) => {
+      row.object.getAncestors().forEach((ancestor:WorkPackageResource) => {
         this.parentsWithVisibleChildren[ancestor.id!] = true;
       });
     });
@@ -73,7 +73,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
         return;
       }
 
-      if (workPackage.ancestors.length) {
+      if (workPackage.getAncestors().length) {
         // If we have ancestors, render it
         this.buildWithHierarchy(row);
       } else {
@@ -96,7 +96,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
    * @returns {boolean}
    */
   public deferInsertion(workPackage:WorkPackageResource):boolean {
-    const { ancestors } = workPackage;
+    const ancestors = workPackage.getAncestors();
 
     // Will only defer if at least one ancestor exists
     if (ancestors.length === 0) {
@@ -172,7 +172,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
 
   private buildWithHierarchy(row:WorkPackageTableRow) {
     // Ancestor data [root, med, thisrow]
-    const { ancestors } = row.object;
+    const ancestors = row.object.getAncestors();
     const ancestorGroups:string[] = [];
 
     // Iterate ancestors

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -84,8 +84,9 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
       rowClasses.push(hierarchyRootClass(workPackage.id!));
     }
 
-    if (_.isArray(workPackage.ancestors)) {
-      workPackage.ancestors.forEach((ancestor) => {
+    const ancestors = workPackage.getAncestors();
+    if (_.isArray(ancestors)) {
+      ancestors.forEach((ancestor) => {
         rowClasses.push(hierarchyGroupClass(ancestor.id!));
 
         if (state.collapsed[ancestor.id!]) {
@@ -117,7 +118,8 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
    * @param level Indentation level
    */
   private appendHierarchyIndicator(workPackage:WorkPackageResource, jRow:JQuery, level?:number):void {
-    const hierarchyLevel = level === undefined || null ? workPackage.ancestors.length : level;
+    const ancestors = workPackage.getAncestors();
+    const hierarchyLevel = level === undefined || null ? ancestors.length : level;
     const hierarchyElement = this.buildHierarchyIndicator(workPackage, jRow, hierarchyLevel);
 
     jRow.find('td.subject')

--- a/frontend/src/app/shared/components/datepicker/services/date-modal-relations.service.ts
+++ b/frontend/src/app/shared/components/datepicker/services/date-modal-relations.service.ts
@@ -151,7 +151,7 @@ export class DateModalRelationsService {
 
   get ancestors():HalResource[] {
     const wp = this.changeset.projectedResource;
-    return wp.ancestors || [];
+    return wp.getAncestors() || [];
   }
 
   /**

--- a/spec/features/work_packages/table/baseline/baseline_invisible_project_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_invisible_project_spec.rb
@@ -1,0 +1,102 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe 'baseline with a work package moved to an invisible project',
+               js: true,
+               with_settings: { date_format: '%Y-%m-%d' } do
+  shared_let(:type_bug) { create(:type_bug) }
+  shared_let(:visible_project) { create(:project, types: [type_bug]) }
+  shared_let(:private_project) { create(:project, types: [type_bug]) }
+
+  shared_let(:user) do
+    create(:user,
+           firstname: 'Itsa',
+           lastname: 'Me',
+           member_in_project: visible_project,
+           member_with_permissions: %i[view_work_packages edit_work_packages work_package_assigned assign_versions])
+  end
+
+  shared_let(:wp_bug) do
+    wp = Timecop.travel(5.days.ago) do
+      create(:work_package,
+             project: visible_project,
+             type: type_bug,
+             assigned_to: user,
+             responsible: user,
+             subject: 'WP in public project',
+             start_date: '2023-05-01',
+             due_date: '2023-05-02')
+    end
+
+    Timecop.travel(1.hour.ago) do
+      WorkPackages::UpdateService
+        .new(user: User.system, model: wp)
+        .call(
+          subject: 'Moved to private project',
+          project: private_project
+        )
+        .on_failure { |result| raise result.message }
+        .result
+    end
+  end
+
+  shared_let(:query) do
+    query = create(:query,
+                   name: 'Global query changes since yesterday',
+                   project: nil,
+                   user:)
+
+    query.timestamps = ["P-1d", "PT0S"]
+    query.column_names = %w[id subject status type start_date due_date version priority assigned_to responsible project]
+    query.save!(validate: false)
+
+    query
+  end
+
+  let(:baseline_modal) { Components::WorkPackages::BaselineModal.new }
+  let(:wp_table) { Pages::WorkPackagesTable.new }
+  let(:baseline) { Components::WorkPackages::Baseline.new }
+
+  current_user { user }
+
+  describe 'with feature enabled', with_ee: %i[baseline_comparison], with_flag: { show_changes: true } do
+    it 'shows the item with all values removed' do
+      wp_table.visit_query(query)
+
+      baseline.expect_active
+      baseline.expect_removed wp_bug
+
+      baseline.expect_changed_attributes wp_bug,
+                                         subject: ['WP in public project', ''],
+                                         startDate: ['2023-05-01', ''],
+                                         dueDate: ['2023-05-02', '']
+    end
+  end
+end


### PR DESCRIPTION
Allow rendering of a work package that has no schema, such as when the work package gets moved to an invisible project. In that case, the comparison timestamp is empty.

https://community.openproject.org/wp/48116