### PR TITLE
[#49410] Ensure Baseline functionality is reset when switching to a Builtin View

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -192,6 +192,15 @@ export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
         }
       });
     }
+
+    this.wpTableBaseline
+      .pristine$()
+      .subscribe((timestamps) => {
+        if (_.isEqual(timestamps, [DEFAULT_TIMESTAMP])) {
+          this.resetSelection();
+          this.wpTableBaseline.disable();
+        }
+      });
   }
 
   public resetSelection():void {

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -378,6 +378,49 @@ RSpec.describe 'baseline rendering',
         expect(page).not_to have_selector(".op-wp-single-card--content-baseline")
       end
     end
+
+    shared_examples_for 'selecting a builtin view' do
+      let(:builtin_view_name) { 'All open' }
+
+      before do
+        within '#main-menu' do
+          click_link builtin_view_name
+        end
+      end
+
+      it 'does not show changes or render baseline details' do
+        wp_table.expect_title builtin_view_name
+
+        baseline.expect_inactive
+        baseline.expect_no_legends
+        baseline_modal.toggle_drop_modal
+        baseline_modal.expect_selected '-'
+      end
+    end
+
+    context 'when a baseline filter is set', :with_cuprite do
+      before do
+        wp_table.visit!
+
+        wait_for_reload # Ensure page is fully loaded
+
+        baseline_modal.toggle_drop_modal
+        baseline_modal.select_filter 'yesterday'
+        baseline_modal.apply
+      end
+
+      context 'and the query is saved' do
+        before do
+          wp_table.save_as 'My Baseline Query'
+        end
+
+        it_behaves_like 'selecting a builtin view'
+      end
+
+      context 'and the query is not saved' do
+        it_behaves_like 'selecting a builtin view'
+      end
+    end
   end
 
   describe 'with feature disabled', with_flag: { show_changes: false } do

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -29,7 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe 'baseline rendering',
-               js: true,
+               :js,
+               :with_cuprite,
                with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:list_wp_custom_field) { create(:list_wp_custom_field) }
   shared_let(:multi_list_wp_custom_field) { create(:list_wp_custom_field, multi_value: true) }
@@ -351,7 +352,7 @@ RSpec.describe 'baseline rendering',
                                            "B"
                                          ],
                                          "customField#{multi_list_wp_custom_field.id}": [
-                                           "A, B, ...\n7",
+                                           "A, B, ...7",
                                            "A, B"
                                          ],
                                          "customField#{user_wp_custom_field.id}": [
@@ -398,7 +399,7 @@ RSpec.describe 'baseline rendering',
       end
     end
 
-    context 'when a baseline filter is set', :with_cuprite do
+    context 'when a baseline filter is set' do
       before do
         wp_table.visit!
 


### PR DESCRIPTION
The Baseline component was not watching for changes to the "pristine" state of
the current timestamp query being requested.

By watching for the pristine state being requested, now we can disable and reset
the Baseline details when selecting a builtin view (like "All open") which
doesn't include a timestamp (which would default the timestamp to 'PT0S').

However, when a saved query that includes a timestamp on it is selected due to
it have been saved that way, this will also cover the case of ensuring that
Baseline is not disabled and reset as the timestamp would not be the default.

See: https://community.openproject.org/work_packages/49410