### PR TITLE
Baseline: join with project at the time of the journal

### DIFF
--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
       it "joins the projects table" do
         sql = subject.to_sql.tr('"', '')
         expect(sql).to include \
-          "LEFT OUTER JOIN projects ON projects.id = journables.project_id"
+          "LEFT OUTER JOIN projects ON projects.id = work_package_journals.project_id"
         expect(sql).to include \
           "WHERE projects.id = #{project.id}"
       end


### PR DESCRIPTION
When joining projects, the condition to join against has to be the project_id of `work_package_journals` and not the project_id of the `work_packages` table. The `work_packages` table contains the current state whereas the `work_package_journals` contains the state at the journal time. 

By that, changes between projects are correctly accounted for which is important especially in the context of a timestamped work package query where the project (and its descendants) serves as a context the query is executed in. In such a case, a condition like `AND (projects.id IN (4, 5, 8, 12)` is added by the query and needs to be checked agains the projects the work package used to be in and not the projects the work package is in.

https://community.openproject.org/wp/48592