### PR TITLE
Extend archived projects warning for types to versions

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -180,7 +180,7 @@ class TypesController < ApplicationController
 
       if archived_projects.any?
         error_message << ApplicationController.helpers.sanitize(
-          t(:'error_can_not_delete_type.archived_projects',
+          t(:error_can_not_delete_in_use_archived_work_packages,
             archived_projects_urls: helpers.archived_projects_urls_for(archived_projects)),
           attributes: %w(href target)
         )

--- a/app/helpers/archived_projects_helper.rb
+++ b/app/helpers/archived_projects_helper.rb
@@ -1,0 +1,49 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ArchivedProjectsHelper
+  def archived_projects_urls_for(projects)
+    urls = projects.map do |project|
+      link_to project.name,
+              projects_path(filters: archived_project_filters_for(project)),
+              target: '_blank',
+              rel: 'noopener'
+    end
+
+    safe_join(urls, ', ')
+  end
+
+  private
+
+  def archived_project_filters_for(project)
+    [
+      { active: { operator: '=', values: ['f'] } },
+      { name_and_identifier: { operator: '=', values: [html_escape(project.name)] } }
+    ].to_json
+  end
+end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -113,17 +113,6 @@ module ::TypesHelper
     ::API::V3::Queries::QueryParamsRepresenter.new(query).to_json
   end
 
-  def archived_projects_urls_for(projects)
-    urls = projects.map do |project|
-      link_to project.name,
-              projects_path(filters: archived_project_filters_for(project)),
-              target: '_blank',
-              rel: 'noopener'
-    end
-
-    safe_join(urls, ', ')
-  end
-
   private
 
   ##
@@ -150,12 +139,5 @@ module ::TypesHelper
       is_required: represented[:required] && !represented[:has_default],
       translation: Type.translated_attribute_name(key, represented)
     }
-  end
-
-  def archived_project_filters_for(project)
-    [
-      { active: { operator: '=', values: ['f'] } },
-      { name_and_identifier: { operator: '=', values: [html_escape(project.name)] } }
-    ].to_json
   end
 end

--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -65,6 +65,9 @@ See COPYRIGHT and LICENSE files for more details.
                    t(:label_x_open_work_packages_abbr, count: version.open_issues_count),
                    project_work_packages_open_version_path(version)) %>
     (<%= '%0.0f' % (version.open_issues_count.to_f / version.work_packages.count * 100) %>%)
+    <% if version.projects.archived.exists? %>
+      <%= op_icon('icon-warning', title: I18n.t('versions.overview.work_packages_in_archived_projects')) %>
+    <% end %>
   </p>
 <% else %>
   <%= no_results_box %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -28,26 +28,37 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= toolbar title: @version.name do %>
-    <% if authorize_for(:versions, :edit) %>
-        <li class="toolbar-item">
-          <%= link_to(edit_version_path(@version), class: 'button') do %>
-              <%= op_icon('button--icon icon-edit') %>
-              <span class="button--text"><%= t(:button_edit) %></span>
-          <% end %>
-        </li>
-    <% end %>
-    <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
-        <li class="toolbar-item hidden-for-mobile">
-          <%= link_to({controller: '/wiki', action: 'edit',
-                       project_id: @version.project,
-                       id: @version.wiki_page_title},
-                      class: 'button') do %>
-              <%= op_icon('button--icon icon-edit') %>
-              <span class="button--text"><%= t(:button_edit_associated_wikipage, page_title: truncate(@version.wiki_page_title, length: 50, separator: ' ')) %></span>
-          <% end %>
-        </li>
-    <% end %>
-    <%= call_hook(:view_versions_show_contextual, { version: @version, project: @project }) %>
+  <% if authorize_for(:versions, :edit) %>
+    <li class="toolbar-item">
+      <%= link_to(edit_version_path(@version), class: 'button') do %>
+        <%= op_icon('button--icon icon-edit') %>
+        <span class="button--text"><%= t(:button_edit) %></span>
+      <% end %>
+    </li>
+  <% end %>
+  <% if authorize_for(:versions, :destroy) %>
+    <li class="toolbar-item">
+      <%= link_to version_path(@version),
+                  method: :delete,
+                  data: { confirm: t(:text_are_you_sure) },
+                  class: "button -danger" do %>
+        <%= op_icon 'button--icon icon-delete' %>
+        <span class="button--text"><%= t(:button_delete) %></span>
+      <% end %>
+    </li>
+  <% end %>
+  <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
+    <li class="toolbar-item hidden-for-mobile">
+      <%= link_to({ controller: '/wiki', action: 'edit',
+                    project_id: @version.project,
+                    id: @version.wiki_page_title },
+                  class: 'button') do %>
+        <%= op_icon('button--icon icon-edit') %>
+        <span class="button--text"><%= t(:button_edit_associated_wikipage, page_title: truncate(@version.wiki_page_title, length: 50, separator: ' ')) %></span>
+      <% end %>
+    </li>
+  <% end %>
+  <%= call_hook(:view_versions_show_contextual, { version: @version, project: @project }) %>
 <% end %>
 
 <div class="widget-boxes -grid">
@@ -56,51 +67,52 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 
   <% if @version.estimated_hours > 0 || User.current.allowed_to?(:view_time_entries, @project) %>
-      <div class="widget-box -thin">
-        <fieldset class="form--fieldset">
-          <legend class="form--fieldset-legend"><%= t(:label_estimates_and_time) %></legend>
-          <table>
+    <div class="widget-box -thin">
+      <fieldset class="form--fieldset">
+        <legend class="form--fieldset-legend"><%= t(:label_estimates_and_time) %></legend>
+        <table>
+          <tr>
+            <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
+            <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours)) %></td>
+          </tr>
+          <% if User.current.allowed_to?(:view_time_entries, @project) %>
             <tr>
-              <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
-              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours)) %></td>
+              <td width="130px" align="right"><%= t(:label_spent_time) %></td>
+              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours)) %></td>
             </tr>
-            <% if User.current.allowed_to?(:view_time_entries, @project) %>
-                <tr>
-                  <td width="130px" align="right"><%= t(:label_spent_time) %></td>
-                  <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours)) %></td>
-                </tr>
-            <% end %>
-          </table>
-        </fieldset>
-      </div>
+          <% end %>
+        </table>
+      </fieldset>
+    </div>
   <% end %>
 
   <% if @version.wiki_page %>
-      <div class="widget-box -thin -wider">
-        <%= render(partial: "wiki/text", locals: { page: @version.wiki_page }) if @version.wiki_page %>
-      </div>
+    <div class="widget-box -thin -wider">
+      <%= render(partial: "wiki/text", locals: { page: @version.wiki_page }) if @version.wiki_page %>
+    </div>
   <% end %>
 
   <% if @issues.present? %>
-      <div class="widget-box -thin -wider">
-        <% if @issues.present? %>
-            <fieldset class="form--fieldset related_issues"><legend class="form--fieldset-legend"><%= t(:label_related_work_packages) %></legend>
-              <ul>
-                <% @issues.each do |issue| -%>
-                    <li><%= link_to_work_package(issue, project: issue.project != @version.project) %></li>
-                <% end -%>
-              </ul>
-            </fieldset>
-        <% end %>
-      </div>
+    <div class="widget-box -thin -wider">
+      <% if @issues.present? %>
+        <fieldset class="form--fieldset related_issues">
+          <legend class="form--fieldset-legend"><%= t(:label_related_work_packages) %></legend>
+          <ul>
+            <% @issues.each do |issue| -%>
+              <li><%= link_to_work_package(issue, project: issue.project != @version.project) %></li>
+            <% end -%>
+          </ul>
+        </fieldset>
+      <% end %>
+    </div>
   <% end %>
 
   <% if @version.work_packages.count > 0 %>
-      <div class="widget-box -thin -wider">
-        <wp-overview-graph
-          additional-filter='{ "version": { "operator": "=", "values": [<%= @version.id %>] }}'>
-        </wp-overview-graph>
-      </div>
+    <div class="widget-box -thin -wider">
+      <wp-overview-graph
+        additional-filter='{ "version": { "operator": "=", "values": [<%= @version.id %>] }}'>
+      </wp-overview-graph>
+    </div>
   <% end %>
 </div>
 <%= call_hook :view_versions_show_bottom, version: @version %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,6 +979,7 @@ en:
             principal:
               unassignable: "cannot be assigned to a project."
         version:
+          undeletable_archived_projects: "The version cannot be deleted as it has work packages attached to it."
           undeletable_work_packages_attached: "The version cannot be deleted as it has work packages attached to it."
         status:
           readonly_default_exlusive: "can not be activated for statuses that are marked default."
@@ -1366,9 +1367,10 @@ en:
   error_can_not_archive_project: "This project cannot be archived: %{errors}"
   error_can_not_delete_entry: "Unable to delete entry"
   error_can_not_delete_custom_field: "Unable to delete custom field"
+  error_can_not_delete_in_use_archived_undisclosed: 'There are also work packages in archived projects. You need to ask an administrator to perform the deletion to see which projects are affected.'
+  error_can_not_delete_in_use_archived_work_packages: 'There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the attribute of the respective work packages: %{archived_projects_urls}'
   error_can_not_delete_type:
     explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
-    archived_projects: 'There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the type of the respective work packages: %{archived_projects_urls}'
   error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,7 +415,7 @@ en:
 
   versions:
     overview:
-      work_packages_in_archived_projects: "The version is shared with archived projects which still have work packages assigned to this version. These are coutned, but will not appear in the linked views."
+      work_packages_in_archived_projects: "The version is shared with archived projects which still have work packages assigned to this version. These are counted, but will not appear in the linked views."
       no_results_title_text: There are currently no work packages assigned to this version.
 
   wiki:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,6 +415,7 @@ en:
 
   versions:
     overview:
+      work_packages_in_archived_projects: "The version is shared with archived projects which still have work packages assigned to this version. These are coutned, but will not appear in the linked views."
       no_results_title_text: There are currently no work packages assigned to this version.
 
   wiki:

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe TypesController do
                                      .archived_projects_urls_for([archived_project])
           [
             I18n.t(:'error_can_not_delete_type.explanation'),
-            I18n.t(:'error_can_not_delete_type.archived_projects', archived_projects_urls:)
+            I18n.t(:error_can_not_delete_in_use_archived_work_packages, archived_projects_urls:)
           ]
         end
 

--- a/spec/features/versions/delete_spec.rb
+++ b/spec/features/versions/delete_spec.rb
@@ -1,0 +1,74 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe 'version deletea', js: true, with_cuprite: true do
+  let!(:project) { create(:project, name: 'Parent') }
+  let!(:archived_child) { create(:project, name: 'Archived child', parent: project, active: false) }
+
+  let!(:user) do
+    create(:user,
+           member_in_project: version.project,
+           member_with_permissions: %i[manage_versions view_work_packages])
+  end
+  let!(:version) { create(:version, sharing: 'system') }
+  let!(:wp_archived) { create(:work_package, version:, project: archived_child, subject: 'Task in archive') }
+
+  before do
+    login_as(user)
+  end
+
+  it 'cannot delete a version in use in archived projects, but shows details where it is used' do
+    # from the version show page
+    visit version_path(version)
+
+    within '.toolbar' do
+      accept_confirm do
+        click_link 'Delete'
+      end
+    end
+
+    expect(page).to have_selector('.op-toast.-error', text: I18n.t(:error_can_not_delete_in_use_archived_undisclosed))
+    expect(page).not_to have_selector("a", text: 'Archived child')
+
+    user.update!(admin: true)
+
+    # from the version show page
+    visit version_path(version)
+
+    within '.toolbar' do
+      accept_confirm do
+        click_link 'Delete'
+      end
+    end
+
+    expect(page).to have_selector('.op-toast.-error', text: 'There are also work packages in archived projects.')
+    expect(page).to have_selector("a", text: 'Archived child')
+  end
+end

--- a/spec/features/versions/delete_spec.rb
+++ b/spec/features/versions/delete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'version deletea', js: true, with_cuprite: true do
+RSpec.describe 'version delete', js: true, with_cuprite: true do
   let!(:project) { create(:project, name: 'Parent') }
   let!(:archived_child) { create(:project, name: 'Archived child', parent: project, active: false) }
 

--- a/spec/helpers/archived_projects_helper_spec.rb
+++ b/spec/helpers/archived_projects_helper_spec.rb
@@ -1,0 +1,58 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe ArchivedProjectsHelper do
+  describe '#archived_projects_urls_for' do
+    subject { helper.archived_projects_urls_for([archived_project, other_archived_project]) }
+
+    shared_let(:archived_project) { create(:project, :archived) }
+    shared_let(:other_archived_project) { create(:project, :archived) }
+    shared_let(:archived_project_filters) do
+      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
+        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{archived_project.name}\"]}}]"
+    end
+    shared_let(:other_archived_project_filters) do
+      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
+        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{other_archived_project.name}\"]}}]"
+    end
+
+    it 'returns a comma-separated list of anchor tags for each archived project' do
+      expect(subject)
+        .to eq(
+          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: archived_project_filters)}\">" \
+          "#{archived_project.name}" \
+          "</a>, " \
+          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: other_archived_project_filters)}\">" \
+          "#{other_archived_project.name}" \
+          "</a>"
+        )
+    end
+  end
+end

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -78,31 +78,4 @@ RSpec.describe TypesHelper do
       end
     end
   end
-
-  describe '#archived_projects_urls_for' do
-    subject { helper.archived_projects_urls_for([archived_project, other_archived_project]) }
-
-    shared_let(:archived_project) { create(:project, :archived) }
-    shared_let(:other_archived_project) { create(:project, :archived) }
-    shared_let(:archived_project_filters) do
-      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
-        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{archived_project.name}\"]}}]"
-    end
-    shared_let(:other_archived_project_filters) do
-      "[{\"active\":{\"operator\":\"=\",\"values\":[\"f\"]}}," \
-        "{\"name_and_identifier\":{\"operator\":\"=\",\"values\":[\"#{other_archived_project.name}\"]}}]"
-    end
-
-    it 'returns a comma-separated list of anchor tags for each archived project' do
-      expect(subject)
-        .to eq(
-          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: archived_project_filters)}\">" \
-          "#{archived_project.name}" \
-          "</a>, " \
-          "<a target=\"_blank\" rel=\"noopener\" href=\"#{projects_path(filters: other_archived_project_filters)}\">" \
-          "#{other_archived_project.name}" \
-          "</a>"
-        )
-    end
-  end
 end


### PR DESCRIPTION
Move over the archived projects helpers from versions to types. Added a visibility check to the archived projects (as only admins can access them), so that regular users get a default message that versions are assigned in archived projects.

Adds a simple warning icon with title that the version is used in archived projects, as the open count link shows no results in that case.
<img width="971" alt="Bildschirmfoto 2023-08-15 um 09 25 10" src="https://github.com/opf/openproject/assets/459462/fd27c50d-05ab-45a2-b090-88cffb28cb3e">


https://community.openproject.org/work_packages/49402