### PR TITLE
[40157] Entries in summary emails not clickable in Outlook (links not working)

### DIFF
--- a/app/views/announcement_mailer/announce.html.erb
+++ b/app/views/announcement_mailer/announce.html.erb
@@ -39,5 +39,11 @@
     </tr>
   <% end %>
 
+  <table>
+    <tr>
+      <%= placeholder_cell('20px', vertical: false) %>
+    </tr>
+  </table>
+
   <%= render partial: 'mailer/notification_settings_table' %>
 <% end %>

--- a/app/views/mailer/_border_table.html.erb
+++ b/app/views/mailer/_border_table.html.erb
@@ -13,9 +13,3 @@
     <%= placeholder_cell('12px', vertical: false) %>
   </tr>
 </table>
-
-<table>
-  <tr>
-    <%= placeholder_cell('20px', vertical: false) %>
-  </tr>
-</table>

--- a/app/views/mailer/_notification_row.html.erb
+++ b/app/views/mailer/_notification_row.html.erb
@@ -97,3 +97,21 @@
     </tr>
   <% end %>
 </a>
+
+<table>
+  <tr>
+    <%= placeholder_cell('0px', vertical: false) %>
+  </tr>
+</table>
+
+<a style="margin-left: 12px;"
+   href="<%= notifications_path(work_package.id) %>"
+   target="_blank">
+  <%= I18n.t('mail.work_packages.open_in_browser') %>
+</a>
+
+<table>
+  <tr>
+    <%= placeholder_cell('20px', vertical: false) %>
+  </tr>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2161,6 +2161,7 @@ en:
       more_to_see:
         one: 'There is 1 more work package with notifications.'
         other: 'There are %{count} more work packages with notifications.'
+      open_in_browser: 'Open in browser'
       reason:
         watched: 'Watched'
         assigned: 'Assigned'


### PR DESCRIPTION
Add additional (separate) link below each notification row especially for outlook.

<img width="711" alt="Bildschirmfoto 2023-07-04 um 11 43 54" src="https://github.com/opf/openproject/assets/7457313/2250958b-b00c-4b41-befa-971663214e1b">

https://community.openproject.org/projects/openproject/work_packages/40157/activity