### PR TITLE
[#49680] Today button missing when selecting "Between specific dates"

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -214,13 +214,11 @@ export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
 
   public setToday(key:string):void {
     const today = moment().format('YYYY-MM-DD');
+    const from = key === 'from' ? today : this.selectedDates[0];
     // When setting the "from" date to today, the "to" date must also be set to today,
     // because we do not allow future dates, meaning "to" cannot be anything else but today.
-    if (key === 'from') {
-      this.selectedDates[0] = today;
-    }
-
-    this.selectedDates[1] = today;
+    const to = today;
+    this.dateChange([from, to]);
   }
 
   public onSubmit(e:Event):void {


### PR DESCRIPTION
https://community.openproject.org/work_packages/49680

  - Use the `this.dateChange` method inside the setToday in order to update the datepicker calendar with the newly set Today values.