### PR TITLE
PDF Export: generated documentation for pdf styling yaml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem 'structured_warnings', '~> 0.4.0'
 gem 'airbrake', '~> 13.0.0', require: false
 
 gem 'prawn', '~> 2.2'
-gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '4c42148220ecaa8363134f34331ce90277e1b380'
+gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '76945d45c14b841e2312f992422e2631a4524114'
 # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
 gem 'matrix', '~> 0.4.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 4c42148220ecaa8363134f34331ce90277e1b380
-  ref: 4c42148220ecaa8363134f34331ce90277e1b380
+  revision: 76945d45c14b841e2312f992422e2631a4524114
+  ref: 76945d45c14b841e2312f992422e2631a4524114
   specs:
     md_to_pdf (0.0.19)
       commonmarker (~> 0.23)

--- a/app/models/work_package/pdf_export/schema.json
+++ b/app/models/work_package/pdf_export/schema.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "title": "PDF Export Styling yml",
-  "description": "This documents describes the styles settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)",
+  "description": "This document describes the style settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)",
   "properties": {
     "page": {
       "$ref": "#/$defs/page"

--- a/app/models/work_package/pdf_export/schema.json
+++ b/app/models/work_package/pdf_export/schema.json
@@ -1,359 +1,805 @@
 {
-  "type" : "object",
-  "properties" : {
-    "page" : {
-      "type" : "object",
-      "properties" : {
-        "link_color" : {
-          "$ref" : "#/$defs/color"
-        },
-        "page_break_threshold" : {
-          "$ref" : "#/$defs/measurement"
-        }
-      },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/page"
-        }
-      ]
+  "type": "object",
+  "title": "PDF Export Styling yml",
+  "description": "This documents describes the styles settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)",
+  "properties": {
+    "page": {
+      "$ref": "#/$defs/page"
     },
-    "page_logo" : {
-      "$ref" : "#/$defs/page_logo"
+    "page_logo": {
+      "$ref": "#/$defs/page_logo"
     },
-    "page_header" : {
-      "$ref" : "#/$defs/page_header_footer"
+    "page_header": {
+      "$ref": "#/$defs/page_header"
     },
-    "page_footer" : {
-      "$ref" : "#/$defs/page_header_footer"
+    "page_footer": {
+      "$ref": "#/$defs/page_footer"
     },
-    "page_heading" : {
-      "$ref" : "#/$defs/font_and_margin"
+    "page_heading": {
+      "$ref": "#/$defs/page_heading"
     },
-    "work_package" : {
-      "type" : "object",
-      "properties" : {
-        "subject" : {
-          "$ref" : "#/$defs/font_and_margin"
-        },
-        "label" : {
-          "$ref" : "#/$defs/font_and_margin"
-        },
-        "attributes_table" : {
-          "type" : "object",
-          "properties" : {
-            "cell" : {
-              "$ref" : "#/$defs/table_cell"
-            },
-            "cell_label" : {
-              "$ref" : "#/$defs/table_cell"
-            }
+    "work_package": {
+      "$ref": "#/$defs/work_package"
+    },
+    "toc": {
+      "$ref": "#/$defs/toc"
+    },
+    "overview": {
+      "$ref": "#/$defs/overview"
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "$defs": {
+    "toc": {
+      "title": "Table of content",
+      "description": "Styling for the table of content of the PDF report export",
+      "x-example": {
+        "toc": {
+          "subject_indent": 4,
+          "indent_mode": "stairs",
+          "margin_top": 10,
+          "margin_bottom": 20,
+          "item": {
+            "size": 9,
+            "color": "000000",
+            "margin_bottom": 4
           },
-          "allOf" : [
-            {
-              "$ref" : "#/$defs/margin"
-            }
-          ]
-        },
-        "section" : {
-          "type" : "object",
-          "properties" : {
-            "heading" : {
-              "$ref" : "#/$defs/font_and_margin"
-            },
-            "item" : {
-              "$ref" : "#/$defs/font_and_margin"
-            }
+          "item_level_1": {
+            "size": 10,
+            "styles": [
+              "bold"
+            ],
+            "margin_top": 4,
+            "margin_bottom": 4
+          },
+          "item_level_2": {
+            "size": 10
           }
-        },
-        "markdown_label" : {
-          "$ref" : "#/$defs/font_and_margin"
-        },
-        "markdown_margin" : {
-          "$ref" : "#/$defs/margin"
-        },
-        "markdown" : {
-          "$ref" : "#/$defs/md_to_pdf_markdown"
         }
       },
-      "patternProperties" : {
-        "^subject_level_\\d+" : {
-          "$ref" : "#/$defs/font_and_margin"
-        }
-      },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/margin"
-        }
-      ]
-    },
-    "toc" : {
-      "type" : "object",
-      "properties" : {
-        "subject_indent" : {
-          "$ref" : "#/$defs/measurement"
+      "type": "object",
+      "properties": {
+        "subject_indent": {
+          "title": "Indention width",
+          "description": "Indention width for TOC levels",
+          "$ref": "#/$defs/measurement"
         },
-        "indent_mode" : {
-          "type" : "string",
-          "enum" : [
+        "indent_mode": {
+          "title": "Indention mode",
+          "description": "`flat`= no indention, `stairs` = indent on each level, `third_level` = indent only at 3th level",
+          "type": "string",
+          "enum": [
             "flat",
             "stairs",
             "third_level"
           ]
         },
-        "item" : {
-          "$ref" : "#/$defs/font_and_margin"
+        "item": {
+          "type": "object",
+          "title": "Table of content item",
+          "description": "Default styling for TOC items on all levels.<br/>use item_level_x` as key for TOC items on level `x`.",
+          "x-example": {
+            "item": {
+              "size": 9,
+              "color": "000000",
+              "margin_bottom": 4
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         }
       },
-      "patternProperties" : {
-        "^item_level_\\d+" : {
-          "$ref" : "#/$defs/font_and_margin"
+      "patternProperties": {
+        "^item_level_\\d+": {
+          "title": "Table of content item level",
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/margin"
+          "$ref": "#/$defs/margin"
         }
       ]
     },
-    "overview" : {
-      "type" : "object",
-      "properties" : {
-        "group_heading" : {
-          "$ref" : "#/$defs/font_and_margin"
-        },
-        "table" : {
-          "type" : "object",
-          "properties" : {
-            "subject_indent" : {
-              "$ref" : "#/$defs/measurement"
-            },
-            "cell" : {
-              "$ref" : "#/$defs/table_cell"
-            },
-            "cell_header" : {
-              "$ref" : "#/$defs/table_cell"
-            },
-            "cell_sums" : {
-              "$ref" : "#/$defs/table_cell"
+    "overview": {
+      "title": "Overview",
+      "description": "Styling for the PDF table export",
+      "x-example": {
+        "overview": {
+          "group_heading": {},
+          "table": {}
+        }
+      },
+      "type": "object",
+      "properties": {
+        "group_heading": {
+          "type": "object",
+          "title": "Overview group heading",
+          "description": "Styling for the group lavel if grouping is activated",
+          "x-example": {
+            "group_heading": {
+              "size": 11,
+              "styles": [
+                "bold"
+              ],
+              "margin_bottom": 10
             }
           },
-          "allOf" : [
+          "allOf": [
             {
-              "$ref" : "#/$defs/margin"
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
+        "table": {
+          "type": "object",
+          "title": "Overview table",
+          "x-example": {
+            "table": {
+              "subject_indent": 0,
+              "margin_bottom": 20,
+              "cell": {
+                "size": 9,
+                "color": "000000",
+                "padding": 5
+              },
+              "cell_header": {
+                "size": 9,
+                "styles": [
+                  "bold"
+                ]
+              },
+              "cell_sums": {
+                "size": 8,
+                "styles": [
+                  "bold"
+                ]
+              }
+            }
+          },
+          "properties": {
+            "subject_indent": {
+              "title": "Indent subject",
+              "description": "Indent by work package level in the subject cell",
+              "$ref": "#/$defs/measurement"
+            },
+            "cell": {
+              "title": "Table cell",
+              "description": "Styling for a table value cell",
+              "$ref": "#/$defs/table_cell"
+            },
+            "cell_header": {
+              "title": "Table header cell",
+              "description": "Styling for a table header cell",
+              "$ref": "#/$defs/table_cell"
+            },
+            "cell_sums": {
+              "title": "Table sum cell",
+              "description": "Styling for a table sum cell",
+              "$ref": "#/$defs/table_cell"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
             }
           ]
         }
       }
-    }
-  },
-  "patternProperties" : {
-    "^page_header_\\d+" : {
-      "$ref" : "#/$defs/page_header_footer"
     },
-    "^page_footer_\\d+" : {
-      "$ref" : "#/$defs/page_header_footer"
-    },
-    "^ordered_list_point_\\d+" : {
-      "$ref" : "#/$defs/ordered_list_point"
-    },
-    "^ordered_list_\\d+" : {
-      "$ref" : "#/$defs/ordered_list"
-    },
-    "^unordered_list_point_\\d+" : {
-      "$ref" : "#/$defs/unordered_list_point"
-    },
-    "^unordered_list_\\d+" : {
-      "$ref" : "#/$defs/unordered_list"
-    },
-    "^header_\\d+" : {
-      "$ref" : "#/$defs/header"
-    }
-  },
-  "required" : [],
-  "additionalProperties" : false,
-  "$defs" : {
-    "md_to_pdf_markdown" : {
-      "type" : "object",
-      "properties" : {
-        "font" : {
-          "$ref" : "#/$defs/font"
-        },
-        "paragraph" : {
-          "$ref" : "#/$defs/paragraph"
-        },
-        "table" : {
-          "$ref" : "#/$defs/table"
-        },
-        "headless_table" : {
-          "$ref" : "#/$defs/headless_table"
-        },
-        "code" : {
-          "$ref" : "#/$defs/code"
-        },
-        "codeblock" : {
-          "$ref" : "#/$defs/codeblock"
-        },
-        "link" : {
-          "$ref" : "#/$defs/link"
-        },
-        "image" : {
-          "$ref" : "#/$defs/image"
-        },
-        "image_classes" : {
-          "$ref" : "#/$defs/image_classes"
-        },
-        "hrule" : {
-          "$ref" : "#/$defs/hrule"
-        },
-        "footnote_reference" : {
-          "$ref" : "#/$defs/footnote_reference"
-        },
-        "footnote_definition" : {
-          "$ref" : "#/$defs/footnote_definition"
-        },
-        "header" : {
-          "$ref" : "#/$defs/header"
-        },
-        "blockquote" : {
-          "$ref" : "#/$defs/blockquote"
-        },
-        "unordered_list" : {
-          "$ref" : "#/$defs/unordered_list"
-        },
-        "unordered_list_point" : {
-          "$ref" : "#/$defs/unordered_list_point"
-        },
-        "task_list" : {
-          "$ref" : "#/$defs/unordered_list"
-        },
-        "task_list_point" : {
-          "$ref" : "#/$defs/task_list_point"
-        },
-        "ordered_list" : {
-          "$ref" : "#/$defs/ordered_list"
-        },
-        "ordered_list_point" : {
-          "$ref" : "#/$defs/ordered_list_point"
+    "work_package": {
+      "type": "object",
+      "title": "Work package",
+      "description": "Styling for the Work package section",
+      "x-example": {
+        "work_package": {
+          "margin_bottom": 20,
+          "subject": {
+          },
+          "subject_level_1": {
+          },
+          "subject_level_2": {
+          },
+          "subject_level_3": {
+          },
+          "attributes_table": {},
+          "markdown_label": {},
+          "markdown_margin": {},
+          "markdown": {}
         }
       },
-      "patternProperties" : {
-        "^ordered_list_point_\\d+" : {
-          "$ref" : "#/$defs/ordered_list_point"
+      "properties": {
+        "subject": {
+          "type": "object",
+          "title": "Work package subject",
+          "description": "Styling for the Work package subject headline",
+          "x-example": {
+            "subject": {
+              "size": 10,
+              "styles": [
+                "bold"
+              ],
+              "margin_bottom": 10
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         },
-        "^ordered_list_\\d+" : {
-          "$ref" : "#/$defs/ordered_list"
+        "attributes_table": {
+          "type": "object",
+          "title": "Work package attributes",
+          "description": "Styling for the Work package attributes table",
+          "x-example": {
+            "attributes_table": {
+              "margin_bottom": 10,
+              "cell": {
+                "size": 9,
+                "color": "000000",
+                "padding_left": 5,
+                "padding_right": 5,
+                "padding_top": 0,
+                "padding_bottom": 5,
+                "border_color": "4B4B4B",
+                "border_width": 0.25
+              },
+              "cell_label": {
+                "styles": [
+                  "bold"
+                ]
+              }
+            }
+          },
+          "properties": {
+            "cell": {
+              "title": "Attribute value table cell",
+              "description": "Styling for a table cell with attribute value",
+              "$ref": "#/$defs/table_cell"
+            },
+            "cell_label": {
+              "title": "Attribute label table cell",
+              "description": "Styling for a table cell with attribute label",
+              "$ref": "#/$defs/table_cell"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         },
-        "^unordered_list_point_\\d+" : {
-          "$ref" : "#/$defs/unordered_list_point"
+        "markdown_label": {
+          "type": "object",
+          "title": "Work package markdown label",
+          "description": "Label headline for work package description and long text custom fields",
+          "x-example": {
+            "markdown_label": {
+              "size": 12,
+              "styles": [
+                "bold"
+              ],
+              "margin_top": 2,
+              "margin_bottom": 4
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         },
-        "^unordered_list_\\d+" : {
-          "$ref" : "#/$defs/unordered_list"
+        "markdown_margin": {
+          "type": "object",
+          "title": "Work package markdown margins",
+          "description": "Margins for work package description and long text custom fields",
+          "x-example": {
+            "markdown_margin": {
+              "margin_bottom": 16
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
         },
-        "^header_\\d+" : {
-          "$ref" : "#/$defs/header"
+        "markdown": {
+          "$ref": "#/$defs/markdown"
+        }
+      },
+      "patternProperties": {
+        "^subject_level_\\d+": {
+          "type": "object",
+          "title": "Work package subject level",
+          "x-example": {
+            "subject_level_1": {
+              "size": 14,
+              "styles": [
+                "bold"
+              ]
+            },
+            "subject_level_2": {
+              "size": 13,
+              "styles": [
+                "bold"
+              ]
+            },
+            "subject_level_3": {
+              "size": 12,
+              "styles": [
+                "bold"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/margin"
+        }
+      ]
+    },
+    "markdown": {
+      "type": "object",
+      "title": "Markdown Styling",
+      "description": "Styling for content of work package description and long text custom fields",
+      "x-example": {
+        "markdown": {
+          "font": {},
+          "header": {},
+          "header_1": {},
+          "header_2": {},
+          "header_3": {},
+          "paragraph": {},
+          "unordered_list": {},
+          "unordered_list_point": {},
+          "ordered_list": {},
+          "ordered_list_point": {},
+          "task_list": {},
+          "task_list_point": {},
+          "link": {},
+          "code": {},
+          "blockquote": {},
+          "codeblock": {},
+          "table": {}
+        }
+      },
+      "properties": {
+        "font": {
+          "$ref": "#/$defs/font"
+        },
+        "paragraph": {
+          "title": "Markdown paragraph",
+          "description": "A block of text",
+          "type": "object",
+          "properties": {
+            "align": {
+              "type": "string",
+              "enum": [
+                "left",
+                "center",
+                "right",
+                "justify"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/padding"
+            }
+          ],
+          "x-example": {
+            "paragraph": {
+              "align": "justify",
+              "padding_bottom": "2mm"
+            }
+          }
+        },
+        "table": {
+          "type": "object",
+          "title": "Markdown table",
+          "x-example": {
+            "table": {
+              "auto_width": true,
+              "header": {
+                "background_color": "F0F0F0",
+                "no_repeating": true,
+                "size": 12
+              },
+              "cell": {
+                "background_color": "000FFF",
+                "size": 10
+              }
+            }
+          },
+          "properties": {
+            "auto_width": {
+              "title": "Automatic column widths",
+              "description": "Table columns should fit the content, equal spacing of columns if value is `false`",
+              "type": "boolean"
+            },
+            "header": {
+              "$ref": "#/$defs/table_header"
+            },
+            "cell": {
+              "$ref": "#/$defs/table_cell"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            },
+            {
+              "$ref": "#/$defs/border"
+            }
+          ]
+        },
+        "headless_table": {
+          "type": "object",
+          "title": "Markdown headless table",
+          "description": "Tables without or empty header rows can be styled differently.",
+          "x-example": {
+            "headless_table": {
+              "auto_width": true,
+              "cell": {
+                "style": "underline",
+                "background_color": "000FFF"
+              }
+            }
+          },
+          "properties": {
+            "auto_width": {
+              "title": "Automatic column widths",
+              "description": "Table columns should fit the content, equal spacing of columns if value is `false`",
+              "type": "boolean"
+            },
+            "cell": {
+              "$ref": "#/$defs/table_cell"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            },
+            {
+              "$ref": "#/$defs/border"
+            }
+          ]
+        },
+        "code": {
+          "type": "object",
+          "title": "Markdown code",
+          "description": "Styling to denote a word or phrase as code",
+          "x-example": {
+            "code": {
+              "font": "Consolas",
+              "color": "880000"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            }
+          ]
+        },
+        "codeblock": {
+          "type": "object",
+          "title": "Markdown code block",
+          "description": "Styling to denote a paragraph as code",
+          "x-example": {
+            "codeblock": {
+              "background_color": "F5F5F5",
+              "font": "Consolas",
+              "size": 8,
+              "color": "880000",
+              "padding": "3mm",
+              "margin_top": "2mm",
+              "margin_bottom": "2mm"
+            }
+          },
+          "properties": {
+            "background_color": {
+              "$ref": "#/$defs/color"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/padding"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
+        "link": {
+          "type": "object",
+          "title": "Markdown Link",
+          "description": "Styling a clickable link",
+          "x-example": {
+            "link": {
+              "color": "000088"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            }
+          ]
+        },
+        "image": {
+          "type": "object",
+          "title": "Markdown image",
+          "description": "Styling of images",
+          "x-example": {
+            "image": {
+              "max_width": "50mm",
+              "margin": "2mm",
+              "margin_bottom": "3mm",
+              "align": "center",
+              "caption": {
+                "align": "center",
+                "size": 8
+              }
+            }
+          },
+          "properties": {
+            "max_width": {
+              "$ref": "#/$defs/measurement",
+              "title": "Maximum width of the image"
+            },
+            "align": {
+              "$ref": "#/$defs/alignment"
+            },
+            "caption": {
+              "title": "Image caption",
+              "description": "Styling for the caption below an image",
+              "type": "object",
+              "properties": {
+                "align": {
+                  "type": "string",
+                  "enum": [
+                    "left",
+                    "center",
+                    "right",
+                    "justify"
+                  ]
+                }
+              },
+              "allOf": [
+                {
+                  "$ref": "#/$defs/font"
+                },
+                {
+                  "$ref": "#/$defs/padding"
+                }
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
+        "hrule": {
+          "type": "object",
+          "title": "Markdown horizontal rule",
+          "description": "Styling for horizontal lines",
+          "properties": {
+            "line_width": {
+              "title": "Sets the stroke width of the horizontal rule",
+              "$ref": "#/$defs/measurement"
+            }
+          },
+          "x-example": {
+            "hrule": {
+              "line_width": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
+        "header": {
+          "title": "Markdown header",
+          "description": "Default styling for headers on all levels.<br/>use header_`x` as key for header level `x`.",
+          "$ref": "#/$defs/header"
+        },
+        "blockquote": {
+          "type": "object",
+          "title": "Markdown blockquote",
+          "description": "Styling to denote a paragraph as quote",
+          "x-example": {
+            "blockquote": {
+              "background_color": "f4f9ff",
+              "size": 14,
+              "styles": [
+                "italic"
+              ],
+              "color": "0f3b66",
+              "border_color": "b8d6f4",
+              "border_width": 1,
+              "no_border_right": true,
+              "no_border_left": false,
+              "no_border_bottom": true,
+              "no_border_top": true
+            }
+          },
+          "properties": {
+            "background_color": {
+              "$ref": "#/$defs/color"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/border"
+            },
+            {
+              "$ref": "#/$defs/padding"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
+        "ordered_list": {
+          "title": "Markdown ordered list",
+          "description": "Default styling for ordered lists on all levels.<br/>use ordered_list_`x` as key for ordered list level `x`.",
+          "$ref": "#/$defs/ordered_list"
+        },
+        "ordered_list_point": {
+          "title": "Markdown ordered list point",
+          "description": "Default styling for ordered list points on all levels.<br/>use ordered_list_point_`x` as key for ordered list points level `x`.",
+          "$ref": "#/$defs/ordered_list_point"
+        },
+        "unordered_list": {
+          "title": "Markdown unordered list",
+          "description": "Default styling for unordered lists on all levels.<br/>use unordered_list_`x` as key for unordered list level `x`.",
+          "$ref": "#/$defs/unordered_list"
+        },
+        "unordered_list_point": {
+          "title": "Markdown unordered list point",
+          "description": "Default styling for unordered list points on all levels.<br/>use unordered_list_point_`x` as key for unordered list points level `x`.",
+          "$ref": "#/$defs/unordered_list_point"
+        },
+        "task_list": {
+          "title": "Markdown task list",
+          "x-example": {
+            "task_list": {
+              "spacing": "2mm"
+            }
+          },
+          "$ref": "#/$defs/unordered_list"
+        },
+        "task_list_point": {
+          "title": "Markdown task list point",
+          "$ref": "#/$defs/task_list_point"
+        }
+      },
+      "patternProperties": {
+        "^ordered_list_point_\\d+": {
+          "title": "Markdown ordered list point level",
+          "$ref": "#/$defs/ordered_list_point"
+        },
+        "^ordered_list_\\d+": {
+          "title": "Markdown ordered list level",
+          "$ref": "#/$defs/ordered_list"
+        },
+        "^unordered_list_point_\\d+": {
+          "title": "Markdown unordered list point level",
+          "$ref": "#/$defs/unordered_list_point"
+        },
+        "^unordered_list_\\d+": {
+          "title": "Markdown unordered List Level",
+          "$ref": "#/$defs/unordered_list"
+        },
+        "^header_\\d+": {
+          "title": "Markdown header level",
+          "$ref": "#/$defs/header"
         }
       }
     },
-    "font_and_margin" : {
-      "type" : "object",
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        },
-        {
-          "$ref" : "#/$defs/margin"
-        }
-      ]
-    },
-    "font_specs" : {
-      "type" : "array",
-      "items" : {
-        "$ref" : "#/$defs/font_spec"
-      }
-    },
-    "font_spec" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "pathname" : {
-          "type" : "string"
-        },
-        "regular" : {
-          "type" : "string"
-        },
-        "bold" : {
-          "type" : "string"
-        },
-        "italic" : {
-          "type" : "string"
-        },
-        "bold_italic" : {
-          "type" : "string"
-        }
+    "color": {
+      "type": "string",
+      "title": "Color",
+      "description": "A color in RRGGBB format",
+      "examples": [
+        "F0F0F0"
+      ],
+      "x-example": {
+        "color": "F0F0F0"
       },
-      "required" : [
-        "name",
-        "pathname",
-        "regular",
-        "bold",
-        "italic",
-        "bold_italic"
-      ]
+      "pattern": "^(?:[0-9a-fA-F]{3}){1,2}$"
     },
-    "fallback_font_spec" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "pathname" : {
-          "type" : "string"
-        },
-        "filename" : {
-          "type" : "string"
-        }
+    "font": {
+      "title": "Font properties",
+      "description": "Properties to set the font style",
+      "type": "object",
+      "x-example": {
+        "font": "OpenSans",
+        "size": 10,
+        "character_spacing": 0,
+        "styles": [],
+        "color": "000000",
+        "leading": 2
       },
-      "required" : [
-        "name",
-        "pathname",
-        "filename"
-      ]
-    },
-    "color" : {
-      "type" : "string",
-      "pattern" : "^(?:[0-9a-fA-F]{3}){1,2}$"
-    },
-    "font" : {
-      "type" : "object",
-      "properties" : {
-        "font" : {
-          "type" : "string"
+      "properties": {
+        "font": {
+          "type": "string"
         },
-        "size" : {
-          "$ref" : "#/$defs/measurement"
+        "size": {
+          "$ref": "#/$defs/measurement"
         },
-        "character_spacing" : {
-          "$ref" : "#/$defs/measurement"
+        "character_spacing": {
+          "$ref": "#/$defs/measurement"
         },
-        "leading" : {
-          "$ref" : "#/$defs/measurement"
+        "leading": {
+          "$ref": "#/$defs/measurement"
         },
-        "color" : {
-          "$ref" : "#/$defs/color"
+        "color": {
+          "$ref": "#/$defs/color"
         },
-        "styles" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/$defs/font_style"
+        "styles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/font_style"
           }
         }
       }
     },
-    "font_style" : {
-      "type" : "string",
-      "enum" : [
+    "font_style": {
+      "type": "string",
+      "title": "Font Style",
+      "description": "Style of the font to use",
+      "examples": [
+        "bold"
+      ],
+      "enum": [
         "bold",
         "italic",
         "underline",
@@ -362,19 +808,47 @@
         "subscript"
       ]
     },
-    "page" : {
-      "type" : "object",
-      "properties" : {
-        "page_layout" : {
-          "type" : "string",
-          "enum" : [
+    "page": {
+      "title": "Page settings",
+      "description": "Properties to set the basic page settings",
+      "type": "object",
+      "x-example": {
+        "page": {
+          "page_size": "EXECUTIVE",
+          "margin_top": 60,
+          "margin_bottom": 60,
+          "margin_left": 36,
+          "margin_right": 36,
+          "page_break_threshold": 200,
+          "link_color": "175A8E"
+        }
+      },
+      "properties": {
+        "link_color": {
+          "title": "Link color",
+          "description": "Set the color of clickable links",
+          "$ref": "#/$defs/color"
+        },
+        "page_layout": {
+          "title": "Page layout",
+          "description": "The layout of a page",
+          "type": "string",
+          "examples": [
+            "portrait"
+          ],
+          "enum": [
             "portrait",
             "landscape"
           ]
         },
-        "page_size" : {
-          "type" : "string",
-          "enum" : [
+        "page_size": {
+          "type": "string",
+          "title": "Page size",
+          "description": "The size of a page",
+          "examples": [
+            "EXECUTIVE"
+          ],
+          "enum": [
             "EXECUTIVE",
             "TABLOID",
             "LETTER",
@@ -426,398 +900,481 @@
             "4A0",
             "2A0"
           ]
+        },
+        "page_break_threshold": {
+          "title": "Page break threshold",
+          "description": "If there is a new section, start a new page if space less than the threshold is available",
+          "$ref": "#/$defs/measurement"
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "title": "Default font settings",
+          "$ref": "#/$defs/font"
         },
         {
-          "$ref" : "#/$defs/margin"
+          "title": "Page margins",
+          "$ref": "#/$defs/margin"
         }
       ]
     },
-    "page_header_footer" : {
-      "type" : "object",
-      "properties" : {
-        "filter_pages" : {
-          "$ref" : "#/$defs/pages_filter"
-        },
-        "align" : {
-          "$ref" : "#/$defs/alignment"
-        },
-        "offset" : {
-          "$ref" : "#/$defs/measurement_signed"
+    "page_heading": {
+      "title": "Page heading",
+      "description": "The main page title heading",
+      "x-example": {
+        "page_heading": {
+          "size": 14,
+          "styles": [
+            "bold"
+          ],
+          "margin_bottom": 10
         }
       },
-      "allOf" : [
+      "type": "object",
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
+        },
+        {
+          "$ref": "#/$defs/margin"
         }
       ]
     },
-    "pages_filter" : {
-      "type" : "array",
-      "items" : {
-        "type" : "integer"
-      }
-    },
-    "page_logo" : {
-      "type" : "object",
-      "properties" : {
-        "filter_pages" : {
-          "$ref" : "#/$defs/pages_filter"
-        },
-        "align" : {
-          "$ref" : "#/$defs/alignment"
-        },
-        "height" : {
-          "$ref" : "#/$defs/measurement"
-        },
-        "max_width" : {
-          "$ref" : "#/$defs/measurement"
-        },
-        "offset" : {
-          "$ref" : "#/$defs/measurement_signed"
-        },
-        "disabled" : {
-          "type" : "boolean"
-        }
-      }
-    },
-    "hrule" : {
-      "type" : "object",
-      "properties" : {
-        "line_width" : {
-          "$ref" : "#/$defs/measurement"
+    "page_footer": {
+      "type": "object",
+      "title": "Page footers",
+      "x-example": {
+        "page_footer": {
+          "offset": -30,
+          "size": 8
         }
       },
-      "allOf" : [
+      "properties": {
+        "offset": {
+          "title": "Offset position from page bottom",
+          "examples": [
+            -30
+          ],
+          "$ref": "#/$defs/measurement_signed"
+        },
+       "spacing": {
+          "title": "Minimum spacing between different page footers",
+          "examples": [
+            8
+          ],
+          "$ref": "#/$defs/measurement"
+        }
+      },
+      "allOf": [
         {
-          "$ref" : "#/$defs/margin"
+          "$ref": "#/$defs/font"
         }
       ]
     },
-    "margin" : {
-      "type" : "object",
-      "properties" : {
-        "margin" : {
-          "$ref" : "#/$defs/measurement"
+    "page_header": {
+      "type": "object",
+      "title": "Page headers",
+      "x-example": {
+        "page_header": {
+          "align": "left",
+          "offset": 20,
+          "size": 8
+        }
+      },
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/alignment"
         },
-        "margin_left" : {
-          "$ref" : "#/$defs/measurement"
+        "offset": {
+          "title": "Offset position from page top",
+          "examples": [
+            -30
+          ],
+          "$ref": "#/$defs/measurement_signed"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/font"
+        }
+      ]
+    },
+    "page_logo": {
+      "title": "Page logo",
+      "description": "Styling for logo image in the page header.",
+      "type": "object",
+      "x-example": {
+        "page_logo": {
+          "height": 20,
+          "align": "right"
+        }
+      },
+      "properties": {
+        "height": {
+          "$ref": "#/$defs/measurement",
+          "title": "Height of the image"
         },
-        "margin_right" : {
-          "$ref" : "#/$defs/measurement"
+        "align": {
+          "$ref": "#/$defs/alignment"
         },
-        "margin_top" : {
-          "$ref" : "#/$defs/measurement"
-        },
-        "margin_bottom" : {
-          "$ref" : "#/$defs/measurement"
+        "offset": {
+          "title": "Offset position from page top",
+          "examples": [
+            -30
+          ],
+          "$ref": "#/$defs/measurement_signed"
         }
       }
     },
-    "padding" : {
-      "type" : "object",
-      "properties" : {
-        "padding" : {
-          "$ref" : "#/$defs/measurement"
+    "margin": {
+      "title": "Margin properties",
+      "description": "Properties to set margins",
+      "type": "object",
+      "x-example": {
+        "margin": "10mm",
+        "margin_top": "15mm"
+      },
+      "properties": {
+        "margin": {
+          "title": "Margin",
+          "description": "One value for margin on all sides",
+          "$ref": "#/$defs/measurement"
         },
-        "padding_left" : {
-          "$ref" : "#/$defs/measurement"
+        "margin_left": {
+          "title": "Margin left",
+          "description": "Margin only on the left side",
+          "$ref": "#/$defs/measurement"
         },
-        "padding_right" : {
-          "$ref" : "#/$defs/measurement"
+        "margin_right": {
+          "title": "Margin right",
+          "description": "Margin only on the right side",
+          "$ref": "#/$defs/measurement"
         },
-        "padding_top" : {
-          "$ref" : "#/$defs/measurement"
+        "margin_top": {
+          "title": "Margin top",
+          "description": "Margin only on the top side",
+          "$ref": "#/$defs/measurement"
         },
-        "padding_bottom" : {
-          "$ref" : "#/$defs/measurement"
+        "margin_bottom": {
+          "title": "Margin bottom",
+          "description": "Margin only on the bottom side",
+          "$ref": "#/$defs/measurement"
         }
       }
     },
-    "measurement" : {
-      "type" : [
+    "padding": {
+      "title": "Padding Properties",
+      "description": "Properties to set paddings",
+      "type": "object",
+      "x-example": {
+        "padding": "10mm",
+        "padding_top": "15mm"
+      },
+      "properties": {
+        "padding": {
+          "title": "Padding",
+          "description": "One value for padding on all sides",
+          "$ref": "#/$defs/measurement"
+        },
+        "padding_left": {
+          "title": "Padding left",
+          "description": "Padding only on the left side",
+          "$ref": "#/$defs/measurement"
+        },
+        "padding_right": {
+          "title": "Padding right",
+          "description": "Padding only on the right side",
+          "$ref": "#/$defs/measurement"
+        },
+        "padding_top": {
+          "title": "Padding top",
+          "description": "Padding only on the top side",
+          "$ref": "#/$defs/measurement"
+        },
+        "padding_bottom": {
+          "title": "Padding bottom",
+          "description": "Padding only on the bottom side",
+          "$ref": "#/$defs/measurement"
+        }
+      }
+    },
+    "measurement": {
+      "type": [
         "number",
         "string"
       ],
-      "pattern" : "^([0-9\\.]+)(mm|cm|dm|m|in|ft|yr|pt)$"
+      "pattern": "^([0-9\\.]+)(mm|cm|dm|m|in|ft|yr|pt)$",
+      "description": "A number >= 0 and an optional unit",
+      "examples": [
+        "10mm",
+        "10"
+      ]
     },
-    "measurement_signed" : {
-      "type" : [
+    "measurement_signed": {
+      "type": [
         "number",
         "string"
       ],
-      "pattern" : "^-?([0-9\\.]+)(mm|cm|dm|m|in|ft|yr|pt)$"
+      "pattern": "^-?([0-9\\.]+)(mm|cm|dm|m|in|ft|yr|pt)$",
+      "description": "A positive or negative number and an optional unit"
     },
-    "alignment" : {
-      "type" : "string",
-      "enum" : [
+    "alignment": {
+      "title": "Alignment",
+      "description": "How the element should be aligned",
+      "examples": [
+        "center"
+      ],
+      "type": "string",
+      "enum": [
         "left",
         "center",
         "right"
       ]
     },
-    "unordered_list" : {
-      "type" : "object",
-      "properties" : {
-        "spacing" : {
-          "$ref" : "#/$defs/measurement"
+    "unordered_list": {
+      "title": "Markdown unordered list",
+      "x-example": {
+        "unordered_list": {
+          "spacing": "1.5mm",
+          "padding_top": "2mm",
+          "padding_bottom": "2mm"
         }
       },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        },
-        {
-          "$ref" : "#/$defs/padding"
-        }
-      ]
-    },
-    "unordered_list_point" : {
-      "type" : "object",
-      "properties" : {
-        "sign" : {
-          "type" : "string"
-        },
-        "spacing" : {
-          "$ref" : "#/$defs/measurement"
+      "type": "object",
+      "properties": {
+        "spacing": {
+          "title": "Spacing",
+          "description": "Additional space between list items",
+          "$ref": "#/$defs/measurement"
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
+        },
+        {
+          "$ref": "#/$defs/padding"
         }
       ]
     },
-    "task_list_point" : {
-      "type" : "object",
-      "properties" : {
-        "checked" : {
-          "type" : "string"
-        },
-        "unchecked" : {
-          "type" : "string"
-        },
-        "spacing" : {
-          "$ref" : "#/$defs/measurement"
+    "unordered_list_point": {
+      "title": "Markdown unordered list point",
+      "x-example": {
+        "unordered_list_point": {
+          "sign": "•",
+          "spacing": "0.75mm"
         }
       },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        }
-      ]
-    },
-    "ordered_list" : {
-      "type" : "object",
-      "properties" : {
-        "spacing" : {
-          "$ref" : "#/$defs/measurement"
+      "type": "object",
+      "properties": {
+        "sign": {
+          "title": "Sign",
+          "description": "The 'bullet point' character used in the list",
+          "type": "string"
         },
-        "point_inline" : {
-          "type" : "boolean"
+        "spacing": {
+          "title": "Spacing",
+          "description": "Space between point and list item content",
+          "$ref": "#/$defs/measurement"
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
-        },
-        {
-          "$ref" : "#/$defs/padding"
+          "$ref": "#/$defs/font"
         }
       ]
     },
-    "ordered_list_point" : {
-      "type" : "object",
-      "properties" : {
-        "spacing" : {
-          "$ref" : "#/$defs/measurement"
-        },
-        "alphabetical" : {
-          "type" : "boolean"
-        },
-        "spanning" : {
-          "type" : "boolean"
-        },
-        "template" : {
-          "type" : "string"
+    "task_list_point": {
+      "type": "object",
+      "title": "Markdown task list point",
+      "x-example": {
+        "task_list_point": {
+          "checked": "☑",
+          "unchecked": "☐",
+          "spacing": "0.75mm"
         }
       },
-      "allOf" : [
+      "properties": {
+        "checked": {
+          "title": "Checked sign",
+          "description": "Sign for checked state of a task list item",
+          "type": "string"
+        },
+        "unchecked": {
+          "title": "Unchecked sign",
+          "description": "Sign for unchecked state of a task list item",
+          "type": "string"
+        },
+        "spacing": {
+          "title": "Spacing",
+          "description": "Additional space between point and list item content",
+          "$ref": "#/$defs/measurement"
+        }
+      },
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
         }
       ]
     },
-    "footnote_reference" : {
-      "type" : "object",
-      "allOf" : [
+    "ordered_list": {
+      "title": "Markdown ordered list",
+      "x-example": {
+        "ordered_list": {
+          "spacing": "2mm",
+          "point_inline": false
+        }
+      },
+      "type": "object",
+      "properties": {
+        "spacing": {
+          "title": "Spacing",
+          "description": "Additional space between list items",
+          "$ref": "#/$defs/measurement"
+        },
+        "point_inline": {
+          "title": "Inline Point",
+          "description": "Do not indent paragraph text, but include the point into the first paragraph",
+          "type": "boolean"
+        }
+      },
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
+        },
+        {
+          "$ref": "#/$defs/padding"
         }
       ]
     },
-    "footnote_definition" : {
-      "type" : "object",
-      "properties" : {
-        "point" : {
-          "type" : "object",
-          "allOf" : [
-            {
-              "$ref" : "#/$defs/font"
-            }
+    "ordered_list_point": {
+      "title": "Markdown ordered list point",
+      "type": "object",
+      "x-example": {
+        "ordered_list_point": {
+          "template": "<number>.",
+          "alphabetical": false,
+          "spacing": "0.75mm",
+          "spanning": true
+        }
+      },
+      "properties": {
+        "spacing": {
+          "$ref": "#/$defs/measurement"
+        },
+        "alphabetical": {
+          "title": "Alphabetical bullet points",
+          "description": "Convert the list item number into a character, eg. `a.` `b.` `c.`",
+          "type": "boolean"
+        },
+        "spanning": {
+          "title": "Spanning",
+          "description": "Use the width of the largest bullet as indention.",
+          "type": "boolean"
+        },
+        "template": {
+          "title": "Template",
+          "description": "customize what the prefix should contain, eg. `(<number>)`",
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/font"
+        }
+      ]
+    },
+    "header": {
+      "type": "object",
+      "title": "Markdown header",
+      "x-example": {
+        "header": {
+          "styles": [
+            "bold"
+          ],
+          "padding_top": "2mm",
+          "padding_bottom": "2mm"
+        },
+        "header_1": {
+          "size": 14,
+          "styles": [
+            "bold",
+            "italic"
+          ]
+        },
+        "header_2": {
+          "size": 12,
+          "styles": [
+            "bold"
           ]
         }
-      }
-    },
-    "link" : {
-      "type" : "object",
-      "allOf" : [
+      },
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
-        }
-      ]
-    },
-    "code" : {
-      "type" : "object",
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        }
-      ]
-    },
-    "header" : {
-      "type" : "object",
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
         },
         {
-          "$ref" : "#/$defs/padding"
+          "$ref": "#/$defs/padding"
         }
       ]
     },
-    "blockquote" : {
-      "type" : "object",
-      "properties" : {
-        "background_color" : {
-          "$ref" : "#/$defs/color"
+    "table_cell": {
+      "type": "object",
+      "title": "Table cell",
+      "description": "Styling for a table cell",
+      "x-example": {
+        "table_cell": {
+          "size": 9,
+          "color": "000000",
+          "padding": 5,
+          "border_width": 1
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
         },
         {
-          "$ref" : "#/$defs/border"
+          "$ref": "#/$defs/padding"
         },
         {
-          "$ref" : "#/$defs/padding"
-        },
-        {
-          "$ref" : "#/$defs/margin"
+          "$ref": "#/$defs/border"
         }
       ]
     },
-    "codeblock" : {
-      "type" : "object",
-      "properties" : {
-        "background_color" : {
-          "$ref" : "#/$defs/color"
+    "table_header": {
+      "type": "object",
+      "title": "Table header cell",
+      "description": "Styling for a table header cell",
+      "x-example": {
+        "table_header": {
+          "size": 9,
+          "styles": [
+            "bold"
+          ]
         }
       },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
+      "properties": {
+        "background_color": {
+          "$ref": "#/$defs/color"
         },
-        {
-          "$ref" : "#/$defs/padding"
-        },
-        {
-          "$ref" : "#/$defs/margin"
-        }
-      ]
-    },
-    "table" : {
-      "type" : "object",
-      "properties" : {
-        "auto_width" : {
-          "type" : "boolean"
-        },
-        "header" : {
-          "$ref" : "#/$defs/table_header"
-        },
-        "cell" : {
-          "$ref" : "#/$defs/table_cell"
+        "no_repeating": {
+          "type": "boolean"
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/margin"
-        },
-        {
-          "$ref" : "#/$defs/border"
+          "$ref": "#/$defs/font"
         }
       ]
     },
-    "headless_table" : {
-      "type" : "object",
-      "properties" : {
-        "auto_width" : {
-          "type" : "boolean"
-        },
-        "cell" : {
-          "$ref" : "#/$defs/table_cell"
-        }
-      },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/margin"
-        },
-        {
-          "$ref" : "#/$defs/border"
-        }
-      ]
-    },
-    "table_cell" : {
-      "type" : "object",
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        },
-        {
-          "$ref" : "#/$defs/padding"
-        },
-        {
-          "$ref" : "#/$defs/border"
-        }
-      ]
-    },
-    "table_header" : {
-      "type" : "object",
-      "properties" : {
-        "background_color" : {
-          "$ref" : "#/$defs/color"
-        },
-        "no_repeating" : {
-          "type" : "boolean"
-        }
-      },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/font"
-        }
-      ]
-    },
-    "paragraph" : {
-      "type" : "object",
-      "properties" : {
-        "align" : {
-          "type" : "string",
-          "enum" : [
+    "paragraph": {
+      "type": "object",
+      "title": "Markdown paragraph",
+      "properties": {
+        "align": {
+          "type": "string",
+          "enum": [
             "left",
             "center",
             "right",
@@ -825,137 +1382,104 @@
           ]
         }
       },
-      "allOf" : [
+      "allOf": [
         {
-          "$ref" : "#/$defs/font"
+          "$ref": "#/$defs/font"
         },
         {
-          "$ref" : "#/$defs/padding"
+          "$ref": "#/$defs/padding"
         }
       ]
     },
-    "image" : {
-      "type" : "object",
-      "properties" : {
-        "max_width" : {
-          "$ref" : "#/$defs/measurement"
-        },
-        "align" : {
-          "$ref" : "#/$defs/alignment"
-        },
-        "caption" : {
-          "$ref" : "#/$defs/paragraph"
-        }
+    "border": {
+      "type": "object",
+      "title": "Border Properties",
+      "description": "Properties to set borders",
+      "x-example": {
+        "border_color": "F000FF",
+        "border_color_top": "000FFF",
+        "border_color_bottom": "FFF000",
+        "no_border_left": true,
+        "no_border_right": true,
+        "border_width": "0.25mm",
+        "border_width_left": "0.5mm",
+        "border_width_right": "0.5mm"
       },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/margin"
-        }
-      ]
-    },
-    "border" : {
-      "type" : "object",
-      "properties" : {
-        "border_width" : {
-          "$ref" : "#/$defs/measurement"
+      "properties": {
+        "border_width": {
+          "title": "Border width",
+          "description": "One value for border line width on all sides",
+          "$ref": "#/$defs/measurement"
         },
-        "border_width_left" : {
-          "$ref" : "#/$defs/measurement"
+        "border_width_left": {
+          "title": "Border width left",
+          "description": "Border width only on the left side",
+          "$ref": "#/$defs/measurement"
         },
-        "border_width_top" : {
-          "$ref" : "#/$defs/measurement"
+        "border_width_top": {
+          "title": "Border width top",
+          "description": "Border width only on the top side",
+          "$ref": "#/$defs/measurement"
         },
-        "border_width_right" : {
-          "$ref" : "#/$defs/measurement"
+        "border_width_right": {
+          "title": "Border width right",
+          "description": "Border width only on the right side",
+          "$ref": "#/$defs/measurement"
         },
-        "border_width_bottom" : {
-          "$ref" : "#/$defs/measurement"
+        "border_width_bottom": {
+          "title": "Border width bottom",
+          "description": "Border width only on the bottom side",
+          "$ref": "#/$defs/measurement"
         },
-        "border_color" : {
-          "$ref" : "#/$defs/color"
+        "border_color": {
+          "title": "Border color",
+          "description": "One value for border color on all sides",
+          "$ref": "#/$defs/color"
         },
-        "border_color_left" : {
-          "$ref" : "#/$defs/color"
+        "border_color_left": {
+          "title": "Border color left",
+          "description": "Border color only on the left side",
+          "$ref": "#/$defs/color"
         },
-        "border_color_top" : {
-          "$ref" : "#/$defs/color"
+        "border_color_top": {
+          "title": "Border color top",
+          "description": "Border color only on the top side",
+          "$ref": "#/$defs/color"
         },
-        "border_color_right" : {
-          "$ref" : "#/$defs/color"
+        "border_color_right": {
+          "title": "Border color right",
+          "description": "Border color only on the right side",
+          "$ref": "#/$defs/color"
         },
-        "border_color_bottom" : {
-          "$ref" : "#/$defs/color"
+        "border_color_bottom": {
+          "title": "Border color bottom",
+          "description": "Border color only on the bottom side",
+          "$ref": "#/$defs/color"
         },
-        "no_border" : {
-          "type" : "boolean"
+        "no_border": {
+          "title": "Disable borders",
+          "description": "Turn off borders on all sides",
+          "type": "boolean"
         },
-        "no_border_left" : {
-          "type" : "boolean"
+        "no_border_left": {
+          "title": "Disable border left",
+          "description": "Turn off border on the left sides",
+          "type": "boolean"
         },
-        "no_border_top" : {
-          "type" : "boolean"
+        "no_border_top": {
+          "title": "Disable border top",
+          "description": "Turn off border on the top sides",
+          "type": "boolean"
         },
-        "no_border_right" : {
-          "type" : "boolean"
+        "no_border_right": {
+          "title": "Disable border right",
+          "description": "Turn off border on the right sides",
+          "type": "boolean"
         },
-        "no_border_bottom" : {
-          "type" : "boolean"
-        }
-      },
-      "allOf" : [
-        {
-          "$ref" : "#/$defs/margin"
-        }
-      ]
-    },
-    "image_classes" : {
-      "type" : "object",
-      "patternProperties" : {
-        ".*" : {
-          "$ref" : "#/$defs/image"
-        }
-      }
-    },
-    "fields_default" : {
-      "type" : "object",
-      "properties" : {
-        "pdf_language" : {
-          "type" : "string"
-        },
-        "pdf_header" : {
-          "type" : "string"
-        },
-        "pdf_header_2" : {
-          "type" : "string"
-        },
-        "pdf_header_3" : {
-          "type" : "string"
-        },
-        "pdf_footer" : {
-          "type" : "string"
-        },
-        "pdf_footer_2" : {
-          "type" : "string"
-        },
-        "pdf_footer_3" : {
-          "type" : "string"
-        },
-        "pdf_header_logo" : {
-          "type" : "string"
-        },
-        "pdf_hyphenation" : {
-          "type" : "boolean"
-        },
-        "pdf_fields" : {
-          "type" : "object",
-          "patternProperties" : {
-            ".*" : {
-              "type" : [
-                "string",
-                "number"
-              ]
-            }
-          }
+        "no_border_bottom": {
+          "title": "Disable border bottom",
+          "description": "Turn off border on the bottom sides",
+          "type": "boolean"
         }
       }
     }

--- a/app/models/work_package/pdf_export/standard.yml
+++ b/app/models/work_package/pdf_export/standard.yml
@@ -14,6 +14,7 @@ page_header:
 page_footer:
   offset: -30
   size: 8
+  spacing: 6
 
 page_logo:
   height: 20
@@ -82,9 +83,6 @@ work_package:
   subject_level_4:
     size: 11
     styles: [ "bold" ]
-  label:
-    size: 11
-    styles: [ "bold" ]
   attributes_table:
     margin_bottom: 10
     cell:
@@ -98,16 +96,6 @@ work_package:
       border_width: 0.25
     cell_label:
       styles: [ "bold" ]
-  section:
-    heading:
-      size: 9
-      styles: [ "bold" ]
-      margin_top: 4
-      margin_bottom: 4
-    item:
-      size: 9
-      styles: [ "italic" ]
-      margin_left: 10
   markdown_label:
     size: 12
     styles: [ "bold" ]

--- a/app/models/work_package/pdf_export/style.rb
+++ b/app/models/work_package/pdf_export/style.rb
@@ -161,30 +161,6 @@ module WorkPackage::PDFExport::Style
       resolve_margin(@styles[:work_package])
     end
 
-    def wp_section_heading
-      resolve_font(@styles.dig(:work_package, :section, :heading))
-    end
-
-    def wp_section_heading_margins
-      resolve_margin(@styles.dig(:work_package, :section, :heading))
-    end
-
-    def wp_section_item
-      resolve_font(@styles.dig(:work_package, :section, :item))
-    end
-
-    def wp_section_item_margins
-      resolve_margin(@styles.dig(:work_package, :section, :item))
-    end
-
-    def wp_label
-      resolve_font(@styles.dig(:work_package, :label))
-    end
-
-    def wp_label_margins
-      resolve_margin(@styles.dig(:work_package, :label))
-    end
-
     def wp_subject(level)
       resolve_font(@styles.dig(:work_package, :subject)).merge(
         resolve_font(@styles.dig(:work_package, "subject_level_#{level}".to_sym))

--- a/docs/system-admin-guide/design/pdf-export-styles/README.md
+++ b/docs/system-admin-guide/design/pdf-export-styles/README.md
@@ -1,7 +1,7 @@
 
 # PDF Export Styling yml
 
-This documents describes the styles settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)
+This document describes the style settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)
 
 | Key | Description | Data type |
 | - | - | - |

--- a/docs/system-admin-guide/design/pdf-export-styles/README.md
+++ b/docs/system-admin-guide/design/pdf-export-styles/README.md
@@ -1,0 +1,922 @@
+
+# PDF Export Styling yml
+
+This documents describes the styles settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)
+
+| Key | Description | Data type |
+| - | - | - |
+| `page` | **Page settings**<br/>Properties to set the basic page settings<br/>See [Page settings](#page-settings) | object |
+| `page_logo` | **Page logo**<br/>Styling for logo image in the page header.<br/>See [Page logo](#page-logo) | object |
+| `page_header` | **Page headers**<br/>See [Page headers](#page-headers) | object |
+| `page_footer` | **Page footers**<br/>See [Page footers](#page-footers) | object |
+| `page_heading` | **Page heading**<br/>The main page title heading<br/>See [Page heading](#page-heading) | object |
+| `work_package` | **Work package**<br/>Styling for the Work package section<br/>See [Work package](#work-package) | object |
+| `toc` | **Table of content**<br/>Styling for the table of content of the PDF report export<br/>See [Table of content](#table-of-content) | object |
+| `overview` | **Overview**<br/>Styling for the PDF table export<br/>See [Overview](#overview) | object |
+
+## Border Properties
+
+Properties to set borders
+
+Key: `border`
+
+Example:
+```yml
+border_color: F000FF
+border_color_top: 000FFF
+border_color_bottom: FFF000
+no_border_left: true
+no_border_right: true
+border_width: 0.25mm
+border_width_left: 0.5mm
+border_width_right: 0.5mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `border_width` | **Border width**<br/>One value for border line width on all sides<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `border_width_left` | **Border width left**<br/>Border width only on the left side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `border_width_top` | **Border width top**<br/>Border width only on the top side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `border_width_right` | **Border width right**<br/>Border width only on the right side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `border_width_bottom` | **Border width bottom**<br/>Border width only on the bottom side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `border_color` | **Border color**<br/>One value for border color on all sides<br/>Example: `F0F0F0` | string |
+| `border_color_left` | **Border color left**<br/>Border color only on the left side<br/>Example: `F0F0F0` | string |
+| `border_color_top` | **Border color top**<br/>Border color only on the top side<br/>Example: `F0F0F0` | string |
+| `border_color_right` | **Border color right**<br/>Border color only on the right side<br/>Example: `F0F0F0` | string |
+| `border_color_bottom` | **Border color bottom**<br/>Border color only on the bottom side<br/>Example: `F0F0F0` | string |
+| `no_border` | **Disable borders**<br/>Turn off borders on all sides | boolean |
+| `no_border_left` | **Disable border left**<br/>Turn off border on the left sides | boolean |
+| `no_border_top` | **Disable border top**<br/>Turn off border on the top sides | boolean |
+| `no_border_right` | **Disable border right**<br/>Turn off border on the right sides | boolean |
+| `no_border_bottom` | **Disable border bottom**<br/>Turn off border on the bottom sides | boolean |
+
+## Font properties
+
+Properties to set the font style
+
+Key: `font`
+
+Example:
+```yml
+font: OpenSans
+size: 10
+character_spacing: 0
+styles: []
+color: '000000'
+leading: 2
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `font` |  | string |
+| `size` | A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `character_spacing` | A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `leading` | A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `color` | **Color**<br/>A color in RRGGBB format<br/>Example: `F0F0F0` | string |
+| `styles` | Example: `[bold]`<br/>Valid values:<br/>`bold`, `italic`, `underline`, `strikethrough`, `superscript`, `subscript` | array of string |
+
+## Image caption
+
+Styling for the caption below an image
+
+Key: `caption`
+
+| Key | Description | Data type |
+| - | - | - |
+| `align` | Valid values:<br/>`left`, `center`, `right`, `justify` | string |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+
+## Margin properties
+
+Properties to set margins
+
+Key: `margin`
+
+Example:
+```yml
+margin: 10mm
+margin_top: 15mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `margin` | **Margin**<br/>One value for margin on all sides<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `margin_left` | **Margin left**<br/>Margin only on the left side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `margin_right` | **Margin right**<br/>Margin only on the right side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `margin_top` | **Margin top**<br/>Margin only on the top side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `margin_bottom` | **Margin bottom**<br/>Margin only on the bottom side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+
+## Markdown Link
+
+Styling a clickable link
+
+Key: `link`
+
+Example:
+```yml
+link:
+  color: '000088'
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+
+## Markdown Styling
+
+Styling for content of work package description and long text custom fields
+
+Key: `markdown`
+
+Example:
+```yml
+markdown:
+  font: {}
+  header: {}
+  header_1: {}
+  header_2: {}
+  header_3: {}
+  paragraph: {}
+  unordered_list: {}
+  unordered_list_point: {}
+  ordered_list: {}
+  ordered_list_point: {}
+  task_list: {}
+  task_list_point: {}
+  link: {}
+  code: {}
+  blockquote: {}
+  codeblock: {}
+  table: {}
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `font` | **Font properties**<br/>Properties to set the font style<br/>See [Font properties](#font-properties) | object |
+| `paragraph` | **Markdown paragraph**<br/>A block of text<br/>See [Markdown paragraph](#markdown-paragraph) | object |
+| `table` | **Markdown table**<br/>See [Markdown table](#markdown-table) | object |
+| `headless_table` | **Markdown headless table**<br/>Tables without or empty header rows can be styled differently.<br/>See [Markdown headless table](#markdown-headless-table) | object |
+| `code` | **Markdown code**<br/>Styling to denote a word or phrase as code<br/>See [Markdown code](#markdown-code) | object |
+| `codeblock` | **Markdown code block**<br/>Styling to denote a paragraph as code<br/>See [Markdown code block](#markdown-code-block) | object |
+| `link` | **Markdown Link**<br/>Styling a clickable link<br/>See [Markdown Link](#markdown-link) | object |
+| `image` | **Markdown image**<br/>Styling of images<br/>See [Markdown image](#markdown-image) | object |
+| `hrule` | **Markdown horizontal rule**<br/>Styling for horizontal lines<br/>See [Markdown horizontal rule](#markdown-horizontal-rule) | object |
+| `header` | **Markdown header**<br/>Default styling for headers on all levels.<br/>use header_`x` as key for header level `x`.<br/>See [Markdown header](#markdown-header) | object |
+| `blockquote` | **Markdown blockquote**<br/>Styling to denote a paragraph as quote<br/>See [Markdown blockquote](#markdown-blockquote) | object |
+| `ordered_list` | **Markdown ordered list**<br/>Default styling for ordered lists on all levels.<br/>use ordered_list_`x` as key for ordered list level `x`.<br/>See [Markdown ordered list](#markdown-ordered-list) | object |
+| `ordered_list_point` | **Markdown ordered list point**<br/>Default styling for ordered list points on all levels.<br/>use ordered_list_point_`x` as key for ordered list points level `x`.<br/>See [Markdown ordered list point](#markdown-ordered-list-point) | object |
+| `unordered_list` | **Markdown unordered list**<br/>Default styling for unordered lists on all levels.<br/>use unordered_list_`x` as key for unordered list level `x`.<br/>See [Markdown unordered list](#markdown-unordered-list) | object |
+| `unordered_list_point` | **Markdown unordered list point**<br/>Default styling for unordered list points on all levels.<br/>use unordered_list_point_`x` as key for unordered list points level `x`.<br/>See [Markdown unordered list point](#markdown-unordered-list-point) | object |
+| `task_list` | **Markdown task list**<br/>See [Markdown unordered list](#markdown-unordered-list) | object |
+| `task_list_point` | **Markdown task list point**<br/>See [Markdown task list point](#markdown-task-list-point) | object |
+| `ordered_list_point_1`<br/>`ordered_list_point_2`<br/>`ordered_list_point_x` | Markdown ordered list point level<br/>See [Markdown ordered list point](#markdown-ordered-list-point) | object |
+| `ordered_list_1`<br/>`ordered_list_2`<br/>`ordered_list_x` | Markdown ordered list level<br/>See [Markdown ordered list](#markdown-ordered-list) | object |
+| `unordered_list_point_1`<br/>`unordered_list_point_2`<br/>`unordered_list_point_x` | Markdown unordered list point level<br/>See [Markdown unordered list point](#markdown-unordered-list-point) | object |
+| `unordered_list_1`<br/>`unordered_list_2`<br/>`unordered_list_x` | Markdown unordered List Level<br/>See [Markdown unordered list](#markdown-unordered-list) | object |
+| `header_1`<br/>`header_2`<br/>`header_x` | Markdown header level<br/>See [Markdown header](#markdown-header) | object |
+
+## Markdown blockquote
+
+Styling to denote a paragraph as quote
+
+Key: `blockquote`
+
+Example:
+```yml
+blockquote:
+  background_color: f4f9ff
+  size: 14
+  styles:
+    - italic
+  color: 0f3b66
+  border_color: b8d6f4
+  border_width: 1
+  no_border_right: true
+  no_border_left: false
+  no_border_bottom: true
+  no_border_top: true
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `background_color` | **Color**<br/>A color in RRGGBB format<br/>Example: `F0F0F0` | string |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Border Properties](#border-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Markdown code
+
+Styling to denote a word or phrase as code
+
+Key: `code`
+
+Example:
+```yml
+code:
+  font: Consolas
+  color: '880000'
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+
+## Markdown code block
+
+Styling to denote a paragraph as code
+
+Key: `codeblock`
+
+Example:
+```yml
+codeblock:
+  background_color: F5F5F5
+  font: Consolas
+  size: 8
+  color: '880000'
+  padding: 3mm
+  margin_top: 2mm
+  margin_bottom: 2mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `background_color` | **Color**<br/>A color in RRGGBB format<br/>Example: `F0F0F0` | string |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Markdown header
+
+Key: `header`
+
+Example:
+```yml
+header:
+  styles:
+    - bold
+  padding_top: 2mm
+  padding_bottom: 2mm
+header_1:
+  size: 14
+  styles:
+    - bold
+    - italic
+header_2:
+  size: 12
+  styles:
+    - bold
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+
+## Markdown headless table
+
+Tables without or empty header rows can be styled differently.
+
+Key: `headless_table`
+
+Example:
+```yml
+headless_table:
+  auto_width: true
+  cell:
+    style: underline
+    background_color: 000FFF
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `auto_width` | **Automatic column widths**<br/>Table columns should fit the content, equal spacing of columns if value is `false` | boolean |
+| `cell` | **Table cell**<br/>Styling for a table cell<br/>See [Table cell](#table-cell) | object |
+| … | See [Margin properties](#margin-properties) |  |
+| … | See [Border Properties](#border-properties) |  |
+
+## Markdown horizontal rule
+
+Styling for horizontal lines
+
+Key: `hrule`
+
+Example:
+```yml
+hrule:
+  line_width: 1
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `line_width` | **Sets the stroke width of the horizontal rule**<br/>A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Markdown image
+
+Styling of images
+
+Key: `image`
+
+Example:
+```yml
+image:
+  max_width: 50mm
+  margin: 2mm
+  margin_bottom: 3mm
+  align: center
+  caption:
+    align: center
+    size: 8
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `max_width` | **Maximum width of the image**<br/>A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `align` | **Alignment**<br/>How the element should be aligned<br/>Example: `center`<br/>Valid values:<br/>`left`, `center`, `right` | string |
+| `caption` | **Image caption**<br/>Styling for the caption below an image<br/>See [Image caption](#image-caption) | object |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Markdown ordered list
+
+Key: `ordered_list`
+
+Example:
+```yml
+ordered_list:
+  spacing: 2mm
+  point_inline: false
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `spacing` | **Spacing**<br/>Additional space between list items<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `point_inline` | **Inline Point**<br/>Do not indent paragraph text, but include the point into the first paragraph | boolean |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+
+## Markdown ordered list point
+
+Key: `ordered_list_point`
+
+Example:
+```yml
+ordered_list_point:
+  template: "<number>."
+  alphabetical: false
+  spacing: 0.75mm
+  spanning: true
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `spacing` | A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `alphabetical` | **Alphabetical bullet points**<br/>Convert the list item number into a character, eg. `a.` `b.` `c.` | boolean |
+| `spanning` | **Spanning**<br/>Use the width of the largest bullet as indention. | boolean |
+| `template` | **Template**<br/>customize what the prefix should contain, eg. `(<number>)` | string |
+| … | See [Font properties](#font-properties) |  |
+
+## Markdown paragraph
+
+A block of text
+
+Key: `paragraph`
+
+Example:
+```yml
+paragraph:
+  align: justify
+  padding_bottom: 2mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `align` | Valid values:<br/>`left`, `center`, `right`, `justify` | string |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+
+## Markdown table
+
+Key: `table`
+
+Example:
+```yml
+table:
+  auto_width: true
+  header:
+    background_color: F0F0F0
+    no_repeating: true
+    size: 12
+  cell:
+    background_color: 000FFF
+    size: 10
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `auto_width` | **Automatic column widths**<br/>Table columns should fit the content, equal spacing of columns if value is `false` | boolean |
+| `header` | **Table header cell**<br/>Styling for a table header cell<br/>See [Table header cell](#table-header-cell) | object |
+| `cell` | **Table cell**<br/>Styling for a table cell<br/>See [Table cell](#table-cell) | object |
+| … | See [Margin properties](#margin-properties) |  |
+| … | See [Border Properties](#border-properties) |  |
+
+## Markdown task list point
+
+Key: `task_list_point`
+
+Example:
+```yml
+task_list_point:
+  checked: "☑"
+  unchecked: "☐"
+  spacing: 0.75mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `checked` | **Checked sign**<br/>Sign for checked state of a task list item | string |
+| `unchecked` | **Unchecked sign**<br/>Sign for unchecked state of a task list item | string |
+| `spacing` | **Spacing**<br/>Additional space between point and list item content<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| … | See [Font properties](#font-properties) |  |
+
+## Markdown unordered list
+
+Key: `unordered_list`
+
+Example:
+```yml
+unordered_list:
+  spacing: 1.5mm
+  padding_top: 2mm
+  padding_bottom: 2mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `spacing` | **Spacing**<br/>Additional space between list items<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+
+## Markdown unordered list point
+
+Key: `unordered_list_point`
+
+Example:
+```yml
+unordered_list_point:
+  sign: "•"
+  spacing: 0.75mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `sign` | **Sign**<br/>The 'bullet point' character used in the list | string |
+| `spacing` | **Spacing**<br/>Space between point and list item content<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| … | See [Font properties](#font-properties) |  |
+
+## Overview
+
+Styling for the PDF table export
+
+Key: `overview`
+
+Example:
+```yml
+overview:
+  group_heading: {}
+  table: {}
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `group_heading` | **Overview group heading**<br/>Styling for the group lavel if grouping is activated<br/>See [Overview group heading](#overview-group-heading) | object |
+| `table` | **Overview table**<br/>See [Overview table](#overview-table) | object |
+
+## Overview group heading
+
+Styling for the group lavel if grouping is activated
+
+Key: `group_heading`
+
+Example:
+```yml
+group_heading:
+  size: 11
+  styles:
+    - bold
+  margin_bottom: 10
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Overview table
+
+Key: `table`
+
+Example:
+```yml
+table:
+  subject_indent: 0
+  margin_bottom: 20
+  cell:
+    size: 9
+    color: '000000'
+    padding: 5
+  cell_header:
+    size: 9
+    styles:
+    - bold
+  cell_sums:
+    size: 8
+    styles:
+    - bold
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `subject_indent` | **Indent subject**<br/>Indent by work package level in the subject cell<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `cell` | **Table cell**<br/>Styling for a table value cell<br/>See [Table cell](#table-cell) | object |
+| `cell_header` | **Table header cell**<br/>Styling for a table header cell<br/>See [Table cell](#table-cell) | object |
+| `cell_sums` | **Table sum cell**<br/>Styling for a table sum cell<br/>See [Table cell](#table-cell) | object |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Padding Properties
+
+Properties to set paddings
+
+Key: `padding`
+
+Example:
+```yml
+padding: 10mm
+padding_top: 15mm
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `padding` | **Padding**<br/>One value for padding on all sides<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `padding_left` | **Padding left**<br/>Padding only on the left side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `padding_right` | **Padding right**<br/>Padding only on the right side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `padding_top` | **Padding top**<br/>Padding only on the top side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `padding_bottom` | **Padding bottom**<br/>Padding only on the bottom side<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+
+## Page footers
+
+Key: `page_footer`
+
+Example:
+```yml
+page_footer:
+  offset: -30
+  size: 8
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `offset` | **Offset position from page bottom**<br/>A positive or negative number and an optional unit<br/>Example: `-30` | number or string<br/>See [Units](#units) |
+| `spacing` | **Minimum spacing between different page footers**<br/>A number >= 0 and an optional unit<br/>Example: `8` | number or string<br/>See [Units](#units) |
+| … | See [Font properties](#font-properties) |  |
+
+## Page headers
+
+Key: `page_header`
+
+Example:
+```yml
+page_header:
+  align: left
+  offset: 20
+  size: 8
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `align` | **Alignment**<br/>How the element should be aligned<br/>Example: `center`<br/>Valid values:<br/>`left`, `center`, `right` | string |
+| `offset` | **Offset position from page top**<br/>A positive or negative number and an optional unit<br/>Example: `-30` | number or string<br/>See [Units](#units) |
+| … | See [Font properties](#font-properties) |  |
+
+## Page heading
+
+The main page title heading
+
+Key: `page_heading`
+
+Example:
+```yml
+page_heading:
+  size: 14
+  styles:
+    - bold
+  margin_bottom: 10
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Page logo
+
+Styling for logo image in the page header.
+
+Key: `page_logo`
+
+Example:
+```yml
+page_logo:
+  height: 20
+  align: right
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `height` | **Height of the image**<br/>A number >= 0 and an optional unit<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `align` | **Alignment**<br/>How the element should be aligned<br/>Example: `center`<br/>Valid values:<br/>`left`, `center`, `right` | string |
+| `offset` | **Offset position from page top**<br/>A positive or negative number and an optional unit<br/>Example: `-30` | number or string<br/>See [Units](#units) |
+
+## Page settings
+
+Properties to set the basic page settings
+
+Key: `page`
+
+Example:
+```yml
+page:
+  page_size: EXECUTIVE
+  margin_top: 60
+  margin_bottom: 60
+  margin_left: 36
+  margin_right: 36
+  page_break_threshold: 200
+  link_color: 175A8E
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `link_color` | **Link color**<br/>Set the color of clickable links<br/>Example: `F0F0F0` | string |
+| `page_layout` | **Page layout**<br/>The layout of a page<br/>Example: `portrait`<br/>Valid values:<br/>`portrait`, `landscape` | string |
+| `page_size` | **Page size**<br/>The size of a page<br/>Example: `EXECUTIVE`<br/>Valid values:<br/>`EXECUTIVE`, `TABLOID`, `LETTER`, `LEGAL`, `FOLIO`, `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `A7`, `A8`, `A9`, `A10`, `B0`, `B1`, `B2`, `B3`, `B4`, `B5`, `B6`, `B7`, `B8`, `B9`, `B10`, `C0`, `C1`, `C2`, `C3`, `C4`, `C5`, `C6`, `C7`, `C8`, `C9`, `C10`, `RA0`, `RA1`, `RA2`, `RA3`, `RA4`, `SRA0`, `SRA1`, `SRA2`, `SRA3`, `SRA4`, `4A0`, `2A0` | string |
+| `page_break_threshold` | **Page break threshold**<br/>If there is a new section, start a new page if space less than the threshold is available<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| … | Default font settings<br/>See [Font properties](#font-properties) |  |
+| … | Page margins<br/>See [Margin properties](#margin-properties) |  |
+
+## Table cell
+
+Styling for a table cell
+
+Key: `table_cell`
+
+Example:
+```yml
+table_cell:
+  size: 9
+  color: '000000'
+  padding: 5
+  border_width: 1
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Padding Properties](#padding-properties) |  |
+| … | See [Border Properties](#border-properties) |  |
+
+## Table header cell
+
+Styling for a table header cell
+
+Key: `table_header`
+
+Example:
+```yml
+table_header:
+  size: 9
+  styles:
+    - bold
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `background_color` | **Color**<br/>A color in RRGGBB format<br/>Example: `F0F0F0` | string |
+| `no_repeating` |  | boolean |
+| … | See [Font properties](#font-properties) |  |
+
+## Table of content
+
+Styling for the table of content of the PDF report export
+
+Key: `toc`
+
+Example:
+```yml
+toc:
+  subject_indent: 4
+  indent_mode: stairs
+  margin_top: 10
+  margin_bottom: 20
+  item:
+    size: 9
+    color: '000000'
+    margin_bottom: 4
+  item_level_1:
+    size: 10
+    styles:
+    - bold
+    margin_top: 4
+    margin_bottom: 4
+  item_level_2:
+    size: 10
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `subject_indent` | **Indention width**<br/>Indention width for TOC levels<br/>Examples: `10mm`, `10` | number or string<br/>See [Units](#units) |
+| `indent_mode` | **Indention mode**<br/>`flat`= no indention, `stairs` = indent on each level, `third_level` = indent only at 3th level<br/>Valid values:<br/>`flat`, `stairs`, `third_level` | string |
+| `item` | **Table of content item**<br/>Default styling for TOC items on all levels.<br/>use item_level_x` as key for TOC items on level `x`.<br/>See [Table of content item](#table-of-content-item) | object |
+| … | See [Margin properties](#margin-properties) |  |
+| `item_level_1`<br/>`item_level_2`<br/>`item_level_x` | See [Table of content item level](#table-of-content-item-level) | object |
+
+## Table of content item
+
+Default styling for TOC items on all levels.<br/>use item_level_x` as key for TOC items on level `x`.
+
+Key: `item`
+
+Example:
+```yml
+item:
+  size: 9
+  color: '000000'
+  margin_bottom: 4
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Table of content item level
+
+Key: `item_level_x`
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Work package
+
+Styling for the Work package section
+
+Key: `work_package`
+
+Example:
+```yml
+work_package:
+  margin_bottom: 20
+  subject: {}
+  subject_level_1: {}
+  subject_level_2: {}
+  subject_level_3: {}
+  attributes_table: {}
+  markdown_label: {}
+  markdown_margin: {}
+  markdown: {}
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `subject` | **Work package subject**<br/>Styling for the Work package subject headline<br/>See [Work package subject](#work-package-subject) | object |
+| `attributes_table` | **Work package attributes**<br/>Styling for the Work package attributes table<br/>See [Work package attributes](#work-package-attributes) | object |
+| `markdown_label` | **Work package markdown label**<br/>Label headline for work package description and long text custom fields<br/>See [Work package markdown label](#work-package-markdown-label) | object |
+| `markdown_margin` | **Work package markdown margins**<br/>Margins for work package description and long text custom fields<br/>See [Work package markdown margins](#work-package-markdown-margins) | object |
+| `markdown` | **Markdown Styling**<br/>Styling for content of work package description and long text custom fields<br/>See [Markdown Styling](#markdown-styling) | object |
+| … | See [Margin properties](#margin-properties) |  |
+| `subject_level_1`<br/>`subject_level_2`<br/>`subject_level_x` | See [Work package subject level](#work-package-subject-level) | object |
+
+## Work package attributes
+
+Styling for the Work package attributes table
+
+Key: `attributes_table`
+
+Example:
+```yml
+attributes_table:
+  margin_bottom: 10
+  cell:
+    size: 9
+    color: '000000'
+    padding_left: 5
+    padding_right: 5
+    padding_top: 0
+    padding_bottom: 5
+    border_color: 4B4B4B
+    border_width: 0.25
+  cell_label:
+    styles:
+    - bold
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| `cell` | **Attribute value table cell**<br/>Styling for a table cell with attribute value<br/>See [Table cell](#table-cell) | object |
+| `cell_label` | **Attribute label table cell**<br/>Styling for a table cell with attribute label<br/>See [Table cell](#table-cell) | object |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Work package markdown label
+
+Label headline for work package description and long text custom fields
+
+Key: `markdown_label`
+
+Example:
+```yml
+markdown_label:
+  size: 12
+  styles:
+    - bold
+  margin_top: 2
+  margin_bottom: 4
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Work package markdown margins
+
+Margins for work package description and long text custom fields
+
+Key: `markdown_margin`
+
+Example:
+```yml
+markdown_margin:
+  margin_bottom: 16
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Work package subject
+
+Styling for the Work package subject headline
+
+Key: `subject`
+
+Example:
+```yml
+subject:
+  size: 10
+  styles:
+    - bold
+  margin_bottom: 10
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+
+## Work package subject level
+
+Key: `subject_level_x`
+
+Example:
+```yml
+subject_level_1:
+  size: 14
+  styles:
+    - bold
+subject_level_2:
+  size: 13
+  styles:
+    - bold
+subject_level_3:
+  size: 12
+  styles:
+    - bold
+```
+
+| Key | Description | Data type |
+| - | - | - |
+| … | See [Font properties](#font-properties) |  |
+| … | See [Margin properties](#margin-properties) |  |
+## Units
+
+available units are
+
+`mm` - Millimeter, `cm` - Centimeter, `dm` - Decimeter, `m` - Meter
+
+`in` - Inch, `ft` - Feet, `yr` - Yard
+
+`pt` - [Postscript point](https://en.wikipedia.org/wiki/Point_(typography)#Desktop_publishing_point) (default if no unit is used)

--- a/script/pdf_export/generate_styles_doc
+++ b/script/pdf_export/generate_styles_doc
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# Generates the PDF export styling yaml documentation.
+
+require 'md_to_pdf/style/schema_doc'
+require "yaml"
+require "json"
+
+root = File.expand_path("../../", __dir__)
+schema_file = File.join(root, 'app', 'models', 'work_package', 'pdf_export', 'schema.json')
+schema = JSON::load_file(schema_file)
+generator = MarkdownToPDF::StyleSchemaDocsGenerator.new(schema)
+markdown = generator.generate_markdown
+styles_doc_folder = File.join(root, 'docs', 'system-admin-guide', 'design', 'pdf-export-styles')
+FileUtils.mkdir_p(styles_doc_folder)
+styles_doc_file = File.join(styles_doc_folder, 'README.md')
+File.write(styles_doc_file, markdown)
+puts "Doc written: #{styles_doc_file}"

--- a/script/pdf_export/validate_styles
+++ b/script/pdf_export/validate_styles
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'md_to_pdf/style/validation'
+require 'md_to_pdf/core'
+require 'yaml'
+require 'json'
+
+class SchemaValidator
+  include MarkdownToPDF::StyleValidation
+
+  def validate
+    root = File.expand_path("../../", __dir__)
+    schema = JSON::load_file(File.join(root, 'app', 'models', 'work_package', 'pdf_export', 'schema.json'))
+    styles_file = File.join(root, 'app', 'models', 'work_package', 'pdf_export', 'standard.yml')
+    styles = YAML.load_file(styles_file)
+    validate_schema!(styles, schema)
+    puts "Valid: #{styles_file}"
+  end
+end
+
+SchemaValidator.new.validate


### PR DESCRIPTION
This PR
* adds `bundle exec ./scripts/pdf_export/validate_styles` to validate the styling yml by the schema
* adds `bundle exec ./scripts/pdf_export/generate_styles_doc` to generate a documentation markdown file into [docs/system-admin-guide/design/pdf-export-styles](https://github.com/opf/openproject/tree/documentation/49082-documentation-for-pdf-styling-yaml/docs/system-admin-guide/design/pdf-export-styles)
* removes unused styles

https://community.openproject.org/work_packages/49082