### PR TITLE
fix wiki_contents with missing user as author

### DIFF
--- a/db/migrate/20230322135932_merge_wiki_content_into_page.rb
+++ b/db/migrate/20230322135932_merge_wiki_content_into_page.rb
@@ -26,6 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+require_relative './migration_utils/utils'
+
 class MergeWikiContentIntoPage < ActiveRecord::Migration[7.0]
   include ::Migration::Utils
 

--- a/db/migrate/20230322135932_merge_wiki_content_into_page.rb
+++ b/db/migrate/20230322135932_merge_wiki_content_into_page.rb
@@ -27,11 +27,14 @@
 #++
 
 class MergeWikiContentIntoPage < ActiveRecord::Migration[7.0]
+  include ::Migration::Utils
+
   def change
     add_contents_columns_to_pages
 
     reversible do |dir|
       dir.up do
+        change_null_values_on_contents
         update_wiki_pages_from_contents
         update_journals_to_pages
       end
@@ -76,11 +79,27 @@ class MergeWikiContentIntoPage < ActiveRecord::Migration[7.0]
     end
   end
 
+  def change_null_values_on_contents
+    execute_sql(
+      "
+        UPDATE wiki_contents SET author_id = :deleted_user_id
+        WHERE author_id NOT IN (SELECT id from users)
+      ",
+      deleted_user_id:
+    )
+  end
+
   def change_null_values_on_pages
     change_column_null :wiki_pages, :lock_version, false
 
-    WikiPage.where(author_id: nil).update_all(author_id: DeletedUser.first.id)
+    execute_sql("UPDATE wiki_pages SET author_id = :deleted_user_id WHERE author_id IS NULL", deleted_user_id:)
+
     change_column_null :wiki_pages, :author_id, false
+  end
+
+  def deleted_user_id
+    # We use the model to make sure one is created in case it doesn't exist yet
+    @deleted_user_id ||= DeletedUser.first.id
   end
 
   def rename_and_adapt_journal_data

--- a/db/migrate/migration_utils/utils.rb
+++ b/db/migrate/migration_utils/utils.rb
@@ -47,5 +47,24 @@ module Migration
         remove_index table_name, name: index_name
       end
     end
+
+    ##
+    # Executes the given SQL query while passing in sanitized parameters.
+    #
+    # @param query [String] SQL query including parameter references like `:param`
+    # @param params [Hash] Hash containing values for referenced parameters
+    #
+    # @raise [ActiveRecord::ActiveRecordError] If the query fails
+    # @return [PG::Result]
+    #
+    # Example:
+    #
+    #   execute_sql "select id from users where mail = :email", email: params[:email]
+    #
+    def execute_sql(query, params = {})
+      query = ActiveRecord::Base.sanitize_sql [query, params]
+
+      ActiveRecord::Base.connection.execute query
+    end
   end
 end


### PR DESCRIPTION
otherwise the migration will fail trying to insert wiki pages due to a foreign key constraint error like the following:

```
-- execute("UPDATE wiki_pages SET text = wiki_contents.text, author_id = wiki_contents.author_id, lock_version = wiki_contents.lock_version FROM wiki_contents WHERE wiki_contents.page_id = wiki_pages.id")
   (4.3ms)  UPDATE wiki_pages SET text = wiki_contents.text, author_id = wiki_contents.author_id, lock_version = wiki_contents.lock_version FROM wiki_contents WHERE wiki_contents.page_id = wiki_pages.id
  TRANSACTION (0.8ms)  ROLLBACK
   (1.0ms)  SELECT pg_advisory_unlock(2193071229178148760)
StandardError: An error has occurred, this and all later migrations canceled:

PG::ForeignKeyViolation: ERROR:  insert or update on table "wiki_pages" violates foreign key constraint "fk_rails_4189064f3f"
DETAIL:  Key (author_id)=(1) is not present in table "users".

from /home/ec2-user/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.6/lib/active_record/connection_adapters/postgresql/database_statements.rb:48:in `exec'
Caused by ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR:  insert or update on table "wiki_pages" violates foreign key constraint "fk_rails_4189064f3f"
DETAIL:  Key (author_id)=(1) is not present in table "users".

from /home/ec2-user/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.6/lib/active_record/connection_adapters/postgresql/database_statements.rb:48:in `exec'
Caused by PG::ForeignKeyViolation: ERROR:  insert or update on table "wiki_pages" violates foreign key constraint "fk_rails_4189064f3f"
DETAIL:  Key (author_id)=(1) is not present in table "users".
```