### PR TITLE
[#49610] Fix Projects not alphabetically sorted on Index Pages

### DIFF
--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -92,8 +92,23 @@ class TableComponent < ApplicationComponent
 
   def initialize_sorted_model
     helpers.sort_init *initial_sort.map(&:to_s)
-    helpers.sort_update sortable_columns.map(&:to_s)
+    helpers.sort_update sortable_columns_correlation
     @model = paginate_collection apply_sort(model)
+  end
+
+  ##
+  # If +initial_sort+ or +sortable_columns+ and the table column names in the database
+  # don't map 1 to 1, or there is an ambiguous column dilemma due
+  # to the joining of tables, these correlation methods can be extended by +TableComponent+
+  # subclasses to set the appropriate sort criteria for said edge-cases.
+  #
+  def initial_sort_correlation
+    initial_sort
+  end
+
+  def sortable_columns_correlation
+    sortable_columns.to_h { [_1.to_s, _1.to_s] }
+                    .with_indifferent_access
   end
 
   def sort_criteria
@@ -155,7 +170,7 @@ class TableComponent < ApplicationComponent
   end
 
   def initial_order
-    initial_sort.join(' ')
+    initial_sort_correlation.join(' ')
   end
 
   def paginated?

--- a/modules/boards/app/components/boards/row_component.rb
+++ b/modules/boards/app/components/boards/row_component.rb
@@ -30,7 +30,7 @@
 
 module Boards
   class RowComponent < ::RowComponent
-    def project_id
+    def project_name
       helpers.link_to_project model.project, {}, {}, false
     end
 

--- a/modules/boards/app/components/boards/table_component.rb
+++ b/modules/boards/app/components/boards/table_component.rb
@@ -31,10 +31,16 @@
 module Boards
   class TableComponent < ::TableComponent
     options :current_project, :current_user
-    sortable_columns :name, :project_id, :created_at
+    sortable_columns :name, :project_name, :created_at
 
-    def initial_sort
-      %i[name asc]
+    def initial_sort_correlation
+      %w[grids.name asc]
+    end
+
+    def sortable_columns_correlation
+      super.merge(name: 'grids.name',
+                  project_name: 'projects.name',
+                  created_at: 'grids.created_at')
     end
 
     def paginated?
@@ -42,18 +48,16 @@ module Boards
     end
 
     def headers
-      columns.map do |attr|
-        [attr, { caption: Boards::Grid.human_attribute_name(attr) }]
-      end
+      @headers ||= [
+        [:name, { caption: Boards::Grid.human_attribute_name(:name) }],
+        current_project.blank? ? [:project_name, { caption: I18n.t('attributes.project') }] : nil,
+        [:type, { caption: Boards::Grid.human_attribute_name(:type) }],
+        [:created_at, { caption: Boards::Grid.human_attribute_name(:created_at) }]
+      ].compact
     end
 
     def columns
-      @columns ||= [
-        :name,
-        (:project_id if current_project.blank?),
-        :type,
-        :created_at
-      ].compact
+      @columns ||= headers.map(&:first)
     end
   end
 end

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -60,12 +60,11 @@ module ::Boards
     private
 
     def load_query
-      if @project
-        @board_grids = Boards::Grid.includes(:project).where(project: @project)
-      else
-        projects = Project.allowed_to(User.current, :show_board_views)
-        @board_grids = Boards::Grid.includes(:project).where(project: projects)
-      end
+      projects = @project || Project.allowed_to(User.current, :show_board_views)
+
+      @board_grids = Boards::Grid.includes(:project)
+                                 .references(:project)
+                                 .where(project: projects)
     end
 
     def find_board_grid

--- a/modules/boards/spec/features/board_index_spec.rb
+++ b/modules/boards/spec/features/board_index_spec.rb
@@ -135,6 +135,34 @@ RSpec.describe 'Work Package Project Boards Index Page',
       end
     end
 
+    describe 'sorting' do
+      it 'allows sorting by "Name" and "Created on"' do
+        # Initial sort is Name ASC
+        # We can assert this behavior by expected the order to be
+        # 1. board_view
+        # 2. other_board_view
+        # upon page load
+        aggregate_failures 'Sorting by Name' do
+          board_index.expect_boards_listed_in_order(board_view,
+                                                    other_board_view)
+
+          board_index.click_to_sort_by('Name')
+          board_index.expect_boards_listed_in_order(other_board_view,
+                                                    board_view)
+        end
+
+        aggregate_failures 'Sorting by Created on' do
+          board_index.click_to_sort_by('Created on')
+          board_index.expect_boards_listed_in_order(board_view,
+                                                    other_board_view)
+
+          board_index.click_to_sort_by('Created on')
+          board_index.expect_boards_listed_in_order(other_board_view,
+                                                    board_view)
+        end
+      end
+    end
+
     it 'paginates results', with_settings: { per_page_options: '1' } do
       # First page displays the historically last meeting
       board_index.expect_boards_listed(board_view)

--- a/modules/boards/spec/features/board_index_spec.rb
+++ b/modules/boards/spec/features/board_index_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe 'Work Package Project Boards Index Page',
       it 'does not render delete links' do
         board_index.visit!
 
-        board_index.expect_no_delete_button(board_view)
-        board_index.expect_no_delete_button(other_board_view)
+        board_index.expect_no_delete_buttons(board_view)
+        board_index.expect_no_delete_buttons(other_board_view)
       end
     end
 

--- a/modules/boards/spec/features/board_overview_spec.rb
+++ b/modules/boards/spec/features/board_overview_spec.rb
@@ -27,122 +27,159 @@
 #++
 
 require 'spec_helper'
-require_relative './support/board_overview_page'
+require_relative 'support/board_overview_page'
 
 RSpec.describe 'Work Package Boards Overview',
                :with_cuprite,
                with_ee: %i[board_view] do
   # The identifier is important to test https://community.openproject.com/wp/29754
-  shared_let(:project) { create(:project, identifier: 'boards', enabled_module_names: %i[work_package_tracking board_view]) }
-  shared_let(:other_project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
-
-  shared_let(:management_permissions) do
-    %i[show_board_views manage_board_views add_work_packages view_work_packages manage_public_queries]
+  shared_let(:project) do
+    create(:project,
+           name: 'Project 2',
+           identifier: 'boards',
+           enabled_module_names: %i[work_package_tracking board_view])
   end
-  shared_let(:view_only_permissions) do
-    %i[show_board_views add_work_packages view_work_packages]
+  shared_let(:other_project) do
+    create(:project,
+           name: 'Project 1',
+           enabled_module_names: %i[work_package_tracking board_view])
+  end
+
+  shared_let(:management_role) do
+    create(:role,
+           permissions: %i[
+             show_board_views
+             manage_board_views
+             add_work_packages
+             view_work_packages
+             manage_public_queries
+           ])
+  end
+
+  shared_let(:view_only_role) do
+    create(:role,
+           permissions: %i[
+             show_board_views
+             add_work_packages
+             view_work_packages
+           ])
+  end
+
+  shared_let(:admin) do
+    create(:admin)
+  end
+  shared_let(:user_with_full_permissions) do
+    create(:user,
+           member_in_project: project,
+           member_through_role: management_role)
+  end
+  shared_let(:user_with_limited_permissions) do
+    create(:user,
+           member_in_project: project,
+           member_through_role: view_only_role)
+  end
+  shared_let(:user_without_permissions) do
+    create(:user,
+           member_in_project: project)
   end
 
   shared_let(:priority) { create(:default_priority) }
   shared_let(:status) { create(:default_status) }
 
-  let(:user) do
-    create(:user,
-           member_in_project: project,
-           member_through_role: role)
-  end
-  let(:permissions) { management_permissions }
-  let(:role) { create(:role, permissions:) }
-
-  let(:board_view) { create(:board_grid_with_query, name: 'My board', project:) }
-  let(:other_board_view) { create(:board_grid_with_query, name: 'My other board', project:) }
-  let(:other_project_board_view) { create(:board_grid_with_query, name: 'Unseeable Board', project: other_project) }
-
+  let(:current_user) { admin }
   let(:board_overview) { Pages::BoardOverview.new }
 
   before do
-    login_as user
+    login_as current_user
+    board_overview.visit!
   end
 
   it 'renders the global menu with its item selected' do
-    board_overview.visit!
-
     board_overview.expect_global_menu_item_selected
   end
 
-  context 'as a user with board management permissions' do
-    let(:permissions) { management_permissions }
+  describe 'create button' do
+    context 'as a user with board management permissions' do
+      let(:current_user) { user_with_full_permissions }
 
-    it 'shows a create button' do
-      board_overview.visit!
-
-      board_overview.expect_create_button
+      it 'is shown' do
+        board_overview.expect_create_button
+      end
     end
-  end
 
-  context 'as a user without board management permissions' do
-    let(:permissions) { view_only_permissions }
+    context 'as a user with view only permissions' do
+      let(:current_user) { user_with_limited_permissions }
 
-    it 'does not show a create button' do
-      board_overview.visit!
-
-      board_overview.expect_no_create_button
+      it 'is shown' do
+        board_overview.expect_no_create_button
+      end
     end
   end
 
   context 'when no boards exist' do
     it 'displays the empty message' do
-      board_overview.visit!
-
-      board_overview.expect_no_boards_listed
-    end
-  end
-
-  context 'when only boards exist that the user does not have access to' do
-    before do
-      other_project_board_view
-    end
-
-    it 'displays the empty message' do
-      board_overview.visit!
-
       board_overview.expect_no_boards_listed
     end
   end
 
   context 'when boards exist' do
-    before do
-      board_view
-      other_board_view
-      other_project_board_view
+    shared_let(:board_view) do
+      create(:board_grid_with_query,
+             name: 'My board',
+             project:)
+    end
+    shared_let(:other_board_view) do
+      create(:board_grid_with_query,
+             name: 'My other board',
+             project:)
+    end
+    shared_let(:other_project_board_view) do
+      create(:board_grid_with_query,
+             name: 'Other Project Board',
+             project: other_project)
     end
 
-    it 'lists the boards' do
-      board_overview.visit!
+    context 'as an admin' do
+      let(:current_user) { admin }
 
-      board_overview.expect_boards_listed(board_view, other_board_view)
-      board_overview.expect_boards_not_listed(other_project_board_view)
+      it 'lists all boards' do
+        board_overview.expect_boards_listed(board_view,
+                                            other_board_view,
+                                            other_project_board_view)
+      end
+    end
+
+    context 'as a project member' do
+      let(:current_user) { user_with_full_permissions }
+
+      it 'lists the boards' do
+        board_overview.expect_boards_listed(board_view, other_board_view)
+        board_overview.expect_boards_not_listed(other_project_board_view)
+      end
     end
 
     it 'does not render delete links' do
-      board_overview.visit!
-
-      board_overview.expect_no_delete_button(board_view)
-      board_overview.expect_no_delete_button(other_board_view)
-      board_overview.expect_no_delete_button(other_project_board_view)
+      board_overview.expect_no_delete_buttons(board_view,
+                                              other_board_view,
+                                              other_project_board_view)
     end
 
     it 'paginates results', with_settings: { per_page_options: '1' } do
       # First page displays the historically last meeting
-      board_overview.visit!
       board_overview.expect_boards_listed(board_view)
-      board_overview.expect_boards_not_listed(other_board_view)
-
+      board_overview.expect_boards_not_listed(other_board_view,
+                                              other_project_board_view)
       board_overview.expect_to_be_on_page(1)
 
       board_overview.to_page(2)
       board_overview.expect_boards_listed(other_board_view)
-      board_overview.expect_boards_not_listed(board_view)
+      board_overview.expect_boards_not_listed(board_view, other_project_board_view)
+      board_overview.expect_to_be_on_page(2)
+
+      board_overview.to_page(3)
+      board_overview.expect_boards_listed(other_project_board_view)
+      board_overview.expect_boards_not_listed(board_view, other_board_view)
+      board_overview.expect_to_be_on_page(3)
     end
   end
 end

--- a/modules/boards/spec/features/board_overview_spec.rb
+++ b/modules/boards/spec/features/board_overview_spec.rb
@@ -164,6 +164,55 @@ RSpec.describe 'Work Package Boards Overview',
                                               other_project_board_view)
     end
 
+    describe 'sorting' do
+      it 'allows sorting by "Name", "Project" and "Created on"' do
+        # Initial sort is Name ASC
+        # We can assert this behavior by expected the order to be
+        # 1. board_view
+        # 2. other_board_view
+        # 3. other_project_board_view
+        # upon page load
+        aggregate_failures 'Sorting by Name' do
+          board_overview.expect_boards_listed_in_order(board_view,
+                                                       other_board_view,
+                                                       other_project_board_view)
+
+          board_overview.click_to_sort_by('Name')
+          board_overview.expect_boards_listed_in_order(other_project_board_view,
+                                                       other_board_view,
+                                                       board_view)
+        end
+
+        aggregate_failures 'Sorting by Project' do
+          board_overview.click_to_sort_by('Project')
+          # TODO: for Aaron
+          #   This is the current behavior. Sorting seems to stack with the previous sort
+          #   even though to the user, one can only sort by a single column at a time.
+          #   It seems unintuitive to someone who would not know about this. Ask about
+          #   it in tomorrow's daily.
+          board_overview.expect_boards_listed_in_order(other_project_board_view,
+                                                       other_board_view,
+                                                       board_view)
+          board_overview.click_to_sort_by('Project')
+          board_overview.expect_boards_listed_in_order(other_board_view,
+                                                       board_view,
+                                                       other_project_board_view)
+        end
+
+        aggregate_failures 'Sorting by Created on' do
+          board_overview.click_to_sort_by('Created on')
+          board_overview.expect_boards_listed_in_order(board_view,
+                                                       other_board_view,
+                                                       other_project_board_view)
+
+          board_overview.click_to_sort_by('Created on')
+          board_overview.expect_boards_listed_in_order(other_project_board_view,
+                                                       other_board_view,
+                                                       board_view)
+        end
+      end
+    end
+
     it 'paginates results', with_settings: { per_page_options: '1' } do
       # First page displays the historically last meeting
       board_overview.expect_boards_listed(board_view)

--- a/modules/boards/spec/features/board_overview_spec.rb
+++ b/modules/boards/spec/features/board_overview_spec.rb
@@ -185,11 +185,16 @@ RSpec.describe 'Work Package Boards Overview',
 
         aggregate_failures 'Sorting by Project' do
           board_overview.click_to_sort_by('Project')
-          # TODO: for Aaron
-          #   This is the current behavior. Sorting seems to stack with the previous sort
-          #   even though to the user, one can only sort by a single column at a time.
-          #   It seems unintuitive to someone who would not know about this. Ask about
-          #   it in tomorrow's daily.
+          # Sorting is performed on multiple columns at a time, taking into account
+          # previous sorting criteria and using the latest clicked column as
+          # the first column in the +ORDER BY+ clause and previously sorted by columns after.
+          #
+          # This is unintuitive to a user who is visually being informed by arrows in table headers
+          # that only one column is taken into account for sorting.
+          # TODO:
+          #   Fix sorting behavior to un-toggle previous columns sorted by or provide
+          #   visual feedback of all columns currently being taken into account for
+          #   sorting.
           board_overview.expect_boards_listed_in_order(other_project_board_view,
                                                        other_board_view,
                                                        board_view)

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -46,9 +46,11 @@ module Pages
       end
     end
 
-    def expect_delete_button(board)
+    def expect_delete_buttons(*boards)
       within '#content-wrapper' do
-        expect(page).to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+        boards.each do |board|
+          expect(page).to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+        end
       end
     end
 

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -63,31 +63,42 @@ module Pages
     end
 
     def expect_boards_listed(*boards)
-      board_names = if boards.all? { |board| board.to_s == board }
-                      boards
-                    else
-                      boards.map(&:name)
-                    end
+      expected_board_names = board_names_for(boards)
 
       within '#content-wrapper' do
-        board_names.each do |board_name|
+        expected_board_names.each do |board_name|
           expect(page).to have_selector("td.name", text: board_name)
         end
       end
     end
 
+    def click_to_sort_by(header_name)
+      within '.generic-table thead' do
+        click_link header_name
+      end
+    end
+
+    def expect_boards_listed_in_order(*boards)
+      within '#content-wrapper' do
+        listed_board_names = all("td.name").map(&:text)
+        expect_board_names = board_names_for(boards)
+
+        expect(listed_board_names).to match_array(expect_board_names)
+      end
+    end
+
     def expect_boards_not_listed(*boards)
-      board_names = if boards.all? { |board| board.to_s == board }
-                      boards
-                    else
-                      boards.map(&:name)
-                    end
+      unexpected_board_names = board_names_for(boards)
 
       within '#content-wrapper' do
-        board_names.each do |board_name|
+        unexpected_board_names.each do |board_name|
           expect(page).not_to have_selector("td.title", text: board_name)
         end
       end
+    end
+
+    def board_names_for(boards)
+      boards.map { |board| board.to_s == board ? board : board.name }
     end
 
     def expect_no_boards_listed

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -52,9 +52,11 @@ module Pages
       end
     end
 
-    def expect_no_delete_button(board)
+    def expect_no_delete_buttons(*boards)
       within '#content-wrapper' do
-        expect(page).not_to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+        boards.each do |board|
+          expect(page).not_to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+        end
       end
     end
 

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -72,12 +72,6 @@ module Pages
       end
     end
 
-    def click_to_sort_by(header_name)
-      within '.generic-table thead' do
-        click_link header_name
-      end
-    end
-
     def expect_boards_listed_in_order(*boards)
       within '#content-wrapper' do
         listed_board_names = all("td.name").map(&:text)

--- a/modules/calendar/app/components/calendar/row_component.rb
+++ b/modules/calendar/app/components/calendar/row_component.rb
@@ -38,7 +38,7 @@ module Calendar
       link_to query.name, project_calendar_path(project, query.id)
     end
 
-    def project_id
+    def project_name
       link_to project.name, project_path(project)
     end
 

--- a/modules/calendar/app/components/calendar/table_component.rb
+++ b/modules/calendar/app/components/calendar/table_component.rb
@@ -30,7 +30,11 @@ module Calendar
   class TableComponent < ::TableComponent
     options :current_project, :current_user
 
-    sortable_columns :name, :project_id, :created_at
+    sortable_columns :name, :project_name, :created_at
+
+    def sortable_columns_correlation
+      super.merge(project_name: 'projects.name')
+    end
 
     def initial_sort
       %i[name asc]
@@ -42,9 +46,9 @@ module Calendar
 
     def headers
       @headers ||= [
-        ['name', { caption: I18n.t(:label_name) }],
-        current_project.blank? ? ['project_id', { caption: I18n.t('attributes.project') }] : nil,
-        ['created_at', { caption: I18n.t('attributes.created_at') }]
+        [:name, { caption: I18n.t(:label_name) }],
+        current_project.blank? ? [:project_name, { caption: I18n.t('attributes.project') }] : nil,
+        [:created_at, { caption: I18n.t('attributes.created_at') }]
       ].compact
     end
 

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -93,7 +93,7 @@ module ::Calendar
     def visible_views
       base_query = Query
                      .visible(current_user)
-                     .joins(:views)
+                     .joins(:views, :project)
                      .where('views.type' => 'work_packages_calendar')
 
       if @project

--- a/modules/calendar/spec/features/calendars_index_spec.rb
+++ b/modules/calendar/spec/features/calendars_index_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative '../support/pages/calendar'
 
-RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
+RSpec.describe 'Calendars', 'index', :with_cuprite do
   # The order the Projects are created in is important. By naming `project` alphanumerically
   # after `other_project`, we can ensure that subsequent specs that assert sorting is
   # correct for the right reasons (sorting by Project name and not id)
@@ -69,7 +69,7 @@ RSpec.describe 'Calendars', 'index', :js, :with_cuprite do
 
   let(:current_user) { user }
 
-  context 'when navigating to the global index page' do
+  context 'when navigating to the global index page', :js do
     shared_examples 'global index page is reachable' do
       it 'is reachable' do
         expect(page).to have_current_path(calendars_path)

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -175,12 +175,6 @@ module Pages
       expect(page).not_to have_selector 'td', text: query.name
     end
 
-    def click_to_sort_by(header_name)
-      within '.generic-table thead' do
-        click_link header_name
-      end
-    end
-
     def expect_views_listed_in_order(*queries)
       within '.generic-table tbody' do
         listed_view_names = all('tr td.name').map(&:text)

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -174,5 +174,19 @@ module Pages
     def expect_view_not_visible(query)
       expect(page).not_to have_selector 'td', text: query.name
     end
+
+    def click_to_sort_by(header_name)
+      within '.generic-table thead' do
+        click_link header_name
+      end
+    end
+
+    def expect_views_listed_in_order(*queries)
+      within '.generic-table tbody' do
+        listed_view_names = all('tr td.name').map(&:text)
+
+        expect(listed_view_names).to eq(queries.map(&:name))
+      end
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -30,7 +30,7 @@
 
 module Meetings
   class RowComponent < ::RowComponent
-    def project_id
+    def project_name
       helpers.link_to_project model.project, {}, {}, false
     end
 

--- a/modules/meeting/app/components/meetings/table_component.rb
+++ b/modules/meeting/app/components/meetings/table_component.rb
@@ -32,17 +32,20 @@ module Meetings
   class TableComponent < ::TableComponent
     options :current_project # used to determine if displaying the projects column
 
-    sortable_columns :title, :project_id, :start_time, :duration, :location
+    sortable_columns :title, :project_name, :start_time, :duration, :location
 
     def initial_sort
       %i[start_time asc]
     end
 
+    def sortable_columns_correlation
+      super.merge(project_name: 'projects.name')
+    end
+
     def initialize_sorted_model
       helpers.sort_clear
-      helpers.sort_init *initial_sort.map(&:to_s)
-      helpers.sort_update disambiguated_sortable_columns
-      @model = paginate_collection apply_sort(model)
+
+      super
     end
 
     def paginated?
@@ -52,7 +55,7 @@ module Meetings
     def headers
       @headers ||= [
         [:title, { caption: Meeting.human_attribute_name(:title) }],
-        current_project.blank? ? [:project_id, { caption: Meeting.human_attribute_name(:project) }] : nil,
+        current_project.blank? ? [:project_name, { caption: Meeting.human_attribute_name(:project) }] : nil,
         [:start_time, { caption: Meeting.human_attribute_name(:start_time) }],
         [:duration, { caption: Meeting.human_attribute_name(:duration) }],
         [:location, { caption: Meeting.human_attribute_name(:location) }]
@@ -61,13 +64,6 @@ module Meetings
 
     def columns
       @columns ||= headers.map(&:first)
-    end
-
-    private
-
-    def disambiguated_sortable_columns
-      sortable_columns.to_h { [_1.to_s, _1.to_s] }
-                      .merge('project_id' => 'meetings.project_id')
     end
   end
 end

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -31,8 +31,11 @@ require 'spec_helper'
 require_relative '../support/pages/meetings/index'
 
 RSpec.describe 'Meetings', 'Index', :with_cuprite do
-  shared_let(:project) { create(:project, name: 'Project 1', enabled_module_names: %w[meetings]) }
-  shared_let(:other_project) { create(:project, name: 'Project 2', enabled_module_names: %w[meetings]) }
+  # The order the Projects are created in is important. By naming `project` alphanumerically
+  # after `other_project`, we can ensure that subsequent specs that assert sorting is
+  # correct for the right reasons (sorting by Project name and not id)
+  shared_let(:project) { create(:project, name: 'Project 2', enabled_module_names: %w[meetings]) }
+  shared_let(:other_project) { create(:project, name: 'Project 1', enabled_module_names: %w[meetings]) }
   let(:role) { create(:role, permissions:) }
   let(:permissions) { %i(view_meetings) }
   let(:user) do
@@ -252,11 +255,11 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
 
         aggregate_failures 'Sorting by Project' do
           meetings_page.click_to_sort_by('Project')
-          meetings_page.expect_meetings_listed_in_order(meeting,
-                                                        other_project_meeting)
-          meetings_page.click_to_sort_by('Project')
           meetings_page.expect_meetings_listed_in_order(other_project_meeting,
                                                         meeting)
+          meetings_page.click_to_sort_by('Project')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        other_project_meeting)
         end
 
         aggregate_failures 'Sorting by Time' do

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -50,13 +50,25 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
   end
 
   let(:meeting) do
-    create(:meeting, project:, title: 'Awesome meeting today!', start_time: Time.current)
+    create(:meeting,
+           project:,
+           title: 'Awesome meeting today!',
+           start_time: Time.current)
   end
   let(:tomorrows_meeting) do
-    create(:meeting, project:, title: 'Awesome meeting tomorrow!', start_time: 1.day.from_now, location: 'no-protocol.com')
+    create(:meeting,
+           project:,
+           title: 'Awesome meeting tomorrow!',
+           start_time: 1.day.from_now,
+           duration: 2.0,
+           location: 'no-protocol.com')
   end
   let(:meeting_with_no_location) do
-    create(:meeting, project:, title: 'Boring meeting without a location!', start_time: 1.day.from_now, location: '')
+    create(:meeting,
+           project:,
+           title: 'Boring meeting without a location!',
+           start_time: 1.day.from_now,
+           location: '')
   end
   let(:meeting_with_malicious_location) do
     create(:meeting,
@@ -271,24 +283,6 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
                                                         meeting)
         end
 
-        aggregate_failures 'Sorting by Time' do
-          meetings_page.click_to_sort_by('Time')
-          meetings_page.expect_meetings_listed_in_order(meeting,
-                                                        other_project_meeting)
-          meetings_page.click_to_sort_by('Time')
-          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
-                                                        meeting)
-        end
-
-        aggregate_failures 'Sorting by Duration' do
-          meetings_page.click_to_sort_by('Duration')
-          meetings_page.expect_meetings_listed_in_order(meeting,
-                                                        other_project_meeting)
-          meetings_page.click_to_sort_by('Duration')
-          meetings_page.expect_meetings_listed_in_order(other_project_meeting,
-                                                        meeting)
-        end
-
         aggregate_failures 'Sorting by Duration' do
           meetings_page.click_to_sort_by('Duration')
           meetings_page.expect_meetings_listed_in_order(meeting,
@@ -381,6 +375,76 @@ RSpec.describe 'Meetings', 'Index', :with_cuprite do
       meetings_page.expect_plaintext_meeting_location(tomorrows_meeting)
       meetings_page.expect_plaintext_meeting_location(meeting_with_malicious_location)
       meetings_page.expect_no_meeting_location(meeting_with_no_location)
+    end
+
+    describe 'sorting' do
+      before do
+        meeting
+        tomorrows_meeting
+        meetings_page.visit!
+        # Start Time ASC is the default sort order for Upcoming meetings
+        # We can assert the initial sort by expecting the order is
+        # 1. `meeting`
+        # 2. `tomorrows_meeting`
+        # upon page load
+        meetings_page.expect_meetings_listed_in_order(meeting, tomorrows_meeting)
+      end
+
+      it 'allows sorting by every column' do
+        aggregate_failures 'Sorting by Title' do
+          meetings_page.click_to_sort_by('Title')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Title')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Time' do
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Time' do
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Time')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Duration' do
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Duration' do
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Duration')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+
+        aggregate_failures 'Sorting by Location' do
+          meetings_page.click_to_sort_by('Location')
+          meetings_page.expect_meetings_listed_in_order(meeting,
+                                                        tomorrows_meeting)
+          meetings_page.click_to_sort_by('Location')
+          meetings_page.expect_meetings_listed_in_order(tomorrows_meeting,
+                                                        meeting)
+        end
+      end
     end
   end
 end

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -82,12 +82,6 @@ module Pages::Meetings
       end
     end
 
-    def click_to_sort_by(header_name)
-      within '.generic-table thead' do
-        click_link header_name
-      end
-    end
-
     def set_sidebar_filter(filter_name)
       within '#main-menu' do
         click_link text: filter_name

--- a/modules/team_planner/app/components/team_planner/overview/row_component.rb
+++ b/modules/team_planner/app/components/team_planner/overview/row_component.rb
@@ -39,7 +39,7 @@ module TeamPlanner
         link_to query.name, project_team_planner_path(project, query.id)
       end
 
-      def project_id
+      def project_name
         helpers.link_to_project model.project, {}, {}, false
       end
 

--- a/modules/team_planner/app/components/team_planner/overview/table_component.rb
+++ b/modules/team_planner/app/components/team_planner/overview/table_component.rb
@@ -30,15 +30,17 @@ module TeamPlanner
   module Overview
     class TableComponent < ::TableComponent
       options :current_user
-      columns :name, :project_id, :created_at
-      sortable_columns :name, :project_id, :created_at
+      columns :name, :project_name, :created_at
+      sortable_columns :name, :project_name, :created_at
 
-      def initial_sort
-        %w[name asc]
+      def initial_sort_correlation
+        ['queries.name', 'asc']
       end
 
-      def sortable?
-        true
+      def sortable_columns_correlation
+        super.merge(name: 'queries.name',
+                    project_name: 'projects.name',
+                    created_at: 'queries.created_at')
       end
 
       def paginated?
@@ -48,7 +50,7 @@ module TeamPlanner
       def headers
         [
           [:name, { caption: I18n.t(:label_name) }],
-          [:project_id, { caption: Query.human_attribute_name(:project) }],
+          [:project_name, { caption: Query.human_attribute_name(:project) }],
           [:created_at, { caption: Query.human_attribute_name(:created_at) }]
         ]
       end

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -94,6 +94,7 @@ module ::TeamPlanner
         .visible(current_user)
         .includes(:project)
         .joins(:views)
+        .references(:projects)
         .where('views.type' => 'team_planner')
         .order('queries.name ASC')
 

--- a/modules/team_planner/spec/features/team_planner_index_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_index_spec.rb
@@ -30,67 +30,105 @@ require 'spec_helper'
 require_relative 'shared_context'
 
 RSpec.describe 'Team planner index', :js, :with_cuprite, with_ee: %i[team_planner_view] do
-  include_context 'with team planner full access'
+  shared_let(:project) do
+    create(:project)
+  end
 
-  let(:current_user) { user }
-  let(:query) { create(:query, user:, project:, public: true) }
-  let(:team_plan) { create(:view_team_planner, query:) }
+  shared_let(:user_with_full_permissions) do
+    create(:user,
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages edit_work_packages add_work_packages
+             view_team_planner manage_team_planner
+             save_queries manage_public_queries
+             work_package_assigned
+           ])
+  end
+  shared_let(:user_with_limited_permissions) do
+    create(:user,
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[view_work_packages view_team_planner])
+  end
+
+  let(:team_planner) { Pages::TeamPlanner.new(project) }
+
+  let(:current_user) { user_with_full_permissions }
 
   before do
     login_as current_user
-    team_plan
     visit project_team_planners_path(project)
   end
 
-  context 'with no view' do
-    let(:team_plan) { nil }
+  it 'shows a create button' do
+    team_planner.expect_create_button
+  end
 
+  it 'can create an action through the sidebar' do
+    find('[data-qa-selector="team-planner--create-button"]').click
+
+    team_planner.expect_no_toaster
+    team_planner.expect_title
+  end
+
+  context 'with no views' do
     it 'shows an empty index action' do
       team_planner.expect_no_views_rendered
     end
-
-    it 'shows a create button' do
-      team_planner.expect_create_button
-    end
-
-    it 'can create an action through the sidebar' do
-      find('[data-qa-selector="team-planner--create-button"]').click
-
-      team_planner.expect_no_toaster
-      team_planner.expect_title
-    end
   end
 
-  context 'with an existing view' do
-    it 'shows that view' do
-      team_planner.expect_view_rendered query
-      team_planner.expect_delete_button_for query
+  context 'with existing views' do
+    shared_let(:query) do
+      create(:public_query, user: user_with_full_permissions, project:)
+    end
+    shared_let(:team_plan) do
+      create(:view_team_planner, query:)
     end
 
-    context 'with another user with limited access' do
-      let(:current_user) do
-        create(:user,
-               firstname: 'Bernd',
-               member_in_project: project,
-               member_with_permissions: %w[view_work_packages view_team_planner])
+    shared_let(:other_query) do
+      create(:public_query, user: user_with_full_permissions, project:)
+    end
+    shared_let(:other_team_plan) do
+      create(:view_team_planner, query: other_query)
+    end
+
+    shared_let(:private_query) do
+      create(:private_query, user: user_with_full_permissions, project:)
+    end
+    shared_let(:private_team_plan) do
+      create(:view_team_planner, query: private_query)
+    end
+
+    context 'as a user with full permissions within a project' do
+      let(:current_user) { user_with_full_permissions }
+
+      it 'shows views' do
+        team_planner.expect_views_rendered(query, private_query, other_query)
       end
+
+      it 'shows management buttons' do
+        team_planner.expect_delete_buttons_for(query, private_query, other_query)
+      end
+
+      context 'and as the author of a private view' do
+        it 'shows my private view' do
+          team_planner.expect_views_rendered(query, private_query, other_query)
+
+          team_planner.expect_delete_buttons_for(query, private_query, other_query)
+        end
+      end
+    end
+
+    context 'as a user with limited permissions within a project' do
+      let(:current_user) { user_with_limited_permissions }
 
       it 'does not show the management buttons' do
-        team_planner.expect_view_rendered query
-
-        team_planner.expect_no_delete_button_for query
         team_planner.expect_no_create_button
+        team_planner.expect_no_delete_buttons_for(query, other_query)
       end
 
-      context 'when the view is non-public' do
-        let(:query) { create(:query, user:, project:, public: false) }
-
-        it 'does not show a non-public view' do
-          team_planner.expect_no_views_rendered
-          team_planner.expect_view_not_rendered query
-
-          team_planner.expect_no_create_button
-        end
+      it 'shows public views only' do
+        team_planner.expect_views_rendered(query, other_query)
       end
     end
   end

--- a/modules/team_planner/spec/features/team_planner_overview_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_overview_spec.rb
@@ -171,11 +171,16 @@ RSpec.describe 'Team planner overview',
 
         aggregate_failures 'Sorting by Project' do
           team_planner.click_to_sort_by('Project')
-          # TODO: for Aaron
-          #   This is the current behavior. Sorting seems to stack with the previous sort
-          #   even though to the user, one can only sort by a single column at a time.
-          #   It seems unintuitive to someone who would not know about this. Ask about
-          #   it in tomorrow's daily.
+          # Sorting is performed on multiple columns at a time, taking into account
+          # previous sorting criteria and using the latest clicked column as
+          # the first column in the +ORDER BY+ clause and previously sorted by columns after.
+          #
+          # This is unintuitive to a user who is visually being informed by arrows in table headers
+          # that only one column is taken into account for sorting.
+          # TODO:
+          #   Fix sorting behavior to un-toggle previous columns sorted by or provide
+          #   visual feedback of all columns currently being taken into account for
+          #   sorting.
           team_planner.expect_views_listed_in_order(other_project_query, other_query, query)
           team_planner.click_to_sort_by('Project')
           team_planner.expect_views_listed_in_order(other_query, query, other_project_query)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -149,16 +149,20 @@ module Pages
       expect(page).to have_text 'There is currently nothing to display.'
     end
 
-    def expect_view_rendered(query)
-      expect(page).to have_selector 'td', text: query.name
+    def expect_views_rendered(*queries)
+      rendered_query_names = all('td.name').map(&:text)
+
+      expect(rendered_query_names).to match_array(queries.map(&:name))
     end
 
     def expect_delete_button_for(query)
       expect(page).to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
     end
 
-    def expect_no_delete_button_for(query)
-      expect(page).not_to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+    def expect_no_delete_buttons_for(*queries)
+      queries.each do |query|
+        expect(page).not_to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+      end
     end
 
     def expect_view_not_rendered(query)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -155,8 +155,10 @@ module Pages
       expect(rendered_query_names).to match_array(queries.map(&:name))
     end
 
-    def expect_delete_button_for(query)
-      expect(page).to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+    def expect_delete_buttons_for(*queries)
+      queries.each do |query|
+        expect(page).to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+      end
     end
 
     def expect_no_delete_buttons_for(*queries)
@@ -178,6 +180,20 @@ module Pages
     def expect_no_create_button
       within '.toolbar-items' do
         expect(page).not_to have_link text: 'Team planner'
+      end
+    end
+
+    def click_to_sort_by(header_name)
+      within '.generic-table thead' do
+        click_link header_name
+      end
+    end
+
+    def expect_views_listed_in_order(*queries)
+      within '.generic-table tbody' do
+        listed_view_names = all('tr td.name').map(&:text)
+
+        expect(listed_view_names).to eq(queries.map(&:name))
       end
     end
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -183,12 +183,6 @@ module Pages
       end
     end
 
-    def click_to_sort_by(header_name)
-      within '.generic-table thead' do
-        click_link header_name
-      end
-    end
-
     def expect_views_listed_in_order(*queries)
       within '.generic-table tbody' do
         listed_view_names = all('tr td.name').map(&:text)

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -121,6 +121,12 @@ module Pages
       end
     end
 
+    def click_to_sort_by(header_name)
+      within '.generic-table thead' do
+        click_link header_name
+      end
+    end
+
     def drag_and_drop_list(from:, to:, elements:, handler:)
       # Wait a bit because drag & drop in selenium is easily offended
       sleep 1


### PR DESCRIPTION
## Bug description
The culprit of this bug is that we were sorting by `project_id` instead of the associated project's name

## Fix
Extend the composed behavior of the `TableComponent` to allow specificity of what the table's columns correlate to in database terms. This also aids in ambiguous column errors when we join tables attempt to sort by a column that has the same name in both tables (e.g. `name` and `projects.name`)

## Notes
I discovered that as the implementation stood, we sort by more than one column at a time in the `ORDER BY` clause (specifically by columns I have previously sorted by that are stored in the session) and there are two issues with this:
1. The user gets no real indication on a UI level that this is happening
2. The user has no ability to stop taking a column into account for sorting and sort solely on the column he's interested in.
Left a TODO comment and a spec that demonstrates this behavior to keep a tab on this and discuss what this should become. With the Primer do-over coming, this will probably have to be re-worked anyway.

See the Work Package related to this PR: https://community.openproject.org/work_packages/49610