### PR TITLE
Fix/align headers on user activity page

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -118,6 +118,10 @@ module UsersHelper
     end
   end
 
+  def visible_user_information?(user)
+    user.pref.can_expose_mail? || user.visible_custom_field_values.any? { _1.value.present? }
+  end
+
   def user_name(user)
     user ? user.name : I18n.t('user.deleted')
   end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -94,6 +94,10 @@ class UserPreference < ApplicationRecord
     settings.fetch(:hide_mail, true)
   end
 
+  def can_expose_mail?
+    !hide_mail
+  end
+
   def auto_hide_popups=(value)
     settings[:auto_hide_popups] = to_boolean(value)
   end

--- a/app/views/common/feed.atom.builder
+++ b/app/views/common/feed.atom.builder
@@ -60,7 +60,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       if author
         xml.author do
           xml.name(author)
-          xml.email(author.mail) if author.is_a?(User) && author.mail.present? && !author.pref.hide_mail
+          xml.email(author.mail) if author.is_a?(User) && author.mail.present? && author.pref.can_expose_mail?
         end
       end
       xml.content "type" => "html" do

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -44,7 +44,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.updated change.created_at.xmlschema
       xml.author do
         xml.name change.user.name
-        xml.email(change.user.mail) if change.user.is_a?(User) && change.user.mail.present? && !change.user.pref.hide_mail
+        xml.email(change.user.mail) if change.user.is_a?(User) && change.user.mail.present? && change.user.pref.can_expose_mail?
       end
       xml.content "type" => "html" do
         xml.text! '<ul>'

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,16 +45,18 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="grid-block medium-up-2">
   <div class="grid-content">
     <%= call_hook :view_account_left_top, user: @user %>
-    <ul>
-      <% unless @user.pref.hide_mail %>
-        <li><%= User.human_attribute_name(:mail) %>: <%= mail_to(h(escape_javascript(@user.mail)), nil, encode: 'javascript') %></li>
-      <% end %>
-      <% @user.visible_custom_field_values.each do |custom_value| %>
-        <% if !custom_value.value.blank? %>
-          <li><%=h custom_value.custom_field.name%>: <%=h show_value(custom_value) %></li>
+    <% if visible_user_information?(@user) %>
+      <ul>
+        <% if @user.pref.can_expose_mail? %>
+          <li><%= User.human_attribute_name(:mail) %>: <%= mail_to(h(escape_javascript(@user.mail)), nil, encode: 'javascript') %></li>
         <% end %>
-      <% end %>
-    </ul>
+        <% @user.visible_custom_field_values.each do |custom_value| %>
+          <% if custom_value.value.present? %>
+            <li><%=h custom_value.custom_field.name%>: <%=h show_value(custom_value) %></li>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
 
     <%= call_hook :view_account_left_middle, user: @user %>
 

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -143,7 +143,7 @@ module API
                  getter: ->(*) { represented.mail },
                  setter: ->(fragment:, represented:, **) { represented.mail = fragment },
                  exec_context: :decorator,
-                 cache_if: -> { !represented.pref.hide_mail || represented.new_record? || current_user_can_manage? }
+                 cache_if: -> { represented.pref.can_expose_mail? || represented.new_record? || current_user_can_manage? }
 
         property :avatar,
                  exec_context: :decorator,

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -114,4 +114,41 @@ RSpec.describe UsersHelper do
       end
     end
   end
+
+  describe '#visible_user_information?' do
+    subject { visible_user_information?(user) }
+
+    context 'when user has hide_mail = false in their preferences' do
+      let(:user) { build(:user, preferences: { hide_mail: false }) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when user has hide_mail = true in their preferences' do
+      let(:user) { build(:user, preferences: { hide_mail: true }) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when user has a custom field with a present value' do
+      let(:custom_field) { create(:string_user_custom_field) }
+      let(:user) { build(:user, custom_values: [build(:custom_value, custom_field:, value: 'Hello')]) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when user has a custom field with a blank value' do
+      let(:custom_field) { create(:string_user_custom_field) }
+      let(:user) { build(:user, custom_values: [build(:custom_value, custom_field:, value: '  ')]) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when user has a non-visible custom field with a present value' do
+      let(:custom_field) { create(:string_user_custom_field, visible: false) }
+      let(:user) { build(:user, custom_values: [build(:custom_value, custom_field:, value: 'Hello')]) }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end


### PR DESCRIPTION
Maya noticed that headers are not aligned on the users activity page.

Indeed there is a space where the user email and the custom fields would be displayed, but it is still eating place if there is nothing.
This PR removes the extra space when it's not allowed to expose user's email and there are no visible custom values.

Before:

![image](https://github.com/opf/openproject/assets/176055/e1850886-6665-4526-902d-027d6664d218)

After:

![image](https://github.com/opf/openproject/assets/176055/a1768277-6f66-4dd9-9101-fdc964ecc46c)
