### PR TITLE
[#48642] Add missing link to archived projects on `Type` deletion error   

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -178,11 +178,11 @@ class TypesController < ApplicationController
         )
       ]
 
-      archived_projects = @type.projects.filter(&:archived?)
-      if !archived_projects.empty?
-        error_message.push(
+      if archived_projects.any?
+        error_message << ApplicationController.helpers.sanitize(
           t(:'error_can_not_delete_type.archived_projects',
-            archived_projects: archived_projects.map(&:name).join(', '))
+            archived_projects_urls: helpers.archived_projects_urls_for(archived_projects)),
+          attributes: %w(href target)
         )
       end
 
@@ -192,5 +192,9 @@ class TypesController < ApplicationController
 
   def belonging_wps_url(type_id)
     work_packages_path query_props: "{\"f\":[{\"n\":\"type\",\"o\":\"=\",\"v\":[#{type_id}]}]}"
+  end
+
+  def archived_projects
+    @archived_projects ||= @type.projects.archived
   end
 end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -32,6 +32,7 @@ class TypesController < ApplicationController
   layout 'admin'
 
   before_action :require_admin
+  before_action :find_type, only: %i[update move destroy]
 
   def index
     @types = ::Type.page(page_param).per_page(per_page_param)
@@ -78,8 +79,6 @@ class TypesController < ApplicationController
   end
 
   def update
-    @type = ::Type.find(params[:id])
-
     UpdateTypeService
       .new(@type, current_user)
       .call(permitted_type_params) do |call|
@@ -95,8 +94,6 @@ class TypesController < ApplicationController
   end
 
   def move
-    @type = ::Type.find(params[:id])
-
     if @type.update(permitted_params.type_move)
       flash[:notice] = I18n.t(:notice_successful_update)
       redirect_to types_path
@@ -107,7 +104,6 @@ class TypesController < ApplicationController
   end
 
   def destroy
-    @type = ::Type.find(params[:id])
     # types cannot be deleted when they have work packages
     # or they are standard types
     # put that into the model and do a `if @type.destroy`
@@ -121,6 +117,10 @@ class TypesController < ApplicationController
   end
 
   protected
+
+  def find_type
+    @type = ::Type.find(params[:id])
+  end
 
   def permitted_type_params
     # having to call #to_unsafe_h as a query hash the attribute_groups
@@ -160,7 +160,7 @@ class TypesController < ApplicationController
   end
 
   def update_success_message
-    if params[:tab].in?(["form_configuration", "projects"])
+    if params[:tab].in?(%w[form_configuration projects])
       t(:notice_successful_update_custom_fields_added_to_type)
     else
       t(:notice_successful_update)

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -191,7 +191,7 @@ class TypesController < ApplicationController
   end
 
   def belonging_wps_url(type_id)
-    work_packages_path query_props: "{\"f\":[{\"n\":\"type\",\"o\":\"=\",\"v\":[#{type_id}]}]}"
+    work_packages_path query_props: { f: [{ n: "type", o: "=", v: [type_id] }] }.to_json
   end
 
   def archived_projects

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -113,6 +113,17 @@ module ::TypesHelper
     ::API::V3::Queries::QueryParamsRepresenter.new(query).to_json
   end
 
+  def archived_projects_urls_for(projects)
+    urls = projects.map do |project|
+      link_to project.name,
+              projects_path(filters: archived_project_filters_for(project)),
+              target: '_blank',
+              rel: 'noopener'
+    end
+
+    safe_join(urls, ', ')
+  end
+
   private
 
   ##
@@ -139,5 +150,12 @@ module ::TypesHelper
       is_required: represented[:required] && !represented[:has_default],
       translation: Type.translated_attribute_name(key, represented)
     }
+  end
+
+  def archived_project_filters_for(project)
+    [
+      { active: { operator: '=', values: ['f'] } },
+      { name_and_identifier: { operator: '=', values: [html_escape(project.name)] } }
+    ].to_json
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -157,6 +157,7 @@ class Project < ApplicationRecord
   scope :visible, ->(user = User.current) { where(id: Project.visible_by(user)) }
   scope :newest, -> { order(created_at: :desc) }
   scope :active, -> { where(active: true) }
+  scope :archived, -> { where(active: false) }
   scope :with_member, ->(user = User.current) { where(id: user.memberships.select(:project_id)) }
   scope :without_member, ->(user = User.current) { where.not(id: user.memberships.select(:project_id)) }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1362,7 +1362,7 @@ en:
   error_can_not_delete_custom_field: "Unable to delete custom field"
   error_can_not_delete_type:
     explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
-    archived_projects: 'There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the type of the respective work packages: %{archived_projects}'
+    archived_projects: 'There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the type of the respective work packages: %{archived_projects_urls}'
   error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -78,4 +78,31 @@ RSpec.describe TypesHelper do
       end
     end
   end
+
+  describe '#archived_projects_urls_for' do
+    subject { helper.archived_projects_urls_for([archived_project, other_archived_project]) }
+
+    shared_let(:archived_project) { create(:project, :archived) }
+    shared_let(:other_archived_project) { create(:project, :archived) }
+    shared_let(:archived_project_filters) do
+      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
+        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{archived_project.name}\"]}}]"
+    end
+    shared_let(:other_archived_project_filters) do
+      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
+        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{other_archived_project.name}\"]}}]"
+    end
+
+    it 'returns a comma-separated list of anchor tags for each archived project' do
+      expect(subject)
+        .to eq(
+          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: archived_project_filters)}\">" \
+          "#{archived_project.name}" \
+          "</a>, " \
+          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: other_archived_project_filters)}\">" \
+          "#{other_archived_project.name}" \
+          "</a>"
+        )
+    end
+  end
 end


### PR DESCRIPTION
**NOTE:** The Work Package's comments suggest using a `contains` operator (`~`) for filtering the archived project. I preferred the use of an `is` operator (`=`) since there might be cases where two archived projects contain the word "Project" ("Project A", "Project B"), but only "Project A" is being flagged because of the type attempting to be deleted. Using a `contains` operator would result in both "Project A" and "Project B" being listed in the projects list the user is directed to, however "Project B" is not in that list for the right reasons; it just happens to be similarly named.

See: https://community.openproject.org/work_packages/48642