### PR TITLE
Stabilise sidemenu loading

### DIFF
--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -38,7 +38,6 @@ import { map } from 'rxjs/operators';
 import {
   BehaviorSubject,
   combineLatest,
-  Observable,
 } from 'rxjs';
 import { States } from 'core-app/core/states/states.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -74,8 +73,6 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
     no_results: this.I18n.t('js.autocompleter.notFoundText'),
   };
 
-  public views$:Observable<IOpSidemenuItem[]>;
-
   @Input() menuItems:string[] = [];
 
   @Input() projectId:string|undefined;
@@ -83,6 +80,8 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
   @Input() baseRoute:string;
 
   @Input() viewType:ViewType;
+
+  public items:IOpSidemenuItem[] = [];
 
   private apiViewType:string;
 
@@ -122,22 +121,31 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
       .onActivate(...this.menuItems)
       .subscribe(() => this.initializeAutocomplete());
 
-    this.views$ = combineLatest([
+    combineLatest([
       this.search$,
       this.viewCategories$,
     ]).pipe(
-      map(([searchText, categories]) => categories
-        .map((category) => {
-          if (ViewSelectComponent.matchesText(category.title, searchText)) {
-            return category;
-          }
+      map(([searchText, categories]) => {
+        // We go the way of assigning the variable instead of using the observable directly with the async pipe.
+        // For whatever the reason Angular's change detection does not catch the changes made here.
+        // Thus, the sidemenu items were only updated with the next global change event (e.g. notifications push or some user interaction).
+        this.items = categories
+          .map((category) => {
+            if (ViewSelectComponent.matchesText(category.title, searchText)) {
+              return category;
+            }
+            const filteredChildren = category.children
+              ?.filter((query) => ViewSelectComponent.matchesText(query.title, searchText));
 
-          const filteredChildren = category.children
-            ?.filter((query) => ViewSelectComponent.matchesText(query.title, searchText));
-          return { title: category.title, children: filteredChildren, collapsible: true };
-        })
-        .filter((category) => category.children && category.children.length > 0)),
-    );
+            return { title: category.title, children: filteredChildren, collapsible: true };
+          })
+          .filter((category) => category.children && category.children.length > 0);
+
+        this.cdRef.detectChanges();
+
+        return this.items;
+      }),
+    ).subscribe();
   }
 
   private initializeAutocomplete():void {

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.template.html
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.template.html
@@ -14,12 +14,12 @@
     </div>
 
     <p class="searchable-menu--no-results-container"
-       [hidden]="(views$ | async).length > 0"
+       [hidden]="items.length > 0"
        [textContent]="text.no_results"></p>
 
     <op-sidemenu
       class="op-view-select--search-results"
-      [items]="views$ | async"
+      [items]="items"
       [collapsible]="true"
       [searchable]="true"
     >


### PR DESCRIPTION
Use variable instead of async pipe and fire change detection manually, because the changes were not recognised otherwise.



