### PR TITLE
Increase priority Storages::ManageNextcloudIntegrationEventsJob.

### DIFF
--- a/modules/storages/app/workers/storages/manage_nextcloud_integration_events_job.rb
+++ b/modules/storages/app/workers/storages/manage_nextcloud_integration_events_job.rb
@@ -29,6 +29,8 @@
 class Storages::ManageNextcloudIntegrationEventsJob < ApplicationJob
   DEBOUNCE_TIME = 5.seconds.freeze
 
+  queue_with_priority :high
+
   def self.debounce
     count = Delayed::Job
               .where("handler LIKE ?", "%job_class: #{self}%")

--- a/modules/storages/app/workers/storages/manage_nextcloud_integration_events_job.rb
+++ b/modules/storages/app/workers/storages/manage_nextcloud_integration_events_job.rb
@@ -29,7 +29,7 @@
 class Storages::ManageNextcloudIntegrationEventsJob < ApplicationJob
   DEBOUNCE_TIME = 5.seconds.freeze
 
-  queue_with_priority :high
+  queue_with_priority :above_normal
 
   def self.debounce
     count = Delayed::Job

--- a/modules/storages/spec/workers/storages/manage_nextcloud_integration_events_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_nextcloud_integration_events_job_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 RSpec.describe Storages::ManageNextcloudIntegrationEventsJob, type: :job do
   describe '.priority' do
     it 'has a maximum priority' do
-      expect(described_class.priority).to eq(0)
+      expect(described_class.priority).to eq(7)
     end
   end
 

--- a/modules/storages/spec/workers/storages/manage_nextcloud_integration_events_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_nextcloud_integration_events_job_spec.rb
@@ -29,6 +29,12 @@
 require 'spec_helper'
 
 RSpec.describe Storages::ManageNextcloudIntegrationEventsJob, type: :job do
+  describe '.priority' do
+    it 'has a maximum priority' do
+      expect(described_class.priority).to eq(0)
+    end
+  end
+
   describe '.debounce' do
     it 'debounces job with 1 minute timeframe' do
       ActiveJob::Base.disable_test_adapter


### PR DESCRIPTION
The job triggers are user events/interactions. So, it makes sense to start synchronization as soon as possible in this case to decrease a possibility of inconsistent behavior in the UI.