### PR TITLE
[#49574] Misplaced asterisk in automatically managed project folders switch

### DIFF
--- a/modules/storages/app/views/storages/admin/storages/automatically_managed_project_folders/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/automatically_managed_project_folders/edit.html.erb
@@ -51,7 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
 
     <div class="form--field-container -horizontal">
-      <label class="form--label -flex">
+      <label class="form--field-inline-buttons-container">
         <%= angular_component_tag 'spot-switch',
                                   inputs: {
                                     id: "storages_#{@storage.short_provider_type}_storage_automatically_managed",


### PR DESCRIPTION
- https://community.openproject.org/work_packages/49574
- replaced css classes on mandatory label
  - is fixed when no longer angular switch is used