### PR TITLE
Fix "implicit String conversion" Deprecation Warning

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,7 +198,7 @@ module ApplicationHelper
 
       content_tag :div, class: 'form--field' do
         label_tag(id, object, object_options) do
-          styled_check_box_tag(name, object.id, false, id:) + object
+          styled_check_box_tag(name, object.id, false, id:) + object.to_s
         end
       end
     end.join.html_safe


### PR DESCRIPTION
A Deprecation Warning was popping up while running some specs announcing that the implicit String conversion performed in the modified method will no longer be supported in Rails 7.1

```
DEPRECATION WARNING: Implicit conversion of Role into String by ActiveSupport::SafeBuffer is deprecated and will be removed in Rails 7.1. You must explicitly cast it to a String. (called from block (3 levels) in labeled_check_box_tags at /Users/aaroncontreras/dev/client_projects/openproject/app/helpers/application_helper.rb:201)
```