### PR TITLE
[#48647] PDF Export: Manage long query titles in footer

### DIFF
--- a/app/models/work_package/pdf_export/page.rb
+++ b/app/models/work_package/pdf_export/page.rb
@@ -27,6 +27,8 @@
 #++
 
 module WorkPackage::PDFExport::Page
+  MAX_NR_OF_PDF_FOOTER_LINES = 3
+
   def configure_page_size!(layout)
     pdf.options[:page_layout] = layout
     pdf.options[:page_size] = styles.page_size
@@ -92,16 +94,23 @@ module WorkPackage::PDFExport::Page
 
   def write_footers!
     pdf.repeat :all, dynamic: true do
-      draw_footer_on_page!
+      draw_footer_on_page
     end
   end
 
-  def draw_footer_on_page!
+  def draw_footer_on_page
     top = styles.page_footer_offset
     text_style = styles.page_footer
+    spacing = styles.page_footer_horizontal_spacing
     page_nr_x, page_nr_width = draw_text_centered(footer_page_nr, text_style, top)
-    draw_text_multiline_left(footer_date, text_style, page_nr_x, top)
-    draw_text_multiline_right(footer_title, text_style, page_nr_x + page_nr_width, top)
+    draw_text_multiline_left(
+      text: footer_date, max_left: page_nr_x - spacing,
+      text_style:, top:, max_lines: MAX_NR_OF_PDF_FOOTER_LINES
+    )
+    draw_text_multiline_right(
+      text: footer_title, max_left: page_nr_x + page_nr_width + spacing,
+      text_style:, top:, max_lines: MAX_NR_OF_PDF_FOOTER_LINES
+    )
   end
 
   def footer_page_nr

--- a/app/models/work_package/pdf_export/style.rb
+++ b/app/models/work_package/pdf_export/style.rb
@@ -49,6 +49,10 @@ module WorkPackage::PDFExport::Style
       resolve_pt(@styles.dig(:page_footer, :offset), -30)
     end
 
+    def page_footer_horizontal_spacing
+      resolve_pt(@styles.dig(:page_footer, :spacing), 6)
+    end
+
     def page_logo_height
       resolve_pt(@styles.dig(:page_logo, :height), 20)
     end

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -72,7 +72,7 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
   end
 
   def heading
-    "#{work_package.project} - #{work_package.type} ##{work_package.id}"
+    "#{work_package.project} - #{work_package.type} ##{work_package.id} - #{work_package.subject}"
   end
 
   def title


### PR DESCRIPTION
* limit footer lines amount to 3
* if there are more than 3 lines, last one is displayed with an ellipsis
<img width="847" alt="Truncation" src="https://github.com/opf/openproject/assets/77627197/421541ff-370e-43fe-b331-f7775f738d84">

https://community.openproject.org/work_packages/48647
