### PR TITLE
Pass strategy key into filtered_strategy?

### DIFF
--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -46,8 +46,9 @@ module OpenProject::Plugins
     end
 
     def self.providers_for(strategy)
-      matching = Array(strategies[strategy_key(strategy)])
-      filtered_strategies matching.map(&:call).flatten.map(&:to_hash)
+      key = strategy_key(strategy)
+      matching = Array(strategies[key])
+      filtered_strategies(key, matching.map(&:call).flatten.map(&:to_hash))
     end
 
     def self.login_provider_for(user)
@@ -63,19 +64,24 @@ module OpenProject::Plugins
 
     def self.providers
       RequestStore.fetch(:openproject_omniauth_filtered_strategies) do
-        filtered_strategies strategies.values.flatten.map(&:call).flatten.map(&:to_hash)
+        strategies.flat_map do |strategy_key, values|
+          filtered_strategies(strategy_key, values.flat_map(&:call).flat_map(&:to_hash))
+        end
       end
     end
 
-    def self.filtered_strategies(options)
+    def self.filtered_strategies(strategy_key, options)
       options.select do |provider|
-        name = provider[:name]&.to_s
-        next true if !EnterpriseToken.show_banners? || name == 'developer'
+        filtered = filtered_strategy?(strategy_key, provider)
+        warn_unavailable(name) unless filtered
 
-        warn_unavailable(name)
-
-        false
+        filtered
       end
+    end
+
+    def self.filtered_strategy?(_strategy_key, provider)
+      name = provider[:name]&.to_s
+      !EnterpriseToken.show_banners? || name == 'developer'
     end
 
     def self.strategy_key(strategy)


### PR DESCRIPTION
There is no way to identify the OmniAuth strategy of a values hash when trying to filter it