### PR TITLE
[#49630] Nextcloud/Administration link is stripped when host has a subpath

### DIFF
--- a/modules/storages/app/views/storages/admin/storages/automatically_managed_project_folders/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/automatically_managed_project_folders/edit.html.erb
@@ -80,7 +80,8 @@ See COPYRIGHT and LICENSE files for more details.
     <p class="form--field-instructions -xwide">
       <%= t(:"storages.instructions.managed_project_folders_application_password") %>
       <a
-        href="<%= URI.join(@storage.oauth_application.integration.host, 'settings/admin/openproject') %>"
+        href="<%= Storages::Peripherals::StorageInteraction::Nextcloud::Util
+                    .join_uri_path(@storage.oauth_application.integration.host, 'settings/admin/openproject') %>"
         target="_blank"
         class="spot-link"
       >

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -213,6 +213,17 @@ RSpec.describe 'Admin storages', :storage_server_helpers, js: true do
 
     ######### Begin Edit Automatically managed project folders #########
     page.find('.button--icon.icon-edit').click
+
+    # Confirm update of host URL with subpath renders correctly Nextcloud/Administration link
+    mock_server_capabilities_response("https://example.com/with/subpath")
+    mock_server_config_check_response("https://example.com/with/subpath")
+    page.find_by_id('storages_storage_host').set("https://example.com/with/subpath")
+    page.click_button('Save')
+
+    # Check for updated host URL
+    expect(page).to have_text("https://example.com/with/subpath")
+
+    page.find('.button--icon.icon-edit').click
     page.find('a', text: 'Edit automatically managed project folders').click
 
     expect(page).to have_title("Automatically managed project folders")
@@ -221,6 +232,7 @@ RSpec.describe 'Admin storages', :storage_server_helpers, js: true do
     expect(automatically_managed_switch).to be_checked
     expect(application_password_input.value).to be_empty
     expect(application_password_input['placeholder']).to eq("●●●●●●●●●●●●●●●●")
+    expect(page).to have_link(text: 'Nextcloud Administration / OpenProject', href: 'https://example.com/with/subpath/settings/admin/openproject')
 
     # Clicking submit without inputing new application password should show an error
     page.click_button('Save')


### PR DESCRIPTION
##### https://community.openproject.org/work_packages/49630

Use singular interface [`Storages::Peripherals::StorageInteraction::Nextcloud::Util.join_uri_path`](https://github.com/opf/openproject/blob/dev/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb#L50-L56) that uses `File.join` given [`URI.join`](https://apidock.com/ruby/URI/join/class) is buggy with subpaths.

> [URI.join](https://apidock.com/ruby/URI/join/class) uses a delimiter – forward slash (/) – to decide if joined strings are a path or endpoint. In order to include strings as part of the path, they must end with a forward slash (/). Otherwise, they are assumed to be an endpoint and are overritten by your new “endpoint”.

> ```ruby
>  > [URI](https://apidock.com/ruby/URI).[join](https://apidock.com/ruby/URI/join/class)("http://localhost/", "test", "main.json")
>  => #<URI::HTTP:0x007fa68cec0ba0 URL:http://localhost/main.json> 
> 
>  > [URI](https://apidock.com/ruby/URI).[join](https://apidock.com/ruby/URI/join/class)("http://localhost/", "test/", "main.json")
>  => #<URI::HTTP:0x007fa68ce14c60 URL:http://localhost/test/main.json>
> ```

![image](https://github.com/opf/openproject/assets/17295175/b3d710a4-0e22-47ba-92f4-b2e9a4d5337d)
