### PR TITLE
Force application/json in redirect to job status

### DIFF
--- a/lib/api/v3/utilities/endpoints/delayed_modify.rb
+++ b/lib/api/v3/utilities/endpoints/delayed_modify.rb
@@ -42,6 +42,7 @@ module API
 
           def redirect_to_status(request, job)
             request.redirect api_v3_paths.job_status(job.job_id)
+            request.content_type 'application/json'
           end
         end
       end


### PR DESCRIPTION
Grape redirects with text/plain and doesn't allow overriding it. If clients are following the location and taking over the content-type, they get an API error.

https://community.openproject.org/work_packages/48622