### PR TITLE
[OP#43836] Fix the remaining hours calculation 

### DIFF
--- a/db/migrate/20230808140921_add_derived_remaining_hours_to_work_packages.rb
+++ b/db/migrate/20230808140921_add_derived_remaining_hours_to_work_packages.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#--copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddDerivedRemainingHoursToWorkPackages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :work_packages, :derived_remaining_hours, :float
+    add_column :work_package_journals, :derived_remaining_hours, :float
+
+    reversible do |change|
+      change.up do
+        WorkPackage.transaction do
+          migrate_to_derived_remaining_hours!
+        end
+      end
+
+      change.down do
+        WorkPackage.transaction do
+          rollback_from_derived_remaining_hours!
+        end
+      end
+    end
+  end
+
+  def work_packages_to_update
+    leaf_node_ids = WorkPackage.leaves.pluck(:id)
+    WorkPackage.where.not(id: leaf_node_ids)
+  end
+
+  def migrate_to_derived_remaining_hours!
+    scope = work_packages_to_update
+              .where.not(remaining_hours: nil)
+    scope.update_all("derived_remaining_hours = remaining_hours, remaining_hours = NULL")
+  end
+
+  def journal_user = SystemUser.first
+
+  def rollback_from_derived_remaining_hours!
+    scope = work_packages_to_update
+              .where.not(derived_remaining_hours: nil)
+    scope.update_all("remaining_hours = derived_remaining_hours")
+  end
+end

--- a/db/migrate/20230808140921_add_derived_remaining_hours_to_work_packages.rb
+++ b/db/migrate/20230808140921_add_derived_remaining_hours_to_work_packages.rb
@@ -35,22 +35,17 @@ class AddDerivedRemainingHoursToWorkPackages < ActiveRecord::Migration[7.0]
 
     reversible do |change|
       change.up do
-        WorkPackage.transaction do
-          migrate_to_derived_remaining_hours!
-        end
+        migrate_to_derived_remaining_hours!
       end
 
       change.down do
-        WorkPackage.transaction do
-          rollback_from_derived_remaining_hours!
-        end
+        rollback_from_derived_remaining_hours!
       end
     end
   end
 
   def work_packages_to_update
-    leaf_node_ids = WorkPackage.leaves.pluck(:id)
-    WorkPackage.where.not(id: leaf_node_ids)
+    WorkPackage.where.not(id: WorkPackage.leaves)
   end
 
   def migrate_to_derived_remaining_hours!

--- a/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
@@ -51,7 +51,6 @@ import { LinkedWorkPackageDisplayField } from 'core-app/shared/components/fields
 import { CombinedDateDisplayField } from 'core-app/shared/components/fields/display/field-types/combined-date-display.field';
 import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
 import { DaysDurationDisplayField } from 'core-app/shared/components/fields/display/field-types/days-duration-display-field.module';
-import { HoursDurationDisplayField } from 'core-app/shared/components/fields/display/field-types/hours-duration-display-field.module';
 
 export function initializeCoreDisplayFields(displayFieldService:DisplayFieldService) {
   return () => {
@@ -76,7 +75,7 @@ export function initializeCoreDisplayFields(displayFieldService:DisplayFieldServ
       .addFieldType(MultipleUserFieldModule, 'users', ['[]User'])
       .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])
       .addFieldType(DaysDurationDisplayField, 'duration', ['duration'])
-      .addFieldType(HoursDurationDisplayField, 'remainingTime', ['remainingTime'])
+      .addFieldType(EstimatedTimeDisplayField, 'remainingTime', ['remainingTime'])
       .addFieldType(EstimatedTimeDisplayField, 'estimatedTime', ['estimatedTime'])
       .addFieldType(DateDisplayField, 'date', ['Date'])
       .addFieldType(DateTimeDisplayField, 'datetime', ['DateTime'])

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
         position: "Position"
         remaining_hours: "Remaining hours"
         remaining_time: "Remaining hours"
+        derived_remaining_hours: "Derived remaining hours"
+        derived_remaining_time: "Derived remaining hours"
         story_points: "Story Points"
         backlogs_work_package_type: "Backlog type"
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
@@ -41,24 +41,35 @@ module OpenProject::Backlogs
 
             property :story_points,
                      render_nil: true,
-                     skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points)) }
+                     skip_render: ->(*) {
+                                    !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points))
+                                  }
 
             property :remaining_time,
                      exec_context: :decorator,
                      render_nil: true,
-                     skip_render: ->(represented:, **) { !represented.backlogs_enabled? }
+                     skip_render: ->(represented:, **) { !represented.backlogs_enabled? },
+                     getter: ->(*) do
+                       datetime_formatter.format_duration_from_hours(represented.remaining_hours, allow_nil: true)
+                     end
+
+            property :derived_remaining_time,
+                     exec_context: :decorator,
+                     render_nil: true,
+                     skip_render: ->(represented:, **) { !represented.backlogs_enabled? },
+                     getter: ->(*) do
+                       datetime_formatter.format_duration_from_hours(represented.derived_remaining_hours, allow_nil: true)
+                     end
 
             # cannot use def here as it wouldn't define the method on the representer
-            define_method :remaining_time do
-              datetime_formatter.format_duration_from_hours(represented.remaining_hours,
-                                                            allow_nil: true)
+            define_method :remaining_time= do |value|
+              represented.remaining_hours = datetime_formatter
+                                                      .parse_duration_to_hours(value, 'remainingTime', allow_nil: true)
             end
 
-            define_method :remaining_time= do |value|
-              remaining = datetime_formatter.parse_duration_to_hours(value,
-                                                                     'remainingTime',
-                                                                     allow_nil: true)
-              represented.remaining_hours = remaining
+            define_method :derived_remaining_time= do |value|
+              represented.derived_remaining_hours = datetime_formatter
+                                                      .parse_duration_to_hours(value, 'derivedRemainingTime', allow_nil: true)
             end
           end
         end

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
@@ -37,13 +37,15 @@ module OpenProject::Backlogs
           ->(*) do
             property :position,
                      render_nil: true,
-                     skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:position)) }
+                     skip_render: ->(*) do
+                       !(backlogs_enabled? && type && type.passes_attribute_constraint?(:position))
+                     end
 
             property :story_points,
                      render_nil: true,
-                     skip_render: ->(*) {
-                                    !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points))
-                                  }
+                     skip_render: ->(*) do
+                       !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points))
+                     end
 
             property :remaining_time,
                      exec_context: :decorator,
@@ -64,7 +66,7 @@ module OpenProject::Backlogs
             # cannot use def here as it wouldn't define the method on the representer
             define_method :remaining_time= do |value|
               represented.remaining_hours = datetime_formatter
-                                                      .parse_duration_to_hours(value, 'remainingTime', allow_nil: true)
+                                              .parse_duration_to_hours(value, 'remainingTime', allow_nil: true)
             end
 
             define_method :derived_remaining_time= do |value|

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
@@ -56,6 +56,12 @@ module OpenProject::Backlogs
                    required: false,
                    show_if: ->(*) { represented.project && represented.project.backlogs_enabled? }
 
+            schema :derived_remaining_time,
+                   type: 'Duration',
+                   name_source: :derived_remaining_hours,
+                   required: false,
+                   show_if: ->(*) { represented.project && represented.project.backlogs_enabled? }
+
             define_method :backlogs_constraint_passed? do |attribute|
               represented.project&.backlogs_enabled? &&
                 (!represented.type || represented.type.passes_attribute_constraint?(attribute))

--- a/modules/backlogs/lib/open_project/backlogs/patches/update_ancestors_service_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/update_ancestors_service_patch.rb
@@ -39,12 +39,13 @@ module OpenProject::Backlogs::Patches::UpdateAncestorsServicePatch
     def inherit_attributes(ancestor, loader, attributes)
       super
 
-      inherit_remaining_hours(ancestor, loader) if inherit?(attributes, :remaining_hours)
+      derive_remaining_hours(ancestor, loader) if inherit?(attributes, :remaining_hours)
     end
 
-    def inherit_remaining_hours(ancestor, loader)
-      ancestor.remaining_hours = all_remaining_hours(loader.leaves_of(ancestor)).sum.to_f
-      ancestor.remaining_hours = nil if ancestor.remaining_hours == 0.0
+    def derive_remaining_hours(work_package, loader)
+      descendants = loader.descendants_of(work_package)
+
+      work_package.derived_remaining_hours = not_zero(all_remaining_hours(descendants).sum.to_f)
     end
 
     def all_remaining_hours(work_packages)

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -33,9 +33,10 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     prepend InstanceMethods
     extend ClassMethods
 
-    before_validation :backlogs_before_validation, if: lambda { backlogs_enabled? }
+    before_validation :backlogs_before_validation, if: -> { backlogs_enabled? }
 
     register_journal_formatted_fields(:fraction, 'remaining_hours')
+    register_journal_formatted_fields(:fraction, 'derived_remaining_hours')
     register_journal_formatted_fields(:decimal, 'story_points')
     register_journal_formatted_fields(:decimal, 'position')
 
@@ -43,12 +44,17 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
                                              allow_nil: true,
                                              greater_than_or_equal_to: 0,
                                              less_than: 10_000,
-                                             if: lambda { backlogs_enabled? }
+                                             if: -> { backlogs_enabled? }
 
     validates_numericality_of :remaining_hours, only_integer: false,
                                                 allow_nil: true,
                                                 greater_than_or_equal_to: 0,
-                                                if: lambda { backlogs_enabled? }
+                                                if: -> { backlogs_enabled? }
+
+    validates_numericality_of :derived_remaining_hours, only_integer: false,
+                                                        allow_nil: true,
+                                                        greater_than_or_equal_to: 0,
+                                                        if: -> { backlogs_enabled? }
 
     include OpenProject::Backlogs::List
   end
@@ -106,9 +112,7 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
       if is_story?
         Story.find(id)
       elsif is_task?
-        ancestors
-          .where(type_id: Story.types)
-          .first
+        ancestors.where(type_id: Story.types).first
       end
     end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
@@ -33,11 +33,11 @@ module OpenProject::Backlogs::Patches::WorkPackages::UpdateAncestors::LoaderPatc
     private
 
     def selected_descendants_attributes
-      super + %i(remaining_hours derived_remaining_hours)
+      super + %i(remaining_hours)
     end
 
     def selected_leaves_attributes
-      super + [:remaining_hours]
+      super + %i[remaining_hours derived_remaining_hours]
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_packages/update_ancestors/loader_patch.rb
@@ -32,6 +32,10 @@ module OpenProject::Backlogs::Patches::WorkPackages::UpdateAncestors::LoaderPatc
   module InstanceMethods
     private
 
+    def selected_descendants_attributes
+      super + %i(remaining_hours derived_remaining_hours)
+    end
+
     def selected_leaves_attributes
       super + [:remaining_hours]
     end

--- a/modules/backlogs/spec/api/work_package_resource_spec.rb
+++ b/modules/backlogs/spec/api/work_package_resource_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'API v3 Work package resource' do
       it { is_expected.to be_json_eql(work_package.story_points.to_json).at_path('storyPoints') }
 
       it { is_expected.to be_json_eql('PT5H'.to_json).at_path('remainingTime') }
+
+      it { is_expected.to be_json_eql(nil.to_json).at_path('derivedRemainingTime') }
     end
 
     context 'backlogs deactivated' do
@@ -77,6 +79,8 @@ RSpec.describe 'API v3 Work package resource' do
       it { is_expected.not_to have_json_path('storyPoints') }
 
       it { is_expected.not_to have_json_path('remainingTime') }
+
+      it { is_expected.not_to have_json_path('derivedRemainingTime') }
     end
   end
 

--- a/modules/backlogs/spec/services/stories/create_service_spec.rb
+++ b/modules/backlogs/spec/services/stories/create_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Stories::CreateService, type: :model do
       let(:remaining_hours) { 15.0 }
 
       it 'does update the parents remaining hours' do
-        expect(story.reload.remaining_hours).to eq(15)
+        expect(story.reload.derived_remaining_hours).to eq(15)
       end
     end
 

--- a/spec/services/work_packages/update_ancestors/loader_spec.rb
+++ b/spec/services/work_packages/update_ancestors/loader_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe WorkPackages::UpdateAncestors::Loader, type: :model do
         "id" => hashed_work_package.id,
         "ignore_non_working_days" => false,
         "parent_id" => hashed_work_package.parent_id,
+        "remaining_hours" => nil,
         "schedule_manually" => false }
     end
 
@@ -257,6 +258,7 @@ RSpec.describe WorkPackages::UpdateAncestors::Loader, type: :model do
         "id" => hashed_work_package.id,
         "ignore_non_working_days" => false,
         "parent_id" => hashed_work_package.parent_id,
+        "remaining_hours" => nil,
         "schedule_manually" => false }
     end
 


### PR DESCRIPTION
##### Relevant Work Package: [OP#43836](https://community.openproject.org/projects/openproject/work_packages/43836/github?query_id=491)

The issue is derived from the fact that we bubble up the remaining hours and during the summing process we add all the child `remaining_hours`.

The appropriate solution for this is to give it the same treatment that we have for `estimated_hours`, which also unlocks the possibility to add remaining hours to parent work package.

Previous:
![Screenshot from 2023-08-10 10-15-19](https://github.com/opf/openproject/assets/10281/efb2ee8e-71fe-445c-ab76-b57c98f9402b)

Current:
![Screenshot from 2023-08-10 10-27-44](https://github.com/opf/openproject/assets/10281/827aad23-2ee4-4e4f-909d-9332a6c6cbb6)
