### PR TITLE
Fix double render and missing translation on `types_controller#move`

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -99,11 +99,11 @@ class TypesController < ApplicationController
 
     if @type.update(permitted_params.type_move)
       flash[:notice] = I18n.t(:notice_successful_update)
+      redirect_to types_path
     else
-      flash.now[:error] = t('type_could_not_be_saved')
+      flash.now[:error] = I18n.t(:error_type_could_not_be_saved)
       render action: 'edit'
     end
-    redirect_to types_path
   end
 
   def destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,6 +1374,7 @@ en:
   error_password_change_failed: 'An error occurred when trying to change the password.'
   error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
   error_scm_not_found: "The entry or revision was not found in the repository."
+  error_type_could_not_be_saved: "Type could not be saved"
   error_unable_delete_status: "The work package status cannot be deleted since it is used by at least one work package."
   error_unable_delete_default_status: "Unable to delete the default work package status. Please select another default work package status before deleting the current one."
   error_unable_to_connect: "Unable to connect (%{value})"

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -300,19 +300,45 @@ RSpec.describe TypesController do
     end
 
     describe 'POST move' do
-      let!(:type) { create(:type, name: 'My type', position: '1') }
-      let!(:type2) { create(:type, name: 'My type 2', position: '2') }
-      let(:params) { { 'id' => type.id, 'type' => { move_to: 'lower' } } }
+      context 'with a successful update' do
+        let!(:type) { create(:type, name: 'My type', position: '1') }
+        let!(:type2) { create(:type, name: 'My type 2', position: '2') }
+        let(:params) { { 'id' => type.id, 'type' => { move_to: 'lower' } } }
 
-      before do
-        post :move, params:
+        before do
+          post :move, params:
+        end
+
+        it { expect(response).to be_redirect }
+        it { expect(response).to redirect_to(types_path) }
+
+        it 'has the position updated' do
+          expect(Type.find_by(name: 'My type').position).to eq(2)
+        end
       end
 
-      it { expect(response).to be_redirect }
-      it { expect(response).to redirect_to(types_path) }
+      context 'with a failed update' do
+        let!(:type) { create(:type, name: 'My type', position: '1') }
+        let!(:type2) { create(:type, name: 'My type 2', position: '2') }
+        let(:params) { { 'id' => type.id, 'type' => { move_to: 'lower' } } }
 
-      it 'has the position updated' do
-        expect(Type.find_by(name: 'My type').position).to eq(2)
+        before do
+          allow(Type).to receive(:find).and_return(type)
+          allow(type).to receive(:update).and_return false
+
+          post :move, params:
+        end
+
+        it { expect(response).not_to be_redirect }
+        it { expect(response).to render_template('edit') }
+
+        it 'has an unsuccessful move flash' do
+          expect(flash[:error]).to eq(I18n.t(:error_type_could_not_be_saved))
+        end
+
+        it "doesn't update the position" do
+          expect(Type.find_by(name: 'My type').position).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
In said where the call to `@type.update` returned `false`, both a missing translation would be added as a flash message and a double render error would be raised.

1. Double-render error on failed updated.
```bash
Failures:

  1) TypesController with an authorized account POST move
     Failure/Error: redirect_to types_path

     AbstractController::DoubleRenderError:
       Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return".
```

2. Translation missing error.
```bash
[5] pry(#<RSpec::ExampleGroups::TypesController::WithAnAuthorizedAccount::POSTMove>)> controller.flash
=> #<ActionDispatch::Flash::FlashHash:0x0000000133a75308
 @discard=#<Set: {"error"}>,
 @flashes={"error"=>"Translation missing: en.type_could_not_be_saved"},
 @now=#<ActionDispatch::Flash::FlashNow:0x0000000133a75100 @flash=#<ActionDispatch::Flash::FlashHash:0x0000000133a75308 ...>>>
```
