### PR TITLE
Include nulled settings

### DIFF
--- a/lib/api/v3/user_preferences/notification_setting_representer.rb
+++ b/lib/api/v3/user_preferences/notification_setting_representer.rb
@@ -35,9 +35,12 @@ module API
 
         NotificationSetting.all_settings.each do |setting|
           if setting.in?(NotificationSetting.date_alert_settings)
-            duration_property setting, if: ->(*) { EnterpriseToken.allows_to?(:date_alerts) }
+            duration_property setting,
+                              if: ->(*) { EnterpriseToken.allows_to?(:date_alerts) },
+                              render_nil: true
           else
-            property setting
+            property setting,
+                     render_nil: true
           end
         end
 

--- a/spec/features/notifications/settings/my_notifications_settings_spec.rb
+++ b/spec/features/notifications/settings/my_notifications_settings_spec.rb
@@ -3,15 +3,14 @@ require_relative '../../users/notifications/shared_examples'
 require 'support/pages/my/notifications'
 
 describe "My notifications settings", js: true do
-  current_user { create(:user) }
+  shared_let(:user) { create(:user) }
 
-  let(:settings_page) { Pages::My::Notifications.new(current_user) }
+  let(:settings_page) { Pages::My::Notifications.new(user) }
 
   before do
+    login_as user
     settings_page.visit!
   end
 
-  it_behaves_like 'notification settings workflow' do
-    let(:user) { current_user }
-  end
+  it_behaves_like 'notification settings workflow'
 end

--- a/spec/features/users/notifications/shared_examples.rb
+++ b/spec/features/users/notifications/shared_examples.rb
@@ -1,10 +1,10 @@
 shared_examples 'notification settings workflow' do
   describe 'with another project the user can see', with_ee: %i[date_alerts] do
-    let!(:project) { create(:project) }
-    let!(:project_alt) { create(:project) }
-    let!(:role) { create(:role, permissions: %i[view_project]) }
-    let!(:member) { create(:member, user:, project:, roles: [role]) }
-    let!(:member_two) { create(:member, user:, project: project_alt, roles: [role]) }
+    shared_let(:project) { create(:project) }
+    shared_let(:project_alt) { create(:project) }
+    shared_let(:role) { create(:role, permissions: %i[view_project]) }
+    shared_let(:member) { create(:member, user:, project:, roles: [role]) }
+    shared_let(:member_two) { create(:member, user:, project: project_alt, roles: [role]) }
 
     it 'allows to control notification settings' do
       # Expect default settings
@@ -113,6 +113,26 @@ shared_examples 'notification settings workflow' do
       settings_page.search_autocomplete container, query: project.name, results_selector: 'body'
       expect(page).to have_text 'This project is already selected'
       expect(page).to have_selector('.ng-option-disabled', text: project.name)
+    end
+
+    context 'when overdue alerts are disabled for one project, enabled for another' do
+      let!(:setting) { build(:notification_setting, user:, project:) }
+      let!(:setting_alt) { build(:notification_setting, user:, project: project_alt) }
+      let(:mail_settings_page) { Pages::My::Reminders.new(user) }
+
+      it 'allows to save with a partially disabled overdue alert' do
+        setting.start_date = nil
+        setting.due_date = nil
+        setting.save!
+
+        setting_alt.start_date = 1
+        setting_alt.due_date = 1
+        setting_alt.save!
+
+        mail_settings_page.visit!
+        mail_settings_page.save
+        mail_settings_page.expect_and_dismiss_toaster(message: 'Successful update')
+      end
     end
 
     context 'without enterprise', with_ee: false do


### PR DESCRIPTION
When having a project specific notification setting, trying to save the _email reminders_ (not the reminder settings) will break the page as the upsert call does not have the same number of hash keys.

https://community.openproject.org/work_packages/49487