### PR TITLE
[#49430] Ensure long text values don't spill over in the WP view

### DIFF
--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -66,6 +66,7 @@
     margin-bottom: 0.1875rem
     padding: 0.375rem 0
     height: 100%
+    overflow: hidden
 
     p
       font-size: $form-label-fontsize


### PR DESCRIPTION
By adding `overflow: hidden` to the `.attributes-key-value--value-container` we ensure that no fields (name or not) will spill over into their adjacent fields.

See: https://community.openproject.org/work_packages/49430

**Previews:**
![image](https://github.com/opf/openproject/assets/61627014/4504f0ac-e124-488d-aede-aac26a582322)
![image](https://github.com/opf/openproject/assets/61627014/8de71a63-9b1e-495a-b26b-251d4c0ce062)