### PR TITLE
Move the activity sidebar into the menu

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -27,25 +27,24 @@
 #++
 
 class ActivitiesController < ApplicationController
+  include Layout
+
   menu_item :activity
   before_action :find_optional_project,
                 :verify_activities_module_activated,
-                :determine_date_range,
                 :determine_subprojects,
+                :set_activity
+
+  before_action :determine_date_range,
                 :determine_author,
-                :set_current_activity_page
+                :set_current_activity_page,
+                only: :index
 
   after_action :set_session
 
   accept_key_auth :index
 
   def index
-    @activity = Activities::Fetcher.new(User.current,
-                                        project: @project,
-                                        with_subprojects: @with_subprojects,
-                                        author: @author,
-                                        scope: activity_scope)
-
     @events = @activity.events(from: @date_from.to_datetime, to: @date_to.to_datetime)
 
     respond_to do |format|
@@ -61,7 +60,19 @@ class ActivitiesController < ApplicationController
     render_404 I18n.t(:error_can_not_find_all_resources)
   end
 
+  def menu
+    render layout: nil
+  end
+
   private
+
+  def set_activity
+    @activity = Activities::Fetcher.new(User.current,
+                                        project: @project,
+                                        with_subprojects: @with_subprojects,
+                                        author: @author,
+                                        scope: activity_scope)
+  end
 
   def verify_activities_module_activated
     render_403 if @project && !@project.module_enabled?('activity')
@@ -79,8 +90,11 @@ class ActivitiesController < ApplicationController
   end
 
   def determine_subprojects
-    @with_subprojects = if params[:with_subprojects].nil?
+    @with_subprojects = if params[:with_subprojects].nil? &&
+                          (session[:activity].nil? || session[:activity][:with_subprojects].nil?)
                           Setting.display_subprojects_work_packages?
+                        elsif params[:with_subprojects].nil?
+                          session[:activity][:with_subprojects]
                         else
                           params[:with_subprojects] == '1'
                         end
@@ -91,7 +105,7 @@ class ActivitiesController < ApplicationController
   end
 
   def respond_html
-    render layout: !request.xhr?
+    render locals: { menu_name: project_or_global_activity_menu }
   end
 
   def respond_atom
@@ -108,7 +122,7 @@ class ActivitiesController < ApplicationController
     if params[:event_types]
       params[:event_types]
     elsif session[:activity]
-      session[:activity]
+      session[:activity][:scope]
     elsif @author.nil?
       :default
     else
@@ -121,6 +135,7 @@ class ActivitiesController < ApplicationController
   end
 
   def set_session
-    session[:activity] = @activity.scope
+    session[:activity] = { scope: @activity.scope,
+                           with_subprojects: @with_subprojects }
   end
 end

--- a/app/controllers/concerns/layout.rb
+++ b/app/controllers/concerns/layout.rb
@@ -40,11 +40,19 @@ module Layout
       end
     end
 
-    def project_or_wp_query_menu
+    def project_or_global_wp_query_menu
       if @project
         :project_menu
       else
-        :wp_query_menu
+        :global_work_packages_menu
+      end
+    end
+
+    def project_or_global_activity_menu
+      if @project
+        :project_menu
+      else
+        :global_activities_menu
       end
     end
   end

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -45,7 +45,7 @@ class WorkPackagesController < ApplicationController
     respond_to do |format|
       format.html do
         render :index,
-               locals: { query: @query, project: @project, menu_name: project_or_wp_query_menu },
+               locals: { query: @query, project: @project, menu_name: project_or_global_wp_query_menu },
                layout: 'angular/angular'
       end
 
@@ -63,7 +63,7 @@ class WorkPackagesController < ApplicationController
     respond_to do |format|
       format.html do
         render :show,
-               locals: { work_package:, menu_name: project_or_wp_query_menu },
+               locals: { work_package:, menu_name: project_or_global_wp_query_menu },
                layout: 'angular/angular'
       end
 

--- a/app/views/activities/_filters_menu.html.erb
+++ b/app/views/activities/_filters_menu.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag "activity_menu",
+                    src: url_for(controller: '/activities', action: :menu, project_id: @project),
+                    data: { turbo: false },
+                    loading: :lazy do %>
+<% end %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -70,37 +70,4 @@ See COPYRIGHT and LICENSE files for more details.
                               { format: 'atom', from: nil, key: User.current.rss_key }) %>
 <% end %>
 
-<% content_for :sidebar do %>
-  <%= form_tag({}, method: :get) do %>
-    <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= t(:description_filter) %></legend>
-    <p>
-      <%= hidden_field_tag "event_types[]" %>
-      <% @activity.event_types.sort_by { |type| t("activity.filter.#{type.singularize}") }.each do |t| %>
-        <% unless t == "project_attributes" %>
-          <%= check_box_tag "event_types[]", t, @activity.scope.include?(t), id: "event_types_#{t}" %>
-          <label for="event_types_<%=t%>"><%=t("activity.filter.#{t.singularize}")%></label>
-          <br />
-        <% end -%>
-      <% end %>
-    </p>
-    <p>
-      <% if @activity.event_types.include?("project_attributes") %>
-        <%= check_box_tag "event_types[]", "project_attributes", @activity.scope.include?("project_attributes"), id: "event_types_project_attributes" %>
-        <label for="event_types_project_attributes"><%=t("activity.filter.project_attribute")%></label>
-        <br />
-      <% end -%>
-      <% if @project && @project.descendants.active.any? %>
-        <%= hidden_field_tag 'with_subprojects', 0 %>
-        <%= check_box_tag 'with_subprojects', 1, @with_subprojects, id: "with_subprojects" %>
-        <label for="with_subprojects"><%=t("activity.filter.subproject")%></label>
-      <% end %>
-    </p>
-    <%= hidden_field_tag('user_id', params[:user_id]) if params[:user_id].present? %>
-    <%= hidden_field_tag('from', params[:from]) if params[:from].present? %>
-    <p><%= submit_tag t(:button_apply), class: 'button -small -highlight', name: nil %></p>
-    </fieldset>
-  <% end %>
-<% end %>
-
 <% html_title(t(:label_activity), @author) -%>

--- a/app/views/activities/menu.html.erb
+++ b/app/views/activities/menu.html.erb
@@ -1,0 +1,34 @@
+<%= turbo_frame_tag "activity_menu", target: "_top" do %>
+  <%= form_tag(polymorphic_url([@project, :activities]), method: :get) do %>
+    <fieldset class="form--fieldset sidebar">
+      <legend class="form--fieldset-legend"><%= t(:description_filter) %></legend>
+      <p>
+        <%= hidden_field_tag "event_types[]" %>
+        <% @activity.event_types.sort_by { |type| t("activity.filter.#{type.singularize}") }.each do |t| %>
+          <% unless t == "project_attributes" %>
+            <%= check_box_tag "event_types[]", t, @activity.scope.include?(t), id: "event_types_#{t}" %>
+            <label for="event_types_<%=t%>"><%=t("activity.filter.#{t.singularize}")%></label>
+            <br />
+          <% end -%>
+        <% end %>
+      </p>
+      <p>
+        <% if @activity.event_types.include?("project_attributes") %>
+          <%= check_box_tag "event_types[]", "project_attributes", @activity.scope.include?("project_attributes"), id: "event_types_project_attributes" %>
+          <label for="event_types_project_attributes"><%=t("activity.filter.project_attribute")%></label>
+          <br />
+        <% end -%>
+        <% if @project && @project.descendants.active.any? %>
+          <%= hidden_field_tag 'with_subprojects', 0, id: nil %>
+          <%= check_box_tag 'with_subprojects', 1, @with_subprojects, id: "with_subprojects" %>
+          <label for="with_subprojects"><%=t("activity.filter.subproject")%></label>
+        <% end %>
+      </p>
+      <%= hidden_field_tag('user_id', params[:user_id]) if params[:user_id].present? %>
+      <%= hidden_field_tag('from', params[:from]) if params[:from].present? %>
+      <p><%= submit_tag t(:button_apply),
+                        class: 'button -small -highlight',
+                        name: nil %></p>
+    </fieldset>
+  <% end %>
+<% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -118,12 +118,16 @@ Redmine::MenuManager.map :account_menu do |menu|
             if: Proc.new { User.current.logged? }
 end
 
-Redmine::MenuManager.map :application_menu do |menu|
+Redmine::MenuManager.map :global_work_packages_menu do |menu|
   menu.push :work_packages_query_select,
             { controller: '/work_packages', action: 'index' },
-            parent: :work_packages,
-            partial: 'work_packages/menu_query_select',
-            last: true
+            partial: 'work_packages/menu_query_select'
+end
+
+Redmine::MenuManager.map :global_activities_menu do |menu|
+  menu.push :activity_filters,
+            { controller: '/activities', action: 'index' },
+            partial: 'activities/filters_menu'
 end
 
 Redmine::MenuManager.map :notifications_menu do |menu|
@@ -460,6 +464,12 @@ Redmine::MenuManager.map :project_menu do |menu|
             { controller: '/activities', action: 'index' },
             if: Proc.new { |p| p.module_enabled?('activity') },
             icon: 'checkmark'
+
+  menu.push :activity_filters,
+            { controller: '/activities', action: 'index' },
+            if: Proc.new { |p| p.module_enabled?('activity') },
+            parent: :activity,
+            partial: 'activities/filters_menu'
 
   menu.push :roadmap,
             { controller: '/versions', action: 'index' },

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -363,7 +363,7 @@ Rails.application.reloader.to_prepare do
 
     map.project_module :activity do
       map.permission :view_project_activity,
-                     { activities: [:index] },
+                     { activities: %i[index menu] },
                      public: true,
                      contract_actions: { activities: %i[read] }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,7 +264,11 @@ OpenProject::Application.routes.draw do
       get '(/*state)' => 'work_packages#show', on: :member, as: ''
     end
 
-    resources :activity, :activities, only: :index, controller: 'activities'
+    resources :activity, :activities, only: :index, controller: 'activities' do
+      collection do
+        get :menu
+      end
+    end
 
     resources :forums do
       member do
@@ -462,7 +466,11 @@ OpenProject::Application.routes.draw do
     end
   end
 
-  resources :activity, :activities, only: :index, controller: 'activities'
+  resources :activity, :activities, only: :index, controller: 'activities' do
+    collection do
+      get :menu
+    end
+  end
 
   resources :users, constraints: { id: /(\d+|me)/ }, except: :edit do
     resources :memberships, controller: 'users/memberships', only: %i[update create destroy]

--- a/frontend/src/global_styles/common/input/input.component.sass
+++ b/frontend/src/global_styles/common/input/input.component.sass
@@ -1,5 +1,0 @@
-.op-input
-  background: white
-  border: 1px solid #e2e8f0
-  border-radius: 2px
-  display: flex

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -261,8 +261,9 @@ fieldset.form--fieldset
       @include icon-mixin-arrow-down1
       padding: 0.625rem 0.25rem 0 0.25rem
 
-#sidebar .form--fieldset-legend
+#main-menu .form--fieldset-legend
   color: var(--main-menu-fieldset-header-color)
+  margin-bottom: 1rem
 
 .form--toolbar
   float: right

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -257,6 +257,8 @@ a.main-menu--parent-node
 
 #sidebar
   margin: 30px 0 0 0
+
+#sidebar, #menu-sidebar .sidebar
   padding: 0 17px 0 17px
   width: auto
   color: var(--main-menu-sidebar-font-color)

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -47,8 +47,6 @@ module Redmine::MenuManager::MenuHelper
     elsif menu == :project_menu && project && project.persisted?
       build_wiki_menus(project)
       render_menu(:project_menu, project)
-    elsif menu == :wp_query_menu
-      render_menu(:application_menu, project)
     else
       render_menu(menu, project)
     end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -202,30 +202,36 @@ RSpec.describe ActivitiesController do
 
         it { expect(assigns(:activity).scope).to match_array(default_scope) }
 
-        it { expect(session[:activity]).to match_array(default_scope) }
+        it { expect(session[:activity][:scope]).to match_array(default_scope) }
+
+        it { expect(session[:activity][:with_subprojects]).to be(true) }
       end
 
       describe 'subsequent activity requests' do
         let(:scope) { [] }
         let(:params) { {} }
-        let(:session_hash) { { activity: [] } }
+        let(:session_hash) { { activity: { scope: [], with_subprojects: true } } }
 
         include_context 'for GET index with params'
 
         it { expect(assigns(:activity).scope).to match_array(scope) }
 
-        it { expect(session[:activity]).to match_array(scope) }
+        it { expect(session[:activity][:scope]).to match_array(scope) }
+
+        it { expect(session[:activity][:with_subprojects]).to be(true) }
       end
 
       describe 'selection with apply' do
         let(:scope) { [] }
-        let(:params) { { event_types: [''] } }
+        let(:params) { { event_types: [''], with_subprojects: 0 } }
 
         include_context 'for GET index with params'
 
         it { expect(assigns(:activity).scope).to match_array(scope) }
 
-        it { expect(session[:activity]).to match_array(scope) }
+        it { expect(session[:activity][:scope]).to match_array(scope) }
+
+        it { expect(session[:activity][:with_subprojects]).to be(false) }
       end
     end
   end

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Activity page navigation' do
+RSpec.describe 'Activity page navigation', js: true do
   include ActiveSupport::Testing::TimeHelpers
 
   shared_let(:project) { create(:project, enabled_module_names: Setting.default_projects_modules + ['activity']) }
@@ -42,12 +42,14 @@ RSpec.describe 'Activity page navigation' do
   end
   shared_let(:project_work_package) { create(:work_package, project:, subject: 'Work package for parent project') }
   shared_let(:subproject_work_package) { create(:work_package, project: subproject, subject: 'Work package for subproject') }
+
   shared_let(:project_older_work_package) do
     travel_to 45.days.ago
     create(:work_package, project:, subject: 'Work package older for parent project')
   ensure
     travel_back
   end
+
   shared_let(:subproject_older_work_package) do
     travel_to 45.days.ago
     create(:work_package, project: subproject, subject: 'Work package older for subproject')

--- a/spec/features/activities/disabled_activity_spec.rb
+++ b/spec/features/activities/disabled_activity_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Disabled activity' do
+RSpec.describe 'Disabled activity', js: true do
   shared_let(:admin) { create(:admin) }
 
   let(:project1) do
@@ -55,9 +55,7 @@ RSpec.describe 'Disabled activity' do
     create(:wiki_page, wiki:)
   end
 
-  before do
-    login_as(admin)
-  end
+  current_user { admin }
 
   it 'does not display activities on projects disabling it' do
     visit activity_index_path

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -49,10 +49,17 @@ RSpec.describe Redmine::MenuManager do
       end
     end
 
-    context 'for the application_menu' do
+    context 'for the global_work_packages_menu' do
       it 'includes the expected items' do
-        expect(described_class.items(:application_menu).map(&:name))
+        expect(described_class.items(:global_work_packages_menu).map(&:name))
           .to include(:work_packages_query_select)
+      end
+    end
+
+    context 'for the global_activities_menu' do
+      it 'includes the expected items' do
+        expect(described_class.items(:global_activities_menu).map(&:name))
+          .to include(:activity_filters)
       end
     end
 

--- a/spec/routing/activities_spec.rb
+++ b/spec/routing/activities_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe ActivitiesController, 'routing' do
                                               action: 'index',
                                               format: 'atom')
   }
+  it {
+    expect(get('/activity/menu')).to route_to(controller: 'activities',
+                                              action: 'menu')
+  }
 
   context 'project scoped' do
     it {
@@ -52,6 +56,12 @@ RSpec.describe ActivitiesController, 'routing' do
                                                              action: 'index',
                                                              project_id: 'abc',
                                                              format: 'atom')
+    }
+
+    it {
+      expect(get('/projects/abc/activity/menu')).to route_to(controller: 'activities',
+                                                             action: 'menu',
+                                                             project_id: 'abc')
     }
   end
 end


### PR DESCRIPTION
Without changing the behaviour of the activity filter section, moves it to become a submenu item of 'Activity' instead of placing it in the sidebar:

Before:

<img width="228" alt="image" src="https://github.com/opf/openproject/assets/617519/7ef270c3-ad4b-4232-acbd-7b510229edf8">
 

After:
<img width="221" alt="image" src="https://github.com/opf/openproject/assets/617519/e93ebe97-ef7c-421d-b977-a26e4c301b99">

In the global scope, the top padding is too small.

<img width="228" alt="image" src="https://github.com/opf/openproject/assets/617519/57cc3029-480d-4a50-8aea-ce6ebe58a4f6">

Chances are high that, when adding a global menu to the application in 13.0, the global activities will receive a heading same as the project activities and then the padding should be ok. 
