### PR TITLE
Include location in iCal meeting export

### DIFF
--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -93,6 +93,7 @@ class MeetingMailer < UserMailer
       e.description = ical_subject(meeting, content_type)
       e.uid = "#{meeting.id}@#{meeting.project.identifier}"
       e.organizer = ical_organizer meeting
+      e.location = meeting.location.presence
     end
 
     calendar.publish

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe MeetingMailer do
     it 'renders the headers' do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
-      expect(mail.to).to match_array([author.mail])
+      expect(mail.to).to contain_exactly(author.mail)
       expect(mail.from).to eq([Setting.mail_from])
     end
 
@@ -92,7 +92,7 @@ RSpec.describe MeetingMailer do
         expect(mail.html_part.body).to include('Tokyo')
         expect(mail.html_part.body).to include('GMT+09:00')
 
-        expect(mail.to).to match_array([watcher1.mail])
+        expect(mail.to).to contain_exactly(watcher1.mail)
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe MeetingMailer do
           expect(mail.html_part.body).to include('11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin')
           expect(mail.text_part.body).to include('11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin')
 
-          expect(mail.to).to match_array([author.mail])
+          expect(mail.to).to contain_exactly(author.mail)
         end
       end
 
@@ -123,7 +123,7 @@ RSpec.describe MeetingMailer do
           expect(mail.text_part.body).to include('11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo')
           expect(mail.html_part.body).to include('11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo')
 
-          expect(mail.to).to match_array([watcher1.mail])
+          expect(mail.to).to contain_exactly(watcher1.mail)
         end
       end
     end
@@ -135,6 +135,7 @@ RSpec.describe MeetingMailer do
              author:,
              project:,
              title: 'Important meeting',
+             location: 'https://example.com/meet/important-meeting',
              start_time: "2021-01-19T10:00:00Z".to_time(:utc),
              duration: 1.0)
     end
@@ -143,7 +144,7 @@ RSpec.describe MeetingMailer do
     it 'renders the headers' do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
-      expect(mail.to).to match_array([author.mail])
+      expect(mail.to).to contain_exactly(author.mail)
       expect(mail.from).to eq([Setting.mail_from])
     end
 
@@ -153,6 +154,7 @@ RSpec.describe MeetingMailer do
       it 'renders the text body' do
         expect(body).to include(meeting.project.name)
         expect(body).to include(meeting.title)
+        expect(body).to include(meeting.location)
         expect(body).to include('01/19/2021 11:00 AM-12:00 PM (GMT+01:00) Europe/Berlin')
         expect(body).to include(meeting.participants[0].name)
         expect(body).to include(meeting.participants[1].name)
@@ -165,6 +167,7 @@ RSpec.describe MeetingMailer do
       it 'renders the text body' do
         expect(body).to include(meeting.project.name)
         expect(body).to include(meeting.title)
+        expect(body).to include(meeting.location)
         expect(body).to include('01/19/2021 11:00 AM-12:00 PM (GMT+01:00) Europe/Berlin')
         expect(body).to include(meeting.participants[0].name)
         expect(body).to include(meeting.participants[1].name)
@@ -184,6 +187,7 @@ RSpec.describe MeetingMailer do
         expect(entry.dtend.utc).to eq meeting.start_time + 1.hour
         expect(entry.summary).to eq '[My project] Important meeting'
         expect(entry.description).to eq "[My project] Agenda: Important meeting"
+        expect(entry.location).to eq(meeting.location.presence)
       end
 
       it 'has the correct time matching the timezone' do
@@ -202,7 +206,7 @@ RSpec.describe MeetingMailer do
         expect(mail.html_part.body).to include('01/19/2021 07:00 PM-08:00 PM (GMT+09:00) Asia/Tokyo')
         expect(mail.html_part.body).to include("#{author.name} has put the")
 
-        expect(mail.to).to match_array([watcher1.mail])
+        expect(mail.to).to contain_exactly(watcher1.mail)
       end
     end
 
@@ -221,7 +225,7 @@ RSpec.describe MeetingMailer do
           expect(mail.text_part.body).to include('11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin')
           expect(mail.html_part.body).to include('11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin')
 
-          expect(mail.to).to match_array([author.mail])
+          expect(mail.to).to contain_exactly(author.mail)
         end
       end
 
@@ -233,7 +237,7 @@ RSpec.describe MeetingMailer do
           expect(mail.text_part.body).to include('11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo')
           expect(mail.html_part.body).to include('11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo')
 
-          expect(mail.to).to match_array([watcher1.mail])
+          expect(mail.to).to contain_exactly(watcher1.mail)
         end
       end
     end


### PR DESCRIPTION
Adds the `Location` field in the iCal file that is send from the meetings module.

Fixes https://community.openproject.org/projects/openproject/work_packages/47224