### PR TITLE
Feature/48839 scroll handle on the work package sidebar

### DIFF
--- a/frontend/src/global_styles/content/work_packages/resizer/resizer.sass
+++ b/frontend/src/global_styles/content/work_packages/resizer/resizer.sass
@@ -3,7 +3,6 @@
   top: 0
   bottom: 0
   height: 100%
-  left: -12px
   cursor: col-resize
   color: var(--light-gray)
   font-size: 14px
@@ -11,7 +10,6 @@
   &:before
     position: relative
     top: 50%
-    left: 10px
 
 .work-packages--tabletimeline--timeline--resizer
   .work-packages--resizer

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -131,17 +131,6 @@
       display: block !important
       visibility: hidden
 
-  &--resizer
-    position: sticky
-    top: 50%
-    bottom: 50%
-    width: 18px
-    .work-packages--resizer
-      left: -2px
-      width: 18px
-      &::before
-        left: 0
-
 .nosidebar
   ul.subject-header
     width: 67%


### PR DESCRIPTION
https://community.openproject.org/work_packages/48839

<details><summary>Demo</summary>
<p>

![Jun-29-2023 20-34-06](https://github.com/opf/openproject/assets/83396/a0788638-27c7-40f8-8c59-0c1b3af6c66e)

</p>
</details> 

Admittedly I removed some classes that does _not seem_ to be necessary anymore. I tested out the different work package views to make sure the resizer looks as expected on both full and split views.