### PR TITLE
[#49587] Bugfix: PDF Export not possible if hierarchy too deep

### DIFF
--- a/app/models/work_package/pdf_export/style.rb
+++ b/app/models/work_package/pdf_export/style.rb
@@ -133,6 +133,10 @@ module WorkPackage::PDFExport::Style
       resolve_pt(@styles.dig(:overview, :table, :subject_indent), 0)
     end
 
+    def toc_max_depth
+      @styles.dig(:toc, :max_depth) || 4
+    end
+
     def toc_margins
       resolve_margin(@styles[:toc])
     end

--- a/app/models/work_package/pdf_export/table_of_contents.rb
+++ b/app/models/work_package/pdf_export/table_of_contents.rb
@@ -45,7 +45,7 @@ module WorkPackage::PDFExport::TableOfContents
 
   def build_toc_data_list_entry(work_package, id_wp_meta_map)
     level_path = id_wp_meta_map[work_package.id][:level_path]
-    level = level_path.length
+    level = [level_path.length, styles.toc_max_depth].min
     level_style = styles.toc_item(level)
     level_string = "#{level_path.join('.')}. "
     page_nr_string = (id_wp_meta_map[work_package.id][:page_number] || '000').to_s

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -102,7 +102,7 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
   def render_work_packages_pdfs(work_packages, filename)
     write_title!
     write_work_packages_toc! work_packages, @id_wp_meta_map if with_descriptions?
-    write_work_packages_overview! work_packages, @id_wp_meta_map unless with_descriptions?
+    write_work_packages_overview! work_packages unless with_descriptions?
     write_work_packages_sums! work_packages if with_sums_table? && with_descriptions?
     if should_be_batched?(work_packages)
       render_batched(work_packages, filename)


### PR DESCRIPTION
This PR:
* removes the hierarchy indenting of subjects in the "PDF Table" export (overview_table.rb)
* adds a limit of hierarchy indenting in the TOC of the "PDF Report" export
* allows hierarchy indenting limit configuration by yml

https://community.openproject.org/work_packages/49587