### PR TITLE
[#49229] Make Project deletion aware of Project Storage Deletion

### DIFF
--- a/app/services/projects/delete_service.rb
+++ b/app/services/projects/delete_service.rb
@@ -53,6 +53,7 @@ module Projects
 
       delete_all_members
       destroy_all_work_packages
+      destroy_all_storages
 
       super
     end
@@ -73,6 +74,12 @@ module Projects
         wp.destroy
       rescue ActiveRecord::RecordNotFound
         # Everything fine, we wanted to delete it anyway
+      end
+    end
+
+    def destroy_all_storages
+      model.projects_storages.map do |project_storage|
+        Storages::ProjectStorages::DeleteService.new(user:, model: project_storage).call
       end
     end
 


### PR DESCRIPTION
##### Original Ticket: OP#49229 https://community.openproject.org/projects/openproject/work_packages/49229

Implements a call to the `ProjectsStorages::DeleteService` while deleting the project.