### PR TITLE
[45677] Custom actions buttons look inactive until we hover over them and click

### DIFF
--- a/frontend/src/global_styles/content/_custom_actions.sass
+++ b/frontend/src/global_styles/content/_custom_actions.sass
@@ -40,11 +40,21 @@
     max-width: calc(100vw - 20px)
     @include text-shortener
 
-    .button
+    .custom-action--button
       @include text-shortener
       width: 100%
       // The margin is necessary for all buttons so that the alignment is correct on small screens
       margin-right: 10px
+
+      // Disabled custom action buttons should only hint that via the cursor on hover.
+      // Was introduced by #45677
+      &[disabled]
+        opacity: 1
+        // As the `disabled` attribute already prevents that a button is clickable we can allow pointer-events
+        // and thus modify the cursor
+        pointer-events: auto
+        &:hover
+          cursor: not-allowed
 
 wp-custom-actions-admin-date-action
   display: flex


### PR DESCRIPTION
# Problem
The custom action buttons normally get disabled when another change is currently in action to avoid race conditions. However, Angulars change detection don't get the completion of that change as the component is reinitialized leaving the buttons disabled. Only when hovering a button, the state is checked correctly again. See [the ticket](https://community.openproject.org/projects/14/work_packages/45677/github?query_id=2865) for details.

# Solution
This leads us to this pragmatic "solution", as we don't won't to spend that much time any more on Angular. The design of the disabld state is change to only show the "not-allowed" cursor on hover. So, for correctly disabled buttons, the cursor indicates that. For those that switch back to the correct state on hover, the user sees no change assuming that it always have been enabled. I know that this is quite hacky, but much faster than spending more time than I already did on debugging the change detection of angular.