### PR TITLE
Fix deprecated use of implicit block syntax as expectation subject

### DIFF
--- a/spec/lib/open_project/authentication/strategies/warden/global_basic_auth_spec.rb
+++ b/spec/lib/open_project/authentication/strategies/warden/global_basic_auth_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Strategies::GlobalBasicAuth do
     end
 
     it 'raises an error' do
-      expect(config).to raise_error("global user must not be 'schluessel'")
+      expect(&config).to raise_error("global user must not be 'schluessel'")
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Strategies::GlobalBasicAuth do
     let(:password) { '' }
 
     it 'raises an error' do
-      expect(config).to raise_error('password must not be empty')
+      expect(&config).to raise_error('password must not be empty')
     end
   end
 


### PR DESCRIPTION
Solves the following RSpec deprecation warning:

```
The implicit block expectation syntax is deprecated, you should pass a block rather
than an argument to `expect` to use the provided block expectation matcher or the
matcher must implement `supports_value_expectations?`.
```