### PR TITLE
[#49096] Check explicitly if user is a project member before show the link to project folder in the menu.

### DIFF
--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -133,7 +133,7 @@ module OpenProject::Storages
            User.current.allowed_to?(:view_file_links, project)
           project.projects_storages.each do |project_storage|
             storage = project_storage.storage
-            href = if project_storage.project_folder_inactive?
+            href = if project_storage.project_folder_inactive? || !User.current.member_of?(project)
                      storage.host
                    else
                      ::Storages::Peripherals::StorageUrlHelper.storage_url_open_file(storage, project_storage.project_folder_id)

--- a/modules/storages/spec/features/storages_menu_links_spec.rb
+++ b/modules/storages/spec/features/storages_menu_links_spec.rb
@@ -28,7 +28,7 @@
 
 require_relative '../spec_helper'
 
-RSpec.describe 'Project menu', js: true do
+RSpec.describe 'Project menu', js: true, with_cuprite: true do
   let(:storage) { create(:storage, name: "Storage 1") }
   let(:another_storage) { create(:storage, name: "Storage 2") }
   let(:unlinked_storage) { create(:storage, name: "Storage 3") }
@@ -49,14 +49,31 @@ RSpec.describe 'Project menu', js: true do
     visit(project_path(project))
   end
 
-  it 'has links to enabled storages' do
-    visit(project_path(id: project.id))
+  context 'if user has permission to see storage links' do
+    it 'has links to enabled storages' do
+      visit(project_path(id: project.id))
 
-    expect(page).to have_link(storage.name, href: storage.host)
-    project_folder_id = project_storage_with_manual_folder.project_folder_id
-    folder_href = "#{another_storage.host}/index.php/f/#{project_folder_id}?openfile=1"
-    expect(page).to have_link(another_storage.name, href: folder_href)
-    expect(page).not_to have_link(unlinked_storage.name)
+      expect(page).to have_link(storage.name, href: storage.host)
+      project_folder_id = project_storage_with_manual_folder.project_folder_id
+      folder_href = "#{another_storage.host}/index.php/f/#{project_folder_id}?openfile=1"
+      expect(page).to have_link(another_storage.name, href: folder_href)
+      expect(page).not_to have_link(unlinked_storage.name)
+    end
+
+    context 'if user is an admin but not a member of the project' do
+      let(:user) { create(:admin) }
+
+      it 'has a link to enabled storage, but not to hidden for him project' do
+        visit(project_path(id: project.id))
+
+        expect(page).to have_link(storage.name, href: storage.host)
+        project_folder_id = project_storage_with_manual_folder.project_folder_id
+        folder_href = "#{another_storage.host}/index.php/f/#{project_folder_id}?openfile=1"
+        expect(page).not_to have_link(another_storage.name, href: folder_href)
+        expect(page).to have_link(another_storage.name, href: another_storage.host)
+        expect(page).not_to have_link(unlinked_storage.name)
+      end
+    end
   end
 
   context 'if user has no permission to see storage links' do


### PR DESCRIPTION
https://community.openproject.org/work_packages/49096

- In case an admin is not a member show the link to a storage root folder
- Add a test case
- Enable cuprite for `modules/storages/spec/features/storages_menu_links_spec.rb`