### PR TITLE
Add focus state to datepicker input fields

### DIFF
--- a/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
@@ -37,8 +37,12 @@
   &--date-field
     &_current,
     &_current:hover
-      outline: 2px solid var(--primary-color)
-      outline-offset: -2px
+      // We want this to feel like the focus outline, but we cannot make it an actual outline
+      // because that would overwrite the focus outline when the input field is focused.
+      // So we make a border 2px wide like the outline, and then reduce margins by 1px so the
+      // size of the element does not change.
+      border: 2px solid var(--primary-color)
+      margin: -1px
 
   &--date-container
     display: inline-grid


### PR DESCRIPTION
The datepicker input fields have an active state which was overriding the focus state.

Closes https://community.openproject.org/work_packages/48435/activity