### PR TITLE
[49581] Translate names from common files when seeding

### DIFF
--- a/app/seeders/source/seed_data_loader.rb
+++ b/app/seeders/source/seed_data_loader.rb
@@ -52,18 +52,24 @@ class Source::SeedDataLoader
   end
 
   def seed_data
-    @seed_data ||= Source::SeedData.new(translate(raw_seed_files_content))
+    @seed_data ||= Source::SeedData.new(translated_seed_files_content)
   end
 
-  def raw_seed_files_content
-    seed_files.reduce({}) do |raw_content, seed_file|
-      raw_content.deep_merge(seed_file.raw_content)
-    end
+  def translated_seed_files_content
+    seed_files
+      .map { |seed_file| translate_seed_file(seed_file) }
+      .reduce({}) do |merged_content, seed_file_content|
+        merged_content.deep_merge(seed_file_content)
+      end
   end
 
   private
 
   def seed_files
     Source::SeedFile.with_names(seed_name, 'common')
+  end
+
+  def translate_seed_file(seed_file)
+    translate(seed_file.raw_content, "#{Source::Translate::I18N_PREFIX}.#{seed_file.name}")
   end
 end

--- a/app/seeders/source/translate.rb
+++ b/app/seeders/source/translate.rb
@@ -33,7 +33,7 @@ module Source::Translate
   TRANSLATABLE_PREFIX = 't_'
   TRANSLATABLE_PREFIX_PATTERN = /^#{TRANSLATABLE_PREFIX}/
 
-  def translate(hash, i18n_key = "#{I18N_PREFIX}.#{seed_name}")
+  def translate(hash, i18n_key)
     translate_translatable_keys(hash, i18n_key)
     translate_nested_enumerations(hash, i18n_key)
     hash

--- a/db/migrate/20230808080001_remove_some_string_length_constraints.rb
+++ b/db/migrate/20230808080001_remove_some_string_length_constraints.rb
@@ -1,0 +1,17 @@
+class RemoveSomeStringLengthConstraints < ActiveRecord::Migration[7.0]
+  def up
+    change_column(:categories, :name, :string, limit: nil)
+    change_column(:enumerations, :name, :string, limit: nil)
+    change_column(:news, :title, :string, limit: nil)
+    change_column(:roles, :name, :string, limit: nil)
+    change_column(:statuses, :name, :string, limit: nil)
+  end
+
+  def down
+    change_column(:categories, :name, :string, limit: 256)
+    change_column(:enumerations, :name, :string, limit: 30)
+    change_column(:news, :title, :string, limit: 60)
+    change_column(:roles, :name, :string, limit: 30)
+    change_column(:statuses, :name, :string, limit: 30)
+  end
+end

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -189,10 +189,10 @@ RSpec.describe RootSeeder,
       end
     end
 
-    # Check that the tests are running with German as default language during seeding
     it 'seeds with the specified language' do
       expect(Status.where(name: 'Neu')).to exist
-      expect(Type.where(name: 'Arbeitspaket')).to exist
+      expect(Type.where(name: 'Meilenstein')).to exist
+      expect(Color.where(name: 'Gelb')).to exist
     end
 
     include_examples 'creates BIM demo data'

--- a/spec/models/db_and_ar_length_constraints_spec.rb
+++ b/spec/models/db_and_ar_length_constraints_spec.rb
@@ -1,0 +1,76 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require 'spec_helper'
+
+RSpec.describe 'DB and ActiveRecord constraints' do # rubocop:disable RSpec/DescribeClass
+  def self.has_max_length_validator?(model)
+    max_length_validators(model).any?
+  end
+
+  def self.max_length_validators(model)
+    model.validators.filter do |validator|
+      validator.is_a?(ActiveRecord::Validations::LengthValidator) \
+      && validator.options.has_key?(:maximum) \
+      && model.columns_hash.has_key?(validator.attributes.first.to_s)
+    end
+  end
+
+  def self.db_maximum_length(table_name, column_name)
+    query = ActiveRecord::Base.sanitize_sql(
+      [
+        "SELECT character_maximum_length " \
+        "FROM information_schema.columns " \
+        "WHERE table_name = :table_name and column_name = :column_name",
+        { table_name:, column_name: }
+      ]
+    )
+    rows = ActiveRecord::Base.connection.execute(query)
+    rows.first['character_maximum_length']
+  end
+
+  ApplicationRecord.descendants
+    .filter(&:table_exists?)
+    .filter { |model| has_max_length_validator?(model) }
+    .each do |model|
+      describe "#{model} (table name: #{model.table_name})" do
+        max_length_validators(model).each do |validator|
+          attribute = validator.attributes.first
+          model_max_length = validator.options[:maximum]
+          db_max_length = db_maximum_length(model.table_name, attribute)
+          if db_max_length
+            db_field = "#{model.table_name}.#{attribute}"
+            specify "max length of #{attribute.inspect} is #{model_max_length} for database field #{db_field}" do
+              expect(db_max_length).to eq(model_max_length),
+                                       "database maximum length of #{db_field} is #{db_max_length}, " \
+                                       "should be #{model_max_length} like the model or removed"
+            end
+          end
+        end
+      end
+    end
+end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -190,6 +190,9 @@ RSpec.describe RootSeeder,
       it 'seeds with the specified language' do
         willkommen = I18n.t("#{Source::Translate::I18N_PREFIX}.standard.welcome.title", locale: 'de')
         expect(Setting.welcome_title).to eq(willkommen)
+        expect(Status.where(name: 'Neu')).to exist
+        expect(Type.where(name: 'Meilenstein')).to exist
+        expect(Color.where(name: 'Gelb')).to exist
       end
 
       it 'sets Setting.default_language to the given language' do


### PR DESCRIPTION
https://community.openproject.org/wp/49581

So that the role names, the color names, and the document categories are correctly translated when another language than English is selected.