### PR TITLE
[#48633] Fix missing "Clear individual filter" buttons on Time and Costs page

### DIFF
--- a/modules/reporting/lib/widget/filters/remove_button.rb
+++ b/modules/reporting/lib/widget/filters/remove_button.rb
@@ -31,7 +31,7 @@ class Widget::Filters::RemoveButton < Widget::Filters::Base
     hidden_field = tag :input, id: "rm_#{filter_class.underscore_name}",
                                name: 'fields[]', type: 'hidden', value: ''
     button = content_tag(:a, href: "#", class: "filter_rem") do
-      icon_wrapper('icon-context advanced-filters--remove-filter-icon', I18n.t(:description_remove_filter))
+      icon_wrapper('icon-close advanced-filters--remove-filter-icon', I18n.t(:description_remove_filter))
     end
 
     write(content_tag(:div, hidden_field + button, id: "rm_box_#{filter_class.underscore_name}",

--- a/modules/reporting/spec/features/filter_spec.rb
+++ b/modules/reporting/spec/features/filter_spec.rb
@@ -1,21 +1,40 @@
 require 'spec_helper'
 
-RSpec.describe 'Cost report calculations', js: true do
+RSpec.describe 'Cost report calculations', :js, :with_cuprite do
   let(:project) { create(:project) }
   let(:user) { create(:admin) }
 
   before do
-    login_as(user)
+    login_as user
     visit cost_reports_path(project)
+  end
+
+  def clear_project_filter
+    within '#filter_project_id' do
+      find('.filter_rem').click
+    end
+  end
+
+  def reload_page
+    page.refresh
+    wait_for_reload
   end
 
   it 'provides filtering' do
     # Then filter "spent_on" should be visible
     # And filter "user_id" should be visible
+    expect(page).to have_selector("#filter_project_id")
     expect(page).to have_selector("#filter_spent_on")
     expect(page).to have_selector("#filter_user_id")
 
+    # Regression #48633
     # Remove filter:
+    # And I click on the filter's "Clear" button
+    clear_project_filter
+    # Then filter "project_id" should not be visible
+    expect(page).not_to have_selector('#filter_project_id')
+
+    # Remove filters:
     # And I click on "Clear"
     click_on 'Clear'
     # Then filter "spent_on" should not be visible
@@ -26,7 +45,7 @@ RSpec.describe 'Cost report calculations', js: true do
     # Reload restores the query
     # And the user with the login "developer" should be selected for "User Value"
     # And "!" should be selected for "User Operator Open this filter with 'ALT' and arrow keys."
-    visit cost_reports_path(project)
+    reload_page
     expect(page).to have_selector("#filter_spent_on")
     expect(page).to have_selector("#filter_user_id")
 


### PR DESCRIPTION
The CSS class being applied to the clear filter buttons was no longer valid.
Spec to cover regression added and migrated corresponding spec file to cuprite ;)

Work Package: https://community.openproject.org/work_packages/48633
