### PR TITLE
Ensure `folderModeValue` is updated to the selected radio button

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
@@ -157,6 +157,8 @@ export default class ProjectStorageFormController extends Controller {
         this.projectFolderIdInputTarget.value = '';
     }
 
+    this.folderModeValue = mode;
+
     this.toggleFolderDisplay(mode);
   }
 


### PR DESCRIPTION
[This spec](https://github.com/opf/openproject/actions/runs/5682891683/job/15402295804?pr=13259) has been failing in my last couple of CI runs and after inspecting it, it seems to be flaky for a legitimate reason and not just timing or luck.

The subscription in the `connect()` lifecycle hook uses `folderModeValue` which is not updated until form submission when the template is re-rendered.

This was fine for initial rendering but for being able to update the `projectFolderSection` dynamically when toggling between the different folder mode radio buttons, this value needs to be updated to the currently selected folder mode in `updateForm()`.

**No more flakiness**
![image](https://github.com/opf/openproject/assets/61627014/3414c2f2-ef70-4394-a36c-f74f83111857)
