### PR TITLE
[#49331] Added project folder deletion on project storage deletion

### DIFF
--- a/modules/storages/app/models/storages/storage_error.rb
+++ b/modules/storages/app/models/storages/storage_error.rb
@@ -27,6 +27,8 @@
 #++
 
 class Storages::StorageError
+  extend ActiveModel::Naming
+
   attr_reader :code, :log_message, :data
 
   def initialize(code:, log_message: nil, data: nil)
@@ -47,4 +49,9 @@ class Storages::StorageError
     output << " | #{data}" unless data.nil?
     output
   end
+
+  def storage_error = "storage error"
+  def read_attribute_for_validation(attr) = send(attr)
+  def self.human_attribute_name(attr, _options = {}) = attr
+  def self.lookup_ancestors = [self]
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -10,6 +10,12 @@ en:
   permission_share_files: "Share files"
   project_module_storages: "File storages"
 
+  errors:
+    attributes:
+      storage_error:
+        not_authorized: "Not authorized for external connection to storage."
+        not_found: "The requested resource could not be found at the external file storage."
+
   activerecord:
     models:
       file_link: "File link"

--- a/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
@@ -31,17 +31,21 @@ require_module_spec_helper
 require 'services/base_services/behaves_like_delete_service'
 require_relative 'shared_synchronization_trigger_examples'
 
-RSpec.describe Storages::ProjectStorages::DeleteService, type: :model do
+RSpec.describe Storages::ProjectStorages::DeleteService, type: :model, webmock: true do
   context 'with records written to DB' do
     let(:user) { create(:user) }
     let(:role) { create(:existing_role, permissions: [:manage_storages_in_project]) }
     let(:project) { create(:project, members: { user => role }) }
     let(:other_project) { create(:project) }
-    let(:project_storage) { create(:project_storage, project:) }
+    let(:storage) { create(:storage) }
+    let(:project_storage) { create(:project_storage, project:, storage:) }
     let(:work_package) { create(:work_package, project:) }
     let(:other_work_package) { create(:work_package, project: other_project) }
-    let(:file_link) { create(:file_link, container: work_package, storage: project_storage.storage) }
-    let(:other_file_link) { create(:file_link, container: other_work_package, storage: project_storage.storage) }
+    let(:file_link) { create(:file_link, container: work_package, storage:) }
+    let(:other_file_link) { create(:file_link, container: other_work_package, storage:) }
+    let(:delete_folder_url) do
+      "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+    end
 
     it 'destroys the record' do
       project_storage
@@ -61,6 +65,39 @@ RSpec.describe Storages::ProjectStorages::DeleteService, type: :model do
         .not_to exist
       expect(Storages::FileLink.where(id: other_file_link.id))
         .to exist
+    end
+
+    context 'with Nextcloud storage' do
+      let(:storage) { create(:nextcloud_storage) }
+
+      before do
+        stub_request(:delete, delete_folder_url).to_return(status: 204, body: nil, headers: {})
+      end
+
+      it 'tries to remove the project folder at the external nextcloud storage' do
+        expect(described_class.new(model: project_storage, user:).call).to be_success
+      end
+
+      context 'if project folder is not present' do
+        before do
+          stub_request(:delete, delete_folder_url).to_return(status: 404, body: nil, headers: {})
+        end
+
+        it 'tries to remove the project folder at the external nextcloud storage and still succeed with deletion' do
+          expect(described_class.new(model: project_storage, user:).call).to be_success
+        end
+      end
+
+      context 'if access is not authorized' do
+        before do
+          stub_request(:delete, delete_folder_url).to_return(status: 401, body: nil, headers: {})
+        end
+
+        it 'tries to remove the project folder at the external nextcloud storage, fails and does not delete project storage' do
+          expect(described_class.new(model: project_storage, user:).call).not_to be_success
+          expect(Storages::ProjectStorage.where(id: project_storage.id)).to exist
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- https://community.openproject.org/work_packages/49331
- added before_perform hook to project storage delete service
  - skip if project folder was not found
  - cancel deletion, if deletion is not possible