### PR TITLE
[Passion Chore] Define Reusable `AttributeGroup` View Components

### DIFF
--- a/app/components/attribute_groups/attribute_group_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_component.html.erb
@@ -1,0 +1,9 @@
+<div class="attributes-group">
+  <%= group_header %>
+
+  <div class="attributes-key-value">
+    <% attributes_key_value.each do |attribute_key_value| %>
+      <%= attribute_key_value %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/attribute_groups/attribute_group_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_component.html.erb
@@ -6,4 +6,8 @@
       <%= attribute_key_value %>
     <% end %>
   </div>
+
+  <div class="attributes-group--content">
+    <%= content %>
+  </div>
 </div>

--- a/app/components/attribute_groups/attribute_group_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <div class="attributes-group">
   <%= group_header %>
 

--- a/app/components/attribute_groups/attribute_group_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_component.html.erb
@@ -28,11 +28,11 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div class="attributes-group">
-  <%= group_header %>
+  <%= header %>
 
   <div class="attributes-key-value">
-    <% attributes_key_value.each do |attribute_key_value| %>
-      <%= attribute_key_value %>
+    <% attributes.each do |attribute| %>
+      <%= attribute %>
     <% end %>
   </div>
 

--- a/app/components/attribute_groups/attribute_group_component.rb
+++ b/app/components/attribute_groups/attribute_group_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module AttributeGroups
-  class AttributeGroupComponent < ::RailsComponent
+  class AttributeGroupComponent < ::ApplicationComponent
     renders_one :header, AttributeGroups::AttributeGroupHeaderComponent
     renders_many :attributes, AttributeGroups::AttributeKeyValueComponent
   end

--- a/app/components/attribute_groups/attribute_group_component.rb
+++ b/app/components/attribute_groups/attribute_group_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module AttributeGroups
+  class AttributeGroupComponent < ::RailsComponent
+    renders_one :group_header, AttributeGroups::AttributeGroupHeaderComponent
+    renders_many :attributes_key_value, AttributeGroups::AttributeKeyValueComponent
+  end
+end

--- a/app/components/attribute_groups/attribute_group_component.rb
+++ b/app/components/attribute_groups/attribute_group_component.rb
@@ -30,7 +30,7 @@
 
 module AttributeGroups
   class AttributeGroupComponent < ::RailsComponent
-    renders_one :group_header, AttributeGroups::AttributeGroupHeaderComponent
-    renders_many :attributes_key_value, AttributeGroups::AttributeKeyValueComponent
+    renders_one :header, AttributeGroups::AttributeGroupHeaderComponent
+    renders_many :attributes, AttributeGroups::AttributeKeyValueComponent
   end
 end

--- a/app/components/attribute_groups/attribute_group_header_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_header_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <div class="attributes-group--header">
   <div class="attributes-group--header-container">
     <h3 class="attributes-group--header-text"><%= title %></h3>

--- a/app/components/attribute_groups/attribute_group_header_component.html.erb
+++ b/app/components/attribute_groups/attribute_group_header_component.html.erb
@@ -1,0 +1,5 @@
+<div class="attributes-group--header">
+  <div class="attributes-group--header-container">
+    <h3 class="attributes-group--header-text"><%= title %></h3>
+  </div>
+</div>

--- a/app/components/attribute_groups/attribute_group_header_component.rb
+++ b/app/components/attribute_groups/attribute_group_header_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module AttributeGroups
-  class AttributeGroupHeaderComponent < ::RailsComponent
+  class AttributeGroupHeaderComponent < ::ApplicationComponent
     options :title
   end
 end

--- a/app/components/attribute_groups/attribute_group_header_component.rb
+++ b/app/components/attribute_groups/attribute_group_header_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module AttributeGroups
+  class AttributeGroupHeaderComponent < ::RailsComponent
+    options :title
+
+    def initialize(title:, **options)
+      super(title:, **options)
+    end
+  end
+end

--- a/app/components/attribute_groups/attribute_group_header_component.rb
+++ b/app/components/attribute_groups/attribute_group_header_component.rb
@@ -31,9 +31,5 @@
 module AttributeGroups
   class AttributeGroupHeaderComponent < ::RailsComponent
     options :title
-
-    def initialize(title:, **options)
-      super(title:, **options)
-    end
   end
 end

--- a/app/components/attribute_groups/attribute_key_value_component.html.erb
+++ b/app/components/attribute_groups/attribute_key_value_component.html.erb
@@ -1,3 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
 <div class="attributes-key-value--key"><%= key %></div>
 <div class="attributes-key-value--value-container">
   <div class="attributes-key-value--value -text">

--- a/app/components/attribute_groups/attribute_key_value_component.html.erb
+++ b/app/components/attribute_groups/attribute_key_value_component.html.erb
@@ -1,0 +1,6 @@
+<div class="attributes-key-value--key"><%= attribute_key %></div>
+<div class="attributes-key-value--value-container">
+  <div class="attributes-key-value--value -text">
+    <span><%= attribute_value %></span>
+  </div>
+</div>

--- a/app/components/attribute_groups/attribute_key_value_component.html.erb
+++ b/app/components/attribute_groups/attribute_key_value_component.html.erb
@@ -1,6 +1,6 @@
-<div class="attributes-key-value--key"><%= attribute_key %></div>
+<div class="attributes-key-value--key"><%= key %></div>
 <div class="attributes-key-value--value-container">
   <div class="attributes-key-value--value -text">
-    <span><%= attribute_value %></span>
+    <span><%= value %></span>
   </div>
 </div>

--- a/app/components/attribute_groups/attribute_key_value_component.rb
+++ b/app/components/attribute_groups/attribute_key_value_component.rb
@@ -30,7 +30,7 @@
 
 module AttributeGroups
   class AttributeKeyValueComponent < ::RailsComponent
-    options :attribute_key, :attribute_value
+    options :key, :value
 
     def initialize(attribute_key:, attribute_value:, **options)
       super(attribute_key:, attribute_value:, **options)

--- a/app/components/attribute_groups/attribute_key_value_component.rb
+++ b/app/components/attribute_groups/attribute_key_value_component.rb
@@ -31,9 +31,5 @@
 module AttributeGroups
   class AttributeKeyValueComponent < ::RailsComponent
     options :key, :value
-
-    def initialize(attribute_key:, attribute_value:, **options)
-      super(attribute_key:, attribute_value:, **options)
-    end
   end
 end

--- a/app/components/attribute_groups/attribute_key_value_component.rb
+++ b/app/components/attribute_groups/attribute_key_value_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module AttributeGroups
-  class AttributeKeyValueComponent < ::RailsComponent
+  class AttributeKeyValueComponent < ::ApplicationComponent
     options :key, :value
   end
 end

--- a/app/components/attribute_groups/attribute_key_value_component.rb
+++ b/app/components/attribute_groups/attribute_key_value_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module AttributeGroups
+  class AttributeKeyValueComponent < ::RailsComponent
+    options :attribute_key, :attribute_value
+
+    def initialize(attribute_key:, attribute_value:, **options)
+      super(attribute_key:, attribute_value:, **options)
+    end
+  end
+end

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -12,9 +12,9 @@
 
 <% if @object.oauth_application %>
   <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
-    <% component.with_group_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
+    <% component.with_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
 
-    <% component.with_attributes_key_value([
+    <% component.with_attributes([
       { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @object.oauth_application.uid },
       { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
     ]) %>
@@ -28,10 +28,10 @@
 <% end %>
 
 <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
-  <% component.with_group_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
+  <% component.with_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
 
   <% if @object.oauth_client %>
-    <% component.with_attributes_key_value([
+    <% component.with_attributes([
       { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}",
         value: @object.oauth_client.client_id },
       { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}",

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -11,48 +11,33 @@
 <% end %>
 
 <% if @object.oauth_application %>
-  <fieldset class="form--fieldset">
-    <legend class="form--fieldset-legend">OpenProject <%= t(:'storages.label_oauth_application_details') %></legend>
-    <div class="attributes-key-value">
-      <div class="attributes-key-value--key">OpenProject <%= Storages::Admin::LABEL_OAUTH_CLIENT_ID %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= @object.oauth_application.uid %></span>
-        </div>
-      </div>
-      <div class="attributes-key-value--key">OpenProject <%= Storages::Admin::LABEL_OAUTH_CLIENT_SECRET %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span>●●●●●●●●●●●●●●●●</span>
-        </div>
-      </div>
-    </div>
+  <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
+    <% component.with_group_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
+
+    <% component.with_attributes_key_value([
+      { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @object.oauth_application.uid },
+      { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
+    ]) %>
 
     <%= link_to(t("storages.buttons.replace_openproject_oauth"),
                 replace_oauth_application_admin_settings_storage_path(@object),
                 method: :delete,
                 data: { confirm: t(:'storages.confirm_replace_oauth_application') },
                 class: 'button -with-icon icon-reload') %>
-  </fieldset>
+  <% end %>
 <% end %>
 
-<fieldset class="form--fieldset">
-  <legend class="form--fieldset-legend"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= t(:'storages.label_oauth_client_details') %></legend>
+<%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
+  <% component.with_group_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
+
   <% if @object.oauth_client %>
-    <div class="attributes-key-value">
-      <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= Storages::Admin::LABEL_OAUTH_CLIENT_ID %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= @object.oauth_client.client_id %></span>
-        </div>
-      </div>
-      <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= Storages::Admin::LABEL_OAUTH_CLIENT_SECRET %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= short_secret(@object.oauth_client.client_secret) %></span>
-        </div>
-      </div>
-    </div>
+    <% component.with_attributes_key_value([
+      { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}",
+        value: @object.oauth_client.client_id },
+      { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}",
+        value: short_secret(@object.oauth_client.client_secret) },
+    ]) %>
+
     <%= link_to(t("storages.buttons.replace_provider_type_oauth", provider_type: t("storages.provider_types.#{@object.short_provider_type}.name")),
                 new_admin_settings_storage_oauth_client_path(@object),
                 data: { confirm: t(:'storages.confirm_replace_oauth_client') },
@@ -60,4 +45,4 @@
   <% else %>
     <%= link_to(t("js.label_create"), new_admin_settings_storage_oauth_client_path(@object), class: 'button -with-icon icon-add') %>
   <% end %>
-</fieldset>
+<% end %>

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -88,8 +88,10 @@ See COPYRIGHT and LICENSE files for more details.
 
   <% if @object.oauth_client %>
     <% component.with_attributes_key_value([
-      { key: t(:'storages.label_oauth_client_id'), value: @object.oauth_client.client_id },
-      { key: t(:'storages.label_oauth_client_secret'), value: short_secret(@object.oauth_client.client_secret) },
+      { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}",
+        value: @object.oauth_client.client_id },
+      { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}",
+        value: short_secret(@object.oauth_client.client_secret) },
     ]) %>
   <% else %>
     <% t(:'storages.oauth_client_details_missing') %>

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -61,9 +61,9 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
-  <% component.with_group_header(title: t(:label_general)) %>
+  <% component.with_header(title: t(:label_general)) %>
 
-  <% component.with_attributes_key_value([
+  <% component.with_attributes([
       { key: t(:'storages.label_name'), value: @object.name },
       { key: t(:'storages.label_provider_type'), value: t(:"storages.provider_types.#{@object.short_provider_type}.name") },
       { key: t(:'storages.label_host'), value: link_to(@object.host, @object.host) },
@@ -74,9 +74,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% if @object.oauth_application %>
   <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
-    <% component.with_group_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
+    <% component.with_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
 
-    <% component.with_attributes_key_value([
+    <% component.with_attributes([
       { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @object.oauth_application.uid },
       { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
     ]) %>
@@ -84,10 +84,10 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
-  <% component.with_group_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
+  <% component.with_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
 
   <% if @object.oauth_client %>
-    <% component.with_attributes_key_value([
+    <% component.with_attributes([
       { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}",
         value: @object.oauth_client.client_id },
       { key: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}",

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -60,95 +60,38 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 <% end %>
 
-<div class="attributes-group">
-  <div class="attributes-group--header">
-    <div class="attributes-group--header-container">
-      <h3 class="attributes-group--header-text"><%= t(:label_general) %></h3>
-    </div>
-  </div>
+<%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
+  <% component.with_group_header(title: t(:label_general)) %>
 
-  <div class="attributes-key-value">
-    <div class="attributes-key-value--key"><%= t(:'storages.label_name') %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text"><span><%= @object.name %></span></div>
-    </div>
-
-    <div class="attributes-key-value--key"><%= t(:'storages.label_provider_type') %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
-        <span><%= t(:"storages.provider_types.#{@object.short_provider_type}.name") %></span>
-      </div>
-    </div>
-
-    <div class="attributes-key-value--key"><%= t(:'storages.label_host') %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
-        <span><%= link_to @object.host, @object.host %></span>
-      </div>
-    </div>
-
-    <div class="attributes-key-value--key"><%= t(:'storages.label_creator') %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
-        <span><%= @object.creator.name %></span>
-      </div>
-    </div>
-
-    <div class="attributes-key-value--key"><%= Storages::ProjectStorage.human_attribute_name(:created_at) %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
-        <span><%= format_time(@object.created_at) %></span>
-      </div>
-    </div>
-  </div>
-</div>
-
-<% if @object.oauth_application %>
-  <div class="attributes-group">
-    <div class="attributes-group--header">
-      <div class="attributes-group--header-container">
-        <h3 class="attributes-group--header-text">OpenProject <%= t(:'storages.label_oauth_application_details') %></h3>
-      </div>
-    </div>
-    <div class="attributes-key-value">
-      <div class="attributes-key-value--key">OpenProject <%= Storages::Admin::LABEL_OAUTH_CLIENT_ID %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= @object.oauth_application.uid %></span>
-        </div>
-      </div>
-      <div class="attributes-key-value--key">OpenProject <%= Storages::Admin::LABEL_OAUTH_CLIENT_SECRET %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span>●●●●●●●●●●●●●●●●</span>
-        </div>
-      </div>
-    </div>
-  </div>
+  <% component.with_attributes_key_value([
+      { key: t(:'storages.label_name'), value: @object.name },
+      { key: t(:'storages.label_provider_type'), value: t(:"storages.provider_types.#{@object.short_provider_type}.name") },
+      { key: t(:'storages.label_host'), value: link_to(@object.host, @object.host) },
+      { key: t(:'storages.label_creator'), value: @object.creator.name },
+      { key: Storages::ProjectStorage.human_attribute_name(:created_at), value: format_time(@object.created_at) }
+  ]) %>
 <% end %>
 
-<div class="attributes-group">
-  <div class="attributes-group--header">
-    <div class="attributes-group--header-container">
-      <h3 class="attributes-group--header-text"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= t(:'storages.label_oauth_client_details') %></h3>
-    </div>
-  </div>
-  <% if @object.oauth_client %>
-    <div class="attributes-key-value">
-      <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= Storages::Admin::LABEL_OAUTH_CLIENT_ID %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= @object.oauth_client.client_id %></span>
-        </div>
-      </div>
-      <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.short_provider_type}.name") %> <%= Storages::Admin::LABEL_OAUTH_CLIENT_SECRET %></div>
-      <div class="attributes-key-value--value-container">
-        <div class="attributes-key-value--value -text">
-          <span><%= short_secret(@object.oauth_client.client_secret) %></span>
-        </div>
-      </div>
-    </div>
-  <% else %>
-    <%= t("storages.oauth_client_details_missing") %>
+<% if @object.oauth_application %>
+  <%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
+    <% component.with_group_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
+
+    <% component.with_attributes_key_value([
+      { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @object.oauth_application.uid },
+      { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
+    ]) %>
   <% end %>
-</div>
+<% end %>
+
+<%= render(AttributeGroups::AttributeGroupComponent.new) do |component| %>
+  <% component.with_group_header(title: "#{t("storages.provider_types.#{@object.short_provider_type}.name")} #{t(:'storages.label_oauth_client_details')}") %>
+
+  <% if @object.oauth_client %>
+    <% component.with_attributes_key_value([
+      { key: t(:'storages.label_oauth_client_id'), value: @object.oauth_client.client_id },
+      { key: t(:'storages.label_oauth_client_secret'), value: short_secret(@object.oauth_client.client_secret) },
+    ]) %>
+  <% else %>
+    <% t(:'storages.oauth_client_details_missing') %>
+  <% end %>
+<% end %>

--- a/spec/components/attribute_groups/attribute_group_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_component_spec.rb
@@ -58,4 +58,19 @@ RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
        have_css('.attributes-key-value--value.-text', text: 'Attribute Value 2')
     end
   end
+
+  it 'renders content when provided' do
+    render_inline(described_class.new) do |component|
+      component.with_group_header(title: "A Title")
+
+      "Raw Content"
+    end
+
+    expect(page).to have_css('.attributes-group--content', text: 'Raw Content')
+
+    aggregate_failures 'group header' do
+      expect(page).to have_css('.attributes-group')
+      expect(page).to have_css('h3.attributes-group--header-text', text: 'A Title')
+    end
+  end
 end

--- a/spec/components/attribute_groups/attribute_group_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_component_spec.rb
@@ -33,9 +33,9 @@ require "rails_helper"
 RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
   it 'renders the title' do
     render_inline(described_class.new) do |component|
-      component.with_group_header(title: "A Title")
+      component.with_header(title: "A Title")
 
-      component.with_attributes_key_value(
+      component.with_attributes(
         [{ key: "Attribute Key 1", value: "Attribute Value 1" },
          { key: "Attribute Key 2", value: "Attribute Value 2" }]
       )
@@ -57,7 +57,7 @@ RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
 
   it 'renders content when provided' do
     render_inline(described_class.new) do |component|
-      component.with_group_header(title: "A Title")
+      component.with_header(title: "A Title")
 
       "Raw Content"
     end

--- a/spec/components/attribute_groups/attribute_group_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_component_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
+  subject(:component_render) do
+    render_inline(described_class.new) do |component|
+      component.with_group_header(title: "A Title")
+
+      component.with_attributes_key_value(
+        [{ attribute_key: "Attribute Key 1", attribute_value: "Attribute Value 1" },
+         { attribute_key: "Attribute Key 2", attribute_value: "Attribute Value 2" }]
+      )
+    end
+  end
+
+  before { component_render }
+
+  it 'renders the title' do
+    aggregate_failures 'group header' do
+      expect(page).to have_css('.attributes-group')
+      expect(page).to have_css('h3.attributes-group--header-text', text: 'A Title')
+    end
+
+    aggregate_failures 'attribute key value' do
+      expect(page).to have_css('.attributes-key-value')
+      expect(page).to have_css('.attributes-key-value--key', text: 'Attribute Key 1') &
+       have_css('.attributes-key-value--value.-text', text: 'Attribute Value 1')
+      expect(page).to have_css('.attributes-key-value--key', text: 'Attribute Key 2') &
+       have_css('.attributes-key-value--value.-text', text: 'Attribute Value 2')
+    end
+  end
+end

--- a/spec/components/attribute_groups/attribute_group_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_component_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
       component.with_group_header(title: "A Title")
 
       component.with_attributes_key_value(
-        [{ attribute_key: "Attribute Key 1", attribute_value: "Attribute Value 1" },
-         { attribute_key: "Attribute Key 2", attribute_value: "Attribute Value 2" }]
+        [{ key: "Attribute Key 1", value: "Attribute Value 1" },
+         { key: "Attribute Key 2", value: "Attribute Value 2" }]
       )
     end
   end

--- a/spec/components/attribute_groups/attribute_group_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_component_spec.rb
@@ -31,7 +31,7 @@
 require "rails_helper"
 
 RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
-  subject(:component_render) do
+  it 'renders the title' do
     render_inline(described_class.new) do |component|
       component.with_group_header(title: "A Title")
 
@@ -40,11 +40,7 @@ RSpec.describe AttributeGroups::AttributeGroupComponent, type: :component do
          { key: "Attribute Key 2", value: "Attribute Value 2" }]
       )
     end
-  end
 
-  before { component_render }
-
-  it 'renders the title' do
     aggregate_failures 'group header' do
       expect(page).to have_css('.attributes-group')
       expect(page).to have_css('h3.attributes-group--header-text', text: 'A Title')

--- a/spec/components/attribute_groups/attribute_group_header_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_header_component_spec.rb
@@ -31,13 +31,9 @@
 require "rails_helper"
 
 RSpec.describe AttributeGroups::AttributeGroupHeaderComponent, type: :component do
-  subject(:component_render) do
-    render_inline(described_class.new(title: 'A Title'))
-  end
-
-  before { component_render }
-
   it 'renders the title' do
+    render_inline(described_class.new(title: 'A Title'))
+
     expect(page).to have_css('h3.attributes-group--header-text', text: 'A Title')
   end
 end

--- a/spec/components/attribute_groups/attribute_group_header_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_group_header_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe AttributeGroups::AttributeGroupHeaderComponent, type: :component do
+  subject(:component_render) do
+    render_inline(described_class.new(title: 'A Title'))
+  end
+
+  before { component_render }
+
+  it 'renders the title' do
+    expect(page).to have_css('h3.attributes-group--header-text', text: 'A Title')
+  end
+end

--- a/spec/components/attribute_groups/attribute_key_value_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_key_value_component_spec.rb
@@ -32,7 +32,7 @@ require "rails_helper"
 
 RSpec.describe AttributeGroups::AttributeKeyValueComponent, type: :component do
   subject(:component_render) do
-    render_inline(described_class.new(attribute_key: 'Attribute Key', attribute_value: 'Attribute Value'))
+    render_inline(described_class.new(key: 'Attribute Key', value: 'Attribute Value'))
   end
 
   before { component_render }

--- a/spec/components/attribute_groups/attribute_key_value_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_key_value_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe AttributeGroups::AttributeKeyValueComponent, type: :component do
+  subject(:component_render) do
+    render_inline(described_class.new(attribute_key: 'Attribute Key', attribute_value: 'Attribute Value'))
+  end
+
+  before { component_render }
+
+  it 'renders the attribute key and value' do
+    expect(page).to have_css('.attributes-key-value--key', text: 'Attribute Key') &
+      have_css('.attributes-key-value--value.-text', text: 'Attribute Value')
+  end
+end

--- a/spec/components/attribute_groups/attribute_key_value_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_key_value_component_spec.rb
@@ -31,13 +31,9 @@
 require "rails_helper"
 
 RSpec.describe AttributeGroups::AttributeKeyValueComponent, type: :component do
-  subject(:component_render) do
-    render_inline(described_class.new(key: 'Attribute Key', value: 'Attribute Value'))
-  end
-
-  before { component_render }
-
   it 'renders the attribute key and value' do
+    render_inline(described_class.new(key: 'Attribute Key', value: 'Attribute Value'))
+
     expect(page).to have_css('.attributes-key-value--key', text: 'Attribute Key') &
       have_css('.attributes-key-value--value.-text', text: 'Attribute Value')
   end


### PR DESCRIPTION
Reduce ERB template HTML duplication, perceived complexity by defining unit testable view components

### Tasks

- [x] Define View Components
  - [x] `AttributeGroupComponent` _[Slot component](https://viewcomponent.org/guide/slots.html)_ that renders `AttributeGroupHeaderComponent` and `AttributeKeyValueComponent`
- [x] Update related views _*priority scope is storages module to begin with_
  - [x] `admin/storages/show`
  - [x] `admin/storages/edit`
- [x] Rebase https://github.com/opf/openproject/pull/12935 (non-blocking for code review :) )


_Known issue: attribute keys styling is broken as  of #12588_

https://community.openproject.org/projects/expedition/work_packages/48620