### PR TITLE
remove clear icon from project input on wp#move

### DIFF
--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -68,7 +68,8 @@ See COPYRIGHT and LICENSE files for more details.
                                                 name: 'new_project_id',
                                                 value: @target_project,
                                                 appendTo: 'body',
-                                                hiddenFieldAction: 'change->refresh-on-form-changes#triggerReload'
+                                                hiddenFieldAction: 'change->refresh-on-form-changes#triggerReload',
+                                                clearable: false,
                                               },
                                               id: 'new_project_id',
                                               class: 'remote-field--input',

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.html
@@ -10,6 +10,7 @@
   [labelForId]="labelForId"
 
   [dropdownPosition]="dropdownPosition"
+  [clearable]="clearable"
 
   [appendTo]="appendTo"
 

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -121,6 +121,8 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
 
   @Input() public hiddenFieldAction = '';
 
+  @Input() public clearable?:boolean = true;
+
   dataLoaded = false;
 
   projects:IProjectAutocompleteItem[];


### PR DESCRIPTION
Clearing the project doesn't make sense as the user chose the option to move the work packages to a different project.

https://community.openproject.org/projects/openproject/work_packages/49109