### PR TITLE
Provide configuration variables for admin user seed

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Generate .env.pullpreview file
       run: |
-        echo "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off" >> .env.pullpreview
+        echo "OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET=false" >> .env.pullpreview
         echo "OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING=false" >> .env.pullpreview
         echo "OPENPROJECT_FEATURE__STORAGES__MODULE__ACTIVE=true" >> .env.pullpreview
         echo "OPENPROJECT_FEATURE__SHOW__CHANGES__ACTIVE=true" >> .env.pullpreview

--- a/app/seeders/admin_user_seeder.rb
+++ b/app/seeders/admin_user_seeder.rb
@@ -54,10 +54,11 @@ class AdminUserSeeder < Seeder
     User.new.tap do |user|
       user.admin = true
       user.login = 'admin'
-      user.password = 'admin'
-      user.firstname = 'OpenProject'
-      user.lastname = 'Admin'
-      user.mail = ENV['ADMIN_EMAIL'].presence || 'admin@example.net'
+      user.password = Setting.seed_admin_user_password
+      first, last = Setting.seed_admin_user_name.split(' ', 2)
+      user.firstname = first
+      user.lastname = last
+      user.mail = Setting.seed_admin_user_mail
       user.language = I18n.locale.to_s
       user.status = User.statuses[:active]
       user.force_password_change = force_password_change?
@@ -66,16 +67,8 @@ class AdminUserSeeder < Seeder
   end
 
   def force_password_change?
-    !Rails.env.development? && !force_password_change_disabled?
-  end
+    return false if Rails.env.development?
 
-  def force_password_change_disabled?
-    off_values = ["off", "false", "no", "0"]
-
-    off_values.include? ENV.fetch(force_password_change_env_switch_name, nil)
-  end
-
-  def force_password_change_env_switch_name
-    "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE"
+    Setting.seed_admin_user_password_reset?
   end
 end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -809,6 +809,26 @@ module Settings
         default: "https://releases.openproject.com/v1/check.svg",
         writable: false
       },
+      seed_admin_user_password: {
+        description: 'Password to set for the initially created admin user (Login remains "admin").',
+        default: 'admin',
+        writable: false
+      },
+      seed_admin_user_mail: {
+        description: 'E-mail to set for the initially created admin user.',
+        default: 'admin@example.net',
+        writable: false
+      },
+      seed_admin_user_name: {
+        description: 'Name to set for the initially created admin user.',
+        default: 'OpenProject Admin',
+        writable: false
+      },
+      seed_admin_user_password_reset: {
+        description: 'Whether to force a password reset for the initially created admin user.',
+        default: true,
+        writable: false
+      },
       self_registration: {
         default: 2
       },

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -162,6 +162,7 @@ Configuring OpenProject through environment variables is described in detail [in
 
 ## Examples for common use cases
 
+* [`admin_user`](#admin-user) (default: 'repositories')
 * `attachments_storage_path`
 * `autologin_cookie_name` (default: 'autologin'),
 * `autologin_cookie_path` (default: '/')
@@ -190,6 +191,29 @@ Configuring OpenProject through environment variables is described in detail [in
 * [`show_community_links`](#show-community-links)
 * [`web`](#web) (nested configuration)
 * [`statsd`](#statsd) (nested configuration)
+
+
+
+## Admin user
+
+**Note:** These variables are only applicable during the first initial setup of your OpenProject setup. Changing or setting them later will have no effect, as the admin user will already have been created.
+
+By default, an admin user will be created with the login and password set to `admin`. You will be required to change this password on first login.
+
+In case of automated deployments, you might find it useful to seed an admin user with password and attributes of your choosing. For that, you can use the following set of variables:
+
+
+
+```bash
+OPENPROJECT_SEED_ADMIN_USER_PASSWORD="admin" # Password to set for the admin user
+OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET="true" # Whether to force a password reset on first login (true/false)
+OPENPROJECT_SEED_ADMIN_USER_NAME="OpenProject Admin" # Name to assign to that user (First and lastnames will be split on the space character)
+OPENPROJECT_SEED_ADMIN_USER_MAIL="admin@example.net" # Email attribute to assign to that user. Note that in packaged installations, a wizard step will assign this variable as well.
+```
+
+
+
+
 
 ## Setting session options
 

--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -51,6 +51,16 @@ storage config above like this:
 OPENPROJECT_STORAGE_TYPE=nfs
 ```
 
+
+
+## Seed variables
+
+Some of the provided variables are only applicable during the seeding of a new installation (i.e., during the first start or run of the `db:seeds` setup task).
+
+These variables are prefixed with `OPENPROJECT_SEED_*` to identify them. Changing these variables to a new value in a running system of OpenProject will likely have no effect unless explicitly marked in the configuration guides.
+
+
+
 ## Passing data structures to the app
 
 The configuration uses YAML to parse overrides from ENV. Using YAML inline syntax, you can:
@@ -102,230 +112,239 @@ docker exec -it $(docker ps | grep web | cut -d' ' -f 1) bash -c "RAILS_ENV=prod
 The default value is also visible for each variable in parenthesis. The following are the correct values at the time of writing and that you should use the commands shown above to make sure to get the up-to-date list.
 
 ```bash
-OPENPROJECT_ACTIVITY__DAYS__DEFAULT (default=30)
-OPENPROJECT_ADDITIONAL__FOOTER__CONTENT (default=nil)
-OPENPROJECT_AFTER__FIRST__LOGIN__REDIRECT__URL (default=nil)
-OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL (default=nil)
-OPENPROJECT_APIV3__CORS__ENABLED (default=false)
-OPENPROJECT_APIV3__CORS__ORIGINS (default=[])
-OPENPROJECT_APIV3__DOCS__ENABLED (default=true)
-OPENPROJECT_APIV3__ENABLE__BASIC__AUTH (default=true)
-OPENPROJECT_APIV3__MAX__PAGE__SIZE (default=1000)
-OPENPROJECT_APP__TITLE (default="OpenProject")
-OPENPROJECT_APPSIGNAL__FRONTEND__KEY (default=nil)
-OPENPROJECT_ATTACHMENT__MAX__SIZE (default=5120)
-OPENPROJECT_ATTACHMENT__WHITELIST (default=[])
-OPENPROJECT_ATTACHMENTS__GRACE__PERIOD (default=180)
-OPENPROJECT_ATTACHMENTS__STORAGE (default=:file)
-OPENPROJECT_ATTACHMENTS__STORAGE__PATH (default=nil)
-OPENPROJECT_AUTH__SOURCE__SSO (default=nil)
-OPENPROJECT_AUTHENTICATION (default=nil)
-OPENPROJECT_AUTOFETCH__CHANGESETS (default=true)
-OPENPROJECT_AUTOLOGIN (default=0)
-OPENPROJECT_AUTOLOGIN__COOKIE__NAME (default="autologin")
-OPENPROJECT_AUTOLOGIN__COOKIE__PATH (default="/")
-OPENPROJECT_AUTOLOGIN__COOKIE__SECURE (default=false)
-OPENPROJECT_AVAILABLE__LANGUAGES (default=["en", "de", "fr", "es", "pt", "pt-BR", "it", "zh-CN", "ko", "ru"])
-OPENPROJECT_AVATAR__LINK__EXPIRY__SECONDS (default=86400)
-OPENPROJECT_BACKUP__ATTACHMENT__SIZE__MAX__SUM__MB (default=1024)
-OPENPROJECT_BACKUP__DAILY__LIMIT (default=3)
-OPENPROJECT_BACKUP__ENABLED (default=true)
-OPENPROJECT_BACKUP__INCLUDE__ATTACHMENTS (default=true)
-OPENPROJECT_BACKUP__INITIAL__WAITING__PERIOD (default=86400)
-OPENPROJECT_BCC__RECIPIENTS (default=true)
-OPENPROJECT_BLACKLISTED__ROUTES (default=[])
-OPENPROJECT_BOARDS__DEMO__DATA__AVAILABLE (default=false)
-OPENPROJECT_BRUTE__FORCE__BLOCK__AFTER__FAILED__LOGINS (default=20)
-OPENPROJECT_BRUTE__FORCE__BLOCK__MINUTES (default=30)
-OPENPROJECT_CACHE__EXPIRES__IN__SECONDS (default=nil)
-OPENPROJECT_CACHE__FORMATTED__TEXT (default=true)
-OPENPROJECT_CACHE__MEMCACHE__SERVER (default=nil)
-OPENPROJECT_CACHE__NAMESPACE (default=nil)
-OPENPROJECT_COMMIT__FIX__DONE__RATIO (default=100)
-OPENPROJECT_COMMIT__FIX__KEYWORDS (default="fixes,closes")
-OPENPROJECT_COMMIT__FIX__STATUS__ID (default=nil)
-OPENPROJECT_COMMIT__LOGS__ENCODING (default="UTF-8")
-OPENPROJECT_COMMIT__LOGTIME__ACTIVITY__ID (default=nil)
-OPENPROJECT_COMMIT__LOGTIME__ENABLED (default=false)
-OPENPROJECT_COMMIT__REF__KEYWORDS (default="refs,references,IssueID")
-OPENPROJECT_CONSENT__DECLINE__MAIL (default=nil)
-OPENPROJECT_CONSENT__INFO (default={"en"=>"## Consent\n\nYou need to agree to the [privacy and security policy](https://www.openproject.org/data-privacy-and-security/) of this OpenProject instance."})
-OPENPROJECT_CONSENT__REQUIRED (default=false)
-OPENPROJECT_CONSENT__TIME (default=nil)
-OPENPROJECT_COST__REPORTING__CACHE__FILTER__CLASSES (default=true)
-OPENPROJECT_CROSS__PROJECT__WORK__PACKAGE__RELATIONS (default=true)
-OPENPROJECT_CROWDIN__IN__CONTEXT__TRANSLATIONS (default=true)
-OPENPROJECT_DATABASE__CIPHER__KEY (default=nil)
-OPENPROJECT_DATE__FORMAT (default=nil)
-OPENPROJECT_DEFAULT__AUTO__HIDE__POPUPS (default=true)
-OPENPROJECT_DEFAULT__COMMENT__SORT__ORDER (default="asc")
-OPENPROJECT_DEFAULT__LANGUAGE (default="en")
-OPENPROJECT_DEFAULT__PROJECTS__MODULES (default=["calendar", "board_view", "work_package_tracking", "news", "costs", "wiki"])
-OPENPROJECT_DEFAULT__PROJECTS__PUBLIC (default=false)
-OPENPROJECT_DEMO__PROJECTS__AVAILABLE (default=false)
-OPENPROJECT_DEMO__VIEW__OF__TYPE__TEAM__PLANNER__SEEDED (default=false)
-OPENPROJECT_DEMO__VIEW__OF__TYPE__WORK__PACKAGES__TABLE__SEEDED (default=false)
-OPENPROJECT_DIFF__MAX__LINES__DISPLAYED (default=1500)
-OPENPROJECT_DIRECT__UPLOADS (default=true)
-OPENPROJECT_DISABLE__BROWSER__CACHE (default=true)
-OPENPROJECT_DISABLE__PASSWORD__CHOICE (default=false)
-OPENPROJECT_DISABLE__PASSWORD__LOGIN (default=false)
-OPENPROJECT_DISABLED__MODULES (default=[])
-OPENPROJECT_DISPLAY__SUBPROJECTS__WORK__PACKAGES (default=true)
-OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGIN (default=false)
-OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGOUT (default=true)
-OPENPROJECT_EDITION (default="standard")
-OPENPROJECT_EE__MANAGER__VISIBLE (default=true)
-OPENPROJECT_EMAIL__DELIVERY__CONFIGURATION (default="inapp")
-OPENPROJECT_EMAIL__DELIVERY__METHOD (default=nil)
-OPENPROJECT_EMAIL__LOGIN (default=false)
-OPENPROJECT_EMAILS__FOOTER (default={"en"=>""})
-OPENPROJECT_EMAILS__HEADER (default={"en"=>""})
-OPENPROJECT_ENABLE__INTERNAL__ASSETS__SERVER (default=false)
-OPENPROJECT_ENABLED__PROJECTS__COLUMNS (default=["project_status", "public", "created_at", "latest_activity_at", "required_disk_space"])
-OPENPROJECT_ENABLED__SCM (default=["subversion", "git"])
-OPENPROJECT_ENTERPRISE__CHARGEBEE__SITE (default="openproject-enterprise")
-OPENPROJECT_ENTERPRISE__PLAN (default="enterprise-on-premises---euro---1-year")
-OPENPROJECT_ENTERPRISE__TRIAL__CREATION__HOST (default="https://augur.openproject.com")
-OPENPROJECT_FEEDS__ENABLED (default=true)
-OPENPROJECT_FEEDS__LIMIT (default=15)
-OPENPROJECT_FILE__MAX__SIZE__DISPLAYED (default=512)
-OPENPROJECT_FIRST__WEEK__OF__YEAR (default=nil)
-OPENPROJECT_FOG (default={})
-OPENPROJECT_FOG__DOWNLOAD__URL__EXPIRES__IN (default=21600)
-OPENPROJECT_FORCE__FORMATTING__HELP__LINK (default=nil)
-OPENPROJECT_FORCE__HELP__LINK (default=nil)
-OPENPROJECT_FORCED__SINGLE__PAGE__SIZE (default=250)
-OPENPROJECT_GRAVATAR__FALLBACK__IMAGE (default="404")
-OPENPROJECT_HEALTH__CHECKS__AUTHENTICATION__PASSWORD (default=nil)
-OPENPROJECT_HEALTH__CHECKS__BACKLOG__THRESHOLD (default=20)
-OPENPROJECT_HEALTH__CHECKS__JOBS__NEVER__RAN__MINUTES__AGO (default=5)
-OPENPROJECT_HEALTH__CHECKS__JOBS__QUEUE__COUNT__THRESHOLD (default=50)
-OPENPROJECT_HIDDEN__MENU__ITEMS (default={})
-OPENPROJECT_HOST__NAME (default="localhost:3000")
-OPENPROJECT_HSTS (default=true)
-OPENPROJECT_HTTPS (default=true)
-OPENPROJECT_IMPRESSUM__LINK (default=nil)
-OPENPROJECT_INSTALLATION__TYPE (default="manual")
-OPENPROJECT_INSTALLATION__UUID (default=nil)
-OPENPROJECT_INTERNAL__PASSWORD__CONFIRMATION (default=true)
-OPENPROJECT_INVITATION__EXPIRATION__DAYS (default=7)
-OPENPROJECT_JOURNAL__AGGREGATION__TIME__MINUTES (default=5)
-OPENPROJECT_LDAP__AUTH__SOURCE__TLS__OPTIONS (default=nil)
-OPENPROJECT_LDAP__FORCE__NO__PAGE (default=nil)
-OPENPROJECT_LDAP__GROUPS__DISABLE__SYNC__JOB (default=false)
-OPENPROJECT_LDAP__TLS__OPTIONS (default={})
-OPENPROJECT_LDAP__USERS__DISABLE__SYNC__JOB (default=false)
-OPENPROJECT_LDAP__USERS__SYNC__STATUS (default=false)
-OPENPROJECT_LOG__LEVEL (default="info")
-OPENPROJECT_LOG__REQUESTING__USER (default=false)
-OPENPROJECT_LOGIN__REQUIRED (default=false)
-OPENPROJECT_LOGRAGE__FORMATTER (default=nil)
-OPENPROJECT_LOST__PASSWORD (default=true)
-OPENPROJECT_MAIL__FROM (default="openproject@example.net")
-OPENPROJECT_MAIL__HANDLER__API__KEY (default=nil)
-OPENPROJECT_MAIL__HANDLER__BODY__DELIMITER__REGEX (default="")
-OPENPROJECT_MAIL__HANDLER__BODY__DELIMITERS (default="")
-OPENPROJECT_MAIL__HANDLER__IGNORE__FILENAMES (default="signature.asc")
-OPENPROJECT_MAIL__SUFFIX__SEPARATORS (default="+")
-OPENPROJECT_MAIN__CONTENT__LANGUAGE (default="english")
-OPENPROJECT_MIGRATION__CHECK__ON__EXCEPTIONS (default=true)
-OPENPROJECT_NEW__PROJECT__USER__ROLE__ID (default=nil)
-OPENPROJECT_NOTIFICATION__EMAIL__DELAY__MINUTES (default=15)
-OPENPROJECT_NOTIFICATION__EMAIL__DIGEST__TIME (default="08:00")
-OPENPROJECT_OAUTH__ALLOW__REMAPPING__OF__EXISTING__USERS (default=false)
-OPENPROJECT_OMNIAUTH__DIRECT__LOGIN__PROVIDER (default=nil)
-OPENPROJECT_ONBOARDING__ENABLED (default=true)
-OPENPROJECT_ONBOARDING__VIDEO__URL (default="https://player.vimeo.com/video/163426858?autoplay=1")
-OPENPROJECT_OPENID__CONNECT (default={})
-OPENPROJECT_OVERRIDE__BCRYPT__COST__FACTOR (default=nil)
-OPENPROJECT_PASSWORD__ACTIVE__RULES (default=["lowercase", "uppercase", "numeric", "special"])
-OPENPROJECT_PASSWORD__COUNT__FORMER__BANNED (default=0)
-OPENPROJECT_PASSWORD__DAYS__VALID (default=0)
-OPENPROJECT_PASSWORD__MIN__ADHERED__RULES (default=0)
-OPENPROJECT_PASSWORD__MIN__LENGTH (default=10)
-OPENPROJECT_PER__PAGE__OPTIONS (default="20, 100")
-OPENPROJECT_PLAIN__TEXT__MAIL (default=false)
-OPENPROJECT_PLUGIN__COSTS (default={"costs_currency"=>"EUR", "costs_currency_format"=>"%n %u"})
-OPENPROJECT_PLUGIN__OPENPROJECT__AUTH__SAML (default={"providers"=>nil})
-OPENPROJECT_PLUGIN__OPENPROJECT__AVATARS (default={"enable_gravatars"=>true, "enable_local_avatars"=>true})
-OPENPROJECT_PLUGIN__OPENPROJECT__BACKLOGS (default={"story_types"=>nil, "task_type"=>nil, "points_burn_direction"=>"up", "wiki_template"=>""})
-OPENPROJECT_PLUGIN__OPENPROJECT__BIM (default={})
-OPENPROJECT_PLUGIN__OPENPROJECT__BOARDS (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__CALENDAR (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__LDAP__GROUPS (default={})
-OPENPROJECT_PLUGIN__OPENPROJECT__OPENID__CONNECT (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__RECAPTCHA (default={"recaptcha_type"=>"disabled"})
-OPENPROJECT_PLUGIN__OPENPROJECT__STORAGES (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__TEAM__PLANNER (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__TWO__FACTOR__AUTHENTICATION (default={"active_strategies"=>[], "enforced"=>false, "allow_remember_for_days"=>0})
-OPENPROJECT_PROJECT__GANTT__QUERY (default=nil)
-OPENPROJECT_RAILS__ASSET__HOST (default=nil)
-OPENPROJECT_RAILS__CACHE__STORE (default=:file_store)
-OPENPROJECT_RAILS__RELATIVE__URL__ROOT (default="")
-OPENPROJECT_RECAPTCHA__VIA__HCAPTCHA (default=false)
-OPENPROJECT_REGISTRATION__FOOTER (default={"en"=>""})
-OPENPROJECT_REPORT__INCOMING__EMAIL__ERRORS (default=true)
-OPENPROJECT_REPOSITORIES__AUTOMATIC__MANAGED__VENDOR (default=nil)
-OPENPROJECT_REPOSITORIES__ENCODINGS (default=nil)
-OPENPROJECT_REPOSITORY__AUTHENTICATION__CACHING__ENABLED (default=true)
-OPENPROJECT_REPOSITORY__CHECKOUT__DATA (default={"git"=>{"enabled"=>0}, "subversion"=>{"enabled"=>0}})
-OPENPROJECT_REPOSITORY__LOG__DISPLAY__LIMIT (default=100)
-OPENPROJECT_REPOSITORY__STORAGE__CACHE__MINUTES (default=720)
-OPENPROJECT_REPOSITORY__TRUNCATE__AT (default=500)
-OPENPROJECT_REST__API__ENABLED (default=true)
-OPENPROJECT_SAML (default=nil)
-OPENPROJECT_SCM (default={})
-OPENPROJECT_SCM__GIT__COMMAND (default=nil)
-OPENPROJECT_SCM__LOCAL__CHECKOUT__PATH (default="repositories")
-OPENPROJECT_SCM__SUBVERSION__COMMAND (default=nil)
-OPENPROJECT_SECURITY__BADGE__DISPLAYED (default=true)
-OPENPROJECT_SECURITY__BADGE__URL (default="https://releases.openproject.com/v1/check.svg")
-OPENPROJECT_SELF__REGISTRATION (default=2)
-OPENPROJECT_SENDMAIL__ARGUMENTS (default="-i")
-OPENPROJECT_SENDMAIL__LOCATION (default="/usr/sbin/sendmail")
-OPENPROJECT_SESSION__COOKIE__NAME (default="_open_project_session")
-OPENPROJECT_SESSION__STORE (default=:active_record_store)
-OPENPROJECT_SESSION__TTL (default=120)
-OPENPROJECT_SESSION__TTL__ENABLED (default=false)
-OPENPROJECT_SHOW__COMMUNITY__LINKS (default=true)
-OPENPROJECT_SHOW__PENDING__MIGRATIONS__WARNING (default=true)
-OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING (default=true)
-OPENPROJECT_SHOW__STORAGE__INFORMATION (default=true)
-OPENPROJECT_SHOW__WARNING__BARS (default=true)
-OPENPROJECT_SMTP__ADDRESS (default="")
-OPENPROJECT_SMTP__AUTHENTICATION (default="plain")
-OPENPROJECT_SMTP__DOMAIN (default="your.domain.com")
-OPENPROJECT_SMTP__ENABLE__STARTTLS__AUTO (default=false)
-OPENPROJECT_SMTP__OPENSSL__VERIFY__MODE (default="peer")
-OPENPROJECT_SMTP__PASSWORD (default="")
-OPENPROJECT_SMTP__PORT (default=587)
-OPENPROJECT_SMTP__SSL (default=false)
-OPENPROJECT_SMTP__USER__NAME (default="")
-OPENPROJECT_SOFTWARE__NAME (default="OpenProject")
-OPENPROJECT_SOFTWARE__URL (default="https://www.openproject.org/")
-OPENPROJECT_SQL__SLOW__QUERY__THRESHOLD (default=2000)
-OPENPROJECT_START__OF__WEEK (default=nil)
-OPENPROJECT_STATSD (default={"host"=>nil, "port"=>8125})
-OPENPROJECT_SYS__API__ENABLED (default=false)
-OPENPROJECT_SYS__API__KEY (default=nil)
-OPENPROJECT_TIME__FORMAT (default=nil)
-OPENPROJECT_USER__DEFAULT__TIMEZONE (default=nil)
-OPENPROJECT_USER__FORMAT (default=:firstname_lastname)
-OPENPROJECT_USERS__DELETABLE__BY__ADMINS (default=false)
-OPENPROJECT_USERS__DELETABLE__BY__SELF (default=false)
-OPENPROJECT_WEB (default={"workers"=>2, "timeout"=>120, "wait_timeout"=>10, "min_threads"=>4, "max_threads"=>16})
-OPENPROJECT_WELCOME__ON__HOMESCREEN (default=false)
-OPENPROJECT_WELCOME__TEXT (default=nil)
-OPENPROJECT_WELCOME__TITLE (default=nil)
-OPENPROJECT_WORK__PACKAGE__DONE__RATIO (default="field")
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__COLUMNS (default=["id", "subject", "type", "status", "assigned_to", "priority"])
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTED__ATTRIBUTES (default=[])
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTING__MODE (default="none")
-OPENPROJECT_WORK__PACKAGE__STARTDATE__IS__ADDDATE (default=false)
-OPENPROJECT_WORK__PACKAGES__DURATION__FIELD__ACTIVE (default=false)
-OPENPROJECT_WORK__PACKAGES__PROJECTS__EXPORT__LIMIT (default=500)
-OPENPROJECT_YOUTUBE__CHANNEL (default="https://www.youtube.com/c/OpenProjectCommunity")
+OPENPROJECT_ACTIVITY__DAYS__DEFAULT (default=30) Days displayed on project activity
+OPENPROJECT_AFTER__FIRST__LOGIN__REDIRECT__URL (default=nil) URL users logging in for the first time will be redirected to (e.g., a help screen)
+OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL (default=nil) Override URL to which logged in users are redirected instead of the My page
+OPENPROJECT_APIV3__CORS__ENABLED (default=false) Enable CORS headers for APIv3 server responses
+OPENPROJECT_APIV3__CORS__ORIGINS (default=[]) API V3 Cross-Origin Resource Sharing (CORS) allowed origins
+OPENPROJECT_APIV3__DOCS__ENABLED (default=true) Enable interactive APIv3 documentation as part of the application
+OPENPROJECT_APIV3__ENABLE__BASIC__AUTH (default=true) Enable API token or global basic authentication for APIv3 requests
+OPENPROJECT_APIV3__MAX__PAGE__SIZE (default=1000) Maximum API page size
+OPENPROJECT_APP__TITLE (default="OpenProject") Application title
+OPENPROJECT_APPSIGNAL__FRONTEND__KEY (default=nil) Appsignal API key for JavaScript error reporting
+OPENPROJECT_ATTACHMENT__MAX__SIZE (default=5120) Attachment max. size
+OPENPROJECT_ATTACHMENT__WHITELIST (default=[]) Attachment upload whitelist
+OPENPROJECT_ATTACHMENTS__GRACE__PERIOD (default=180) Time to wait before uploaded files not attached to any container are removed
+OPENPROJECT_ATTACHMENTS__STORAGE (default=:file) File storage configuration
+OPENPROJECT_ATTACHMENTS__STORAGE__PATH (default=nil) File storage disk location (only applicable for local file storage)
+OPENPROJECT_AUTH__SOURCE__SSO (default=nil) Configuration for Header-based Single Sign-On
+OPENPROJECT_AUTHENTICATION (default=nil) Configuration options for global basic auth
+OPENPROJECT_AUTOFETCH__CHANGESETS (default=true) Autofetch repository changes
+OPENPROJECT_AUTOLOGIN (default=0) Autologin
+OPENPROJECT_AUTOLOGIN__COOKIE__NAME (default="autologin") Cookie name for autologin cookie
+OPENPROJECT_AUTOLOGIN__COOKIE__PATH (default="/") Cookie path for autologin cookie
+OPENPROJECT_AUTOLOGIN__COOKIE__SECURE (default=false) Cookie secure mode for autologin cookie
+OPENPROJECT_AVAILABLE__LANGUAGES (default=["en", "de", "fr", "es", "pt", "it", "zh-CN", "ko", "ru"]) Available languages
+OPENPROJECT_AVATAR__LINK__EXPIRY__SECONDS (default=86400) Cache duration for avatar image API responses
+OPENPROJECT_BACKUP__ATTACHMENT__SIZE__MAX__SUM__MB (default=1024) Maximum limit of attachment size to include into application backups
+OPENPROJECT_BACKUP__DAILY__LIMIT (default=3) Maximum number of application backups allowed per day
+OPENPROJECT_BACKUP__ENABLED (default=true) Enable application backups through the UI
+OPENPROJECT_BACKUP__INCLUDE__ATTACHMENTS (default=true) Allow inclusion of attachments in application backups
+OPENPROJECT_BACKUP__INITIAL__WAITING__PERIOD (default=86400) Wait time before newly created backup tokens are usable
+OPENPROJECT_BCC__RECIPIENTS (default=true) Blind carbon copy recipients (bcc)
+OPENPROJECT_BLACKLISTED__ROUTES (default=[]) Blocked routes to prevent access to certain modules or pages
+OPENPROJECT_BOARDS__DEMO__DATA__AVAILABLE (default=false) Internal setting determining availability of demo seed data
+OPENPROJECT_BRUTE__FORCE__BLOCK__AFTER__FAILED__LOGINS (default=20) Number of login attempts per user before assuming brute force attack
+OPENPROJECT_BRUTE__FORCE__BLOCK__MINUTES (default=30) Number of minutes to block users after presumed brute force attack
+OPENPROJECT_CACHE__EXPIRES__IN__SECONDS (default=nil) Expiration time for memcache entries, empty for no expiry be default
+OPENPROJECT_CACHE__FORMATTED__TEXT (default=true) Cache formatted text
+OPENPROJECT_CACHE__MEMCACHE__SERVER (default=nil) The memcache server host and IP
+OPENPROJECT_CACHE__NAMESPACE (default=nil) Namespace for cache keys, useful when multiple applications use a single memcache server
+OPENPROJECT_COMMIT__FIX__DONE__RATIO (default=100) Progress to apply when commit fixes work package
+OPENPROJECT_COMMIT__FIX__KEYWORDS (default="fixes,closes") Keywords to look for in commit for fixing work packages
+OPENPROJECT_COMMIT__FIX__STATUS__ID (default=nil) Assigned status when fixing keyword is found
+OPENPROJECT_COMMIT__LOGS__ENCODING (default="UTF-8") Encoding used to convert commit logs to UTF-8
+OPENPROJECT_COMMIT__LOGTIME__ACTIVITY__ID (default=nil) Activity for logged time
+OPENPROJECT_COMMIT__LOGTIME__ENABLED (default=false) Allow logging time through commit message
+OPENPROJECT_COMMIT__REF__KEYWORDS (default="refs,references,IssueID") Keywords used in commits for referencing work packages
+OPENPROJECT_CONSENT__DECLINE__MAIL (default=nil) Consent contact mail address
+OPENPROJECT_CONSENT__INFO (default={"en"=>"## Consent\n\nYou need to agree to the [privacy and security policy](https://www.openproject.org/data-privacy-and-security/) of this OpenProject instance."}) Consent information text
+OPENPROJECT_CONSENT__REQUIRED (default=false) Consent required
+OPENPROJECT_CONSENT__TIME (default=nil) Consent time
+OPENPROJECT_COST__REPORTING__CACHE__FILTER__CLASSES (default=true) 
+OPENPROJECT_CROSS__PROJECT__WORK__PACKAGE__RELATIONS (default=true) Allow cross-project work package relations
+OPENPROJECT_CROWDIN__IN__CONTEXT__TRANSLATIONS (default=true) Add crowdin in-context translations helper
+OPENPROJECT_DATABASE__CIPHER__KEY (default=nil) Encryption key for repository credentials
+OPENPROJECT_DATE__FORMAT (default=nil) Date
+OPENPROJECT_DEFAULT__AUTO__HIDE__POPUPS (default=true) Whether to automatically hide success notifications by default
+OPENPROJECT_DEFAULT__COMMENT__SORT__ORDER (default="asc") Default sort order for activities
+OPENPROJECT_DEFAULT__LANGUAGE (default="en") Default language
+OPENPROJECT_DEFAULT__PROJECTS__MODULES (default=["calendar", "board_view", "work_package_tracking", "news", "costs", "wiki"]) Default enabled modules for new projects
+OPENPROJECT_DEFAULT__PROJECTS__PUBLIC (default=false) New projects are public by default
+OPENPROJECT_DEMO__PROJECTS__AVAILABLE (default=false) 
+OPENPROJECT_DEMO__VIEW__OF__TYPE__TEAM__PLANNER__SEEDED (default=false) 
+OPENPROJECT_DEMO__VIEW__OF__TYPE__WORK__PACKAGES__TABLE__SEEDED (default=false) 
+OPENPROJECT_DIFF__MAX__LINES__DISPLAYED (default=1500) Max number of diff lines displayed
+OPENPROJECT_DIRECT__UPLOADS (default=true) Enable direct uploads to AWS S3. Only applicable with enabled Fog / AWS S3 configuration
+OPENPROJECT_DISABLE__BROWSER__CACHE (default=true) Prevent browser from caching any logged-in responses for security reasons
+OPENPROJECT_DISABLE__PASSWORD__CHOICE (default=false) If enabled a user's password cannot be set to an arbitrary value, but can only be randomized.
+OPENPROJECT_DISABLE__PASSWORD__LOGIN (default=false) Disable internal logins and instead only allow SSO through OmniAuth.
+OPENPROJECT_DISABLED__MODULES (default=[]) A list of module names to prevent access to in the application
+OPENPROJECT_DISPLAY__SUBPROJECTS__WORK__PACKAGES (default=true) Display subprojects work packages on main projects by default
+OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGIN (default=false) Destroy all sessions for current_user on login
+OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGOUT (default=true) Destroy all sessions for current_user on logout
+OPENPROJECT_EDITION (default="standard") OpenProject edition mode
+OPENPROJECT_EE__MANAGER__VISIBLE (default=true) Show or hide the Enterprise configuration page and enterprise banners
+OPENPROJECT_EMAIL__DELIVERY__CONFIGURATION (default="inapp") 
+OPENPROJECT_EMAIL__DELIVERY__METHOD (default=nil) Email delivery method
+OPENPROJECT_EMAIL__LOGIN (default=false) Use email as login
+OPENPROJECT_EMAILS__FOOTER (default={"en"=>""}) Emails footer
+OPENPROJECT_EMAILS__HEADER (default={"en"=>""}) Emails header
+OPENPROJECT_ENABLE__INTERNAL__ASSETS__SERVER (default=false) Serve assets through the Rails internal asset server
+OPENPROJECT_ENABLED__PROJECTS__COLUMNS (default=["project_status", "public", "created_at", "latest_activity_at", "required_disk_space"]) Visible in project list
+OPENPROJECT_ENABLED__SCM (default=["subversion", "git"]) Enabled SCM
+OPENPROJECT_ENTERPRISE__CHARGEBEE__SITE (default="openproject-enterprise") Site name for EE trial service
+OPENPROJECT_ENTERPRISE__PLAN (default="enterprise-on-premises---euro---1-year") Default EE selected plan
+OPENPROJECT_ENTERPRISE__TRIAL__CREATION__HOST (default="https://augur.openproject.com") Host for EE trial service
+OPENPROJECT_FEATURE__MANAGED__PROJECT__FOLDERS__ACTIVE (default=true) 
+OPENPROJECT_FEATURE__MORE__GLOBAL__INDEX__PAGES__ACTIVE (default=true) 
+OPENPROJECT_FEATURE__SHOW__CHANGES__ACTIVE (default=true) 
+OPENPROJECT_FEATURE__STORAGE__FILE__PICKING__SELECT__ALL__ACTIVE (default=true) 
+OPENPROJECT_FEATURE__STORAGE__PROJECT__FOLDERS__ACTIVE (default=true) 
+OPENPROJECT_FEEDS__ENABLED (default=true) Enable Feeds
+OPENPROJECT_FEEDS__LIMIT (default=15) Feed content limit
+OPENPROJECT_FILE__MAX__SIZE__DISPLAYED (default=512) Max size of text files displayed inline
+OPENPROJECT_FIRST__WEEK__OF__YEAR (default=nil) First week in year contains
+OPENPROJECT_FOG (default={}) Configure fog, e.g. when using an S3 uploader
+OPENPROJECT_FOG__DOWNLOAD__URL__EXPIRES__IN (default=21600) Expiration time in seconds of created shared presigned URLs
+OPENPROJECT_FORCE__FORMATTING__HELP__LINK (default=nil) You can set a custom URL for the help button in the WYSIWYG editor.
+OPENPROJECT_FORCE__HELP__LINK (default=nil) You can set a custom URL for the help button in application header menu.
+OPENPROJECT_FORCED__SINGLE__PAGE__SIZE (default=250) Forced page size for manually sorted work package views
+OPENPROJECT_GRAVATAR__FALLBACK__IMAGE (default="404") Set default gravatar image fallback
+OPENPROJECT_HEALTH__CHECKS__AUTHENTICATION__PASSWORD (default=nil) Add an authentication challenge for the /health_check endpoint
+OPENPROJECT_HEALTH__CHECKS__BACKLOG__THRESHOLD (default=20) Set threshold of outstanding HTTP requests to fail health check
+OPENPROJECT_HEALTH__CHECKS__JOBS__NEVER__RAN__MINUTES__AGO (default=5) Set threshold of outstanding background jobs to fail health check
+OPENPROJECT_HEALTH__CHECKS__JOBS__QUEUE__COUNT__THRESHOLD (default=50) Set threshold of backed up background jobs to fail health check
+OPENPROJECT_HIDDEN__MENU__ITEMS (default={}) Hide menu items in the menu sidebar for each main menu (such as Administration and Projects).
+OPENPROJECT_HOME__URL (default=nil) Override default link when clicking on the top menu logo (Homescreen by default).
+OPENPROJECT_HOST__NAME (default="localhost:3000") Host name
+OPENPROJECT_HSTS (default=true) Allow disabling of HSTS headers and http -> https redirects
+OPENPROJECT_HTTPS (default=false) Set assumed connection security for the Rails processes
+OPENPROJECT_ICAL__ENABLED (default=true) Enable iCalendar Subscriptions
+OPENPROJECT_IMPRESSUM__LINK (default=nil) Impressum link to be set, hidden by default
+OPENPROJECT_INSTALLATION__TYPE (default="manual") 
+OPENPROJECT_INSTALLATION__UUID (default=nil) 
+OPENPROJECT_INTERNAL__PASSWORD__CONFIRMATION (default=true) Require password confirmations for certain administrative actions
+OPENPROJECT_INVITATION__EXPIRATION__DAYS (default=7) Activation email expires after
+OPENPROJECT_JOURNAL__AGGREGATION__TIME__MINUTES (default=5) User actions aggregated within
+OPENPROJECT_LDAP__FORCE__NO__PAGE (default=nil) Force LDAP to respond as a single page, in case paged responses do not work with your server.
+OPENPROJECT_LDAP__GROUPS__DISABLE__SYNC__JOB (default=false) Deactivate regular synchronization job for groups in case scheduled as a separate cronjob
+OPENPROJECT_LDAP__TLS__OPTIONS (default={}) 
+OPENPROJECT_LDAP__USERS__DISABLE__SYNC__JOB (default=false) Deactive user attributes synchronization from LDAP
+OPENPROJECT_LDAP__USERS__SYNC__STATUS (default=false) Enable user status (locked/unlocked) synchronization from LDAP
+OPENPROJECT_LOG__LEVEL (default="debug") Set the OpenProject logger level
+OPENPROJECT_LOG__REQUESTING__USER (default=false) Log user login, name, and mail address for all requests
+OPENPROJECT_LOGIN__REQUIRED (default=false) Authentication required
+OPENPROJECT_LOGRAGE__FORMATTER (default=nil) Use lograge formatter for outputting logs
+OPENPROJECT_LOST__PASSWORD (default=true) Activate or deactivate lost password form
+OPENPROJECT_MAIL__FROM (default="openproject@example.net") Emission email address
+OPENPROJECT_MAIL__HANDLER__API__KEY (default=nil) API key
+OPENPROJECT_MAIL__HANDLER__BODY__DELIMITER__REGEX (default="") Truncate emails matching this regex
+OPENPROJECT_MAIL__HANDLER__BODY__DELIMITERS (default="") Truncate emails after one of these lines
+OPENPROJECT_MAIL__HANDLER__IGNORE__FILENAMES (default="signature.asc") Ignored mail attachments
+OPENPROJECT_MAIL__SUFFIX__SEPARATORS (default="+") 
+OPENPROJECT_MAIN__CONTENT__LANGUAGE (default="english") Main content language for PostgreSQL full text features
+OPENPROJECT_MIGRATION__CHECK__ON__EXCEPTIONS (default=true) Check for missing migrations in internal errors
+OPENPROJECT_NEW__PROJECT__USER__ROLE__ID (default=nil) Role given to a non-admin user who creates a project
+OPENPROJECT_OAUTH__ALLOW__REMAPPING__OF__EXISTING__USERS (default=true) When set to false, prevent users from other identity providers to take over accounts connected to another identity provider.
+OPENPROJECT_OMNIAUTH__DIRECT__LOGIN__PROVIDER (default=nil) Clicking on login sends a login request to the specified OmniAuth provider.
+OPENPROJECT_ONBOARDING__ENABLED (default=true) Enable or disable onboarding guided tour for new users
+OPENPROJECT_ONBOARDING__VIDEO__URL (default="https://player.vimeo.com/video/163426858?autoplay=1") Onboarding guide instructional video URL
+OPENPROJECT_OPENID__CONNECT (default={}) 
+OPENPROJECT_OVERRIDE__BCRYPT__COST__FACTOR (default=nil) Set a custom BCrypt cost factor for deriving a user's bcrypt hash.
+OPENPROJECT_PASSWORD__ACTIVE__RULES (default=["lowercase", "uppercase", "numeric", "special"]) Active character classes
+OPENPROJECT_PASSWORD__COUNT__FORMER__BANNED (default=0) Number of most recently used passwords banned for reuse
+OPENPROJECT_PASSWORD__DAYS__VALID (default=0) Number of days, after which to enforce a password change
+OPENPROJECT_PASSWORD__MIN__ADHERED__RULES (default=0) Minimum number of required classes
+OPENPROJECT_PASSWORD__MIN__LENGTH (default=10) Minimum length
+OPENPROJECT_PER__PAGE__OPTIONS (default="20, 100") Objects per page options
+OPENPROJECT_PLAIN__TEXT__MAIL (default=false) Plain text mail (no HTML)
+OPENPROJECT_PLUGIN__COSTS (default={"costs_currency"=>"EUR", "costs_currency_format"=>"%n %u"}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__AUTH__SAML (default={"providers"=>nil}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__AVATARS (default={"enable_gravatars"=>true, "enable_local_avatars"=>true}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__BACKLOGS (default={"story_types"=>nil, "task_type"=>nil, "points_burn_direction"=>"up", "wiki_template"=>""}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__BIM (default={}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__BOARDS (default=nil) 
+OPENPROJECT_PLUGIN__OPENPROJECT__CALENDAR (default=nil) 
+OPENPROJECT_PLUGIN__OPENPROJECT__LDAP__GROUPS (default={}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__OPENID__CONNECT (default=nil) 
+OPENPROJECT_PLUGIN__OPENPROJECT__RECAPTCHA (default={"recaptcha_type"=>"disabled"}) 
+OPENPROJECT_PLUGIN__OPENPROJECT__STORAGES (default=nil) 
+OPENPROJECT_PLUGIN__OPENPROJECT__TEAM__PLANNER (default=nil) 
+OPENPROJECT_PLUGIN__OPENPROJECT__TWO__FACTOR__AUTHENTICATION (default={"active_strategies"=>[], "enforced"=>false, "allow_remember_for_days"=>0}) 
+OPENPROJECT_PROJECT__GANTT__QUERY (default=nil) Project portfolio Gantt view
+OPENPROJECT_RAILS__ASSET__HOST (default=nil) Custom asset hostname for serving assets (e.g., Cloudfront)
+OPENPROJECT_RAILS__CACHE__STORE (default=:file_store) Set cache store implemenation to use with OpenProject
+OPENPROJECT_RAILS__RELATIVE__URL__ROOT (default="") Set a URL prefix / base path to run OpenProject under, e.g., host.tld/openproject
+OPENPROJECT_RECAPTCHA__VIA__HCAPTCHA (default=false) 
+OPENPROJECT_REGISTRATION__FOOTER (default={"en"=>""}) Registration footer
+OPENPROJECT_REMOTE__STORAGE__DOWNLOAD__HOST (default=nil) Host the frontend uses to download files, which has to be added to the CSP.
+OPENPROJECT_REMOTE__STORAGE__UPLOAD__HOST (default=nil) Host the frontend uses to upload files to, which has to be added to the CSP.
+OPENPROJECT_REPORT__INCOMING__EMAIL__ERRORS (default=true) Respond to incoming mails with error details
+OPENPROJECT_REPOSITORIES__AUTOMATIC__MANAGED__VENDOR (default=nil) Automatic repository vendor type
+OPENPROJECT_REPOSITORIES__ENCODINGS (default=nil) Repositories encodings
+OPENPROJECT_REPOSITORY__AUTHENTICATION__CACHING__ENABLED (default=true) Enable caching for authentication request of version control software
+OPENPROJECT_REPOSITORY__CHECKOUT__DATA (default={"git"=>{"enabled"=>0}, "subversion"=>{"enabled"=>0}}) 
+OPENPROJECT_REPOSITORY__LOG__DISPLAY__LIMIT (default=100) Maximum number of revisions displayed on file log
+OPENPROJECT_REPOSITORY__STORAGE__CACHE__MINUTES (default=720) Repository disk size cache
+OPENPROJECT_REPOSITORY__TRUNCATE__AT (default=500) Maximum number of files displayed in the repository browser
+OPENPROJECT_REST__API__ENABLED (default=true) Enable REST web service
+OPENPROJECT_SAML (default=nil) 
+OPENPROJECT_SCM (default={}) 
+OPENPROJECT_SCM__GIT__COMMAND (default=nil) 
+OPENPROJECT_SCM__LOCAL__CHECKOUT__PATH (default="repositories") 
+OPENPROJECT_SCM__SUBVERSION__COMMAND (default=nil) 
+OPENPROJECT_SECURITY__BADGE__DISPLAYED (default=true) Display security badge
+OPENPROJECT_SECURITY__BADGE__URL (default="https://releases.openproject.com/v1/check.svg") URL of the update check badge
+OPENPROJECT_SEED__ADMIN__USER__MAIL (default="admin@example.net") E-mail to set for the initially created admin user.
+OPENPROJECT_SEED__ADMIN__USER__NAME (default="OpenProject Admin") Name to set for the initially created admin user.
+OPENPROJECT_SEED__ADMIN__USER__PASSWORD (default="admin") Password to set for the initially created admin user (Login remains "admin").
+OPENPROJECT_SEED__ADMIN__USER__PASSWORD__RESET (default=true) Whether to force a password reset for the initially created admin user.
+OPENPROJECT_SELF__REGISTRATION (default=2) Self-registration
+OPENPROJECT_SENDMAIL__ARGUMENTS (default="-i") Arguments to call sendmail with in case it is configured as outgoing email setup
+OPENPROJECT_SENDMAIL__LOCATION (default="/usr/sbin/sendmail") Location of sendmail to call if it is configured as outgoing email setup
+OPENPROJECT_SESSION__COOKIE__NAME (default="_open_project_session") Set session cookie name
+OPENPROJECT_SESSION__TTL (default=120) Session expiry time after inactivity
+OPENPROJECT_SESSION__TTL__ENABLED (default=false) Session expires
+OPENPROJECT_SHOW__COMMUNITY__LINKS (default=true) Enable or disable links to OpenProject community instances
+OPENPROJECT_SHOW__PENDING__MIGRATIONS__WARNING (default=true) Enable or disable warning bar in case of pending migrations
+OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING (default=true) Show mismatched protocol/hostname warning. In cases where they must differ this can be disabled
+OPENPROJECT_SHOW__STORAGE__INFORMATION (default=true) Show available and taken storage information under administration / info
+OPENPROJECT_SHOW__WARNING__BARS (default=true) Render warning bars (pending migrations, deprecation, unsupported browsers)
+OPENPROJECT_SMTP__ADDRESS (default="") SMTP server
+OPENPROJECT_SMTP__AUTHENTICATION (default="plain") SMTP authentication
+OPENPROJECT_SMTP__DOMAIN (default="your.domain.com") SMTP HELO domain
+OPENPROJECT_SMTP__ENABLE__STARTTLS__AUTO (default=false) Automatically use STARTTLS if available
+OPENPROJECT_SMTP__OPENSSL__VERIFY__MODE (default="peer") Globally set verify mode for OpenSSL. Careful: Setting to none will disable any SSL verification!
+OPENPROJECT_SMTP__PASSWORD (default="") SMTP password
+OPENPROJECT_SMTP__PORT (default=587) SMTP port
+OPENPROJECT_SMTP__SSL (default=false) Use SSL connection
+OPENPROJECT_SMTP__USER__NAME (default="") SMTP username
+OPENPROJECT_SOFTWARE__NAME (default="OpenProject") Override software application name
+OPENPROJECT_SOFTWARE__URL (default="https://www.openproject.org/") Override software application URL
+OPENPROJECT_SQL__SLOW__QUERY__THRESHOLD (default=2000) Time limit in ms after which queries will be logged as slow queries
+OPENPROJECT_START__OF__WEEK (default=nil) Week starts on
+OPENPROJECT_STATSD (default={"host"=>nil, "port"=>8125}) enable statsd metrics (currently puma only) by configuring host
+OPENPROJECT_SYS__API__ENABLED (default=false) Enable internal system API for setting up managed repositories
+OPENPROJECT_SYS__API__KEY (default=nil) Internal system API key for setting up managed repositories
+OPENPROJECT_TIME__FORMAT (default=nil) Time
+OPENPROJECT_USER__DEFAULT__TIMEZONE (default=nil) Users default time zone
+OPENPROJECT_USER__FORMAT (default=:firstname_lastname) Users name format
+OPENPROJECT_USERS__DELETABLE__BY__ADMINS (default=false) User accounts deletable by admins
+OPENPROJECT_USERS__DELETABLE__BY__SELF (default=false) Users allowed to delete their accounts
+OPENPROJECT_WEB (default={"workers"=>2, "timeout"=>120, "wait_timeout"=>10, "min_threads"=>4, "max_threads"=>16}) Web worker count and threads configuration
+OPENPROJECT_WELCOME__ON__HOMESCREEN (default=false) Display welcome block on homescreen
+OPENPROJECT_WELCOME__TEXT (default=nil) Welcome block text
+OPENPROJECT_WELCOME__TITLE (default=nil) Welcome block title
+OPENPROJECT_WORK__PACKAGE__DONE__RATIO (default="field") Calculate the work package done ratio with
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__COLUMNS (default=["id", "subject", "type", "status", "assigned_to", "priority"]) Display by default
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTED__ATTRIBUTES (default=[]) Default inline highlighted attributes
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTING__MODE (default="none") Default highlighting mode
+OPENPROJECT_WORK__PACKAGE__STARTDATE__IS__ADDDATE (default=false) Use current date as start date for new work packages
+OPENPROJECT_WORK__PACKAGES__BULK__REQUEST__LIMIT (default=10) 
+OPENPROJECT_WORK__PACKAGES__PROJECTS__EXPORT__LIMIT (default=500) Work packages / Projects export limit
+OPENPROJECT_WORKING__DAYS (default=[1, 2, 3, 4, 5]) Set working days of the week (Array of 1 to 7, where 1=Monday, 7=Sunday)
+OPENPROJECT_YOUTUBE__CHANNEL (default="https://www.youtube.com/c/OpenProjectCommunity") Link to YouTube channel in help menu
 ```
 
 # Environment-specific configuration variables

--- a/packaging/addons/openproject/bin/postinstall
+++ b/packaging/addons/openproject/bin/postinstall
@@ -7,7 +7,7 @@ set -e
 CLI="${APP_NAME}"
 
 # Set the configured admin email
-ADMIN_EMAIL="$(wiz_get "openproject/admin_email" || wiz_get "smtp/admin_email")"
+${CLI} config:set OPENPROJECT_SEED_ADMIN_USER_MAIL="$(wiz_get "openproject/admin_email" || wiz_get "smtp/admin_email")"
 ${CLI} config:set RECOMPILE_RAILS_ASSETS="true"
 
 # Set the configured default language

--- a/spec/seeders/admin_user_seeder_spec.rb
+++ b/spec/seeders/admin_user_seeder_spec.rb
@@ -39,6 +39,32 @@ RSpec.describe AdminUserSeeder do
     expect { seeder.seed! }.to change { User.admin.count }.by(1)
   end
 
+  context 'when providing admin user seed variables',
+          :settings_reset,
+          with_env: {
+            OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET: 'false',
+            OPENPROJECT_SEED_ADMIN_USER_PASSWORD: 'foobar',
+            OPENPROJECT_SEED_ADMIN_USER_MAIL: 'foobar@example.com',
+            OPENPROJECT_SEED_ADMIN_USER_NAME: 'foo bar'
+          } do
+    it 'uses those variables' do
+      reset(:seed_admin_user_password)
+      reset(:seed_admin_user_password_reset)
+      reset(:seed_admin_user_name)
+      reset(:seed_admin_user_mail)
+
+      seeder.seed!
+
+      admin = User.admin.last
+      expect(admin.firstname).to eq 'foo'
+      expect(admin.lastname).to eq 'bar'
+      expect(admin.mail).to eq 'foobar@example.com'
+      expect(admin.force_password_change).to be false
+      expect(admin.check_password?('admin')).to be false
+      expect(admin.check_password?('foobar')).to be true
+    end
+  end
+
   it 'references the admin user as :openproject_admin in the seed_data' do
     seeder.seed!
     expect(seed_data.find_reference(:openproject_admin)).to eq(User.admin.first)


### PR DESCRIPTION
The admin user is generated at all times with a standard password 'admin' currently

For automated deployments, this is not a viable option

https://community.openproject.org/work_packages/48972

:warning: Helm chart extension for this feature: https://github.com/opf/helm-charts/pull/14