### PR TITLE
Fix flaky test by adding change detection

### DIFF
--- a/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.html
+++ b/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.html
@@ -93,7 +93,7 @@
           [attr.data-qa-highlighted]=" showFieldAsActive('duration') || undefined"
           [ngClass]="{'op-datepicker-modal--date-field_current' : showFieldAsActive('duration')}"
           [ngModel]="durationFocused ? duration : displayedDuration"
-          [showClearButton]="durationFocused"
+          [showClearButton]="currentlyActivatedDateField === 'duration'"
           pattern="\d*"
           inputmode="numeric"
           (ngModelChange)="durationChanges$.next($event)"

--- a/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
@@ -414,6 +414,7 @@ export class OpWpMultiDateFormComponent extends UntilDestroyedMixin implements A
   handleDurationFocusOut():void {
     setTimeout(() => {
       this.durationFocused = false;
+      this.cdRef.detectChanges();
     });
   }
 

--- a/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.ts
@@ -48,6 +48,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DayElement } from 'flatpickr/dist/types/instance';
 import flatpickr from 'flatpickr';
 import {
+  debounce,
   debounceTime,
   filter,
   map,
@@ -58,6 +59,7 @@ import {
   merge,
   Observable,
   Subject,
+  timer,
 } from 'rxjs';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
@@ -210,7 +212,7 @@ export class OpWpMultiDateFormComponent extends UntilDestroyedMixin implements A
     .durationChanges$
     .pipe(
       this.untilDestroyed(),
-      debounceTime(500),
+      debounce((value) => (value ? timer(500) : timer(0))),
       map((value) => (value === '' ? null : Math.abs(parseInt(value, 10)))),
       filter((val) => val === null || !Number.isNaN(val)),
       filter((val) => val !== this.duration),


### PR DESCRIPTION
Failing test was ./spec/features/work_packages/datepicker/datepicker_logic_spec.rb:168

The " days" suffix was not appended to the duration field. Duration field text is controlled with `[ngModel]="durationFocused ? duration : displayedDuration"`, but when `durationFocused` is changed, it sometimes is not detected.

Forcing the detection fixes it.