### PR TITLE
Replace Selenium with Cuprite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -230,6 +230,7 @@ RSpec/ContextWording:
   Prefixes:
     - as
     - for
+    - having
     - if
     - 'on'
     - to

--- a/Gemfile
+++ b/Gemfile
@@ -236,6 +236,7 @@ group :test do
 
   gem 'capybara', '~> 3.39.0'
   gem 'capybara-screenshot', '~> 1.0.17'
+  gem 'cuprite', '~> 0.14.3'
   gem 'selenium-webdriver', '~> 4.0'
   gem 'webdrivers', '~> 5.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.14.3)
+      capybara (~> 3.0)
+      ferrum (~> 0.13.0)
     daemons (1.4.1)
     dalli (3.2.5)
     date (3.3.3)
@@ -454,6 +457,11 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     fastimage (2.2.7)
+    ferrum (0.13)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.5)
     flamegraph (0.9.5)
     fog-aws (3.19.0)
@@ -1011,6 +1019,7 @@ DEPENDENCIES
   commonmarker (~> 0.23.9)
   compare-xml (~> 0.66)
   costs!
+  cuprite (~> 0.14.3)
   daemons
   dalli (~> 3.2.0)
   dashboards!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,12 +154,14 @@ services:
       - db-test
       - selenium-hub
       - frontend-test
+      - cuprite-chrome
     environment:
       RAILS_ENV: test
       OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"
       DATABASE_URL: postgresql://openproject:openproject@db-test/openproject
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SELENIUM_GRID_URL: http://selenium-hub:4444/wd/hub
+      CHROME_URL: http://cuprite-chrome:3333
       CAPYBARA_SERVER_PORT: 3000
       CAPYBARA_DYNAMIC_BIND_IP: 1
       CAPYBARA_APP_HOSTNAME: backend-test
@@ -241,3 +243,18 @@ services:
       # in case we want multiple sessions per container
       NODE_MAX_INSTANCES: "${CI_JOBS:-4}"
       NODE_MAX_SESSION: "${CI_JOBS:-4}"
+
+  cuprite-chrome:
+    # Currently, Apple M1 is only supported in unnumbered "latest" versions.
+    # See https://github.com/browserless/chrome/issues/1393
+    image: browserless/chrome:latest
+    networks:
+      - testing
+    ports:
+      - "3333:3333"
+    environment:
+      # By default, it uses 3000, which is typically used by Rails.
+      PORT: 3333
+      # Set connection timeout to avoid timeout exception during debugging
+      # https://docs.browserless.io/docs/docker.html#connection-timeout
+      CONNECTION_TIMEOUT: 600000

--- a/modules/avatars/spec/features/shared_avatar_examples.rb
+++ b/modules/avatars/spec/features/shared_avatar_examples.rb
@@ -78,8 +78,9 @@ RSpec.shared_examples 'avatar management' do
       expect(%i(jpeg jpg)).to include image_data.type
 
       # Delete the avatar
-      find('.avatars--local-avatar-delete-link').click
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        find('.avatars--local-avatar-delete-link').click
+      end
 
       expect(page).to have_selector('.avatars--current-local-avatar', text: 'none', wait: 20)
     end

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 require_relative '../support/pages/backlogs'
 
 RSpec.describe 'Backlogs in backlog view',
-               js: true do
+               js: true,
+               with_cuprite: false do
   let!(:project) do
     create(:project,
            types: [story, task],

--- a/modules/backlogs/spec/features/empty_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/empty_backlogs_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Empty backlogs project',
     let(:role) { create(:role, permissions: %i(view_master_backlog)) }
     let(:current_user) { create(:user, member_in_project: project, member_through_role: role) }
 
-    it 'onlies show a no results box' do
+    it 'only shows a no results box' do
       expect(page).to have_selector '.generic-table--no-results-container', text: I18n.t(:backlogs_empty_title)
       expect(page).not_to have_selector '.generic-table--no-results-description'
     end

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 require_relative '../support/pages/backlogs'
 
 RSpec.describe 'Stories in backlog',
-               js: true do
+               js: true,
+               with_cuprite: false do
   let!(:project) do
     create(:project,
            types: [story, task, other_story],

--- a/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
+++ b/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 require_relative '../support/pages/taskboard'
 
 RSpec.describe 'Tasks on taskboard',
-               js: true do
+               js: true,
+               with_cuprite: false do
   let!(:project) do
     create(:project,
            types: [story, task, other_story],

--- a/modules/backlogs/spec/features/work_packages/story_points_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/story_points_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe 'Work packages having story points', js: true do
       wp_page.expect_subject
 
       wp_page.expect_attributes storyPoints: story_points
-
-      wp_page.ensure_page_loaded
     end
   end
 end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Attribute help texts', js: true do
+RSpec.describe 'Attribute help texts',
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
 
   let(:instance) { AttributeHelpText.last }
@@ -43,13 +45,14 @@ RSpec.describe 'Attribute help texts', js: true do
       visit attribute_help_texts_path
     end
 
-    context 'with direct uploads (Regression #34285)', with_direct_uploads: true do
+    # TODO: Migrate to cuprite when the `better_cuprite_billy` driver is added
+    context 'with direct uploads (Regression #34285)', with_cuprite: false, with_direct_uploads: true do
       before do
         allow_any_instance_of(Attachment).to receive(:diskfile).and_return image_fixture
       end
 
       it 'can upload an image' do
-        page.find('.attribute-help-texts--create-button').click
+        find('.attribute-help-texts--create-button').click
         select 'Status', from: 'attribute_help_text_attribute_name'
 
         editor.set_markdown('My attribute help text')
@@ -69,7 +72,7 @@ RSpec.describe 'Attribute help texts', js: true do
 
         # Create help text
         # -> new
-        page.find('.attribute-help-texts--create-button').click
+        find('.attribute-help-texts--create-button').click
 
         # Set attributes
         # -> create
@@ -103,7 +106,7 @@ RSpec.describe 'Attribute help texts', js: true do
 
         # -> edit
         SeleniumHubWaiter.wait
-        page.find('.attribute-help-text--entry td a', text: 'Status').click
+        find('.attribute-help-text--entry td a', text: 'Status').click
         SeleniumHubWaiter.wait
         expect(page).to have_selector('#attribute_help_text_attribute_name[disabled]')
         editor.set_markdown(' ')
@@ -135,14 +138,15 @@ RSpec.describe 'Attribute help texts', js: true do
         visit attribute_help_texts_path
 
         # Create new, status is now blocked
-        page.find('.attribute-help-texts--create-button').click
+        find('.attribute-help-texts--create-button').click
         expect(page).to have_selector('#attribute_help_text_attribute_name option', text: 'Assignee')
         expect(page).not_to have_selector('#attribute_help_text_attribute_name option', text: 'Status')
         visit attribute_help_texts_path
 
         # Destroy
-        page.find('.attribute-help-text--entry .icon-delete').click
-        page.driver.browser.switch_to.alert.accept
+        accept_alert do
+          find('.attribute-help-text--entry .icon-delete').click
+        end
 
         expect(page).to have_selector('.generic-table--no-results-container')
         expect(AttributeHelpText.count).to be_zero

--- a/spec/features/admin/custom_fields/list_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/list_custom_field_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'List custom fields edit', js: true do
+RSpec.describe 'List custom fields edit',
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
 
   before do
@@ -40,11 +42,12 @@ RSpec.describe 'List custom fields edit', js: true do
     # Create CF
     click_on 'Create a new custom field'
 
-    SeleniumHubWaiter.wait
+    wait_for_reload
+
     fill_in 'custom_field_name', with: 'My List CF'
     select 'List', from: 'custom_field_field_format'
 
-    expect(page).to have_selector('input#custom_field_custom_options_attributes_0_value')
+    expect(page).to have_field('custom_field_custom_options_attributes_0_value')
     fill_in 'custom_field_custom_options_attributes_0_value', with: 'A'
 
     click_on 'Save'
@@ -55,10 +58,9 @@ RSpec.describe 'List custom fields edit', js: true do
     expect(cf.possible_values.map(&:value)).to eq %w(A)
 
     # Edit again
-    SeleniumHubWaiter.wait
-    page.find('a', text: 'My List CF').click
+    find('a', text: 'My List CF').click
 
-    expect(page).to have_selector('input#custom_field_custom_options_attributes_0_value')
+    expect(page).to have_field('custom_field_custom_options_attributes_0_value')
     fill_in 'custom_field_custom_options_attributes_0_value', with: 'B'
 
     click_on 'Save'

--- a/spec/features/admin/enterprise/token_domain_spec.rb
+++ b/spec/features/admin/enterprise/token_domain_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Enterprise Edition token domain', js: true do
+RSpec.describe 'Enterprise Edition token domain',
+               js: true,
+               with_cuprite: true do
   let(:current_user) { create(:admin) }
   let(:ee_token) { Rails.root.join("spec/fixtures/ee_tokens/v2_1_user_localhost_3001.token").read }
 
@@ -40,9 +42,11 @@ RSpec.describe 'Enterprise Edition token domain', js: true do
     before do
       visit '/admin/enterprise'
 
-      fill_in "enterprise_token[encoded_token]", with: ee_token
+      within '#new_enterprise_token' do
+        fill_in "enterprise_token[encoded_token]", with: ee_token
 
-      click_on "Save"
+        click_on "Save"
+      end
     end
   end
 
@@ -51,9 +55,6 @@ RSpec.describe 'Enterprise Edition token domain', js: true do
       it_behaves_like 'when uploading a token' do
         it 'saves the token' do
           expect(body).to have_text 'Successful update.'
-        end
-
-        it 'shows the token info' do
           expect(page).to have_selector('[data-qa-selector="ee-active-trial-email"]', text: 'operations@openproject.com')
         end
       end
@@ -81,9 +82,10 @@ RSpec.describe 'Enterprise Edition token domain', js: true do
       before do
         click_on "Replace your current support token"
 
-        fill_in "enterprise_token[encoded_token]", with: new_token
-
-        click_on "Save"
+        within '#new_enterprise_token' do
+          fill_in "enterprise_token[encoded_token]", with: new_token
+          click_on "Save"
+        end
       end
     end
 

--- a/spec/features/admin/oauth/oauth_applications_management_spec.rb
+++ b/spec/features/admin/oauth/oauth_applications_management_spec.rb
@@ -28,11 +28,13 @@
 
 require 'spec_helper'
 
-RSpec.describe 'OAuth applications management', js: true do
+RSpec.describe 'OAuth applications management',
+               js: true,
+               with_cuprite: true do
   let(:admin) { create(:admin) }
 
   before do
-    login_as(admin)
+    login_as admin
     visit oauth_applications_path
   end
 
@@ -43,7 +45,6 @@ RSpec.describe 'OAuth applications management', js: true do
     # Create application
     find('.button', text: 'Add').click
 
-    SeleniumHubWaiter.wait
     fill_in 'application_name', with: 'My API application'
     # Fill invalid redirect_uri
     fill_in 'application_redirect_uri', with: "not a url!"
@@ -51,7 +52,6 @@ RSpec.describe 'OAuth applications management', js: true do
 
     expect(page).to have_selector('.errorExplanation', text: 'Redirect URI must be an absolute URI.')
 
-    SeleniumHubWaiter.wait
     fill_in('application_redirect_uri', with: "")
     # Fill rediret_uri which does not provide a Secure Context
     fill_in 'application_redirect_uri', with: "http://example.org"
@@ -60,7 +60,6 @@ RSpec.describe 'OAuth applications management', js: true do
     expect(page).to have_selector('.errorExplanation', text: 'Redirect URI is not providing a "Secure Context"')
 
     # Can create localhost without https (https://community.openproject.com/wp/34025)
-    SeleniumHubWaiter.wait
     fill_in 'application_redirect_uri', with: "urn:ietf:wg:oauth:2.0:oob\nhttp://localhost/my/callback"
     click_on 'Create'
 
@@ -74,15 +73,12 @@ RSpec.describe 'OAuth applications management', js: true do
     expect(page.first('.attributes-key-value--value code').text).to match /\w+/
 
     # Edit again
-    SeleniumHubWaiter.wait
     click_on 'Edit'
 
-    SeleniumHubWaiter.wait
     fill_in 'application_redirect_uri', with: "urn:ietf:wg:oauth:2.0:oob"
     click_on 'Save'
 
     # Show application
-    SeleniumHubWaiter.wait
     find('td a', text: 'My API application').click
 
     expect(page).not_to have_selector('.attributes-key-value--key', text: 'Client secret')
@@ -90,9 +86,9 @@ RSpec.describe 'OAuth applications management', js: true do
     expect(page).to have_selector('.attributes-key-value--key', text: 'Client ID')
     expect(page).to have_selector('.attributes-key-value--value', text: "urn:ietf:wg:oauth:2.0:oob")
 
-    SeleniumHubWaiter.wait
-    click_on 'Delete'
-    page.driver.browser.switch_to.alert.accept
+    accept_alert do
+      click_on 'Delete'
+    end
 
     # Table is empty again
     expect(page).to have_selector('.generic-table--empty-row', text: 'There is currently nothing to display')

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -28,11 +28,11 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Test mail notification', js: true do
+RSpec.describe 'Test mail notification', js: true, with_cuprite: true do
   shared_let(:admin) { create(:admin) }
 
   before do
-    login_as(admin)
+    login_as admin
     visit admin_settings_mail_notifications_path(tab: :notifications)
   end
 

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Working Days', js: true do
+RSpec.describe 'Working Days', js: true, with_cuprite: true do
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }

--- a/spec/features/categories/delete_spec.rb
+++ b/spec/features/categories/delete_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/categories/categories_page'
 
-RSpec.describe 'Deletion', js: true do
+RSpec.describe 'Deletion', js: true, with_cuprite: true do
   let(:current_user) do
     create(:user,
            member_in_project: category.project,
@@ -46,9 +46,9 @@ RSpec.describe 'Deletion', js: true do
     before do
       categories_page.visit_settings
 
-      find(delete_button).click
-
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        find(delete_button).click
+      end
     end
   end
 

--- a/spec/features/custom_fields/activate_in_project_spec.rb
+++ b/spec/features/custom_fields/activate_in_project_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true do
+RSpec.describe 'custom fields', js: true, with_cuprite: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
   let(:for_all_cf) { create(:list_wp_custom_field, is_for_all: true) }
@@ -37,15 +37,14 @@ RSpec.describe 'custom fields', js: true do
   let(:work_package) do
     wp = build(:work_package).tap do |wp|
       wp.type.custom_fields = [for_all_cf, project_specific_cf]
+      wp.save!
     end
-    wp.save!
-    wp
   end
   let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
   let(:project_settings_page) { Pages::Projects::Settings.new(work_package.project) }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   it 'is only visible in the project if it has been activated' do

--- a/spec/features/custom_fields/create_bool_spec.rb
+++ b/spec/features/custom_fields/create_bool_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true do
+RSpec.describe 'custom fields', js: true, with_cuprite: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   describe "available fields" do
@@ -28,6 +28,7 @@ RSpec.describe 'custom fields', js: true do
     before do
       cf_page.visit!
       click_on "Create a new custom field"
+      wait_for_reload
     end
 
     it "creates a new bool custom field" do

--- a/spec/features/custom_fields/create_date_spec.rb
+++ b/spec/features/custom_fields/create_date_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true do
+RSpec.describe 'custom fields', js: true, with_cuprite: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   describe "creating a new date custom field" do
@@ -14,6 +14,7 @@ RSpec.describe 'custom fields', js: true do
       cf_page.visit!
 
       click_on "Create a new custom field"
+      wait_for_reload
     end
 
     it "creates a new date custom field" do

--- a/spec/features/custom_fields/create_float_spec.rb
+++ b/spec/features/custom_fields/create_float_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true do
+RSpec.describe 'custom fields', js: true, with_cuprite: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   describe "creating a new float custom field" do
@@ -14,7 +14,7 @@ RSpec.describe 'custom fields', js: true do
       cf_page.visit!
 
       click_on "Create a new custom field"
-      SeleniumHubWaiter.wait
+      wait_for_reload
     end
 
     it "creates a new float custom field" do

--- a/spec/features/custom_fields/create_int_spec.rb
+++ b/spec/features/custom_fields/create_int_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true do
+RSpec.describe 'custom fields', js: true, with_cuprite: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   describe "creating a new float custom field" do
@@ -14,6 +14,7 @@ RSpec.describe 'custom fields', js: true do
       cf_page.visit!
 
       click_on "Create a new custom field"
+      wait_for_reload
     end
 
     it "creates a new float custom field" do

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
-RSpec.describe "multi select custom values", js: true do
+RSpec.describe "multi select custom values",
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
@@ -28,7 +30,7 @@ RSpec.describe "multi select custom values", js: true do
   before do
     login_as current_user
     wp_page.visit!
-    wp_page.ensure_page_loaded
+    wait_for_reload
   end
 
   describe 'with mixed users, group, and placeholdders' do
@@ -143,6 +145,8 @@ RSpec.describe "multi select custom values", js: true do
         expect(page).to have_text "Anton Lupin"
 
         page.find(".inline-edit--display-field", text: "Billy Nobbler").click
+
+        wait_for_reload
 
         cf_edit_field.unset_value "Anton Lupin", multi: true
         cf_edit_field.set_value "Cooper Quatermaine"

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
-RSpec.describe "multi select custom values", js: true do
+RSpec.describe "multi select custom values",
+               js: true,
+               with_cuprite: true do
   let(:type) { create(:type) }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
   let(:wp_table) { Pages::WorkPackagesTable.new project }
@@ -127,7 +129,7 @@ RSpec.describe "multi select custom values", js: true do
         hierarchy.expect_no_hierarchies
 
         # Should show truncated values
-        expect(page).to have_text "ham, pineapple, ...\n3"
+        expect(page).to have_text "ham, pineapple, ...3"
         expect(page).not_to have_text "onions"
 
         # Group by the CF
@@ -203,7 +205,7 @@ RSpec.describe "multi select custom values", js: true do
         expect(page).to have_selector('.group--value', text: 'ham, mushrooms, onions, pineapple (1)')
         expect(page).to have_selector('.group--value', text: 'ham (1)')
 
-        wp1_field.expect_state_text ", ...\n4"
+        wp1_field.expect_state_text ", ...4"
       end
     end
 

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -28,12 +28,14 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Global role: Global Create project', js: true do
+RSpec.describe 'Global role: Global Create project',
+               js: true,
+               with_cuprite: true do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   describe 'Create Project is not a member permission' do
@@ -86,7 +88,7 @@ RSpec.describe 'Global role: Global Create project', js: true do
 
       name_field.set_value 'New project name'
 
-      page.find('button:not([disabled])', text: 'Save').click
+      find('button:not([disabled])', text: 'Save').click
 
       expect(page).to have_current_path '/projects/new-project-name/'
     end

--- a/spec/features/global_roles/global_role_assignment_spec.rb
+++ b/spec/features/global_roles/global_role_assignment_spec.rb
@@ -29,9 +29,11 @@
 require 'spec_helper'
 require_relative './mock_global_permissions'
 
-RSpec.describe 'Global role: Global role assignment', js: true do
+RSpec.describe 'Global role: Global role assignment',
+               js: true,
+               with_cuprite: true do
   before do
-    login_as(current_user)
+    login_as current_user
   end
 
   describe 'Going to the global role assignment page' do
@@ -65,7 +67,6 @@ RSpec.describe 'Global role: Global role assignment', js: true do
         expect(page).to have_text 'global_role2'
       end
 
-      SeleniumHubWaiter.wait
       # And I select the available global role "global_role"
       check 'global_role2'
       # And I press "Add"
@@ -86,7 +87,6 @@ RSpec.describe 'Global role: Global role assignment', js: true do
 
       # And I delete the assigned role "global_role"
       page.within("#assigned_global_role_#{global_role1.id}") do
-        SeleniumHubWaiter.wait
         page.find('.buttons a.icon-delete').click
       end
 

--- a/spec/features/global_roles/global_role_crud_spec.rb
+++ b/spec/features/global_roles/global_role_crud_spec.rb
@@ -29,12 +29,14 @@
 require 'spec_helper'
 require_relative './mock_global_permissions'
 
-RSpec.describe 'Global role: Global role CRUD', js: true do
+RSpec.describe 'Global role: Global role CRUD',
+               js: true,
+               with_cuprite: true do
   # Scenario: Global Role creation
   # Given there is the global permission "glob_test" of the module "global_group"
   before do
     mock_global_permissions [['glob_test', { project_module: 'global_group' }]]
-    login_as(current_user)
+    login_as current_user
   end
 
   current_user { create(:admin) }

--- a/spec/features/global_roles/member_roles_spec.rb
+++ b/spec/features/global_roles/member_roles_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Global role: Unchanged Member Roles', js: true do
+RSpec.describe 'Global role: Unchanged Member Roles',
+               js: true,
+               with_cuprite: true do
   let(:admin) { create(:admin) }
   let(:project) { create(:project) }
   let!(:role) { create(:role, name: 'MemberRole1') }
@@ -37,7 +39,7 @@ RSpec.describe 'Global role: Unchanged Member Roles', js: true do
   let(:members) { Pages::Members.new project.identifier }
 
   before do
-    login_as(admin)
+    login_as admin
   end
 
   it 'Global Rights Modules do not exist as Project -> Settings -> Modules' do

--- a/spec/features/global_roles/no_module_spec.rb
+++ b/spec/features/global_roles/no_module_spec.rb
@@ -29,13 +29,15 @@
 require 'spec_helper'
 require_relative './mock_global_permissions'
 
-RSpec.describe 'Global role: No module', js: true do
+RSpec.describe 'Global role: No module',
+               js: true,
+               with_cuprite: true do
   let(:admin) { create(:admin) }
   let(:project) { create(:project) }
   let!(:role) { create(:role) }
 
   before do
-    login_as(admin)
+    login_as admin
   end
 
   it 'Global Rights Modules do not exist as Project -> Settings -> Modules' do

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'group memberships through groups page', js: true do
+RSpec.describe 'group memberships through groups page',
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let!(:project) do
     create(:project, name: 'Project 1', identifier: 'project1', members: project_members)
@@ -53,16 +55,11 @@ RSpec.describe 'group memberships through groups page', js: true do
   end
 
   it 'adding a user to a group adds the user to the project as well' do
-    members_page.visit!
-    expect(members_page).not_to have_user 'Hannibal Smith'
-
     group_page.visit!
 
-    SeleniumHubWaiter.wait
     group_page.add_to_project! 'Project 1', as: 'Manager'
     expect(page).to have_text 'Successful update'
 
-    SeleniumHubWaiter.wait
     group_page.add_user! 'Hannibal'
 
     members_page.visit!
@@ -76,11 +73,7 @@ RSpec.describe 'group memberships through groups page', js: true do
     let(:project_members) { { group => [manager] } }
 
     it 'removing a user from the group removes them from the project too' do
-      members_page.visit!
-      expect(members_page).to have_user 'Hannibal Smith'
-
       group_page.visit!
-      SeleniumHubWaiter.wait
       group_page.remove_user! 'Hannibal Smith'
 
       members_page.visit!
@@ -112,18 +105,6 @@ RSpec.describe 'group memberships through groups page', js: true do
     let(:project_members) { { peter => manager, group => developer } }
 
     it 'can add a new user to the group with correct member roles (Regression #33659)' do
-      members_page1.visit!
-
-      expect(members_page1).to have_group 'A-Team', roles: [developer]
-      expect(members_page1).to have_user 'Peter Pan', roles: [manager, developer]
-      expect(members_page1).not_to have_user 'Hannibal Smith'
-
-      members_page2.visit!
-
-      expect(members_page2).to have_group 'A-Team', roles: [developer]
-      expect(members_page2).to have_user 'Peter Pan', roles: [manager, developer]
-      expect(members_page2).not_to have_user 'Hannibal Smith'
-
       # Add hannibal to the group
       group_page.visit!
       group_page.add_user! 'Hannibal'
@@ -153,7 +134,7 @@ RSpec.describe 'group memberships through groups page', js: true do
 
       # Remove the group from members page
       members_page2.remove_group! 'A-Team'
-      expect(page).to have_text 'Removed A-Team from project.', wait: 10
+      expect(page).to have_text 'Removed A-Team from project.'
       expect(members_page2).to have_user 'Peter Pan', roles: [manager]
 
       expect(members_page2).not_to have_group 'A-Team'
@@ -162,7 +143,7 @@ RSpec.describe 'group memberships through groups page', js: true do
       # Expect we can remove peter pan now
       members_page2.remove_user! 'Peter Pan'
 
-      expect(page).to have_text 'Removed Peter Pan from project.', wait: 10
+      expect(page).to have_text 'Removed Peter Pan from project.'
       expect(members_page2).not_to have_user 'Peter Pan'
       expect(members_page2).not_to have_group 'A-Team'
       expect(members_page2).not_to have_user 'Hannibal Smith'

--- a/spec/features/groups/groups_spec.rb
+++ b/spec/features/groups/groups_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'group memberships through groups page', js: true do
+RSpec.describe 'group memberships through groups page',
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let!(:group) { create(:group, lastname: "Bob's Team") }
 

--- a/spec/features/groups/membership_spec.rb
+++ b/spec/features/groups/membership_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'group memberships through project members page', js: true do
+RSpec.describe 'group memberships through project members page',
+               js: true,
+               with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let(:project) { create(:project, name: 'Project 1', identifier: 'project1', members: project_member) }
 
@@ -52,7 +54,7 @@ RSpec.describe 'group memberships through project members page', js: true do
 
     current_user { bob }
 
-    it 'adding group1 as a member with the beta role' do
+    specify 'adding group1 as a member with the beta role' do
       members_page.visit!
       members_page.add_user! 'group1', as: 'beta'
 
@@ -64,7 +66,7 @@ RSpec.describe 'group memberships through project members page', js: true do
       let(:project_member) { { group => beta } }
 
       context 'with the members having no roles of their own' do
-        it 'removing the group removes its members too' do
+        specify 'removing the group removes its members too' do
           members_page.visit!
           expect(members_page).to have_user('Alice Wonderland')
 
@@ -83,7 +85,7 @@ RSpec.describe 'group memberships through project members page', js: true do
             .each   { |m| m.roles << alpha }
         end
 
-        it 'removing the group leaves the user without their group roles' do
+        specify 'removing the group leaves the user without their group roles' do
           members_page.visit!
           expect(members_page).to have_user('Alice Wonderland', roles: ['alpha', 'beta'])
 
@@ -108,7 +110,7 @@ RSpec.describe 'group memberships through project members page', js: true do
       alice # create alice
     end
 
-    it 'adding members to that group adds them to the project too' do
+    specify 'adding members to that group adds them to the project too' do
       members_page.visit!
 
       expect(members_page).not_to have_user('Alice Wonderland') # Alice not in the project yet

--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Homescreen index' do
       expect(page).to have_current_path project_path(project)
     end
 
-    it 'can change the welcome text and still have a valid link', js: true do
+    it 'can change the welcome text and still have a valid link', js: true, with_cuprite: true do
       login_as admin
 
       general_settings_page.visit!

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Admin menu items', js: true do
+RSpec.describe 'Admin menu items',
+               js: true,
+               with_cuprite: true do
   let(:user) { create(:admin) }
 
   before do
@@ -49,7 +51,7 @@ RSpec.describe 'Admin menu items', js: true do
     end
   end
 
-  context 'with having custom hidden menu items',
+  context 'having custom hidden menu items',
           with_config: {
             'hidden_menu_items' => { 'admin_menu' => ['colors'] }
           } do

--- a/spec/features/menu_items/help_menu_spec.rb
+++ b/spec/features/menu_items/help_menu_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Help menu items', js: true do
+RSpec.describe 'Help menu items',
+               js: true,
+               with_cuprite: true do
   let(:user) { create(:admin) }
   let(:help_item) { find('.op-app-help .op-app-menu--item-action') }
   let(:help_menu_dropdown_selector) { '.op-app-menu--dropdown.op-menu' }

--- a/spec/features/menu_items/menu_permissions_spec.rb
+++ b/spec/features/menu_items/menu_permissions_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'menu permissions', js: true do
+RSpec.describe 'menu permissions',
+               js: true,
+               with_cuprite: true do
   let(:user) do
     create(:user,
            member_in_project: project,
@@ -40,7 +42,7 @@ RSpec.describe 'menu permissions', js: true do
 
   context 'as an admin' do
     before do
-      login_as(admin)
+      login_as admin
 
       # Allowed to see the settings version page
       visit project_settings_versions_path(project)
@@ -52,7 +54,7 @@ RSpec.describe 'menu permissions', js: true do
       expect(page).to have_selector('#menu-sidebar .op-menu--item-title', text: 'Modules')
     end
 
-    it 'the parent node directs to the general settings page' do
+    specify 'the parent node directs to the general settings page' do
       # The settings menu item exists
       expect(page).to have_selector('#menu-sidebar .main-item-wrapper', text: 'Project settings', visible: false)
 
@@ -62,9 +64,9 @@ RSpec.describe 'menu permissions', js: true do
     end
   end
 
-  context 'as an user who can only manage_versions' do
+  context 'as a user who can only manage_versions' do
     before do
-      login_as(user)
+      login_as user
 
       # Allowed to see the settings version page
       visit project_settings_versions_path(project)
@@ -76,7 +78,7 @@ RSpec.describe 'menu permissions', js: true do
       expect(page).not_to have_selector('#menu-sidebar .op-menu--item-title', text: 'Modules')
     end
 
-    it 'the parent node directs to the only visible children page' do
+    specify 'the parent node directs to the only visible children page' do
       # The settings menu item exists
       expect(page).to have_selector('#menu-sidebar .main-item-wrapper', text: 'Project settings', visible: false)
 

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -31,7 +31,9 @@ require 'features/page_objects/notification'
 require 'features/work_packages/shared_contexts'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'Query menu items', js: true do
+RSpec.describe 'Query menu items',
+               js: true,
+               with_cuprite: true do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:work_packages_page) { WorkPackagesPage.new(project) }
@@ -84,7 +86,7 @@ RSpec.describe 'Query menu items', js: true do
       work_packages_page.ensure_loaded
     end
 
-    it 'can be added', js: true, selenium: true do
+    it 'can be added' do
       visit_index_page(query)
 
       click_on 'More actions'
@@ -98,14 +100,14 @@ RSpec.describe 'Query menu items', js: true do
   end
 
   describe 'renaming a menu item' do
-    let(:query_a) do
+    let!(:query_a) do
       create(:query_with_view_work_packages_table,
              public: true,
              name: 'bbbb',
              project:,
              user:)
     end
-    let(:query_b) do
+    let!(:query_b) do
       create(:query_with_view_work_packages_table,
              public: true,
              name: 'zzzz',
@@ -135,7 +137,7 @@ RSpec.describe 'Query menu items', js: true do
     it 'is renaming and reordering the list' do
       # Renaming the query should also reorder the queries.  As it is renamed
       # from zzzz to aaaa, it should now be the first query menu item.
-      expect(page).to have_selector('li:nth-child(3) a', text: new_name)
+      expect(page).to have_selector('.op-sidemenu--items li:first-child', text: new_name)
     end
   end
 end

--- a/spec/features/menu_items/quick_add_menu_spec.rb
+++ b/spec/features/menu_items/quick_add_menu_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Quick-add menu', js: true, selenium: true do
+RSpec.describe 'Quick-add menu', js: true, with_cuprite: true do
   let(:quick_add) { Components::QuickAddMenu.new }
 
   context 'as a logged in user with add_project permission' do

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Top menu items', js: true, selenium: true do
+RSpec.describe 'Top menu items', js: true, with_cuprite: true do
   let(:user) { create(:user) }
   let(:open_menu) { true }
 
@@ -68,13 +68,13 @@ RSpec.describe 'Top menu items', js: true, selenium: true do
   end
 
   describe 'Modules' do
-    !let(:top_menu) { find(:css, "[title=#{I18n.t('label_modules')}]") }
+    let!(:top_menu) { find("[title=#{I18n.t('label_modules')}]") }
 
     let(:news_item) { I18n.t('label_news_plural') }
     let(:project_item) { I18n.t('label_projects_menu') }
     let(:reporting_item) { I18n.t('cost_reports_title') }
 
-    let(:all_items) { [news_item, project_item, reporting_item] }
+    let!(:all_items) { [news_item, project_item, reporting_item] }
 
     context 'as an admin' do
       let(:user) { create(:admin) }

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -85,18 +85,16 @@ RSpec.describe 'Wiki menu items' do
     end
   end
 
-  it 'allows managing the menu item of a wiki page', js: true do
+  it 'allows managing the menu item of a wiki page', js: true, with_cuprite: true do
     other_wiki_page
     another_wiki_page
 
     visit project_wiki_path(project, wiki_page)
 
     # creating the menu item with the pages name for the menu item
-    SeleniumHubWaiter.wait
     click_link 'More'
     click_link 'Configure menu item'
 
-    SeleniumHubWaiter.wait
     choose "Show as menu item in project navigation"
 
     click_button "Save"
@@ -104,14 +102,12 @@ RSpec.describe 'Wiki menu items' do
     expect(page)
       .to have_selector('.main-menu--children-menu-header', text: wiki_page.title)
 
-    SeleniumHubWaiter.wait
     find('.main-menu--arrow-left-to-project').click
 
     expect(page)
       .to have_selector('.main-item-wrapper', text: wiki_page.title)
 
     # clicking the menu item leads to the page
-    SeleniumHubWaiter.wait
     click_link wiki_page.title
 
     expect(page)
@@ -119,11 +115,9 @@ RSpec.describe 'Wiki menu items' do
 
     # modifying the menu item to a different name and to be a subpage
 
-    SeleniumHubWaiter.wait
     click_link 'More'
     click_link 'Configure menu item'
 
-    SeleniumHubWaiter.wait
     fill_in 'Name of menu item', with: 'Custom page name'
 
     choose "Show as submenu item of"
@@ -139,14 +133,12 @@ RSpec.describe 'Wiki menu items' do
     expect(page)
       .to have_selector('.wiki-menu--sub-item', text: 'Custom page name')
 
-    SeleniumHubWaiter.wait
     click_link 'Custom page name'
 
     expect(page)
       .to have_current_path(project_wiki_path(project, wiki_page))
 
     # the submenu item is not visible on top level
-    SeleniumHubWaiter.wait
     find('.main-menu--arrow-left-to-project').click
 
     expect(page)
@@ -156,12 +148,12 @@ RSpec.describe 'Wiki menu items' do
     visit project_wiki_path(project, wiki_page)
 
     click_link 'More'
-    click_link 'Delete'
-
-    page.driver.browser.switch_to.alert.accept
+    accept_alert do
+      click_link 'Delete'
+    end
 
     within '#menu-sidebar' do
-      expect(page).to have_no_content('Custom page name')
+      expect(page).not_to have_content('Custom page name')
     end
 
     # removing the menu item which is also the last wiki menu item
@@ -177,7 +169,6 @@ RSpec.describe 'Wiki menu items' do
     click_button 'Save'
 
     # Because it is the last wiki menu item, the user is prompted to select another menu item
-    SeleniumHubWaiter.wait
     select another_wiki_page.title, from: 'main-menu-item-select'
 
     click_button 'Save'

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "Notification center navigation", js: true do
+RSpec.describe "Notification center navigation", js: true, with_cuprite: true do
   shared_association_default(:project) { create(:project) }
 
   shared_let(:work_package) { create(:work_package, project:) }

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 require 'features/page_objects/notification'
 
 # rubocop:disable RSpec/ScatteredLet
-RSpec.describe "Notification center date alerts", js: true, with_settings: { journal_aggregation_time_minutes: 0 } do
+RSpec.describe "Notification center date alerts",
+               js: true,
+               with_cuprite: true,
+               with_settings: { journal_aggregation_time_minutes: 0 } do
   include ActiveSupport::Testing::TimeHelpers
 
   # Find an assignable time zone with the same UTC offset as the local time zone
@@ -197,6 +200,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
     perform_enqueued_jobs
     login_as user
     visit notifications_center_path
+    wait_for_reload
   end
 
   context 'without date alerts ee' do
@@ -234,6 +238,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
 
       # When switch to date alerts, it shows the alert, no longer the mention
       side_menu.click_item 'Date alert'
+      wait_for_network_idle
       center.expect_item(notification_wp_double_date_alert, 'Finish date is in 1 day')
       center.expect_no_item(notification_wp_double_mention)
 
@@ -250,6 +255,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
       center.click_item notification_wp_start_past
       split_screen = Pages::SplitWorkPackage.new wp_start_past
       split_screen.expect_tab :overview
+      wait_for_network_idle
 
       # We expect no badge count
       activity_tab.expect_no_notification_badge
@@ -258,6 +264,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
       center.click_item notification_wp_double_date_alert
       split_screen = Pages::SplitWorkPackage.new wp_double_notification
       split_screen.expect_tab :overview
+      wait_for_network_idle
 
       # We expect one badge
       activity_tab.expect_notification_count 1
@@ -265,6 +272,7 @@ RSpec.describe "Notification center date alerts", js: true, with_settings: { jou
       # When a work package is updated to a different date
       wp_double_notification.update_column(:due_date, time_zone.now + 5.days)
       page.driver.refresh
+      wait_for_reload
 
       center.expect_item(notification_wp_double_date_alert, 'Finish date is in 5 days')
       center.expect_no_item(notification_wp_double_mention)

--- a/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe "Notification center sidemenu",
                js: true,
+               with_cuprite: true,
                with_ee: %i[date_alerts] do
   shared_let(:project) { create(:project) }
   shared_let(:project2) { create(:project) }
@@ -71,6 +72,7 @@ RSpec.describe "Notification center sidemenu",
     notifications
     login_as recipient
     center.visit!
+    wait_for_reload
   end
 
   context 'with no notifications to show' do

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe "Notification center",
                js: true,
+               with_cuprite: true,
                with_ee: %i[date_alerts],
                with_settings: { journal_aggregation_time_minutes: 0 } do
   # Notice that the setup in this file here is not following the normal rules as
@@ -59,6 +60,7 @@ RSpec.describe "Notification center",
 
     it 'will not show all details of the journal' do
       visit home_path
+      wait_for_reload
       center.expect_bell_count 2
       center.open
 
@@ -76,12 +78,14 @@ RSpec.describe "Notification center",
 
     it 'can see the notification and dismiss it' do
       visit home_path
+      wait_for_reload
       center.expect_bell_count 2
       center.open
 
       center.expect_work_package_item notification
       center.expect_work_package_item notification2
       center.mark_all_read
+      wait_for_network_idle
 
       retry_block do
         notification.reload
@@ -104,6 +108,7 @@ RSpec.describe "Notification center",
 
       it 'can dismiss all notifications of the currently selected filter' do
         visit home_path
+        wait_for_reload
         center.expect_bell_count '99+'
         center.open
 
@@ -116,6 +121,7 @@ RSpec.describe "Notification center",
         side_menu.click_item 'Watcher'
         side_menu.finished_loading
         center.mark_all_read
+        wait_for_network_idle
 
         center.expect_bell_count '99+'
         side_menu.expect_item_with_count 'Inbox', 101
@@ -126,6 +132,7 @@ RSpec.describe "Notification center",
         side_menu.click_item 'Inbox'
         side_menu.finished_loading
         center.mark_all_read
+        wait_for_network_idle
 
         center.expect_bell_count 0
         side_menu.expect_item_with_no_count 'Inbox'
@@ -136,6 +143,7 @@ RSpec.describe "Notification center",
 
     it 'can open the split screen of the notification' do
       visit home_path
+      wait_for_reload
       center.expect_bell_count 2
       center.open
 
@@ -146,13 +154,14 @@ RSpec.describe "Notification center",
       center.expect_work_package_item notification2
 
       center.mark_notification_as_read notification
-
+      wait_for_network_idle
       retry_block do
         notification.reload
         raise "Expected notification to be marked read" unless notification.read_ian
       end
 
       visit home_path
+      wait_for_reload
       center.expect_bell_count 1
 
       center.open
@@ -264,6 +273,7 @@ RSpec.describe "Notification center",
 
       it "displays the date alerts; allows reading and filtering them" do
         visit home_path
+        wait_for_reload
         center.open
         # Three date alerts and the standard (created) notification
         center.expect_bell_count 4
@@ -274,11 +284,13 @@ RSpec.describe "Notification center",
 
         # Reading one will update the unread notification list
         center.mark_notification_as_read start_date_notification
+        wait_for_network_idle
 
         center.expect_bell_count 3
 
         # Filtering for only date alert notifications (that are unread)
         side_menu.click_item 'Date alert'
+        wait_for_reload
 
         center.expect_work_package_item due_date_notification
         center.expect_work_package_item overdue_date_notification
@@ -299,6 +311,7 @@ RSpec.describe "Notification center",
 
     it 'opens the next notification after marking one as read' do
       visit home_path
+      wait_for_reload
       center.expect_bell_count 2
       center.open
 
@@ -307,6 +320,8 @@ RSpec.describe "Notification center",
 
       # Marking the first notification as read (via icon on the notification row)
       center.mark_notification_as_read notification
+      wait_for_network_idle
+
       retry_block do
         notification.reload
         raise "Expected notification to be marked read" unless notification.read_ian
@@ -318,6 +333,7 @@ RSpec.describe "Notification center",
       # When marking the second as closed (via the icon in the split screen)
       # the empty state is shown
       split_screen2.mark_notifications_as_read
+      wait_for_network_idle
 
       retry_block do
         notification.reload
@@ -353,6 +369,7 @@ RSpec.describe "Notification center",
 
       it 'aggregates notifications per work package and sets all as read when opened' do
         visit home_path
+        wait_for_reload
         center.expect_bell_count 4
         center.open
 
@@ -363,6 +380,7 @@ RSpec.describe "Notification center",
 
         split_screen.expect_open
         center.mark_notification_as_read notification4
+        wait_for_network_idle
 
         retry_block do
           notification4.reload
@@ -380,7 +398,7 @@ RSpec.describe "Notification center",
 
         split_screen2.expect_open
         center.mark_notification_as_read notification3
-
+        wait_for_network_idle
         retry_block do
           notification3.reload
           raise "Expected notification to be marked read" unless notification3.read_ian

--- a/spec/features/notifications/notification_center/split_screen_spec.rb
+++ b/spec/features/notifications/notification_center/split_screen_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe "Split screen in the notification center", js: true do
+RSpec.describe "Split screen in the notification center",
+               js: true,
+               with_cuprite: true do
   let(:global_html_title) { Components::HtmlTitle.new }
   let(:center) { Pages::Notifications::Center.new }
   let(:split_screen) { Pages::Notifications::SplitScreen.new work_package }
@@ -35,6 +37,7 @@ RSpec.describe "Split screen in the notification center", js: true do
 
     before do
       visit home_path
+      wait_for_reload
       center.open
     end
 
@@ -112,6 +115,7 @@ RSpec.describe "Split screen in the notification center", js: true do
     before do
       Notification.where(recipient:).update_all(read_ian: true)
       visit home_path
+      wait_for_reload
       center.open
     end
 

--- a/spec/features/notifications/reminder_mail_spec.rb
+++ b/spec/features/notifications/reminder_mail_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../users/notifications/shared_examples'
 
-RSpec.describe "Reminder email sending", js: true do
+RSpec.describe "Reminder email sending", js: true, with_cuprite: true do
   let!(:project) { create(:project, members: { current_user => role }) }
   let!(:mute_project) { create(:project, members: { current_user => role }) }
   let(:role) { create(:role, permissions: %i[view_work_packages]) }

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe "Immediate reminder settings", js: true do
+RSpec.describe "Immediate reminder settings",
+               js: true,
+               with_cuprite: true do
   shared_examples 'immediate reminder settings' do
     it 'allows to configure the reminder settings' do
       # Save prefs so we can reload them later
@@ -51,7 +53,7 @@ RSpec.describe "Immediate reminder settings", js: true do
     it_behaves_like 'immediate reminder settings'
   end
 
-  describe 'email sending', js: false do
+  describe 'email sending', js: false, with_cuprite: false do
     let(:project) { create(:project) }
     let(:work_package) { create(:work_package, project:) }
     let(:receiver) do

--- a/spec/features/notifications/settings/my_notifications_settings_spec.rb
+++ b/spec/features/notifications/settings/my_notifications_settings_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require_relative '../../users/notifications/shared_examples'
 require 'support/pages/my/notifications'
 
-RSpec.describe "My notifications settings", js: true do
+RSpec.describe "My notifications settings", js: true, with_cuprite: true do
   current_user { create(:user) }
 
   let(:settings_page) { Pages::My::Notifications.new(current_user) }

--- a/spec/features/notifications/settings/pause_reminder_settings_spec.rb
+++ b/spec/features/notifications/settings/pause_reminder_settings_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe "Pause reminder settings", js: true do
+RSpec.describe "Pause reminder settings",
+               js: true,
+               with_cuprite: true do
   shared_examples 'pause reminder settings' do
     let(:first) { Time.zone.today.beginning_of_month }
     let(:last) { (Time.zone.today.beginning_of_month + 10.days) }
@@ -17,8 +19,6 @@ RSpec.describe "Pause reminder settings", js: true do
       reminders_settings_page.set_paused(true,
                                          first:,
                                          last:)
-
-      sleep 2
 
       reminders_settings_page.save
 

--- a/spec/features/notifications/settings/reminder_email_settings_spec.rb
+++ b/spec/features/notifications/settings/reminder_email_settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../users/notifications/shared_examples'
 
-RSpec.describe "Reminder email", js: true do
+RSpec.describe "Reminder email", js: true, with_cuprite: true do
   shared_examples 'reminder settings' do
     it 'allows to configure the reminder settings' do
       # Configure the digest

--- a/spec/features/notifications/settings/workdays_settings_spec.rb
+++ b/spec/features/notifications/settings/workdays_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "Workday notification settings", js: true do
+RSpec.describe "Workday notification settings", js: true, with_cuprite: true do
   shared_examples 'workday settings' do
     before do
       current_user.language = locale

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Project attribute help texts', js: true do
+RSpec.describe 'Project attribute help texts', js: true, with_cuprite: true do
   let(:project) { create(:project) }
 
   let(:instance) do

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Projects copy',
       clear_performed_jobs
     end
 
-    fit 'copies projects and the associated objects' do
+    it 'copies projects and the associated objects' do
       original_settings_page = Pages::Projects::Settings.new(project)
       original_settings_page.visit!
 

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 
 # rubocop:disable RSpec:MultipleMemoizedHelpers
 RSpec.describe 'Projects copy',
-               js: true do
+               js: true,
+               with_cuprite: true do
   describe 'with a full copy example' do
     let!(:project) do
       create(:project,
@@ -134,7 +135,7 @@ RSpec.describe 'Projects copy',
       clear_performed_jobs
     end
 
-    it 'copies projects and the associated objects' do
+    fit 'copies projects and the associated objects' do
       original_settings_page = Pages::Projects::Settings.new(project)
       original_settings_page.visit!
 
@@ -142,7 +143,7 @@ RSpec.describe 'Projects copy',
 
       expect(page).to have_text "Copy project \"#{project.name}\""
 
-      fill_in 'Name', with: 'Copied project', wait: 10
+      fill_in 'Name', with: 'Copied project'
 
       # Expand advanced settings
       click_on 'Advanced settings'

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects', 'creation', js: true do
+RSpec.describe 'Projects', 'creation',
+               js: true,
+               with_cuprite: true do
   let(:name_field) { FormFields::InputFormField.new :name }
 
   current_user { create(:admin) }
@@ -45,10 +47,8 @@ RSpec.describe 'Projects', 'creation', js: true do
     name_field.set_value 'Foo bar'
     click_button 'Save'
 
-    sleep 1
-
-    expect(page).to have_content 'Foo bar'
     expect(page).to have_current_path /\/projects\/foo-bar\/?/
+    expect(page).to have_content 'Foo bar'
   end
 
   it 'does not create a project with an already existing identifier' do
@@ -94,8 +94,8 @@ RSpec.describe 'Projects', 'creation', js: true do
 
     find('.op-fieldset--toggle', text: 'ADVANCED SETTINGS').click
 
-    expect(page).to have_no_content 'Active'
-    expect(page).to have_no_content 'Identifier'
+    expect(page).not_to have_content 'Active'
+    expect(page).not_to have_content 'Identifier'
   end
 
   context 'with optional and required custom fields' do
@@ -111,7 +111,7 @@ RSpec.describe 'Projects', 'creation', js: true do
                             is_required: true)
     end
 
-    it 'seperates optional and required custom fields for new' do
+    it 'separates optional and required custom fields for new' do
       visit new_project_path
 
       expect(page).to have_content 'Required Foo'

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -29,7 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects#destroy',
-               js: true do
+               js: true,
+               with_cuprite: true do
   let!(:project) { create(:project, name: 'foo', identifier: 'foo') }
   let(:project_page) { Pages::Projects::Destroy.new(project) }
   let(:danger_zone) { DangerZone.new(page) }

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects', 'editing settings', js: true do
+RSpec.describe 'Projects', 'editing settings',
+               js: true,
+               with_cuprite: true do
   let(:name_field) { FormFields::InputFormField.new :name }
   let(:parent_field) { FormFields::SelectFormField.new :parent }
   let(:permissions) { %i(edit_project) }
@@ -54,9 +56,7 @@ RSpec.describe 'Projects', 'editing settings', js: true do
     it 'updates the project identifier' do
       visit projects_path
       click_on project.name
-      SeleniumHubWaiter.wait
       click_on 'Project settings'
-      SeleniumHubWaiter.wait
       click_on 'Change identifier'
 
       expect(page).to have_content "Change the project's identifier".upcase

--- a/spec/features/projects/export_spec.rb
+++ b/spec/features/projects/export_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'project export', js: true do
+RSpec.describe 'project export', js: true, with_cuprite: true do
   shared_let(:important_project) { create(:project, name: 'Important schedule plan') }
   shared_let(:party_project) { create(:project, name: 'Christmas party') }
   shared_let(:user) do

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects autocomplete page', js: true do
+RSpec.describe 'Projects autocomplete page', js: true, with_cuprite: true do
   let!(:user) { create(:user) }
   let(:top_menu) { Components::Projects::TopMenu.new }
 
@@ -131,7 +131,7 @@ RSpec.describe 'Projects autocomplete page', js: true do
     top_menu.clear_search
 
     top_menu.expect_result 'Plain project'
-    top_menu.expect_result '<strong>foobar</strong>'
+    top_menu.expect_result '<strong>foobar</strong>', disabled: true
     top_menu.expect_item_with_hierarchy_level hierarchy_level: 2, item_name: 'Plain other project'
 
     # Show hierarchy of project

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects status administration', js: true do
+RSpec.describe 'Projects status administration',
+               js: true,
+               with_cuprite: true do
   include_context 'ng-select-autocomplete helpers'
 
   let(:current_user) do

--- a/spec/features/projects/projects_custom_fields_spec.rb
+++ b/spec/features/projects/projects_custom_fields_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects custom fields', js: true do
+RSpec.describe 'Projects custom fields',
+               js: true,
+               with_cuprite: true do
   shared_let(:current_user) { create(:admin) }
   shared_let(:project) { create(:project, name: 'Foo project', identifier: 'foo-project') }
   let(:name_field) { FormFields::InputFormField.new :name }
@@ -161,7 +163,8 @@ RSpec.describe 'Projects custom fields', js: true do
     end
 
     context 'with german locale',
-            driver: :firefox_de do
+            driver: :firefox_de,
+            with_cuprite: false do
       let(:current_user) { create(:admin, language: 'de') }
 
       it 'displays the float with german locale' do

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -30,6 +30,7 @@ require 'spec_helper'
 
 RSpec.describe 'Projects index page',
                js: true,
+               with_cuprite: true,
                with_settings: { login_required?: false } do
   shared_let(:admin) { create(:admin) }
 
@@ -83,9 +84,9 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'restricts project visibility' do
-    describe 'for a anonymous user' do
-      it 'only public projects shall be visible' do
+  describe 'project visibility restriction' do
+    context 'for an anonymous user' do
+      specify 'only public projects shall be visible' do
         Role.anonymous
         visit projects_path
 
@@ -97,7 +98,7 @@ RSpec.describe 'Projects index page',
       end
     end
 
-    describe 'for project members', with_ee: %i[custom_fields_in_projects_list] do
+    context 'for project members', with_ee: %i[custom_fields_in_projects_list] do
       shared_let(:user) do
         create(:user,
                member_in_project: development_project,
@@ -107,7 +108,7 @@ RSpec.describe 'Projects index page',
                lastname: 'Turing')
       end
 
-      it 'only public project or those the user is member of shall be visible' do
+      specify 'only public projects or those the user is a member of shall be visible' do
         Role.non_member
         login_as(user)
         visit projects_path
@@ -122,14 +123,14 @@ RSpec.describe 'Projects index page',
       end
     end
 
-    describe 'for admins' do
+    context 'for admins' do
       before do
         project.update(created_at: 7.days.ago, description: 'I am a nice project')
 
         news
       end
 
-      it 'test that all projects are visible' do
+      specify 'all projects are visible' do
         login_as(admin)
         visit projects_path
 
@@ -163,7 +164,7 @@ RSpec.describe 'Projects index page',
         end
       end
 
-      it 'test that flash sortBy is being escaped' do
+      specify 'flash sortBy is being escaped' do
         login_as(admin)
         visit projects_path(sortBy: "[[\"><script src='/foobar.js'></script>\",\"\"]]")
 
@@ -177,8 +178,8 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'without valid Enterprise token' do
-    it 'CF columns and filters are not visible' do
+  context 'without valid Enterprise token' do
+    specify 'CF columns and filters are not visible' do
       load_and_open_filters admin
 
       # CF's columns are not present:
@@ -188,15 +189,15 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'with valid Enterprise token', with_ee: %i[custom_fields_in_projects_list] do
-    it 'CF columns and filters are not visible by default' do
+  context 'with valid Enterprise token', with_ee: %i[custom_fields_in_projects_list] do
+    specify 'CF columns and filters are not visible by default' do
       load_and_open_filters admin
 
       # CF's columns are not shown due to setting
       expect(page).not_to have_text(custom_field.name.upcase)
     end
 
-    it 'CF columns and filters are visible when added to settings' do
+    specify 'CF columns and filters are visible when added to settings' do
       Setting.enabled_projects_columns += [custom_field.column_name, invisible_custom_field.column_name]
       load_and_open_filters admin
 
@@ -211,8 +212,8 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'with a filter set' do
-    it 'onlies show the matching projects and filters' do
+  context 'with a filter set' do
+    it 'only shows the matching projects and filters' do
       load_and_open_filters admin
 
       projects_page.set_filter('name_and_identifier',
@@ -229,25 +230,25 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'when paginating' do
+  context 'when paginating' do
     before do
       allow(Setting).to receive(:per_page_options_array).and_return([1, 5])
     end
 
-    it 'keeps applying filters and order' do
+    it 'keeps applying filters and orders' do
       load_and_open_filters admin
 
-      SeleniumHubWaiter.wait
       projects_page.set_filter('name_and_identifier',
                                'Name or identifier',
                                'doesn\'t contain',
                                ['Plain'])
 
       click_on 'Apply'
+      wait_for_reload
 
       # Sorts ASC by name
-      SeleniumHubWaiter.wait
       click_on 'Sort by "Name"'
+      wait_for_reload
 
       # Results should be filtered and ordered ASC by name
       expect(page).to have_text(development_project.name)
@@ -256,11 +257,10 @@ RSpec.describe 'Projects index page',
       expect(page).not_to have_text(public_project.name) # as it is on the second page
 
       # Changing the page size to 5 and back to 1 should not change the filters (which we test later on the second page)
-      SeleniumHubWaiter.wait
       find('.op-pagination--options .op-pagination--item', text: '5').click # click page size '5'
-      SeleniumHubWaiter.wait
+      wait_for_reload
       find('.op-pagination--options .op-pagination--item', text: '1').click # return back to page size '1'
-      SeleniumHubWaiter.wait
+      wait_for_reload
       click_on '2' # Go to pagination page 2
 
       # On page 2 you should see the second page of the filtered set ordered ASC by name
@@ -270,8 +270,8 @@ RSpec.describe 'Projects index page',
       expect(page).not_to have_text(development_project.name) # That one should be on page 1
 
       # Sorts DESC by name
-      SeleniumHubWaiter.wait
       click_on 'Ascending sorted by "Name"'
+      wait_for_reload
 
       # On page 2 the same filters should still be intact but the order should be DESC on name
       expect(page).to have_text(development_project.name)
@@ -281,8 +281,8 @@ RSpec.describe 'Projects index page',
       expect(page).to have_selector('.sort.desc', text: 'NAME')
 
       # Sending the filter form again what implies to compose the request freshly
-      SeleniumHubWaiter.wait
       click_on 'Apply'
+      wait_for_reload
 
       # We should see page 1, resetting pagination, as it is a new filter, but keeping the DESC order on the project
       # name
@@ -294,25 +294,24 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'when filter of type' do
-    it 'Name and identifier gives results in both, name and identifier' do
+  context 'when filter of type' do
+    specify 'Name and identifier gives results in both, name and identifier' do
       load_and_open_filters admin
 
       # Filter on model attribute 'name'
-      SeleniumHubWaiter.wait
       projects_page.set_filter('name_and_identifier',
                                'Name or identifier',
                                'doesn\'t contain',
                                ['Plain'])
 
       click_on 'Apply'
+      wait_for_reload
 
       expect(page).to have_text(development_project.name)
       expect(page).to have_text(public_project.name)
       expect(page).not_to have_text(project.name)
 
       # Filter on model attribute 'identifier'
-      SeleniumHubWaiter.wait
       remove_filter('name_and_identifier')
 
       projects_page.set_filter('name_and_identifier',
@@ -321,6 +320,7 @@ RSpec.describe 'Projects index page',
                                ['plain-project'])
 
       click_on 'Apply'
+      wait_for_reload
 
       expect(page).to have_text(project.name)
       expect(page).not_to have_text(development_project.name)
@@ -340,7 +340,7 @@ RSpec.describe 'Projects index page',
                parent: parent_project)
       end
 
-      it 'filter on "status", archive and unarchive' do
+      specify 'filter on "status", archive and unarchive' do
         load_and_open_filters admin
 
         # value selection defaults to "active"'
@@ -352,9 +352,10 @@ RSpec.describe 'Projects index page',
         expect(page).to have_text('Development project')
         expect(page).to have_text('Public project')
 
-        SeleniumHubWaiter.wait
-        projects_page.click_menu_item_of('Archive', parent_project)
-        projects_page.accept_alert_dialog!
+        accept_alert do
+          projects_page.click_menu_item_of('Archive', parent_project)
+        end
+        wait_for_reload
 
         expect(page).not_to have_text(parent_project.name)
         # The child project gets archived automatically
@@ -372,7 +373,6 @@ RSpec.describe 'Projects index page',
 
         load_and_open_filters admin
 
-        SeleniumHubWaiter.wait
         projects_page.filter_by_active('no')
 
         expect(page).to have_text("ARCHIVED #{parent_project.name}")
@@ -387,7 +387,6 @@ RSpec.describe 'Projects index page',
           expect(menu).not_to have_text('Settings')
           expect(menu).not_to have_text('New subproject')
 
-          SeleniumHubWaiter.wait
           click_link('Unarchive')
         end
 
@@ -400,7 +399,6 @@ RSpec.describe 'Projects index page',
 
         load_and_open_filters admin
 
-        SeleniumHubWaiter.wait
         projects_page.filter_by_active('yes')
 
         expect(page).to have_text(parent_project.name)
@@ -425,23 +423,20 @@ RSpec.describe 'Projects index page',
                name: 'Green project')
       end
 
-      it 'sort and filter on project status' do
+      it 'sorts and filters on project status' do
         login_as(admin)
         projects_page.visit!
 
-        SeleniumHubWaiter.wait
         click_link('Sort by "Status"')
 
         expect_project_at_place(green_project, 1)
         expect(page).to have_text('(1 - 5/5)')
 
-        SeleniumHubWaiter.wait
         click_link('Ascending sorted by "Status"')
 
         expect_project_at_place(green_project, 5)
         expect(page).to have_text('(1 - 5/5)')
 
-        SeleniumHubWaiter.wait
         projects_page.open_filters
 
         projects_page.set_filter('project_status_code',
@@ -450,28 +445,29 @@ RSpec.describe 'Projects index page',
                                  ['On track'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(green_project.name)
         expect(page).not_to have_text(no_status_project.name)
 
-        SeleniumHubWaiter.wait
         projects_page.set_filter('project_status_code',
                                  'Project status',
                                  'is not empty',
                                  [])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(green_project.name)
         expect(page).not_to have_text(no_status_project.name)
 
-        SeleniumHubWaiter.wait
         projects_page.set_filter('project_status_code',
                                  'Project status',
                                  'is empty',
                                  [])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).not_to have_text(green_project.name)
         expect(page).to have_text(no_status_project.name)
@@ -482,6 +478,7 @@ RSpec.describe 'Projects index page',
                                  ['On track'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).not_to have_text(green_project.name)
         expect(page).to have_text(no_status_project.name)
@@ -543,23 +540,22 @@ RSpec.describe 'Projects index page',
       before do
         project_created_on_today
         load_and_open_filters admin
-        SeleniumHubWaiter.wait
       end
 
-      it 'selecting operator' do
+      specify 'selecting operator' do
         # created on 'today' shows projects that were created today
         projects_page.set_filter('created_at',
                                  'Created on',
                                  'today')
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_this_week.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
 
         # created on 'this week' shows projects that were created within the last seven days
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('created_at',
@@ -567,13 +563,13 @@ RSpec.describe 'Projects index page',
                                  'this week')
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).to have_text(project_created_on_this_week.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
 
         # created on 'on' shows projects that were created within the last seven days
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('created_at',
@@ -582,13 +578,13 @@ RSpec.describe 'Projects index page',
                                  ['2017-11-11'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_fixed_date.name)
         expect(page).not_to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_this_week.name)
 
         # created on 'less than days ago'
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('created_at',
@@ -597,12 +593,12 @@ RSpec.describe 'Projects index page',
                                  ['1'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
 
         # created on 'more than days ago'
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('created_at',
@@ -611,12 +607,12 @@ RSpec.describe 'Projects index page',
                                  ['1'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_fixed_date.name)
         expect(page).not_to have_text(project_created_on_today.name)
 
         # created on 'between'
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('created_at',
@@ -625,12 +621,12 @@ RSpec.describe 'Projects index page',
                                  ['2017-11-10', '2017-11-12'])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_fixed_date.name)
         expect(page).not_to have_text(project_created_on_today.name)
 
         # Latest activity at 'today'. This spot check would fail if the data does not get collected from multiple tables
-        SeleniumHubWaiter.wait
         remove_filter('created_at')
 
         projects_page.set_filter('latest_activity_at',
@@ -638,12 +634,12 @@ RSpec.describe 'Projects index page',
                                  'today')
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
 
         # CF List
-        SeleniumHubWaiter.wait
         remove_filter('latest_activity_at')
 
         projects_page.set_filter(list_custom_field.column_name,
@@ -652,6 +648,7 @@ RSpec.describe 'Projects index page',
                                  [list_custom_field.possible_values[2].value])
 
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
@@ -661,17 +658,16 @@ RSpec.describe 'Projects index page',
         within(cf_filter) do
           # Initial filter is a 'single select'
           expect(cf_filter.find(:select, 'value')).not_to be_multiple
-          SeleniumHubWaiter.wait
           click_on 'Toggle multiselect'
           # switching to multiselect keeps the current selection
           expect(cf_filter.find(:select, 'value')).to be_multiple
           expect(cf_filter).to have_select('value', selected: list_custom_field.possible_values[2].value)
 
-          SeleniumHubWaiter.wait
           select list_custom_field.possible_values[3].value, from: 'value'
         end
 
         click_on 'Apply'
+        wait_for_reload
 
         cf_filter = page.find("li[filter-name='#{list_custom_field.column_name}']")
         within(cf_filter) do
@@ -683,7 +679,6 @@ RSpec.describe 'Projects index page',
                                        list_custom_field.possible_values[3].value])
 
           # switching to single select keeps the first selection
-          SeleniumHubWaiter.wait
           select list_custom_field.possible_values[1].value, from: 'value'
           unselect list_custom_field.possible_values[2].value, from: 'value'
 
@@ -694,6 +689,7 @@ RSpec.describe 'Projects index page',
         end
 
         click_on 'Apply'
+        wait_for_reload
 
         cf_filter = page.find("li[filter-name='#{list_custom_field.column_name}']")
         within(cf_filter) do
@@ -702,7 +698,6 @@ RSpec.describe 'Projects index page',
         end
 
         # CF date filter work (at least for one operator)
-        SeleniumHubWaiter.wait
         remove_filter(list_custom_field.column_name)
 
         projects_page.set_filter(date_custom_field.column_name,
@@ -710,8 +705,8 @@ RSpec.describe 'Projects index page',
                                  'on',
                                  ['2011-11-11'])
 
-        SeleniumHubWaiter.wait
         click_on 'Apply'
+        wait_for_reload
 
         expect(page).to have_text(project_created_on_today.name)
         expect(page).not_to have_text(project_created_on_fixed_date.name)
@@ -721,22 +716,22 @@ RSpec.describe 'Projects index page',
     end
 
     describe 'public filter' do
-      it 'filter on "public" status' do
+      it 'filters on "public" status' do
         load_and_open_filters admin
 
         expect(page).to have_text(project.name)
         expect(page).to have_text(public_project.name)
 
-        SeleniumHubWaiter.wait
         projects_page.filter_by_public('no')
+        wait_for_reload
 
         expect(page).to have_text(project.name)
         expect(page).not_to have_text(public_project.name)
 
         load_and_open_filters admin
 
-        SeleniumHubWaiter.wait
         projects_page.filter_by_public('yes')
+        wait_for_reload
 
         expect(page).to have_text(public_project.name)
         expect(page).not_to have_text(project.name)
@@ -744,7 +739,7 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'Non-admins with role with permission' do
+  context 'for non-admins with role with permission' do
     shared_let(:can_copy_projects_role) do
       create(:role, name: 'Can Copy Projects Role', permissions: [:copy_projects])
     end
@@ -901,8 +896,8 @@ RSpec.describe 'Projects index page',
                                child_project_z,
                                public_project)
 
-      SeleniumHubWaiter.wait
       click_link('Name')
+      wait_for_reload
 
       # Projects ordered by name asc
       expect_projects_in_order(child_project_a,
@@ -912,8 +907,8 @@ RSpec.describe 'Projects index page',
                                public_project,
                                child_project_z)
 
-      SeleniumHubWaiter.wait
       click_link('Name')
+      wait_for_reload
 
       # Projects ordered by name desc
       expect_projects_in_order(child_project_z,
@@ -923,8 +918,8 @@ RSpec.describe 'Projects index page',
                                development_project,
                                child_project_a)
 
-      SeleniumHubWaiter.wait
       click_link(integer_custom_field.name)
+      wait_for_reload
 
       # Projects ordered by cf asc first then project name desc
       expect_projects_in_order(project,
@@ -934,8 +929,8 @@ RSpec.describe 'Projects index page',
                                child_project_m,
                                child_project_a)
 
-      SeleniumHubWaiter.wait
       click_link('Sort by "Project hierarchy"')
+      wait_for_reload
 
       # again ordered by name asc on each hierarchical level
       expect_projects_in_order(development_project,
@@ -947,8 +942,8 @@ RSpec.describe 'Projects index page',
     end
   end
 
-  describe 'blacklisted filters' do
-    it 'are not visible' do
+  describe 'blacklisted filter' do
+    it 'is not visible' do
       load_and_open_filters admin
 
       expect(page).not_to have_select('add_filter_select', with_options: ["Principal"])

--- a/spec/features/projects/projects_portfolio_spec.rb
+++ b/spec/features/projects/projects_portfolio_spec.rb
@@ -29,7 +29,9 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects index page',
-               js: true, with_ee: %i[custom_fields_in_projects_list], with_settings: { login_required?: false } do
+               js: true,
+               with_cuprite: true,
+               with_ee: %i[custom_fields_in_projects_list], with_settings: { login_required?: false } do
   shared_let(:admin) { create(:admin) }
 
   let(:modal) { Components::WorkPackages::TableConfigurationModal.new }

--- a/spec/features/projects/subproject_creation_spec.rb
+++ b/spec/features/projects/subproject_creation_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Subproject creation', js: true do
+RSpec.describe 'Subproject creation', js: true, with_cuprite: true do
   let(:name_field) { FormFields::InputFormField.new :name }
   let(:parent_field) { FormFields::SelectFormField.new :parent }
   let(:add_subproject_role) { create(:role, permissions: %i[edit_project add_subprojects]) }

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Project templates', js: true do
+RSpec.describe 'Project templates', js: true, with_cuprite: true do
   describe 'making project a template' do
     let(:project) { create(:project) }
 

--- a/spec/features/projects/work_package_type_mgmt_spec.rb
+++ b/spec/features/projects/work_package_type_mgmt_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects', 'work package type mgmt', js: true do
+RSpec.describe 'Projects', 'work package type mgmt',
+               js: true,
+               with_cuprite: true do
   current_user { create(:user, member_in_project: project, member_with_permissions: %i[edit_project manage_types]) }
 
   let(:phase_type)     { create(:type, name: 'Phase', is_default: true) }

--- a/spec/features/roles/create_spec.rb
+++ b/spec/features/roles/create_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Role creation', js: true do
+RSpec.describe 'Role creation',
+               js: true,
+               with_cuprite: true do
   let!(:admin) { create(:admin) }
   let!(:existing_role) { create(:role) }
   let!(:existing_workflow) { create(:workflow_with_default_status, role: existing_role, type:) }
@@ -38,7 +40,7 @@ RSpec.describe 'Role creation', js: true do
   end
 
   before do
-    login_as(admin)
+    login_as admin
   end
 
   it 'allows creating roles and handles errors' do
@@ -48,7 +50,6 @@ RSpec.describe 'Role creation', js: true do
       click_link 'Role'
     end
 
-    SeleniumHubWaiter.wait
     fill_in 'Name', with: existing_role.name
     select existing_role.name, from: 'Copy workflow from'
     check 'Edit work packages'
@@ -59,7 +60,6 @@ RSpec.describe 'Role creation', js: true do
     expect(page)
       .to have_selector('.errorExplanation', text: 'Name has already been taken')
 
-    SeleniumHubWaiter.wait
     fill_in 'Name', with: 'New role name'
 
     # This will lead to an error as manage versions requires view versions
@@ -71,7 +71,6 @@ RSpec.describe 'Role creation', js: true do
       .to have_selector('.errorExplanation',
                         text: "Permissions need to also include 'View members' as 'Manage members' is selected.")
 
-    SeleniumHubWaiter.wait
     check 'View members'
     select existing_role.name, from: 'Copy workflow from'
 
@@ -86,7 +85,6 @@ RSpec.describe 'Role creation', js: true do
     expect(page)
       .to have_selector('table td', text: 'New role name')
 
-    SeleniumHubWaiter.wait
     click_link 'New role name'
 
     expect(page)
@@ -113,7 +111,6 @@ RSpec.describe 'Role creation', js: true do
     # Workflow routes are not resource-oriented.
     visit(url_for(controller: :workflows, action: :edit, only_path: true))
 
-    SeleniumHubWaiter.wait
     select 'New role name', from: 'Role'
     select type.name, from: 'Type'
     click_button 'Edit'

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -60,7 +60,14 @@ module Components
     def close!
       # make backdrop click an the pixel x:10,y:10
       page.find('.spot-modal-overlay').tap do |element|
-        element.click(x: -((element.native.size.width / 2) - 10), y: -((element.native.size.height / 2) - 10))
+        if RSpec.current_example.metadata[:with_cuprite]
+          width = element.style('width')["width"].to_i
+          height = element.style('height')["height"].to_i
+        else
+          width = element.native.size.width
+          height = element.native.size.height
+        end
+        element.click(x: -((width / 2) - 10), y: -((height / 2) - 10))
       end
       expect(page).not_to have_selector('[data-qa-selector="attribute-help-text--header"]', text: help_text.attribute_caption)
     end

--- a/spec/features/types/activate_in_project_spec.rb
+++ b/spec/features/types/activate_in_project_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'types', js: true do
+RSpec.describe 'types', js: true, with_cuprite: true do
   let(:user) do
     create(:user,
            member_in_project: project,
@@ -42,7 +42,7 @@ RSpec.describe 'types', js: true do
   let(:work_packages_page) { Pages::WorkPackagesTable.new(project) }
 
   before do
-    login_as(user)
+    login_as user
   end
 
   it 'is only visible in the project if it has been activated' do

--- a/spec/features/types/crud_spec.rb
+++ b/spec/features/types/crud_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Types', js: true do
+RSpec.describe 'Types', js: true, with_cuprite: true do
   shared_let(:admin) { create(:admin) }
 
   let!(:existing_role) { create(:role) }

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'create users', selenium: true do
+RSpec.describe 'create users', with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let!(:auth_source) { create(:dummy_auth_source) }

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'user deletion:', js: true do
+RSpec.describe 'user deletion:', js: true, with_cuprite: true do
   let(:dialog) { Components::PasswordConfirmationDialog.new }
 
   before do
@@ -43,7 +43,7 @@ RSpec.describe 'user deletion:', js: true do
              password_confirmation: user_password)
     end
 
-    it 'can delete their own account', js: true do
+    it 'can delete their own account', signout_via_visit: true do
       Setting.users_deletable_by_self = 1
       visit delete_my_account_info_path
 
@@ -70,7 +70,7 @@ RSpec.describe 'user deletion:', js: true do
     let!(:user) { create(:user) }
     let(:current_user) { create(:user, global_permission: :manage_user) }
 
-    it 'can not delete even if settings allow it', js: true do
+    it 'can not delete even if settings allow it' do
       Setting.users_deletable_by_admins = 1
       visit edit_user_path(user)
 
@@ -91,7 +91,7 @@ RSpec.describe 'user deletion:', js: true do
              password_confirmation: user_password)
     end
 
-    it 'can delete other users if the setting permits it', selenium: true do
+    it 'can delete other users if the setting permits it' do
       Setting.users_deletable_by_admins = 1
       visit edit_user_path(user)
 
@@ -115,7 +115,7 @@ RSpec.describe 'user deletion:', js: true do
       expect(page).to have_current_path '/users'
     end
 
-    it 'can delete and confirm with keyboard (Regression #44499)', selenium: true do
+    it 'can delete and confirm with keyboard (Regression #44499)' do
       Setting.users_deletable_by_admins = 1
       visit edit_user_path(user)
 

--- a/spec/features/users/edit_users_spec.rb
+++ b/spec/features/users/edit_users_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'edit users', js: true do
+RSpec.describe 'edit users', js: true, with_cuprite: true do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let(:user) { create(:user, mail: 'foo@example.com') }
@@ -40,11 +40,11 @@ RSpec.describe 'edit users', js: true do
   end
 
   def auth_select
-    find :css, 'select#user_auth_source_id'
+    find 'select#user_auth_source_id'
   end
 
   def user_password
-    find :css, 'input#user_password'
+    find 'input#user_password'
   end
 
   context 'with internal authentication' do
@@ -60,7 +60,7 @@ RSpec.describe 'edit users', js: true do
     it 'hides password settings when switching to an LDAP auth source' do
       auth_select.select auth_source.name
 
-      expect(page).not_to have_selector('input#user_password')
+      expect(page).not_to have_field('#user_password')
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe 'edit users', js: true do
 
     it 'shows external authentication being selected and no password settings' do
       expect(auth_select.value).to eq auth_source.id.to_s
-      expect(page).not_to have_selector('input#user_password')
+      expect(page).not_to have_field('#user_password')
     end
 
     it 'shows password settings when switching back to internal authentication' do
@@ -95,15 +95,19 @@ RSpec.describe 'edit users', js: true do
       expect(page).not_to have_selector('.users-and-permissions-menu-item', text: 'Users and permissions')
       expect(page).to have_selector('.users-menu-item.selected', text: 'Users')
 
-      expect(page).to have_selector 'select#user_auth_source_id'
-      expect(page).not_to have_selector 'input#user_password'
+      expect(page).to have_select(id: 'user_auth_source_id')
+      expect(page).not_to have_field '#user_password'
 
       expect(page).to have_selector '#user_login'
       expect(page).to have_selector '#user_firstname'
       expect(page).to have_selector '#user_lastname'
       expect(page).to have_selector '#user_mail'
 
-      fill_in 'user[firstname]', with: 'NewName', fill_options: { clear: :backspace }
+      firstname_field = find_by_id('user_firstname')
+      firstname_field.value.length.times do
+        firstname_field.send_keys(:backspace)
+      end
+      firstname_field.set 'NewName'
       select auth_source.name, from: 'user[auth_source_id]'
 
       click_on 'Save'

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -28,12 +28,12 @@
 
 require 'spec_helper'
 
-RSpec.describe 'index users', js: true do
+RSpec.describe 'index users', js: true, with_cuprite: true do
   shared_let(:current_user) { create(:admin, firstname: 'admin', lastname: 'admin', created_at: 1.hour.ago) }
   let(:index_page) { Pages::Admin::Users::Index.new }
 
   before do
-    login_as(current_user)
+    login_as current_user
   end
 
   describe 'with some sortable users' do

--- a/spec/features/users/invitation_spec.rb
+++ b/spec/features/users/invitation_spec.rb
@@ -28,38 +28,43 @@
 
 require 'spec_helper'
 
-RSpec.describe 'invitation spec', js: true do
+RSpec.describe 'invitations', js: true, with_cuprite: true do
   let(:user) { create(:invited_user, mail: 'holly@openproject.com') }
 
   before do
     allow(User).to receive(:current).and_return current_user
   end
 
-  shared_examples 'resends the invitation' do
-    visit edit_user_path(user)
-    click_on I18n.t(:label_send_invitation)
-    expect(page).to have_text 'An invitation has been sent to holly@openproject.com.'
+  shared_examples 'resending invitations' do
+    it 'resends the invitation' do
+      visit edit_user_path(user)
+      click_on I18n.t(:label_send_invitation)
+      expect(page).to have_text 'An invitation has been sent to holly@openproject.com.'
 
-    # Logout admin
-    logout
+      # Logout admin
+      logout
 
-    # Visit invitation with wrong token
-    visit account_activate_path(token: 'some invalid value')
-    expect(page).to have_text 'Invalid activation token'
+      # Visit invitation with wrong token
+      visit account_activate_path(token: 'some invalid value')
+      expect(page).to have_text 'Invalid activation token'
 
-    # Visit invitation link with correct token
-    visit account_activate_path(token: Token::Invitation.last.value)
+      # Visit invitation link with correct token
+      visit account_activate_path(token: Token::Invitation.last.value)
 
-    expect(page).to have_selector('.spot-modal--header', text: 'Welcome to OpenProject')
+      expect(page).to have_selector('.spot-modal--header', text: 'Welcome to OpenProject')
+    end
   end
 
   context 'as admin' do
     shared_let(:admin) { create(:admin) }
     let(:current_user) { admin }
+    include_examples 'resending invitations'
   end
 
   context 'as global user' do
     shared_let(:global_manage_user) { create(:user, global_permission: :manage_user) }
     let(:current_user) { global_manage_user }
+
+    include_examples 'resending invitations'
   end
 end

--- a/spec/features/users/invite_user_modal/custom_fields_spec.rb
+++ b/spec/features/users/invite_user_modal/custom_fields_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal custom fields', js: true do
+RSpec.describe 'Invite user modal custom fields', js: true, with_cuprite: true do
   shared_let(:project) { create(:project) }
 
   let(:permissions) { %i[view_project manage_members] }

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal', js: true do
+RSpec.describe 'Invite user modal', js: true, with_cuprite: true do
   shared_let(:project) { create(:project) }
   shared_let(:work_package) { create(:work_package, project:) }
 
@@ -204,7 +204,7 @@ RSpec.describe 'Invite user modal', js: true do
                    roles: [role_no_permissions])
           end
 
-          it 'disables projects for which you do not have rights' do
+          it 'disables projects for which you do not have rights', with_cuprite: false do
             ngselect = modal.open_select_in_step '.ng-select-container'
             expect(ngselect).to have_text "#{project_no_permissions.name}\nYou are not allowed to invite members to this project"
           end
@@ -215,7 +215,7 @@ RSpec.describe 'Invite user modal', js: true do
           # Use admin to ensure all projects are visible
           let(:current_user) { create(:admin) }
 
-          it 'disables projects for which you do not have rights' do
+          it 'disables projects for which you do not have rights', with_cuprite: false do
             ngselect = modal.open_select_in_step '.ng-select-container'
             expect(ngselect).not_to have_text archived_project
           end

--- a/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
+++ b/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Inviting user in project the current user is lacking permission in', js: true do
+RSpec.describe 'Inviting user in project the current user is lacking permission in',
+               js: true,
+               with_cuprite: true do
   let(:modal) do
     Components::Users::InviteUserModal.new project: invite_project,
                                            principal: other_user,
@@ -53,7 +55,7 @@ RSpec.describe 'Inviting user in project the current user is lacking permission 
     create(:user)
   end
 
-  it 'user cannot invite in current project but for different one' do
+  specify 'user cannot invite in current project but for different one' do
     visit project_path(view_project)
 
     quick_add.expect_visible
@@ -61,6 +63,8 @@ RSpec.describe 'Inviting user in project the current user is lacking permission 
     quick_add.toggle
 
     quick_add.click_link 'Invite user'
+
+    wait_for_network_idle
 
     modal.expect_help_displayed I18n.t('js.invite_user_modal.project.lacking_permission_info')
 

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal subprojects', js: true do
+RSpec.describe 'Invite user modal subprojects', js: true, with_cuprite: true do
   shared_let(:project) { create(:project, name: 'Parent project') }
   shared_let(:subproject) { create(:project, name: 'Subproject', parent: project) }
   shared_let(:work_package) { create(:work_package, project: subproject) }

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'my', js: true do
+RSpec.describe 'my', js: true, with_cuprite: true do
   let(:user_password) { 'bob' * 4 }
   let(:user) do
     create(:user,
@@ -53,7 +53,7 @@ RSpec.describe 'my', js: true do
   end
 
   before do
-    login_as(user)
+    login_as user
 
     # Create dangling session
     session = Sessions::SqlBypass.new data: { user_id: user.id }, session_id: 'other'

--- a/spec/features/users/notifications/shared_examples.rb
+++ b/spec/features/users/notifications/shared_examples.rb
@@ -7,130 +7,134 @@ RSpec.shared_examples 'notification settings workflow' do
     let!(:member_two) { create(:member, user:, project: project_alt, roles: [role]) }
 
     it 'allows to control notification settings' do
-      # Expect default settings
-      settings_page.expect_represented
-
-      # Add projects columns
-      settings_page.add_project project
-      settings_page.add_project project_alt
-
-      # Set settings for global email
-      settings_page.configure_global assignee: true,
-                                     responsible: true,
-                                     work_package_commented: true,
-                                     work_package_created: true,
-                                     work_package_processed: true,
-                                     work_package_prioritized: true,
-                                     work_package_scheduled: true
-
-      # Set settings for global date alerts
-      settings_page.set_reminder('start-date', '3 days before')
-      settings_page.enable_date_alert('overdue', true)
-      settings_page.set_reminder('overdue', 'every week')
-
-      # Set settings for project email
-      settings_page.configure_project project:,
-                                      assignee: true,
-                                      responsible: true,
-                                      work_package_commented: false,
-                                      work_package_created: false,
-                                      work_package_processed: false,
-                                      work_package_prioritized: false,
-                                      work_package_scheduled: false
-
-      # Set settings for project date alerts
-      settings_page.set_project_reminder('start-date', '3 days before', project)
-      settings_page.set_project_reminder('due-date', '3 days before', project)
-      settings_page.set_project_reminder('overdue', 'every week', project)
-
-      settings_page.save
-      settings_page.expect_and_dismiss_toaster(message: 'Successful update')
-
-      notification_settings = user.reload.notification_settings
-      expect(notification_settings.count).to eq 3
-      expect(notification_settings.where(project: nil).count).to eq(1)
-      expect(notification_settings.where(project:).count).to eq 1
-
-      global_settings = notification_settings.find_by(project: nil)
-      expect(global_settings.assignee).to be_truthy
-      expect(global_settings.responsible).to be_truthy
-      expect(global_settings.mentioned).to be_truthy
-      expect(global_settings.watched).to be_truthy
-      expect(global_settings.work_package_commented).to be_truthy
-      expect(global_settings.work_package_created).to be_truthy
-      expect(global_settings.work_package_processed).to be_truthy
-      expect(global_settings.work_package_prioritized).to be_truthy
-      expect(global_settings.work_package_scheduled).to be_truthy
-      expect(global_settings.start_date).to eq(3)
-      expect(global_settings.due_date).to eq(1)
-      expect(global_settings.overdue).to eq(7)
-
-      project_settings = notification_settings.find_by(project:)
-      expect(project_settings.assignee).to be_truthy
-      expect(project_settings.responsible).to be_truthy
-      expect(project_settings.mentioned).to be_truthy
-      expect(project_settings.watched).to be_truthy
-      expect(project_settings.work_package_commented).to be_falsey
-      expect(project_settings.work_package_created).to be_falsey
-      expect(project_settings.work_package_processed).to be_falsey
-      expect(project_settings.work_package_prioritized).to be_falsey
-      expect(project_settings.work_package_scheduled).to be_falsey
-      expect(project_settings.start_date).to eq(3)
-      expect(project_settings.due_date).to eq(3)
-      expect(project_settings.overdue).to eq(7)
-
-      # Unset global date alert settings
-      settings_page.enable_date_alert('start', false)
-      settings_page.enable_date_alert('overdue', false)
-      settings_page.enable_date_alert('due', false)
-
-      # Unset project date alert settings
-      settings_page.set_project_reminder('start-date', 'No notification', project)
-      settings_page.set_project_reminder('due-date', 'No notification', project)
-      settings_page.set_project_reminder('overdue', 'No notification', project)
-
-      settings_page.save
-      settings_page.expect_and_dismiss_toaster(message: 'Successful update')
-
-      notification_settings = user.reload.notification_settings
-      expect(notification_settings.count).to eq 3
-      expect(notification_settings.where(project: nil).count).to eq(1)
-      expect(notification_settings.where(project:).count).to eq 1
-
-      global_settings = notification_settings.find_by(project: nil)
-      expect(global_settings.start_date).to be_nil
-      expect(global_settings.due_date).to be_nil
-      expect(global_settings.overdue).to be_nil
-
-      project_settings = notification_settings.find_by(project:)
-      expect(project_settings.start_date).to be_nil
-      expect(project_settings.due_date).to be_nil
-      expect(project_settings.overdue).to be_nil
-
-      # Trying to add the same project again will not be possible (Regression #38072)
-      click_button 'Add setting for project'
-      container = page.find('[data-qa-selector="notification-setting-inline-create"] ng-select')
-      settings_page.search_autocomplete container, query: project.name, results_selector: 'body'
-      expect(page).to have_text 'This project is already selected'
-      expect(page).to have_selector('.ng-option-disabled', text: project.name)
-    end
-
-    context 'without enterprise', with_ee: false do
-      it 'does not renders the date alerts' do
+      within 'body' do
         # Expect default settings
         settings_page.expect_represented
 
         # Add projects columns
         settings_page.add_project project
+        settings_page.add_project project_alt
 
-        # Expect no date alert fields
-        settings_page.expect_no_date_alert_setting('start-date')
-        settings_page.expect_no_date_alert_setting('due-date')
-        settings_page.expect_no_date_alert_setting('overdue')
+        # Set settings for global email
+        settings_page.configure_global assignee: true,
+                                       responsible: true,
+                                       work_package_commented: true,
+                                       work_package_created: true,
+                                       work_package_processed: true,
+                                       work_package_prioritized: true,
+                                       work_package_scheduled: true
 
-        settings_page.expect_no_project_date_alert_setting('start-date', project)
-        settings_page.expect_no_project_date_alert_setting('due-date', project)
-        settings_page.expect_no_project_date_alert_setting('overdue', project)
+        # Set settings for global date alerts
+        settings_page.set_reminder('start-date', '3 days before')
+        settings_page.enable_date_alert('overdue', true)
+        settings_page.set_reminder('overdue', 'every week')
+
+        # Set settings for project email
+        settings_page.configure_project project:,
+                                        assignee: true,
+                                        responsible: true,
+                                        work_package_commented: false,
+                                        work_package_created: false,
+                                        work_package_processed: false,
+                                        work_package_prioritized: false,
+                                        work_package_scheduled: false
+
+        # Set settings for project date alerts
+        settings_page.set_project_reminder('start-date', '3 days before', project)
+        settings_page.set_project_reminder('due-date', '3 days before', project)
+        settings_page.set_project_reminder('overdue', 'every week', project)
+
+        settings_page.save
+        settings_page.expect_and_dismiss_toaster(message: 'Successful update')
+
+        notification_settings = user.reload.notification_settings
+        expect(notification_settings.count).to eq 3
+        expect(notification_settings.where(project: nil).count).to eq(1)
+        expect(notification_settings.where(project:).count).to eq 1
+
+        global_settings = notification_settings.find_by(project: nil)
+        expect(global_settings.assignee).to be_truthy
+        expect(global_settings.responsible).to be_truthy
+        expect(global_settings.mentioned).to be_truthy
+        expect(global_settings.watched).to be_truthy
+        expect(global_settings.work_package_commented).to be_truthy
+        expect(global_settings.work_package_created).to be_truthy
+        expect(global_settings.work_package_processed).to be_truthy
+        expect(global_settings.work_package_prioritized).to be_truthy
+        expect(global_settings.work_package_scheduled).to be_truthy
+        expect(global_settings.start_date).to eq(3)
+        expect(global_settings.due_date).to eq(1)
+        expect(global_settings.overdue).to eq(7)
+
+        project_settings = notification_settings.find_by(project:)
+        expect(project_settings.assignee).to be_truthy
+        expect(project_settings.responsible).to be_truthy
+        expect(project_settings.mentioned).to be_truthy
+        expect(project_settings.watched).to be_truthy
+        expect(project_settings.work_package_commented).to be_falsey
+        expect(project_settings.work_package_created).to be_falsey
+        expect(project_settings.work_package_processed).to be_falsey
+        expect(project_settings.work_package_prioritized).to be_falsey
+        expect(project_settings.work_package_scheduled).to be_falsey
+        expect(project_settings.start_date).to eq(3)
+        expect(project_settings.due_date).to eq(3)
+        expect(project_settings.overdue).to eq(7)
+
+        # Unset global date alert settings
+        settings_page.enable_date_alert('start', false)
+        settings_page.enable_date_alert('overdue', false)
+        settings_page.enable_date_alert('due', false)
+
+        # Unset project date alert settings
+        settings_page.set_project_reminder('start-date', 'No notification', project)
+        settings_page.set_project_reminder('due-date', 'No notification', project)
+        settings_page.set_project_reminder('overdue', 'No notification', project)
+
+        settings_page.save
+        settings_page.expect_and_dismiss_toaster(message: 'Successful update')
+
+        notification_settings = user.reload.notification_settings
+        expect(notification_settings.count).to eq 3
+        expect(notification_settings.where(project: nil).count).to eq(1)
+        expect(notification_settings.where(project:).count).to eq 1
+
+        global_settings = notification_settings.find_by(project: nil)
+        expect(global_settings.start_date).to be_nil
+        expect(global_settings.due_date).to be_nil
+        expect(global_settings.overdue).to be_nil
+
+        project_settings = notification_settings.find_by(project:)
+        expect(project_settings.start_date).to be_nil
+        expect(project_settings.due_date).to be_nil
+        expect(project_settings.overdue).to be_nil
+
+        # Trying to add the same project again will not be possible (Regression #38072)
+        click_button 'Add setting for project'
+        container = page.find('[data-qa-selector="notification-setting-inline-create"] ng-select')
+        settings_page.search_autocomplete container, query: project.name, results_selector: 'body'
+        expect(page).to have_text 'This project is already selected'
+        expect(page).to have_selector('.ng-option-disabled', text: project.name)
+      end
+    end
+
+    context 'without enterprise', with_ee: false do
+      it 'does not render the date alerts' do
+        within 'body' do
+          # Expect default settings
+          settings_page.expect_represented
+
+          # Add projects columns
+          settings_page.add_project project
+
+          # Expect no date alert fields
+          settings_page.expect_no_date_alert_setting('start-date')
+          settings_page.expect_no_date_alert_setting('due-date')
+          settings_page.expect_no_date_alert_setting('overdue')
+
+          settings_page.expect_no_project_date_alert_setting('start-date', project)
+          settings_page.expect_no_project_date_alert_setting('due-date', project)
+          settings_page.expect_no_project_date_alert_setting('overdue', project)
+        end
       end
     end
   end

--- a/spec/features/users/notifications/user_notifications_settings_spec.rb
+++ b/spec/features/users/notifications/user_notifications_settings_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 require_relative './shared_examples'
 
-RSpec.describe "user notifications settings", js: true do
+RSpec.describe "user notifications settings",
+               js: true,
+               with_cuprite: true do
   shared_let(:user) { create(:user) }
 
   let(:settings_page) { Pages::Notifications::Settings.new(user) }
@@ -11,13 +13,13 @@ RSpec.describe "user notifications settings", js: true do
     settings_page.visit!
   end
 
-  context 'as admin' do
+  context 'as an admin' do
     let(:current_user) { create(:admin) }
 
     it_behaves_like 'notification settings workflow'
   end
 
-  context 'as regular user' do
+  context 'as a regular user' do
     let(:current_user) { create(:user) }
 
     it 'does not allow to visit the page' do

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'random password generation', js: true do
+RSpec.describe 'random password generation', js: true, with_cuprite: true do
   shared_let(:admin) { create(:admin) }
 
   let(:auth_source) { build(:dummy_auth_source) }
@@ -42,7 +42,7 @@ RSpec.describe 'random password generation', js: true do
       login_with admin.login, 'adminADMIN!'
     end
 
-    it 'can log in with a random generated password', js: true do
+    it 'can log in with a random generated password' do
       user_page.visit!
 
       expect(page).to have_selector('#user_password')
@@ -108,16 +108,8 @@ RSpec.describe 'random password generation', js: true do
       visit my_account_path
       expect(page).to have_selector('.account-menu-item.selected')
     end
-  end
 
-  ##
-  # Converted from cuke password_complexity_checks.feature
-  context 'as an admin' do
-    before do
-      login_as admin
-    end
-
-    it 'can configure and enforce password rules', js: true do
+    it 'can configure and enforce password rules' do
       visit admin_settings_authentication_path
       expect_angular_frontend_initialized
 

--- a/spec/features/users/self_registration_spec.rb
+++ b/spec/features/users/self_registration_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'user self registration', js: true do
+RSpec.describe 'user self registration', js: true, with_cuprite: true do
   let(:admin_password) { 'Test123Test123' }
   let(:admin) { create(:admin, password: admin_password, password_confirmation: admin_password) }
   let(:home_page) { Pages::Home.new }
@@ -55,20 +55,18 @@ RSpec.describe 'user self registration', js: true do
         .to have_content('Your account was created and is now pending administrator approval.')
     end
 
-    it 'allows self registration and activation by an admin' do
+    it 'allows self registration and activation by an admin', signout_via_visit: true do
       home_page.visit!
 
       # registration as an anonymous user
       within '.op-app-header' do
         click_link 'Sign in'
 
-        SeleniumHubWaiter.wait
         click_link 'Create a new account'
       end
 
       # deliberately inserting a wrong password confirmation
       within '.registration-modal' do
-        SeleniumHubWaiter.wait
         fill_in 'Username', with: 'heidi'
         fill_in 'First name', with: 'Heidi'
         fill_in 'Last name', with: 'Switzerland'
@@ -86,7 +84,6 @@ RSpec.describe 'user self registration', js: true do
       within '.registration-modal' do
         # Cannot use 'Password' here as the error message on 'Confirmation' is part of the label
         # and contains the string 'Password' as well
-        SeleniumHubWaiter.wait
         fill_in 'user_password', with: 'test123=321test'
         fill_in 'Confirmation', with: 'test123=321test'
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'index users', js: true do
+RSpec.describe 'index users', js: true, with_cuprite: true do
   current_user { create(:admin) }
 
   let(:index_page) { Pages::Admin::Users::Index.new }

--- a/spec/features/users/user_memberships_spec.rb
+++ b/spec/features/users/user_memberships_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative '../principals/shared_memberships_examples'
 
-RSpec.describe 'user memberships through user page', js: true do
+RSpec.describe 'user memberships through user page', js: true, with_cuprite: true do
   include_context 'principal membership management context'
 
   shared_let(:principal) { create(:user, firstname: 'Foobar', lastname: 'Blabla') }

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -89,18 +89,19 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
                             query: 'Target',
                             select_text: 'Target',
                             results_selector: 'body'
-        SeleniumHubWaiter.wait
+        if using_cuprite?
+          wait_for_network_idle
+        else
+          SeleniumHubWaiter.wait
+        end
       end
 
       context 'when the limit to move in the frontend is 1',
               with_settings: { work_packages_bulk_request_limit: 1 } do
-        it 'copies them in the background and shows a status page' do
-          # Clicking move and follow might be broken due to the location.href
-          # in the refresh-on-form-changes component
-          retry_block do
-            click_on 'Move and follow'
-            page.find('[data-qa-selector="job-status--header"]')
-          end
+        it 'copies them in the background and shows a status page', :with_cuprite do
+          click_on 'Move and follow'
+          wait_for_reload
+          page.find('[data-qa-selector="job-status--header"]')
 
           expect(page).to have_text 'The job has been queued and will be processed shortly.'
 
@@ -114,14 +115,11 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
         end
       end
 
-      it 'moves parent and child wp to a new project' do
-        # Clicking move and follow might be broken due to the location.href
-        # in the refresh-on-form-changes component
-        retry_block do
-          click_on 'Move and follow'
-          page.find('.inline-edit--container.subject', text: work_package.subject, wait: 10)
-          page.find_by_id('projects-menu', text: 'Target')
-        end
+      it 'moves parent and child wp to a new project', :with_cuprite do
+        click_on 'Move and follow'
+        wait_for_reload
+        page.find('.inline-edit--container.subject', text: work_package.subject)
+        page.find_by_id('projects-menu', text: 'Target')
 
         # Should move its children
         child_wp.reload
@@ -131,14 +129,11 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
       context 'when the target project does not have the type' do
         let!(:project2) { create(:project, name: 'Target', types: [type2]) }
 
-        it 'does moves the work package and changes the type' do
-          # Clicking move and follow might be broken due to the location.href
-          # in the refresh-on-form-changes component
-          retry_block do
-            click_on 'Move and follow'
-            page.find('.inline-edit--container.subject', text: work_package.subject, wait: 10)
-            page.find_by_id('projects-menu', text: 'Target')
-          end
+        it 'does moves the work package and changes the type', :with_cuprite do
+          click_on 'Move and follow'
+          wait_for_reload
+          page.find('.inline-edit--container.subject', text: work_package.subject)
+          page.find_by_id('projects-menu', text: 'Target')
 
           # Should NOT have moved
           child_wp.reload

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -28,7 +28,10 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
+RSpec.describe 'Custom actions',
+               js: true,
+               with_cuprite: true,
+               with_ee: %i[custom_actions] do
   shared_let(:admin) { create(:admin) }
 
   let(:permissions) { %i(view_work_packages edit_work_packages move_work_packages work_package_assigned) }
@@ -140,16 +143,15 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
   let(:index_ca_page) { Pages::Admin::CustomActions::Index.new }
 
   before do
-    login_as(admin)
+    login_as admin
   end
 
-  it 'viewing workflow buttons' do
+  it 'viewing workflow buttons', with_cuprite: true do
     # create custom action 'Unassign'
     index_ca_page.visit!
 
     new_ca_page = index_ca_page.new
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Unassign')
       new_ca_page.set_description('Removes the assignee')
       new_ca_page.add_action('Assignee', '-')
@@ -170,7 +172,6 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
     new_ca_page = index_ca_page.new
 
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Close')
 
       new_ca_page.add_action('Status', 'Close')
@@ -198,7 +199,6 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
     new_ca_page = index_ca_page.new
 
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Escalate')
       new_ca_page.add_action('Priority', immediate_priority.name)
       new_ca_page.expect_action('priority', immediate_priority.id)
@@ -226,7 +226,6 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
     new_ca_page = index_ca_page.new
 
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Reset')
 
       new_ca_page.add_action('Priority', default_priority.name)
@@ -259,7 +258,6 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
 
     new_ca_page = index_ca_page.new
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Other roles action')
 
       new_ca_page.add_action('Status', default_status.name)
@@ -282,13 +280,18 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
     new_ca_page = index_ca_page.new
 
     retry_block do
-      new_ca_page.visit!
       new_ca_page.set_name('Move project')
       # Add date custom action which has a different admin layout
-      select date_custom_field.name, from: 'Add action'
-      select 'on', from: date_custom_field.name
 
-      date = (Date.today + 5.days)
+      ignore_ferrum_javascript_error do
+        select date_custom_field.name, from: 'Add action'
+      end
+
+      ignore_ferrum_javascript_error do
+        select 'on', from: date_custom_field.name
+      end
+
+      date = (Date.current + 5.days)
       find("#custom_action_actions_custom_field_#{date_custom_field.id}_visible").click
       datepicker = Components::Datepicker.new 'body'
       datepicker.set_date date
@@ -366,7 +369,6 @@ RSpec.describe 'Custom actions', js: true, with_ee: %i[custom_actions] do
     edit_ca_page = index_ca_page.edit('Reset')
 
     retry_block do
-      edit_ca_page.visit!
       edit_ca_page.set_name 'Reject'
       edit_ca_page.remove_action 'Priority'
       edit_ca_page.set_action 'Assignee', '-'

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Work Package highlighting fields',
-               js: true, with_ee: %i[conditional_highlighting] do
+               js: true,
+               with_ee: %i[conditional_highlighting] do
   let(:user) { create(:admin) }
 
   let(:project) { create(:project) }
@@ -192,7 +193,7 @@ RSpec.describe 'Work Package highlighting fields',
     expect(page).to have_selector(".__hl_inline_priority_#{priority1.id}")
   end
 
-  it 'correctly parses custom selected inline attributes' do
+  it 'correctly parses custom selected inline attributes', :with_cuprite do
     # Highlight only one attribute
     highlighting.switch_inline_attribute_highlight "Priority"
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -64,10 +64,12 @@ module AuthenticationHelpers
   end
 
   def logout
-    if using_cuprite?
-      page.driver.cookies.clear
-    else
+    # There are a select number of specs that rely on some implementation detail
+    # of `visit signout_path` that a cookie clear just doesn't cut.
+    if !using_cuprite? || RSpec.current_example.metadata[:signout_via_visit]
       visit signout_path
+    else
+      page.driver.cookies.clear
     end
   end
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -34,12 +34,12 @@ module AuthenticationHelpers
   end
 
   def login_as(user)
-    if is_a? RSpec::Rails::FeatureExampleGroup
+    if is_a?(RSpec::Rails::FeatureExampleGroup)
       # If we want to mock having finished the login process
       # we must set the user_id in rack.session accordingly
       # Otherwise e.g. calls to Warden will behave unexpectantly
       # as they will login AnonymousUser
-      if using_cuprite?
+      if using_cuprite? && js_enabled?
         page.driver.set_cookie(
           OpenProject::Configuration['session_cookie_name'],
           session_value_for(user).to_s
@@ -74,6 +74,10 @@ module AuthenticationHelpers
   end
 
   private
+
+  def js_enabled?
+    RSpec.current_example.metadata[:js]
+  end
 
   def using_cuprite?
     RSpec.current_example.metadata[:with_cuprite]

--- a/spec/support/components/autocompleter/autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/autocomplete_helpers.rb
@@ -35,6 +35,8 @@ module Components::Autocompleter
       sleep(0.1)
       element.set(query)
 
+      wait_for_network_idle if using_cuprite?
+
       ##
       # Find the open dropdown
       list =

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -53,9 +53,9 @@ module Components::Autocompleter
         input.send_keys(query[0..-2])
         sleep 0.2
         input.send_keys(query[-1])
-      else
-        input.send_keys(query)
       end
+
+      wait_for_network_idle if using_cuprite?
     end
 
     ##

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -38,7 +38,11 @@ module Components::Autocompleter
     # Insert the query, typing
     def ng_enter_query(element, query)
       input = element.find('input[type=text]', visible: :all).native
-      input.clear
+      if Capybara.javascript_driver == :better_cuprite_en
+        input.set ''
+      else
+        input.clear
+      end
 
       query = query.to_s
 

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -50,9 +50,15 @@ module Components::Autocompleter
       if query.length > 1
         # Send all keys, and then with a delay the last one
         # to emulate normal typing
-        input.send_keys(query[0..-2])
-        sleep 0.2
-        input.send_keys(query[-1])
+        if using_cuprite?
+          input.native.node.type(query[0..-2])
+          sleep 0.2
+          input.native.node.type(query[-1])
+        else
+          input.send_keys(query[0..-2])
+          sleep 0.2
+          input.send_keys(query[-1])
+        end
       end
 
       wait_for_network_idle if using_cuprite?

--- a/spec/support/components/common/sidemenu.rb
+++ b/spec/support/components/common/sidemenu.rb
@@ -60,6 +60,7 @@ module Components
       end
 
       def finished_loading
+        wait_for_network_idle if using_cuprite?
         expect(page).not_to have_selector('[data-qa-selector="op-ian-center--loading-indicator"]')
       end
 

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -81,11 +81,12 @@ module Components
         raise ArgumentError, "Invalid value #{value} for day, expected 1-31"
       end
 
+      expect(flatpickr_container).to have_text(value)
+
       retry_block do
         flatpickr_container
           .first('.flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)',
-                 text: value,
-                 exact_text: true)
+                 text: value)
           .click
       end
     end

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -37,6 +37,7 @@ module Components
 
       def toggle
         page.find_by_id('projects-menu').click
+        wait_for_network_idle if using_cuprite?
       end
 
       def open?

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -89,7 +89,9 @@ module Components
       end
 
       def open_select_in_step(selector, query = '')
-        search_autocomplete modal_element.find(selector),
+        select_field = modal_element.find(selector)
+
+        search_autocomplete select_field,
                             query:,
                             results_selector: 'body'
       end

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -128,7 +128,9 @@ module Components
       end
 
       def autocomplete(selector, query, select_text: query)
-        select_autocomplete modal_element.find(selector),
+        select_field = modal_element.find(selector)
+
+        select_autocomplete select_field,
                             query:,
                             select_text:,
                             results_selector: 'body'

--- a/spec/support/components/work_packages/sort_by.rb
+++ b/spec/support/components/work_packages/sort_by.rb
@@ -36,13 +36,15 @@ module Components
       def sort_via_header(name, selector: nil, descending: false)
         text = descending ? 'Sort descending' : 'Sort ascending'
 
-        SeleniumHubWaiter.wait
+        SeleniumHubWaiter.wait unless using_cuprite?
         open_table_column_context_menu(name, selector)
-        SeleniumHubWaiter.wait
+        SeleniumHubWaiter.wait unless using_cuprite?
 
         within_column_context_menu do
           click_button text
         end
+
+        wait_for_network_idle if using_cuprite?
       end
 
       def update_criteria(first, second = nil, third = nil)

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -85,7 +85,10 @@ end
 
 register_better_cuprite 'en'
 
-MODULES_WITH_CUPRITE_ENABLED = %w[avatars].freeze
+MODULES_WITH_CUPRITE_ENABLED = %w[
+  avatars
+  backlogs
+].freeze
 
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/(#{MODULES_WITH_CUPRITE_ENABLED.join('|')})/spec/features/}) do |meta|

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require 'capybara/cuprite'
+
+def headful_mode?
+  ActiveRecord::Type::Boolean.new.cast(ENV.fetch('OPENPROJECT_TESTING_NO_HEADLESS', nil))
+end
+
+def headless_mode?
+  !headful_mode?
+end
+
+def register_better_cuprite(language, name: :"better_cuprite_#{language}")
+  Capybara.register_driver(name) do |app|
+    options = {
+      process_timeout: 10,
+      inspector: true,
+      headless: headless_mode?
+    }
+    options = options.merge(window_size: [1920, 1080]) if headless_mode?
+
+    if ENV['CHROME_URL'].present?
+      options = options.merge(url: ENV['CHROME_URL'])
+    end
+
+    browser_options = {
+      'no-sandbox': nil,
+      'disable-gpu': nil,
+      'disable-popup-blocking': nil,
+      'disable-dev-shm-usage': nil,
+      lang: language
+    }
+
+    if ENV['OPENPROJECT_TESTING_AUTO_DEVTOOLS'].present?
+      browser_options = browser_options.merge('auto-open-devtools-for-tabs': nil)
+    end
+
+    driver_options = options.merge(browser_options:)
+
+    Capybara::Cuprite::Driver.new(app, **driver_options)
+  end
+
+  Capybara::Screenshot.register_driver(name) do |driver, path|
+    driver.save_screenshot(path)
+  end
+end
+
+register_better_cuprite 'en'
+
+RSpec.configure do |config|
+  config.around(:each, type: :feature, with_cuprite: true) do |example|
+    original_driver = Capybara.javascript_driver
+    Capybara.javascript_driver = :better_cuprite_en
+
+    example.run
+
+    Capybara.javascript_driver = original_driver
+  end
+end

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -85,7 +85,15 @@ end
 
 register_better_cuprite 'en'
 
+MODULES_WITH_CUPRITE_ENABLED = %w[avatars].freeze
+
 RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{/(#{MODULES_WITH_CUPRITE_ENABLED.join('|')})/spec/features/}) do |meta|
+    if meta[:js] && !meta.key?(:with_cuprite)
+      meta[:with_cuprite] = true
+    end
+  end
+
   config.around(:each, type: :feature, with_cuprite: true) do |example|
     original_driver = Capybara.javascript_driver
     Capybara.javascript_driver = :better_cuprite_en

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -53,11 +53,11 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
     end
 
     browser_options = {
-      'no-sandbox': nil,
+      'disable-dev-shm-usage': nil,
       'disable-gpu': nil,
       'disable-popup-blocking': nil,
-      'disable-dev-shm-usage': nil,
-      lang: language
+      lang: language,
+      'no-sandbox': nil
     }
 
     if ENV['OPENPROJECT_TESTING_AUTO_DEVTOOLS'].present?

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -88,6 +88,7 @@ register_better_cuprite 'en'
 MODULES_WITH_CUPRITE_ENABLED = %w[
   avatars
   backlogs
+  job_status
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -39,6 +39,15 @@ def headless_mode?
   !headful_mode?
 end
 
+# Customize browser download path until https://github.com/rubycdp/cuprite/pull/217 is released.
+module SetCupriteDownloadPath
+  def initialize(app, options = {})
+    super
+    @options[:save_path] = DownloadList::SHARED_PATH.to_s
+  end
+end
+Capybara::Cuprite::Driver.prepend(SetCupriteDownloadPath)
+
 def register_better_cuprite(language, name: :"better_cuprite_#{language}")
   Capybara.register_driver(name) do |app|
     options = {

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -135,7 +135,7 @@ class EditField
   end
 
   def submit_by_dashboard
-    field_container.find('.inplace-edit--control--save', wait: 5).click
+    field_container.find('.inplace-edit--control--save').click
   end
 
   ##

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -73,9 +73,9 @@ class EditField
   def activate!(expect_open: true)
     retry_block do
       unless active?
-        SeleniumHubWaiter.wait
+        SeleniumHubWaiter.wait unless using_cuprite?
         scroll_to_and_click(display_element)
-        SeleniumHubWaiter.wait
+        SeleniumHubWaiter.wait unless using_cuprite?
       end
 
       if expect_open && !active?
@@ -88,6 +88,7 @@ class EditField
 
   def openSelectField
     autocomplete_selector.click
+    wait_for_network_idle if using_cuprite?
   end
 
   def expect_state!(open:)
@@ -145,6 +146,9 @@ class EditField
     scroll_to_element(input_element)
     if autocompleter_field?
       autocomplete(content)
+    elsif using_cuprite?
+      clear_input_field_contents(input_element)
+      input_element.fill_in with: content
     else
       # A normal fill_in would cause the focus loss on the input for empty strings.
       # Thus the form would be submitted.

--- a/spec/support/form_fields/input_form_field.rb
+++ b/spec/support/form_fields/input_form_field.rb
@@ -20,10 +20,8 @@ module FormFields
       # A normal fill_in would cause the focus loss on the input for empty strings.
       # Thus the form would be submitted.
       # https://github.com/erikras/redux-form/issues/686
-      if Capybara.javascript_driver == :better_cuprite_en
-        input_element.value.length.times do
-          input_element.send_keys(:backspace)
-        end
+      if using_cuprite?
+        clear_input_field_contents(input_element)
         input_element.fill_in with: content
       else
         input_element.fill_in with: content, fill_options: { clear: :backspace }

--- a/spec/support/form_fields/input_form_field.rb
+++ b/spec/support/form_fields/input_form_field.rb
@@ -20,7 +20,14 @@ module FormFields
       # A normal fill_in would cause the focus loss on the input for empty strings.
       # Thus the form would be submitted.
       # https://github.com/erikras/redux-form/issues/686
-      input_element.fill_in with: content, fill_options: { clear: :backspace }
+      if Capybara.javascript_driver == :better_cuprite_en
+        input_element.value.length.times do
+          input_element.send_keys(:backspace)
+        end
+        input_element.fill_in with: content
+      else
+        input_element.fill_in with: content, fill_options: { clear: :backspace }
+      end
     end
 
     def send_keys(*args)

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -36,7 +36,6 @@ module Pages
         include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 
         def set_name(name)
-          fill_in 'Name', with: ''
           fill_in 'Name', with: name
         end
 
@@ -45,12 +44,13 @@ module Pages
         end
 
         def add_action(name, value)
-          sleep 1
-          select name, from: 'Add action'
-          sleep 1
+          ignore_ferrum_javascript_error do
+            select name, from: 'Add action'
+          end
           set_action_value(name, value)
-          sleep 1
-          page.assert_selector('#custom-actions-form--active-actions .form--label', text: name)
+          within '#custom-actions-form--active-actions' do
+            expect(page).to have_selector('.form--label', text: name)
+          end
         end
 
         def remove_action(name)
@@ -68,11 +68,13 @@ module Pages
         def expect_action(name, value)
           value = 'null' if value.nil?
 
-          if value.is_a?(Array)
-            value.each { |name| expect_selected_option(name.to_s) }
-          else
-            element = page.find("input[name='custom_action[actions][#{name}]']", visible: :all)
-            expect(element.value).to eq value.to_s
+          within '#custom-actions-form--actions' do
+            if value.is_a?(Array)
+              value.each { |name| expect_selected_option(name.to_s) }
+            else
+              element = find("input[name='custom_action[actions][#{name}]']", visible: :all)
+              expect(element.value).to eq value.to_s
+            end
           end
         end
 
@@ -97,8 +99,6 @@ module Pages
             within '#custom-actions-form--conditions' do
               expect_selected_option val
             end
-
-            sleep 1
           end
         end
 

--- a/spec/support/pages/admin/custom_actions/index.rb
+++ b/spec/support/pages/admin/custom_actions/index.rb
@@ -50,10 +50,10 @@ module Pages
         end
 
         def delete(name)
-          within_buttons_of name do
-            find('.icon-delete').click
-
-            accept_alert_dialog!
+          accept_alert do
+            within_buttons_of name do
+              find('.icon-delete').click
+            end
           end
         end
 
@@ -68,25 +68,25 @@ module Pages
 
         def move_top(name)
           within_row_of(name) do
-            click_link 'Move to top'
+            find("a[title='Move to top']").trigger('click')
           end
         end
 
         def move_bottom(name)
           within_row_of(name) do
-            click_link 'Move to bottom'
+            find("a[title='Move to bottom']").trigger('click')
           end
         end
 
         def move_up(name)
           within_row_of(name) do
-            click_link 'Move up'
+            find("a[title='Move up']").trigger('click')
           end
         end
 
         def move_down(name)
           within_row_of(name) do
-            click_link 'Move down'
+            find("a[title='Move down']").trigger('click')
           end
         end
 

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -51,8 +51,9 @@ module Pages
     end
 
     def delete_group!(name)
-      find_group(name).find('a[data-method=delete]').click
-      accept_alert_dialog!
+      accept_alert do
+        find_group(name).find('a[data-method=delete]').click
+      end
     end
 
     def find_group(name)

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -31,6 +31,7 @@ module Pages
     class Center < ::Pages::Page
       def open
         bell_element.click
+        wait_for_network_idle if using_cuprite?
         expect_open
       end
 

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -46,7 +46,12 @@ module Pages
     end
 
     def reload!
-      page.driver.browser.navigate.refresh
+      if using_cuprite?
+        page.driver.browser.refresh
+        wait_for_reload
+      else
+        page.driver.browser.navigate.refresh
+      end
     end
 
     def accept_alert_dialog!

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -148,6 +148,7 @@ module Pages
           row.hover
           menu = find('ul.project-actions')
           menu.click
+          expect(page).to have_selector('.menu-drop-down-container')
           yield menu
         end
       end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -148,6 +148,7 @@ module Pages
           row.hover
           menu = find('ul.project-actions')
           menu.click
+          wait_for_network_idle if using_cuprite?
           expect(page).to have_selector('.menu-drop-down-container')
           yield menu
         end

--- a/spec/support/pages/types/index.rb
+++ b/spec/support/pages/types/index.rb
@@ -64,11 +64,11 @@ module Pages
       end
 
       def delete(type)
-        within_row(type) do
-          find('.icon-delete').click
+        accept_alert do
+          within_row(type) do
+            find('.icon-delete').click
+          end
         end
-
-        accept_alert_dialog!
       end
 
       private

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -120,9 +120,9 @@ module Pages
       attribute_expectations.each do |label_name, value|
         label = label_name.to_s
         if label == 'status'
-          expect(page).to have_selector("[data-qa-selector='op-wp-status-button'] .button", text: value, wait: 10)
+          expect(page).to have_selector("[data-qa-selector='op-wp-status-button'] .button", text: value)
         else
-          expect(page).to have_selector(".inline-edit--container.#{label.camelize(:lower)}", text: value, wait: 10)
+          expect(page).to have_selector(".inline-edit--container.#{label.camelize(:lower)}", text: value)
         end
       end
     end

--- a/spec/support/pages/work_packages/split_work_package.rb
+++ b/spec/support/pages/work_packages/split_work_package.rb
@@ -48,6 +48,7 @@ module Pages
     end
 
     def expect_open
+      wait_for_reload if using_cuprite?
       expect(page).to have_selector(@selector)
       expect_subject
     end

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -29,11 +29,29 @@
 # ++
 #
 
-# Wrapper for Cuprite's `page.driver.wait_for_reload`
-# Used to wait for both:
-# 1. Network traffic to become idle.
-# 2. Waiting for DOM to be loaded and ready avoiding
-#    AJAX timing issues.
+# Wrapper for Cuprite's `page.driver.wait_for_network_idle`
+# Used to wait for Network traffic to become idle, helping
+# in specs where AJAX requests are performed by angular components.
+# This is especially helpful as it doesn't depend on DOM elements
+# being present or gone. Instead the execution is halted until
+# requested data is done being fetched.
+def wait_for_network_idle
+  page.driver.wait_for_network_idle
+end
+
+# Takes the above `wait_for_network_idle` a step further by waiting
+# for the page to be reloaded after some triggering action.
 def wait_for_reload
   page.driver.wait_for_reload
+end
+
+# Ferrum is yet support `fill_options` as a Hash
+def clear_input_field_contents(input_element)
+  input_element.value.length.times do
+    input_element.send_keys(:backspace)
+  end
+end
+
+def using_cuprite?
+  Capybara.javascript_driver == :better_cuprite_en
 end

--- a/spec/support/shared/ferrum_patches.rb
+++ b/spec/support/shared/ferrum_patches.rb
@@ -1,6 +1,8 @@
-#-- copyright
+# frozen_string_literal: true
+
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) 2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,24 +26,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
+#
 
-require 'support/pages/page'
+# A Cuprite edge-case with our use of select
+# fields causes a Ferrum::JavaScriptError to be raised
+# when an option HTMLElement is removed from its select field
+#
+# Use this as a temporary patch
 
-require_relative 'form'
+require 'ferrum/errors'
 
-module Pages
-  module Admin
-    module CustomActions
-      class New < Form
-        def create
-          click_button 'Create'
-        end
-
-        def path
-          new_custom_action_path
-        end
-      end
-    end
-  end
+def ignore_ferrum_javascript_error
+  yield
+rescue Ferrum::JavaScriptError
 end

--- a/spec/support/shared/scroll_into_view_helpers.rb
+++ b/spec/support/shared/scroll_into_view_helpers.rb
@@ -31,7 +31,11 @@ def scroll_to_element(element)
   script = <<-JS
     arguments[0].scrollIntoView(true);
   JS
-  Capybara.current_session.driver.browser.execute_script(script, element.native)
+  if Capybara.javascript_driver == :better_cuprite_en
+    page.driver.execute_script(script, element.native)
+  else
+    Capybara.current_session.driver.browser.execute_script(script, element.native)
+  end
 end
 
 def scroll_to_and_click(element)

--- a/spec/support/shared/scroll_into_view_helpers.rb
+++ b/spec/support/shared/scroll_into_view_helpers.rb
@@ -31,7 +31,7 @@ def scroll_to_element(element)
   script = <<-JS
     arguments[0].scrollIntoView(true);
   JS
-  if Capybara.javascript_driver == :better_cuprite_en
+  if using_cuprite?
     page.driver.execute_script(script, element.native)
   else
     Capybara.current_session.driver.browser.execute_script(script, element.native)

--- a/spec/support/shared/scroll_into_view_helpers.rb
+++ b/spec/support/shared/scroll_into_view_helpers.rb
@@ -43,6 +43,7 @@ def scroll_to_and_click(element)
     scroll_to_element(element)
     sleep 0.2
     element.click
+    wait_for_network_idle if using_cuprite?
   end
 end
 

--- a/spec/support/shared/wait_for_reload.rb
+++ b/spec/support/shared/wait_for_reload.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+# Wrapper for Cuprite's `page.driver.wait_for_reload`
+# Used to wait for both:
+# 1. Network traffic to become idle.
+# 2. Waiting for DOM to be loaded and ready avoiding
+#    AJAX timing issues.
+def wait_for_reload
+  page.driver.wait_for_reload
+end

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -61,7 +61,7 @@ class WithDirectUploads
   end
 
   def around(example)
-    example.metadata[:driver] = :chrome_billy
+    example.metadata[:javascript_driver] = example.metadata[:driver] = :chrome_billy
 
     csp_config = SecureHeaders::Configuration.instance_variable_get("@default_config").csp
 


### PR DESCRIPTION
This PR replaces Selenium with Cuprite in a [Strangler Fig Pattern approach](https://martinfowler.com/bliki/StranglerFigApplication.html).

Selenium and Cuprite live side by side and each example group/example defines whether
to use cuprite or not with the `:with_cuprite` metadata.

The short/medium term goal is to transition all our suite to running on Cuprite. However, we are at a point
right now where we can start benefiting from the performance improvement.

**Results:**
Our test suite is now consistently running in the 7 minute range with setup steps cached, and in the 9 minute range when setup steps are uncached.

Read more about [Cuprite](https://github.com/rubycdp/cuprite)