### PR TITLE
chore(View Components): Rename base class to `ApplicationComponent`

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RailsComponent < ViewComponent::Base
+class ApplicationComponent < ViewComponent::Base
   attr_reader :model, :options
 
   def initialize(model = nil, **options)

--- a/app/components/components/on_off_status_component.rb
+++ b/app/components/components/on_off_status_component.rb
@@ -31,7 +31,7 @@
 module Components
   ##
   # A language switch and text area for updating a localized text setting.
-  class OnOffStatusComponent < ::RailsComponent
+  class OnOffStatusComponent < ::ApplicationComponent
     options :on_text
     options :on_description
     options :off_text

--- a/app/components/individual_principal_base_filter_component.rb
+++ b/app/components/individual_principal_base_filter_component.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class IndividualPrincipalBaseFilterComponent < RailsComponent
+class IndividualPrincipalBaseFilterComponent < ApplicationComponent
   class << self
     def query(params)
       q = base_query.new

--- a/app/components/members/role_form_component.rb
+++ b/app/components/members/role_form_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module Members
-  class RoleFormComponent < ::RailsComponent
+  class RoleFormComponent < ::ApplicationComponent
     options :row, :params, :roles
 
     def member

--- a/app/components/row_component.rb
+++ b/app/components/row_component.rb
@@ -30,7 +30,7 @@
 
 ##
 # Abstract view component. Subclass this for a concrete table row.
-class RowComponent < RailsComponent
+class RowComponent < ApplicationComponent
   attr_reader :table
 
   def initialize(row:, table:, **options)

--- a/app/components/settings/numeric_setting_component.rb
+++ b/app/components/settings/numeric_setting_component.rb
@@ -31,7 +31,7 @@
 module Settings
   ##
   # A text field to enter numeric values.
-  class NumericSettingComponent < ::RailsComponent
+  class NumericSettingComponent < ::ApplicationComponent
     options :unit, :title
     options size: 3
 

--- a/app/components/settings/text_setting_component.rb
+++ b/app/components/settings/text_setting_component.rb
@@ -31,7 +31,7 @@
 module Settings
   ##
   # A language switch and text area for updating a localized text setting.
-  class TextSettingComponent < ::RailsComponent
+  class TextSettingComponent < ::ApplicationComponent
     include OpenProject::FormTagHelper
 
     options :name # name of setting and tag to differentiate between different language selects

--- a/app/components/settings/time_zone_setting_component.rb
+++ b/app/components/settings/time_zone_setting_component.rb
@@ -31,7 +31,7 @@
 module Settings
   ##
   # A text field to enter numeric values.
-  class TimeZoneSettingComponent < ::RailsComponent
+  class TimeZoneSettingComponent < ::ApplicationComponent
     options :form, :title
     options container_class: "-wide"
     options include_blank: true

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -30,7 +30,7 @@
 
 ##
 # Abstract view component. Subclass this for a concrete table.
-class TableComponent < RailsComponent
+class TableComponent < ApplicationComponent
   def initialize(rows: [], **options)
     super(rows, **options)
   end

--- a/modules/webhooks/app/components/webhooks/outgoing/deliveries/response_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/deliveries/response_component.rb
@@ -1,7 +1,7 @@
 module ::Webhooks
   module Outgoing
     module Deliveries
-      class ResponseComponent < RailsComponent
+      class ResponseComponent < ApplicationComponent
         property :id
         property :response_headers
         property :response_body


### PR DESCRIPTION
The name `RailsComponent` was a result of the now deprecated "RailsCells" which have been replaced by view components. ApplicationComponent is more conventional now.