### PR TITLE
Fix ng-select dropdown repositionning

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
@@ -48,6 +48,7 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
 import { QueryFilterResource } from 'core-app/features/hal/resources/query-filter-resource';
 import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service';
 import { combineLatestWith } from 'rxjs';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 const ADD_FILTER_SELECT_INDEX = -1;
 
@@ -184,12 +185,6 @@ export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit
   }
 
   public onOpen() {
-    setTimeout(() => {
-      const component = this.ngSelectComponent as any;
-      if (component && component.dropdownPanel) {
-        component.dropdownPanel._updateXPosition();
-        component.dropdownPanel._updateYPosition();
-      }
-    }, 25);
+    repositionDropdownBugfix(this.ngSelectComponent);
   }
 }

--- a/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
@@ -187,7 +187,8 @@ export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit
     setTimeout(() => {
       const component = this.ngSelectComponent as any;
       if (component && component.dropdownPanel) {
-        component.dropdownPanel._updatePosition();
+        component.dropdownPanel._updateXPosition();
+        component.dropdownPanel._updateYPosition();
       }
     }, 25);
   }

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -14,6 +14,7 @@ import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/q
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { States } from 'core-app/core/states/states.service';
 import { enterpriseDocsUrl } from 'core-app/core/setup/globals/constants.const';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 @Component({
   templateUrl: './highlighting-tab.component.html',
@@ -114,13 +115,8 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
     return schema.highlightedAttributes.allowedValues;
   }
 
-  public onOpen(component:any) {
-    setTimeout(() => {
-      if (component.dropdownPanel) {
-        component.dropdownPanel._updateXPosition();
-        component.dropdownPanel._updateYPosition();
-      }
-    }, 25);
+  public onOpen(component:unknown) {
+    repositionDropdownBugfix(component);
   }
 
   private setSelectedValues() {

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -117,7 +117,8 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
   public onOpen(component:any) {
     setTimeout(() => {
       if (component.dropdownPanel) {
-        component.dropdownPanel._updatePosition();
+        component.dropdownPanel._updateXPosition();
+        component.dropdownPanel._updateYPosition();
       }
     }, 25);
   }

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -49,6 +49,7 @@ import { Subject } from 'rxjs';
 import { typeFromHref } from 'core-app/shared/components/principal/principal-helper';
 import { compareByHref } from 'core-app/shared/helpers/angular/tracking-functions';
 import { filter } from 'rxjs/operators';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 export interface CreateAutocompleterValueOption {
   name:string;
@@ -144,16 +145,7 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
   }
 
   public opened() {
-    // Force reposition as a workaround for BUG
-    // https://github.com/ng-select/ng-select/issues/1259
-    setTimeout(() => {
-      const component = this.ngSelectComponent as any;
-      if (this.appendTo && component && component.dropdownPanel) {
-        component.dropdownPanel._updateXPosition();
-        component.dropdownPanel._updateYPosition();
-      }
-    }, 25);
-
+    repositionDropdownBugfix(this.ngSelectComponent);
     this.onOpen.emit();
   }
 

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -149,7 +149,8 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
     setTimeout(() => {
       const component = this.ngSelectComponent as any;
       if (this.appendTo && component && component.dropdownPanel) {
-        component.dropdownPanel._updatePosition();
+        component.dropdownPanel._updateXPosition();
+        component.dropdownPanel._updateYPosition();
       }
     }, 25);
 

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -138,7 +138,8 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
     setTimeout(() => {
       const component = this.ngSelectComponent as any;
       if (component && component.dropdownPanel) {
-        component.dropdownPanel._updatePosition();
+        component.dropdownPanel._updateXPosition();
+        component.dropdownPanel._updateYPosition();
       }
     }, 25);
   }

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -15,6 +15,7 @@ import { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { merge } from 'rxjs';
 import { setBodyCursor } from 'core-app/shared/helpers/dom/set-window-cursor.helper';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 export interface DraggableOption {
   name:string;
@@ -133,15 +134,7 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
   }
 
   opened() {
-    // Force reposition as a workaround for BUG
-    // https://github.com/ng-select/ng-select/issues/1259
-    setTimeout(() => {
-      const component = this.ngSelectComponent as any;
-      if (component && component.dropdownPanel) {
-        component.dropdownPanel._updateXPosition();
-        component.dropdownPanel._updateYPosition();
-      }
-    }, 25);
+    repositionDropdownBugfix(this.ngSelectComponent);
   }
 
   private updateAvailableOptions() {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/autocompleter.helper.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/autocompleter.helper.ts
@@ -1,0 +1,21 @@
+interface NgSelectShim {
+  appendTo?:string;
+  dropdownPanel?:{
+    _updateXPosition():void;
+    _updateYPosition():void;
+  }
+}
+
+// Force reposition as a workaround for BUG
+// https://github.com/ng-select/ng-select/issues/1259
+export function repositionDropdownBugfix(component?:unknown) {
+  const instance = component as NgSelectShim;
+  if (instance?.appendTo && instance?.dropdownPanel) {
+    setTimeout(() => {
+      // eslint-disable-next-line no-underscore-dangle
+      instance.dropdownPanel?._updateXPosition();
+      // eslint-disable-next-line no-underscore-dangle
+      instance.dropdownPanel?._updateYPosition();
+    }, 25);
+  }
+}

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -49,6 +49,7 @@ import { OpAutocompleterService } from './services/op-autocompleter.service';
 import { OpAutocompleterHeaderTemplateDirective } from './directives/op-autocompleter-header-template.directive';
 import { OpAutocompleterLabelTemplateDirective } from './directives/op-autocompleter-label-template.directive';
 import { OpAutocompleterOptionTemplateDirective } from './directives/op-autocompleter-option-template.directive';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 @Component({
   selector: 'op-autocompleter',
@@ -277,18 +278,7 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
   }
 
   public repositionDropdown() {
-    if (this.ngSelectInstance) {
-      setTimeout(() => {
-        this.cdRef.detectChanges();
-        const component = this.ngSelectInstance;
-        if (this.appendTo && component && component.dropdownPanel) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,no-underscore-dangle
-          (component.dropdownPanel as any)._updateXPosition();
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,no-underscore-dangle
-          (component.dropdownPanel as any)._updateYPosition();
-        }
-      }, 25);
-    }
+    repositionDropdownBugfix(this.ngSelectInstance);
   }
 
   public opened():void { // eslint-disable-line no-unused-vars
@@ -398,10 +388,8 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
   private getDebounceTimeout():number {
     if (this.initialDebounce) {
       this.initialDebounce = false;
-      console.log('initial debouncing of 0');
       return 0;
     }
-    console.log('debouncing of 50');
     return 50;
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -283,7 +283,9 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
         const component = this.ngSelectInstance;
         if (this.appendTo && component && component.dropdownPanel) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,no-underscore-dangle
-          (component.dropdownPanel as any)._updatePosition();
+          (component.dropdownPanel as any)._updateXPosition();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,no-underscore-dangle
+          (component.dropdownPanel as any)._updateYPosition();
         }
       }, 25);
     }
@@ -373,6 +375,7 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
       filter(() => !!(this.defaultData || this.getOptionsFn)),
       distinctUntilChanged(),
       tap(() => this.loading$.next(true)),
+      // tap(() => console.log('Debounce is ', this.getDebounceTimeout())),
       debounce(() => timer(this.getDebounceTimeout())),
       switchMap((queryString:string) => {
         if (this.defaultData) {
@@ -395,8 +398,10 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
   private getDebounceTimeout():number {
     if (this.initialDebounce) {
       this.initialDebounce = false;
+      console.log('initial debouncing of 0');
       return 0;
     }
+    console.log('debouncing of 50');
     return 50;
   }
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/project-status-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/project-status-edit-field.component.ts
@@ -97,7 +97,8 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
     setTimeout(() => {
       const component = (this.ngSelectComponent) as any;
       if (component && component.dropdownPanel) {
-        component.dropdownPanel._updatePosition();
+        component.dropdownPanel._updateXPosition();
+        component.dropdownPanel._updateYPosition();
       }
 
       jQuery(this.hiddenOverflowContainer).one('scroll.autocompleteContainer', () => {

--- a/frontend/src/app/shared/components/fields/edit/field-types/project-status-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/project-status-edit-field.component.ts
@@ -36,6 +36,7 @@ import {
 } from 'core-app/shared/components/fields/helpers/project-status-helper';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 interface ProjectStatusOption {
   href:string
@@ -92,19 +93,11 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
   }
 
   public onOpen() {
-    // Force reposition as a workaround for BUG
-    // https://github.com/ng-select/ng-select/issues/1259
-    setTimeout(() => {
-      const component = (this.ngSelectComponent) as any;
-      if (component && component.dropdownPanel) {
-        component.dropdownPanel._updateXPosition();
-        component.dropdownPanel._updateYPosition();
-      }
+    repositionDropdownBugfix(this.ngSelectComponent);
 
-      jQuery(this.hiddenOverflowContainer).one('scroll.autocompleteContainer', () => {
-        this.ngSelectComponent.close();
-      });
-    }, 25);
+    jQuery(this.hiddenOverflowContainer).one('scroll.autocompleteContainer', () => {
+      this.ngSelectComponent.close();
+    });
   }
 
   public onClose() {


### PR DESCRIPTION
I noticed the following javascript error while debugging something else:

```
Uncaught TypeError: component.dropdownPanel._updatePosition is not a function
    at op-autocompleter.component.ts:287:44
```

It looks like `_updatePosition` has been split into `_updateXPosition` and `_updateYPosition` in this [ng-select commit](https://github.com/ng-select/ng-select/commit/348c1179763f982e9a4c69b1013705110aca651a) on Oct 6, 2020.

I replaced the `_updatePosition` calls to use `_updateXPosition` and `_updateYPosition` instead.
I'm not sure how to extract a method to factorize this code. Any help appreciated.
I'm not sure about the eslint errors either.
