### PR TITLE
[chore] fixed some holes in docker TLS support guide

### DIFF
--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -5,8 +5,13 @@ services:
       OPENPROJECT_CLI_PROXY: '${OPENPROJECT_DEV_URL}'
       OPENPROJECT_DEV_EXTRA_HOSTS: '${OPENPROJECT_DEV_HOST}'
       OPENPROJECT_HTTPS: true
+      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
     networks:
       - external
+    volumes:
+      # This volume mount is the usual volume mount for a linux environment.
+      # It must be amended accordingly to OS.
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
 
   frontend:
     networks:

--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -234,8 +234,8 @@ and `443` and redirect those requests to the specific container. To make it happ
 define for your services to your `/etc/hosts`.
 
 ```shell
-127.0.0.1   openproject.local traefik.local step.local
-::1         openproject.local traefik.local step.local
+127.0.0.1   openproject.local traefik.local
+::1         openproject.local traefik.local
 ```
 
 #### DNS? Where are you?


### PR DESCRIPTION
I detected those holes in the docker dev env with TLS guide.