### PR TITLE
Make internal login route easier, allowing POST /login without session

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -41,7 +41,6 @@ class AccountController < ApplicationController
   before_action :disable_api
   before_action :check_auth_source_sso_failure, only: :auth_source_sso_failed
   before_action :check_internal_login_enabled, only: :internal_login
-  after_action :remove_internal_login_flag, only: :login
 
   layout 'no_menu'
 
@@ -51,7 +50,7 @@ class AccountController < ApplicationController
 
     if user.logged?
       redirect_after_login(user)
-    elsif omniauth_direct_login? && !session[:internal_login]
+    elsif request.get? && omniauth_direct_login?
       direct_login(user)
     elsif request.post?
       authenticate_user
@@ -59,8 +58,7 @@ class AccountController < ApplicationController
   end
 
   def internal_login
-    session[:internal_login] = true
-    redirect_to action: :login
+    render 'account/login'
   end
 
   # Log out current user and redirect to welcome page
@@ -537,9 +535,5 @@ class AccountController < ApplicationController
 
   def check_internal_login_enabled
     render_404 unless omniauth_direct_login?
-  end
-
-  def remove_internal_login_flag
-    session.delete :internal_login
   end
 end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -99,20 +99,18 @@ describe AccountController,
   end
 
   describe 'GET #internal_login' do
+    shared_let(:admin) { create(:admin) }
+
     context 'when direct login enabled', with_config: { omniauth_direct_login_provider: 'some_provider' } do
       it 'allows to login internally using a special route' do
         get :internal_login
 
-        expect(response).to redirect_to '/login'
-        expect(session[:internal_login]).to be true
+        expect(response).to render_template 'account/login'
       end
 
-      it 'allows to login internally using a session flag' do
-        session[:internal_login] = true
-        get :login
-
-        expect(response).to render_template 'login'
-        expect(session).not_to have_key :internal_login
+      it 'allows to post to login' do
+        post :login, params: { username: admin.login, password: 'adminADMIN!' }
+        expect(response).to redirect_to '/my/page'
       end
     end
 
@@ -486,17 +484,9 @@ describe AccountController,
     describe 'POST' do
       shared_let(:admin) { create(:admin) }
 
-      it 'redirects to some_provider' do
-        post :login, params: { username: 'foo', password: 'bar' }
-
-        expect(response).to redirect_to '/auth/some_provider'
-      end
-
-      it 'allows to login internally using a session flag' do
-        session[:internal_login] = true
+      it 'allows to login internally still' do
         post :login, params: { username: admin.login, password: 'adminADMIN!' }
-
-        expect(response).to redirect_to '/my/page'
+        expect(response).to redirect_to "/my/page"
       end
     end
   end


### PR DESCRIPTION
The session flag got removed after the first redirect, breaking the login. Instead of remembering a session token, simply allow POSTs to go through to /login, which makes everything easier.

https://community.openproject.org/work_packages/47930