### PR TITLE
[#49144] Fix missing link to meeting location in details section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'rouge', '~> 4.1.0'
 # HTML sanitization used for html-pipeline
 gem 'sanitize', '~> 6.0.2'
 # HTML autolinking for mails and urls (replaces autolink)
-gem 'rinku', '~> 2.0.4'
+gem 'rinku', '~> 2.0.4', require: %w[rinku rails_rinku]
 # Version parsing with semver
 gem 'semantic', '~> 1.6.1'
 

--- a/lib/open_project/text_formatting/filters/autolink_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_filter.rb
@@ -25,7 +25,6 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require 'rails_rinku'
 
 module OpenProject::TextFormatting
   module Filters

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -77,7 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
       <p><strong><%= Meeting.human_attribute_name(:start_time) %></strong>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, false %> - <%= format_time @meeting.end_time, false %> <%= Time.zone %></p>
     </div>
     <div class="grid-content small-6">
-      <p><strong><%= Meeting.human_attribute_name(:location) %></strong>: <%=h @meeting.location %></p>
+      <p><strong><%= Meeting.human_attribute_name(:location) %></strong>: <%= auto_link(h(@meeting.location), link: :all, html: { target: '_blank' }) %></p>
     </div>
     <div class="grid-content small-12">
       <p><strong><%= Meeting.human_attribute_name(:participants_invited) %></strong>: <%= format_participant_list @meeting.participants.invited %></p>

--- a/modules/meeting/spec/features/meetings_show_spec.rb
+++ b/modules/meeting/spec/features/meetings_show_spec.rb
@@ -57,6 +57,28 @@ RSpec.describe 'Meetings', js: true do
                                     text: 'There is currently nothing to display')
     end
 
+    context 'with a location' do
+      context 'as a valid url' do
+        it 'renders a link to the meeting location' do
+          show_page.visit!
+
+          show_page.expect_link_to_location(meeting.location)
+        end
+      end
+
+      context 'as an invalid url' do
+        before do
+          meeting.update!(location: 'badurl')
+        end
+
+        it 'renders the meeting location as plaintext' do
+          show_page.visit!
+
+          show_page.expect_plaintext_location(meeting.location)
+        end
+      end
+    end
+
     context 'with an open agenda' do
       let!(:agenda) { create(:meeting_agenda, meeting:, text: 'foo') }
       let(:agenda_update) { create(:meeting_agenda, meeting:, text: 'bla') }

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -48,7 +48,7 @@ module Pages::Meetings
 
     def expect_invited(*users)
       users.each do |user|
-        within(".meeting.details") do
+        within(meeting_details_container) do
           expect(page)
             .to have_link(user.name)
         end
@@ -57,7 +57,7 @@ module Pages::Meetings
 
     def expect_uninvited(*users)
       users.each do |user|
-        within(".meeting.details") do
+        within(meeting_details_container) do
           expect(page)
             .not_to have_link(user.name)
         end
@@ -67,6 +67,23 @@ module Pages::Meetings
     def expect_date_time(expected)
       expect(page)
         .to have_content("Time: #{expected}")
+    end
+
+    def expect_link_to_location(location)
+      within(meeting_details_container) do
+        expect(page).to have_link location
+      end
+    end
+
+    def expect_plaintext_location(location)
+      within(meeting_details_container) do
+        expect(page).not_to have_link location
+        expect(page).to have_text(location)
+      end
+    end
+
+    def meeting_details_container
+      find('.meeting.details')
     end
 
     def click_edit


### PR DESCRIPTION
Follow-up to https://github.com/opf/openproject/pull/13440

See: https://community.openproject.org/work_packages/49144