### PR TITLE
Update lookbook to 2.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -207,7 +207,7 @@ gem "appsignal", "~> 3.0", require: false
 
 gem 'view_component'
 # Lookbook
-gem 'lookbook', '~> 2.0.3'
+gem 'lookbook', '~> 2.0.5'
 
 gem 'turbo-rails', "~> 1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1074,7 +1074,7 @@ DEPENDENCIES
   letter_opener
   listen (~> 3.8.0)
   lograge (~> 0.12.0)
-  lookbook (~> 2.0.3)
+  lookbook (~> 2.0.5)
   mail (= 2.8.1)
   matrix (~> 0.4.2)
   md_to_pdf!

--- a/lib/open_project/patches/lookbook_tree_node_inflector.rb
+++ b/lib/open_project/patches/lookbook_tree_node_inflector.rb
@@ -41,7 +41,7 @@ module OpenProject
 end
 
 if Rails.env.development?
-  OpenProject::Patches.patch_gem_version 'lookbook', '2.0.3' do
+  OpenProject::Patches.patch_gem_version 'lookbook', '2.0.5' do
     Lookbook::TreeNode.prepend OpenProject::Patches::LookbookTreeNodeInflector
   end
 end


### PR DESCRIPTION
Fixing the development error:
`OpenProject expects to patch gem 'lookbook' at version 2.0.3 but found version 2.0.5. Please check whether the patch is still valid.`