### PR TITLE
[#35804] CFs marked as searchable are so globally and even if they aren't filters

### DIFF
--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -75,19 +75,18 @@ class Queries::WorkPackages::Filter::SearchFilter <
     # Does not remove custom fields that are not marked as filters
     # as the intend of this filter is to search and it is used in the
     # search context. Thus, only the searchable flag is of interest.
-    custom_fields =
-      if context&.project
-        context.project.all_work_package_custom_fields.select do |custom_field|
-          %w(text string).include?(custom_field.field_format) &&
-            custom_field.searchable == true
-        end
-      else
-        ::WorkPackageCustomField
-          .where(field_format: %w(text string),
-                 searchable: true)
-      end
+    custom_fields = if context&.project
+                      context
+                        .project
+                        .all_work_package_custom_fields
+                    else
+                      ::WorkPackageCustomField
+                    end
 
-    custom_fields.map do |custom_field|
+    custom_fields
+      .where(field_format: %w(text string),
+             searchable: true)
+      .map do |custom_field|
       Queries::WorkPackages::Filter::FilterConfiguration.new(
         Queries::WorkPackages::Filter::CustomFieldFilter,
         custom_field.column_name,

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -82,7 +82,6 @@ class Queries::WorkPackages::Filter::SearchFilter <
       else
         ::WorkPackageCustomField
           .filter
-          .for_all
           .where(field_format: %w(text string),
                  is_filter: true,
                  searchable: true)

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -72,18 +72,18 @@ class Queries::WorkPackages::Filter::SearchFilter <
   end
 
   def custom_field_configurations
+    # Does not remove custom fields that are not marked as filters
+    # as the intend of this filter is to search and it is used in the
+    # search context. Thus, only the searchable flag is of interest.
     custom_fields =
       if context&.project
         context.project.all_work_package_custom_fields.select do |custom_field|
           %w(text string).include?(custom_field.field_format) &&
-            custom_field.is_filter == true &&
             custom_field.searchable == true
         end
       else
         ::WorkPackageCustomField
-          .filter
           .where(field_format: %w(text string),
-                 is_filter: true,
                  searchable: true)
       end
 

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -28,16 +28,12 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Search', js: true, with_mail: false, with_settings: { per_page_options: '5' } do
+RSpec.describe 'Search', js: true, with_settings: { per_page_options: '5' } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   shared_let(:admin) { create(:admin) }
-  let(:user) { admin }
-  let(:project) { create(:project) }
-  let(:searchable) { true }
-  let(:is_filter) { true }
-
-  let!(:work_packages) do
+  shared_let(:project) { create(:project) }
+  shared_let(:work_packages) do
     (1..12).map do |n|
       Timecop.freeze("2016-11-21 #{n}:00".to_datetime) do
         subject = "Subject No. #{n} WP"
@@ -47,6 +43,11 @@ RSpec.describe 'Search', js: true, with_mail: false, with_settings: { per_page_o
       end
     end
   end
+
+  let(:user) { admin }
+  let(:searchable) { true }
+  let(:is_filter) { true }
+
   let(:custom_field_text_value) { 'cf text value' }
   let!(:custom_field_text) do
     create(:text_wp_custom_field,
@@ -202,7 +203,7 @@ RSpec.describe 'Search', js: true, with_mail: false, with_settings: { per_page_o
         end
       end
 
-      context 'as custom fields are searchable' do
+      context 'when custom fields are searchable' do
         it "finds WP global custom fields" do
           select_autocomplete(page.find('.top-menu-search--input'),
                               query: "string",
@@ -211,6 +212,16 @@ RSpec.describe 'Search', js: true, with_mail: false, with_settings: { per_page_o
           table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.expect_work_package_subject(work_packages[1].subject)
+        end
+
+        it "finds WP non global custom fields" do
+          select_autocomplete(page.find('.top-menu-search--input'),
+                              query: "text",
+                              select_text: "In all projects ↵",
+                              wait_dropdown_open: false)
+          table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
+          table.ensure_work_package_not_listed!(work_packages[1])
+          table.expect_work_package_subject(work_packages[0].subject)
         end
       end
 

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -192,14 +192,24 @@ RSpec.describe 'Search', js: true, with_settings: { per_page_options: '5' } do
       context 'as custom fields are no filters' do
         let(:is_filter) { false }
 
-        it "does not find WP via custom fields" do
+        it "finds WP global custom fields" do
+          select_autocomplete(page.find('.top-menu-search--input'),
+                              query: "string",
+                              select_text: "In all projects ↵",
+                              wait_dropdown_open: false)
+          table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
+          table.ensure_work_package_not_listed!(work_packages[0])
+          table.expect_work_package_subject(work_packages[1].subject)
+        end
+
+        it "finds WP non global custom fields" do
           select_autocomplete(page.find('.top-menu-search--input'),
                               query: "text",
                               select_text: "In all projects ↵",
                               wait_dropdown_open: false)
           table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
-          table.ensure_work_package_not_listed!(work_packages[0])
           table.ensure_work_package_not_listed!(work_packages[1])
+          table.expect_work_package_subject(work_packages[0].subject)
         end
       end
 


### PR DESCRIPTION
Includes two changes to searchable custom fields:
* They don't have to filters as well for them to be included in the `search_filter`. While the name implies it to be a filter it is actually used in the context of the search. On top of that, if the two attributes would be required to be true in lockstep, it does not have any benefits of having the two fields as separate entities.
* A searchable custom field is also active in the global context. It no longer has to be marked to be active in all projects to be considered in the search. This will decrease the performance of the search in case there are a lot of searchable custom fields. This drawback might have to be addressed later depending on user feedback. This part addresses https://community.openproject.org/wp/35804 