### PR TITLE
Add breadcrumb toolbar to the show page and render in Admin Layout when possible

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,7 +72,7 @@ class UsersController < ApplicationController
 
     if can_show_user?
       @events = events
-      render layout: 'no_menu'
+      render layout: (can_manage_or_create_users? ? 'admin' : 'no_menu')
     else
       render_404
     end
@@ -232,12 +232,16 @@ class UsersController < ApplicationController
   private
 
   def can_show_user?
-    return true if current_user.allowed_to_globally?(:manage_user)
-    return true if current_user.allowed_to_globally?(:create_user)
+    return true if can_manage_or_create_users?
     return true if @user == User.current
 
     (@user.active? || @user.registered?) \
     && (@memberships.present? || events.present?)
+  end
+
+  def can_manage_or_create_users?
+    current_user.allowed_to_globally?(:manage_user) ||
+    current_user.allowed_to_globally?(:create_user)
   end
 
   def events
@@ -304,7 +308,7 @@ class UsersController < ApplicationController
   end
 
   def show_local_breadcrumb
-    action_name != 'show'
+    true
   end
 
   def build_user_update_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -308,7 +308,7 @@ class UsersController < ApplicationController
   end
 
   def show_local_breadcrumb
-    true
+    can_manage_or_create_users?
   end
 
   def build_user_update_params

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,8 +29,9 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_for :header_tags do %>
   <%= call_hook :users_show_head %>
 <% end %>
+<% local_assigns[:additional_breadcrumb] = @user.name %>
 <% html_title t(:label_administration), t(:label_user_plural) -%>
-<%= toolbar title: "#{avatar @user} #{h(@user.name)}".html_safe do %>
+<%= breadcrumb_toolbar "#{avatar @user} #{h(@user.name)}".html_safe do %>
   <% if User.current.allowed_to_globally?(:manage_user) %>
     <li class="toolbar-item">
       <%= link_to edit_user_path(@user), class: 'button', accesskey: accesskey(:edit) do %>


### PR DESCRIPTION
While preparing to present the new create user / manage user split, we are using the `users/show` page a bit more. But this one does currently not show the breadcrumbs and thus it becomes a bit problematic to navigate for those admins that have the create user role.

## Before

![Bildschirmfoto 2023-07-27 um 12 25 46](https://github.com/opf/openproject/assets/522537/6a1ac1ca-3e87-4063-9a1a-24dfae6bab81)


## After

### When allowed to manage or create users:

![Bildschirmfoto 2023-07-27 um 12 23 35](https://github.com/opf/openproject/assets/522537/1f776714-e3af-47b5-a465-053a30ba588f)

### When just accessing a /users/$id page:

![Bildschirmfoto 2023-07-27 um 12 25 46](https://github.com/opf/openproject/assets/522537/6a1ac1ca-3e87-4063-9a1a-24dfae6bab81)


When the user is not allowed to access the admin namespace, they will still see the page as the old design