### PR TITLE
[#48246] Fix GitHub Integration Comments listing incorrect Actor

### DIFF
--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -48,7 +48,7 @@ en:
 
       github_actions: Actions
       pull_requests:
-        message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} has been %{pr_state} by %{github_user_link}."
+        message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} has been %{pr_state}."
         referenced_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} referenced this work package."
         states:
           opened: 'opened'

--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -49,7 +49,7 @@ en:
       github_actions: Actions
       pull_requests:
         message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} has been %{pr_state} by %{github_user_link}."
-        referenced_message: "%{github_user_link} referenced this work package in pull request #%{pr_number} %{pr_link} on %{repository_link}."
+        referenced_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} referenced this work package."
         states:
           opened: 'opened'
           closed: 'closed'

--- a/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
@@ -36,7 +36,7 @@ import {
 } from '@angular/core';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
-import { IGithubPullRequest } from '../state/github-pull-request.model';
+import { IGithubPullRequest, IGithubUserResource } from '../state/github-pull-request.model';
 import { GithubPullRequestResourceService } from '../state/github-pull-request.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -85,7 +85,8 @@ export class PullRequestMacroComponent implements OnInit {
   }
 
   private buildText(pr:IGithubPullRequest):string {
-    const githubUserLink = this.htmlLink(pr._embedded.githubUser.htmlUrl, pr._embedded.githubUser.login);
+    const actor = this.deriveActor(pr) as IGithubUserResource;
+    const actorLink = this.htmlLink(actor.htmlUrl, actor.login);
     const repositoryLink = this.htmlLink(pr.repositoryHtmlUrl, pr.repository);
     const prLink = this.htmlLink(pr.htmlUrl, pr.title);
 
@@ -100,9 +101,18 @@ export class PullRequestMacroComponent implements OnInit {
           `js.github_integration.pull_requests.states.${this.pullRequestState}`,
           { defaultValue: this.pullRequestState || '(unknown state)' },
         ),
-        github_user_link: githubUserLink,
+        github_user_link: actorLink,
       },
     );
+  }
+
+
+  private deriveActor(pr:IGithubPullRequest) {
+    if (this.pullRequestState === 'merged') {
+      return pr._embedded.mergedBy;
+    } else {
+      return pr._embedded.githubUser;
+    }
   }
 
   private htmlLink(href:string, title:string):string {

--- a/modules/github_integration/spec/features/work_package_activity_spec.rb
+++ b/modules/github_integration/spec/features/work_package_activity_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'Work Package Activity Tab',
                'Comments by Github',
                :js,
                :with_cuprite do
-  shared_let(:github_system_user) { create(:admin) }
+  shared_let(:github_system_user) { create(:admin, firstname: 'Github', lastname: 'System User') }
   shared_let(:admin) { create(:admin) }
 
   shared_let(:project) { create(:project, enabled_module_names: Setting.default_projects_modules + %w[activity]) }
   shared_let(:work_package) { create(:work_package, project:) }
 
-  shared_let(:pull_request_author) { create(:github_user) }
-  shared_let(:pull_request_merging_user) { create(:github_user) }
+  shared_let(:pull_request_author) { create(:github_user, github_login: 'i_am_the_author') }
+  shared_let(:pull_request_merging_user) { create(:github_user, github_login: 'i_merged') }
   shared_let(:pull_request) do
     create(:github_pull_request,
            github_user: pull_request_author)
@@ -26,9 +26,25 @@ RSpec.describe 'Work Package Activity Tab',
     pull_request.reload
   end
 
+  def upsert_pull_request_with_reference
+    OpenProject::GithubIntegration::NotificationHandler::PullRequest.new
+                                                                    .process(referenced_payload)
+
+    pull_request.reload
+  end
+
   let(:closed_merged_payload) do
     {
       'action' => 'closed',
+      'open_project_user_id' => github_system_user.id,
+      'pull_request' => pull_request_hash,
+      'sender' => sender_section_hash
+    }
+  end
+
+  let(:referenced_payload) do
+    {
+      'action' => 'referenced',
       'open_project_user_id' => github_system_user.id,
       'pull_request' => pull_request_hash,
       'sender' => sender_section_hash
@@ -43,37 +59,29 @@ RSpec.describe 'Work Package Activity Tab',
       'title' => pull_request.title,
       'html_url' => pull_request.github_html_url,
       'updated_at' => Time.current.iso8601,
-      'state' => 'closed',
+      'state' => state,
       'draft' => false,
       'merged' => true,
       'merged_by' => merged_by_section_hash,
-      'merged_at' => Time.current.iso8601,
+      'merged_at' => merged_at,
       'comments' => pull_request.comments_count + 1,
       'review_comments' => pull_request.review_comments_count,
       'additions' => pull_request.additions_count,
       'deletions' => pull_request.deletions_count,
       'changed_files' => pull_request.changed_files_count,
       'labels' => pull_request.labels,
-      'user' => author_section_hash,
-      'base' => base_section_hash
-    }
-  end
-
-  let(:merged_by_section_hash) do
-    {
-      'id' => pull_request_merging_user.github_id,
-      'login' => pull_request_merging_user.github_login,
-      'html_url' => pull_request_merging_user.github_html_url,
-      'avatar_url' => pull_request_merging_user.github_avatar_url
-    }
-  end
-
-  let(:author_section_hash) do
-    {
-      'id' => pull_request_author.github_id,
-      'login' => pull_request_author.github_login,
-      'html_url' => pull_request_author.github_html_url,
-      'avatar_url' => pull_request_author.github_avatar_url
+      'user' => {
+        'id' => pull_request_author.github_id,
+        'login' => pull_request_author.github_login,
+        'html_url' => pull_request_author.github_html_url,
+        'avatar_url' => pull_request_author.github_avatar_url
+      },
+      'base' => {
+        'repo' => {
+          'full_name' => 'author_user/repo',
+          'html_url' => 'github.com/author_user/repo'
+        }
+      }
     }
   end
 
@@ -84,27 +92,26 @@ RSpec.describe 'Work Package Activity Tab',
     }
   end
 
-  let(:base_section_hash) do
-    {
-      'repo' => {
-        'full_name' => 'author_user/repo',
-        'html_url' => 'github.com/author_user/repo'
-      }
-    }
-  end
-
   let(:work_package_page) { Pages::SplitWorkPackage.new(work_package, project) }
-
-  before do
-    login_as admin
-  end
 
   context 'when the pull request is merged' do
     before do
       upsert_pull_request_with_merge
+      login_as admin
     end
 
     context "and I visit the work package's activity tab" do
+      let(:merged_by_section_hash) do
+        {
+          'id' => pull_request_merging_user.github_id,
+          'login' => pull_request_merging_user.github_login,
+          'html_url' => pull_request_merging_user.github_html_url,
+          'avatar_url' => pull_request_merging_user.github_avatar_url
+        }
+      end
+      let(:merged_at) { Time.current.iso8601 }
+      let(:state) { 'closed' }
+
       before do
         work_package_page.visit_tab! 'activity'
         work_package_page.ensure_page_loaded
@@ -121,6 +128,37 @@ RSpec.describe 'Work Package Activity Tab',
         GITHUB_MERGE_COMMENT
 
         expect(page).to have_selector('.user-comment > .message', text: expected_merge_comment)
+      end
+    end
+  end
+
+  context 'when the Work Package is referenced in a Pull Request' do
+    let(:merged_by_section_hash) { {} }
+    let(:merged_at) { nil }
+    let(:state) { 'open' }
+
+    before do
+      upsert_pull_request_with_reference
+      login_as admin
+    end
+
+    context "and I visit the work package's activity tab" do
+      before do
+        work_package_page.visit_tab! 'activity'
+        work_package_page.ensure_page_loaded
+      end
+
+      it 'renders a comment stating the Work Package was referenced in the Pull Request' do
+        expected_referenced_comment = <<~GITHUB_REFERENCED_COMMENT.squish
+          Referenced#{I18n.t('js.github_integration.pull_requests.referenced_message',
+                             pr_number: pull_request.number,
+                             pr_link: pull_request.title,
+                             repository_link: pull_request.repository,
+                             pr_state: 'referenced',
+                             github_user_link: pull_request_author.github_login)}
+        GITHUB_REFERENCED_COMMENT
+
+        expect(page).to have_selector('.user-comment > .message', text: expected_referenced_comment)
       end
     end
   end

--- a/modules/github_integration/spec/features/work_package_activity_spec.rb
+++ b/modules/github_integration/spec/features/work_package_activity_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Work Package Activity Tab',
+               'Comments by Github',
+               :js,
+               :with_cuprite do
+  shared_let(:github_system_user) { create(:admin) }
+  shared_let(:admin) { create(:admin) }
+
+  shared_let(:project) { create(:project, enabled_module_names: Setting.default_projects_modules + %w[activity]) }
+  shared_let(:work_package) { create(:work_package, project:) }
+
+  shared_let(:pull_request_author) { create(:github_user) }
+  shared_let(:pull_request_merging_user) { create(:github_user) }
+  shared_let(:pull_request) do
+    create(:github_pull_request,
+           github_user: pull_request_author)
+  end
+
+  def upsert_pull_request_with_merge
+    OpenProject::GithubIntegration::NotificationHandler::PullRequest.new
+                                                                    .process(closed_merged_payload)
+
+    pull_request.reload
+  end
+
+  let(:closed_merged_payload) do
+    {
+      'action' => 'closed',
+      'open_project_user_id' => github_system_user.id,
+      'pull_request' => pull_request_hash,
+      'sender' => sender_section_hash
+    }
+  end
+
+  let(:pull_request_hash) do
+    {
+      'id' => pull_request.id,
+      'number' => pull_request.number,
+      'body' => "Mentioning OP##{work_package.id}",
+      'title' => pull_request.title,
+      'html_url' => pull_request.github_html_url,
+      'updated_at' => Time.current.iso8601,
+      'state' => 'closed',
+      'draft' => false,
+      'merged' => true,
+      'merged_by' => merged_by_section_hash,
+      'merged_at' => Time.current.iso8601,
+      'comments' => pull_request.comments_count + 1,
+      'review_comments' => pull_request.review_comments_count,
+      'additions' => pull_request.additions_count,
+      'deletions' => pull_request.deletions_count,
+      'changed_files' => pull_request.changed_files_count,
+      'labels' => pull_request.labels,
+      'user' => author_section_hash,
+      'base' => base_section_hash
+    }
+  end
+
+  let(:merged_by_section_hash) do
+    {
+      'id' => pull_request_merging_user.github_id,
+      'login' => pull_request_merging_user.github_login,
+      'html_url' => pull_request_merging_user.github_html_url,
+      'avatar_url' => pull_request_merging_user.github_avatar_url
+    }
+  end
+
+  let(:author_section_hash) do
+    {
+      'id' => pull_request_author.github_id,
+      'login' => pull_request_author.github_login,
+      'html_url' => pull_request_author.github_html_url,
+      'avatar_url' => pull_request_author.github_avatar_url
+    }
+  end
+
+  let(:sender_section_hash) do
+    {
+      'login' => 'test_user',
+      'html_url' => 'github.com/test_user'
+    }
+  end
+
+  let(:base_section_hash) do
+    {
+      'repo' => {
+        'full_name' => 'author_user/repo',
+        'html_url' => 'github.com/author_user/repo'
+      }
+    }
+  end
+
+  let(:work_package_page) { Pages::SplitWorkPackage.new(work_package, project) }
+
+  before do
+    login_as admin
+  end
+
+  context 'when the pull request is merged' do
+    before do
+      upsert_pull_request_with_merge
+    end
+
+    context "and I visit the work package's activity tab" do
+      before do
+        work_package_page.visit_tab! 'activity'
+        work_package_page.ensure_page_loaded
+      end
+
+      it 'renders a comment stating the Pull Request was merged by the merge actor' do
+        expected_merge_comment = <<~GITHUB_MERGE_COMMENT.squish
+          Merged#{I18n.t('js.github_integration.pull_requests.message',
+                         pr_number: pull_request.number,
+                         pr_link: pull_request.title,
+                         repository_link: pull_request.repository,
+                         pr_state: 'merged',
+                         github_user_link: pull_request_merging_user.github_login)}
+        GITHUB_MERGE_COMMENT
+
+        expect(page).to have_selector('.user-comment > .message', text: expected_merge_comment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Bugs:
### Issue 1
When merging a pull request, the comment generated by the Github Integration would reference the author every time instead of the merging user.

### Issue 2
When referencing a work package in Github Pull request, the user displayed as referencing the work package is the author every time instead of the commenter. Furthermore, this not only happens when referencing, but with every action: be it marking as ready for review, converting to draft, etc...

### Root cause
We're not referencing the correct _**Actor**_ in each scenario; meaning we default to the author every time.

## Fixes
### Issue 1
We now derive which should be the correct actor to link to in the Work Package activity comments depending on what type of state the pull request was in when their journal is saved.

- If the state was merged, the actor should be the `merged_by` user.
- Otherwise, set the author as the actor.

![image](https://github.com/opf/openproject/assets/61627014/e91c4d56-f02c-40bf-a4c0-907c22f1c79b)

### Issue 2
As we do not currently have any traces or store the `sender` provided in the web hook payload (and since after some discussion, linking to the Github User's profile who referenced the work package in a pull request is not really important/relevant information), the wording for the rendered message in the comment was modified.

Since this really is an issue for all actions as the author would also be referenced as the actor. The wording for other
actions, such as marking as ready for review was adapted to match that of referencing to avoid incorrectness

![image](https://github.com/opf/openproject/assets/61627014/de620d26-1e51-48c9-a10d-36c8b2d4574f)
![image](https://github.com/opf/openproject/assets/61627014/6a4093cc-c2c6-4a74-bf4e-7d89a21ae801)

## Notes:
- Feature specs added to cover the journal rendering of the Github Integration References and demonstrate the expectation of the proper wording and rendering of comments.
- Work Package where bug was reported: https://community.openproject.org/work_packages/48246