### PR TITLE
Fix flaky `team_planner_onboarding_tour_spec` test

### DIFF
--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -30,8 +30,8 @@ require 'spec_helper'
 require_relative './../../support/onboarding/onboarding_steps'
 
 RSpec.describe 'team planner onboarding tour',
-               js: true,
-               with_cuprite: false,
+               :js,
+               :with_cuprite,
                with_ee: %i[team_planner_view] do
   let(:next_button) { find('.enjoyhint_next_btn') }
 
@@ -85,7 +85,7 @@ RSpec.describe 'team planner onboarding tour',
 
   after do
     # Clear session to avoid that the onboarding tour starts
-    page.execute_script("window.sessionStorage.clear();")
+    page.driver.cookies.clear
   end
 
   context 'as a new user' do
@@ -102,7 +102,7 @@ RSpec.describe 'team planner onboarding tour',
 
     it "I do not see the team planner onboarding tour in the scrum project" do
       # Set sessionStorage value so that the tour knows that it is in the scum tour
-      page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startMainTourFromBacklogs');")
+      page.driver.set_cookie('openProject-onboardingTour', 'startMainTourFromBacklogs')
 
       # Set the tour parameter so that we can start on the wp page
       visit "/projects/#{scrum_project.identifier}/work_packages?start_onboarding_tour=true"

--- a/modules/team_planner/spec/support/onboarding/onboarding_steps.rb
+++ b/modules/team_planner/spec/support/onboarding/onboarding_steps.rb
@@ -29,22 +29,27 @@
 module OnboardingSteps
   def step_through_onboarding_team_planner_tour
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.overview')), normalize_ws: true
 
     # The team planner is long to load
     next_button.click
+    wait_for_reload
     expect(page)
-      .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.calendar')), normalize_ws: true, wait: 10
+      .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.calendar')), normalize_ws: true, wait: 20
 
     next_button.click
+    wait_for_reload
     expect(page)
       .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.add_assignee')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page)
       .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.add_existing')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page)
       .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.card')), normalize_ws: true
   end

--- a/spec/support/onboarding_helper.rb
+++ b/spec/support/onboarding_helper.rb
@@ -34,41 +34,52 @@ module OnboardingHelper
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.list')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_current_path project_work_package_path(project, wp.id, 'activity')
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.full_view')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.back_button')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.create_button')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.timeline_button')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.timeline')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.sidebar_arrow')), normalize_ws: true
   end
 
   def step_through_onboarding_main_menu_tour(has_full_capabilities:)
     if has_full_capabilities
       next_button.click
+      wait_for_reload
       expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.members')), normalize_ws: true
 
       next_button.click
+      wait_for_reload
       expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wiki')), normalize_ws: true
 
       next_button.click
+      wait_for_reload
       expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.quick_add_button')), normalize_ws: true
     end
 
     next_button.click
+    wait_for_reload
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.help_menu')), normalize_ws: true
 
     next_button.click
+    wait_for_reload
     expect(page).not_to have_selector '.enjoy_hint_label'
   end
 

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -42,7 +42,7 @@ end
 # Takes the above `wait_for_network_idle` a step further by waiting
 # for the page to be reloaded after some triggering action.
 def wait_for_reload
-  page.driver.wait_for_reload
+  page.driver.wait_for_reload if using_cuprite?
 end
 
 # Ferrum is yet support `fill_options` as a Hash


### PR DESCRIPTION
* Migrated the spec to using cuprite.
* Increased wait time on specific long-running expectation. It just
  takes a while to load as indicated in the already existing comment...