### PR TITLE
(fix): Keep project filters section hidden when using predefined filters from sidebar

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -29,8 +29,8 @@
 module ProjectsHelper
   include WorkPackagesFilterHelper
 
-  def filter_set?
-    params[:filters].present?
+  def show_filters_section?
+    params[:filters].present? && !params.key?(:hide_filters_section)
   end
 
   def allowed_filters(query)
@@ -127,7 +127,7 @@ module ProjectsHelper
   def projects_path_with_filters(filters)
     return projects_path if filters.empty?
 
-    projects_path(filters: filters.to_json)
+    projects_path(filters: filters.to_json, hide_filters_section: true)
   end
 
   def global_menu_item_css_class(path)

--- a/app/views/projects/filters/_form.html.erb
+++ b/app/views/projects/filters/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag({},
              method: :get,
-             class: "project-filters #{filter_set? ? '-expanded' : ''}",
+             class: "project-filters #{show_filters_section? ? '-expanded' : ''}",
              data: {
                'project-target': 'filterForm',
                action: 'submit->project#sendForm:prevent'

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <li class="toolbar-item">
       <button title="<%= t(:label_filters_toggle) %>"
-              class="button toolbar-icon <%= filter_set? ? '-active' : '' %>"
+              class="button toolbar-icon <%= show_filters_section? ? '-active' : '' %>"
               data-project-target="filterFormToggle"
               data-action="project#toggleFilterForm">
         <%= op_icon("icon-filter button--icon") %>

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe 'Projects index page',
                                              public_project,
                                              development_project)
 
-        expect(page).to have_selector('li[filter-name="active"]', visible: :hidden)
+        projects_page.expect_filters_container_hidden
+        projects_page.expect_filter_set 'active'
       end
     end
 
@@ -251,7 +252,8 @@ RSpec.describe 'Projects index page',
         projects_page.expect_projects_listed(project)
         projects_page.expect_projects_not_listed(public_project, development_project)
 
-        expect(page).to have_selector('li[filter-name="active"]', visible: :hidden)
+        projects_page.expect_filters_container_hidden
+        projects_page.expect_filter_set 'member_of'
       end
     end
 
@@ -265,7 +267,8 @@ RSpec.describe 'Projects index page',
         projects_page.expect_projects_not_listed(project,
                                                  development_project)
 
-        expect(page).to have_selector('li[filter-name="public"]')
+        projects_page.expect_filters_container_hidden
+        projects_page.expect_filter_set 'public'
       end
     end
 
@@ -287,7 +290,8 @@ RSpec.describe 'Projects index page',
                                                  project,
                                                  development_project)
 
-        expect(page).to have_selector('li[filter-name="active"]')
+        projects_page.expect_filters_container_hidden
+        projects_page.expect_filter_set 'active'
       end
     end
   end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -68,6 +68,19 @@ module Pages
         end
       end
 
+      def expect_filters_container_toggled
+        expect(page).to have_selector('form.project-filters')
+      end
+
+      def expect_filters_container_hidden
+        expect(page).to have_selector('form.project-filters', visible: :hidden)
+      end
+
+      def expect_filter_set(filter_name)
+        expect(page).to have_selector("li[filter-name='#{filter_name}']:not(.hidden)",
+                                      visible: :hidden)
+      end
+
       def filter_by_active(value)
         set_filter('active',
                    'Active',


### PR DESCRIPTION
As per requirements and the highlight presented [here](https://community.openproject.org/projects/openproject/work_packages/47850/activity#activity-61), ensuring that the filters section remains hidden when using the filters from the sidebar.

Added some specs to demonstrate the undesired behavior and the subsequent code that fulfills the expectations.

**Demo:** Hidden sidebar when clicking on sidebar item, followed by a demonstration of the filter being set on the filters section

![hidden_sidebar_demo](https://github.com/opf/openproject/assets/61627014/12666c56-a0bd-4f28-9ebc-21c345da0e31)
