### PR TITLE
[#49397]: Replace primer icon with legacy op icon

### DIFF
--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -53,7 +53,7 @@ module Storages::ProjectStorages::Members
       connection_result = storage_connection_status
 
       if connection_result == :not_connected
-        render(Primer::Beta::Octicon.new(:'alert-fill', size: :small, color: :severe)) +
+        helpers.op_icon('icon-warning -warning') +
           content_tag(:span,
                       I18n.t("storages.member_connection_status.not_connected",
                              files_label: content_tag(:span,


### PR DESCRIPTION
#### https://community.openproject.org/projects/openproject/work_packages/49397/activity#activity-21

Update of #13340 

![Screenshot 2023-08-16 at 5 37 45 PM](https://github.com/opf/openproject/assets/17295175/46b6454f-044a-4e0f-a6fe-ce1d49fbe13c)
