### PR TITLE
Use the CustomValue eagerloading inside the HistoricAttributes eagerloading wrapper.

### DIFF
--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -72,12 +72,12 @@ module API
 
           def eager_loader_classes_all
             [
-              ::API::V3::WorkPackages::EagerLoading::HistoricAttributes,
               ::API::V3::WorkPackages::EagerLoading::Hierarchy,
               ::API::V3::WorkPackages::EagerLoading::Ancestor,
               ::API::V3::WorkPackages::EagerLoading::Project,
               ::API::V3::WorkPackages::EagerLoading::Checksum,
               ::API::V3::WorkPackages::EagerLoading::CustomValue,
+              ::API::V3::WorkPackages::EagerLoading::HistoricAttributes,
               ::API::V3::WorkPackages::EagerLoading::CustomAction
             ]
           end


### PR DESCRIPTION
https://community.openproject.org/wp/47064
Eliminate the N+1 loading of custom values from the `::API::V3::WorkPackages::EagerLoading::HistoricAttributes`