### PR TITLE
Declare enum in `Storages::LastProjectFolder` for string <> symbol coercion benefits

### DIFF
--- a/modules/storages/app/models/storages/last_project_folder.rb
+++ b/modules/storages/app/models/storages/last_project_folder.rb
@@ -29,5 +29,5 @@
 class Storages::LastProjectFolder < ApplicationRecord
   belongs_to :projects_storage, class_name: 'Storages::ProjectStorage'
 
-  enum mode: { manual: 'manual', automatic: 'automatic' }.freeze
+  enum mode: { inactive: 'inactive', manual: 'manual', automatic: 'automatic' }.freeze
 end

--- a/modules/storages/spec/models/last_project_folder_spec.rb
+++ b/modules/storages/spec/models/last_project_folder_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Storages::LastProjectFolder do
 
     it do
       expect(last_project_folder).to define_enum_for(:mode)
-        .with_values(manual: 'manual', automatic: 'automatic')
+        .with_values(inactive: 'inactive', manual: 'manual', automatic: 'automatic')
         .backed_by_column_of_type(:enum)
     end
   end

--- a/modules/storages/spec/models/last_project_folder_spec.rb
+++ b/modules/storages/spec/models/last_project_folder_spec.rb
@@ -26,8 +26,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Storages::LastProjectFolder < ApplicationRecord
-  belongs_to :projects_storage, class_name: 'Storages::ProjectStorage'
+require_relative '../spec_helper'
 
-  enum mode: { manual: 'manual', automatic: 'automatic' }.freeze
+RSpec.describe Storages::LastProjectFolder do
+  describe '#mode' do
+    let(:last_project_folder) { build(:last_project_folder) }
+
+    it do
+      expect(last_project_folder).to define_enum_for(:mode)
+        .with_values(manual: 'manual', automatic: 'automatic')
+        .backed_by_column_of_type(:enum)
+    end
+  end
 end

--- a/modules/storages/spec/models/project_storage_spec.rb
+++ b/modules/storages/spec/models/project_storage_spec.rb
@@ -76,4 +76,15 @@ RSpec.describe Storages::ProjectStorage do
       expect(Storages::FileLink.count).not_to eq 0
     end
   end
+
+  describe '#project_folder_mode' do
+    let(:project_storage) { build(:project_storage) }
+
+    it do
+      expect(project_storage).to define_enum_for(:project_folder_mode)
+        .with_values(inactive: 'inactive', manual: 'manual', automatic: 'automatic')
+        .with_prefix(:project_folder)
+        .backed_by_column_of_type(:enum)
+    end
+  end
 end


### PR DESCRIPTION
This addresses a bug observed in Edge where the project folder mode fails to update.

More on Enums: https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Enum.html