### PR TITLE
[49449] Loading indicator in flash message is broken

### DIFF
--- a/frontend/src/app/shared/components/toaster/toast.component.html
+++ b/frontend/src/app/shared/components/toaster/toast.component.html
@@ -1,16 +1,16 @@
 <div class="op-toast -{{ type }}" tabindex="0">
   <div class="op-toast--content" role="alert" aria-atomic="true">
     <ng-container *ngIf="type === 'loading'">
+      <p [textContent]="toast.message"></p>
       <svg
         *ngIf="(loading$ | async)"
-        class="op-loading-indicator"
+        class="op-loading-indicator op-loading-indicator_in-toast"
       >
         <rect rx="4px"/>
         <rect rx="4px"/>
         <rect rx="4px"/>
         <rect rx="2px"/>
       </svg>
-      <p [textContent]="toast.message"></p>
     </ng-container>
     <p *ngIf="type !== 'loading'">
       <span [textContent]="toast.message"></span>

--- a/frontend/src/global_styles/content/_loading_indicator.sass
+++ b/frontend/src/global_styles/content/_loading_indicator.sass
@@ -104,3 +104,7 @@ $loading-indicator-height: 70px
       transform: rotate(45deg)
       animation-name: svg_ani-2
       animation-delay: 2130ms
+
+  &_in-toast
+    top: 0
+    left: 50px

--- a/frontend/src/global_styles/content/_toast.sass
+++ b/frontend/src/global_styles/content/_toast.sass
@@ -129,7 +129,8 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   &.-error,
   &.-success,
   &.-warning,
-  &.-info
+  &.-info,
+  &.-loading
     padding: $nm-box-padding
 
   &.-ee-upsale
@@ -165,6 +166,9 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
     &::before
       @include messages-icon
       @extend %nm-icon-info
+
+  &.-loading
+    @extend %info-placeholder
 
   &.-ee-upsale
     @extend %info-placeholder
@@ -262,9 +266,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
         border-radius: $nm-pb-border-radius
 
 .op-toast.-loading
-  width: 150px
-  margin: 0 auto
-
+  width: 400px
   .op-toast--content
     display: flex
     align-items: center


### PR DESCRIPTION
Show loading indicator in toast message correctly

### Before
<img width="345" alt="Bildschirmfoto 2023-07-28 um 10 23 38" src="https://github.com/opf/openproject/assets/7457313/62a4914d-5096-4016-afd1-b8f561fedb0e">

### After
<img width="558" alt="Bildschirmfoto 2023-08-01 um 13 02 52" src="https://github.com/opf/openproject/assets/7457313/cd5ffb5b-b722-461d-a417-af9174add9fd">


https://community.openproject.org/projects/14/work_packages/49449/activity