### PR TITLE
Gracefully deal with nil containers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1499,6 +1499,7 @@ en:
 
     caused_changes:
       dates_changed: "Dates changed"
+      system_update: "OpenProject update"
 
     cause_descriptions:
       work_package_predecessor_changed_times: by changes to predecessor %{link}
@@ -1514,6 +1515,9 @@ en:
         dates:
           working: "%{date} is now working"
           non_working: "%{date} is now non-working"
+      system_update:
+        file_links_journal: 'added File links to Activities'
+
 
   links:
     configuration_guide: 'Configuration guide'

--- a/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
+++ b/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
@@ -31,7 +31,7 @@
 class AddFileLinkJournalsToExistingContainers < ActiveRecord::Migration[7.0]
   def up
     system_user = SystemUser.first
-    containers = Storages::FileLink.includes(:container).map(&:container).uniq
+    containers = Storages::FileLink.includes(:container).map(&:container).uniq.compact
 
     containers.each do |container|
       next unless container.class.journaled?

--- a/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
+++ b/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
@@ -36,7 +36,8 @@ class AddFileLinkJournalsToExistingContainers < ActiveRecord::Migration[7.0]
     containers.each do |container|
       next unless container.class.journaled?
 
-      Journals::CreateService.new(container, system_user).call(notes: "File link activity added by a system update")
+      Journals::CreateService.new(container, system_user)
+                             .call(cause: { type: 'system_update', feature: 'file_links_journal' })
     end
   end
 

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -44,20 +44,28 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
 
   private
 
-  def cause_type_translation(_type)
-    # currently only date changes have a cause, but in the future when other changes have a cause,
-    # those can be changed here.
-
-    I18n.t('journals.caused_changes.dates_changed')
+  def cause_type_translation(type)
+    case type
+    when 'system_update'
+      I18n.t("journals.caused_changes.system_update")
+    else
+      I18n.t("journals.caused_changes.dates_changed")
+    end
   end
 
   def cause_description(cause, html)
     case cause['type']
+    when 'system_update'
+      system_update_message(cause)
     when 'working_days_changed'
       working_days_changed_message(cause['changed_days'])
     else
       related_work_package_changed_message(cause, html)
     end
+  end
+
+  def system_update_message(cause)
+    I18n.t("journals.cause_descriptions.system_update.#{cause['feature']}")
   end
 
   def related_work_package_changed_message(cause, html)

--- a/spec/lib/journal_formatter/cause_spec.rb
+++ b/spec/lib/journal_formatter/cause_spec.rb
@@ -282,4 +282,31 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       end
     end
   end
+
+  context 'when the change was caused by a system update' do
+    let(:cause) do
+      {
+        "type" => 'system_update',
+        "feature" => 'file_links_journal'
+      }
+    end
+
+    context 'when rendering HTML variant' do
+      let(:html) { true }
+
+      it do
+        expect(subject).to eq "<strong>#{I18n.t('journals.caused_changes.system_update')}</strong> " \
+                              "#{I18n.t('journals.cause_descriptions.system_update.file_links_journal')}"
+      end
+    end
+
+    context 'when rendering raw variant' do
+      let(:html) { false }
+
+      it do
+        expect(subject).to eq "#{I18n.t('journals.caused_changes.system_update')} " \
+                              "#{I18n.t('journals.cause_descriptions.system_update.file_links_journal')}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
As reported by @oliverguenther in [Element](https://matrix.to/#/!xcCvdAzoRtrTNmmFlD:openproject.org/$ogcmaRuunyUkMBRYAIUkhMf7qO7Mtn3SuMxP2UUHXbc?via=openproject.org) we can have a `nil` container.

The fix for this is just to compact the list of containers. Also added a i18n cause exemplified below.

![image](https://github.com/opf/openproject/assets/10281/28f002f8-9d0d-426d-87cd-4c8cd887c274)
