### PR TITLE
[#49607] PDF Export report fails with with an empty table

### DIFF
--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -131,6 +131,8 @@ module WorkPackage::PDFExport::Common
   end
 
   def pdf_table_auto_widths(data, column_widths, options, &)
+    return if data.empty?
+
     pdf.table(data, options.merge({ width: pdf.bounds.width }), &)
   rescue Prawn::Errors::CannotFit
     pdf.table(data, options.merge({ column_widths: }), &)

--- a/app/models/work_package/pdf_export/work_package_detail.rb
+++ b/app/models/work_package/pdf_export/work_package_detail.rb
@@ -75,6 +75,8 @@ module WorkPackage::PDFExport::WorkPackageDetail
 
   def write_attributes_table!(work_package)
     rows = attribute_table_rows(work_package)
+    return if rows.empty?
+
     with_margin(styles.wp_attributes_table_margins) do
       pdf.table(
         rows,


### PR DESCRIPTION
Prawnpdf throws an exception for empty tables. This PR adds safeguards to shield it.

https://community.openproject.org/work_packages/49607
