### PR TITLE
[#49403] Show custom field changes in the baseline comparison

### DIFF
--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -121,7 +121,8 @@ class Journable::WithHistoricAttributes
       # Build the associated customizable_journals as custom values, this way the historic work packages
       # will behave just as the normal ones. Additionally set the reverse customized association
       # on the custom_values that points to the work_package itself.
-      historic_custom_values = customizable_journals.map do |customizable_journal|
+      all_journals = Journal::CustomizableJournal.all
+      historic_custom_values = all_journals.map do |customizable_journal|
         customizable_journal.as_custom_value(customized: work_package)
       end
 

--- a/app/models/journable/with_historic_attributes/loader.rb
+++ b/app/models/journable/with_historic_attributes/loader.rb
@@ -114,15 +114,14 @@ class Journable::WithHistoricAttributes
       Journal::CustomizableJournal
         .where(journal_id: journal_ids)
         .includes(:custom_field)
-        .index_by(&:journal_id)
+        .group_by(&:journal_id)
     end
 
     def set_custom_value_association_from_journal!(work_package:, customizable_journals:)
       # Build the associated customizable_journals as custom values, this way the historic work packages
       # will behave just as the normal ones. Additionally set the reverse customized association
       # on the custom_values that points to the work_package itself.
-      all_journals = Journal::CustomizableJournal.all
-      historic_custom_values = all_journals.map do |customizable_journal|
+      historic_custom_values = customizable_journals.map do |customizable_journal|
         customizable_journal.as_custom_value(customized: work_package)
       end
 

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -65,9 +65,13 @@
         max-width: 90%
         display: inline-block
         vertical-align: middle
-        line-height: 32px
+        // Inherit from Parent, e.g. strikethrough for baseline comparison
+        text-decoration: inherit
         &:first-of-type
           padding-right: 5px
+
+      .badge
+        height: 1rem
 
   &.split-time-field
     white-space: nowrap

--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -54,7 +54,7 @@ module API
           parent
         ].freeze
 
-        SUPPORTED_CUSTOM_PROPERTIES = [/^custom_field_\d+$/].freeze
+        SUPPORTED_CUSTOM_PROPERTIES = [/^customField\d+$/].freeze
 
         SUPPORTED_PROPERTIES = (SUPPORTED_NON_LINK_PROPERTIES + SUPPORTED_LINK_PROPERTIES).freeze
 
@@ -102,7 +102,7 @@ module API
             represented
               .attributes_changed_to_baseline
               .flat_map do |property|
-              if property.ends_with?('_id')
+              if property.ends_with?('_id') || property.starts_with?("custom_field_")
                 API::Utilities::PropertyNameConverter.from_ar_name(property)
               elsif %w[start_date due_date].include?(property)
                 ['date', property]

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journable_differ.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journable_differ.rb
@@ -38,8 +38,8 @@ module Acts::Journalized
           .with_indifferent_access
       end
 
-      def association_changes(original, changed, *association_params)
-        get_association_changes(original, changed, *association_params)
+      def association_changes(original, changed, *)
+        get_association_changes(original, changed, *)
       end
 
       private
@@ -90,12 +90,12 @@ module Acts::Journalized
 
       def added_references(merged_references)
         merged_references
-          .select { |_, (old_value, new_value)| old_value.nil? && new_value.present? }
+          .select { |_, (old_value, new_value)| old_value.to_s.empty? && new_value.present? }
       end
 
       def removed_references(merged_references)
         merged_references
-          .select { |_, (old_value, new_value)| old_value.present? && new_value.nil? }
+          .select { |_, (old_value, new_value)| old_value.present? && new_value.to_s.empty? }
       end
 
       def changed_references(merged_references)

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -39,9 +39,6 @@ FactoryBot.define do
     visible { true }
     field_format { 'bool' }
 
-    trait :global do
-      is_for_all { true }
-    end
 
     callback(:after_create) do
       # As the request store keeps track of the created custom fields

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -39,7 +39,6 @@ FactoryBot.define do
     visible { true }
     field_format { 'bool' }
 
-
     callback(:after_create) do
       # As the request store keeps track of the created custom fields
       RequestStore.clear!

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
     visible { true }
     field_format { 'bool' }
 
+    trait :global do
+      is_for_all { true }
+    end
+
     callback(:after_create) do
       # As the request store keeps track of the created custom fields
       RequestStore.clear!

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -78,8 +78,10 @@ FactoryBot.define do
       custom_values = evaluator.custom_values || {}
 
       if custom_values.is_a? Hash
-        custom_values.each_pair do |custom_field_id, value|
-          work_package.custom_values.build custom_field_id:, value:
+        custom_values.each_pair do |custom_field_id, values|
+          Array(values).each do |value|
+            work_package.custom_values.build custom_field_id:, value:
+          end
         end
       else
         custom_values.each { |cv| work_package.custom_values << cv }

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -209,9 +209,9 @@ RSpec.describe 'baseline rendering',
       int_wp_custom_field.id => 1,
       string_wp_custom_field.id => 'this is a string',
       bool_wp_custom_field.id => true,
-      float_wp_custom_field.id => 2.9,
+      float_wp_custom_field.id => nil,
       date_wp_custom_field.id => Date.yesterday,
-      list_wp_custom_field.id => list_wp_custom_field.possible_values.first,
+      list_wp_custom_field.id => nil,
       multi_list_wp_custom_field.id => multi_list_wp_custom_field.possible_values, # not working
       user_wp_custom_field.id => [assignee.id.to_s],
       version_wp_custom_field.id => version_a
@@ -220,14 +220,14 @@ RSpec.describe 'baseline rendering',
 
   shared_let(:changed_custom_values) do
     {
-      "custom_field_#{int_wp_custom_field.id}": 2,
+      "custom_field_#{int_wp_custom_field.id}": nil,
       "custom_field_#{string_wp_custom_field.id}": 'this is a changed string',
       "custom_field_#{bool_wp_custom_field.id}": false,
       "custom_field_#{float_wp_custom_field.id}": 3.7,
       "custom_field_#{date_wp_custom_field.id}": Time.zone.today,
       "custom_field_#{list_wp_custom_field.id}": [list_wp_custom_field.possible_values.second],
       "custom_field_#{multi_list_wp_custom_field.id}": multi_list_wp_custom_field.possible_values.take(2),
-      "custom_field_#{user_wp_custom_field.id}": [user.id.to_s],
+      "custom_field_#{user_wp_custom_field.id}": nil,
       "custom_field_#{version_wp_custom_field.id}": version_b
     }
   end
@@ -328,7 +328,7 @@ RSpec.describe 'baseline rendering',
       baseline.expect_changed_attributes wp_task_cf,
                                          "customField#{int_wp_custom_field.id}": [
                                            '1',
-                                           '2'
+                                           '-'
                                          ],
                                          "customField#{string_wp_custom_field.id}": [
                                            'this is a string',
@@ -339,7 +339,7 @@ RSpec.describe 'baseline rendering',
                                            'no'
                                          ],
                                          "customField#{float_wp_custom_field.id}": [
-                                           '2.9',
+                                           '-',
                                            '3.7'
                                          ],
                                          "customField#{date_wp_custom_field.id}": [
@@ -347,8 +347,8 @@ RSpec.describe 'baseline rendering',
                                            Time.zone.today.iso8601
                                          ],
                                          "customField#{list_wp_custom_field.id}": [
-                                           list_wp_custom_field.possible_values.first.value,
-                                           list_wp_custom_field.possible_values.second.value
+                                           "-",
+                                           "B"
                                          ],
                                          "customField#{multi_list_wp_custom_field.id}": [
                                            "A, B, ...\n7",
@@ -356,7 +356,7 @@ RSpec.describe 'baseline rendering',
                                          ],
                                          "customField#{user_wp_custom_field.id}": [
                                            'Assigned User',
-                                           'Itsa Me'
+                                           '-'
                                          ],
                                          "customField#{version_wp_custom_field.id}": [
                                            'Version A',

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -205,39 +205,30 @@ RSpec.describe 'baseline rendering',
   end
 
   shared_let(:initial_custom_values) do
-    # For some reason, only one the last change is being displayed on the table.
-    # I'm still trying to figure out why it is happening, but until then please activate only
-    # the custom field you are trying to fix.
-
     {
-      # int_wp_custom_field.id => 1,
-      # string_wp_custom_field.id => 'this is a string',
-      # bool_wp_custom_field.id => true,
-      # float_wp_custom_field.id => 2.9,
-      # date_wp_custom_field.id => Date.yesterday,
-      # list_wp_custom_field.id => list_wp_custom_field.possible_values.first,
-      multi_list_wp_custom_field.id => multi_list_wp_custom_field.possible_values.take(3) # not working
-      # user_wp_custom_field.id => [assignee.id.to_s],
-      # version_wp_custom_field.id => version_a
+      int_wp_custom_field.id => 1,
+      string_wp_custom_field.id => 'this is a string',
+      bool_wp_custom_field.id => true,
+      float_wp_custom_field.id => 2.9,
+      date_wp_custom_field.id => Date.yesterday,
+      list_wp_custom_field.id => list_wp_custom_field.possible_values.first,
+      multi_list_wp_custom_field.id => multi_list_wp_custom_field.possible_values, # not working
+      user_wp_custom_field.id => [assignee.id.to_s],
+      version_wp_custom_field.id => version_a
     }
   end
 
   shared_let(:changed_custom_values) do
-    # For some reason, only one the last change is being displayed on the table.
-    # I'm still trying to figure out why it is happening, but until then please activate only
-    # the custom field you are trying to fix.
-
     {
-      # :"custom_field_#{int_wp_custom_field.id}" => 2,
-      # :"custom_field_#{string_wp_custom_field.id}" => 'this is a changed string',
-      # :"custom_field_#{bool_wp_custom_field.id}" => false,
-      # :"custom_field_#{float_wp_custom_field.id}" => 3.7,
-      # :"custom_field_#{date_wp_custom_field.id}" => Time.zone.today,
-
-      # "custom_field_#{list_wp_custom_field.id}": [list_wp_custom_field.possible_values.second],
-      "custom_field_#{multi_list_wp_custom_field.id}": multi_list_wp_custom_field.possible_values.take(2)
-      # "custom_field_#{user_wp_custom_field.id}": [user.id.to_s],
-      # "custom_field_#{version_wp_custom_field.id}": version_b
+      "custom_field_#{int_wp_custom_field.id}": 2,
+      "custom_field_#{string_wp_custom_field.id}": 'this is a changed string',
+      "custom_field_#{bool_wp_custom_field.id}": false,
+      "custom_field_#{float_wp_custom_field.id}": 3.7,
+      "custom_field_#{date_wp_custom_field.id}": Time.zone.today,
+      "custom_field_#{list_wp_custom_field.id}": [list_wp_custom_field.possible_values.second],
+      "custom_field_#{multi_list_wp_custom_field.id}": multi_list_wp_custom_field.possible_values.take(2),
+      "custom_field_#{user_wp_custom_field.id}": [user.id.to_s],
+      "custom_field_#{version_wp_custom_field.id}": version_b
     }
   end
 
@@ -334,57 +325,43 @@ RSpec.describe 'baseline rendering',
                                            :type, :subject, :start_date, :due_date,
                                            :version, :priority, :assignee, :accountable
 
-      # These expectations will be re-enabled once I figure out why it is showing
-      # only the last changed custom field.
-      # baseline.expect_changed_attributes wp_task_cf,
-      #                                    "customField#{int_wp_custom_field.id}": [
-      #                                     '1',
-      #                                     '2'
-      #                                    ],
-      #                                    "customField#{string_wp_custom_field.id}": [
-      #                                     'this is a string',
-      #                                     'this is a changed string'
-      #                                    ],
-      #                                    "customField#{bool_wp_custom_field.id}": [
-      #                                     'yes',
-      #                                     'no'
-      #                                    ],
-      #                                    "customField#{float_wp_custom_field.id}": [
-      #                                     '2.9',
-      #                                     '3.7'
-      #                                    ],
-      #                                    "customField#{date_wp_custom_field.id}": [
-      #                                      Date.yesterday.iso8601,
-      #                                      Time.zone.today.iso8601
-      #                                    ]
-
-      # Not working:
-
-      # baseline.expect_changed_attributes wp_task_cf,
-      #                                    "customField#{list_wp_custom_field.id}": [
-      #                                      list_wp_custom_field.possible_values.first.value,
-      #                                      list_wp_custom_field.possible_values.second.value
-      #                                    ]
-
-      # This expectation is not clear if it works, because the multi values are being joined just by a
-      # space, probably a rework on the expectation is also needed.
-
       baseline.expect_changed_attributes wp_task_cf,
+                                         "customField#{int_wp_custom_field.id}": [
+                                           '1',
+                                           '2'
+                                         ],
+                                         "customField#{string_wp_custom_field.id}": [
+                                           'this is a string',
+                                           'this is a changed string'
+                                         ],
+                                         "customField#{bool_wp_custom_field.id}": [
+                                           'yes',
+                                           'no'
+                                         ],
+                                         "customField#{float_wp_custom_field.id}": [
+                                           '2.9',
+                                           '3.7'
+                                         ],
+                                         "customField#{date_wp_custom_field.id}": [
+                                           Date.yesterday.iso8601,
+                                           Time.zone.today.iso8601
+                                         ],
+                                         "customField#{list_wp_custom_field.id}": [
+                                           list_wp_custom_field.possible_values.first.value,
+                                           list_wp_custom_field.possible_values.second.value
+                                         ],
                                          "customField#{multi_list_wp_custom_field.id}": [
-                                           "A, B, ...\n5",
+                                           "A, B, ...\n7",
                                            "A, B"
+                                         ],
+                                         "customField#{user_wp_custom_field.id}": [
+                                           'Assigned User',
+                                           'Itsa Me'
+                                         ],
+                                         "customField#{version_wp_custom_field.id}": [
+                                           'Version A',
+                                           'Version B'
                                          ]
-
-      # baseline.expect_changed_attributes wp_task_cf,
-      #                                    "customField#{user_wp_custom_field.id}": [
-      #                                      'Assigned User',
-      #                                      'Itsa Me'
-      #                                    ]
-      # baseline.expect_changed_attributes wp_task_cf,
-      #                                    "customField#{version_wp_custom_field.id}": [
-      #                                      'Version A',
-      #                                      'Version B'
-      #                                    ]
 
       # show icons on work package single card
       display_representation.switch_to_card_layout

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -210,16 +210,15 @@ RSpec.describe 'baseline rendering',
     # the custom field you are trying to fix.
 
     {
-      # int_wp_custom_field.id => 1, # working
-      # string_wp_custom_field.id => 'this is a string', # working
-      # bool_wp_custom_field.id => true, #working
-      # float_wp_custom_field.id => 2.9, #working
-      date_wp_custom_field.id => Date.yesterday # working
-
-      # list_wp_custom_field.id => list_wp_custom_field.possible_values.first, # not working
-      # multi_list_wp_custom_field.id => multi_list_wp_custom_field.possible_values.take(2) # not working
-      # user_wp_custom_field.id => [assignee.id.to_s] # not working
-      # version_wp_custom_field.id => version_a # not working
+      # int_wp_custom_field.id => 1,
+      # string_wp_custom_field.id => 'this is a string',
+      # bool_wp_custom_field.id => true,
+      # float_wp_custom_field.id => 2.9,
+      # date_wp_custom_field.id => Date.yesterday,
+      # list_wp_custom_field.id => list_wp_custom_field.possible_values.first,
+      multi_list_wp_custom_field.id => multi_list_wp_custom_field.possible_values.take(3) # not working
+      # user_wp_custom_field.id => [assignee.id.to_s],
+      # version_wp_custom_field.id => version_a
     }
   end
 
@@ -233,12 +232,11 @@ RSpec.describe 'baseline rendering',
       # :"custom_field_#{string_wp_custom_field.id}" => 'this is a changed string',
       # :"custom_field_#{bool_wp_custom_field.id}" => false,
       # :"custom_field_#{float_wp_custom_field.id}" => 3.7,
-      "custom_field_#{date_wp_custom_field.id}" => Time.zone.today
+      # :"custom_field_#{date_wp_custom_field.id}" => Time.zone.today,
 
-      # Not working, needs UI fix
       # "custom_field_#{list_wp_custom_field.id}": [list_wp_custom_field.possible_values.second],
-      # "custom_field_#{multi_list_wp_custom_field.id}": multi_list_wp_custom_field.possible_values.take(3)
-      # "custom_field_#{user_wp_custom_field.id}": [user.id.to_s]
+      "custom_field_#{multi_list_wp_custom_field.id}": multi_list_wp_custom_field.possible_values.take(2)
+      # "custom_field_#{user_wp_custom_field.id}": [user.id.to_s],
       # "custom_field_#{version_wp_custom_field.id}": version_b
     }
   end
@@ -253,7 +251,7 @@ RSpec.describe 'baseline rendering',
                :skip_validations,
                project:,
                type: type_task,
-               subject: 'A task',
+               subject: 'A task with CFs',
                custom_values: initial_custom_values)
       end
     end
@@ -338,28 +336,27 @@ RSpec.describe 'baseline rendering',
 
       # These expectations will be re-enabled once I figure out why it is showing
       # only the last changed custom field.
-
-      baseline.expect_changed_attributes wp_task_cf,
-                                         # "customField#{int_wp_custom_field.id}": [
-                                         #  '1',
-                                         #  '2'
-                                         # ],
-                                         # "customField#{string_wp_custom_field.id}": [
-                                         #  'this is a string',
-                                         #  'this is a changed string'
-                                         # ],
-                                         # "customField#{bool_wp_custom_field.id}": [
-                                         #  'yes',
-                                         #  'no'
-                                         # ],
-                                         # "customField#{float_wp_custom_field.id}": [
-                                         #  '2.9',
-                                         #  '3.7'
-                                         # ],
-                                         "customField#{date_wp_custom_field.id}": [
-                                           Date.yesterday.iso8601,
-                                           Time.zone.today.iso8601
-                                         ]
+      # baseline.expect_changed_attributes wp_task_cf,
+      #                                    "customField#{int_wp_custom_field.id}": [
+      #                                     '1',
+      #                                     '2'
+      #                                    ],
+      #                                    "customField#{string_wp_custom_field.id}": [
+      #                                     'this is a string',
+      #                                     'this is a changed string'
+      #                                    ],
+      #                                    "customField#{bool_wp_custom_field.id}": [
+      #                                     'yes',
+      #                                     'no'
+      #                                    ],
+      #                                    "customField#{float_wp_custom_field.id}": [
+      #                                     '2.9',
+      #                                     '3.7'
+      #                                    ],
+      #                                    "customField#{date_wp_custom_field.id}": [
+      #                                      Date.yesterday.iso8601,
+      #                                      Time.zone.today.iso8601
+      #                                    ]
 
       # Not working:
 
@@ -372,11 +369,11 @@ RSpec.describe 'baseline rendering',
       # This expectation is not clear if it works, because the multi values are being joined just by a
       # space, probably a rework on the expectation is also needed.
 
-      # baseline.expect_changed_attributes wp_task_cf,
-      #                                    "customField#{multi_list_wp_custom_field.id}": [
-      #                                      multi_list_wp_custom_field.possible_values.take(3).pluck(:value).join(" "),
-      #                                      multi_list_wp_custom_field.possible_values.take(2).pluck(:value).join(" ")
-      #                                    ]
+      baseline.expect_changed_attributes wp_task_cf,
+                                         "customField#{multi_list_wp_custom_field.id}": [
+                                           "A, B, ...\n5",
+                                           "A, B"
+                                         ]
 
       # baseline.expect_changed_attributes wp_task_cf,
       #                                    "customField#{user_wp_custom_field.id}": [


### PR DESCRIPTION
Closes:
- [X] https://community.openproject.org/wp/49403
- [X] https://community.openproject.org/wp/49411
- [X] Fix the bug only one custom field change being displayed per work package.
- [X] Fix visual issue with multi-select custom fields old values not being crossed.
- [x] Fix bug when a custom field is being unset it is not showing the previous value.