### PR TITLE
load the environment to have the crowdin path added to I18n.load_path

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -78,7 +78,7 @@ namespace :assets do
   end
 
   desc 'Export frontend locale files'
-  task :export_locales do
+  task export_locales: :environment do
     puts "Exporting I18n.js locales"
     time = Benchmark.realtime do
       I18nJS.call(config_file: Rails.root.join('config/i18n.yml'))


### PR DESCRIPTION
Loading the environment will trigger the [assignment of the crowdin files to I18n.load_path](https://github.com/opf/openproject/blob/dev/config/application.rb#L139)