### PR TITLE
[44963] Add premium/enterprise feature icon also in the Project settings

### DIFF
--- a/app/views/projects/settings/modules/_form.html.erb
+++ b/app/views/projects/settings/modules/_form.html.erb
@@ -29,11 +29,24 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% sorted_modules = OpenProject::AccessControl.available_project_modules.sort_by { |name| t(:"project_module_#{name}") } %>
 <% sorted_modules.each do |name| %>
-  <div class="form--field">
-    <%= form.collection_check_box :enabled_module_names,
-                                  name,
-                                  @project.module_enabled?(name),
-                                  l_or_humanize(name, prefix: "project_module_") %>
 
+  <div class="form--field">
+    <label class="form--label">
+      <%= l_or_humanize(name, prefix: "project_module_")  %>
+      <% if !EnterpriseToken.active? && OpenProject::AccessControl.module_enterprise_feature?(name) %>
+        <%= spot_icon('enterprise-addons',
+                      inline: true,
+                      size: '1_25',
+                      classnames: 'upsale-icon_highlighted') %>
+      <% end %>
+    </label>
+    <div class="form--field-container">
+     <%= form.collection_check_box :enabled_module_names,
+                                    name,
+                                    @project.module_enabled?(name),
+                                    l_or_humanize(name, prefix: "project_module_"),
+                                    no_label: true
+      %>
+    </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2457,7 +2457,7 @@ en:
 
   project_module_activity: "Activity"
   project_module_forums: "Forums"
-  project_module_work_package_tracking: "Work package tracking"
+  project_module_work_package_tracking: "Work packages"
   project_module_news: "News"
   project_module_repository: "Repository"
   project_module_wiki: "Wiki"

--- a/frontend/src/global_styles/common/menu/menu.sass
+++ b/frontend/src/global_styles/common/menu/menu.sass
@@ -12,9 +12,6 @@
       display: inline-flex
       align-items: center
 
-      .spot-icon_enterprise-addons
-        color: $spot-color-feedback-warning-dark
-
     &-action
       display: flex
       align-items: center

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -40,6 +40,10 @@
 .widget-box--blocks--upsale-info-button
   margin: 0.5rem 1rem 0 0
 
+.upsale-icon
+  &_highlighted
+    color: $spot-color-feedback-warning-dark
+
 .widget-box--blocks--upsale-title
   font-weight: 400
   font-size: 20px

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -125,6 +125,14 @@ module OpenProject
         @mapped_permissions.select { |p| p.project_module.nil? || modules.include?(p.project_module.to_s) }
       end
 
+      def module_enterprise_feature?(name)
+        current_module = modules.select { |m| m[:name] == name }[0]
+
+        return false if current_module.nil? || current_module[:enterprise_feature].nil?
+
+        current_module[:enterprise_feature]
+      end
+
       def contract_actions_map
         @contract_actions_map ||= permissions.each_with_object({}) do |p, hash|
           next if p.contract_actions.none?

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -231,7 +231,7 @@ module Redmine::MenuManager::MenuHelper
                              lang: menu_item_locale(item)) do
       title_text = ''.html_safe + content_tag(:span, caption, class: 'ellipsis') + badge_for(item)
       if item.enterprise_feature.present? && !EnterpriseToken.allows_to?(item.enterprise_feature)
-        title_text << (''.html_safe + spot_icon('enterprise-addons', size: '1_25'))
+        title_text << (''.html_safe + spot_icon('enterprise-addons', size: '1_25', classnames: 'upsale-icon_highlighted'))
       end
       title_text
     end

--- a/modules/calendar/config/locales/en.yml
+++ b/modules/calendar/config/locales/en.yml
@@ -4,4 +4,4 @@ en:
   permission_view_calendar: "View calendars"
   permission_manage_calendars: "Manage calendars"
   permission_share_calendars: "Subscribe to iCalendars"
-  project_module_calendar_view: "Calendar"
+  project_module_calendar_view: "Calendars"

--- a/modules/team_planner/config/locales/en.yml
+++ b/modules/team_planner/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   permission_view_team_planner: "View team planner"
   permission_manage_team_planner: "Manage team planner"
-  project_module_team_planner_view: "Team planner"
+  project_module_team_planner_view: "Team planners"
 
   team_planner:
     label_team_planner: "Team planner"

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -27,7 +27,7 @@ module OpenProject::TeamPlanner
              bundled: true,
              settings: {},
              name: 'OpenProject Team Planner' do
-      project_module :team_planner_view, dependencies: :work_package_tracking do
+      project_module :team_planner_view, dependencies: :work_package_tracking, enterprise_feature: true do
         permission :view_team_planner,
                    { 'team_planner/team_planner': %i[index show upsale overview] },
                    dependencies: %i[view_work_packages],


### PR DESCRIPTION
- [x] Change names of the modules in the project settings overview to be consistent with the actual module name
- [x] Show the enterprise icon after those modules that are EE only (currently only team planners)

https://community.openproject.org/projects/14/work_packages/44963/activity