### PR TITLE
Give components a selector even if not used

### DIFF
--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 
 @Component({
+  selector: 'op-wp-graph-configuration-filters-tab',
   templateUrl: './filters-tab.component.html',
 })
 export class WpGraphConfigurationFiltersTabComponent implements TabComponent {

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.ts
@@ -2,6 +2,7 @@ import { TabComponent } from 'core-app/features/work-packages/components/wp-tabl
 import { Component, ViewChild } from '@angular/core';
 
 @Component({
+  selector: 'op-wp-graph-configuration-settings-tab',
   templateUrl: './settings-tab.component.html',
 })
 export class WpGraphConfigurationSettingsTabComponent implements TabComponent {


### PR DESCRIPTION
Will prevent this error

```
2023-06-19 10:31:45 +0000 WARNING: http://localhost:3009/assets/frontend/vendor.241f6b4a22d2c400.js 253904:16 "NG0912: Component ID generation collision detected. Components 'WpGraphConfigurationSettingsTabComponent' and 'WpGraphConfigurationFiltersTabComponent' with selector 'ng-component' generated the same component ID. To fix this, you can change the selector of one of those components or add an extra host attribute to force a different ID. Find more at https://angular.io/errors/NG0912"
```