### PR TITLE
Fix flaky `mobile_date_filter_spec` file

### DIFF
--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'mobile date filter work packages', js: true do
+RSpec.describe 'mobile date filter work packages', :js, :with_cuprite do
   shared_let(:user) { create(:admin) }
   shared_let(:project) { create(:project) }
   shared_let(:wp_table) { Pages::WorkPackagesTable.new(project) }
@@ -54,13 +54,15 @@ RSpec.describe 'mobile date filter work packages', js: true do
       start_field = find('[data-qa-selector="op-basic-range-date-picker-start"]')
       end_field = find('[data-qa-selector="op-basic-range-date-picker-end"]')
 
-      start_field.native.clear
-      end_field.native.clear
+      clear_input_field_contents(start_field)
+      clear_input_field_contents(end_field)
 
-      start_field.set 1.day.ago.strftime('%m/%d/%Y')
-      end_field.set Date.current.strftime('%m/%d/%Y')
+      start_field.set 1.day.ago.to_date
+      start_field.send_keys :tab
+      end_field.set Date.current
       end_field.send_keys :tab
 
+      wait_for_reload
       loading_indicator_saveguard
 
       wp_cards.expect_work_package_count 1
@@ -85,9 +87,10 @@ RSpec.describe 'mobile date filter work packages', js: true do
       date_field = find_field 'values-dueDate'
       expect(date_field['type']).to eq 'date'
 
-      date_field.native.clear
-      date_field.set Date.current.strftime('%m/%d/%Y')
+      clear_input_field_contents(date_field)
+      date_field.set Date.current
 
+      wait_for_reload
       loading_indicator_saveguard
 
       wp_cards.expect_work_package_count 1

--- a/spec/support/shared/with_mobile_screen.rb
+++ b/spec/support/shared/with_mobile_screen.rb
@@ -26,21 +26,38 @@
 
 RSpec.shared_context 'with mobile screen size' do |width, height|
   let!(:height_before) do
-    page.driver.browser.manage.window.size.height
+    if using_cuprite?
+      page.current_window.size.second
+    else
+      page.driver.browser.manage.window.size.height
+    end
   end
+
   let!(:width_before) do
-    page.driver.browser.manage.window.size.width
+    if using_cuprite?
+      page.current_window.size.first
+    else
+      page.driver.browser.manage.window.size.width
+    end
   end
 
   before do
     # Change browser size
-    page.driver.browser.manage.window.resize_to(width || 500, height || 1000)
-
-    # Refresh the page
-    page.driver.browser.navigate.refresh
+    # and refresh the page
+    if using_cuprite?
+      page.driver.resize(width || 500, height || 1000)
+      page.driver.refresh
+    else
+      page.driver.browser.manage.window.resize_to(width || 500, height || 1000)
+      page.driver.browser.navigate.refresh
+    end
   end
 
   after do
-    page.driver.browser.manage.window.resize_to(width_before, height_before)
+    if using_cuprite?
+      page.driver.resize(width_before, height_before)
+    else
+      page.driver.browser.manage.window.resize_to(width_before, height_before)
+    end
   end
 end


### PR DESCRIPTION
This one's been flaky for quite some time 😓 but I believe we've nailed it this time

* Migrated the spec file to cuprite.
* Solves the cause of flakiness being that the expectations/assertions are being executed while still loading.
`wait_for_reload` + `loading_indicator_saveguard` ensures that both network requests are idle, javascript is completely loaded and the loading indicator isn't present.

3 consecutive runs of `script/bulk_run_rspec ./spec/features/work_packages/table/queries/mobile_date_filter_spec.rb` resulting in
![image](https://github.com/opf/openproject/assets/61627014/a3a00684-7c57-4c89-8bb1-e5fbea7f0037)


