### PR TITLE
[46827] Custom project attribute triggers error when selected during project creation

### DIFF
--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -83,7 +83,7 @@ export class CurrentUserService {
           const filters:ApiV3ListFilter[] = [userFilter];
 
           if (projectContext) {
-            filters.push(['context', '=', [projectContext === 'global' ? 'g' : `p${projectContext}`]]);
+            filters.push(['context', '=', [projectContext === 'global' || projectContext === 'projects' ? 'g' : `p${projectContext}`]]);
           }
 
           if (actions.length > 0) {

--- a/spec/features/projects/projects_custom_fields_spec.rb
+++ b/spec/features/projects/projects_custom_fields_spec.rb
@@ -275,5 +275,17 @@ describe 'Projects custom fields', js: true do
       cv = project.custom_values.find_by(custom_field_id: custom_field.id).typed_value
       expect(cv).to eq invisible_user
     end
+
+    it 'does not show invite user button when there is no project selected' do
+      visit new_project_path
+
+      name_field.set_value 'My project name'
+
+      find('.op-fieldset--toggle', text: 'ADVANCED SETTINGS').click
+
+      cf_field.expect_visible
+      cf_field.expect_no_option invisible_user
+      expect(page).not_to have_selector('.ng-dropdown-footer button', text: 'Invite')
+    end
   end
 end


### PR DESCRIPTION
While creating a new project, the project context is projects, so it should behave like 'global'.

https://community.openproject.org/wp/46827