### PR TITLE
[#49501] Log time modal is not scrollable

### DIFF
--- a/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
+++ b/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
@@ -9,7 +9,7 @@
 
   <div class="spot-divider"></div>
 
-  <div class="spot-modal--body spot-modal--body_no-scroll spot-container">
+  <div class="spot-modal--body spot-container">
     <te-form
       #editForm
       [changeset]="changeset"

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -71,9 +71,6 @@
     flex-shrink: 1
     overflow-y: auto
 
-    &_no-scroll
-      overflow: visible
-
     &:focus
       outline-style: none
 


### PR DESCRIPTION
- https://community.openproject.org/work_packages/49501
- removed `no_scroll` modifier for `spot-model--body`

⚠️ IMPORTANT:
This change basically reverts what was introduced (among other changes, of course) in [this commit](https://github.com/opf/openproject/commit/a066f83350483da738170528a124e639e8dec71e#diff-d589a9a84f284fb0615c75cd63c3754f16a148e23bb4d7fc51ea148f90448748R2) by @b12f .

I'm not sure, if the requirements are simply clashing with what was true in January. So, please check extra carefully. ;)

Just, FYI: if the datepicker is open, if would of course clash with a very narrow window height:
![image](https://github.com/opf/openproject/assets/38206611/c243eb74-823b-4903-8f46-2b7e8c907b2e)

Take notice of the extra scrollbars (h and v), but those are on edge, too.