### PR TITLE
[#49585] Fix 500 error when sorting by Project in global Meetings index page

### DIFF
--- a/modules/meeting/app/components/meetings/table_component.rb
+++ b/modules/meeting/app/components/meetings/table_component.rb
@@ -41,7 +41,7 @@ module Meetings
     def initialize_sorted_model
       helpers.sort_clear
       helpers.sort_init *initial_sort.map(&:to_s)
-      helpers.sort_update sortable_columns.map(&:to_s)
+      helpers.sort_update disambiguated_sortable_columns
       @model = paginate_collection apply_sort(model)
     end
 
@@ -61,6 +61,13 @@ module Meetings
 
     def columns
       @columns ||= headers.map(&:first)
+    end
+
+    private
+
+    def disambiguated_sortable_columns
+      sortable_columns.to_h { [_1.to_s, _1.to_s] }
+                      .merge('project_id' => 'meetings.project_id')
     end
   end
 end

--- a/modules/meeting/spec/factories/meeting_factory.rb
+++ b/modules/meeting/spec/factories/meeting_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     project
     start_time { Date.tomorrow + 10.hours }
     duration { 1.0 }
+    location { 'some-url' }
     m.sequence(:title) { |n| "Meeting #{n}" }
 
     after(:create) do |meeting, evaluator|

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -31,8 +31,8 @@ require 'spec_helper'
 require_relative '../support/pages/meetings/index'
 
 RSpec.describe 'Meetings', 'Index', :with_cuprite do
-  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
-  shared_let(:other_project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:project) { create(:project, name: 'Project 1', enabled_module_names: %w[meetings]) }
+  shared_let(:other_project) { create(:project, name: 'Project 2', enabled_module_names: %w[meetings]) }
   let(:role) { create(:role, permissions:) }
   let(:permissions) { %i(view_meetings) }
   let(:user) do
@@ -47,7 +47,7 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
   end
 
   let(:meeting) do
-    create(:meeting, project:, title: 'Awesome meeting today!', start_time: Time.current)
+    create(:meeting, project:, title: 'Awesome meeting today!', start_time: Time.current, location: 'a.com')
   end
   let(:tomorrows_meeting) do
     create(:meeting, project:, title: 'Awesome meeting tomorrow!', start_time: 1.day.from_now)
@@ -57,7 +57,12 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
   end
 
   shared_let(:other_project_meeting) do
-    create(:meeting, project: other_project, title: 'Awesome other project meeting!', start_time: 2.days.from_now)
+    create(:meeting,
+           project: other_project,
+           title: 'Awesome other project meeting!',
+           start_time: 2.days.from_now,
+           duration: 2.0,
+           location: 'b.com')
   end
 
   def setup_meeting_involvement
@@ -195,6 +200,84 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
         meetings_page.navigate_by_modules_menu
 
         meetings_page.expect_no_create_new_buttons
+      end
+    end
+
+    describe 'sorting' do
+      before do
+        meeting
+        visit meetings_path
+        # Start Time ASC is the default sort order for Upcoming meetings
+        # We can assert the initial sort by expecting the order is
+        # 1. `meeting`
+        # 2. `other_project_meeting`
+        # upon page load
+        meetings_page.expect_meetings_listed_in_order(meeting, other_project_meeting)
+      end
+
+      it 'allows sorting by every column' do
+        aggregate_failures 'Sorting by Title' do
+          meetings_page.click_to_sort_by('Title')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Title')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Project' do
+          meetings_page.click_to_sort_by('Project')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Project')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Time' do
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Time' do
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Duration' do
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Duration' do
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Location' do
+          meetings_page.click_to_sort_by('Location')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
+          meetings_page.click_to_sort_by('Location')
+          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
+                                                        meeting)
+        end
       end
     end
 

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -82,6 +82,12 @@ module Pages::Meetings
       end
     end
 
+    def click_to_sort_by(header_name)
+      within '.generic-table thead' do
+        click_link header_name
+      end
+    end
+
     def set_sidebar_filter(filter_name)
       within '#main-menu' do
         click_link text: filter_name


### PR DESCRIPTION
## Error Description
There was an ambiguous column error when attempting to sort by `project_id` caused by the other join tables in the Meeting Query.

```
ActionView::Template::Error (PG::AmbiguousColumn: ERROR:  column reference "project_id" is ambiguous
LINE 1: ...UE AND ("meetings"."start_time" < NOW()) ORDER BY project_id...
                                                             ^
):
    33: <% if @meetings.empty? -%>
    34:   <%= no_results_box %>
    35: <% else -%>
    36:   <%= render Meetings::TableComponent.new(rows: @meetings, current_project: @project) %>
    37: <% end -%>

app/components/table_component.rb:150:in `render_collection'
app/components/table_component.html.erb:68:in `call'
modules/meeting/app/views/meetings/index.html.erb:36
modules/meeting/app/controllers/meetings_controller.rb:51:in `index'
modules/meeting/app/controllers/meetings_controller.rb:158:in `set_time_zone'
```

## Notes
Some specs were added to ensure we have coverage for this edge case in the global meetings index page

See: https://community.openproject.org/work_packages/49585