### PR TITLE
Small fixes based on rbs research

### DIFF
--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -34,7 +34,9 @@ class WorkPackageCustomField < CustomField
                           join_table: "#{table_name_prefix}custom_fields_types#{table_name_suffix}",
                           foreign_key: 'custom_field_id'
   has_many :work_packages,
-           through: :work_package_custom_values
+           through: :custom_values,
+           source: :customized,
+           source_type: "WorkPackage"
 
   scope :visible_by_user, ->(user) {
     if user.allowed_to_globally?(:select_custom_fields)

--- a/lib/tasks/attachment_migrations.rake
+++ b/lib/tasks/attachment_migrations.rake
@@ -41,7 +41,7 @@ module Migrations
     class CurrentWikiPage < ::ActiveRecord::Base
       self.table_name = "wiki_pages"
 
-      has_one :content, class_name: 'WikiContent', foreign_key: 'page_id', dependent: :destroy
+      has_one :content, class_name: 'CurrentWikiContent', foreign_key: 'page_id', dependent: :destroy
     end
 
     class CurrentWikiContent < ::ActiveRecord::Base


### PR DESCRIPTION
While working on #12916 the type checker has identified those 2 issues. Regardless of if the PR gets merged, those fixes should be implemented.

```ruby
# Current dev
[1] pry(main)> WorkPackageCustomField.first.work_packages
  WorkPackageCustomField Load (2.6ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 ORDER BY "custom_fields"."id" ASC LIMIT $2  [["type", "WorkPackageCustomField"], ["LIMIT", 1]]
ActiveRecord::HasManyThroughAssociationNotFoundError: Could not find the association :work_package_custom_values in model WorkPackageCustomField
from /Users/klaustopher/.rvm/gems/ruby-3.2.1/gems/activerecord-7.0.5/lib/active_record/reflection.rb:944:in `check_validity!'

# This branch
[1] pry(main)> WorkPackageCustomField.first.work_packages
  WorkPackageCustomField Load (0.7ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 ORDER BY "custom_fields"."id" ASC LIMIT $2  [["type", "WorkPackageCustomField"], ["LIMIT", 1]]
  WorkPackage Load (13.2ms)  SELECT "work_packages".* FROM "work_packages" INNER JOIN "custom_values" ON "work_packages"."id" = "custom_values"."customized_id" WHERE "custom_values"."custom_field_id" = $1 AND "custom_values"."customized_type" = $2  [["custom_field_id", 1], ["customized_type", "WorkPackage"]]
=> [#<WorkPackage:0x000000010dd2a128 ...>]
```