### PR TITLE
[49571][49572]Mobile issues in toolbar

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.sass
@@ -29,12 +29,15 @@
     &-added,
     &-removed
       margin-right: $spot-spacing-0_5
-  
+
     &-icon-added
       color: #5F42E0
-    
+
     &--icon-removed
       color: #555555
 
     &-icon-changed
       color: #54AFE0
+
+  @media screen and (max-width: $breakpoint-sm)
+    margin-left: $spot-spacing-1

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -13,6 +13,6 @@
     <span class="button--text"
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>
-    <span class="spot-icon spot-icon_1 spot-icon_pulldown"></span>
+    <span class="spot-icon spot-icon_dropdown"></span>
   </button>
 </div>

--- a/frontend/src/global_styles/layout/_toolbar_mobile.sass
+++ b/frontend/src/global_styles/layout/_toolbar_mobile.sass
@@ -41,11 +41,12 @@
         margin-right: 0
 
         .toolbar-item
-          margin-left: 10px
+          margin: 0 0 0 10px
 
         // Hide toolbar button texts on mobile
         .button--text:not(.button--text_without_icon),
-        .icon-pulldown
+        .icon-pulldown,
+        .spot-icon_dropdown
           display: none
 
         .op-icon--wrapper


### PR DESCRIPTION
Show no dropdown arrows in toolbar buttons on mobile and fix some spacings

### Before
<img width="478" alt="Bildschirmfoto 2023-08-07 um 08 55 34" src="https://github.com/opf/openproject/assets/7457313/e427dda1-8988-4cb1-bfde-e1dfd434d6c0">

### After
<img width="469" alt="Bildschirmfoto 2023-08-07 um 08 55 06" src="https://github.com/opf/openproject/assets/7457313/6d1c1030-1316-437c-9c7f-8de53e1210ba">


https://community.openproject.org/projects/14/work_packages/49572/activity
https://community.openproject.org/projects/openproject/work_packages/49571/activity