### PR TITLE
Optimized Docker TLS dev stack

### DIFF
--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -16,8 +16,6 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.openproject.rule=Host(`${OPENPROJECT_DEV_HOST}`)"
       - "traefik.http.routers.openproject.entrypoints=websecure"
-      - "traefik.http.routers.openproject.tls=true"
-      - "traefik.http.routers.openproject.tls.certresolver=step"
 
 # You need to define the same external network
 # that is defined in the TLS proxy compose file

--- a/docker/dev/tls/docker-compose.override.example.yml
+++ b/docker/dev/tls/docker-compose.override.example.yml
@@ -1,8 +1,5 @@
 services:
   traefik:
-    volumes:
-      # Linux: mount the certificate bundle
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
     networks:
       external:
         aliases:

--- a/docker/dev/tls/docker-compose.yml
+++ b/docker/dev/tls/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       --entryPoints.websecure.address=:443
       --entryPoints.websecure.http.tls=true
       --entryPoints.websecure.http.tls.certresolver=step
-      --certificatesresolvers.step.acme.caserver=https://step:9000/acme/traefik/directory
+      --certificatesresolvers.step.acme.caserver=https://step:9000/acme/acme/directory
       --certificatesresolvers.step.acme.tlschallenge=true
       --certificatesresolvers.step.acme.email=root@localhost
       --certificatesresolvers.step.acme.keytype=RSA4096
@@ -53,6 +53,7 @@ services:
       - DOCKER_STEPCA_INIT_DNS_NAMES=step,localhost
       - DOCKER_STEPCA_INIT_PROVISIONER_NAME=openproject
       - DOCKER_STEPCA_INIT_PASSWORD=openproject
+      - DOCKER_STEPCA_INIT_ACME=true
     volumes:
       - step:/home/step
     networks:

--- a/docker/dev/tls/docker-compose.yml
+++ b/docker/dev/tls/docker-compose.yml
@@ -4,26 +4,32 @@ services:
   traefik:
     image: traefik:latest
     command: >
+      --log.level=INFO
       --providers.docker
       --providers.docker.network=gateway
       --providers.docker.exposedByDefault=false
       --api.dashboard=true
+      --api.disabledashboardad=true
       --entryPoints.web.address=:80
+      --entryPoints.web.http.redirections.entrypoint.to=websecure
       --entryPoints.websecure.address=:443
-      --log.level=INFO
-      --certificatesresolvers.step.acme.caserver=https://step.local:9000/acme/traefik/directory
+      --entryPoints.websecure.http.tls=true
+      --entryPoints.websecure.http.tls.certresolver=step
+      --certificatesresolvers.step.acme.caserver=https://step:9000/acme/traefik/directory
       --certificatesresolvers.step.acme.tlschallenge=true
       --certificatesresolvers.step.acme.email=root@localhost
       --certificatesresolvers.step.acme.keytype=RSA4096
       --certificatesresolvers.step.acme.storage=acme.json
     environment:
       - TZ=UTC
+      - LEGO_CA_CERTIFICATES=/step/certs/root_ca.crt
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./acme.json:/acme.json
+      - step:/step:ro
     restart: unless-stopped
     depends_on:
       step:
@@ -37,10 +43,6 @@ services:
       - "traefik.http.routers.traefik.rule=Host(`traefik.local`)"
       - "traefik.http.routers.traefik.service=api@internal"
       - "traefik.http.routers.traefik.entrypoints=websecure"
-      - "traefik.http.routers.traefik.tls=true"
-      - "traefik.http.routers.traefik.tls.certresolver=step"
-      - "traefik.http.middlewares.redirect.redirectscheme.scheme=https"
-      - "traefik.http.middlewares.redirect.redirectscheme.permanent=false"
 
   step:
     image: smallstep/step-ca:latest
@@ -48,15 +50,13 @@ services:
     environment:
       - TZ=UTC
       - DOCKER_STEPCA_INIT_NAME=OpenProject Development
-      - DOCKER_STEPCA_INIT_DNS_NAMES=step.local,step,localhost
+      - DOCKER_STEPCA_INIT_DNS_NAMES=step,localhost
       - DOCKER_STEPCA_INIT_PROVISIONER_NAME=openproject
       - DOCKER_STEPCA_INIT_PASSWORD=openproject
     volumes:
       - step:/home/step
     networks:
-      external:
-        aliases:
-          - step.local
+      - external
 
 volumes:
   step:


### PR DESCRIPTION
- removed volume mount to host ceatificates for traefik
- mount step ca root certificate directly into traefik
- moved TLS settings to global traefik CLI parameters