### PR TITLE
[49668] Activity View Design Change Makes Day-Break Hard to Find

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1032,9 +1032,11 @@ en:
       created_by_on: "created by %{user} on %{datetime}"
       created_by_on_time_entry: "time logged by %{user} on %{datetime}"
       created_on: "created on %{datetime}"
+      created_on_time_entry: "time logged on %{datetime}"
       updated_by_on: "updated by %{user} on %{datetime}"
-      updated_by_on_time_entry: "time logged updated by %{user} on %{datetime}"
+      updated_by_on_time_entry: "logged time updated by %{user} on %{datetime}"
       updated_on: "updated on %{datetime}"
+      updated_on_time_entry: "logged time updated on %{datetime}"
       parent_without_of: "Subproject"
       parent_no_longer: "No longer subproject of"
       time_entry:

--- a/frontend/src/global_styles/content/_activity_days.sass
+++ b/frontend/src/global_styles/content/_activity_days.sass
@@ -2,8 +2,3 @@
   display: flex
   flex-direction: column
   margin: 0
-
-  &--header
-    @include spot-body-small (bold)
-    padding: 0
-    color: $spot-color-basic-gray-1

--- a/spec/components/activities/item_subtitle_component_spec.rb
+++ b/spec/components/activities/item_subtitle_component_spec.rb
@@ -82,6 +82,6 @@ RSpec.describe Activities::ItemSubtitleComponent, type: :component do
     let(:user) { build_stubbed(:user) }
     let(:journable_type) { 'TimeEntry' }
 
-    it { is_expected.to have_text("time logged updated by  #{user.name} on #{format_time(datetime)}") }
+    it { is_expected.to have_text("logged time updated by  #{user.name} on #{format_time(datetime)}") }
   end
 end


### PR DESCRIPTION
Remove custom override for the activity header and fix broken translations for the activity page. This is only a small improvement, however we agreed that we won't spend any more time on that page until it is completely redesigned with Primer.

https://community.openproject.org/projects/14/work_packages/49668/github?query_id=2331