### PR TITLE
Add proper "pending" metadata to `storage_requests_spec`

### DIFF
--- a/modules/storages/spec/common/peripherals/storage_requests_spec.rb
+++ b/modules/storages/spec/common/peripherals/storage_requests_spec.rb
@@ -353,8 +353,7 @@ RSpec.describe Storages::Peripherals::StorageRequests, webmock: true do
           .to_return(status: 200, body: expected_response_body, headers: {})
       end
 
-      context 'with Nextcloud storage type selected' do
-        pending "TODO BROKEN MODULE SPEC"
+      context 'with Nextcloud storage type selected', pending: 'TODO BROKEN SPEC FILE' do
         it 'must return a list of files when called' do
           result = subject
                      .file_query


### PR DESCRIPTION
RSpec contexts don't pick up a `pending "XXX"` call within the block as metadata to the entire context. Instead, the metadata needs to be added directly on the `context` method call with `pending: 'XXX'`.

Broken spec fixed in https://github.com/opf/openproject/pull/13043 but this ensures a green state on the dev branch until merged.