### PR TITLE
[33375] Save newly created meeting via cmd+Enter

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -69,8 +69,6 @@ export const attachmentsSelector = 'op-attachments';
 export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @HostBinding('attr.data-qa-selector') public qaSelector = 'op-attachments';
 
-  @HostBinding('id.attachments_fields') public hostId = true;
-
   @HostBinding('class.op-file-section') public className = true;
 
   @Input() public resource:HalResource;

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -76,8 +76,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   public wrappedTextArea:HTMLTextAreaElement;
 
-  public attachmentsElement:HTMLElement;
-
   // Remember if the user changed
   public changed = false;
 
@@ -125,7 +123,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     this.initialContent = this.wrappedTextArea.value;
     this.readOnly = this.wrappedTextArea.disabled;
 
-    this.attachmentsElement = this.formElement.querySelector('#attachments_fields') as HTMLElement;
     this.context = {
       type: this.editorType,
       resource: this.halResource,
@@ -154,7 +151,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   public saveForm():void {
     this.syncToTextarea();
-    this.addUploadedAttachmentsToForm();
     window.OpenProject.pageIsSubmitted = true;
     this.formElement.submit();
   }
@@ -236,35 +232,5 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     fromEvent(label, 'click')
       .pipe(this.untilDestroyed())
       .subscribe(() => ckContent.focus());
-  }
-
-  private addUploadedAttachmentsToForm() {
-    if (!this.halResource || !this.halResource.attachments || this.halResource.id) {
-      return;
-    }
-
-    const attachments = Array.from(this.attachmentsElement.querySelectorAll<HTMLInputElement>("input[type='file']"));
-    const takenIds = attachments.map((input) => {
-      const match = /attachments\[(\d+)\]\[(?:file|id)\]/.exec((input.name || ''));
-
-      if (match) {
-        return parseInt(match[1], 10);
-      }
-      return 0;
-    });
-
-    const maxValue:number = takenIds.sort().pop() || 0;
-
-    const addedAttachments = this.halResource?.attachments.elements || [];
-
-    addedAttachments.forEach((attachment:HalResource, index:number) => {
-      const input = document.createElement('input');
-      input.type = 'hidden';
-
-      input.name = `attachments[${maxValue + index + 1}][id]`;
-      input.value = attachment.id as string;
-
-      this.attachmentsElement.appendChild(input);
-    });
   }
 }

--- a/frontend/src/global_styles/content/_forms.lsg
+++ b/frontend/src/global_styles/content/_forms.lsg
@@ -855,7 +855,7 @@ The modifier classes **-middle**, **-wide**, ... can be applied to the form-[inp
     <a href="#">Files<span class="fieldset-toggle-state-label hidden-for-sighted">expanded</span></a>
   </legend>
   <div style="">
-    <div id="attachments_fields">
+    <div>
       <div class="grid-block" id="attachment_template">
         <div class="form--field">
           <div class="attachment_field form--field-container -vertical -shrink">

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -173,6 +173,11 @@ RSpec.describe 'Meetings new', :js do
 
     context 'as an admin' do
       let(:current_user) { admin }
+      let(:field) do
+        TextEditorField.new(page,
+                            '',
+                            selector: '[data-qa-selector="op-meeting--meeting_agenda"]')
+      end
 
       it 'allows creating meeting in a project without members' do
         index_page.visit!
@@ -187,6 +192,30 @@ RSpec.describe 'Meetings new', :js do
 
         # Not sure if that is then intended behaviour but that is what is currently programmed
         show_page.expect_invited(admin)
+      end
+
+      it 'can save the meeting agenda via cmd+Enter' do
+        index_page.visit!
+
+        new_page = index_page.click_create_new
+
+        new_page.set_title 'Some title'
+
+        show_page = new_page.click_create
+
+        show_page.expect_toast(message: 'Successful creation')
+
+        meeting = Meeting.last
+
+        field.set_value('My new meeting text')
+
+        field.submit_by_enter
+
+        show_page.expect_and_dismiss_toaster message: 'Successful update'
+
+        meeting.reload
+
+        expect(meeting.agenda.text).to eq 'My new meeting text'
       end
     end
   end


### PR DESCRIPTION
Remove old code which is not needed as

* the attachment-list adds the hidden fields itself
* and the old code is crashing as the ID is not correctly set

https://community.openproject.org/projects/14/work_packages/33375/activity