### PR TITLE
Allow saving CKEditor with ctrl+enter or cmd+enter

### DIFF
--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.component.html
@@ -2,9 +2,9 @@
   <op-ckeditor
       [context]="ckEditorContext"
       [content]="value?.raw"
-      (onContentChange)="onContentChange($event)"
-      (onInitializationFailed)="initializationError = true"
-      (onInitialized)="onCkeditorSetup($event)"
+      (contentChanged)="onContentChange($event)"
+      (initializationFailed)="initializationError = true"
+      (initializeDone)="onCkeditorSetup($event)"
   >
   </op-ckeditor>
 </div>

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -2,8 +2,8 @@
   <op-ckeditor
     [context]="context"
     [content]="initialContent"
-    (onInitialized)="setup($event)"
-    (onContentChange)="markEdited()"
+    (initializeDone)="setup($event)"
+    (contentChanged)="markEdited()"
   ></op-ckeditor>
 </div>
 

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
@@ -4,6 +4,22 @@ import {
   ICKEditorType,
 } from 'core-app/shared/components/editor/components/ckeditor/ckeditor-setup.service';
 
+export interface CKEditorEvent {
+  stop:() => void;
+}
+
+export interface CKEditorListenOptions {
+  priority:string;
+}
+
+export interface CKEditorDomEventData {
+  altKey:boolean;
+  shiftKey:boolean;
+  ctrlKey:boolean;
+  metaKey:boolean;
+  keyCode:number;
+}
+
 export interface ICKEditorInstance {
   getData(options:{ trim:boolean }):string;
 
@@ -12,12 +28,20 @@ export interface ICKEditorInstance {
   destroy():void;
 
   enableReadOnlyMode(lockId:string):void;
+
   disableReadOnlyMode(lockId:string):void;
 
   on(event:string, callback:() => unknown):void;
 
+  listenTo(node:unknown, key:string, callback:(evt:CKEditorEvent, data:CKEditorDomEventData) => unknown, options:CKEditorListenOptions):void;
+
   model:any;
-  editing:any;
+  editing:{
+    view:{
+      focus():void;
+      document:Document
+    }
+  };
   config:any;
   ui:any;
   element:HTMLElement;

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
@@ -35,7 +35,13 @@ export interface ICKEditorInstance {
 
   listenTo(node:unknown, key:string, callback:(evt:CKEditorEvent, data:CKEditorDomEventData) => unknown, options:CKEditorListenOptions):void;
 
-  model:any;
+  model:{
+    on(ev:string, callback:() => unknown):void
+    fire(ev:string, data:unknown):void
+    document:{
+      on(ev:string, callback:() => unknown):void
+    };
+  };
   editing:{
     view:{
       focus():void;

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
@@ -2,9 +2,9 @@
   <div class="op-ckeditor--wrapper op-ckeditor-element">
     <op-ckeditor [context]="ckEditorContext"
                  [content]="initialContent"
-                 (onContentChange)="onContentChange($event)"
-                 (onInitializationFailed)="initializationError = true"
-                 (onInitialized)="onCkeditorSetup($event)"
+                 (contentChanged)="onContentChange($event)"
+                 (initializationFailed)="initializationError = true"
+                 (initializeDone)="onCkeditorSetup($event)"
                  (saveRequested)="handleUserSubmit()"
                  >
     </op-ckeditor>

--- a/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component.html
@@ -5,6 +5,7 @@
                  (onContentChange)="onContentChange($event)"
                  (onInitializationFailed)="initializationError = true"
                  (onInitialized)="onCkeditorSetup($event)"
+                 (saveRequested)="handleUserSubmit()"
                  >
     </op-ckeditor>
   </div>

--- a/spec/features/work_packages/details/markdown/description_editor_spec.rb
+++ b/spec/features/work_packages/details/markdown/description_editor_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe 'description inplace editor', js: true, selenium: true do
       # Cancelling through the action panel
       field.cancel_by_click
       field.expect_inactive!
+
+      # Saving the field with ctrl+enter
+      field.activate!
+      field.set_value "Edit to be saved by keyboard"
+      field.submit_by_enter
+
+      wp_page.expect_toast message: I18n.t('js.notice_successful_update')
+      field.expect_state_text 'Edit to be saved by keyboard'
     end
   end
 

--- a/spec/support/edit_fields/text_editor_field.rb
+++ b/spec/support/edit_fields/text_editor_field.rb
@@ -49,6 +49,10 @@ class TextEditorField < EditField
     input_element.native.send_keys :tab
   end
 
+  def submit_by_enter
+    input_element.native.send_keys %i[control enter]
+  end
+
   def cancel_by_click
     target = field_container.find(control_link(:cancel), wait: 10)
     scroll_to_element(target)


### PR DESCRIPTION
Allow saving frontend ckeditor fields with ctrl+enter or cmd+enter (such as description fields, custom fields, comments, etc.)

https://community.openproject.org/work_packages/33375

To be clarified (by @psatyal or @marcalcobe perhaps?): Should this functionality work in wiki pages as well, were saving the field causes a full page request?