### PR TITLE
Move modal pattern to lookbook docs

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -30,9 +30,17 @@ See COPYRIGHT and LICENSE files for more details.
 <head>
   <%= include_frontend_assets %>
 </head>
-<body class="viewcomponent-preview">
+<%
+  styles = []
+  min_height = params[:lookbook][:display][:min_height]
+  styles << "min-height: #{min_height}" if min_height.present?
+%>
+
+<%= content_tag :body,
+                class: 'viewcomponent-preview',
+                style: styles.join(";") do %>
   <section class="viewcomponent-preview--content">
     <%= yield %>
   </section>
-</body>
+<% end %>
 </html>

--- a/spec/components/docs/patterns/modals.md.erb
+++ b/spec/components/docs/patterns/modals.md.erb
@@ -1,10 +1,7 @@
-import { Meta } from '@storybook/blocks';
 
-<Meta title="Patterns/Modal Dialogue" />
+<%= embed ModalPreview, :danger_zone %>
 
-# Modal dialogue
-
-> Example of modal with two buttons: Cancel and Delete (danger)
+> Example of modal with two buttons: Cancel and Continue (danger)
 
 The modal dialogue is used to to provide actions that require the user’s attention. They interrupt the user’s regular navigation in that they cover the screen and make interaction behind it not possible whilst it is displayed.
 
@@ -35,7 +32,7 @@ This component does not by itself define the types of content it can contain. So
 
 ## Behaviour
 
-The modal is launched by user action and displayed in a lightbox (a semi-transparent grey background). 
+The modal is launched by user action and displayed in a lightbox (a semi-transparent grey background).
 
 The action bar always has only two actions, one of which is always “Cancel” (secondary) and the other one usually an confirmational action like “Apply” or “Save”. As with any action bar, a third action (usually a checkbox) can optionally be displayed on the left corner.
 
@@ -59,7 +56,7 @@ The container has 4px rounded corners.
 
 The modal (in desktop form) has two acceptable widths: 40 REM and 60 REM.
 
-The header has 16px padding (left and right) and a 16px top margin. 
+The header has 16px padding (left and right) and a 16px top margin.
 
 Note that the optional divider in the header a 16px top margin but no additional margin/padding, and must take 100% of the width of the modal.
 

--- a/spec/components/previews/modal_preview.rb
+++ b/spec/components/previews/modal_preview.rb
@@ -1,4 +1,5 @@
 # @logical_path OpenProject
+# @display min_height 500px
 class ModalPreview < Lookbook::Preview
   def default; end
 


### PR DESCRIPTION
Demonstrates embedding a preview in docs using the modals pattern from storybook:

<img width="1092" alt="Bildschirmfoto 2023-08-02 um 21 34 14" src="https://github.com/opf/openproject/assets/459462/cdb4af92-b5de-444e-823b-bee1157e818a">


To properly embed a modal, the iframe'd body needs a min-height as it otherwise shrinks due to the overflow. To address that, we're using display params for the viewcomponent layout