### PR TITLE
Fix WikiPage#destroy when destroying child, then parent

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -93,6 +93,18 @@ class WikiPage < ApplicationRecord
     title.to_localized_slug(locale: :en)
   end
 
+  # Using a hook will not allow us to retry the call
+  # rubocop:disable Rails/ActiveRecordOverride
+  def destroy
+    super
+  rescue ActiveRecord::StaleObjectError
+    # Due to closure_tree, parent_id might have changed
+    # when destroying all wiki pages
+    reload
+    super
+  end
+  # rubocop:enable Rails/ActiveRecordOverride
+
   def delete_wiki_menu_item
     menu_item&.destroy
     # ensure there is a menu item for the wiki


### PR DESCRIPTION
Stumbled upon that while destroying all wiki pages of a project. Steps to reproduce:

- Create two wiki pages A and B
- make B parent of A
- Destroy the entire project