### PR TITLE
[48450] Find why some translation source files are not correctly sent to crowdin

### DIFF
--- a/script/i18n/generate_seeders_i18n_source_file
+++ b/script/i18n/generate_seeders_i18n_source_file
@@ -63,6 +63,7 @@ class GenerateSeederSourceTranslationFiles
         .each do |dir, seed_files|
           create_crowdin_source_file(dir, seed_files)
         end
+      create_additional_dummy_crowdin_source_file
       puts "Done"
     end
 
@@ -76,6 +77,24 @@ class GenerateSeederSourceTranslationFiles
         f.puts comment
         YAML.dump(source_data, f)
       end
+    end
+
+    def create_additional_dummy_crowdin_source_file
+      dummy_file = Rails.root.join('modules/boards/config/locales/en.seeders.yml')
+      content = <<~CONTENT
+        #{comment}
+        #
+        # This file is needed to prevent bug #48450: at least two 'en.seeders.yml' files
+        # located in the modules directories are needed to have crowdin cli correctly
+        # compute the path to the uploaded source file.
+        #
+        # This file does not contain any i18n strings.
+
+        en:
+      CONTENT
+      File.write(dummy_file, content)
+
+      puts "Generate additional dummy crowdin source file #{relative_path(dummy_file.to_s)}"
     end
 
     def source_file_path(seed_file_path)


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/48450

`config/locales/en.seeders.yml` source is sent as `dev/en.seeders.yml` to crowdin, but `modules/bim/config/locales/en.seeders.yml` is also sent as `dev/en.seeders.yml`, so it's ignored:

```
STARTING CROWDIN ACTION
UPLOAD SOURCES
✔️  Fetching project info
⏭  Branch 'dev' already exists in the project
✔️  File 'dev/en.yml'
✔️  File 'dev/js-en.yml'
✔️  File 'dev/en.seeders.yml'
✔️  File 'dev/team_planner/config/locales/en.yml'
✔️  File 'dev/overviews/config/locales/en.yml'
✔️  File 'dev/backlogs/config/locales/en.yml'
✔️  File 'dev/dashboards/config/locales/en.yml'
✔️  File 'dev/costs/config/locales/en.yml'
✔️  File 'dev/xls_export/config/locales/en.yml'
✔️  File 'dev/budgets/config/locales/en.yml'
✔️  File 'dev/reporting/config/locales/en.yml'
✔️  File 'dev/avatars/config/locales/en.yml'
✔️  File 'dev/calendar/config/locales/en.yml'
✔️  File 'dev/documents/config/locales/en.yml'
✔️  File 'dev/grids/config/locales/en.yml'
✔️  File 'dev/ldap_groups/config/locales/en.yml'
✔️  File 'dev/meeting/config/locales/en.yml'
✔️  File 'dev/recaptcha/config/locales/en.yml'
✔️  File 'dev/pdf_export/config/locales/en.yml'
✔️  File 'dev/boards/config/locales/en.yml'
✔️  File 'dev/openid_connect/config/locales/en.yml'
✔️  File 'dev/webhooks/config/locales/en.yml'
✔️  File 'dev/github_integration/config/locales/en.yml'
✔️  File 'dev/storages/config/locales/en.yml'
✔️  File 'dev/bim/config/locales/en.yml'
✔️  File 'dev/two_factor_authentication/config/locales/en.yml'
✔️  File 'dev/costs/config/locales/js-en.yml'
✔️  File 'dev/job_status/config/locales/js-en.yml'
✔️  File 'dev/github_integration/config/locales/js-en.yml'
✔️  File 'dev/bim/config/locales/js-en.yml'
✔️  File 'dev/my_page/config/locales/js-en.yml'
✔️  File 'dev/storages/config/locales/js-en.yml'
✔️  File 'dev/dashboards/config/locales/js-en.yml'
✔️  File 'dev/overviews/config/locales/js-en.yml'
✔️  File 'dev/team_planner/config/locales/js-en.yml'
✔️  File 'dev/calendar/config/locales/js-en.yml'
✔️  File 'dev/budgets/config/locales/js-en.yml'
✔️  File 'dev/grids/config/locales/js-en.yml'
✔️  File 'dev/avatars/config/locales/js-en.yml'
✔️  File 'dev/backlogs/config/locales/js-en.yml'
✔️  File 'dev/reporting/config/locales/js-en.yml'
✔️  File 'dev/boards/config/locales/js-en.yml'
⚠️  Skipping file 'dev/en.seeders.yml' because it is already uploading/uploaded
```

This needs to be debugged.