### PR TITLE
[#49507] File Drag and Drop

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -113,7 +113,13 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
   };
 
   private onGlobalDragEnter:(_event:DragEvent) => void = (_event) => {
-    this.dragging += 1;
+    // When the global drag and drop is active and the dragging happens over the DOM
+    // elements, the dragenter and dragleave events are always fired in pairs.
+    // On dragenter the this.dragging is set to 2 and on dragleave we deduct it to 1,
+    // meaning the drag and drop remains active. When the drag and drop action is canceled
+    // i.e. by the "Escape" key, an extra dragleave event is fired.
+    // In this case this.dragging will be deducted to 0, disabling the active drop areas.
+    this.dragging = 2;
     this.cdRef.detectChanges();
   };
 

--- a/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
@@ -232,13 +232,6 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
         model.on('op:attachment-added', () => document.body.dispatchEvent(new DragEvent('dragend')));
         model.on('op:attachment-removed', () => document.body.dispatchEvent(new DragEvent('dragend')));
 
-        // Emitting a global dragleave on every dragleave of the ckeditor element
-        // IMPORTANT: This emits much more dragleave events then dragenter events.
-        // In the end, this leads to a break in every drop zone that listens to those two global events
-        // to determine its state. Without it, if no dragleave is fired, the drop zones enter a failed state,
-        // not vanishing after ending the drag.
-        this.$element.on('dragleave', () => document.body.dispatchEvent(new DragEvent('dragleave')));
-
         this.initializeDone.emit(watchdog.editor);
         return watchdog.editor;
       });

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -194,7 +194,13 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
   };
 
   private onGlobalDragEnter:(_event:DragEvent) => void = (_event) => {
-    this.dragging += 1;
+    // When the global drag and drop is active and the dragging happens over the DOM
+    // elements, the dragenter and dragleave events are always fired in pairs.
+    // On dragenter the this.dragging is set to 2 and on dragleave we deduct it to 1,
+    // meaning the drag and drop remains active. When the drag and drop action is canceled
+    // i.e. by the "Escape" key, an extra dragleave event is fired.
+    // In this case this.dragging will be deducted to 0, disabling the active drop areas.
+    this.dragging = 2;
     this.cdRef.detectChanges();
   };
 

--- a/spec/support/components/attachments/attachments.rb
+++ b/spec/support/components/attachments/attachments.rb
@@ -7,11 +7,15 @@ module Components
 
     ##
     # Drag and Drop the file loaded from path on to the (native) target element
-    def drag_and_drop_file(target, path, position = :center, stopover = nil)
+    def drag_and_drop_file(target, path, position = :center, stopover = nil, cancel_drop: false, delay_dragleave: false)
       # Remove any previous input, if any
       page.execute_script <<-JS
         jQuery('#temporary_attachment_files').remove()
       JS
+
+      if stopover.is_a?(Array) && !stopover.all?(String)
+        raise ArgumentError, 'In case the stopover is an array, it must contain only string selectors.'
+      end
 
       element =
         if target.is_a?(String)
@@ -27,7 +31,9 @@ module Components
         element,
         'temporary_attachment_files',
         position.to_s,
-        stopover
+        stopover,
+        cancel_drop,
+        delay_dragleave
       )
 
       attach_file_on_input(path, 'temporary_attachment_files')

--- a/spec/support/components/attachments/attachments_input.js
+++ b/spec/support/components/attachments/attachments_input.js
@@ -10,7 +10,67 @@ let name = params[1];
 let position = params[2];
 
 // We might want to drag the file over something, then wait a bit and drag it elsewhere
-let stopover = params[3];
+let stopovers;
+
+if (params[3] === null) {
+  stopovers = [];
+} else if (Array.isArray(params[3])) {
+  stopovers = params[3];
+} else {
+  stopovers = [params[3]];
+}
+
+// Cancel the drop event
+let cancelDrop = params[4];
+
+// Delay drag leave to allow the work package tabs to become active on dragover event
+let delayDragleave = params[5];
+
+function buildDragEvent(type, targetX, targetY, dataTransfer) {
+  let event = new MouseEvent(type, { clientX: targetX, clientY: targetY, bubbles: true });
+
+  // Override the constructor to the DragEvent class
+  Object.setPrototypeOf(event, null);
+  event.dataTransfer = dataTransfer;
+  Object.setPrototypeOf(event, DragEvent.prototype);
+  return event;
+}
+
+function dropOnStopover(stopover, dataTransfer) {
+  // Look up the selector
+  if (typeof stopover === 'string') {
+    stopover = document.querySelector(stopover);
+  }
+
+  // We need coordinates to drop to the element
+  let stopbox = stopover.getBoundingClientRect();
+  let stopX;
+  let stopY;
+
+  stopX = stopbox.left + (stopbox.width / 2);
+  stopY = stopbox.top + (stopbox.height / 2);
+
+  // Fire multiple drag events, to better simulate the mouse movement.
+  let eventTypes = ['dragenter', 'dragover', 'dragleave']
+
+  if (cancelDrop) {
+    // Firing a second 'dragleave' means the drag and drop is canceled.
+    eventTypes.push('dragleave');
+  }
+
+  eventTypes.forEach(function (type) {
+    let event = buildDragEvent(type, stopX, stopY, dataTransfer);
+    if (delayDragleave && type === 'dragleave') {
+      setTimeout(() => {
+        console.log("Dispatching event %O", event);
+        stopover.dispatchEvent(event);
+      }, 500);
+    } else {
+      console.log("Dispatching event %O", event);
+      stopover.dispatchEvent(event);
+    }
+  });
+}
 
 function dropOnTarget(dataTransfer) {
   // Look up the selector
@@ -37,13 +97,7 @@ function dropOnTarget(dataTransfer) {
   }
 
   ['dragenter', 'dragover', 'drop'].forEach(function (type) {
-    let event = new MouseEvent(type, { clientX: targetX, clientY: targetY });
-
-    // Override the constructor to the DragEvent class
-    Object.setPrototypeOf(event, null);
-    event.dataTransfer = dataTransfer;
-    Object.setPrototypeOf(event, DragEvent.prototype);
-
+    let event = buildDragEvent(type, targetX, targetY, dataTransfer);
     console.log("Dispatching event %O", event);
     target.dispatchEvent(event);
   });
@@ -71,31 +125,21 @@ let input = jQuery('<input>')
         setDragImage  : function setDragImage(){}
       };
 
-      // If we have a stopover, do that first and then get the target
-      if (stopover) {
-        // We need coordinates to drop to the element
-        let stopbox = stopover.getBoundingClientRect();
-        let stopX;
-        let stopY;
+      // If we have stopovers, do those first and then get the target
+      if (stopovers.length > 0) {
+        stopovers.forEach((stopover) => dropOnStopover(stopover, dataTransfer));
 
-        stopX = stopbox.left + (stopbox.width / 2);
-        stopY = stopbox.top + (stopbox.height / 2);
-
-        ['dragenter', 'dragover'].forEach(function (type) {
-          let event = new MouseEvent(type, { clientX: stopX, clientY: stopY });
-
-          // Override the constructor to the DragEvent class
-          Object.setPrototypeOf(event, null);
-          event.dataTransfer = dataTransfer;
-          Object.setPrototypeOf(event, DragEvent.prototype);
-
-          console.log("Dispatching event %O", event);
-          stopover.dispatchEvent(event);
-        });
-
-        setTimeout(() => dropOnTarget(dataTransfer), 2000);
+        setTimeout(() => {
+          if (!cancelDrop) {
+            // After we left the stopover DOM elements, the target element should remain visible.
+            // If it's not visible, we raise an error.
+            if (target.offsetParent === null) {
+              throw new Error("Cannot drop the file on an invisible target");
+            };
+            dropOnTarget(dataTransfer);
+          }
+        }, 2000);
       } else {
         dropOnTarget(dataTransfer);
       }
-
     });


### PR DESCRIPTION
https://community.openproject.org/work_packages/49507

The issue is, when the active file drag arrives over the description input (ckeditor), then it loses the dragging state and it does not allow the upload to happen. Removing the counter and relying on the `dragenter` `dragleave` events only fixes the issue.
<details>
  <summary>Demo</summary>

![Aug-17-2023 14-15-09](https://github.com/opf/openproject/assets/83396/63e65d06-44a2-4cb9-bc09-e1f6e1c60499)

</details>