### PR TITLE
[#42974] Add database indices for WorkPackageJournals and CustomizableJournals

### DIFF
--- a/db/migrate/20230803113215_add_indices_to_work_package_journals.rb
+++ b/db/migrate/20230803113215_add_indices_to_work_package_journals.rb
@@ -1,0 +1,16 @@
+class AddIndicesToWorkPackageJournals < ActiveRecord::Migration[7.0]
+  def change
+    add_index :work_package_journals, :assigned_to_id
+    add_index :work_package_journals, :author_id
+    add_index :work_package_journals, :category_id
+    add_index :work_package_journals, :parent_id
+    add_index :work_package_journals, :responsible_id
+    add_index :work_package_journals, :status_id
+    add_index :work_package_journals, :type_id
+    add_index :work_package_journals, :version_id
+
+    add_index :work_package_journals, :schedule_manually
+    add_index :work_package_journals, :start_date
+    add_index :work_package_journals, :due_date
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/42974

The baseline feature substitutes the `work_packages` table with `work_package_journals` in all the `WorkPackage` related queries. It makes sense to add all the indices we have on the `work_packages` to the `work_package_journals`.

The `customizable_journals` indices do not need any update, because they are already optimized to the table's structure, which differs from the `custom_fields` table.