### PR TITLE
css[Op#48413] Add explicit margin bottom to project storages danger zone`ul` using primer css

### DIFF
--- a/modules/storages/app/views/storages/project_settings/destroy_info.html.erb
+++ b/modules/storages/app/views/storages/project_settings/destroy_info.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
     <p>
       <%= t('storages.delete_warning.project_storage', file_storage: "<strong>#{h(@project_storage_to_destroy.storage.name)}</strong>").html_safe %>
     </p>
-    <ul>
+    <ul class="mb-3">
       <li> <%= t('storages.delete_warning.project_storage_delete_result_1') %>
       <li> <%= t('storages.delete_warning.project_storage_delete_result_2') %>
     </ul>


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/48413

#### 🚧 Bug: Missing Margin Bottom

![broken-spacing-danger-zone](https://github.com/opf/openproject/assets/17295175/69797724-a8f5-41d4-b0df-08357cbb78aa)

Since the Primer release in #13126 `global_styles/vendor/foundation-apps/scss/components/_typography.scss` was removed which defined a margin-bottom for `ul` elements.

```css
// DEPRECATED: global_styles/vendor/foundation-apps/scss/components/_typography.scss
  /* Lists */
  ul,
  ol,
  dl {
    margin-bottom: $list-margin-bottom;
    // ....
  }
```

Hence update to use PrimerCSS [Margin Directional](https://primer.style/css/storybook/?path=/story/utilities-margin--directional) utility

![Screenshot 2023-07-31 at 2 53 09 PM](https://github.com/opf/openproject/assets/17295175/448261ca-3f2f-4e10-8f27-4145032903bb)
