### PR TITLE
Allow Memberships for sub-project resources

### DIFF
--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -63,7 +63,7 @@ module Capabilities::Scopes
           LEFT OUTER JOIN "role_permissions" ON "role_permissions"."permission" = "actions"."permission"
           LEFT OUTER JOIN "roles" ON "roles".id = "role_permissions".role_id OR "actions"."public"
           LEFT OUTER JOIN "member_roles" ON "member_roles".role_id = "roles".id
-          LEFT OUTER JOIN "members" ON members.id = member_roles.member_id
+          LEFT OUTER JOIN "members" ON members.id = member_roles.member_id AND members.entity_type IS NULL AND members.entity_id IS NULL
           JOIN (#{Principal.visible.not_builtin.not_locked.to_sql}) users
             ON "users".id = members.user_id
           LEFT OUTER JOIN "projects"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -29,19 +29,23 @@
 class Member < ApplicationRecord
   include ::Scopes::Scoped
 
+  ALLOWED_ENTITIES = [
+    "WorkPackage"
+  ].freeze
+
   extend DeprecatedAlias
-  belongs_to :principal, foreign_key: 'user_id'
+  belongs_to :principal, foreign_key: 'user_id', inverse_of: 'members', optional: false
+  belongs_to :entity, polymorphic: true, optional: true
+  belongs_to :project, optional: true
+
   has_many :member_roles, dependent: :destroy, autosave: true, validate: false
   has_many :roles, -> { distinct }, through: :member_roles
   has_many :oauth_client_tokens, foreign_key: :user_id, primary_key: :user_id, dependent: nil # rubocop:disable Rails/InverseOf
 
-  belongs_to :project
-
-  validates :principal, presence: true
-  validates :user_id, uniqueness: { scope: :project_id }
+  validates :user_id, uniqueness: { scope: %i[project_id entity_type entity_id] }
+  validates :entity_type, inclusion: { in: ALLOWED_ENTITIES, allow_blank: true }
 
   validate :validate_presence_of_role
-  validate :validate_presence_of_principal
 
   scopes :assignable,
          :global,
@@ -103,10 +107,6 @@ class Member < ApplicationRecord
 
       errors.add :roles, :role_blank
     end
-  end
-
-  def validate_presence_of_principal
-    errors.add :base, :principal_blank if principal.blank?
   end
 
   private

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -96,6 +96,16 @@ class Member < ApplicationRecord
     user? && principal&.invited? && principal.memberships.none? { |m| m.project_id != project_id }
   end
 
+  def self.can_be_member_of?(entity_or_class)
+    checked_class = if entity_or_class.is_a?(Class)
+                      entity_or_class.name
+                    else
+                      entity_or_class.class.name
+                    end
+
+    ALLOWED_ENTITIES.include?(checked_class)
+  end
+
   protected
 
   attr_accessor :prune_watchers_on_destruction

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -46,6 +46,7 @@ class Member < ApplicationRecord
   validates :entity_type, inclusion: { in: ALLOWED_ENTITIES, allow_blank: true }
 
   validate :validate_presence_of_role
+  validate :validate_presence_of_principal
 
   scopes :assignable,
          :global,
@@ -107,6 +108,10 @@ class Member < ApplicationRecord
 
       errors.add :roles, :role_blank
     end
+  end
+
+  def validate_presence_of_principal
+    errors.add :base, :principal_blank if principal.blank?
   end
 
   private

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -43,8 +43,9 @@ class Principal < ApplicationRecord
   has_one :preference,
           dependent: :destroy,
           class_name: 'UserPreference',
-          foreign_key: 'user_id'
-  has_many :members, foreign_key: 'user_id', dependent: :destroy
+          foreign_key: 'user_id',
+          inverse_of: :user
+  has_many :members, foreign_key: 'user_id', dependent: :destroy, inverse_of: :principal
   has_many :memberships,
            -> {
              includes(:project, :roles)
@@ -57,7 +58,7 @@ class Principal < ApplicationRecord
            class_name: 'Member',
            foreign_key: 'user_id'
   has_many :projects, through: :memberships
-  has_many :categories, foreign_key: 'assigned_to_id', dependent: :nullify
+  has_many :categories, foreign_key: 'assigned_to_id', dependent: :nullify, inverse_of: :assigned_to
 
   has_paper_trail
 

--- a/app/models/queries/members/member_query.rb
+++ b/app/models/queries/members/member_query.rb
@@ -37,6 +37,8 @@ class Queries::Members::MemberQuery < Queries::BaseQuery
   end
 
   def default_scope
-    Member.visible(User.current)
+    # TODO: For now we exclude entity specific memberships in the API until we have updated the
+    # frontend and representers to show those properly
+    Member.visible(User.current).where(entity: nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,8 +43,6 @@ class User < Principal
   include ::Users::Avatars
   extend DeprecatedAlias
 
-  has_many :categories, foreign_key: 'assigned_to_id',
-                        dependent: :nullify
   has_many :watches, class_name: 'Watcher',
                      dependent: :delete_all
   has_many :changesets, dependent: :nullify

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,7 +466,7 @@ class User < Principal
 
   # Return user's roles for project
   def roles_for_project(project)
-    project_role_cache.fetch(project:)
+    project_role_cache.fetch(project)
   end
   alias :roles :roles_for_project
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,7 +466,7 @@ class User < Principal
 
   # Return user's roles for project
   def roles_for_project(project)
-    project_role_cache.fetch(project)
+    project_role_cache.fetch(project:)
   end
   alias :roles :roles_for_project
 

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -47,7 +47,7 @@ class Users::ProjectRoleCache
     # Return all roles if user is admin
     return all_givable_roles if user.admin?
 
-    ::Authorization.roles(user, project).eager_load(:role_permissions)
+    ::Authorization.roles(user, project:).eager_load(:role_permissions)
   end
 
   def cache

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -33,21 +33,21 @@ class Users::ProjectRoleCache
     self.user = user
   end
 
-  def fetch(project: nil, entity: nil)
-    cache[entity || project] ||= roles(project:, entity:)
+  def fetch(cacheable)
+    cache[cacheable] ||= roles(cacheable)
   end
 
   private
 
-  def roles(project: nil, entity: nil)
+  def roles(context)
     # Return all roles if user is admin
     return all_givable_roles if user.admin?
 
     # Project is nil if checking global role
     # No roles on archived projects, unless the active state is being changed
-    return [] if project && archived?(project)
+    return [] if context.is_a?(Project) && archived?(context)
 
-    ::Authorization.roles(user, project:, entity:).eager_load(:role_permissions)
+    ::Authorization.roles(user, context).eager_load(:role_permissions)
   end
 
   def cache

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -33,25 +33,39 @@ class Users::ProjectRoleCache
     self.user = user
   end
 
-  def fetch(project)
-    cache[project] ||= roles(project)
+  def fetch(project: nil, entity: nil)
+    if project
+      project_cache[project] ||= roles(project:)
+    elsif entity
+      entity_cache[entity] ||= roles(entity:)
+    else
+      []
+    end
   end
 
   private
 
-  def roles(project)
-    # Project is nil if checking global role
-    # No roles on archived projects, unless the active state is being changed
-    return [] if project && archived?(project)
-
+  def roles(project: nil, entity: nil)
     # Return all roles if user is admin
     return all_givable_roles if user.admin?
 
-    ::Authorization.roles(user, project:).eager_load(:role_permissions)
+    if project
+      # Project is nil if checking global role
+      # No roles on archived projects, unless the active state is being changed
+      return [] if archived?(project)
+
+      ::Authorization.roles(user, project:).eager_load(:role_permissions)
+    elsif entity
+      ::Authorization.roles(user, entity:).eager_load(:role_permissions)
+    end
   end
 
-  def cache
-    @cache ||= {}
+  def project_cache
+    @project_cache ||= {}
+  end
+
+  def entity_cache
+    @entity_cache ||= {}
   end
 
   def all_givable_roles

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -46,16 +46,18 @@ class Users::ProjectRoleCache
   private
 
   def roles(project: nil, entity: nil)
-    # Return all roles if user is admin
-    return all_givable_roles if user.admin?
-
     if project
       # Project is nil if checking global role
       # No roles on archived projects, unless the active state is being changed
       return [] if archived?(project)
+      # Return all roles if user is admin
+      return all_givable_roles if user.admin?
 
       ::Authorization.roles(user, project:).eager_load(:role_permissions)
     elsif entity
+      # Return all roles if user is admin
+      return all_givable_roles if user.admin?
+
       ::Authorization.roles(user, entity:).eager_load(:role_permissions)
     end
   end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -67,6 +67,9 @@ class WorkPackage < ApplicationRecord
 
   has_and_belongs_to_many :github_pull_requests # rubocop:disable Rails/HasAndBelongsToMany
 
+  has_many :members, as: :entity, dependent: :destroy
+  has_many :principals, through: :members
+
   scope :recently_updated, -> {
     order(updated_at: :desc)
   }

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -68,7 +68,7 @@ class WorkPackage < ApplicationRecord
   has_and_belongs_to_many :github_pull_requests # rubocop:disable Rails/HasAndBelongsToMany
 
   has_many :members, as: :entity, dependent: :destroy
-  has_many :principals, through: :members
+  has_many :member_principals, through: :members, class_name: 'Principal', source: :principal
 
   scope :recently_updated, -> {
     order(updated_at: :desc)

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -39,7 +39,7 @@ module Authorization
     Authorization::ProjectQuery.query(user, action)
   end
 
-  # Returns all roles a user has in a certain project, for a specific enttiy or globally
+  # Returns all roles a user has in a certain project, for a specific entity or globally
   def roles(user, project: nil, entity: nil)
     if entity
       Authorization::UserEntityRolesQuery.query(user, entity)

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -39,7 +39,7 @@ module Authorization
     Authorization::ProjectQuery.query(user, action)
   end
 
-  # Returns all roles a user has in a certain project or globally
+  # Returns all roles a user has in a certain project, for a specific enttiy or globally
   def roles(user, project: nil, entity: nil)
     if entity
       Authorization::UserEntityRolesQuery.query(user, entity)

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -42,9 +42,9 @@ module Authorization
   # Returns all roles a user has in a certain project, for a specific entity or globally
   def roles(user, context = nil)
     if context.is_a?(Project)
-      Authorization::UserProjectRolesQuery.query(user, project)
+      Authorization::UserProjectRolesQuery.query(user, context)
     elsif Member.can_be_member_of?(context)
-      Authorization::UserEntityRolesQuery.query(user, entity)
+      Authorization::UserEntityRolesQuery.query(user, context)
     else
       Authorization::UserGlobalRolesQuery.query(user)
     end

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -40,8 +40,10 @@ module Authorization
   end
 
   # Returns all roles a user has in a certain project or globally
-  def roles(user, project = nil)
-    if project
+  def roles(user, project: nil, entity: nil)
+    if entity
+      Authorization::UserEntityRolesQuery.query(user, entity)
+    elsif project
       Authorization::UserProjectRolesQuery.query(user, project)
     else
       Authorization::UserGlobalRolesQuery.query(user)

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -40,11 +40,11 @@ module Authorization
   end
 
   # Returns all roles a user has in a certain project, for a specific entity or globally
-  def roles(user, project: nil, entity: nil)
-    if entity
-      Authorization::UserEntityRolesQuery.query(user, entity)
-    elsif project
+  def roles(user, context = nil)
+    if context.is_a?(Project)
       Authorization::UserProjectRolesQuery.query(user, project)
+    elsif Member.can_be_member_of?(context)
+      Authorization::UserEntityRolesQuery.query(user, entity)
     else
       Authorization::UserGlobalRolesQuery.query(user)
     end

--- a/app/services/authorization/project_query.rb
+++ b/app/services/authorization/project_query.rb
@@ -33,6 +33,8 @@ class Authorization::ProjectQuery < Authorization::AbstractQuery
     projects_table[:id]
       .eq(members_table[:project_id])
       .and(members_table[:user_id].eq(user.id))
+      .and(members_table[:entity_type].eq(nil))
+      .and(members_table[:entity_id].eq(nil))
       .and(project_active_condition)
   end
 

--- a/app/services/authorization/user_allowed_service.rb
+++ b/app/services/authorization/user_allowed_service.rb
@@ -69,8 +69,6 @@ class Authorization::UserAllowedService
       allowed_to_globally?(action)
     elsif context.is_a? Project
       allowed_to_in_project?(action, context)
-    elsif supported_entity?(context)
-      allowed_to_in_entity?(action, context)
     elsif context.respond_to?(:to_a)
       allowed_to_in_all_projects?(action, context)
     else
@@ -79,12 +77,13 @@ class Authorization::UserAllowedService
   end
 
   def allowed_to_in_entity?(action, entity)
-    # Short circuit: When the user is already allowed to execute the action on the project,
-    # there's no need to do a check on the entity
-    return true if entity.respond_to?(:project) && allowed_to_in_project?(action, entity.project)
-
     # Inactive users are never authorized
     return false unless authorizable_user?
+
+    # Short circuit: When the user is already allowed to execute the action baed
+    # on the project, there's no need to do a check on the entity
+    return true if entity.respond_to?(:project) && allowed_to_in_project?(action, entity.project)
+
     # Admin users are authorized for anything else
     # unless the permission is explicitly flagged not to be granted to admins.
     return true if granted_to_admin?(action)
@@ -165,7 +164,6 @@ class Authorization::UserAllowedService
   def supported_context?(context, global:)
     (context.nil? && global) ||
       context.is_a?(Project) ||
-      supported_entity?(context) ||
       (!context.nil? && context.respond_to?(:to_a))
   end
 

--- a/app/services/authorization/user_allowed_service.rb
+++ b/app/services/authorization/user_allowed_service.rb
@@ -90,7 +90,7 @@ class Authorization::UserAllowedService
     # unless the permission is explicitly flagged not to be granted to admins.
     return true if granted_to_admin?(action)
 
-    has_authorized_role?(action, entity:)
+    has_authorized_role?(action, entity)
   end
 
   def allowed_to_in_project?(action, project)
@@ -108,7 +108,7 @@ class Authorization::UserAllowedService
     # unless the permission is explicitly flagged not to be granted to admins.
     return true if granted_to_admin?(action)
 
-    has_authorized_role?(action, project:)
+    has_authorized_role?(action, project)
   end
 
   # Authorize if user is authorized on every element of the array
@@ -142,9 +142,9 @@ class Authorization::UserAllowedService
     user.admin? && OpenProject::AccessControl.grant_to_admin?(action)
   end
 
-  def has_authorized_role?(action, project: nil, entity: nil)
+  def has_authorized_role?(action, context = nil)
     project_role_cache
-      .fetch(project:, entity:)
+      .fetch(context)
       .any? do |role|
       role.allowed_to?(action)
     end

--- a/app/services/authorization/user_allowed_service.rb
+++ b/app/services/authorization/user_allowed_service.rb
@@ -69,6 +69,8 @@ class Authorization::UserAllowedService
       allowed_to_globally?(action)
     elsif context.is_a? Project
       allowed_to_in_project?(action, context)
+    elsif supported_entity?(context)
+      allowed_to_in_entity?(action, context)
     elsif context.respond_to?(:to_a)
       allowed_to_in_all_projects?(action, context)
     else
@@ -164,6 +166,7 @@ class Authorization::UserAllowedService
   def supported_context?(context, global:)
     (context.nil? && global) ||
       context.is_a?(Project) ||
+      supported_entity?(context) ||
       (!context.nil? && context.respond_to?(:to_a))
   end
 

--- a/app/services/authorization/user_entity_roles_query.rb
+++ b/app/services/authorization/user_entity_roles_query.rb
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Authorization::UserEntityRolesQuery < Authorization::UserRolesQuery
+  transformations.register :all, :user_restriction do |statement, user, _|
+    statement.where(users_table[:id].eq(user.id))
+  end
+
+  transformations.register users_members_join, :entity_restriction do |statement, _, entity|
+    statement
+      .and(members_table[:entity_type].eq(entity.class.to_s))
+      .and(members_table[:entity_id].eq(entity.id))
+
+    statement.and(members_table[:project_id].eq(entity.project.id)) if entity.respond_to?(:project)
+  end
+end

--- a/app/services/authorization/user_entity_roles_query.rb
+++ b/app/services/authorization/user_entity_roles_query.rb
@@ -32,10 +32,12 @@ class Authorization::UserEntityRolesQuery < Authorization::UserRolesQuery
   end
 
   transformations.register users_members_join, :entity_restriction do |statement, _, entity|
-    statement
+    statement = statement
       .and(members_table[:entity_type].eq(entity.class.to_s))
       .and(members_table[:entity_id].eq(entity.id))
 
-    statement.and(members_table[:project_id].eq(entity.project.id)) if entity.respond_to?(:project)
+    statement = statement.and(members_table[:project_id].eq(entity.project_id)) if entity.respond_to?(:project_id)
+
+    statement
   end
 end

--- a/app/services/authorization/user_project_roles_query.rb
+++ b/app/services/authorization/user_project_roles_query.rb
@@ -32,7 +32,10 @@ class Authorization::UserProjectRolesQuery < Authorization::UserRolesQuery
   end
 
   transformations.register users_members_join, :project_id_limit do |statement, _, project|
-    statement.and(members_table[:project_id].eq(project.id))
+    statement
+      .and(members_table[:project_id].eq(project.id))
+      .and(members_table[:entity_type].eq(nil))
+      .and(members_table[:entity_id].eq(nil))
   end
 
   transformations.register roles_member_roles_join, :builtin_role do |statement, user, project|

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -96,7 +96,7 @@ module Groups
           SELECT group_memberships.project_id, found_users.user_id, (SELECT time from timestamp), (SELECT time from timestamp)
           FROM found_users, group_memberships
           WHERE NOT EXISTS (SELECT 1 FROM existing_members WHERE existing_members.user_id = found_users.user_id AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id)
-          ON CONFLICT(project_id, user_id) DO NOTHING
+          ON CONFLICT DO NOTHING
           RETURNING id, user_id, project_id
         ),
         -- copy the member roles of the group

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -69,13 +69,15 @@ module Groups
         ),
         -- select existing memberships of the group
         group_memberships AS (
-          SELECT project_id, user_id FROM #{Member.table_name} WHERE user_id = :group_id AND #{project_limit}
+          SELECT project_id, user_id, entity_type, entity_id FROM #{Member.table_name} WHERE user_id = :group_id AND #{project_limit}
         ),
         -- select existing member_roles of the group
         group_roles AS (
           SELECT members.project_id AS project_id,
                  members.user_id AS user_id,
                  members.id AS member_id,
+                 members.entity_type AS entity_type,
+                 members.entity_id AS entity_id,
                  member_roles.role_id AS role_id,
                  member_roles.id AS member_role_id
           FROM #{MemberRole.table_name} member_roles
@@ -84,28 +86,39 @@ module Groups
         ),
         -- find members that already exist
         existing_members AS (
-          SELECT members.id, found_users.user_id, members.project_id
+          SELECT members.id, found_users.user_id, members.project_id, members.entity_type, members.entity_id
           FROM members, found_users, group_memberships
           WHERE members.user_id = found_users.user_id
           AND members.project_id IS NOT DISTINCT FROM group_memberships.project_id
+          AND members.entity_type = group_memberships.entity_type
+          AND members.entity_id = group_memberships.entity_id
           AND members.id IS NOT NULL
         ),
         -- insert the group user into members
         new_members AS (
-          INSERT INTO #{Member.table_name} (project_id, user_id, updated_at, created_at)
-          SELECT group_memberships.project_id, found_users.user_id, (SELECT time from timestamp), (SELECT time from timestamp)
+          INSERT INTO #{Member.table_name} (project_id, user_id, updated_at, created_at, entity_type, entity_id)
+          SELECT group_memberships.project_id, found_users.user_id, (SELECT time from timestamp), (SELECT time from timestamp), group_memberships.entity_type, group_memberships.entity_id
           FROM found_users, group_memberships
-          WHERE NOT EXISTS (SELECT 1 FROM existing_members WHERE existing_members.user_id = found_users.user_id AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id)
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM existing_members
+            WHERE existing_members.user_id = found_users.user_id
+            AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id
+            AND existing_members.entity_type = group_memberships.entity_type
+            AND existing_members.entity_id = group_memberships.entity_id
+          )
           ON CONFLICT DO NOTHING
-          RETURNING id, user_id, project_id
+          RETURNING id, user_id, project_id, entity_type, entity_id
         ),
         -- copy the member roles of the group
         add_roles AS (
           INSERT INTO #{MemberRole.table_name} (member_id, role_id, inherited_from)
           SELECT members.id, group_roles.role_id, group_roles.member_role_id
           FROM group_roles
-          JOIN
-            (SELECT * FROM new_members UNION SELECT * from existing_members) members ON group_roles.project_id IS NOT DISTINCT FROM members.project_id
+          JOIN (SELECT * FROM new_members UNION SELECT * from existing_members) members
+            ON group_roles.project_id IS NOT DISTINCT FROM members.project_id
+            AND group_roles.entity_type = members.entity_type
+            AND group_roles.entity_id = members.entity_id
           -- Ignore if the role was already inserted by us
           ON CONFLICT DO NOTHING
           RETURNING id, member_id, role_id

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -90,8 +90,8 @@ module Groups
           FROM members, found_users, group_memberships
           WHERE members.user_id = found_users.user_id
           AND members.project_id IS NOT DISTINCT FROM group_memberships.project_id
-          AND members.entity_type = group_memberships.entity_type
-          AND members.entity_id = group_memberships.entity_id
+          AND members.entity_type IS NOT DISTINCT FROM group_memberships.entity_type
+          AND members.entity_id IS NOT DISTINCT FROM group_memberships.entity_id
           AND members.id IS NOT NULL
         ),
         -- insert the group user into members
@@ -104,8 +104,8 @@ module Groups
             FROM existing_members
             WHERE existing_members.user_id = found_users.user_id
             AND existing_members.project_id IS NOT DISTINCT FROM group_memberships.project_id
-            AND existing_members.entity_type = group_memberships.entity_type
-            AND existing_members.entity_id = group_memberships.entity_id
+            AND existing_members.entity_type IS NOT DISTINCT FROM group_memberships.entity_type
+            AND existing_members.entity_id IS NOT DISTINCT FROM group_memberships.entity_id
           )
           ON CONFLICT DO NOTHING
           RETURNING id, user_id, project_id, entity_type, entity_id
@@ -117,8 +117,8 @@ module Groups
           FROM group_roles
           JOIN (SELECT * FROM new_members UNION SELECT * from existing_members) members
             ON group_roles.project_id IS NOT DISTINCT FROM members.project_id
-            AND group_roles.entity_type = members.entity_type
-            AND group_roles.entity_id = members.entity_id
+            AND group_roles.entity_type IS NOT DISTINCT FROM members.entity_type
+            AND group_roles.entity_id IS NOT DISTINCT FROM members.entity_id
           -- Ignore if the role was already inserted by us
           ON CONFLICT DO NOTHING
           RETURNING id, member_id, role_id

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -88,6 +88,7 @@ class WorkPackages::UpdateService < BaseServices::Update
       moved_work_packages = [work_package] + work_package.descendants
       delete_relations(moved_work_packages)
       move_time_entries(moved_work_packages, work_package.project_id)
+      move_work_package_memberships(moved_work_packages, work_package.project_id)
     end
     if work_package.saved_change_to_type_id?
       reset_custom_values(work_package)
@@ -105,6 +106,12 @@ class WorkPackages::UpdateService < BaseServices::Update
   def move_time_entries(work_packages, project_id)
     TimeEntry
       .on_work_packages(work_packages)
+      .update_all(project_id:)
+  end
+
+  def move_work_package_memberships(work_packages, project_id)
+    Member
+      .where(entity: work_packages)
       .update_all(project_id:)
   end
 

--- a/db/migrate/20230810074642_add_optional_entity_to_members.rb
+++ b/db/migrate/20230810074642_add_optional_entity_to_members.rb
@@ -1,0 +1,16 @@
+class AddOptionalEntityToMembers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :members, :entity, foreign_key: false, polymorphic: true, index: true
+    remove_index :members, %i[user_id project_id], unique: true
+
+    add_index :members, %i[user_id project_id],
+              unique: true,
+              where: "entity_type IS NULL AND entity_id IS NULL",
+              name: 'index_members_on_user_id_and_project_without_entity'
+
+    add_index :members, %i[user_id project_id entity_type entity_id],
+              unique: true,
+              where: "entity_type IS NOT NULL AND entity_id IS NOT NULL",
+              name: 'index_members_on_user_id_and_project_with_entity'
+  end
+end

--- a/docs/development/concepts/permissions/README.md
+++ b/docs/development/concepts/permissions/README.md
@@ -16,7 +16,7 @@ With RBAC, the application defines a set of roles that users and groups can be i
 *Permissions in OpenProject...*
 
 - use the Role-based access control (RBAC) approach to allow fine-grained access to authorized resources
-- are assigned to users and groups through roles on a per-project, per-resource or global level
+- are assigned to users and groups through roles on a per-resource, per-project, or global level
 - are often communicated to the frontend through the presence of action links in HAL resources
 
 ## Definition of roles

--- a/docs/development/concepts/permissions/README.md
+++ b/docs/development/concepts/permissions/README.md
@@ -94,8 +94,8 @@ When a set of records is to be returned, e.g. for an index action, it is best to
 |---------- | ------| ------ |
 | All projects a user is allowed a permission in | `Authorization.projects(permission, user)` | `Authorization.projects(:view_work_packages, User.current)` |
 | All users granted a permission in a project | `Authorization.users(permission, project: project)` | `Authorization.users(:view_work_packages, project: project)` |
-| All roles a user has in a project | `Authorization.roles(user, project:)` | `Authorization.roles(User.current, project: project)` |
-| All roles a user has for a specific resource | `Authorization.roles(user, entity:)` | `Authorization.roles(User.current, entity: work_package)` |
+| All roles a user has in a project | `Authorization.roles(user, project)` | `Authorization.roles(User.current, project: project)` |
+| All roles a user has for a specific resource | `Authorization.roles(user, entity:` | `Authorization.roles(User.current, entity: work_package)` |
 | All roles a user has globally | `Authorization.roles(user)` | `Authorization.roles(User.current)` |
 
 Most of the time, a developer will not witness those queries as they are the embedded deeply within the existing scopes. E.g. the `visible` scopes defined for most AR models, under the hood rely on `Authorization.projects(permission, user)` by checking that the `project_id` attribute of the record is within that set of projects.

--- a/docs/development/concepts/permissions/README.md
+++ b/docs/development/concepts/permissions/README.md
@@ -32,8 +32,6 @@ There are multiple types of roles:
 - *Anonymous* roles that is a special role, similar to the *non member* role but applying to non-authenticated users.
 - All other roles, which are saved in the database and contain a user-defined set of permissions that this role will grant.
 
-**Surprisingly, when looking up permissions, the non member role is always factored in, even it the user does have other roles within the project as well. That means that if the user has a role in a project not granting "Create new work package", but the non member role is granting the permission, the user will in effect have that permission.**
-
 In the following screenshot, you can see the builtin, non-deletable roles *Non member* and *Anonymous*, as well as three additional, user-created roles.
 
 ![Overview of some of the roles](roles-administration.png)

--- a/docs/development/concepts/permissions/README.md
+++ b/docs/development/concepts/permissions/README.md
@@ -94,8 +94,8 @@ When a set of records is to be returned, e.g. for an index action, it is best to
 |---------- | ------| ------ |
 | All projects a user is allowed a permission in | `Authorization.projects(permission, user)` | `Authorization.projects(:view_work_packages, User.current)` |
 | All users granted a permission in a project | `Authorization.users(permission, project: project)` | `Authorization.users(:view_work_packages, project: project)` |
-| All roles a user has in a project | `Authorization.roles(user, project)` | `Authorization.roles(User.current, project: project)` |
-| All roles a user has for a specific resource | `Authorization.roles(user, entity:` | `Authorization.roles(User.current, entity: work_package)` |
+| All roles a user has in a project | `Authorization.roles(user, project)` | `Authorization.roles(User.current, project)` |
+| All roles a user has for a specific resource | `Authorization.roles(user, entity)` | `Authorization.roles(User.current, work_package)` |
 | All roles a user has globally | `Authorization.roles(user)` | `Authorization.roles(User.current)` |
 
 Most of the time, a developer will not witness those queries as they are the embedded deeply within the existing scopes. E.g. the `visible` scopes defined for most AR models, under the hood rely on `Authorization.projects(permission, user)` by checking that the `project_id` attribute of the record is within that set of projects.

--- a/lib/api/v3/memberships/memberships_api.rb
+++ b/lib/api/v3/memberships/memberships_api.rb
@@ -35,7 +35,9 @@ module API
         resources :memberships do
           get &::API::V3::Utilities::Endpoints::Index
                  .new(model: Member,
-                      scope: -> { Member.includes(MembershipRepresenter.to_eager_load) },
+                      # TODO: For now we exclude entity specific memberships in the API until we have updated the
+                      # frontend and representers to show those properly
+                      scope: -> { Member.where(entity: nil).includes(MembershipRepresenter.to_eager_load) },
                       api_name: 'Membership')
                  .mount
 

--- a/spec/factories/member_factory.rb
+++ b/spec/factories/member_factory.rb
@@ -37,6 +37,7 @@
 FactoryBot.define do
   factory :member do
     project
+    entity { nil }
 
     transient do
       user { nil }
@@ -53,5 +54,6 @@ FactoryBot.define do
 
   factory :global_member, parent: :member do
     project { nil }
+    entity { nil }
   end
 end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -1228,7 +1228,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:setup) do
             allow(Authorization)
               .to receive(:roles)
-              .with(current_user, project:, entity: nil)
+              .with(current_user, project)
               .and_return(roles)
 
             allow(roles)

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -1228,7 +1228,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:setup) do
             allow(Authorization)
               .to receive(:roles)
-              .with(current_user, project)
+              .with(current_user, project:, entity: nil)
               .and_return(roles)
 
             allow(roles)

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -92,4 +92,26 @@ RSpec.describe Member do
       expect(project_membership).not_to be_deletable_role(project_role)
     end
   end
+
+  describe '.can_be_member_of?' do
+    it 'returns true when a whitelisted entity is passed in' do
+      result = described_class.can_be_member_of?(build(:work_package))
+      expect(result).to be_truthy
+    end
+
+    it 'returns true when the class name of a whitelisted entity is passed in' do
+      result = described_class.can_be_member_of?(WorkPackage)
+      expect(result).to be_truthy
+    end
+
+    it 'returns false when a non-whitelisted entity is passed in' do
+      result = described_class.can_be_member_of?(build(:user))
+      expect(result).to be_falsey
+    end
+
+    it 'returns false when the class name of a whitelisted entity is passed in' do
+      result = described_class.can_be_member_of?(User)
+      expect(result).to be_falsey
+    end
+  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -30,66 +30,66 @@ require 'spec_helper'
 
 RSpec.describe Member do
   let(:user) { create(:user) }
-  let(:role) { create(:role) }
+  let(:project_role) { create(:role) }
+  let(:global_role) { create(:global_role) }
   let(:project) { create(:project) }
-  let(:member) { create(:member, user:, roles: [role]) }
-  let(:new_member) { build(:member, user:, roles: [role], project:) }
+  let(:work_package) { create(:work_package, project:) }
 
-  describe 'Associations' do
-    it { expect(member).to belong_to(:principal) }
-    it { expect(member).to have_many(:member_roles) }
-    it { expect(member).to have_many(:roles) }
+  subject(:member) { build(:global_member, user:, roles: [global_role]) }
+
+  describe 'relations' do
+    it { expect(member).to have_many(:member_roles).dependent(:destroy) }
+    it { expect(member).to belong_to(:project).optional }
+    it { expect(member).to have_many(:roles).through(:member_roles) }
+    it { expect(member).to belong_to(:principal).required }
+    it { expect(member).to belong_to(:entity).optional }
 
     it do
-      expect(member).to have_many(:oauth_client_tokens)
-        .with_foreign_key(:user_id)
-        .with_primary_key(:user_id)
-        .dependent(nil)
+      expect(member).to have_many(:oauth_client_tokens).with_foreign_key(:user_id).with_primary_key(:user_id).dependent(nil)
     end
   end
 
-  describe '#project' do
-    context 'with a project' do
-      it 'is valid' do
-        expect(new_member)
-          .to be_valid
-      end
+  describe 'validations' do
+    it { expect(member).to validate_uniqueness_of(:user_id).scoped_to(%i[project_id entity_type entity_id]) }
+    it { expect(member).to validate_inclusion_of(:entity_type).in_array(["WorkPackage"]).allow_blank }
+  end
+
+  describe '#deletable?' do
+    it 'is deletable, when no roles are inherited' do
+      member.member_roles.first.inherited_from = nil
+      expect(member).to be_deletable
     end
 
-    context 'without a project (global)' do
-      let(:project) { nil }
-
-      it 'is valid' do
-        expect(new_member)
-          .to be_valid
-      end
-    end
-
-    context 'without a project (global) but with a global membership already existing' do
-      let(:project) { nil }
-      let!(:existing_member) { create(:member, user:, roles: [role], project:) }
-
-      it 'is invalid' do
-        expect(new_member)
-          .not_to be_valid
-      end
+    it 'is not deletable, when roles are inherited' do
+      member.member_roles.first.inherited_from = 1
+      expect(member).not_to be_deletable
     end
   end
 
   describe '#deletable_role?' do
-    it 'returns true if not inherited from a group' do
-      expect(member.deletable_role?(role)).to be(true)
-    end
+    it 'can delete directly assigned roles, but not if role is inherited through a group membership' do
+      # user has the global_role by directly being assigned
+      member.save
 
-    it 'returns false if role is inherited' do
-      member
+      # user gets a group that will be assigned the project_role
       group = create(:group, members: [user])
-      create(:member, project:, principal: group, roles: [role])
-      Groups::CreateInheritedRolesService
-        .new(group, current_user: User.system, contract_class: EmptyContract)
-        .call(user_ids: [user.id])
+      create(:member, project:, principal: group, roles: [project_role])
 
-      expect(user.reload.memberships.map { _1.deletable_role?(role) }).to contain_exactly(true, false)
+      # run the service to normalize the users permissions
+      expect do
+        Groups::CreateInheritedRolesService
+          .new(group, current_user: User.system, contract_class: EmptyContract)
+          .call(user_ids: [user.id])
+        user.reload
+      end.to change(user.memberships, :count).by(1)
+
+      # membership of the user is the global roles they got assigned directly
+      global_membership = user.memberships.find_by(project: nil)
+      expect(global_membership).to be_deletable_role(global_role)
+
+      # membership of the user is the project role they got by being a group member
+      project_membership = user.memberships.find_by(project:)
+      expect(project_membership).not_to be_deletable_role(project_role)
     end
   end
 end

--- a/spec/models/queries/members/members_query_integration_spec.rb
+++ b/spec/models/queries/members/members_query_integration_spec.rb
@@ -50,4 +50,23 @@ RSpec.describe Queries::Members::MemberQuery, 'Integration' do
       expect(subject.first.user_id).to eq user.id
     end
   end
+
+  context 'with a project and a work package membership' do
+    let(:project) { create(:project) }
+    let(:work_package) { create(:work_package, project:) }
+    let(:user) { create(:user) }
+    let(:role) { create(:role, permissions: [:manage_members]) }
+    let(:wp_role) { create(:work_package_role, permissions: [:view_work_packages]) }
+    let!(:project_membership) { create(:member, principal: user, project:, roles: [role]) }
+    let!(:wp_membership) { create(:member, principal: user, project:, entity: work_package, roles: [wp_role]) }
+
+    it 'only returns the project membership' do
+      expect(subject.count).to eq(1)
+      expect(subject.first).to have_attributes(
+        project:,
+        entity: nil,
+        user:
+      )
+    end
+  end
 end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -36,23 +36,11 @@ RSpec.describe User, 'allowed_to?' do
   let(:role) { build(:role) }
   let(:role2) { build(:role) }
   let(:anonymous_role) { build(:anonymous_role) }
-  let(:member) do
-    build(:member, project:,
-                   roles: [role],
-                   principal: user)
-  end
-  let(:member2) do
-    build(:member, project: project2,
-                   roles: [role2],
-                   principal: user)
-  end
-  let(:global_permission) { OpenProject::AccessControl.permissions.find { |p| p.global? } }
+  let(:member) { build(:member, project:, roles: [role], principal: user) }
+  let(:member2) { build(:member, project: project2, roles: [role2], principal: user) }
+  let(:global_permission) { OpenProject::AccessControl.permissions.find(&:global?) }
   let(:global_role) { build(:global_role, permissions: [global_permission.name]) }
-  let(:global_member) do
-    build(:global_member,
-          principal: user,
-          roles: [global_role])
-  end
+  let(:global_member) { build(:global_member, principal: user, roles: [global_role]) }
 
   before do
     anonymous_role.save!
@@ -60,7 +48,7 @@ RSpec.describe User, 'allowed_to?' do
     user.save!
   end
 
-  shared_examples_for 'w/ inquiring for project' do
+  shared_examples_for 'when inquiring for project' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
@@ -480,7 +468,7 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  shared_examples_for 'w/ inquiring globally' do
+  shared_examples_for 'when inquiring globally' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
@@ -662,13 +650,13 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  context 'w/o preloaded permissions' do
-    it_behaves_like 'w/ inquiring for project'
-    it_behaves_like 'w/ inquiring globally'
+  context 'without preloaded permissions' do
+    it_behaves_like 'when inquiring for project'
+    it_behaves_like 'when inquiring globally'
   end
 
-  context 'w/ preloaded permissions' do
-    it_behaves_like 'w/ inquiring for project' do
+  context 'with preloaded permissions' do
+    it_behaves_like 'when inquiring for project' do
       let(:final_setup_step) do
         user.preload_projects_allowed_to(permission)
       end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -201,30 +201,6 @@ RSpec.describe User, 'allowed_to?' do
           it { expect(user).not_to be_allowed_to(permission, project) }
         end
 
-        context 'and the permission being assigend to the non-member role' do
-          before do
-            non_member = Role.non_member
-            non_member.add_permission! permission
-
-            final_setup_step
-          end
-
-          it do
-            # TODO: Figure this one out. In the documentation it says:
-            #
-            # Surprisingly, when looking up permissions, the non member role is always factored in, even it the user
-            # does have other roles within the project as well. That means that if the user has a role in a project
-            # not granting "Create new work package", but the non member role is granting the permission, the user
-            # will in effect have that permission.
-            #
-            # So, in my eyes, with the permission being granted to the non-member role, it should be allowed to do the
-            # requested action.
-
-            skip "Have to figure out why this is not working"
-            expect(user).to be_allowed_to(permission, project)
-          end
-        end
-
         context 'and requesting a public permission' do
           let(:permission) { :view_project } # a permission defined as public
 

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -33,8 +33,11 @@ RSpec.describe User, 'allowed_to?' do
   let(:anonymous) { build(:anonymous) }
   let(:project) { build(:project, public: false) }
   let(:project2) { build(:project, public: false) }
+  let(:work_package) { build(:work_package, project:) }
   let(:role) { build(:role) }
   let(:role2) { build(:role) }
+  let(:wp_role) { build(:role) }
+  let(:wp_member) { build(:member, project:, entity: work_package, roles: [wp_role], principal: user) }
   let(:anonymous_role) { build(:anonymous_role) }
   let(:member) { build(:member, project:, roles: [role], principal: user) }
   let(:member2) { build(:member, project: project2, roles: [role2], principal: user) }
@@ -48,7 +51,7 @@ RSpec.describe User, 'allowed_to?' do
     user.save!
   end
 
-  shared_examples_for 'when inquiring for project' do
+  shared_examples_for 'w/ inquiring for project' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
@@ -468,7 +471,7 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  shared_examples_for 'when inquiring globally' do
+  shared_examples_for 'w/ inquiring globally' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
@@ -650,13 +653,13 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  context 'without preloaded permissions' do
-    it_behaves_like 'when inquiring for project'
-    it_behaves_like 'when inquiring globally'
+  context 'w/o preloaded permissions' do
+    it_behaves_like 'w/ inquiring for project'
+    it_behaves_like 'w/ inquiring globally'
   end
 
-  context 'with preloaded permissions' do
-    it_behaves_like 'when inquiring for project' do
+  context 'w/ preloaded permissions' do
+    it_behaves_like 'w/ inquiring for project' do
       let(:final_setup_step) do
         user.preload_projects_allowed_to(permission)
       end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -109,6 +109,21 @@ RSpec.describe User, 'allowed_to?' do
       context 'with the project being private' do
         before { project.update(public: false) }
 
+        context 'with the user being a member of a single work package inside the project' do
+          before do
+            work_package.save!
+            wp_member.save!
+          end
+
+          context 'with the role granting the permission' do
+            before do
+              wp_role.add_permission!(permission)
+            end
+
+            it { expect(user).not_to be_allowed_to(permission, project) }
+          end
+        end
+
         context 'and the permission being assigend to the non-member role' do
           before do
             non_member = Role.non_member

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe User, 'allowed_to?' do
     user.save!
   end
 
-  shared_examples_for 'w/ inquiring for project' do
+  shared_examples_for 'when inquiring for project' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
@@ -392,33 +392,20 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  shared_examples_for 'w/ inquiring globally' do
+  shared_examples_for 'when inquiring globally' do
     let(:permission) { :add_work_packages }
-    let(:final_setup_step) {}
 
-    context 'w/ the user being admin' do
-      before do
-        user.admin = true
-        user.save!
+    context 'when the user is an admin' do
+      before { user.update(admin: true) }
 
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, nil, global: true)
-      end
+      it { expect(user).to be_allowed_to(permission, nil, global: true) }
     end
 
-    context 'w/ the user being a member in a project
-             w/o the role having the necessary permission' do
-      before do
-        member.save!
+    context 'when the user is member of a project' do
+      before { member.save }
 
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, nil, global: true)
+      context 'and a project permission is requested globally' do
+        it { expect(user).not_to be_allowed_to(permission, nil, global: true) }
       end
     end
 
@@ -574,13 +561,13 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
-  context 'w/o preloaded permissions' do
-    it_behaves_like 'w/ inquiring for project'
-    it_behaves_like 'w/ inquiring globally'
+  context 'without preloaded permissions' do
+    it_behaves_like 'when inquiring for project'
+    it_behaves_like 'when inquiring globally'
   end
 
-  context 'w/ preloaded permissions' do
-    it_behaves_like 'w/ inquiring for project' do
+  context 'with preloaded permissions' do
+    it_behaves_like 'when inquiring for project' do
       let(:final_setup_step) do
         user.preload_projects_allowed_to(permission)
       end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -491,9 +491,61 @@ RSpec.describe User, 'allowed_to?' do
     end
   end
 
+  shared_examples_for 'when inquiring for work_package' do
+    let(:permission) { :view_work_package }
+    context 'with the user being a member of the work package' do
+      before do
+        work_package.save!
+        wp_member.save!
+      end
+
+      context 'with the role granting the permission' do
+        before do
+          wp_role.add_permission!(permission)
+        end
+
+        it { expect(user).to be_allowed_to(permission, work_package) }
+      end
+
+      context 'without the role granting the permission' do
+        it { expect(user).not_to be_allowed_to(permission, work_package) }
+
+        context 'with a membership on the project granting the permission' do
+          before do
+            member.save!
+            role.add_permission!(permission)
+          end
+
+          it { expect(user).to be_allowed_to(permission, work_package) }
+        end
+      end
+    end
+
+    context 'without the user being a member of the work package' do
+      context 'with the user being a member of the project the work package belongs to' do
+        before do
+          member.save!
+          role.add_permission!(permission)
+        end
+
+        it { expect(user).to be_allowed_to(permission, work_package) }
+      end
+
+      context 'with the user being a member of another project' do
+        before do
+          member2.save!
+          role.add_permission!(permission)
+        end
+
+        it { expect(user).not_to be_allowed_to(permission, work_package) }
+      end
+    end
+  end
+
   context 'without preloaded permissions' do
     it_behaves_like 'when inquiring for project'
     it_behaves_like 'when inquiring globally'
+    it_behaves_like 'when inquiring for work_package'
   end
 
   context 'with preloaded permissions' do

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe User, 'allowed_to?' do
     let(:permission) { :add_work_packages }
     let(:final_setup_step) {}
 
+    before do
+      project.save
+    end
+
     context 'with the user being admin' do
       before { user.update(admin: true) }
 
@@ -82,7 +86,6 @@ RSpec.describe User, 'allowed_to?' do
         let(:permission) { :create_meetings } # pick a permission from a module
 
         before do
-          project.save
           project.enabled_module_names -= ['meetings']
 
           final_setup_step
@@ -95,8 +98,6 @@ RSpec.describe User, 'allowed_to?' do
         let(:permission) { :work_package_assigned } # permission that is not automatically granted to admins
 
         before do
-          project.save
-
           final_setup_step
         end
 
@@ -104,359 +105,289 @@ RSpec.describe User, 'allowed_to?' do
       end
     end
 
-    context 'w/ the user being a member in the project
-             w/o the role having the necessary permission' do
-      before do
-        member.save!
+    context 'without the user being a member in the project' do
+      context 'with the project being private' do
+        before { project.update(public: false) }
 
-        final_setup_step
+        context 'and the permission being assigend to the non-member role' do
+          before do
+            non_member = Role.non_member
+            non_member.add_permission! permission
+
+            final_setup_step
+          end
+
+          it do
+            expect(user).not_to be_allowed_to(permission, project)
+          end
+        end
+
+        context 'and requesting a public permission' do
+          let(:permission) { :view_project } # a permission defined as public
+
+          before do
+            final_setup_step
+          end
+
+          it { expect(user).not_to be_allowed_to(permission, project) }
+        end
       end
 
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
-      end
-    end
+      context 'and the project being public' do
+        before { project.update(public: true) }
 
-    context 'w/ the user being a member in the project
-             w/ the role having the necessary permission' do
-      before do
-        role.add_permission! permission
+        context 'and the permission not being assigend to the non-member role' do
+          before do
+            non_member = Role.non_member
+            non_member.remove_permission! permission
 
-        member.save!
+            final_setup_step
+          end
 
-        final_setup_step
-      end
+          it { expect(user).not_to be_allowed_to(permission, project) }
+        end
 
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, project)
-      end
-    end
+        context 'and the permission being assigend to the non-member role' do
+          before do
+            non_member = Role.non_member
+            non_member.add_permission! permission
 
-    context 'w/ the user being a member in the project
-             w/ the role having the necessary permission
-             w/o the module being active' do
-      let(:permission) { :view_news }
+            final_setup_step
+          end
 
-      before do
-        role.add_permission! permission
-        project.enabled_module_names = []
+          it do
+            expect(user).to be_allowed_to(permission, project)
+          end
+        end
 
-        member.save!
+        context 'and requesting a public permission' do
+          let(:permission) { :view_project } # a permission defined as public
 
-        final_setup_step
-      end
+          before do
+            final_setup_step
+          end
 
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
-      end
-    end
-
-    context 'w/ the user being a member in the project
-             w/ the role having the necessary permission
-             w/ asking for a controller/action hash
-             w/o the module being active' do
-      let(:permission) { { controller: 'news', action: 'show' } }
-
-      before do
-        role.add_permission! permission
-        project.enabled_module_names = []
-
-        member.save!
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
-      end
-    end
-
-    context 'w/ the user being a member in the project
-             w/o the role having the necessary permission
-             w/ non members having the necessary permission' do
-      before do
-        project.public = false
-
-        non_member = Role.non_member
-        non_member.add_permission! permission
-
-        member.save!
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
+          it { expect(user).to be_allowed_to(permission, project) }
+        end
       end
     end
 
-    context 'w/ the user being a member in the project
-             w/o the role having the necessary permission
-             w/ inquiring for a permission that is public' do
-      let(:permission) { :view_project }
+    context 'with the user being a member in the project' do
+      before { member.save! }
 
-      before do
-        project.public = false
+      context 'without the role granting the requested permission' do
+        before do
+          role.remove_permission!(permission)
+        end
 
-        member.save!
+        context 'and no permissions being assigned to the non-member role' do
+          before { final_setup_step }
 
-        final_setup_step
+          it { expect(user).not_to be_allowed_to(permission, project) }
+        end
+
+        context 'and the permission being assigend to the non-member role' do
+          before do
+            non_member = Role.non_member
+            non_member.add_permission! permission
+
+            final_setup_step
+          end
+
+          it do
+            # TODO: Figure this one out. In the documentation it says:
+            #
+            # Surprisingly, when looking up permissions, the non member role is always factored in, even it the user
+            # does have other roles within the project as well. That means that if the user has a role in a project
+            # not granting "Create new work package", but the non member role is granting the permission, the user
+            # will in effect have that permission.
+            #
+            # So, in my eyes, with the permission being granted to the non-member role, it should be allowed to do the
+            # requested action.
+
+            skip "Have to figure out why this is not working"
+            expect(user).to be_allowed_to(permission, project)
+          end
+        end
+
+        context 'and requesting a public permission' do
+          let(:permission) { :view_project } # a permission defined as public
+
+          before do
+            project.update(public: false)
+            final_setup_step
+          end
+
+          it { expect(user).to be_allowed_to(permission, project) }
+        end
       end
 
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, project)
-      end
-    end
+      context 'with the role granting the requested permission' do
+        let(:permission) { :view_news }
 
-    context 'w/o the user being member in the project
-             w/ non member being allowed the action
-             w/ the project being private' do
-      before do
-        project.public = false
-        project.save!
+        before do
+          role.add_permission!(permission)
+        end
 
-        non_member = Role.non_member
+        context 'with the module being active' do
+          before do
+            project.enabled_module_names += ['news']
 
-        non_member.add_permission! permission
+            final_setup_step
+          end
 
-        final_setup_step
-      end
+          context 'and the permission being requested with the permission name' do
+            it { expect(user).to be_allowed_to(permission, project) }
+          end
 
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
-      end
-    end
+          context 'and the permission being requested with the controller name and action' do
+            it { expect(user).to be_allowed_to({ controller: 'news', action: 'show' }, project) }
+          end
+        end
 
-    context 'w/o the user being member in the project
-             w/ the project being public
-             w/ non members being allowed the action' do
-      before do
-        project.public = true
-        project.save!
+        context 'without the module being active' do
+          before do
+            project.enabled_module_names -= ['news']
 
-        non_member = Role.non_member
+            final_setup_step
+          end
 
-        non_member.add_permission! permission
+          context 'and the permission being requested with the permission name' do
+            it { expect(user).not_to be_allowed_to(permission, project) }
+          end
 
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, project)
-      end
-    end
-
-    context 'w/ the user being member in the project
-             w/ the project being public
-             w/ non members being allowed the action
-             w/o the role being allowed the action' do
-      before do
-        project.public = true
-        project.save!
-
-        non_member = Role.non_member
-        non_member.add_permission! permission
-
-        member.save!
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, project)
-      end
-    end
-
-    context 'w/ the user being anonymous
-             w/ the project being public
-             w/ anonymous being allowed the action' do
-      before do
-        project.public = true
-        project.save!
-
-        anonymous_role.add_permission! permission
-
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(anonymous).to be_allowed_to(permission, project)
+          context 'and the permission being requested with the controller name and action' do
+            it { expect(user).not_to be_allowed_to({ controller: 'news', action: 'show' }, project) }
+          end
+        end
       end
     end
 
-    context 'w/ the user being anonymous
-             w/ the project being public
-             w/ querying for a public permission' do
-      let(:permission) { :view_project }
+    context 'with the user being anonymous' do
+      context 'with the project being public' do
+        before { project.update(public: true) }
 
-      before do
-        project.public = true
-        project.save!
+        context 'without the anonymous role being given the permission' do
+          before do
+            anonymous_role.remove_permission!(permission)
+            final_setup_step
+          end
 
-        anonymous_role.save!
+          it { expect(anonymous).not_to be_allowed_to(permission, project) }
+        end
 
-        final_setup_step
-      end
+        context 'with the anonymous role being given the permission' do
+          before do
+            anonymous_role.add_permission!(permission)
+            final_setup_step
+          end
 
-      it 'is true' do
-        expect(anonymous).to be_allowed_to(permission, project)
-      end
-    end
+          it { expect(anonymous).to be_allowed_to(permission, project) }
+        end
 
-    context 'w/ the user being anonymous
-             w/ requesting a controller and action allowed by multiple permissions
-             w/ the project being public
-             w/ anonymous being allowed the action' do
-      let(:permission) { { controller: '/projects/settings/categories', action: 'show' } }
+        context 'with a public permission' do
+          let(:permission) { :view_project }
 
-      before do
-        project.public = true
-        project.save!
+          before { final_setup_step }
 
-        anonymous_role.add_permission! :manage_categories
+          it { expect(anonymous).to be_allowed_to(permission, project) }
+        end
 
-        final_setup_step
-      end
+        context 'with a controller and action that is allowed via multiple permissions' do
+          let(:permission) { :manage_categories }
 
-      it 'is true' do
-        expect(anonymous)
-          .to be_allowed_to(permission, project)
-      end
-    end
+          before do
+            anonymous_role.add_permission! permission
+            final_setup_step
+          end
 
-    context 'w/ the user being anonymous
-             w/ the project being public
-             w/ anonymous being not allowed the action' do
-      before do
-        project.public = true
-        project.save!
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(anonymous).not_to be_allowed_to(permission, project)
+          it { expect(anonymous).to be_allowed_to({ controller: '/projects/settings/categories', action: 'show' }, project) }
+        end
       end
     end
 
-    context 'w/ the user being a member in two projects
-             w/ the user being allowed the action in both projects' do
-      before do
-        role.add_permission! permission
-        role2.add_permission! permission
+    context 'when requesting permission for multiple projects' do
+      context 'with the user being a member of multiple projects' do
+        before do
+          member.save
+          member2.save
+        end
 
-        member.save!
-        member2.save!
+        context 'with the permission being granted in both projects' do
+          before do
+            role.add_permission! permission
+            role2.add_permission! permission
 
-        final_setup_step
+            final_setup_step
+          end
+
+          it { expect(user).to be_allowed_to(permission, [project, project2]) }
+        end
       end
 
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, [project, project2])
+      context 'with the permission being granted in only one of the two projects' do
+        before do
+          role.add_permission! permission
+          role2.remove_permission! permission
+
+          final_setup_step
+        end
+
+        it { expect(user).not_to be_allowed_to(permission, [project, project2]) }
+      end
+
+      context 'with the user not being member of any projects, but both projects being public' do
+        before do
+          project.update(public: true)
+          project2.update(public: true)
+        end
+
+        context 'with non-member role having the permission' do
+          before do
+            non_member = Role.non_member
+            non_member.add_permission! permission
+            final_setup_step
+          end
+
+          it { expect(user).to be_allowed_to(permission, [project, project2]) }
+        end
+
+        context 'without non-member role having the permission' do
+          before do
+            non_member = Role.non_member
+            non_member.remove_permission! permission
+            final_setup_step
+          end
+
+          it { expect(user).not_to be_allowed_to(permission, [project, project2]) }
+        end
+      end
+
+      context 'with the user not being member of any projects, but one of the projects being public' do
+        before do
+          project.update(public: true)
+          project2.update(public: false)
+        end
+
+        context 'with non-member role having the permission' do
+          before do
+            non_member = Role.non_member
+            non_member.add_permission! permission
+            final_setup_step
+          end
+
+          it { expect(user).not_to be_allowed_to(permission, [project, project2]) }
+        end
       end
     end
 
-    context 'w/ the user being a member in two projects
-             w/ the user being allowed in only one project' do
+    context 'when requesting a global permission, but with the project as a context' do
       before do
-        role.add_permission! permission
-
-        member.save!
-        member2.save!
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, [project, project2])
-      end
-    end
-
-    context 'w/o the user being a member in the two projects
-             w/ both projects being public
-             w/ non member being allowed the action' do
-      before do
-        non_member = Role.non_member
-        non_member.add_permission! permission
-
-        project.update(public: true)
-        project2.update(public: true)
-
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(user).to be_allowed_to(permission, [project, project2])
-      end
-    end
-
-    context 'w/o the user being a member in the two projects
-             w/ only one project being public
-             w/ non member being allowed the action' do
-      before do
-        non_member = Role.non_member
-        non_member.add_permission! permission
-
-        project.update(public: true)
-        project2.update(public: false)
-
-        final_setup_step
-      end
-
-      it 'is false' do
-        expect(user).not_to be_allowed_to(permission, [project, project2])
-      end
-    end
-
-    context "w/o the user being member in a project
-             w/ the user having the global role
-             w/ the global role having the necessary permission" do
-      before do
-        project.save!
-
-        global_role.save!
-
         global_member.save!
       end
 
       it 'is false' do
         expect(user).not_to be_allowed_to(global_permission.name, project)
-      end
-    end
-
-    context 'w/ requesting a controller and action
-             w/ the user being allowed the action' do
-      let(:permission) { :view_wiki_pages }
-
-      before do
-        role.add_permission! permission
-
-        member.save!
-
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(user)
-          .to be_allowed_to({ controller: 'wiki', action: 'show' }, project)
-      end
-    end
-
-    context 'w/ requesting a controller and action allowed by multiple permissions
-             w/ the user being allowed the action' do
-      let(:permission) { :manage_categories }
-
-      before do
-        role.add_permission! permission
-
-        member.save!
-
-        final_setup_step
-      end
-
-      it 'is true' do
-        expect(user)
-          .to be_allowed_to({ controller: 'projects', action: 'show' }, project)
       end
     end
   end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe User, 'allowed_to?' do
   let(:work_package) { build(:work_package, project:) }
   let(:role) { build(:role) }
   let(:role2) { build(:role) }
-  # TODO: Replace with WorkPackage role
-  let(:wp_role) { build(:role) }
+  let(:wp_role) { build(:work_package_role) }
   let(:wp_member) { build(:member, project:, entity: work_package, roles: [wp_role], principal: user) }
   let(:anonymous_role) { build(:anonymous_role) }
   let(:member) { build(:member, project:, roles: [role], principal: user) }

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe WorkPackage do
     end
   end
 
+  describe 'associations' do
+    subject { work_package }
+
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:type) }
+    it { is_expected.to belong_to(:status) }
+    it { is_expected.to belong_to(:author) }
+    it { is_expected.to belong_to(:assigned_to).class_name('Principal').optional }
+    it { is_expected.to belong_to(:responsible).class_name('Principal').optional }
+    it { is_expected.to belong_to(:version).optional }
+    it { is_expected.to belong_to(:priority).class_name('IssuePriority') }
+    it { is_expected.to belong_to(:category).optional }
+    it { is_expected.to have_many(:time_entries).dependent(:delete_all) }
+    it { is_expected.to have_many(:file_links).dependent(:delete_all).class_name("Storages::FileLink") }
+    it { is_expected.to have_many(:storages).through(:project) }
+    it { is_expected.to have_and_belong_to_many(:changesets) }
+    it { is_expected.to have_and_belong_to_many(:github_pull_requests) }
+    it { is_expected.to have_many(:members).dependent(:destroy) }
+    it { is_expected.to have_many(:principals).through(:members) }
+  end
+
   describe '.new' do
     context 'type' do
       let(:type2) { create(:type) }
@@ -253,7 +274,7 @@ RSpec.describe WorkPackage do
 
     it 'returns all open versions of the project' do
       expect(work_package.assignable_versions)
-        .to match_array [version_current, version_open]
+        .to contain_exactly(version_current, version_open)
     end
   end
 
@@ -613,7 +634,7 @@ RSpec.describe WorkPackage do
     context 'when having the move_work_packages permission' do
       it 'returns the project' do
         expect(described_class.allowed_target_projects_on_move(user))
-          .to match_array [project]
+          .to contain_exactly(project)
       end
     end
 
@@ -637,7 +658,7 @@ RSpec.describe WorkPackage do
     context 'when having the add_work_packages permission' do
       it 'returns the project' do
         expect(described_class.allowed_target_projects_on_create(user))
-          .to match_array [project]
+          .to contain_exactly(project)
       end
     end
 
@@ -679,7 +700,7 @@ RSpec.describe WorkPackage do
     describe 'null' do
       subject { described_class.changed_since(nil) }
 
-      it { expect(subject).to match_array([work_package]) }
+      it { expect(subject).to contain_exactly(work_package) }
     end
 
     describe 'now' do
@@ -691,7 +712,7 @@ RSpec.describe WorkPackage do
     describe 'work package update' do
       subject { described_class.changed_since(work_package.reload.updated_at) }
 
-      it { expect(subject).to match_array([work_package]) }
+      it { expect(subject).to contain_exactly(work_package) }
     end
   end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe WorkPackage do
     it { is_expected.to have_and_belong_to_many(:changesets) }
     it { is_expected.to have_and_belong_to_many(:github_pull_requests) }
     it { is_expected.to have_many(:members).dependent(:destroy) }
-    it { is_expected.to have_many(:principals).through(:members) }
+    it { is_expected.to have_many(:member_principals).through(:members).class_name('Principal').source(:principal) }
   end
 
   describe '.new' do

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
            roles: [global_role])
   end
 
+  let(:work_package) { create(:work_package, project:) }
+  let(:work_package_member) do
+    create(:member,
+           user: current_user,
+           project:,
+           entity: work_package,
+           roles: [create(:work_package_role)])
+  end
+
   subject(:response) { last_response }
 
   shared_examples_for 'sends mails' do
@@ -85,7 +94,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
   end
 
   describe 'GET api/v3/memberships' do
-    let(:members) { [own_member, other_member, invisible_member, global_member] }
+    let(:members) { [own_member, other_member, invisible_member, global_member, work_package_member] }
     let(:filters) { nil }
     let(:path) { api_v3_paths.path_for(:memberships, filters:, sort_by: [%i(id asc)]) }
 
@@ -859,7 +868,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         other_member.reload
 
         expect(other_member.roles)
-          .to match_array [another_role]
+          .to contain_exactly(another_role)
 
         # Assigning a new role also updates the member
         expect(other_member.updated_at > other_member_updated_at)
@@ -950,7 +959,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
 
       it 'updates the member and all inherited members but does not update memberships users have already had' do
         expect(other_member.reload.roles)
-          .to match_array [another_role]
+          .to contain_exactly(another_role)
 
         expect(other_member.updated_at > other_member_updated_at)
           .to be_truthy
@@ -958,7 +967,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         last_user_member = Member.find_by(principal: users.last)
 
         expect(last_user_member.roles)
-          .to match_array [another_role]
+          .to contain_exactly(another_role)
 
         expect(last_user_member.updated_at > last_user_member_updated_at)
           .to be_truthy
@@ -966,7 +975,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         first_user_member = Member.find_by(principal: users.first)
 
         expect(first_user_member.roles.uniq)
-          .to match_array [other_role, another_role]
+          .to contain_exactly(other_role, another_role)
 
         expect(first_user_member.updated_at)
           .to eql first_user_member_updated_at
@@ -1034,7 +1043,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         it 'updates the member and all inherited members but does not update memberships users have already had' do
           # other member is the group member
           expect(other_member.reload.roles)
-            .to match_array [another_role]
+            .to contain_exactly(another_role)
 
           expect(other_member.updated_at > other_member_updated_at)
             .to be_truthy
@@ -1042,7 +1051,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
           last_user_member = Member.find_by(principal: users.last)
 
           expect(last_user_member.roles)
-            .to match_array [another_role]
+            .to contain_exactly(another_role)
 
           expect(last_user_member.updated_at > last_user_member_updated_at)
             .to be_truthy
@@ -1050,7 +1059,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
           first_user_member = Member.find_by(principal: users.first)
 
           expect(first_user_member.roles.uniq)
-            .to match_array [other_role, another_role]
+            .to contain_exactly(other_role, another_role)
 
           expect(first_user_member.updated_at)
             .to eql first_user_member_updated_at
@@ -1225,7 +1234,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         first_user_member = Member.find_by(principal: users.first)
 
         expect(first_user_member.roles)
-          .to match_array [another_role]
+          .to contain_exactly(another_role)
 
         expect(first_user_member.updated_at > first_user_member_updated_at)
           .to be_truthy

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
   shared_let(:global_role) { create(:global_role) }
   let(:own_member) do
     create(:member,
-           roles: [create(:role, permissions:)],
+           roles: create_list(:role, 1, permissions:),
            project:,
            user: current_user)
   end
@@ -58,7 +58,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
   end
   let(:invisible_member) do
     create(:member,
-           roles: [create(:role)])
+           roles: create_list(:role, 1))
   end
   let(:global_member) do
     create(:global_member,
@@ -71,7 +71,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
            user: current_user,
            project:,
            entity: work_package,
-           roles: [create(:work_package_role)])
+           roles: create_list(:work_package_role, 1))
   end
 
   subject(:response) { last_response }
@@ -190,7 +190,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       let(:group) { create(:group) }
       let(:group_member) do
         create(:member,
-               roles: [create(:role)],
+               roles: create_list(:role, 1),
                project:,
                principal: group)
       end
@@ -221,7 +221,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       end
       let(:placeholder_member) do
         create(:member,
-               roles: [create(:role)],
+               roles: create_list(:role, 1),
                project:,
                principal: placeholder_user)
       end
@@ -270,7 +270,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
 
       let(:own_other_member) do
         create(:member,
-               roles: [create(:role, permissions:)],
+               roles: create_list(:role, 1, permissions:),
                project: other_project,
                user: current_user)
       end
@@ -299,7 +299,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       let(:group) { create(:group) }
       let(:group_member) do
         create(:member,
-               roles: [create(:role)],
+               roles: create_list(:role, 1),
                principal: group,
                project:)
       end
@@ -511,7 +511,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         create(:group, members: users)
       end
       let(:principal) { group }
-      let(:users) { [create(:user), create(:user)] }
+      let(:users) { create_list(:user, 2) }
       let(:principal_path) { api_v3_paths.group(group.id) }
       let(:body) do
         {
@@ -932,7 +932,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         create(:group, member_in_project: project, member_through_role: other_role, members: users)
       end
       let(:principal) { group }
-      let(:users) { [create(:user), create(:user)] }
+      let(:users) { create_list(:user, 2) }
       let(:other_member) do
         Member.find_by(principal: group).tap do
           # Behaves as if the user had that role before the role's membership was created.
@@ -1115,7 +1115,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         create(:project).tap do |p|
           create(:member,
                  project: p,
-                 roles: [create(:role, permissions: [:manage_members])],
+                 roles: create_list(:role, 1, permissions: [:manage_members]),
                  user: current_user)
         end
       end
@@ -1187,7 +1187,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       end
 
       it 'deletes the member' do
-        expect(Member.exists?(other_member.id)).to be_falsey
+        expect(Member).not_to exist(other_member.id)
       end
 
       context 'for a non-existent version' do
@@ -1203,10 +1203,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       end
       let(:principal) { group }
       let(:users) do
-        [
-          create(:user, notification_settings: [build(:notification_setting, membership_added: true, membership_updated: true)]),
-          create(:user, notification_settings: [build(:notification_setting, membership_added: true, membership_updated: true)])
-        ]
+        create_list(:user, 2, notification_settings: [build(:notification_setting, membership_added: true, membership_updated: true)])
       end
       let(:another_role) { create(:role) }
       let(:other_member) do
@@ -1228,7 +1225,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       end
 
       it 'deletes the member but does not remove the previously assigned role' do
-        expect(Member.exists?(other_member.id)).to be_falsey
+        expect(Member).not_to exist(other_member.id)
         expect(Member.where(principal: users.last)).not_to be_exists
 
         first_user_member = Member.find_by(principal: users.first)
@@ -1252,7 +1249,7 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       it_behaves_like 'unauthorized access'
 
       it 'does not delete the member' do
-        expect(Member.exists?(other_member.id)).to be_truthy
+        expect(Member).to exist(other_member.id)
       end
     end
   end

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -737,7 +737,8 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
         expect(last_response.status).to eq(422)
 
         error_message = "For property 'user' a link like '/api/v3/groups/:id' or " +
-                        "'/api/v3/users/:id' or '/api/v3/placeholder_users/:id' is expected, but got '#{api_v3_paths.role(other_user.id)}'."
+                        "'/api/v3/users/:id' or '/api/v3/placeholder_users/:id' is expected, " +
+                        "but got '#{api_v3_paths.role(other_user.id)}'."
 
         expect(last_response.body)
           .to be_json_eql(error_message.to_json)
@@ -1203,7 +1204,8 @@ RSpec.describe 'API v3 memberships resource', content_type: :json do
       end
       let(:principal) { group }
       let(:users) do
-        create_list(:user, 2, notification_settings: [build(:notification_setting, membership_added: true, membership_updated: true)])
+        create_list(:user, 2,
+                    notification_settings: [build(:notification_setting, membership_added: true, membership_updated: true)])
       end
       let(:another_role) { create(:role) }
       let(:other_member) do

--- a/spec/services/authorization/user_allowed_service_spec.rb
+++ b/spec/services/authorization/user_allowed_service_spec.rb
@@ -28,6 +28,8 @@
 
 require 'spec_helper'
 
+# TODO: Fix tests here
+
 RSpec.describe Authorization::UserAllowedService do
   let(:user) { build_stubbed(:user) }
   let(:instance) { described_class.new(user) }

--- a/spec/services/authorization/user_allowed_service_spec.rb
+++ b/spec/services/authorization/user_allowed_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Authorization::UserAllowedService do
 
         allow(Authorization)
           .to receive(:roles)
-          .with(user, project)
+          .with(user, project:, entity: nil)
           .and_return(user_roles_in_project)
       end
 
@@ -88,7 +88,7 @@ RSpec.describe Authorization::UserAllowedService do
         Array(context).each do |project|
           allow(Authorization)
             .to receive(:roles)
-            .with(user, project)
+            .with(user, project:, entity: nil)
             .and_return(user_roles_in_project)
         end
 
@@ -99,7 +99,7 @@ RSpec.describe Authorization::UserAllowedService do
           expect(Authorization)
             .to have_received(:roles)
             .once
-            .with(user, project)
+            .with(user, project:, entity: nil)
         end
       end
 
@@ -279,7 +279,7 @@ RSpec.describe Authorization::UserAllowedService do
         before do
           allow(Authorization)
             .to receive(:roles)
-            .with(user, nil)
+            .with(user, project: nil, entity: nil)
             .and_return(user_roles_in_project)
 
           allow(role)
@@ -307,7 +307,7 @@ RSpec.describe Authorization::UserAllowedService do
         before do
           allow(Authorization)
             .to receive(:roles)
-            .with(user, nil)
+            .with(user, project: nil, entity: nil)
             .and_return(user_roles_in_project)
 
           allow(role)

--- a/spec/services/authorization/user_allowed_service_spec.rb
+++ b/spec/services/authorization/user_allowed_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Authorization::UserAllowedService do
 
         allow(Authorization)
           .to receive(:roles)
-          .with(user, project:, entity: nil)
+          .with(user, project)
           .and_return(user_roles_in_project)
       end
 
@@ -88,7 +88,7 @@ RSpec.describe Authorization::UserAllowedService do
         Array(context).each do |project|
           allow(Authorization)
             .to receive(:roles)
-            .with(user, project:, entity: nil)
+            .with(user, project)
             .and_return(user_roles_in_project)
         end
 
@@ -99,7 +99,7 @@ RSpec.describe Authorization::UserAllowedService do
           expect(Authorization)
             .to have_received(:roles)
             .once
-            .with(user, project:, entity: nil)
+            .with(user, project)
         end
       end
 
@@ -279,7 +279,7 @@ RSpec.describe Authorization::UserAllowedService do
         before do
           allow(Authorization)
             .to receive(:roles)
-            .with(user, project: nil, entity: nil)
+            .with(user, nil)
             .and_return(user_roles_in_project)
 
           allow(role)
@@ -307,7 +307,7 @@ RSpec.describe Authorization::UserAllowedService do
         before do
           allow(Authorization)
             .to receive(:roles)
-            .with(user, project: nil, entity: nil)
+            .with(user, nil)
             .and_return(user_roles_in_project)
 
           allow(role)

--- a/spec/services/authorization/user_entity_roles_query_spec.rb
+++ b/spec/services/authorization/user_entity_roles_query_spec.rb
@@ -34,9 +34,8 @@ RSpec.describe Authorization::UserEntityRolesQuery do
   let(:work_package) { build(:work_package, project:) }
   let(:work_package2) { build(:work_package, project:) }
   let(:role) { build(:role) }
-  # TODO: Make those work package roles
-  let(:wp_role) { build(:role) }
-  let(:other_wp_role) { build(:role) }
+  let(:wp_role) { build(:work_package_role) }
+  let(:other_wp_role) { build(:work_package_role) }
   let(:non_member) { build(:non_member) }
   let(:member) { build(:member, project:, roles: [wp_role], principal: user, entity: work_package) }
   let(:project_member) { build(:member, project:, roles: [role], principal: user) }

--- a/spec/services/authorization/user_entity_roles_query_spec.rb
+++ b/spec/services/authorization/user_entity_roles_query_spec.rb
@@ -1,0 +1,66 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe Authorization::UserEntityRolesQuery do
+  let(:user) { build(:user) }
+  let(:project) { build(:project, public: false) }
+  let(:work_package) { build(:work_package, project:) }
+  let(:work_package2) { build(:work_package, project:) }
+  let(:wp_role) { build(:role) }
+  let(:non_member) { build(:non_member) }
+  let(:member) { build(:member, project:, roles: [wp_role], principal: user, entity: work_package) }
+
+  describe '.query' do
+    before do
+      non_member.save!
+      user.save!
+    end
+
+    it 'is a relation' do
+      expect(described_class.query(user, work_package)).to be_a ActiveRecord::Relation
+    end
+
+    context 'with the user being a member of the work package' do
+      before do
+        member.save!
+      end
+
+      it 'returns the work package role' do
+        expect(described_class.query(user, work_package)).to match [wp_role]
+      end
+    end
+
+    context 'without the user being member in the project' do
+      it 'is empty' do
+        expect(described_class.query(user, project)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/authorization/user_project_roles_query_spec.rb
+++ b/spec/services/authorization/user_project_roles_query_spec.rb
@@ -34,20 +34,15 @@ RSpec.describe Authorization::UserProjectRolesQuery do
   let(:project) { build(:project, public: false) }
   let(:project2) { build(:project, public: false) }
   let(:public_project) { build(:project, public: true) }
+  let(:work_package) { build(:work_package, project:) }
   let(:role) { build(:role) }
   let(:role2) { build(:role) }
+  let(:wp_role) { build(:role) }
   let(:anonymous_role) { build(:anonymous_role) }
   let(:non_member) { build(:non_member) }
-  let(:member) do
-    build(:member, project:,
-                   roles: [role],
-                   principal: user)
-  end
-  let(:member2) do
-    build(:member, project: project2,
-                   roles: [role2],
-                   principal: user)
-  end
+  let(:member) { build(:member, project:, roles: [role], principal: user) }
+  let(:member2) { build(:member, project: project2, roles: [role2], principal: user) }
+  let(:wp_member) { build(:member, project:, roles: [wp_role], principal: user, entity: work_package) }
 
   describe '.query' do
     before do
@@ -60,7 +55,7 @@ RSpec.describe Authorization::UserProjectRolesQuery do
       expect(described_class.query(user, project)).to be_a ActiveRecord::Relation
     end
 
-    context 'w/ the user being a member in the project' do
+    context 'with the user being a member in the project' do
       before do
         member.save!
       end
@@ -70,42 +65,56 @@ RSpec.describe Authorization::UserProjectRolesQuery do
       end
     end
 
-    context 'w/o the user being member in the project
-             w/ the project being private' do
-      it 'is empty' do
-        expect(described_class.query(user, project)).to be_empty
+    context 'without the user being member in the project' do
+      context 'with the project being private' do
+        it 'is empty' do
+          expect(described_class.query(user, project)).to be_empty
+        end
+      end
+
+      context 'with the project being public' do
+        it 'is the non member role' do
+          expect(described_class.query(user, public_project)).to contain_exactly(non_member)
+        end
       end
     end
 
-    context 'w/o the user being member in the project
-             w/ the project being public' do
-      it 'is the non member role' do
-        expect(described_class.query(user, public_project)).to match_array [non_member]
+    context 'with the user being anonymous' do
+      context 'with the project being public' do
+        it 'is empty' do
+          expect(described_class.query(anonymous, public_project)).to contain_exactly(anonymous_role)
+        end
+      end
+
+      context 'without the project being public' do
+        it 'is empty' do
+          expect(described_class.query(anonymous, project)).to be_empty
+        end
       end
     end
 
-    context 'w/ the user being anonymous
-             w/ the project being public' do
-      it 'is empty' do
-        expect(described_class.query(anonymous, public_project)).to match_array [anonymous_role]
-      end
-    end
-
-    context 'w/ the user being anonymous
-             w/o the project being public' do
-      it 'is empty' do
-        expect(described_class.query(anonymous, project)).to be_empty
-      end
-    end
-
-    context 'w/ the user being a member in two projects' do
+    context 'with the user being a member in two projects' do
       before do
         member.save!
         member2.save!
       end
 
       it 'returns only the roles from the requested project' do
-        expect(described_class.query(user, project)).to match_array [role]
+        expect(described_class.query(user, project)).to contain_exactly(role)
+      end
+    end
+
+    context 'with the user being a member of a work package of the project' do
+      before { wp_member.save! }
+
+      context 'and not being a member of the project itself' do
+        it { expect(described_class.query(user, project)).to be_empty }
+      end
+
+      context 'and being a member of the project as well' do
+        before { member.save! }
+
+        it { expect(described_class.query(user, project)).to contain_exactly(role) }
       end
     end
   end

--- a/spec/services/authorization/user_project_roles_query_spec.rb
+++ b/spec/services/authorization/user_project_roles_query_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Authorization::UserProjectRolesQuery do
   let(:work_package) { build(:work_package, project:) }
   let(:role) { build(:role) }
   let(:role2) { build(:role) }
-  let(:wp_role) { build(:role) }
+  let(:wp_role) { build(:work_package_role) }
   let(:anonymous_role) { build(:anonymous_role) }
   let(:non_member) { build(:non_member) }
   let(:member) { build(:member, project:, roles: [role], principal: user) }

--- a/spec/services/groups/create_inherited_roles_service_integration_spec.rb
+++ b/spec/services/groups/create_inherited_roles_service_integration_spec.rb
@@ -261,6 +261,19 @@ RSpec.describe Groups::CreateInheritedRolesService, 'integration' do
     end
   end
 
+  context 'with a role that was granted to a specific entity' do
+    let(:project_ids) { nil }
+    let(:group_projects) { [] }
+    let(:work_package) { create(:work_package, project: project1) }
+    let!(:group_membership) { create(:member, principal: group, project: project1, entity: work_package, roles: [role1]) }
+
+    it 'inherits the roles of the group to the users also bound to the entity' do
+      expect do
+        expect(service_call).to be_success
+      end.to change(Member.where(project_id: work_package.project_id, entity: work_package), :count).by(user_ids.count)
+    end
+  end
+
   context 'when not an admin' do
     let(:current_user) { User.anonymous }
 

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -136,30 +136,21 @@ RSpec.describe WorkPackages::UpdateService, 'integration tests', type: :model do
     let(:target_types) { [type] }
 
     it 'is is success and updates the project' do
-      expect(subject)
-        .to be_success
-
-      expect(work_package.reload.project)
-        .to eql target_project
+      expect(subject).to be_success
+      expect(work_package.reload.project).to eql target_project
     end
 
     context 'with missing permissions' do
       let(:target_permissions) { [] }
 
       it 'is failure' do
-        expect(subject)
-          .to be_failure
+        expect(subject).to be_failure
       end
     end
 
     describe 'time_entries' do
       let!(:time_entries) do
-        [create(:time_entry,
-                project:,
-                work_package:),
-         create(:time_entry,
-                project:,
-                work_package:)]
+        create_list(:time_entry, 2, project:, work_package:)
       end
 
       it 'moves the time entries along' do
@@ -168,6 +159,38 @@ RSpec.describe WorkPackages::UpdateService, 'integration tests', type: :model do
 
         expect(TimeEntry.where(id: time_entries.map(&:id)).pluck(:project_id).uniq)
           .to contain_exactly(target_project.id)
+      end
+    end
+
+    describe 'memberships' do
+      # TODO: Change to Work Package role after PR has been merged
+      let(:wp_role) { create(:role, permissions: [:view_work_packages]) }
+      let(:other_user) { create(:user) }
+      let!(:membership) do
+        create(:member, project:, entity: work_package, principal: other_user, roles: [wp_role])
+      end
+
+      it 'moves memberships for the entity to the new project' do
+        expect do
+          subject
+          membership.reload
+        end.to change(membership, :project).from(project).to(target_project)
+      end
+
+      describe 'when the work package has descendents' do
+        # TODO: Change to Work Package role after PR has been merged
+        let!(:child_membership) do
+          create(:member, project:, entity: child_work_package, principal: other_user, roles: [wp_role])
+        end
+
+        it 'moves memberships for the entity and its descendents to the new project' do
+          expect do
+            subject
+            membership.reload
+            child_membership.reload
+          end.to change(membership, :project).from(project).to(target_project).and \
+            change(child_membership, :project).from(project).to(target_project)
+        end
       end
     end
 

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -163,8 +163,7 @@ RSpec.describe WorkPackages::UpdateService, 'integration tests', type: :model do
     end
 
     describe 'memberships' do
-      # TODO: Change to Work Package role after PR has been merged
-      let(:wp_role) { create(:role, permissions: [:view_work_packages]) }
+      let(:wp_role) { create(:work_package_role, permissions: [:view_work_packages]) }
       let(:other_user) { create(:user) }
       let!(:membership) do
         create(:member, project:, entity: work_package, principal: other_user, roles: [wp_role])
@@ -178,7 +177,6 @@ RSpec.describe WorkPackages::UpdateService, 'integration tests', type: :model do
       end
 
       describe 'when the work package has descendents' do
-        # TODO: Change to Work Package role after PR has been merged
         let!(:child_membership) do
           create(:member, project:, entity: child_work_package, principal: other_user, roles: [wp_role])
         end


### PR DESCRIPTION
This is the follow-up to #13386. After some more discussions, we have identified, that all the resources we are giving memberships to, are mostly project-scoped. For all of the checks, it will be significantly easier to leave the `project_id` in the members table and optionally add the entity.

So, when a membership is to an entire project, we leave `entity = nil`.

---

Implements https://community.openproject.org/projects/openproject/work_packages/49492/activity
