### PR TITLE
[#49143] Reorder items in the top menu in tandem with the global sidebar

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -39,6 +39,12 @@ Redmine::MenuManager.map :top_menu do |menu|
             if: Proc.new {
               (User.current.logged? || !Setting.login_required?)
             }
+
+  menu.push :activity,
+            { controller: '/activities', action: 'index' },
+            context: :modules,
+            icon: 'checkmark'
+
   menu.push :work_packages,
             { controller: '/work_packages', project_id: nil, state: nil, action: 'index' },
             context: :modules,

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -64,6 +64,8 @@ module OpenProject::Boards
            { controller: '/boards/boards', action: 'overview' },
            context: :modules,
            caption: :project_module_board_view,
+           before: :news,
+           after: :team_planners,
            icon: 'boards',
            if: should_render_global_menu_item
 

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -76,6 +76,7 @@ module OpenProject::Meeting
            :meetings, { controller: '/meetings', action: 'index', project_id: nil },
            context: :modules,
            caption: :label_meeting_plural,
+           last: true,
            icon: 'meetings',
            if: should_render_global_menu_item
 

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -74,6 +74,8 @@ module OpenProject::TeamPlanner
            :team_planners, { controller: '/team_planner/team_planner', action: :overview },
            context: :modules,
            caption: :'team_planner.label_team_planner_plural',
+           before: :boards,
+           after: :calendar_view,
            icon: 'team-planner',
            if: should_render_global_menu_item,
            enterprise_feature: 'team_planner_view'

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -31,7 +31,16 @@ RSpec.describe Redmine::MenuManager do
     context 'for the top_menu' do
       it 'includes the expected items' do
         expect(described_class.items(:top_menu).map(&:name))
-          .to include(:work_packages, :news, :help)
+          .to include(:projects,
+                      :activity,
+                      :work_packages,
+                      :calendar_view,
+                      :team_planners,
+                      :boards,
+                      :news,
+                      :cost_reports_global,
+                      :meetings,
+                      :help)
       end
     end
 


### PR DESCRIPTION
See: https://community.openproject.org/work_packages/49143

**NOTE**: The examples for the `top_menu_items_spec` and the `menu_manager_spec` were somewhat incomplete with the list of modules we currently maintain.  For completeness-sake, added some specs to better cover these features.