### PR TITLE
Use multi-stage dockerfile to parallelize builds

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -44,18 +44,19 @@ jobs:
           ${{ runner.os }}-ci-cache-tests-all-${{ github.ref }}-
           ${{ runner.os }}-ci-cache-tests-all-
     - name: build
-      run: |
-        sudo mkdir -p /tmp/cache && sudo chown -R $(whoami):$(id -ng) $CI_CACHE_PATH
-        docker-compose -f docker-compose.ci.yml build --pull ci
+      run: docker-compose -f docker-compose.ci.yml build --pull ci
     - name: tests
-      run: docker-compose -f docker-compose.ci.yml run ci setup-tests run-units run-features
+      run: |
+        sudo mkdir -p /tmp/cache && sudo chown -R 1000:1000 $CI_CACHE_PATH
+        ls -lrt $CI_CACHE_PATH/op-cache/ || true
+        docker-compose -f docker-compose.ci.yml run ci setup-tests run-units run-features
     - name: cleanup
       if: ${{ always() }}
       run: |
         docker-compose -f docker-compose.ci.yml down --remove-orphans -t 10
-        sudo chown -R $(whoami):$(id -ng) $CI_CACHE_PATH
+        sudo chown -R $(id -u):$(id -g) $CI_CACHE_PATH
         ls -lrt spec/support/turbo*
-        ls -lrt $CI_CACHE_PATH/op-cache/
+        ls -lrt $CI_CACHE_PATH/op-cache/ || true
   api-spec:
     name: APIv3 specification (OpenAPI 3.0)
     if: github.repository == 'opf/openproject'

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,19 +1,43 @@
-FROM ruby:3.2.1-buster
-MAINTAINER operations@openproject.com
+FROM ruby:3.2.1-buster as gems
 
-ENV NODE_VERSION="16.17.0"
-ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb"
+ENV BUNDLER_VERSION="2.4.7"
+ENV BUNDLE_WITHOUT="development:production:docker"
+ENV BUNDLE_JOBS=8
 
-RUN curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \
-  | tar xzf - --strip-components=1 -C /usr/local
+WORKDIR /app
+
+RUN gem install bundler --version "$BUNDLER_VERSION" --no-document
+
+COPY Gemfile Gemfile.modules Gemfile.lock ./
+COPY modules ./modules
+RUN \
+  --mount=type=cache,target=/usr/local/bundle/cache \
+  bundle install
+
+COPY config ./config
+COPY db ./db
+RUN bundle exec rails db:migrate db:schema:dump
+
+FROM node:16.17 as nodejs
+
+WORKDIR /app
+
+COPY package.json ./
+COPY frontend/package.json frontend/package-lock.json frontend/.npmrc ./frontend/
+RUN \
+  --mount=type=cache,target=/app/.npm \
+  JOBS=$(nproc) npm install
+
+FROM ruby:3.2.1-buster as final
 
 RUN wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update -qq && apt-get install -y \
-    postgresql-13 postgresql-client-13 time pandoc imagemagick libpq-dev default-jre-headless firefox-esr
+    postgresql-13 postgresql-client-13 time pandoc imagemagick default-jre-headless firefox-esr
 
+ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb"
 RUN f="/tmp/chrome.deb"; wget --no-verbose -O $f $CHROME_SOURCE_URL && apt install -y $f && rm -f $f
 
 ENV APP_USER=dev
@@ -22,9 +46,6 @@ RUN useradd -d $APP_PATH -m $APP_USER -s /bin/bash
 
 ENV CI=true
 ENV RAILS_ENV=test
-ENV BUNDLER_VERSION="2.4.7"
-ENV BUNDLE_WITHOUT="development:production:docker"
-ENV BUNDLE_JOBS=4
 ENV OPENPROJECT_DISABLE_DEV_ASSET_PROXY=1
 ENV CAPYBARA_DYNAMIC_BIND_IP=1
 ENV CAPYBARA_DOWNLOADED_FILE_DIR=/tmp
@@ -35,28 +56,17 @@ ENV PGVERSION=13
 WORKDIR $APP_PATH
 
 RUN mkdir -p /cache && chown $APP_USER:$APP_USER /cache
-RUN mkdir -p /usr/local/bundle/cache && chown -R $APP_USER:$APP_USER /usr/local/bundle/cache
 
 USER $APP_USER
 
-RUN gem install bundler --version "$BUNDLER_VERSION" --no-document
-
-COPY --chown=$APP_USER:$APP_USER Gemfile Gemfile.modules Gemfile.lock ./
-COPY --chown=$APP_USER:$APP_USER modules ./modules
-RUN \
-  --mount=type=cache,target=/usr/local/bundle/cache,uid=1000,gid=1000 \
-  bundle install
-
-COPY --chown=$APP_USER:$APP_USER package.json ./
-COPY --chown=$APP_USER:$APP_USER frontend/package.json frontend/package-lock.json frontend/.npmrc ./frontend/
-RUN \
-  --mount=type=cache,target=/app/.npm,uid=1000,gid=1000 \
-  JOBS=$(nproc) npm install
-
 COPY ./docker/ci/entrypoint.sh /usr/sbin/entrypoint.sh
+COPY --from=gems --chown=$APP_USER:$APP_USER /usr/local/bundle /usr/local/bundle
+COPY --from=nodejs --chown=$APP_USER:$APP_USER /app/node_modules ./node_modules
+COPY --from=nodejs --chown=$APP_USER:$APP_USER /app/frontend/node_modules ./frontend/node_modules
 COPY --chown=$APP_USER:$APP_USER . .
 
 ENV DATABASE_URL="postgres://appuser:p4ssw0rd@127.0.0.1/appdb"
+ENV BUNDLE_WITHOUT="development:production:docker"
 
 ENTRYPOINT [ "/usr/sbin/entrypoint.sh" ]
 CMD ["setup-tests", "bash"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -14,10 +14,6 @@ RUN \
   --mount=type=cache,target=/usr/local/bundle/cache \
   bundle install
 
-COPY config ./config
-COPY db ./db
-RUN bundle exec rails db:migrate db:schema:dump
-
 FROM node:16.17 as nodejs
 
 WORKDIR /app

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM ruby:3.2.1-buster as gems
 
 ENV BUNDLER_VERSION="2.4.7"
@@ -53,16 +54,21 @@ WORKDIR $APP_PATH
 
 RUN mkdir -p /cache && chown $APP_USER:$APP_USER /cache
 
-USER $APP_USER
+COPY --from=gems /usr/local/bundle /usr/local/bundle
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/node
+COPY --from=nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodejs /usr/local/include/node /usr/local/include/node
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
-COPY ./docker/ci/entrypoint.sh /usr/sbin/entrypoint.sh
-COPY --from=gems --chown=$APP_USER:$APP_USER /usr/local/bundle /usr/local/bundle
-COPY --from=nodejs --chown=$APP_USER:$APP_USER /app/node_modules ./node_modules
-COPY --from=nodejs --chown=$APP_USER:$APP_USER /app/frontend/node_modules ./frontend/node_modules
+COPY --from=nodejs /app/node_modules ./node_modules
+COPY --from=nodejs /app/frontend/node_modules ./frontend/node_modules
 COPY --chown=$APP_USER:$APP_USER . .
 
 ENV DATABASE_URL="postgres://appuser:p4ssw0rd@127.0.0.1/appdb"
 ENV BUNDLE_WITHOUT="development:production:docker"
 
+COPY ./docker/ci/entrypoint.sh /usr/sbin/entrypoint.sh
+
+USER $APP_USER
 ENTRYPOINT [ "/usr/sbin/entrypoint.sh" ]
 CMD ["setup-tests", "bash"]

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -97,6 +97,17 @@ if [ "$1" == "run-features" ]; then
 	cleanup
 fi
 
+if [ "$1" == "run-all" ]; then
+	shift
+	reset_dbs
+	execute_quiet "time bundle exec rails assets:precompile webdrivers:chromedriver:update webdrivers:geckodriver:update"
+	execute_quiet "cp -f /cache/turbo_runtime_all.log spec/support/ || true"
+	execute_quiet "cp -rp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json"
+	execute "time bundle exec turbo_tests --verbose -n $JOBS --runtime-log spec/support/turbo_runtime_all.log spec"
+	execute_quiet "cp -f spec/support/turbo_runtime_all.log /cache/ || true"
+	cleanup
+fi
+
 if [ ! -z "$1" ] ; then
 	exec "$@"
 fi


### PR DESCRIPTION
Docker buildkit can build stages in parallel, which means we can have the bundle install and npm install steps run in parallel instead of sequentially since they do not depend on each other.