### PR TITLE
[#48160] Fix Project dropdown disappearing in Global Boards create form

### DIFF
--- a/modules/boards/app/helpers/boards_helper.rb
+++ b/modules/boards/app/helpers/boards_helper.rb
@@ -27,6 +27,14 @@ module BoardsHelper
   end
 
   def global_board_create_context?
+    global_board_new_action? || global_board_create_action?
+  end
+
+  def global_board_new_action?
     request.path == new_work_package_board_path
+  end
+
+  def global_board_create_action?
+    request.path == work_package_boards_path && @project.nil?
   end
 end

--- a/modules/boards/spec/features/boards_global_create_spec.rb
+++ b/modules/boards/spec/features/boards_global_create_spec.rb
@@ -195,7 +195,9 @@ RSpec.describe 'Boards',
           it 'renders a required attribute validation error' do
             expect(Boards::Grid.all).to be_empty
 
-            expect(page).to have_text("Project can't be blank.")
+            new_board_page.expect_toast message: "Project #{I18n.t('activerecord.errors.messages.blank')}",
+                                        type: :error
+            new_board_page.expect_project_dropdown
           end
         end
       end

--- a/modules/boards/spec/features/support/board_new_page.rb
+++ b/modules/boards/spec/features/support/board_new_page.rb
@@ -22,6 +22,10 @@ module Pages
       fill_in I18n.t(:label_title), with: title
     end
 
+    def expect_project_dropdown
+      find "[data-qa-selector='project_id']"
+    end
+
     def set_project(project)
       select_autocomplete(find('[data-qa-selector="project_id"]'),
                           query: project,


### PR DESCRIPTION
Addresses note 3 in [this comment left by Ivana](https://community.openproject.org/projects/openproject/work_packages/48160/activity#activity-21)

Extends the `global_create_context?` helper in order to detect we're still in a global context when submitting a form and we re-render the `new` template with validation errors. Follows in-line with [this PR](https://github.com/opf/openproject/pull/13323) which addresses the same bug for Meetings.