### PR TITLE
Close active fields on table reload

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-edit-form/table-edit-form.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit-form/table-edit-form.ts
@@ -69,14 +69,19 @@ export class TableEditForm extends EditForm<WorkPackageResource> {
     .requireAndStream()
     .subscribe((wp) => this.resource = wp);
 
-  constructor(public injector:Injector,
+  constructor(
+    public injector:Injector,
     public table:WorkPackageTable,
     public workPackageId:string,
-    public classIdentifier:string) {
+    public classIdentifier:string,
+  ) {
     super(injector);
   }
 
   destroy() {
+    _.each(this.activeFields, (field) => {
+      field.deactivate(false);
+    });
     this.resourceSubscription.unsubscribe();
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/wp-fast-table.ts
@@ -114,8 +114,8 @@ export class WorkPackageTable {
 
     // Insert timeline body
     requestAnimationFrame(() => {
-      this.tbody.innerHTML = '';
-      this.timelineBody.innerHTML = '';
+      this.tbody.replaceChildren();
+      this.timelineBody.replaceChildren();
       this.tbody.appendChild(renderPass.tableBody);
       this.timelineBody.appendChild(renderPass.timeline.timelineBody);
 


### PR DESCRIPTION
This prevents a dangling datepicker modal from staying open and repositioning

https://community.openproject.org/work_packages/47122