### PR TITLE
Add circuit breakers for leaving focused specs in suite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -220,6 +220,10 @@ RSpec/DescribeMethod:
 RSpec/FilePath:
   SpecSuffixOnly: true
 
+# Prevent  "fit" or similar to be committed
+RSpec/Focus:
+  Enabled: true
+
 # We use let!() to ensure dependencies are created
 # instead of let() and referencing them explicitly
 RSpec/LetSetup:

--- a/app/models/work_packages/relations.rb
+++ b/app/models/work_packages/relations.rb
@@ -30,14 +30,14 @@ module WorkPackages::Relations
   included do
     # All relations of the work package in both directions.
     # Mostly used to have the relations destroyed upon destruction of the work package.
-    # rubocop:disable Rails:InverseOf
+    # rubocop:disable Rails/InverseOf
     has_many :relations,
              ->(work_package) {
                unscope(:where)
                  .of_work_package(work_package)
              },
              dependent: :destroy
-    # rubocop:enable Rails:InverseOf
+    # rubocop:enable Rails/InverseOf
 
     # Relations where the current work package follows another one.
     # In this case,

--- a/config/initializers/03-db_check.rb
+++ b/config/initializers/03-db_check.rb
@@ -46,7 +46,7 @@ if (db_config = ActiveRecord::Base.configurations.configs_for(env_name: env)[0])
     ==============================================
   ERROR
 
-  # rubocop:disable Rails:Exit
+  # rubocop:disable Rails/Exit
   Kernel.exit 1
-  # rubocop:enable Rails:Exit
+  # rubocop:enable Rails/Exit
 end

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -27,10 +27,9 @@
 #++
 
 require 'spec_helper'
-require_relative './../support//board_index_page'
-require_relative './../support/board_page'
+require_relative '../support//board_index_page'
+require_relative '../support/board_page'
 
-# rubocop:disable RSpec:MultipleMemoizedHelpers
 RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
   let(:user) do
     create(:user,
@@ -97,7 +96,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       login_as(user)
     end
 
-    fit 'allows management of boards' do
+    it 'allows management of boards' do
       board_page = create_new_version_board
 
       board_page.expect_card 'Open version', work_package.subject, present: true
@@ -140,7 +139,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       # Expect work package to be saved in query first
       subjects = WorkPackage.where(id: first.ordered_work_packages.pluck(:work_package_id)).pluck(:subject, :version_id)
       # Only the explicitly added item is now contained in sort order
-      expect(subjects).to match_array [['Task 1', open_version.id]]
+      expect(subjects).to contain_exactly(['Task 1', open_version.id])
 
       # Move item to Closed
       board_page.move_card(0, from: 'Open version', to: 'A second version')
@@ -155,7 +154,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       end
 
       subjects = WorkPackage.where(id: second.ordered_work_packages.pluck(:work_package_id)).pluck(:subject, :version_id)
-      expect(subjects).to match_array [['Task 1', other_version.id]]
+      expect(subjects).to contain_exactly(['Task 1', other_version.id])
 
       # Add filter
       # Filter for Task
@@ -206,7 +205,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       board_page.expect_card('A second version', 'Task 1', present: true)
 
       subjects = WorkPackage.where(id: second.ordered_work_packages.pluck(:work_package_id)).pluck(:subject, :version_id)
-      expect(subjects).to match_array [['Task 1', other_version.id]]
+      expect(subjects).to contain_exactly(['Task 1', other_version.id])
 
       # Open remaining in split view
       work_package = second.ordered_work_packages.first.work_package
@@ -285,7 +284,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       end
 
       ids = open.ordered_work_packages.pluck(:work_package_id)
-      expect(ids).to match_array [work_package.id, closed_version_wp.id]
+      expect(ids).to contain_exactly(work_package.id, closed_version_wp.id)
 
       closed_version_wp.reload
       expect(closed_version_wp.version_id).to eq(open_version.id)
@@ -305,7 +304,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
     end
   end
 
-  context 'a user with edit_work_packages, but missing assign_versions permissions' do
+  context 'when user has edit_work_packages, but missing assign_versions permissions' do
     let(:no_version_edit_user) do
       create(:user,
              member_in_projects: [project],
@@ -348,4 +347,3 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
     end
   end
 end
-# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -28,7 +28,6 @@
 
 require 'spec_helper'
 
-# rubocop:disable RSpec:MultipleMemoizedHelpers
 RSpec.describe 'Projects copy', :with_cuprite, js: true do
   describe 'with a full copy example' do
     let!(:project) do
@@ -232,12 +231,15 @@ RSpec.describe 'Projects copy', :with_cuprite, js: true do
 
       expect(ActionMailer::Base.deliveries.count).to eql(1)
       expect(ActionMailer::Base.deliveries.last.subject).to eql("Created project Copied project")
-      expect(ActionMailer::Base.deliveries.last.to).to match_array([user.mail])
+      expect(ActionMailer::Base.deliveries.last.to).to contain_exactly(user.mail)
     end
   end
 
   describe 'copying a set of ordered work packages' do
     let(:user) { create(:admin) }
+    let(:wp_table) { Pages::WorkPackagesTable.new project }
+    let(:copied_project) { Project.find_by(name: 'Copied project') }
+    let(:copy_wp_table) { Pages::WorkPackagesTable.new copied_project }
     let(:project) { create(:project, types: [type]) }
     let(:type) { create(:type) }
     let(:status) { create(:status) }
@@ -272,11 +274,6 @@ RSpec.describe 'Projects copy', :with_cuprite, js: true do
       login_as user
     end
 
-    let(:wp_table) { Pages::WorkPackagesTable.new project }
-
-    let(:copied_project) { Project.find_by(name: 'Copied project') }
-    let(:copy_wp_table) { Pages::WorkPackagesTable.new copied_project }
-
     it 'copies them in the same order' do
       wp_table.visit!
       wp_table.expect_work_package_listed *order
@@ -304,4 +301,3 @@ RSpec.describe 'Projects copy', :with_cuprite, js: true do
     end
   end
 end
-# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/services/relations/create_service_spec.rb
+++ b/spec/services/relations/create_service_spec.rb
@@ -28,7 +28,6 @@
 
 require 'spec_helper'
 
-# rubocop:disable RSpec:MultipleMemoizedHelpers
 RSpec.describe Relations::CreateService do
   let(:work_package1_start_date) { nil }
   let(:work_package1_due_date) { Date.today }
@@ -143,7 +142,7 @@ RSpec.describe Relations::CreateService do
 
     it 'has a dependent result for the from-work package' do
       expect(subject.dependent_results)
-        .to match_array [set_schedule_work_package2_result]
+        .to contain_exactly(set_schedule_work_package2_result)
     end
   end
 
@@ -210,6 +209,7 @@ RSpec.describe Relations::CreateService do
 
     context 'on a circular_dependency error' do
       let(:symbols_for_base) { [:'typed_dag.circular_dependency'] }
+
       before do
         allow(relation)
           .to receive(:save) do
@@ -267,4 +267,3 @@ RSpec.describe Relations::CreateService do
     end
   end
 end
-# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,13 +74,6 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.

--- a/spec/support/focused_spec_circuit_breaker.rb
+++ b/spec/support/focused_spec_circuit_breaker.rb
@@ -1,0 +1,15 @@
+##
+# Add circuit breakers for CI builds, such as focused specs
+# that somehow elude linting
+RSpec.configure do |config|
+  if ENV["CI"]
+    config.before(:example, :focus) { |example| raise "Found focused example at #{example.location}" }
+  else
+    # This allows you to limit a spec run to individual examples or groups
+    # you care about by tagging them with `:focus` metadata. When nothing
+    # is tagged with `:focus`, all examples get run. RSpec also provides
+    # aliases for `it`, `describe`, and `context` that include `:focus`
+    # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+    config.filter_run_when_matching :focus
+  end
+end


### PR DESCRIPTION
I found a focused example fit in boards that eluded the rubocop rule that we had active already. Debugging into rubocop I was very confused at first, since the cop appears to be manually disabled. It's this line here:

https://github.com/opf/openproject/pull/13453/files#diff-9e4bb023e0a57a8ff8a904ffeb2b003ffe509910505061d46e0e1481ddfb37bdR99

It was this line that caused it: https://github.com/opf/openproject/pull/13453/files#diff-9e4bb023e0a57a8ff8a904ffeb2b003ffe509910505061d46e0e1481ddfb37bdL33
`# rubocop:disable RSpec:MultipleMemoizedHelpers -> # rubocop:disable RSpec/MultipleMemoizedHelpers.`
 rubocop just disables all cops within the wrong syntax
I added a circuit breaker for CI to check for focused specs and raise an exception instead, so we don't have to rely on linting alone