### PR TITLE
Fix and standardize board routes

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -71,7 +71,7 @@ function startTour(steps:OnboardingStep[]) {
 }
 
 function moduleVisible(name:string):boolean {
-  return document.getElementsByClassName(`${name}-view-menu-item`).length > 0;
+  return document.getElementsByClassName(`${name}-menu-item`).length > 0;
 }
 
 function mainTour(project:ProjectName = ProjectName.demo) {
@@ -88,15 +88,15 @@ function mainTour(project:ProjectName = ProjectName.demo) {
     if (eeTokenAvailable) {
       // ... and available seed data of boards.
       // Then add boards to the tour, otherwise skip it.
-      if (boardsDemoDataAvailable && moduleVisible('board')) {
+      if (boardsDemoDataAvailable && moduleVisible('boards')) {
         steps = steps.concat(boardTourSteps('enterprise', project));
       }
 
       // ... same for team planners
-      if (teamPlannerDemoDataAvailable && moduleVisible('team-planner')) {
+      if (teamPlannerDemoDataAvailable && moduleVisible('team-planner-view')) {
         steps = steps.concat(teamPlannerTourSteps());
       }
-    } else if (boardsDemoDataAvailable && moduleVisible('board')) {
+    } else if (boardsDemoDataAvailable && moduleVisible('boards')) {
       steps = steps.concat(boardTourSteps('basic', project));
     }
 

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -16,11 +16,11 @@ export function boardTourSteps(edition:'basic'|'enterprise', project:ProjectName
 
   return [
     {
-      'next .boards-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
+      'next #boards-wrapper>.boards-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       onNext() {
-        jQuery('.boards-menu-item ~ .toggler')[0].click();
+        jQuery('#boards-wrapper>.boards-menu-item ~ .toggler')[0].click();
         waitForElement(
           '.op-sidemenu--item-action',
           '#main-menu',

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -16,11 +16,11 @@ export function boardTourSteps(edition:'basic'|'enterprise', project:ProjectName
 
   return [
     {
-      'next .board-view-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
+      'next .boards-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       onNext() {
-        jQuery('.board-view-menu-item ~ .toggler')[0].click();
+        jQuery('.boards-menu-item ~ .toggler')[0].click();
         waitForElement(
           '.op-sidemenu--item-action',
           '#main-menu',

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
@@ -79,7 +79,7 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
     // When activating the boards submenu,
     // either initially or through click on the toggle, load the results
     this.mainMenuService
-      .onActivate('board_view')
+      .onActivate('boards')
       .subscribe(() => {
         this.focusBackArrow();
         void this.boardService.loadAllBoards();
@@ -91,7 +91,7 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
   }
 
   private focusBackArrow():void {
-    const buttonArrowLeft = jQuery('*[data-name="board_view"] .main-menu--arrow-left-to-project');
+    const buttonArrowLeft = jQuery('*[data-name="boards"] .main-menu--arrow-left-to-project');
     buttonArrowLeft.focus();
   }
 }

--- a/frontend/src/app/features/boards/openproject-boards.routes.ts
+++ b/frontend/src/app/features/boards/openproject-boards.routes.ts
@@ -33,7 +33,7 @@ import { BoardListContainerComponent } from 'core-app/features/boards/board/boar
 import { makeSplitViewRoutes } from 'core-app/features/work-packages/routing/split-view-routes.template';
 import { WorkPackageSplitViewComponent } from 'core-app/features/work-packages/routing/wp-split-view/wp-split-view.component';
 
-export const menuItemClass = 'board-view-menu-item';
+export const menuItemClass = 'boards-menu-item';
 
 export const BOARDS_ROUTES:Ng2StateDeclaration[] = [
   {

--- a/modules/boards/app/views/boards/boards/new.html.erb
+++ b/modules/boards/app/views/boards/boards/new.html.erb
@@ -32,6 +32,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= labelled_tabular_form_for @board_grid, url: { controller: '/boards/boards', action: 'create', project_id: @project }, :html => {:id => 'board-form'} do |f| -%>
   <%= render :partial => 'form', :locals => {:f => f} %>
   <%= styled_button_tag t(:button_create), class: '-highlight' %>
-  <%= link_to t(:button_cancel), { controller: 'boards/boards', action: (@project ? 'index' : 'overview') },
+  <%= link_to t(:button_cancel), { controller: 'boards/boards', action: :index },
               class: 'button' %>
 <% end %>

--- a/modules/boards/config/routes.rb
+++ b/modules/boards/config/routes.rb
@@ -1,15 +1,15 @@
 OpenProject::Application.routes.draw do
-  get '/boards/all', to: 'boards/boards#overview'
-
   resources :boards,
             controller: 'boards/boards',
-            only: %i[index show new create destroy],
+            only: %i[index new create destroy],
             as: :work_package_boards
 
   scope 'projects/:project_id', as: 'project' do
     resources :boards,
               controller: 'boards/boards',
               only: %i[index show new create],
-              as: :work_package_boards
+              as: :work_package_boards do
+      get '(/*state)' => 'boards/boards#show', on: :member, as: '', constraints: { id: /\d+/ }
+    end
   end
 end

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -29,7 +29,7 @@ module OpenProject::Boards
              name: 'OpenProject Boards' do
       project_module :board_view, dependencies: :work_package_tracking, order: 80 do
         permission :show_board_views,
-                   { 'boards/boards': %i[index show overview] },
+                   { 'boards/boards': %i[index show] },
                    dependencies: :view_work_packages,
                    contract_actions: { boards: %i[read] }
         permission :manage_board_views,
@@ -39,7 +39,7 @@ module OpenProject::Boards
       end
 
       menu :project_menu,
-           :board_view,
+           :boards,
            { controller: '/boards/boards', action: :index },
            caption: :'boards.label_boards',
            after: :work_packages,
@@ -48,7 +48,7 @@ module OpenProject::Boards
       menu :project_menu,
            :board_menu,
            { controller: '/boards/boards', action: :index },
-           parent: :board_view,
+           parent: :boards,
            partial: 'boards/boards/menu_board',
            last: true,
            caption: :'boards.label_boards'
@@ -60,7 +60,7 @@ module OpenProject::Boards
 
       menu :top_menu,
            :boards,
-           { controller: '/boards/boards', action: 'overview' },
+           { controller: '/boards/boards', action: 'index' },
            context: :modules,
            caption: :project_module_board_view,
            before: :news,
@@ -70,7 +70,7 @@ module OpenProject::Boards
 
       menu :global_menu,
            :boards,
-           { controller: '/boards/boards', action: 'overview' },
+           { controller: '/boards/boards', action: 'index' },
            caption: :project_module_board_view,
            before: :news,
            after: :team_planners,

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -280,9 +280,10 @@ RSpec.describe 'Board management spec', js: true, with_ee: %i[board_view] do
 
   context 'with view permission only' do
     let(:permissions) { %i[show_board_views] }
+    let(:board_view) { create(:board_grid_with_queries, project:) }
 
     it 'does not allow viewing of boards' do
-      board_index.visit!
+      visit project_work_package_board_path(project, board_view)
       expect(page).to have_selector('#errorExplanation', text: I18n.t(:notice_not_authorized))
 
       board_index.expect_editable false

--- a/modules/boards/spec/features/boards_global_create_spec.rb
+++ b/modules/boards/spec/features/boards_global_create_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Boards',
 
   context 'within the global index page' do
     before do
-      visit boards_all_path
+      visit work_package_boards_path
     end
 
     context 'when clicking on the create button' do
@@ -210,7 +210,7 @@ RSpec.describe 'Boards',
         end
 
         it 'navigates back to the global index page' do
-          expect(page).to have_current_path(boards_all_path)
+          expect(page).to have_current_path(work_package_boards_path)
         end
       end
     end

--- a/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Global menu item for boards', :js, :with_cuprite do
         click_on boards_label
       end
 
-      expect(page).to have_current_path(boards_all_path)
+      expect(page).to have_current_path(work_package_boards_path)
       expect(page).to have_content(boards_label)
       expect(page).to have_content(I18n.t(:no_results_title_text))
     end

--- a/modules/boards/spec/features/support/board_new_page.rb
+++ b/modules/boards/spec/features/support/board_new_page.rb
@@ -11,7 +11,7 @@ module Pages
     end
 
     def navigate_by_create_button
-      visit boards_all_path unless page.current_path == boards_all_path
+      visit work_package_boards_path unless page.current_path == work_package_boards_path
 
       within '.toolbar-items' do
         click_link 'Board'

--- a/modules/boards/spec/routing/boards_routing_spec.rb
+++ b/modules/boards/spec/routing/boards_routing_spec.rb
@@ -31,20 +31,8 @@ require 'spec_helper'
 RSpec.describe 'Boards routing' do
   it do
     expect(subject)
-      .to route(:get, '/boards/all')
-            .to(controller: 'boards/boards', action: 'overview')
-  end
-
-  it do
-    expect(subject)
       .to route(:get, '/boards')
             .to(controller: 'boards/boards', action: 'index')
-  end
-
-  it do
-    expect(subject)
-      .to route(:get, '/boards/1')
-            .to(controller: 'boards/boards', action: 'show', id: 1)
   end
 
   it do

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Top menu items', :js, :with_cuprite do
     shared_let(:work_packages_item) { menu_link_item.new(I18n.t(:label_work_package_plural), work_packages_path) }
     shared_let(:calendar_item) { menu_link_item.new(I18n.t(:label_calendar_plural), calendars_path) }
     shared_let(:team_planners_item) { menu_link_item.new(I18n.t('team_planner.label_team_planner_plural'), team_planners_path) }
-    shared_let(:boards_item) { menu_link_item.new(I18n.t(:project_module_board_view), boards_all_path) }
+    shared_let(:boards_item) { menu_link_item.new(I18n.t(:project_module_board_view), work_package_boards_path) }
     shared_let(:news_item) { menu_link_item.new(I18n.t(:label_news_plural), news_index_path) }
     shared_let(:reporting_item) { menu_link_item.new(I18n.t(:cost_reports_title), '/cost_reports') }
     shared_let(:meetings_item) { menu_link_item.new(I18n.t(:label_meeting_plural), '/meetings') }

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Redmine::MenuManager do
                       :ifc_models,
                       :calendar_view,
                       :team_planner_view,
-                      :board_view,
+                      :boards,
                       :dashboards,
                       :backlogs,
                       :news,


### PR DESCRIPTION
- [x] Remove special `overview` route as now all routes are Rails. This was introduced to not break the angular-based index route
- [x] Standardize permission checks for global/local routes
- [x] Re-add the dynamic state param to allow frontend state (Fixes https://community.openproject.org/work_packages/49678)
- [x] Add regression test