### PR TITLE
Journal the addition and removal of File Links on Work Packages

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -151,6 +151,10 @@ class Journal < ApplicationRecord
 
   private
 
+  def has_file_links?
+    journable.respond_to?(:file_links)
+  end
+
   def predecessor
     @predecessor ||= if initial?
                        nil

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -51,6 +51,7 @@ class Journal < ApplicationRecord
   register_journal_formatter :wiki_diff, OpenProject::JournalFormatter::WikiDiff
   register_journal_formatter :time_entry_named_association, OpenProject::JournalFormatter::TimeEntryNamedAssociation
   register_journal_formatter :cause, OpenProject::JournalFormatter::Cause
+  register_journal_formatter :file_link, OpenProject::JournalFormatter::FileLink
 
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related
   # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB
@@ -74,6 +75,7 @@ class Journal < ApplicationRecord
 
   has_many :attachable_journals, class_name: 'Journal::AttachableJournal', dependent: :delete_all
   has_many :customizable_journals, class_name: 'Journal::CustomizableJournal', dependent: :delete_all
+  has_many :storable_journals, class_name: 'Journal::StorableJournal', dependent: :delete_all
 
   has_many :notifications, dependent: :destroy
 

--- a/app/models/journal/storable_journal.rb
+++ b/app/models/journal/storable_journal.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Journal::StorableJournal < Journal::AssociatedJournal
+  self.table_name = 'storages_file_links_journals'
+
+  belongs_to :file_link, class_name: 'Storages::FileLink'
+end

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -86,6 +86,7 @@ module WorkPackage::Journalized
     register_journal_formatted_fields(:custom_field, /custom_fields_\d+/)
     register_journal_formatted_fields(:ignore_non_working_days, 'ignore_non_working_days')
     register_journal_formatted_fields(:cause, 'cause')
+    register_journal_formatted_fields(:file_link, /file_links_?\d+/)
 
     # Joined
     register_journal_formatted_fields :named_association, :parent_id, :project_id,

--- a/db/migrate/20230713144232_create_storages_file_link_journals.rb
+++ b/db/migrate/20230713144232_create_storages_file_link_journals.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CreateStoragesFileLinkJournals < ActiveRecord::Migration[7.0]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :storages_file_links_journals do |t|
+      t.belongs_to :journal
+      t.belongs_to :file_link
+
+      t.string :link_name, default: ''
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+  end
+end

--- a/db/migrate/20230713144232_create_storages_file_link_journals.rb
+++ b/db/migrate/20230713144232_create_storages_file_link_journals.rb
@@ -32,10 +32,10 @@ class CreateStoragesFileLinkJournals < ActiveRecord::Migration[7.0]
   def change
     # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :storages_file_links_journals do |t|
-      t.belongs_to :journal
-      t.belongs_to :file_link
+      t.belongs_to :journal, null: false, foreign_key: true
+      t.belongs_to :file_link, null: false
 
-      t.string :link_name, default: ''
+      t.string :link_name, null: false
     end
     # rubocop:enable Rails/CreateTableWithTimestamps
   end

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -38,6 +38,7 @@ module API
             journals = @work_package.journals.includes(:data,
                                                        :customizable_journals,
                                                        :attachable_journals,
+                                                       :storable_journals,
                                                        :bcf_comment)
 
             Activities::ActivityCollectionRepresenter.new(journals,

--- a/lib/api/v3/activities/activity_eager_loading_wrapper.rb
+++ b/lib/api/v3/activities/activity_eager_loading_wrapper.rb
@@ -135,7 +135,7 @@ module API
                   ) AS journals
                 SQL
               )
-              .includes(:attachable_journals, :customizable_journals)
+              .includes(:attachable_journals, :customizable_journals, :storable_journals)
           end
         end
       end

--- a/lib/open_project/journal/attachment_helper.rb
+++ b/lib/open_project/journal/attachment_helper.rb
@@ -35,6 +35,13 @@ module OpenProject
           save
         end
       end
+
+      def file_links_changed(_obj)
+        unless new_record?
+          add_journal
+          save
+        end
+      end
     end
   end
 end

--- a/lib/open_project/journal/attachment_helper.rb
+++ b/lib/open_project/journal/attachment_helper.rb
@@ -35,13 +35,6 @@ module OpenProject
           save
         end
       end
-
-      def file_links_changed(_obj)
-        unless new_record?
-          add_journal
-          save
-        end
-      end
     end
   end
 end

--- a/lib/open_project/journal_formatter/file_link.rb
+++ b/lib/open_project/journal_formatter/file_link.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OpenProject::JournalFormatter::FileLink < JournalFormatter::Base
+  include OpenProject::ObjectLinking
+
+  def render(key, values, options = { html: true })
+    id = key.to_s.sub('file_links_', '')
+    label, old_value, value = format_details(id, values)
+
+    if options[:html]
+      label, old_value, value = *format_html_details(label, old_value, value)
+      value = format_html_file_link_detail(id, value)
+    end
+
+    render_binary_detail_text(label, value, old_value)
+  end
+
+  private
+
+  # Based this off the Attachment formatter. Not sure if it is the best approach
+  def label(_key) = Storages::FileLink.model_name.human
+
+  def format_html_file_link_detail(key, value)
+    if value.present? && a = ::Storages::FileLink.find_by(id: key.to_i)
+      link_to_file_link(a, only_path: false)
+    elsif value.present?
+      value
+    end
+  end
+end

--- a/lib/open_project/journal_formatter/file_link.rb
+++ b/lib/open_project/journal_formatter/file_link.rb
@@ -49,8 +49,8 @@ class OpenProject::JournalFormatter::FileLink < JournalFormatter::Base
   def label(_key) = Storages::FileLink.model_name.human
 
   def format_html_file_link_detail(key, value)
-    if value.present? && a = ::Storages::FileLink.find_by(id: key.to_i)
-      link_to_file_link(a, only_path: false)
+    if value.present? && file_link = ::Storages::FileLink.find_by(id: key.to_i)
+      link_to_file_link(file_link, only_path: false)
     elsif value.present?
       value
     end

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -79,6 +79,14 @@ module OpenProject
               options
     end
 
+    def link_to_file_link(file_link, options = {})
+      text = options.delete(:text) || file_link.origin_name
+
+      link_to text,
+              url_to_file_link(file_link, only_path: options.delete(:only_path) { true }),
+              options
+    end
+
     # Generates a link to a SCM revision
     # Options:
     # * :text - Link text (default to the formatted revision)
@@ -145,6 +153,16 @@ module OpenProject
         v3_paths.attachment_content(attachment.id)
       else
         v3_paths.url_for(:attachment_content, attachment.id)
+      end
+    end
+
+    def url_to_file_link(file_link, only_path: true)
+      v3_paths = API::V3::Utilities::PathHelper::ApiV3Path
+
+      if only_path
+        v3_paths.file_link_open(file_link.id)
+      else
+        v3_paths.url_for(:file_link_open, file_link.id)
       end
     end
   end

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -146,9 +146,6 @@ module OpenProject
     end
 
     def url_to_attachment(attachment, only_path: true)
-      # Including the module breaks the application in strange and mysterious ways
-      v3_paths = API::V3::Utilities::PathHelper::ApiV3Path
-
       if only_path
         v3_paths.attachment_content(attachment.id)
       else
@@ -157,13 +154,16 @@ module OpenProject
     end
 
     def url_to_file_link(file_link, only_path: true)
-      v3_paths = API::V3::Utilities::PathHelper::ApiV3Path
-
       if only_path
         v3_paths.file_link_open(file_link.id)
       else
         v3_paths.url_for(:file_link_open, file_link.id)
       end
+    end
+
+    def v3_paths
+      # Including the module breaks the application in strange and mysterious ways
+      API::V3::Utilities::PathHelper::ApiV3Path
     end
   end
 end

--- a/lib_static/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib_static/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -190,6 +190,10 @@ module Redmine
               (persisted? && allowed_to_on_attachment?(user, self.class.attachable_options[:add_on_persisted_permission]))
           end
 
+          def attachable?
+            true
+          end
+
           private
 
           def allowed_to_on_attachment?(user, permissions)
@@ -242,6 +246,10 @@ module Redmine
             attachments_claimed.any?(&:containered?)
           end
         end
+      end
+
+      def attachable?
+        false
       end
     end
   end

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -64,6 +64,10 @@ module Redmine
           base.extend HumanAttributeName
         end
 
+        def customizable?
+          true
+        end
+
         def available_custom_fields
           self.class.available_custom_fields(self)
         end
@@ -408,6 +412,10 @@ module Redmine
             end
           end
         end
+      end
+
+      def customizable?
+        false
       end
     end
   end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -39,7 +39,7 @@ module JournalChanges
       @changes.merge!(subsequent_journal_data_changes)
     end
 
-    if journable.attachable?
+    if journable&.attachable?
       @changes.merge!(get_association_changes(
                         predecessor,
                         'attachable',
@@ -49,7 +49,7 @@ module JournalChanges
                       ))
     end
 
-    if journable.customizable?
+    if journable&.customizable?
       @changes.merge!(get_association_changes(
                         predecessor,
                         'customizable',

--- a/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -41,6 +41,7 @@ module JournalChanges
 
     @changes.merge!(get_association_changes(predecessor, 'attachable', 'attachments', :attachment_id, :filename))
     @changes.merge!(get_association_changes(predecessor, 'customizable', 'custom_fields', :custom_field_id, :value))
+    @changes.merge!(get_association_changes(predecessor, 'storable', 'file_links', :file_link_id, :link_name))
 
     @changes
   end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -39,9 +39,35 @@ module JournalChanges
       @changes.merge!(subsequent_journal_data_changes)
     end
 
-    @changes.merge!(get_association_changes(predecessor, 'attachable', 'attachments', :attachment_id, :filename))
-    @changes.merge!(get_association_changes(predecessor, 'customizable', 'custom_fields', :custom_field_id, :value))
-    @changes.merge!(get_association_changes(predecessor, 'storable', 'file_links', :file_link_id, :link_name))
+    if journable.attachable?
+      @changes.merge!(get_association_changes(
+                        predecessor,
+                        'attachable',
+                        'attachments',
+                        :attachment_id,
+                        :filename
+                      ))
+    end
+
+    if journable.customizable?
+      @changes.merge!(get_association_changes(
+                        predecessor,
+                        'customizable',
+                        'custom_fields',
+                        :custom_field_id,
+                        :value
+                      ))
+    end
+
+    if has_file_links?
+      @changes.merge!(get_association_changes(
+                        predecessor,
+                        'storable',
+                        'file_links',
+                        :file_link_id,
+                        :link_name
+                      ))
+    end
 
     @changes
   end

--- a/modules/storages/app/models/storages/file_link.rb
+++ b/modules/storages/app/models/storages/file_link.rb
@@ -45,7 +45,7 @@ class Storages::FileLink < ApplicationRecord
   # The object who created the FileLink should be of type User.
   belongs_to :creator, class_name: 'User'
 
-  # FileLinks are attached to a container ()currently a WorkPackage)
+  # FileLinks are attached to a container (currently a WorkPackage)
   # Wieland: This needs to become more flexible in the future
   belongs_to :container, polymorphic: true
 

--- a/modules/storages/app/services/storages/file_links/create_service.rb
+++ b/modules/storages/app/services/storages/file_links/create_service.rb
@@ -47,7 +47,7 @@ class Storages::FileLinks::CreateService < BaseServices::Create
     return service_result unless container&.class&.journaled?
 
     # If journal creation fails, we don't care for now
-    Journals::CreateService.new(container, service_result.result.creator).call
+    container.save_journals
 
     service_result
   end

--- a/modules/storages/app/services/storages/file_links/create_service.rb
+++ b/modules/storages/app/services/storages/file_links/create_service.rb
@@ -39,6 +39,19 @@ class Storages::FileLinks::CreateService < BaseServices::Create
 
   private
 
+  def after_perform(service_result)
+    # This only gets called if service_result is successful
+    container = service_result.result.container
+
+    # If the container isn't journaled, no need to proceed
+    return service_result unless container&.class&.journaled?
+
+    # If journal creation fails, we don't care for now
+    Journals::CreateService.new(container, service_result.result.creator).call
+
+    service_result
+  end
+
   def find_existing(file_link)
     Storages::FileLink.find_by(
       origin_id: file_link.origin_id,

--- a/modules/storages/app/services/storages/file_links/delete_service.rb
+++ b/modules/storages/app/services/storages/file_links/delete_service.rb
@@ -37,7 +37,7 @@ module Storages
         return service_result unless container&.class&.journaled?
 
         # We don't care if the journal creation fails for now.
-        Journals::CreateService.new(container, service_result.result.creator).call
+        container.save_journals
 
         service_result
       end

--- a/modules/storages/app/services/storages/file_links/delete_service.rb
+++ b/modules/storages/app/services/storages/file_links/delete_service.rb
@@ -30,6 +30,17 @@
 module Storages
   module FileLinks
     class DeleteService < ::BaseServices::Delete
+      def after_perform(service_result)
+        container = service_result.result.container
+
+        # No need to continue if container isn't journaled.
+        return service_result unless container&.class&.journaled?
+
+        # We don't care if the journal creation fails for now.
+        Journals::CreateService.new(container, service_result.result.creator).call
+
+        service_result
+      end
     end
   end
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
 
   activerecord:
     models:
+      file_link: "File link"
       storages/storage: "Storage"
     attributes:
       storages/storage:

--- a/modules/storages/spec/services/storages/file_links/create_service_spec.rb
+++ b/modules/storages/spec/services/storages/file_links/create_service_spec.rb
@@ -33,4 +33,22 @@ RSpec.describe Storages::FileLinks::CreateService, type: :model do
   it_behaves_like 'BaseServices create service' do
     let(:factory) { :file_link }
   end
+
+  it 'creates a journal entry for its container' do
+    project_storage = create(:project_storage)
+
+    storage = project_storage.storage
+    project = project_storage.project
+
+    work_package = create(:work_package, project:)
+    user = create(:admin)
+
+    service = described_class.new(user:, contract_class: Storages::FileLinks::CreateContract)
+    params = { creator: user, container: work_package, origin_id: 200, origin_name: 'bob_the_fake_file.png', storage: }
+
+    expect do
+      result = service.call(params)
+      expect(result).to be_success
+    end.to change(Journal, :count).by(1)
+  end
 end

--- a/modules/storages/spec/services/storages/file_links/delete_service_spec.rb
+++ b/modules/storages/spec/services/storages/file_links/delete_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Storages::FileLinks::DeleteService, type: :model do
     let(:factory) { :file_link }
   end
 
-  it 'creates a journal entry for its container' do
+  it 'creates a journal entry for its container', with_settings: { journal_aggregation_time_minutes: 0 } do
     project_storage = create(:project_storage)
     work_package = create(:work_package, project: project_storage.project)
     file_link = create(:file_link, container: work_package, storage: project_storage.storage)

--- a/modules/storages/spec/services/storages/file_links/delete_service_spec.rb
+++ b/modules/storages/spec/services/storages/file_links/delete_service_spec.rb
@@ -24,6 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
+#
 #++
 
 require 'spec_helper'
@@ -32,5 +33,23 @@ require 'services/base_services/behaves_like_delete_service'
 RSpec.describe Storages::FileLinks::DeleteService, type: :model do
   it_behaves_like 'BaseServices delete service' do
     let(:factory) { :file_link }
+  end
+
+  it 'creates a journal entry for its container' do
+    project_storage = create(:project_storage)
+    work_package = create(:work_package, project: project_storage.project)
+    file_link = create(:file_link, container: work_package, storage: project_storage.storage)
+
+    user = create(:admin)
+    service = described_class.new(model: file_link, user:, contract_class: Storages::FileLinks::DeleteContract)
+    params = { id: file_link.id }
+
+    # We need a previous entry that added the file link to record the removal
+    Journals::CreateService.new(work_package, user).call
+
+    expect do
+      result = service.call(params)
+      expect(result).to be_success
+    end.to change(Journal, :count).by(1)
   end
 end

--- a/spec/lib/journal_formatter/file_link_spec.rb
+++ b/spec/lib/journal_formatter/file_link_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe OpenProject::JournalFormatter::FileLink do
+  let(:work_package) { create(:work_package) }
+  let(:journal) { instance_double(Journal, journable: work_package) }
+  let(:file_link) { create(:file_link, container: work_package) }
+  let(:key) { "file_links_#{file_link.id}" }
+
+  subject(:instance) { described_class.new(journal) }
+
+  describe '#render' do
+    context 'having the first value being nil, and the second an file link name as string' do
+      context 'as HTML' do
+        it 'adds a file link added text' do
+          link = "#{Setting.protocol}://#{Setting.host_name}/api/v3/file_links/#{file_link.id}/open"
+          expect(instance.render(key, [nil, file_link.origin_name]))
+            .to eq(I18n.t(:text_journal_added,
+                          label: "<strong>#{I18n.t(:'activerecord.models.file_link')}</strong>",
+                          value: "<a href=\"#{link}\">#{file_link.origin_name}</a>"))
+        end
+
+        context 'with a configured relative url root' do
+          before { allow(OpenProject::Configuration).to receive(:rails_relative_url_root).and_return('/blubs') }
+
+          it 'adds an file link added text' do
+            link = "#{Setting.protocol}://#{Setting.host_name}/blubs/api/v3/file_links/#{file_link.id}/open"
+            expect(instance.render(key, [nil, file_link.origin_name]))
+              .to eq(I18n.t(:text_journal_added,
+                            label: "<strong>#{I18n.t(:'activerecord.models.file_link')}</strong>",
+                            value: "<a href=\"#{link}\">#{file_link.origin_name}</a>"))
+          end
+        end
+      end
+
+      context 'as plain text' do
+        it 'adds a file link added text' do
+          message = I18n.t(:text_journal_added,
+                           label: I18n.t(:'activerecord.models.file_link'),
+                           value: file_link.id)
+
+          expect(instance.render(key, [nil, file_link.id.to_s], html: false)).to eq(message)
+        end
+      end
+    end
+
+    context 'having the first value being an id as string, and the second nil' do
+      context 'as HTML' do
+        it 'adds a file link remove text' do
+          message = I18n.t(:text_journal_deleted,
+                           label: "<strong>#{I18n.t(:'activerecord.models.file_link')}</strong>",
+                           old: "<strike><i>#{file_link.id}</i></strike>")
+
+          expect(instance.render(key, [file_link.id.to_s, nil])).to eq(message)
+        end
+      end
+
+      context 'as plain text' do
+        it 'adds a file link removed' do
+          message = I18n.t(:text_journal_deleted, label: Storages::FileLink.model_name.human, old: file_link.id)
+
+          expect(instance.render(key, [file_link.id.to_s, nil], html: false)).to eq(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
         include_context 'create activity'
       end
 
-      context 'with an errorenous work package' do
+      context 'with an erroneous work package' do
         before do
           work_package.subject = ''
           work_package.save!(validate: false)


### PR DESCRIPTION
###### Original ticket: https://community.openproject.org/projects/openproject/work_packages/42368

###### Disclaimer: This feature send me on multiple wild goose chases with a lot of dead ends, which was fun. xD


### Activities ☑️ 

With the context from the issue, first question is: what constitutes an **Activity**? Any changes of the state to the object of interest. A file added, an assignee added, the creation of the object itself from the aether.

#### How does it work? ⚙️ 

Internally, every activity is an entry in the `Journal` model. Every new object there, has a version attached to it and we compare different versions against each other to create the activities. Each of these changes are a `detail` in `Journal` parlance.

The actual mechanism of the comparison is kinda cool, but I'll leave you to explore that.

So, for `WorkPackage`s (or for any `journalized` model) every time changes happen and are saved to the database, a new `Journal` entry is created that points to the specialized `Journal` model for that object. The specialized `Journal` (`Journal::WorkPackageJournal` in this case) it snapshots the model at the time of saving.

When a `journalized` record is removed, so are all its journal entries.

### Attachments 📋 

Attachments aren't properly an attribute of `WorkPackage` but an associated model. Also, if when you destroy an object, the journal entries go with it, so how does it show the added and removed files on screen (or via the API)?

For those there's a couple of tricks. The `Journals::CreateService` instead of relying on the `Journal::AttachmentJournal` it creates a special type of journal called `Journal::AttachableJournal` that points to an `Attachment` and version of the `Journal` that itself points to the `Journal::WorkPackageJournal`.

When you remove the `Attachment` another `WorkPackageJournal`is added without the `AttachableJournal`, thus making the diff between the records show that the previous file was missing.

All this behaviour is dealt with within the `Journal::CreateService` massive SQL.

## The Solution 🧪 

I've tried to mimic the behaviour already existing by introducing the `Journal::StorableJournal` (yeah, I'm terrible at naming) that will behave exactly as the `Journal::AttachableJournal`. This meant editing the SQL inside the `Journal::CreateService` and adding the necessary queries.

Besides this, I had to add calls to the `Journal::CreateService` on both of our `...FileLink::CreateService` and `...FileLink::DeleteService`. The code is identical, but it felt like overkill to just create another abstraction for it (cue in Sandy Metz "the wrong abstraction is worse than repetition").

I also needed to add a formatter for our `file_links` on the `Journal`. This will allow us to change the rendered templates easily if needed. Besides this there was only a couple of touch-ups on other files to eager-load the new records.