### PR TITLE
[#49607] PDF Export report fails with with an empty table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,8 +152,8 @@ gem 'structured_warnings', '~> 0.4.0'
 # don't require by default, instead load on-demand when actually configured
 gem 'airbrake', '~> 13.0.0', require: false
 
-gem 'prawn', '~> 2.2'
-gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '76945d45c14b841e2312f992422e2631a4524114'
+gem 'prawn', '~> 2.4'
+gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: 'cc286655dfa2ea2b30bf2a149063f42f7081aa3d'
 # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
 gem 'matrix', '~> 0.4.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 76945d45c14b841e2312f992422e2631a4524114
-  ref: 76945d45c14b841e2312f992422e2631a4524114
+  revision: cc286655dfa2ea2b30bf2a149063f42f7081aa3d
+  ref: cc286655dfa2ea2b30bf2a149063f42f7081aa3d
   specs:
-    md_to_pdf (0.0.19)
+    md_to_pdf (0.0.20)
       commonmarker (~> 0.23)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.0)
@@ -1116,7 +1116,7 @@ DEPENDENCIES
   pdf-inspector (~> 1.2)
   pg (~> 1.5.0)
   plaintext (~> 0.3.2)
-  prawn (~> 2.2)
+  prawn (~> 2.4)
   pry-byebug (~> 3.10.0)
   pry-rails (~> 0.3.6)
   pry-rescue (~> 1.5.2)


### PR DESCRIPTION
bump `md-to-pdf` to v0.0.20 which [fixes](https://github.com/opf/md-to-pdf/commit/a145cc98af6bbd59cc381bc843784decd020a1ad) the error (and adds a test for it)

https://community.openproject.org/work_packages/49607