### PR TITLE
[#49285] Fix flaky specs `modules/storages/spec/features/{manage_project_storage_spec.rb,create_file_links_spec.rb}`

### DIFF
--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Managing file links in work package', js: true, webmock: true do
   before do
     allow(Storages::FileLinkSyncService).to receive(:new).and_return(sync_service)
 
-    stub_request(:get, "https://host1.example.com/ocs/v1.php/cloud/user")
+    stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/user")
       .with(
         headers: {
           'Authorization' => 'Bearer 1234567890-1',

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe(
     page.find('.toolbar .button--icon.icon-add').click
     expect(page).to have_current_path new_project_settings_projects_storage_path(project_id: project)
     expect(page).to have_text('Add a file storage')
-    expect(page).to have_select('storages_project_storage_storage_id', options: [storage.name])
+    expect(page).to have_select('storages_project_storage_storage_id',
+                                options: ["#{storage.name} (#{storage.short_provider_type})"])
     page.click_button('Continue')
 
     # by default automatic have to be choosen if storage has automatic management enabled

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe(
   end
 
   before do
-    skip("Flaky test disabled. Fix it in https://community.openproject.org/wp/49285")
-
     oauth_client_token
 
     stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{oauth_client_token.origin_user_id}/")
@@ -117,7 +115,7 @@ RSpec.describe(
     page.find('.toolbar .button--icon.icon-add').click
     expect(page).to have_current_path new_project_settings_projects_storage_path(project_id: project)
     expect(page).to have_text('Add a file storage')
-    expect(page).to have_select('storages_project_storage_storage_id', options: ['Storage 1 (nextcloud)'])
+    expect(page).to have_select('storages_project_storage_storage_id', options: [storage.name])
     page.click_button('Continue')
 
     # by default automatic have to be choosen if storage has automatic management enabled


### PR DESCRIPTION
https://community.openproject.org/work_packages/49285

 - [x] https://github.com/opf/openproject/actions/runs/5619116924/job/15225718924
 - [x] https://github.com/opf/openproject/actions/runs/5618900239/job/15225186621
 
```ruby
Failures:

  1) Activation of storages in projects adds, edits and removes storages to projects
     Failure/Error: Unable to find matching line from backtrace

       expected to find visible select box "storages_project_storage_storage_id" that is not disabled with options ["Storage 1 (nextcloud)"] but there were no matches. Also found "Storage 3 (nextcloud)", which matched the selector but not all filters. Expected options ["Storage 1 (nextcloud)"] found ["Storage 3 (nextcloud)"]
```
- [x] https://github.com/opf/openproject/actions/runs/5656548420/job/15323934659?pr=13236
```ruby
 1st Try error in ./modules/storages/spec/features/create_file_links_spec.rb:85:
Real HTTP connections are disabled. Unregistered request: GET https://host2.example.com/ocs/v1.php/cloud/user with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'***', 'Host'=>'host2.example.com', 'Ocs-Apirequest'=>'true', 'User-Agent'=>'rest-client/2.1.0 (linux x86_64) ruby/3.2.1p31'}

You can stub this request with the following snippet:

stub_request(:get, "https://host2.example.com/ocs/v1.php/cloud/user").
  with(
    headers: {
	  'Accept'=>'application/json',
	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	  'Authorization'=>'***',
	  'Host'=>'host2.example.com',
	  'Ocs-Apirequest'=>'true',
	  'User-Agent'=>'rest-client/2.1.0 (linux x86_64) ruby/3.2.1p31'
    }).
  to_return(status: 200, body: "", headers: {})

registered request stubs:

stub_request(:propfind, "https://host2.example.com/remote.php/dav/files/admin/Folder1")
stub_request(:propfind, "https://host2.example.com/remote.php/dav/files/admin/")
stub_request(:get, "https://host1.example.com/ocs/v1.php/cloud/user").
  with(
    headers: {
	  'Accept'=>'application/json',
	  'Authorization'=>'***',
	  'Host'=>'host1.example.com',
	  'Ocs-Apirequest'=>'true'
    })
```