### PR TITLE
[49726] Validate query filters with the right user

### DIFF
--- a/modules/calendar/app/services/calendar/ical_response_service.rb
+++ b/modules/calendar/app/services/calendar/ical_response_service.rb
@@ -43,11 +43,13 @@ module Calendar
 
       ical_string = nil
 
-      success, errors = validate_and_yield(query, user, options: { ical_token: ical_token_instance }) do
-        ical_string = ical_generation(query, user)
-      end
+      User.execute_as(user) do
+        success, errors = validate_and_yield(query, user, options: { ical_token: ical_token_instance }) do
+          ical_string = ical_generation(query, user)
+        end
 
-      ServiceResult.new(success:, result: ical_string, errors:)
+        ServiceResult.new(success:, result: ical_string, errors:)
+      end
     end
 
     protected

--- a/modules/calendar/spec/controllers/ical_controller_spec.rb
+++ b/modules/calendar/spec/controllers/ical_controller_spec.rb
@@ -29,37 +29,30 @@
 require 'spec_helper'
 
 RSpec.describe Calendar::ICalController do
-  let(:project) { create(:project) }
-  let(:user) do
-    create(:user,
-           member_in_project: project,
-           member_with_permissions: sufficient_permissions)
-  end
-  let(:sufficient_permissions) { %i[view_work_packages share_calendars] }
-  let(:insufficient_permissions) { %i[view_work_packages] }
+  shared_let(:project) { create(:project) }
 
-  let(:work_package_with_due_date) do
+  shared_let(:work_package_with_due_date) do
     create(:work_package, project:,
                           due_date: Time.zone.today + 7.days)
   end
-  let(:work_package_with_start_date) do
+  shared_let(:work_package_with_start_date) do
     create(:work_package, project:,
                           start_date: Time.zone.today + 14.days)
   end
-  let(:work_package_with_start_and_due_date) do
+  shared_let(:work_package_with_start_and_due_date) do
     create(:work_package, project:,
                           start_date: Date.tomorrow,
                           due_date: Time.zone.today + 7.days)
   end
-  let(:work_package_with_due_date_far_in_past) do
+  shared_let(:work_package_with_due_date_far_in_past) do
     create(:work_package, project:,
                           due_date: Time.zone.today - 180.days)
   end
-  let(:work_package_with_due_date_far_in_future) do
+  shared_let(:work_package_with_due_date_far_in_future) do
     create(:work_package, project:,
                           due_date: Time.zone.today + 180.days)
   end
-  let!(:work_packages) do
+  shared_let(:work_packages) do
     [
       work_package_with_due_date,
       work_package_with_start_date,
@@ -68,6 +61,13 @@ RSpec.describe Calendar::ICalController do
       work_package_with_due_date_far_in_future
     ]
   end
+  let(:user) do
+    create(:user,
+           member_in_project: project,
+           member_with_permissions: sufficient_permissions)
+  end
+  let(:sufficient_permissions) { %i[view_work_packages share_calendars] }
+  let(:insufficient_permissions) { %i[view_work_packages] }
   let(:query) do
     create(:query,
            project:,

--- a/modules/calendar/spec/controllers/ical_controller_spec.rb
+++ b/modules/calendar/spec/controllers/ical_controller_spec.rb
@@ -133,6 +133,24 @@ RSpec.describe Calendar::ICalController do
       it_behaves_like 'success'
     end
 
+    context 'with valid params and permissions with a query having a parent filter (bug #49726)' do
+      before do
+        User.execute_as(user) do
+          parent_work_package = create(:work_package, project:, children: work_packages)
+          query.add_filter(:parent, "=", [parent_work_package.id.to_s])
+          query.save!
+        end
+
+        get :show, params: {
+          project_id: project.id,
+          id: query.id,
+          ical_token: valid_ical_token_value
+        }
+      end
+
+      it_behaves_like 'success'
+    end
+
     context 'with valid params and permissions when targeting own query when globally disabled',
             with_settings: { ical_enabled: false } do
       before do


### PR DESCRIPTION
Fixes https://community.openproject.org/wp/49726

`Queries::ICalSharingContract` is inheriting from `Queries::BaseContract` (and not `::BaseContract`), meaning it is a `ModelContract` and will validate the model. When the `Query` instance is validated, it validates its filters and the `:parent` filter is checking if the given values are allowed values. Allowed values are work packages visible by the current user. When the current user is the anonymous user, no work packages are returns and the query is considered invalid and it returns a 404. This is the cause of the bug.

Executing the validation as the ical token owner fixes the issue.