### PR TITLE
Prevent rendering of delete button on global calendars page

### DIFF
--- a/modules/calendar/app/components/calendar/row_component.rb
+++ b/modules/calendar/app/components/calendar/row_component.rb
@@ -51,7 +51,7 @@ module Calendar
     end
 
     def delete_link
-      if table.current_user.allowed_to?(:manage_calendars, project)
+      if render_delete_link?
         link_to(
           '',
           project_calendar_path(project, query.id),
@@ -64,6 +64,12 @@ module Calendar
           title: t(:button_delete)
         )
       end
+    end
+
+    private
+
+    def render_delete_link?
+      table.current_project && table.current_user.allowed_to?(:manage_calendars, project)
     end
   end
 end

--- a/modules/calendar/spec/features/calendars_index_spec.rb
+++ b/modules/calendar/spec/features/calendars_index_spec.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'spec_helper'
+require_relative '../support/pages/calendar'
 
 RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
   shared_let(:project) do
@@ -104,6 +105,7 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
   end
 
   context 'when visiting from a global context', with_flag: { more_global_index_pages: true } do
+    let(:calendars_page) { Pages::Calendar.new(nil) }
     let(:queries) { [query, other_query] }
 
     before do
@@ -114,7 +116,7 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
 
     context 'with permissions to globally manage calendars' do
       it 'shows no create button' do
-        expect(page).not_to have_selector '.button', text: 'Calendar'
+        calendars_page.expect_no_create_button
       end
     end
 
@@ -122,15 +124,15 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
       let(:queries) { [] }
 
       it 'shows an empty index page' do
-        expect(page).to have_text 'There is currently nothing to display.'
+        calendars_page.expect_no_views_visible
       end
     end
 
     context 'with existing views' do
       it 'shows those views', :aggregate_failures do
         queries.each do |q|
-          expect(page).to have_selector 'td', text: q.name
-          expect(page).to have_selector "[data-qa-selector='calendar-remove-#{q.id}']"
+          calendars_page.expect_view_visible(q)
+          calendars_page.expect_no_delete_button(q)
         end
       end
     end
@@ -147,17 +149,18 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
         let(:query) { create(:query, user:, project:, public: false) }
 
         it 'does not show a non-public view' do
-          expect(page).to have_text 'There is currently nothing to display.'
-          expect(page).not_to have_selector 'td', text: query.name
+          calendars_page.expect_no_views_visible
+          calendars_page.expect_view_not_visible query
 
-          # Does not show the delete
-          expect(page).not_to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+          calendars_page.expect_no_delete_button query
         end
       end
     end
   end
 
   context 'when visiting from a project-specific context' do
+    let(:calendars_page) { Pages::Calendar.new(project) }
+
     before do
       login_as current_user
       query
@@ -168,15 +171,15 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
       let(:query) { nil }
 
       it 'shows an empty index page' do
-        expect(page).to have_text 'There is currently nothing to display.'
-        expect(page).to have_selector '.button', text: 'Calendar'
+        calendars_page.expect_no_views_visible
+        calendars_page.expect_create_button
       end
     end
 
     context 'with an existing view' do
       it 'shows that view' do
-        expect(page).to have_selector 'td', text: query.name
-        expect(page).to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
+        calendars_page.expect_view_visible query
+        calendars_page.expect_delete_button query
       end
 
       context 'with another user with limited access' do
@@ -187,28 +190,21 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
                  member_with_permissions: %w[view_work_packages view_calendar])
         end
 
-        it 'does not show the create button' do
-          expect(page).to have_selector 'td', text: query.name
+        it 'does not show the management buttons' do
+          calendars_page.expect_view_visible query
 
-          # Does not show the delete
-          expect(page).not_to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
-
-          # Does not show the create button
-          expect(page).not_to have_selector '.button', text: 'Calendar'
+          calendars_page.expect_no_delete_button query
+          calendars_page.expect_no_create_button
         end
 
         context 'when the view is non-public' do
           let(:query) { create(:query, user:, project:, public: false) }
 
           it 'does not show a non-public view' do
-            expect(page).to have_text 'There is currently nothing to display.'
-            expect(page).not_to have_selector 'td', text: query.name
+            calendars_page.expect_no_views_visible
+            calendars_page.expect_view_not_visible query
 
-            # Does not show the delete
-            expect(page).not_to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
-
-            # Does not show the create button
-            expect(page).not_to have_selector '.button', text: 'Calendar'
+            calendars_page.expect_no_create_button
           end
         end
       end

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -111,5 +111,33 @@ module Pages
     def expect_wp_not_draggable(work_package)
       expect(page).to have_selector('.fc-event:not(.fc-event-draggable)', text: work_package.subject)
     end
+
+    def expect_create_button
+      expect(page).to have_selector '.button', text: 'Calendar'
+    end
+
+    def expect_no_create_button
+      expect(page).not_to have_selector '.button', text: 'Calendar'
+    end
+
+    def expect_delete_button(query)
+      expect(page).to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
+    end
+
+    def expect_no_delete_button(query)
+      expect(page).not_to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
+    end
+
+    def expect_no_views_visible
+      expect(page).to have_text 'There is currently nothing to display.'
+    end
+
+    def expect_view_visible(query)
+      expect(page).to have_selector 'td', text: query.name
+    end
+
+    def expect_view_not_visible(query)
+      expect(page).not_to have_selector 'td', text: query.name
+    end
   end
 end


### PR DESCRIPTION
As per requirements, the global index page for calendars, should not render the delete buttons for each query on the table (in tandem with other global index pages).

See: https://community.openproject.org/work_packages/47850/activity#activity-56

Also, extracted out some expectations into page objects in the calendars#index page. This reads nicer to me and helps keep better track of what is and isn't expected at a high level.