### PR TITLE
Fix features/create_file_links_spec.rb

### DIFF
--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe 'Managing file links in work package', js: true, webmock: true do
       .with(
         headers: {
           'Authorization' => 'Bearer 1234567890-1',
-          'Host' => storage.host,
           'Ocs-Apirequest' => 'true',
           'Accept' => "application/json"
         }


### PR DESCRIPTION
It is not required to match request stub by `Host` HTTP header. Let's remove it then, because it causes a discrepancy like `https://host.rb` vs `host.rb`.