### PR TITLE
Add a lefthook config to run bin/setup_dev after a `git pull`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,3 +17,10 @@ pre-commit:
       files: git diff --name-only --staged
       glob: "*.rb"
       run: bin/dirty-rubocop --uncommitted --force-exclusion {files}
+
+post-merge:
+  commands:
+    setup-dev:
+      files: git diff --name-only HEAD@\{1\} HEAD
+      glob: '{Gemfile.lock,frontend/package-lock.json,db/migrate/*.rb,modules/*/db/migrate/*.rb}'
+      run: bin/setup_dev

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,30 @@ pre-commit:
 
 post-merge:
   commands:
-    setup-dev:
+    bundle-install:
       files: git diff --name-only HEAD@\{1\} HEAD
-      glob: '{Gemfile.lock,frontend/package-lock.json,db/migrate/*.rb,modules/*/db/migrate/*.rb}'
-      run: bin/setup_dev
+      glob: Gemfile.lock
+      run: bin/bundle install
+    tasks:
+      run: lefthook run parallel-post-merge-jobs
+
+parallel-post-merge-jobs:
+  parallel: true
+  commands:
+    npm-install:
+      files: git diff --name-only HEAD@\{1\} HEAD
+      glob: frontend/package-lock.json
+      root: "frontend/"
+      run: npm ci
+    migrate:
+      files: git diff --name-only HEAD@\{1\} HEAD
+      glob: '{db/migrate/*.rb,modules/*/db/migrate/*.rb}'
+      run: bin/rails db:migrate
+    extract-locales:
+      files: git diff --name-only HEAD@\{1\} HEAD
+      glob: '{config/locale/**/*,modules/*/config/locale/**/*}'
+      run: bin/rails i18n:js:export
+    register-frontend-js:
+      files: git diff --name-only HEAD@\{1\} HEAD
+      glob: 'modules/*/frontend/**/*'
+      run: bin/rails openproject:plugins:register_frontend


### PR DESCRIPTION
I added a `post-merge` hook into the lefthook config, that will run `bin/setup_dev` when one of the following conditions apply:

- `Gemfile.lock` was modified in the merge
- `frontend/package-lock.json` was modified in the merge
- a migration was added to `db/migrate/` or any modules migration folder

`post-merge` might be confusing in name, but when running `git pull` this is basically doing a `git fetch && git merge` of the remote branch, so this will apply when using `git pull` as well. See [git docs](https://git-scm.com/docs/githooks#_post_merge)