### PR TITLE
Also allow saving with CTRL/CMD+enter on rails forms

### DIFF
--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -15,12 +15,13 @@ Starting with version 8.0.0, OpenProject features a quasi-WYSIWYG editor, powere
 
 
 
-| Topic                                                                                                                       | Content                                                  |
-|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| [Basic formatting](#basic-formatting)                                                                                       | Basic formatting elements in the WYSIWYG editor          |
-| [Image handling](#image-handling)                                                                                           | How to add images in the WYSIWYG editor.                 |
-| [Macros](#macros)                                                                                                           | Available macros in the WYSIWYG editor                   |
-| [Links to OpenProject resources](#links-to-openproject-resources)                                                           | How to link to resources like wikis, projects, meetings. |
+| Topic                                                        | Content                                                  |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| [Basic formatting](#basic-formatting)                        | Basic formatting elements in the WYSIWYG editor          |
+| [Image handling](#image-handling)                            | How to add images in the WYSIWYG editor.                 |
+| [Keyboard shortcuts](#keyboard-shortcuts)                    | Working with keyboard shortcuts in the WYSIWYG editor.   |
+| [Macros](#macros)                                            | Available macros in the WYSIWYG editor                   |
+| [Links to OpenProject resources](#links-to-openproject-resources) | How to link to resources like wikis, projects, meetings. |
 | [Embedding of work package attributes and project attributes](#embedding-of-work-package-attributes-and-project-attributes) | How to embed attributes and attribute help texts.        |
 
 ## Basic formatting
@@ -73,7 +74,17 @@ The image will be automatically uploaded and stored as an attachment. You can ad
 
 ![resize-imagesshort](resize-imagesshort.gif)
 
- 
+
+
+## Keyboard shortcuts 
+
+CKEditor has a wide variety of keyboard shortcuts you can use. You can find a list of documented shortcuts here: [https://ckeditor.com/docs/ckeditor5/latest/features/keyboard-support.html](https://ckeditor.com/docs/ckeditor5/latest/features/keyboard-support.html).
+
+On top of that, OpenProject adds the following shortcut:
+
+| Shortcut (Windows / Linux) | Shortcut (Mac) | Action                                                       |
+| -------------------------- | -------------- | ------------------------------------------------------------ |
+| CTRL + ENTER               | CMD + ENTER    | **Save changes.** <br />For inline-editable fields, save the field and close it.<br />For pages with a full WYSIWYG (meetings, wiki pages), submit the form. |
 
 ## Macros
 

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -27,7 +27,8 @@
 //++
 
 import {
-  Component, ElementRef, OnInit, ViewChild,
+  ChangeDetectionStrategy,
+  Component, ElementRef, Input, OnInit, ViewChild,
 } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -41,30 +42,41 @@ import {
 } from 'core-app/shared/components/editor/components/ckeditor/ckeditor-setup.service';
 import { OpCkeditorComponent } from 'core-app/shared/components/editor/components/ckeditor/op-ckeditor.component';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
-import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin'; import {
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
+import {
   ICKEditorContext,
   ICKEditorInstance,
 } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
+import { fromEvent } from 'rxjs';
+import { AttachmentCollectionResource } from 'core-app/features/hal/resources/attachment-collection-resource';
+import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 
 export const ckeditorAugmentedTextareaSelector = 'ckeditor-augmented-textarea';
 
 @Component({
   selector: ckeditorAugmentedTextareaSelector,
   templateUrl: './ckeditor-augmented-textarea.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin implements OnInit {
-  public textareaSelector:string;
+  @Input() public textareaSelector:string;
 
-  public previewContext:string;
+  @Input() public previewContext:string;
+
+  @Input() public macros:boolean;
+
+  @Input() public resource?:object;
+
+  @Input() public editorType:ICKEditorType = 'full';
 
   // Which template to include
-  public $element:JQuery;
+  public element:HTMLElement;
 
-  public formElement:JQuery;
+  public formElement:HTMLFormElement;
 
-  public wrappedTextArea:JQuery;
+  public wrappedTextArea:HTMLTextAreaElement;
 
-  public $attachmentsElement:JQuery;
+  public attachmentsElement:HTMLElement;
 
   // Remember if the user changed
   public changed = false;
@@ -75,11 +87,9 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   public readOnly = false;
 
-  public resource?:HalResource;
+  public halResource?:HalResource&{ attachments:AttachmentCollectionResource };
 
   public context:ICKEditorContext;
-
-  public macros:boolean;
 
   public text = {
     attachments: this.I18n.t('js.label_attachments'),
@@ -90,10 +100,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   private attachments:HalResource[];
 
-  private isEditing = false;
-
   constructor(
-    protected elementRef:ElementRef,
+    readonly elementRef:ElementRef<HTMLElement>,
     protected pathHelper:PathHelperService,
     protected halResourceService:HalResourceService,
     protected Notifications:ToastService,
@@ -101,111 +109,118 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     protected states:States,
   ) {
     super();
+    populateInputsFromDataset(this);
   }
 
   ngOnInit() {
-    this.$element = jQuery(this.elementRef.nativeElement);
-
-    // Parse the attribute explicitly since this is likely a bootstrapped element
-    this.textareaSelector = this.$element.attr('textarea-selector')!;
-    this.previewContext = this.$element.attr('preview-context')!;
-    this.macros = this.$element.attr('macros') !== 'false';
-    const editorType = (this.$element.attr('editor-type') || 'full') as ICKEditorType;
+    this.element = this.elementRef.nativeElement;
 
     // Parse the resource if any exists
-    const source = this.$element.data('resource');
-    this.resource = source ? this.halResourceService.createHalResource(source, true) : undefined;
+    this.halResource = this.resource ? this.halResourceService.createHalResource(this.resource, true) : undefined;
 
-    this.formElement = this.$element.closest('form');
-    this.wrappedTextArea = this.formElement.find(this.textareaSelector);
-    this.wrappedTextArea
-      .removeAttr('required')
-      .hide();
-    this.initialContent = this.wrappedTextArea.val() as string;
-    this.readOnly = !!this.wrappedTextArea.attr('disabled');
+    this.formElement = this.element.closest<HTMLFormElement>('form') as HTMLFormElement;
+    this.wrappedTextArea = this.formElement.querySelector(this.textareaSelector) as HTMLTextAreaElement;
+    this.wrappedTextArea.style.display = 'none';
+    this.wrappedTextArea.required = false;
+    this.initialContent = this.wrappedTextArea.value;
+    this.readOnly = this.wrappedTextArea.disabled;
 
-    this.$attachmentsElement = this.formElement.find('#attachments_fields');
+    this.attachmentsElement = this.formElement.querySelector('#attachments_fields') as HTMLElement;
     this.context = {
-      type: editorType,
-      resource: this.resource,
+      type: this.editorType,
+      resource: this.halResource,
       previewContext: this.previewContext,
     };
     if (!this.macros || this.readOnly) {
       this.context.macros = 'none';
     }
+
+    this.registerFormSubmitListener();
   }
 
-  ngOnDestroy() {
-    super.ngOnDestroy();
-    this.formElement.off('submit.ckeditor');
+  private registerFormSubmitListener():void {
+    fromEvent(this.formElement, 'submit')
+      .pipe(
+        this.untilDestroyed(),
+      )
+      .subscribe(() => {
+        this.saveForm();
+      });
   }
 
   public markEdited() {
     window.OpenProject.pageWasEdited = true;
   }
 
+  public saveForm():void {
+    this.syncToTextarea();
+    this.addUploadedAttachmentsToForm();
+    window.OpenProject.pageIsSubmitted = true;
+    this.formElement.submit();
+  }
+
   public setup(editor:ICKEditorInstance) {
     // Have a hacky way to access the editor from outside of angular.
     // This is e.g. employed to set the text from outside to reuse the same editor for different languages.
-    this.$element.data('editor', editor);
+    jQuery(this.element).data('editor', editor);
+
     if (this.readOnly) {
       editor.enableReadOnlyMode('wrapped-text-area-disabled');
     }
 
-    if (this.resource && this.resource.attachments) {
+    if (this.halResource?.attachments) {
       this.setupAttachmentAddedCallback(editor);
       this.setupAttachmentRemovalSignal(editor);
     }
 
-    // Listen for form submission to set textarea content
-    this.formElement.on('submit.ckeditor change.ckeditor', () => {
-      try {
-        const data = this.ckEditorInstance.getRawData();
-        this.wrappedTextArea.val(data);
-      } catch (e) {
-        console.error(`Failed to save CKEditor body to textarea: ${e}.`);
-        this.Notifications.addError(e || this.I18n.t('js.error.internal'));
-
-        // Avoid submission of the form
-        return false;
-      }
-
-      this.addUploadedAttachmentsToForm();
-
-      // Continue with submission
-      return true;
-    });
-
     this.setLabel();
-
     return editor;
+  }
+
+  private syncToTextarea() {
+    try {
+      this.wrappedTextArea.value = this.ckEditorInstance.getRawData();
+    } catch (e) {
+      const message = (e as Error)?.message || (e as object).toString();
+      console.error(`Failed to save CKEditor body to textarea: ${message}.`);
+      this.Notifications.addError(message || this.I18n.t('js.error.internal'));
+      throw e;
+    }
   }
 
   private setupAttachmentAddedCallback(editor:ICKEditorInstance) {
     editor.model.on('op:attachment-added', () => {
-      this.states.forResource(this.resource!)!.putValue(this.resource);
+      this.states.forResource(this.halResource as HalResource)?.putValue(this.halResource);
     });
   }
 
   private setupAttachmentRemovalSignal(editor:ICKEditorInstance) {
-    this.attachments = _.clone(this.resource!.attachments.elements);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+    this.attachments = _.clone((this.halResource as HalResource).attachments.elements);
 
-    this.states.forResource(this.resource!)!.changes$()
+    this
+      .states
+      .forResource(this.halResource as HalResource)
+      ?.changes$()
       .pipe(
         takeUntil(componentDestroyed(this)),
         filter((resource) => !!resource),
-      ).subscribe((resource) => {
-        const missingAttachments = _.differenceBy(this.attachments,
-          resource!.attachments.elements,
-          (attachment:HalResource) => attachment.id);
+      )
+      .subscribe((resource:HalResource&{ attachments:AttachmentCollectionResource }) => {
+        const missingAttachments = _.differenceBy(
+          this.attachments,
+          resource.attachments.elements,
+          (attachment:HalResource) => attachment.id,
+        );
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return
         const removedUrls = missingAttachments.map((attachment) => attachment.downloadLocation.href);
 
         if (removedUrls.length) {
           editor.model.fire('op:attachment-removed', removedUrls);
         }
 
-        this.attachments = _.clone(resource!.attachments.elements);
+        this.attachments = _.clone(resource.attachments.elements);
       });
   }
 
@@ -213,36 +228,43 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     const textareaId = this.textareaSelector.substring(1);
     const label = jQuery(`label[for=${textareaId}]`);
 
-    const ckContent = this.$element.find('.ck-content');
+    const ckContent = this.element.querySelector('.ck-content') as HTMLElement;
 
-    ckContent.attr('aria-label', null);
-    ckContent.attr('aria-labelledby', textareaId);
+    ckContent.removeAttribute('aria-label');
+    ckContent.setAttribute('aria-labelledby', textareaId);
 
-    label.click(() => {
-      ckContent.focus();
-    });
+    fromEvent(label, 'click')
+      .pipe(this.untilDestroyed())
+      .subscribe(() => ckContent.focus());
   }
 
   private addUploadedAttachmentsToForm() {
-    if (!this.resource || !this.resource.attachments || this.resource.id) {
+    if (!this.halResource || !this.halResource.attachments || this.halResource.id) {
       return;
     }
 
-    const takenIds = this.$attachmentsElement.find("input[type='file']").map((index, input) => {
-      const match = /attachments\[(\d+)\]\[(?:file|id)\]/.exec((input.getAttribute('name') || ''));
+    const attachments = Array.from(this.attachmentsElement.querySelectorAll<HTMLInputElement>("input[type='file']"));
+    const takenIds = attachments.map((input) => {
+      const match = /attachments\[(\d+)\]\[(?:file|id)\]/.exec((input.name || ''));
 
       if (match) {
-        return parseInt(match[1]);
+        return parseInt(match[1], 10);
       }
       return 0;
     });
 
-    const maxValue:number = takenIds.toArray().sort().pop() || 0;
+    const maxValue:number = takenIds.sort().pop() || 0;
 
-    const addedAttachments = this.resource.attachments.elements || [];
+    const addedAttachments = this.halResource?.attachments.elements || [];
 
-    jQuery.each(addedAttachments, (index:number, attachment:HalResource) => {
-      this.$attachmentsElement.append(`<input type="hidden" name="attachments[${maxValue + index + 1}][id]" value="${attachment.id}">`);
+    addedAttachments.forEach((attachment:HalResource, index:number) => {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+
+      input.name = `attachments[${maxValue + index + 1}][id]`;
+      input.value = attachment.id as string;
+
+      this.attachmentsElement.appendChild(input);
     });
   }
 }

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -4,18 +4,19 @@
     [content]="initialContent"
     (initializeDone)="setup($event)"
     (contentChanged)="markEdited()"
+    (saveRequested)="saveForm()"
   ></op-ckeditor>
 </div>
 
 <fieldset
   class="form--fieldset"
-  *ngIf="resource && resource.attachments"
+  *ngIf="halResource && halResource.attachments"
 >
   <legend class="form--fieldset-legend">
     {{ text.attachments }}
   </legend>
   <op-attachments
-    [resource]="resource"
+    [resource]="halResource"
     [destroyImmediately]="false"
   ></op-attachments>
 </fieldset>

--- a/lib/open_project/text_formatting/formats/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/helper.rb
@@ -49,13 +49,14 @@ module OpenProject::TextFormatting::Formats
 
         # Pass an optional resource to the CKEditor instance
         resource = context.fetch(:resource, {})
-        helpers.content_tag 'ckeditor-augmented-textarea',
-                            '',
-                            'textarea-selector': "##{field_id}",
-                            'editor-type': context[:editor_type] || 'full',
-                            'preview-context': context[:preview_context],
-                            'data-resource': resource.to_json,
-                            macros: context.fetch(:macros, true)
+        helpers.angular_component_tag 'ckeditor-augmented-textarea',
+                                      inputs: {
+                                        textareaSelector: "##{field_id}",
+                                        editorType: context[:editor_type] || 'full',
+                                        previewContext: context[:preview_context],
+                                        resource:,
+                                        macros: context.fetch(:macros, true)
+                                      }
       end
 
       protected

--- a/modules/meeting/spec/features/meetings_show_spec.rb
+++ b/modules/meeting/spec/features/meetings_show_spec.rb
@@ -27,6 +27,8 @@
 #++
 
 require 'spec_helper'
+require_relative '../support/pages/meetings/show'
+
 
 RSpec.describe 'Meetings', js: true do
   let(:project) { create(:project, enabled_module_names: %w[meetings]) }
@@ -38,6 +40,7 @@ RSpec.describe 'Meetings', js: true do
   end
 
   let!(:meeting) { create(:meeting, project:, title: 'Awesome meeting!') }
+  let(:show_page) { Pages::Meetings::Show.new(meeting) }
 
   current_user { user }
 
@@ -94,6 +97,16 @@ RSpec.describe 'Meetings', js: true do
           find('.toolbar-item', text: 'Edit').click
 
           field.expect_value('foo')
+
+          field.set_value('My new meeting text')
+
+          field.submit_by_enter
+
+          show_page.expect_and_dismiss_toaster message: 'Successful update'
+
+          meeting.reload
+
+          expect(meeting.agenda.text).to eq 'My new meeting text'
         end
       end
 

--- a/spec/support/pages/admin/system_settings/general.rb
+++ b/spec/support/pages/admin/system_settings/general.rb
@@ -39,7 +39,7 @@ module Pages::Admin::SystemSettings
     end
 
     def welcome_text_selector
-      'ckeditor-augmented-textarea[textarea-selector="#settings_welcome_text"]'
+      'ckeditor-augmented-textarea[data-textarea-selector="\"#settings_welcome_text\""]'
     end
   end
 end


### PR DESCRIPTION
Allows saving requests to pass through to the augmented rails form component. To clean it up, converted its manual inputs to use angular mapped inputs instead. Removed jQuery where possible.

https://community.openproject.org/work_packages/33375