### PR TITLE
Fix trailing slash by fixing optional_project route

### DIFF
--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -78,13 +78,13 @@ export const OPENPROJECT_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'optional_project',
     parent: 'root',
-    url: '/{projects}/{projectPath}',
+    url: '/{projects:(?:projects)}/{projectPath}',
     abstract: true,
     params: {
       // value: null makes the parameter optional
       // squash: true avoids duplicate slashes when the parameter is not provided
       projectPath: { type: 'path', value: null, squash: true },
-      projects: { type: 'path', value: null, squash: true },
+      projects: { value: null, squash: true },
     },
     views: {
       '!$default': { component: ApplicationBaseComponent },

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -29,8 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Work package navigation', js: true, selenium: true do
-  let(:user) { create(:admin) }
-  let(:project) { create(:project, name: 'Some project', enabled_module_names: [:work_package_tracking]) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project, name: 'Some project', enabled_module_names: [:work_package_tracking]) }
   let(:work_package) { build(:work_package, project:) }
   let(:global_html_title) { Components::HtmlTitle.new }
   let(:project_html_title) { Components::HtmlTitle.new project }
@@ -39,7 +39,7 @@ RSpec.describe 'Work package navigation', js: true, selenium: true do
     "#{work_package.type.name}: #{work_package.subject} (##{work_package.id})"
   end
 
-  let!(:query) do
+  shared_let(:query) do
     query = build(:query, user:, project:)
     query.column_names = %w(id subject)
     query.name = "My fancy query"
@@ -154,6 +154,15 @@ RSpec.describe 'Work package navigation', js: true, selenium: true do
 
     visit "/projects/#{project.identifier}/work_packages/999999999"
     page404.expect_and_dismiss_toaster type: :error, message: I18n.t('api_v3.errors.not_found.work_package')
+  end
+
+  it 'loading a work package with trailing slash (Regression #49672)' do
+    work_package.subject = 'Foobar'
+    work_package.save!
+    visit "/work_packages/#{work_package.id}/"
+
+    wp_page = Pages::FullWorkPackage.new(work_package)
+    wp_page.expect_subject
   end
 
   # Regression #29994


### PR DESCRIPTION
Optional project route allows the same route to be accessed by

/work_packages/xyz
and
/projects/abc/work_packages/xyz

However, with a trailing slash, the route /work_packages/xyz/ was matched for projects A simple regex condition fixes that

https://community.openproject.org/work_packages/49672