### PR TITLE
[#49673] Limit members check icon to automatically managed project folders

### DIFF
--- a/modules/storages/app/components/storages/project_storages/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/row_component.rb
@@ -51,7 +51,9 @@ module Storages::ProjectStorages
 
     def button_links
       [edit_link, delete_link].tap do |links|
-        links.unshift members_check_link if OpenProject::FeatureDecisions.storage_project_members_check_active?
+        if OpenProject::FeatureDecisions.storage_project_members_check_active? && project_storage.project_folder_automatic?
+          links.unshift members_check_link
+        end
       end
     end
 

--- a/modules/storages/spec/components/project_storages/row_component_spec.rb
+++ b/modules/storages/spec/components/project_storages/row_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Storages::ProjectStorages::RowComponent,
+               type: :component,
+               with_flag: { storage_project_members_check: true } do
+  describe '#button_links' do
+    context 'with non-automatic project storage' do
+      it 'renders edit and delete buttons' do
+        project_storage = build_stubbed(:project_storage)
+        expect(project_storage).not_to be_project_folder_automatic
+
+        table = instance_double(Storages::ProjectStorages::TableComponent, columns: [])
+        component = described_class.new(row: project_storage, table:)
+
+        render_inline(component)
+
+        expect(page).not_to have_css('a.icon.icon-group')
+        expect(page).to have_css('a.icon.icon-edit')
+        expect(page).to have_css('a.icon.icon-delete')
+      end
+    end
+
+    context 'with automatic project storage' do
+      it 'renders members check, edit and delete buttons' do
+        project_storage = build_stubbed(:project_storage, :as_automatically_managed)
+        expect(project_storage).to be_project_folder_automatic
+
+        table = instance_double(Storages::ProjectStorages::TableComponent, columns: [])
+        component = described_class.new(row: project_storage, table:)
+
+        render_inline(component)
+
+        expect(page).to have_css('a.icon.icon-group')
+        expect(page).to have_css('a.icon.icon-edit')
+        expect(page).to have_css('a.icon.icon-delete')
+      end
+    end
+  end
+end

--- a/modules/storages/spec/factories/project_storage_factory.rb
+++ b/modules/storages/spec/factories/project_storage_factory.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
     project factory: :project
     project_folder_id { nil }
     project_folder_mode { 'inactive' }
+
+    trait :as_automatically_managed do
+      project_folder_mode { 'automatic' }
+    end
   end
 end

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe(
 
   let!(:storage) { create_nextcloud_storage_with_oauth_application }
   let!(:project) { create_project_with_storage_and_members }
-  let!(:project_storage) { create(:project_storage, project:, storage:) }
+  let!(:project_storage) { create(:project_storage, :as_automatically_managed, project:, storage:) }
   let(:oauth_client) { create(:oauth_client, integration: storage) }
 
   before do
@@ -80,7 +80,7 @@ RSpec.describe(
   it 'lists no results when there are no project members' do
     login_as admin_user
     project_no_members = create(:project, enabled_module_names: %i[storages])
-    project_storage_no_members = create(:project_storage, project: project_no_members, storage:)
+    project_storage_no_members = create(:project_storage, :as_automatically_managed, project: project_no_members, storage:)
 
     # Go to Projects -> Settings -> File Storages
     visit project_settings_project_storages_path(project_no_members)


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/49673

Only the icon is hidden. If the user manually accesses the UI, then all members will read as "Not Connected".

This follows #13340 

![Screenshot 2023-08-14 at 5 41 19 PM](https://github.com/opf/openproject/assets/17295175/3c24646d-ec27-4fca-adb5-49f4caefa4ae)
