### PR TITLE
fix: Make activity page columns the same width

### DIFF
--- a/app/views/placeholder_users/show.html.erb
+++ b/app/views/placeholder_users/show.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 <% end %>
 
-<div class="grid-block medium-up-2">
+<div class="grid-block grid-block_double-column">
   <div class="grid-content">
     <%= call_hook :view_account_left_top, placeholder_user: @placeholder_user %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
 <% end %>
-<div class="grid-block medium-up-2">
+<div class="grid-block grid-block_double-column">
   <div class="grid-content">
     <%= call_hook :view_account_left_top, user: @user %>
     <% if visible_user_information?(@user) %>

--- a/frontend/src/global_styles/layout/_grid.sass
+++ b/frontend/src/global_styles/layout/_grid.sass
@@ -262,6 +262,15 @@ $block-grid-max-size: 6 !default
     &, .grid-content
       overflow: visible
 
+  &_double-column
+    flex-wrap: wrap
+
+    > .grid-content
+      min-width: 300px
+      flex-basis: 50%
+      flex-shrink: 0
+      flex-grow: 1
+
 .grid-content
   @extend %child-core
   @include grid-content


### PR DESCRIPTION
When having long texts in the changes column, it could take up a ton of space, making the projects column very narrow. This commit hardcodes the widths to be 50% each.

This commit also fixes mobile by wrapping the two columns if there isn't enough horizontal space.

Ref: https://community.openproject.org/projects/openproject/work_packages/49595/activity