### PR TITLE
[#48246] Fix message phrasing used in "Merged" PR Activity Comments

### DIFF
--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -49,6 +49,7 @@ en:
       github_actions: Actions
       pull_requests:
         message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} has been %{pr_state}."
+        merged_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} has been %{pr_state} by %{github_user_link}."
         referenced_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} referenced this work package."
         states:
           opened: 'opened'

--- a/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
@@ -90,7 +90,7 @@ export class PullRequestMacroComponent implements OnInit {
     const repositoryLink = this.htmlLink(pr.repositoryHtmlUrl, pr.repository);
     const prLink = this.htmlLink(pr.htmlUrl, pr.title);
 
-    const message = this.pullRequestState === 'referenced' ? 'referenced_message' : 'message';
+    const message = this.deriveMessage();
     return this.I18n.t(
       `js.github_integration.pull_requests.${message}`,
       {
@@ -113,6 +113,16 @@ export class PullRequestMacroComponent implements OnInit {
     } else {
       return pr._embedded.githubUser;
     }
+  }
+
+  private deriveMessage() {
+    if (this.pullRequestState === 'referenced') {
+      return 'referenced_message';
+    } else if (this.pullRequestState === 'merged') {
+      return 'merged_message';
+    }
+
+    return 'message';
   }
 
   private htmlLink(href:string, title:string):string {

--- a/modules/github_integration/spec/features/work_package_activity_spec.rb
+++ b/modules/github_integration/spec/features/work_package_activity_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Work Package Activity Tab',
 
       it 'renders a comment stating the Pull Request was merged by the merge actor' do
         expected_merge_comment = <<~GITHUB_MERGE_COMMENT.squish
-          Merged#{I18n.t('js.github_integration.pull_requests.message',
+          Merged#{I18n.t('js.github_integration.pull_requests.merged_message',
                          pr_number: pull_request.number,
                          pr_link: pull_request.title,
                          repository_link: pull_request.repository,


### PR DESCRIPTION
## Bug description
The message used for **Merged** PR status comments doesn't really fit in with the standard message. We can leverage the `merged_by` user but with an appropriate phrasing.

## Demo screenshot
I went with what I felt read nicely. If there's another suggestion for what the phrasing could be, I'm open for it :)
![image](https://github.com/opf/openproject/assets/61627014/1da132e4-a930-4aa1-9457-8ae2d2a36dc7)

## Notes
This PR is following up on https://github.com/opf/openproject/pull/13358. 
See the related Work Package: https://community.openproject.org/work_packages/48246