### PR TITLE
fix(export): formatter.format needs options obj

### DIFF
--- a/app/models/exports/formatters/default.rb
+++ b/app/models/exports/formatters/default.rb
@@ -21,12 +21,12 @@ module Exports
       # Takes a resource and an attribute and returns the value to be exported.
       def format(object, **options)
         value = retrieve_value(object)
-        format_value(value)
+        format_value(value, options)
       end
 
       ##
       # Takes a value and returns the formatted value to be exported.
-      def format_value(value)
+      def format_value(value, options)
         case value
         when Date
           format_date value

--- a/app/models/work_package/exports/formatters/currency.rb
+++ b/app/models/work_package/exports/formatters/currency.rb
@@ -32,7 +32,7 @@ module WorkPackage::Exports
         %i[material_costs labor_costs overall_costs].include?(name.to_sym) && export_format == :pdf
       end
 
-      def format_value(value)
+      def format_value(value, _options)
         value.nil? || value.zero? ? '' : number_to_currency(value)
       end
     end

--- a/app/models/work_package/exports/formatters/days.rb
+++ b/app/models/work_package/exports/formatters/days.rb
@@ -32,7 +32,7 @@ module WorkPackage::Exports
         name.to_sym == :duration && export_format == :pdf
       end
 
-      def format_value(value)
+      def format_value(value, _options)
         formatted_days(value)
       end
 

--- a/app/models/work_package/exports/formatters/estimated_hours.rb
+++ b/app/models/work_package/exports/formatters/estimated_hours.rb
@@ -43,7 +43,7 @@ module WorkPackage::Exports
         "#{estimated_hours} #{derived_hours}"
       end
 
-      def format_value(value)
+      def format_value(value, _options)
         formatted_hours(value)
       end
 

--- a/app/models/work_package/exports/formatters/hours.rb
+++ b/app/models/work_package/exports/formatters/hours.rb
@@ -32,7 +32,7 @@ module WorkPackage::Exports
         %i[remaining_hours spent_hours].include?(name.to_sym) && export_format == :pdf
       end
 
-      def format_value(value)
+      def format_value(value, _options)
         formatted_hours(value)
       end
 

--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -100,7 +100,7 @@ module WorkPackage::PDFExport::Common
     return '' if value.nil?
 
     formatter = formatter_for(column_name, :pdf)
-    formatter.format_value(value)
+    formatter.format_value(value, {})
   end
 
   def escape_tags(value)


### PR DESCRIPTION
Fix for AppSignal message 794
`The PDF export could not be saved: undefined local variable or method options for #<Exports::Formatters::CustomField:0x00007f02102b4698 @attribute=:cf_1>`