### PR TITLE
[49697] Toolbar on small screens looks weird

### DIFF
--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -37,10 +37,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% title avatar(@topic.author) + h(@topic.subject) %>
 <%= toolbar title: title do %>
-  <li class="toolbar-item hidden-for-mobile">
+  <li class="toolbar-item hidden-for-tablet">
     <%= watcher_link(@topic, User.current) %>
   </li>
-  <li class="toolbar-item hidden-for-mobile">
+  <li class="toolbar-item hidden-for-tablet">
     <% if !@topic.locked? && authorize_for('messages', 'reply') %>
       <%= link_to(
             { action: 'quote', id: @topic },

--- a/app/views/projects/_toolbar.html.erb
+++ b/app/views/projects/_toolbar.html.erb
@@ -39,14 +39,14 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     </li>
   <% end %>
-  <li class="toolbar-item hidden-for-mobile">
+  <li class="toolbar-item hidden-for-tablet">
     <%= link_to project_identifier_path(@project), class: 'button' do %>
       <%= op_icon('button--icon icon-edit') %>
       <span class="button--text"><%= t('projects.settings.change_identifier') %></span>
     <% end %>
   </li>
   <% if @project.copy_allowed? %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= link_to copy_project_path(@project), class: 'button copy', accesskey: accesskey(:copy) do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>
@@ -54,7 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if User.current.allowed_to?(:archive_project, @project) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= link_to(project_archive_path(@project, status: '', name: @project.name),
                   data: { confirm: t('project.archive.are_you_sure', name: @project.name) },
                   method: :post,
@@ -66,7 +66,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if User.current.admin? %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <% label = @project.templated ? 'remove_from_templates' : 'make_template' %>
       <%= link_to(project_templated_path(@project),
                   method: @project.templated ? :delete : :post,

--- a/app/views/users/_toolbar.html.erb
+++ b/app/views/users/_toolbar.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   </li>
   <% if current_user.allowed_to_globally?(:create_user) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= form_for(@user, html: { class: 'toolbar-item' },
                  url: { action: :resend_invitation },
                  method: :post) do |_form| %>
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
   <% if current_user.admin? %>
     <% unless current_user.id == @user.id %>
-      <%= form_for @user, html: { class: 'toolbar-item hidden-for-mobile' }, :url => { :action => :change_status },
+      <%= form_for @user, html: { class: 'toolbar-item hidden-for-tablet' }, :url => { :action => :change_status },
                    :method => :post do %>
         <li>
           <%= change_user_status_buttons(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if User.current.allowed_to_globally?(:create_user) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= form_for(@user, html: { class: 'toolbar-item' },
                  url: { action: :resend_invitation },
                  method: :post) do |_form| %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -48,7 +48,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= link_to({ controller: '/wiki', action: 'edit',
                     project_id: @version.project,
                     id: @version.wiki_page_title },

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
       </li>
     <% end %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= watcher_link(@page.object, User.current) %>
     </li>
     <% unless @page.current_version? %>

--- a/app/views/workflows/_toolbar.html.erb
+++ b/app/views/workflows/_toolbar.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= toolbar title: title do %>
-  <li class="toolbar-item hidden-for-mobile">
+  <li class="toolbar-item hidden-for-tablet">
     <%= link_to({ action: 'copy' }, class: 'button') do %>
       <%= op_icon('button--icon icon-copy') %>
       <span class="button--text"><%= t(:button_copy) %></span>

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -99,12 +99,12 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent i
     {
       component: BcfImportButtonComponent,
       show: ():boolean => this.ifcData.allowed('manage_bcf'),
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: BcfExportButtonComponent,
       show: ():boolean => this.ifcData.allowed('manage_bcf'),
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: WorkPackageFilterButtonComponent,
@@ -112,11 +112,11 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent i
     },
     {
       component: BcfViewToggleButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: ZenModeButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: BimManageIfcModelsButtonComponent,
@@ -126,7 +126,7 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent i
     },
     {
       component: WorkPackageSettingsButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
       show: ():boolean => this.authorisationService.can('query', 'updateImmediately'),
       inputs: {
         hideTableOptions: true,

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
@@ -126,15 +126,15 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
   toolbarButtonComponents:ToolbarButtonComponentDefinition[] = [
     {
       component: WorkPackageFilterButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: ZenModeButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: BoardsMenuButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
       show: () => this.editable,
       inputs: {
         board$: this.board$,

--- a/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
@@ -108,7 +108,7 @@ export class WorkPackagesCalendarPageComponent extends PartitionedQuerySpacePage
     },
     {
       component: WorkPackageSettingsButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
       inputs: {
         hideTableOptions: true,
         showCalendarSharingOption: true,

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
@@ -78,7 +78,7 @@ export class InAppNotificationCenterPageComponent extends UntilDestroyedMixin im
     },
     {
       component: NotificationSettingsButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
   ];
 

--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -90,7 +90,7 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
     },
     {
       component: WorkPackageSettingsButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
       show: ():boolean => this.authorisationService.can('query', 'updateImmediately'),
       inputs: {
         hideTableOptions: true,

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
@@ -10,10 +10,10 @@
         <wp-type-status [workPackage]="newWorkPackage"></wp-type-status>
       </div>
       <ul class="toolbar-items hide-when-print">
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-tablet">
           <zen-mode-toggle-button></zen-mode-toggle-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-tablet">
           <button id="create-wp-menu-button"
                   [attr.title]="text.button_settings"
                   class="button last work-packages-settings-button toolbar-icon"

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -52,7 +52,8 @@
       min-width: initial
       max-width: 100vw
       max-height: 100%
-
+      
+  @media only screen and (max-width: $breakpoint-md)
     .toolbar
       display: grid
       grid-template-columns: 1fr auto

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -19,13 +19,13 @@
         </div>
       </div>
       <ul id="toolbar-items" class="toolbar-items hide-when-print">
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-tablet">
           <wp-create-button
             [allowed]="['work_package.addChild', 'work_package.copy']"
             [stateName$]="stateName$">
           </wp-create-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile" *ngIf="displayTimerButton">
+        <li class="toolbar-item hidden-for-tablet" *ngIf="displayTimerButton">
           <op-wp-timer-button
             [workPackage]="workPackage"
           >
@@ -42,7 +42,7 @@
             data-qa-selector="mark-notification-read-button"
           ></op-work-package-mark-notification-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-tablet">
           <zen-mode-toggle-button>
           </zen-mode-toggle-button>
         </li>

--- a/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
@@ -75,14 +75,14 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
     },
     {
       component: OpBaselineModalComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: WorkPackageFilterButtonComponent,
     },
     {
       component: WorkPackageViewToggleButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: WorkPackageFoldToggleButtonComponent,
@@ -90,15 +90,15 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
     },
     {
       component: WorkPackageDetailsViewButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: WorkPackageTimelineButtonComponent,
-      containerClasses: 'hidden-for-mobile -no-spacing',
+      containerClasses: 'hidden-for-tablet -no-spacing',
     },
     {
       component: ZenModeButtonComponent,
-      containerClasses: 'hidden-for-mobile',
+      containerClasses: 'hidden-for-tablet',
     },
     {
       component: WorkPackageSettingsButtonComponent,

--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
@@ -5,7 +5,7 @@
       </div>
 
       <ul class="op-grid-page--toolbar-items toolbar-items hidden-for-mobile">
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-tablet">
           <zen-mode-toggle-button></zen-mode-toggle-button>
         </li>
         <li class="toolbar-item">

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -76,6 +76,10 @@
   h2
     font-size: 1.4rem
 
-@include breakpoint(sm)
+@media screen and (min-width: $breakpoint-sm)
   .hidden-for-desktop
+    display: none !important
+
+@media screen and (max-width: $breakpoint-md)
+  .hidden-for-tablet
     display: none !important

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -90,12 +90,10 @@ $nm-color-success-background: #d8fdd1
 
   li
     list-style-type: none
-    flex-grow: 1
 
   .toolbar-item
     margin-right: 10px
-    // spacing between nav items
-    flex-grow: 1
+    margin-bottom: 5px
 
     // hide right margin for e.g., conditional buttons
     &.-no-spacing

--- a/frontend/src/global_styles/layout/_toolbar_mobile.sass
+++ b/frontend/src/global_styles/layout/_toolbar_mobile.sass
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-@media screen and (max-width: $breakpoint-sm)
+@media screen and (max-width: $breakpoint-md)
   #content
     .toolbar-container
       margin-top: 5px

--- a/modules/budgets/app/views/budgets/show.html.erb
+++ b/modules/budgets/app/views/budgets/show.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if authorize_for(:budgets, :copy) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= link_to({ controller: 'budgets', action: 'copy', id: @budget }, class: 'button') do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
             link_to: link_to(@meeting),
             html: { class: 'meeting--main-toolbar' } do %>
   <% unless User.current.anonymous? %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <div class="button">
         <%= watcher_link @meeting, User.current %>
       </div>
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
     </li>
   <% end %>
   <% if authorize_for(:meetings, :copy) %>
-    <li class="toolbar-item hidden-for-mobile">
+    <li class="toolbar-item hidden-for-tablet">
       <%= link_to({:controller => '/meetings', :action => 'copy', :id => @meeting}, class: 'button') do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>


### PR DESCRIPTION
* Change toolbar behavior already at tablet screen size. The buttons show the icon only and less important buttons are hidden
* If there is not enough space to fit the toolbar into one row, the buttons should be shown next to each other instead of having some weird spacing in between

https://community.openproject.org/projects/14/work_packages/49697/activity