### PR TITLE
[#49489] Fix required inputs on the meetings form

### DIFF
--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -112,6 +112,10 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       inputs['show-ignore-non-working-days'] = options[:show_ignore_non_working_days]
     end
 
+    if options[:required]
+      inputs[:required] = options[:required]
+    end
+
     label = label_for_field(field, label_options)
     input = angular_component_tag('op-basic-single-date-picker',
                                   class: options[:class],


### PR DESCRIPTION
https://community.openproject.org/work_packages/49489
This PR fixes the missing `required` attribute on the date selector of the new meetings form.
The Project input cannot simply receive the `required` attribute as it is an `ng-select` input, which does not supports the required tag.