### PR TITLE
Fix flaky Query Filter spec on Work Packages table

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -74,9 +74,7 @@ export class WorkPackageFilterByTextInputComponent extends UntilDestroyedMixin {
         }),
       )
       .subscribe((upstreamTerm:string) => {
-        console.log(`upstream ${upstreamTerm} ${(this.searchTerm as any).timestampOfLastValue}`);
         if (!this.searchTerm.value || this.searchTerm.isValueOlderThan(500)) {
-          console.log(`Upstream value setting to ${upstreamTerm}`);
           this.searchTerm.putValue(upstreamTerm);
         }
       });

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe 'filter work packages', js: true do
     end
     shared_let(:wp_updated_3d_ago) do
       create(:work_package,
-             subject: 'Created today',
+             subject: 'Created 3d ago',
              project:,
              created_at: 3.days.ago,
              updated_at: 3.days.ago)

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -550,7 +550,7 @@ RSpec.describe 'filter work packages', js: true do
       wp_table.ensure_work_package_not_listed! wp_updated_3d_ago, wp_updated_5d_ago
     end
 
-    it 'filters between date by updated_at' do
+    it 'filters between date by updated_at', :with_cuprite do
       skip("Flaky test disabled. Fix it in https://community.openproject.org/wp/49072")
       wp_table.visit!
       loading_indicator_saveguard
@@ -563,6 +563,7 @@ RSpec.describe 'filter work packages', js: true do
                             [4.days.ago.to_date.iso8601, 2.days.ago.to_date.iso8601],
                             'updatedAt'
 
+      wait_for_reload
       loading_indicator_saveguard
 
       wp_table.expect_work_package_listed wp_updated_3d_ago
@@ -572,6 +573,7 @@ RSpec.describe 'filter work packages', js: true do
 
       filters.remove_filter 'updatedAt'
 
+      wait_for_reload
       loading_indicator_saveguard
       wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago
 

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -257,9 +257,10 @@ module Components
 
       def insert_two_single_dates(id, value)
         fill_in("values-#{id}-begin", with: value[0]) if value[0]
-        loading_indicator_saveguard
         fill_in("values-#{id}-end", with: value[1]) if value[1]
-        loading_indicator_saveguard
+
+        ensure_value_is_input_correctly page.find("#values-#{id}-begin"), value: value[0] if value[0]
+        ensure_value_is_input_correctly page.find("#values-#{id}-end"), value: value[1] if value[1]
       end
 
       def insert_date_range(filter_element, value)


### PR DESCRIPTION
https://community.openproject.org/wp/49072

* Migrates spec to cuprite
* Addresses flakiness cause being that assertions occur while loading is still going on. This being prevented now by `wait_for_reload`