### PR TITLE
Fix(WebMock): Allow `openproject-ci-public-logs.s3.eu-west-1.amazonaws.com` CI s3 bucket host

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -43,7 +43,8 @@ RSpec.configure do |config|
     # * chromedriver, since it might need to be downloaded
     WebMock.disable_net_connect!(allow_localhost: true, allow: ["selenium-hub",
                                                                 Capybara.server_host,
-                                                                'chromedriver.storage.googleapis.com'])
+                                                                'chromedriver.storage.googleapis.com',
+                                                                'openproject-ci-public-logs.s3.eu-west-1.amazonaws.com'])
     WebMock.enable!
     example.run
   ensure


### PR DESCRIPTION
https://github.com/opf/openproject/actions/runs/5656548420/job/15323934659?pr=13236

Allow screenshots S3 upload request to bypass webmock on feature test failure

https://community.openproject.org/projects/openproject/work_packages/48093/activity

![Screenshot 2023-07-25 at 3 58 47 PM](https://github.com/opf/openproject/assets/17295175/d5c00b15-3d96-464d-b770-f7afb6c5a685)
