### PR TITLE
Add lookbook param for octicons

### DIFF
--- a/app/views/lookbook/previews/inputs/_octicon.html.erb
+++ b/app/views/lookbook/previews/inputs/_octicon.html.erb
@@ -1,0 +1,1 @@
+<%= select_tag(name, options_for_select([:none, *Octicons::OCTICON_SYMBOLS.keys], value), **input_options, "x-model": "value") %>

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -37,6 +37,8 @@ OpenProject::Application.configure do
   # rubocop:enable Lint/ConstantDefinitionInBlock
 
   Rails.application.reloader.to_prepare do
+    Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
+
     [
       Lookbook::ApplicationController,
       Lookbook::PreviewController,


### PR DESCRIPTION
Prevents an error trying to look at e.g., the overlay preview due to the missing input type