### PR TITLE
Look up existing status data and store them as references

### DIFF
--- a/app/seeders/basic_data/status_seeder.rb
+++ b/app/seeders/basic_data/status_seeder.rb
@@ -29,6 +29,7 @@ module BasicData
   class StatusSeeder < ModelSeeder
     self.model_class = Status
     self.seed_data_model_key = 'statuses'
+    self.attribute_names_for_lookups = %i[name is_closed is_default]
     self.needs = [
       BasicData::ColorSeeder,
       BasicData::ColorSchemeSeeder

--- a/spec/seeders/basic_data/status_seeder_spec.rb
+++ b/spec/seeders/basic_data/status_seeder_spec.rb
@@ -94,6 +94,26 @@ RSpec.describe BasicData::StatusSeeder do
       created_status = Status.last
       expect(seed_data.find_reference(:status_closed)).to eq(created_status)
     end
+
+    context 'when seeding a second time' do
+      subject(:second_seeder) { described_class.new(second_seed_data) }
+
+      let(:second_seed_data) { basic_seed_data.merge(Source::SeedData.new(data_hash)) }
+
+      before do
+        second_seeder.seed!
+      end
+
+      it 'registers existing matching statuses as references in the seed data' do
+        # using the first seed data as the expected value
+        expect(second_seed_data.find_reference(:status_closed))
+          .to eq(seed_data.find_reference(:status_closed))
+        expect(second_seed_data.find_reference(:status_new))
+          .to eq(seed_data.find_reference(:status_new))
+        expect(second_seed_data.find_reference(:status_in_progress))
+          .to eq(seed_data.find_reference(:status_in_progress))
+      end
+    end
   end
 
   context 'without statuses defined' do


### PR DESCRIPTION
Should fix errors that could occur when reseeding some data is needed, like the one encountered by Souvap:

```
  StandardError: Not all statuses needed for seeding a KANBAN board are present. Check that they get seeded.
   /app/app/seeders/demo_data/work_package_board_seeder.rb:106:in `seed_kanban_board_queries'
   /app/app/seeders/demo_data/work_package_board_seeder.rb:70:in `seed_kanban_board'
   /app/app/seeders/demo_data/work_package_board_seeder.rb:43:in `block in seed_data!'
   /app/app/seeders/seeder.rb:57:in `print_status'
```