### PR TITLE
Fix Sidebar not vertically scrolling on Work Packages index pages

### DIFF
--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -24,9 +24,6 @@
       margin-right: 0.5rem
 
   .op-sidemenu
-    display: flex
-    flex-direction: column
-    font-size: 14px
 
     &--title
       display: flex


### PR DESCRIPTION
Addresses issue 1 found [here](https://community.openproject.org/work_packages/48142/activity#activity-50)

By using the class `@HostBinding` for the `sidemenu` component without setting the `encapsulation` option to `ViewEncapsulation.None`, the styles for the `.op-sidemenu` class were never applied when using the component-specific `sidemenu.component.sass` file.

Since the styles for `.op-sidemenu` were moved to a global sass partial file, these styles were now being applied since the collission happening with the component setup was no longer present. With these styles being applied, specifically:

```sass
display: flex
flex-direction: column
font-size: 14px
```

the scrollbar was no longer usable. These styles instead, are already present in `.op-sidebar`.