### PR TITLE
fix flaky team planner onboarding spec - hacky way

### DIFF
--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe 'team planner onboarding tour',
 
   context 'as a new user' do
     it 'I see the team planner onboarding tour in the demo project' do
-      skip("Flaky test disabled. Fix it in https://community.openproject.org/wp/49073")
       # Set the tour parameter so that we can start on the wp page
       visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
 

--- a/modules/team_planner/spec/support/onboarding/onboarding_steps.rb
+++ b/modules/team_planner/spec/support/onboarding/onboarding_steps.rb
@@ -31,10 +31,22 @@ module OnboardingSteps
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.overview')), normalize_ws: true
 
-    # The team planner is long to load
     next_button.click
-    expect(page)
-      .to have_text sanitize_string(I18n.t('js.onboarding.steps.team_planner.calendar')), normalize_ws: true, wait: 10
+    # The team planner (and in fact every PartitionedQuerySpacePageComponent page) suffers from not being shown upon
+    # clicking on an item in the menu unless the mouse is moved (or some other user event). Angular's change detection
+    # apparently does not fire on the initialization. This only happens when moving from one Angular page to the next
+    # without a reload. This is the case here, as the board page is displayed before.
+    # So this is an ugly workaround when actually the page initalization should be fixed. But as this is an edge case
+    # this shortcut is chosen.
+    sleep 0.5
+
+    retry_block do
+      page.execute_script("document.querySelector('#content').dispatchEvent(new MouseEvent('mouseover'));")
+
+      page.find('.enjoy_hint_label',
+                text: sanitize_string(I18n.t('js.onboarding.steps.team_planner.calendar')),
+                normalize_ws: true)
+    end
 
     next_button.click
     expect(page)


### PR DESCRIPTION
Uses a hacky workaround to the problem of the team planner (among other `PartitionedQuerySpacePageComponent` incarnations) not loading without an external event (e.g. the mouse moving or the notification bell update).

https://community.openproject.org/wp/49073