### PR TITLE
Turn query space directives into standalone directives

### DIFF
--- a/frontend/src/app/core/global_search/global-search-work-packages-entry.component.ts
+++ b/frontend/src/app/core/global_search/global-search-work-packages-entry.component.ts
@@ -27,6 +27,9 @@
 //++
 
 import { Component } from '@angular/core';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 export const globalSearchWorkPackagesSelectorEntry = 'global-search-work-packages-entry';
 
@@ -36,11 +39,8 @@ export const globalSearchWorkPackagesSelectorEntry = 'global-search-work-package
  */
 @Component({
   selector: globalSearchWorkPackagesSelectorEntry,
-  template: `
-    <ng-container wp-isolated-query-space>
-      <global-search-work-packages></global-search-work-packages>
-    </ng-container>
-  `,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
+  template: '<global-search-work-packages></global-search-work-packages>',
 })
 export class GlobalSearchWorkPackagesEntryComponent {
 }

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -64,6 +64,9 @@ import {
 } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { firstValueFrom } from 'rxjs';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 export interface DisabledButtonPlaceholder {
   text:string;
@@ -75,6 +78,7 @@ export interface DisabledButtonPlaceholder {
   templateUrl: './board-list.component.html',
   styleUrls: ['./board-list.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   providers: [
     { provide: WorkPackageInlineCreateService, useClass: BoardInlineCreateService },
     BoardListMenuComponent,

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -11,7 +11,6 @@
   >
     <div *ngFor="let boardWidget of boardWidgets; trackBy:trackByQueryId"
          class="boards-list--item"
-         wp-isolated-query-space
          cdkDrag
          [cdkDragData]="boardWidget"
     >

--- a/frontend/src/app/features/boards/boards-root/boards-root.component.ts
+++ b/frontend/src/app/features/boards/boards-root/boards-root.component.ts
@@ -7,10 +7,14 @@ import { QueryUpdatedService } from 'core-app/features/boards/board/query-update
 import { BoardAssigneeActionService } from 'core-app/features/boards/board/board-actions/assignee/assignee-action.service';
 import { BoardSubprojectActionService } from 'core-app/features/boards/board/board-actions/subproject/subproject-action.service';
 import { BoardSubtasksActionService } from 'core-app/features/boards/board/board-actions/subtasks/board-subtasks-action.service';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   selector: 'boards-entry',
-  template: '<ui-view wp-isolated-query-space></ui-view>',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
+  template: '<ui-view></ui-view>',
   providers: [
     BoardConfigurationService,
     BoardStatusActionService,

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
@@ -30,14 +30,20 @@ import { Component, Input, OnInit } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
+import {
+  WorkPackageRelationsHierarchyService,
+} from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
 import { take } from 'rxjs/operators';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   selector: 'wp-relations-hierarchy',
   templateUrl: './wp-relations-hierarchy.template.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
 })
 export class WorkPackageRelationsHierarchyComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackage:WorkPackageResource;

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.template.html
@@ -6,11 +6,9 @@
       </h3>
     </div>
   </div>
-  <ng-container wp-isolated-query-space>
-    <wp-children-query
-        [workPackage]="workPackage"
-        [addExistingChildEnabled]="true"
-        [query]="childrenQueryProps">
-    </wp-children-query>
-  </ng-container>
+  <wp-children-query
+    [workPackage]="workPackage"
+    [addExistingChildEnabled]="true"
+    [query]="childrenQueryProps">
+  </wp-children-query>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
@@ -94,7 +94,7 @@
     [attr.data-overflowing-identifier]="'.__overflowing_' + group.id"
     class="attributes-group __overflowing_element_container"
   >
-    <ng-container wp-isolated-query-space *ngIf="group.isolated">
+    <ng-container opWorkPackageIsolatedQuerySpace *ngIf="group.isolated">
       <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
                    [ndcDynamicInputs]="{ workPackage: workPackage,
                                          group: group,

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -36,15 +36,8 @@ import {
   OnInit,
 } from '@angular/core';
 import { StateService } from '@uirouter/core';
-import {
-  BehaviorSubject,
-  combineLatest,
-} from 'rxjs';
-import {
-  distinctUntilChanged,
-  first,
-  map,
-} from 'rxjs/operators';
+import { BehaviorSubject, combineLatest } from 'rxjs';
+import { distinctUntilChanged, first, map } from 'rxjs/operators';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table-entry.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table-entry.component.ts
@@ -2,18 +2,20 @@ import {
   Component, ElementRef, Input,
 } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 export const wpTableEntrySelector = 'wp-embedded-table-entry';
 
 @Component({
   selector: wpTableEntrySelector,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   template: `
-    <ng-container wp-isolated-query-space>
       <wp-embedded-table [queryProps]="queryProps"
                          [initialLoadingIndicator]="initialLoadingIndicator"
                          [configuration]="configuration">
       </wp-embedded-table>
-    </ng-container>
   `,
 })
 export class WorkPackageEmbeddedTableEntryComponent {

--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.component.ts
@@ -6,6 +6,9 @@ import { WpTableConfigurationService } from 'core-app/features/work-packages/com
 import { RestrictedWpTableConfigurationService } from 'core-app/features/work-packages/components/wp-table/external-configuration/restricted-wp-table-configuration.service';
 import { OpQueryConfigurationLocalsToken } from 'core-app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.constants';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 export interface QueryConfigurationLocals {
   service:any;
@@ -17,6 +20,7 @@ export interface QueryConfigurationLocals {
 
 @Component({
   templateUrl: './external-query-configuration.template.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   providers: [[{ provide: WpTableConfigurationService, useClass: RestrictedWpTableConfigurationService }]],
 })
 export class ExternalQueryConfigurationComponent implements OnInit, AfterViewInit {

--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.template.html
@@ -1,6 +1,4 @@
-<ng-container wp-isolated-query-space>
-  <wp-embedded-table #embeddedTableForConfiguration
-    [queryProps]="queryProps"
-    [configuration]="{ tableVisible: false }">
-  </wp-embedded-table>
-</ng-container>
+<wp-embedded-table #embeddedTableForConfiguration
+                   [queryProps]="queryProps"
+                   [configuration]="{ tableVisible: false }">
+</wp-embedded-table>

--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-relation-query-configuration.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-relation-query-configuration.component.ts
@@ -6,9 +6,13 @@ import { RestrictedWpTableConfigurationService } from 'core-app/features/work-pa
 import { WpTableConfigurationRelationSelectorComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector';
 import { WpTableConfigurationModalPrependToken } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal';
 import { ExternalQueryConfigurationComponent } from 'core-app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.component';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   templateUrl: './external-query-configuration.template.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   providers: [
     [
       { provide: WpTableConfigurationService, useClass: RestrictedWpTableConfigurationService },

--- a/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
@@ -26,47 +26,111 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Directive, ElementRef, Injector } from '@angular/core';
+import { Directive, ElementRef } from '@angular/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { OpTableActionsService } from 'core-app/features/work-packages/components/wp-table/table-actions/table-actions.service';
-import { WorkPackageViewRelationColumnsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service';
-import { WorkPackageViewPaginationService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service';
-import { WorkPackageViewGroupByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
-import { WorkPackageViewHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
-import { WorkPackageViewSortByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service';
-import { WorkPackageViewColumnsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service';
-import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
-import { WorkPackageViewTimelineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service';
-import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
-import { WorkPackageViewSumService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sum.service';
-import { WorkPackageViewAdditionalElementsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service';
-import { WorkPackageViewHighlightingService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service';
+import {
+  OpTableActionsService,
+} from 'core-app/features/work-packages/components/wp-table/table-actions/table-actions.service';
+import {
+  WorkPackageViewRelationColumnsService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service';
+import {
+  WorkPackageViewPaginationService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service';
+import {
+  WorkPackageViewGroupByService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
+import {
+  WorkPackageViewHierarchiesService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
+import {
+  WorkPackageViewSortByService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service';
+import {
+  WorkPackageViewColumnsService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service';
+import {
+  WorkPackageViewFiltersService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
+import {
+  WorkPackageViewTimelineService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service';
+import {
+  WorkPackageViewSelectionService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
+import {
+  WorkPackageViewSumService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sum.service';
+import {
+  WorkPackageViewAdditionalElementsService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service';
+import {
+  WorkPackageViewHighlightingService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service';
 import { WorkPackageCreateService } from 'core-app/features/work-packages/components/wp-new/wp-create.service';
-import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
-import { WorkPackageViewFocusService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
-import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
+import {
+  WorkPackageStatesInitializationService,
+} from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
+import {
+  WorkPackageViewFocusService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
+import {
+  HalResourceEditingService,
+} from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { WorkPackagesListService } from 'core-app/features/work-packages/components/wp-list/wp-list.service';
-import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
-import { WorkPackageFiltersService } from 'core-app/features/work-packages/components/filters/wp-filters/wp-filters.service';
-import { WorkPackageContextMenuHelperService } from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
-import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
-import { WpChildrenInlineCreateService } from 'core-app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service';
-import { WpRelationInlineCreateService } from 'core-app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service';
-import { WorkPackagesListChecksumService } from 'core-app/features/work-packages/components/wp-list/wp-list-checksum.service';
+import {
+  WorkPackageRelationsHierarchyService,
+} from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
+import {
+  WorkPackageFiltersService,
+} from 'core-app/features/work-packages/components/filters/wp-filters/wp-filters.service';
+import {
+  WorkPackageContextMenuHelperService,
+} from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import {
+  WorkPackageInlineCreateService,
+} from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
+import {
+  WpChildrenInlineCreateService,
+} from 'core-app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service';
+import {
+  WpRelationInlineCreateService,
+} from 'core-app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service';
+import {
+  WorkPackagesListChecksumService,
+} from 'core-app/features/work-packages/components/wp-list/wp-list-checksum.service';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
-import { TableDragActionsRegistryService } from 'core-app/features/work-packages/components/wp-table/drag-and-drop/actions/table-drag-actions-registry.service';
-import { WorkPackageViewOrderService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service';
+import {
+  TableDragActionsRegistryService,
+} from 'core-app/features/work-packages/components/wp-table/drag-and-drop/actions/table-drag-actions-registry.service';
+import {
+  WorkPackageViewOrderService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service';
 import { CausedUpdatesService } from 'core-app/features/boards/board/caused-updates/caused-updates.service';
-import { WorkPackageCardViewService } from 'core-app/features/work-packages/components/wp-card-view/services/wp-card-view.service';
-import { WorkPackageViewDisplayRepresentationService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-display-representation.service';
-import { WorkPackageViewIncludeSubprojectsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-include-subprojects.service';
-import { WorkPackageViewHierarchyIdentationService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service';
+import {
+  WorkPackageCardViewService,
+} from 'core-app/features/work-packages/components/wp-card-view/services/wp-card-view.service';
+import {
+  WorkPackageViewDisplayRepresentationService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-display-representation.service';
+import {
+  WorkPackageViewIncludeSubprojectsService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-include-subprojects.service';
+import {
+  WorkPackageViewHierarchyIdentationService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
-import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
+import {
+  WorkPackageNotificationService,
+} from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { TimeEntryCreateService } from 'core-app/shared/components/time_entries/create/create.service';
-import { WorkPackageViewCollapsedGroupsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service';
+import {
+  WorkPackageViewCollapsedGroupsService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service';
 import { WorkPackageService } from 'core-app/features/work-packages/services/work-package.service';
-import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service';
+import {
+  WorkPackageViewBaselineService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service';
 import { TimeEntryEditService } from 'core-app/shared/components/time_entries/edit/edit.service';
 
 /**
@@ -77,7 +141,8 @@ import { TimeEntryEditService } from 'core-app/shared/components/time_entries/ed
  * in a module.
  */
 @Directive({
-  selector: '[wp-isolated-query-space]',
+  standalone: true,
+  selector: '[opWorkPackageIsolatedQuerySpace]',
   providers: [
     // Override the hal notification service
     { provide: HalResourceNotificationService, useExisting: WorkPackageNotificationService },
@@ -135,9 +200,10 @@ import { TimeEntryEditService } from 'core-app/shared/components/time_entries/ed
   ],
 })
 export class WorkPackageIsolatedQuerySpaceDirective {
-  constructor(private elementRef:ElementRef,
+  constructor(
     public querySpace:IsolatedQuerySpace,
-    private injector:Injector) {
-    debugLog('Opening isolated query space %O in %O', injector, elementRef.nativeElement);
+    elementRef:ElementRef,
+  ) {
+    debugLog('Opening isolated query space in %O', elementRef.nativeElement);
   }
 }

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -217,6 +217,8 @@ import { RecentItemsService } from 'core-app/core/recent-items.service';
     EditFieldControlsModule,
     OpenprojectTabsModule,
     OpenprojectStoragesModule,
+
+    WorkPackageIsolatedQuerySpaceDirective,
   ],
   providers: [
     // Notification service
@@ -263,10 +265,6 @@ import { RecentItemsService } from 'core-app/core/recent-items.service';
     // WP list side
     WorkPackageListViewComponent,
     WorkPackageSettingsButtonComponent,
-
-    // Query injector isolation
-    WorkPackageIsolatedQuerySpaceDirective,
-    WorkPackageIsolatedGraphQuerySpaceDirective,
 
     // WP New
     WorkPackageNewFullViewComponent,
@@ -439,8 +437,6 @@ import { RecentItemsService } from 'core-app/core/recent-items.service';
     WorkPackageSingleCardComponent,
     WorkPackageFilterButtonComponent,
     WorkPackageFilterContainerComponent,
-    WorkPackageIsolatedQuerySpaceDirective,
-    WorkPackageIsolatedGraphQuerySpaceDirective,
     QueryFiltersComponent,
 
     WpResizerDirective,

--- a/frontend/src/app/features/work-packages/routing/wp-base/wp--base.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-base/wp--base.component.ts
@@ -29,13 +29,17 @@
 import { Component } from '@angular/core';
 import { EditFormRoutingService } from 'core-app/shared/components/fields/edit/edit-form/edit-form-routing.service';
 import { WorkPackageEditFormRoutingService } from 'core-app/features/work-packages/routing/wp-edit-form/wp-edit-form-routing.service';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 export const wpBaseSelector = 'work-packages-base';
 
 @Component({
   selector: wpBaseSelector,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   template: `
-    <div class="work-packages-page--ui-view" wp-isolated-query-space>
+    <div class="work-packages-page--ui-view">
       <ui-view></ui-view>
     </div>
   `,

--- a/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
@@ -1,14 +1,11 @@
 <widget-header
-    [name]="widgetName"
-    (onRenamed)="renameWidget($event)">
+  [name]="widgetName"
+  (onRenamed)="renameWidget($event)">
 
   <widget-menu
-      slot="menu"
-      [resource]="resource">
+    slot="menu"
+    [resource]="resource">
   </widget-menu>
 </widget-header>
 
-<ng-container wp-isolated-query-space>
-  <op-wp-calendar
-      [static]="true"></op-wp-calendar>
-</ng-container>
+<op-wp-calendar [static]="true"></op-wp-calendar>

--- a/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.ts
@@ -26,13 +26,18 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector } from '@angular/core';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-calendar.component.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
 })
 export class WidgetWpCalendarComponent extends AbstractWidgetComponent {
   constructor(protected readonly i18n:I18nService,

--- a/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table-qs.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table-qs.component.html
@@ -1,4 +1,2 @@
-<ng-container wp-isolated-query-space class="op-wp-table-qs">
-  <widget-wp-table [resource]="resource"
-                   (resourceChanged)="onResourceChanged($event)"> </widget-wp-table>
-</ng-container>
+<widget-wp-table [resource]="resource"
+                 (resourceChanged)="onResourceChanged($event)"></widget-wp-table>

--- a/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table.component.ts
@@ -21,12 +21,16 @@ import {
   skip,
 } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   selector: 'widget-wp-table',
   templateUrl: './wp-table.component.html',
   styleUrls: ['./wp-table.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
 })
 export class WidgetWpTableComponent extends AbstractWidgetComponent implements OnInit {
   public queryId:string|null;

--- a/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
+++ b/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
@@ -1,5 +1,5 @@
 <div
-  class="op-wp-preview-modal" wp-isolated-query-space
+  class="op-wp-preview-modal"
   *ngIf="workPackage"
 >
    <wp-single-card

--- a/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
+++ b/frontend/src/app/shared/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
@@ -50,11 +50,15 @@ import {
   Placement,
   shift,
 } from '@floating-ui/dom';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   templateUrl: './wp-preview.modal.html',
   styleUrls: ['./wp-preview.modal.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
 })
 export class WpPreviewModalComponent extends OpModalComponent implements OnInit {
   public workPackage:WorkPackageResource;

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.html
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.html
@@ -1,3 +1,1 @@
-<ng-container wp-isolated-query-space>
-  <op-filters-tab-inner #tabInner></op-filters-tab-inner>
-</ng-container>
+<op-filters-tab-inner #tabInner></op-filters-tab-inner>

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component.ts
@@ -1,9 +1,13 @@
 import { Component, ViewChild } from '@angular/core';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   selector: 'op-wp-graph-configuration-filters-tab',
   templateUrl: './filters-tab.component.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective], // TODO replace
 })
 export class WpGraphConfigurationFiltersTabComponent implements TabComponent {
   @ViewChild('tabInner', { static: true })

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.html
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.html
@@ -1,4 +1,1 @@
-<ng-container wp-isolated-query-space>
-  <op-settings-tab-inner #tabInner></op-settings-tab-inner>
-</ng-container>
-
+<op-settings-tab-inner #tabInner></op-settings-tab-inner>

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component.ts
@@ -1,9 +1,13 @@
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { Component, ViewChild } from '@angular/core';
+import {
+  WorkPackageIsolatedQuerySpaceDirective,
+} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   selector: 'op-wp-graph-configuration-settings-tab',
   templateUrl: './settings-tab.component.html',
+  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
 })
 export class WpGraphConfigurationSettingsTabComponent implements TabComponent {
   @ViewChild('tabInner', { static: true })


### PR DESCRIPTION
This allows us to use `hostDirectives` and avoid wrapping all these components into ng-containers or entry components.