### PR TITLE
[48327] Do not show archived projects in subprojects widget

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.ts
@@ -23,14 +23,16 @@ export class WidgetSubprojectsComponent extends AbstractWidgetComponent implemen
 
   public projects:ProjectResource[];
 
-  constructor(readonly halResource:HalResourceService,
+  constructor(
+    readonly halResource:HalResourceService,
     readonly pathHelper:PathHelperService,
     readonly i18n:I18nService,
     protected readonly injector:Injector,
     readonly timezone:TimezoneService,
     readonly apiV3Service:ApiV3Service,
     readonly currentProject:CurrentProjectService,
-    readonly cdr:ChangeDetectorRef) {
+    readonly cdr:ChangeDetectorRef,
+  ) {
     super(i18n, injector);
   }
 
@@ -65,7 +67,7 @@ export class WidgetSubprojectsComponent extends AbstractWidgetComponent implemen
   private get projectListParams():ApiV3ListParameters {
     return {
       sortBy: [['name', 'asc']],
-      filters: [['parent_id', '=', [this.currentProject.id!]]],
+      filters: [['parent_id', '=', [this.currentProject.id!]], ['active', '=', ['t']]],
       pageSize: MAGIC_PAGE_NUMBER,
     };
   }

--- a/modules/dashboards/spec/features/subprojects_spec.rb
+++ b/modules/dashboards/spec/features/subprojects_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe 'Subprojects widget on dashboard', js: true do
   let!(:child_project) do
     create(:project, parent: project)
   end
+  let!(:archived_child_project) do
+    create(:project, :archived, parent: project)
+  end
   let!(:invisible_child_project) do
     create(:project, parent: project)
   end
@@ -61,6 +64,7 @@ RSpec.describe 'Subprojects widget on dashboard', js: true do
     create(:user).tap do |u|
       create(:member, project:, roles: [role], user: u)
       create(:member, project: child_project, roles: [role], user: u)
+      create(:member, project: archived_child_project, roles: [role], user: u)
       create(:member, project: grandchild_project, roles: [role], user: u)
       create(:member, project: parent_project, roles: [role], user: u)
     end
@@ -69,33 +73,58 @@ RSpec.describe 'Subprojects widget on dashboard', js: true do
     Pages::Dashboard.new(project)
   end
 
-  before do
-    login_as user
+  context 'as a user' do
+    current_user { user }
 
-    dashboard_page.visit!
-  end
+    it 'can add the widget listing active subprojects the user is member of', :aggregate_failures do
+      dashboard_page.visit!
+      dashboard_page.add_widget(1, 1, :within, "Subprojects")
 
-  it 'can add the widget and see the description in it' do
-    dashboard_page.add_widget(1, 1, :within, "Subprojects")
+      subprojects_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
 
-    sleep(0.1)
-
-    subprojects_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
-
-    expect(page)
-      .to have_link(child_project.name, wait: 10)
-
-    within(subprojects_widget.area) do
       expect(page)
         .to have_link(child_project.name)
-      expect(page)
-        .not_to have_link(grandchild_project.name)
-      expect(page)
-        .not_to have_link(invisible_child_project.name)
-      expect(page)
-        .not_to have_link(parent_project.name)
-      expect(page)
-        .not_to have_link(project.name)
+
+      within(subprojects_widget.area) do
+        expect(page)
+          .to have_link(child_project.name)
+        expect(page)
+          .not_to have_link(archived_child_project.name)
+        expect(page)
+          .not_to have_link(grandchild_project.name)
+        expect(page)
+          .not_to have_link(invisible_child_project.name)
+        expect(page)
+          .not_to have_link(parent_project.name)
+        expect(page)
+          .not_to have_link(project.name)
+      end
+    end
+  end
+
+  context 'as an admin' do
+    current_user { create(:admin) }
+
+    it 'can add the widget listing all active subprojects', :aggregate_failures do
+      dashboard_page.visit!
+      dashboard_page.add_widget(1, 2, :within, "Subprojects")
+
+      subprojects_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')
+
+      within(subprojects_widget.area) do
+        expect(page)
+          .to have_link(child_project.name)
+        expect(page)
+          .not_to have_link(archived_child_project.name)
+        expect(page)
+          .not_to have_link(grandchild_project.name)
+        expect(page)
+          .to have_link(invisible_child_project.name) # admins can see projects they are not member of
+        expect(page)
+          .not_to have_link(parent_project.name)
+        expect(page)
+          .not_to have_link(project.name)
+      end
     end
   end
 end

--- a/modules/dashboards/spec/features/subprojects_spec.rb
+++ b/modules/dashboards/spec/features/subprojects_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Subprojects widget on dashboard', js: true do
         expect(page)
           .not_to have_link(grandchild_project.name)
         expect(page)
-          .to have_link(invisible_child_project.name) # admins can see projects they are not member of
+          .to have_link(invisible_child_project.name) # admins can see projects they are not a member of
         expect(page)
           .not_to have_link(parent_project.name)
         expect(page)

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -95,6 +95,10 @@ FactoryBot.define do
       status_explanation { 'some explanation' }
     end
 
+    trait :archived do
+      active { false }
+    end
+
     trait :updated_a_long_time_ago do
       created_at { 2.years.ago }
       updated_at { 2.years.ago }


### PR DESCRIPTION
https://community.openproject.org/wp/48327

The api endpoint `/api/v3/projects` returns both active and archived projects for admin users. `active = true` must be explicitly added in the filters to hide archived subprojects for admins.