### PR TITLE
[#49493] Add a `WorkPackageRole` type

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -35,12 +35,22 @@ module Roles
     def assignable_permissions
       if model.is_a?(GlobalRole)
         assignable_global_permissions
+      elsif model.is_a?(WorkPackageRole)
+        assignable_work_package_permissions
       else
         assignable_member_permissions
       end
     end
 
     private
+
+    def assignable_global_permissions
+      OpenProject::AccessControl.global_permissions
+    end
+
+    def assignable_work_package_permissions
+      OpenProject::AccessControl.work_package_permissions
+    end
 
     def assignable_member_permissions
       permissions_to_remove = case model.builtin
@@ -52,14 +62,8 @@ module Roles
                                 []
                               end
 
-      OpenProject::AccessControl.permissions -
-        OpenProject::AccessControl.public_permissions -
-        OpenProject::AccessControl.global_permissions -
+      OpenProject::AccessControl.project_permissions -
         permissions_to_remove
-    end
-
-    def assignable_global_permissions
-      OpenProject::AccessControl.global_permissions
     end
 
     def check_permission_prerequisites

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -93,7 +93,7 @@ class RolesController < ApplicationController
   end
 
   def report
-    @roles = Role.order(Arel.sql('builtin, position'))
+    @roles = roles_scope
     @permissions = OpenProject::AccessControl.permissions.reject(&:public?)
   end
 
@@ -151,7 +151,7 @@ class RolesController < ApplicationController
   end
 
   def roles_scope
-    Role.order(Arel.sql('builtin, position'))
+    Role.visible.ordered_by_builtin_and_position
   end
 
   def default_breadcrumb

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -39,6 +39,10 @@ class Role < ApplicationRecord
     where("#{compare} builtin = #{NON_BUILTIN}")
   }
 
+  # Work Package Roles are intentionally visually hidden from users temporarily
+  scope :visible, -> { where.not(type: 'WorkPackageRole') }
+  scope :ordered_by_builtin_and_position, -> { order(Arel.sql('builtin, position')) }
+
   before_destroy(prepend: true) do
     unless deletable?
       errors.add(:base, "can't be destroyed")

--- a/app/models/work_package_role.rb
+++ b/app/models/work_package_role.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackageRole < Role
+  def self.givable
+    none
+  end
+end

--- a/app/seeders/basic_data/base_role_seeder.rb
+++ b/app/seeders/basic_data/base_role_seeder.rb
@@ -26,14 +26,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 module BasicData
-  class RoleSeeder < ModelSeeder
-    self.model_class = Role
-    self.seed_data_model_key = 'roles'
+  class BaseRoleSeeder < ModelSeeder
     self.needs = []
 
     def model_attributes(role_data)
       {
-        type: type(role_data['global']),
+        type:,
         name: role_data['name'],
         position: role_data['position'],
         permissions: role_data['permissions'].uniq,
@@ -43,8 +41,8 @@ module BasicData
 
     private
 
-    def type(global_value)
-      true?(global_value) ? 'GlobalRole' : 'Role'
+    def type
+      model_class.to_s
     end
 
     def builtin(value)
@@ -74,7 +72,9 @@ module BasicData
       when Array
         value
       when :all_assignable_permissions
-        Roles::CreateContract.new(Role.new, nil).assignable_permissions.map(&:name)
+        Roles::CreateContract.new(model_class.new, nil)
+                             .assignable_permissions
+                             .map(&:name)
       end
     end
 

--- a/app/seeders/basic_data/global_role_seeder.rb
+++ b/app/seeders/basic_data/global_role_seeder.rb
@@ -25,21 +25,9 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module Bim
-  class BasicDataSeeder < ::BasicDataSeeder
-    def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::Bim::BasicData::SettingSeeder,
-        ::Bim::BasicData::ThemeSeeder
-      ]
-    end
+module BasicData
+  class GlobalRoleSeeder < BaseRoleSeeder
+    self.model_class = GlobalRole
+    self.seed_data_model_key = 'global_roles'
   end
 end

--- a/app/seeders/basic_data/project_role_seeder.rb
+++ b/app/seeders/basic_data/project_role_seeder.rb
@@ -25,21 +25,9 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module Bim
-  class BasicDataSeeder < ::BasicDataSeeder
-    def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::Bim::BasicData::SettingSeeder,
-        ::Bim::BasicData::ThemeSeeder
-      ]
-    end
+module BasicData
+  class ProjectRoleSeeder < BaseRoleSeeder
+    self.model_class = Role
+    self.seed_data_model_key = 'project_roles'
   end
 end

--- a/app/seeders/basic_data/setting_seeder.rb
+++ b/app/seeders/basic_data/setting_seeder.rb
@@ -28,7 +28,8 @@
 module BasicData
   class SettingSeeder < Seeder
     self.needs = [
-      BasicData::RoleSeeder,
+      BasicData::ProjectRoleSeeder,
+      BasicData::GlobalRoleSeeder,
       BasicData::StatusSeeder
     ]
 

--- a/app/seeders/basic_data/work_package_role_seeder.rb
+++ b/app/seeders/basic_data/work_package_role_seeder.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module BasicData
+  class WorkPackageRoleSeeder < BaseRoleSeeder
+    self.model_class = WorkPackageRole
+    self.seed_data_model_key = 'work_package_roles'
+  end
+end

--- a/app/seeders/basic_data/workflow_seeder.rb
+++ b/app/seeders/basic_data/workflow_seeder.rb
@@ -28,7 +28,8 @@
 module BasicData
   class WorkflowSeeder < Seeder
     self.needs = [
-      BasicData::RoleSeeder,
+      BasicData::ProjectRoleSeeder,
+      BasicData::GlobalRoleSeeder,
       BasicData::StatusSeeder,
       BasicData::TypeSeeder
     ]

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -240,7 +240,32 @@ open_color_palette:
   - '#d9480f'
 
 work_package_roles:
-  # TODO: Fill in with work package default roles and permissions
+  - reference: :default_role_work_package_editor
+    t_name: Work Package Editor
+    position: 7
+    permissions:
+      - :view_work_packages
+      - :edit_work_packages
+      - :work_package_assigned
+      - :add_work_package_notes
+      - :edit_own_work_package_notes
+      - :manage_work_package_relations
+      - :export_work_packages
+  - reference: :default_role_work_package_commenter
+    t_name: Work Package Commenter
+    position: 8
+    permissions:
+      - :view_work_packages
+      - :work_package_assigned
+      - :add_work_package_notes
+      - :edit_own_work_package_notes
+      - :export_work_packages
+  - reference: :default_role_work_package_viewer
+    t_name: Work Package Viewer
+    position: 9
+    permissions:
+      - :view_work_packages
+      - :export_work_packages
 project_roles:
   - reference: :default_role_non_member
     t_name: Non member

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -239,112 +239,114 @@ open_color_palette:
   - '#e8590c'
   - '#d9480f'
 
-roles:
-- reference: :default_role_non_member
-  t_name: Non member
-  position: 0
-  builtin: :non_member
-  permissions:
-  - :view_work_packages
-  - :view_calendar
-  - :comment_news
-  - :browse_repository
-  - :view_changesets
-  - :view_wiki_pages
-- reference: :default_role_anonymous
-  t_name: Anonymous
-  position: 1
-  builtin: :anonymous
-  permissions:
-  - :view_work_packages
-  - :browse_repository
-  - :view_changesets
-  - :view_wiki_pages
-- reference: :default_role_member
-  t_name: Member
-  position: 3
-  permissions:
-  - :view_work_packages
-  - :export_work_packages
-  - :add_work_packages
-  - :move_work_packages
-  - :edit_work_packages
-  - :assign_versions
-  - :work_package_assigned
-  - :add_work_package_notes
-  - :edit_own_work_package_notes
-  - :manage_work_package_relations
-  - :manage_subtasks
-  - :manage_public_queries
-  - :save_queries
-  - :view_work_package_watchers
-  - :add_work_package_watchers
-  - :delete_work_package_watchers
-  - :view_calendar
-  - :comment_news
-  - :manage_news
-  - :log_time
-  - :view_time_entries
-  - :view_own_time_entries
-  - :edit_own_time_entries
-  - :view_timelines
-  - :edit_timelines
-  - :delete_timelines
-  - :view_reportings
-  - :edit_reportings
-  - :delete_reportings
-  - :manage_wiki
-  - :manage_wiki_menu
-  - :rename_wiki_pages
-  - :change_wiki_parent_page
-  - :delete_wiki_pages
-  - :view_wiki_pages
-  - :export_wiki_pages
-  - :view_wiki_edits
-  - :edit_wiki_pages
-  - :delete_wiki_pages_attachments
-  - :protect_wiki_pages
-  - :list_attachments
-  - :add_messages
-  - :edit_own_messages
-  - :delete_own_messages
-  - :browse_repository
-  - :view_changesets
-  - :commit_access
-  - :view_commit_author_statistics
-  - :view_members
-  - :view_team_planner
-- reference: :default_role_reader
-  t_name: Reader
-  position: 4
-  permissions:
-  - :view_work_packages
-  - :add_work_package_notes
-  - :edit_own_work_package_notes
-  - :save_queries
-  - :view_calendar
-  - :comment_news
-  - :view_timelines
-  - :view_reportings
-  - :view_wiki_pages
-  - :export_wiki_pages
-  - :list_attachments
-  - :add_messages
-  - :edit_own_messages
-  - :delete_own_messages
-  - :browse_repository
-  - :view_changesets
-  - :view_team_planner
-- reference: :default_role_project_admin
-  t_name: Project admin
-  position: 5
-  permissions: :all_assignable_permissions
-- reference: :default_role_project_creator_and_staff_manager
-  t_name: Staff and projects manager
-  global: true
-  position: 6
-  permissions:
-  - :add_project
-  - :create_user
-  - :manage_user
-  - :manage_placeholder_user
+work_package_roles:
+  # TODO: Fill in with work package default roles and permissions
+project_roles:
+  - reference: :default_role_non_member
+    t_name: Non member
+    position: 0
+    builtin: :non_member
+    permissions:
+      - :view_work_packages
+      - :view_calendar
+      - :comment_news
+      - :browse_repository
+      - :view_changesets
+      - :view_wiki_pages
+  - reference: :default_role_anonymous
+    t_name: Anonymous
+    position: 1
+    builtin: :anonymous
+    permissions:
+      - :view_work_packages
+      - :browse_repository
+      - :view_changesets
+      - :view_wiki_pages
+  - reference: :default_role_member
+    t_name: Member
+    position: 3
+    permissions:
+      - :view_work_packages
+      - :export_work_packages
+      - :add_work_packages
+      - :move_work_packages
+      - :edit_work_packages
+      - :assign_versions
+      - :work_package_assigned
+      - :add_work_package_notes
+      - :edit_own_work_package_notes
+      - :manage_work_package_relations
+      - :manage_subtasks
+      - :manage_public_queries
+      - :save_queries
+      - :view_work_package_watchers
+      - :add_work_package_watchers
+      - :delete_work_package_watchers
+      - :view_calendar
+      - :comment_news
+      - :manage_news
+      - :log_time
+      - :view_time_entries
+      - :view_own_time_entries
+      - :edit_own_time_entries
+      - :view_timelines
+      - :edit_timelines
+      - :delete_timelines
+      - :view_reportings
+      - :edit_reportings
+      - :delete_reportings
+      - :manage_wiki
+      - :manage_wiki_menu
+      - :rename_wiki_pages
+      - :change_wiki_parent_page
+      - :delete_wiki_pages
+      - :view_wiki_pages
+      - :export_wiki_pages
+      - :view_wiki_edits
+      - :edit_wiki_pages
+      - :delete_wiki_pages_attachments
+      - :protect_wiki_pages
+      - :list_attachments
+      - :add_messages
+      - :edit_own_messages
+      - :delete_own_messages
+      - :browse_repository
+      - :view_changesets
+      - :commit_access
+      - :view_commit_author_statistics
+      - :view_members
+      - :view_team_planner
+  - reference: :default_role_reader
+    t_name: Reader
+    position: 4
+    permissions:
+      - :view_work_packages
+      - :add_work_package_notes
+      - :edit_own_work_package_notes
+      - :save_queries
+      - :view_calendar
+      - :comment_news
+      - :view_timelines
+      - :view_reportings
+      - :view_wiki_pages
+      - :export_wiki_pages
+      - :list_attachments
+      - :add_messages
+      - :edit_own_messages
+      - :delete_own_messages
+      - :browse_repository
+      - :view_changesets
+      - :view_team_planner
+  - reference: :default_role_project_admin
+    t_name: Project admin
+    position: 5
+    permissions: :all_assignable_permissions
+global_roles:
+  - reference: :default_role_project_creator_and_staff_manager
+    t_name: Staff and projects manager
+    position: 6
+    permissions:
+      - :add_project
+      - :create_user
+      - :manage_user
+      - :manage_placeholder_user

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -250,6 +250,7 @@ work_package_roles:
       - :add_work_package_notes
       - :edit_own_work_package_notes
       - :manage_work_package_relations
+      - :copy_work_packages
       - :export_work_packages
   - reference: :default_role_work_package_commenter
     t_name: Work Package Commenter

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -32,7 +32,8 @@ module DemoData
     alias_method :project_data, :seed_data
 
     self.needs = WorkPackageSeeder.needs + [
-      BasicData::RoleSeeder
+      BasicData::ProjectRoleSeeder,
+      BasicData::GlobalRoleSeeder
     ]
 
     def seed_data!

--- a/app/seeders/standard/basic_data_seeder.rb
+++ b/app/seeders/standard/basic_data_seeder.rb
@@ -31,6 +31,7 @@ module Standard
       [
         ::BasicData::BuiltinUsersSeeder,
         ::BasicData::ProjectRoleSeeder,
+        ::BasicData::WorkPackageRoleSeeder,
         ::BasicData::GlobalRoleSeeder,
         ::BasicData::TimeEntryActivitySeeder,
         ::BasicData::ColorSeeder,

--- a/app/seeders/standard/basic_data_seeder.rb
+++ b/app/seeders/standard/basic_data_seeder.rb
@@ -30,7 +30,8 @@ module Standard
     def data_seeder_classes
       [
         ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::RoleSeeder,
+        ::BasicData::ProjectRoleSeeder,
+        ::BasicData::GlobalRoleSeeder,
         ::BasicData::TimeEntryActivitySeeder,
         ::BasicData::ColorSeeder,
         ::BasicData::ColorSchemeSeeder,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -174,6 +174,11 @@ Rails.application.reloader.to_prepare do
                      dependencies: :view_work_packages,
                      contract_actions: { work_packages: %i[move] }
 
+      wpt.permission :copy_work_packages,
+                     {},
+                     require: :loggedin,
+                     permissible_on: %i[work_package project],
+                     dependencies: :view_work_packages
       wpt.permission :add_work_package_notes,
                      {
                        # FIXME: Although the endpoint is removed, the code checking whether a user

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -299,6 +299,7 @@ Rails.application.reloader.to_prepare do
     map.project_module :news do |news|
       news.permission :view_news,
                       { news: %i[index show] },
+                      permissible_on: :project,
                       public: true
 
       news.permission :manage_news,
@@ -306,10 +307,12 @@ Rails.application.reloader.to_prepare do
                         news: %i[new create edit update destroy preview],
                         'news/comments': [:destroy]
                       },
+                      permissible_on: :project,
                       require: :member
 
       news.permission :comment_news,
-                      { 'news/comments': :create }
+                      { 'news/comments': :create },
+                      permissible_on: :project
     end
 
     map.project_module :wiki do |wiki|

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -31,14 +31,15 @@ Rails.application.reloader.to_prepare do
     map.project_module nil, order: 100 do
       map.permission :add_project,
                      { projects: %i[new] },
+                     permissible_on: :global,
                      require: :loggedin,
-                     global: true,
                      contract_actions: { projects: %i[create] }
 
       map.permission :archive_project,
                      {
                        'projects/archive': %i[create]
                      },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :create_backup,
@@ -46,8 +47,8 @@ Rails.application.reloader.to_prepare do
                        admin: %i[index],
                        'admin/backups': %i[delete_token perform_token_reset reset_token show]
                      },
+                     permissible_on: :global,
                      require: :loggedin,
-                     global: true,
                      enabled: -> { OpenProject::Configuration.backup_enabled? }
 
       map.permission :create_user,
@@ -56,8 +57,8 @@ Rails.application.reloader.to_prepare do
                        'users/memberships': %i[create],
                        admin: %i[index]
                      },
+                     permissible_on: :global,
                      require: :loggedin,
-                     global: true,
                      contract_actions: { users: %i[read create] }
 
       map.permission :manage_user,
@@ -66,8 +67,8 @@ Rails.application.reloader.to_prepare do
                        'users/memberships': %i[create update destroy],
                        admin: %i[index]
                      },
+                     permissible_on: :global,
                      require: :loggedin,
-                     global: true,
                      contract_actions: { users: %i[read update] }
 
       map.permission :manage_placeholder_user,
@@ -76,16 +77,18 @@ Rails.application.reloader.to_prepare do
                        'placeholder_users/memberships': %i[create update destroy],
                        admin: %i[index]
                      },
+                     permissible_on: :global,
                      require: :loggedin,
-                     global: true,
                      contract_actions: { placeholder_users: %i[create read update] }
 
       map.permission :view_project,
                      { projects: [:show] },
+                     permissible_on: :project,
                      public: true
 
       map.permission :search_project,
                      { search: :index },
+                     permissible_on: :project,
                      public: true
 
       map.permission :edit_project,
@@ -95,6 +98,7 @@ Rails.application.reloader.to_prepare do
                        'projects/templated': %i[create destroy],
                        'projects/identifier': %i[show update]
                      },
+                     permissible_on: :project,
                      require: :member,
                      contract_actions: { projects: %i[update] }
 
@@ -102,16 +106,19 @@ Rails.application.reloader.to_prepare do
                      {
                        'projects/settings/modules': %i[show update]
                      },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :manage_members,
                      { members: %i[index new create update destroy autocomplete_for_member] },
+                     permissible_on: :project,
                      require: :member,
                      dependencies: :view_members,
                      contract_actions: { members: %i[create update destroy] }
 
       map.permission :view_members,
                      { members: [:index] },
+                     permissible_on: :project,
                      contract_actions: { members: %i[read] }
 
       map.permission :manage_versions,
@@ -119,28 +126,33 @@ Rails.application.reloader.to_prepare do
                        'projects/settings/versions': [:show],
                        versions: %i[new create edit update close_completed destroy]
                      },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :manage_types,
                      {
                        'projects/settings/types': %i[show update]
                      },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :select_custom_fields,
                      {
                        'projects/settings/custom_fields': %i[show update]
                      },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :add_subprojects,
                      { projects: %i[new] },
+                     permissible_on: :project,
                      require: :member
 
       map.permission :copy_projects,
                      {
                        projects: %i[copy]
                      },
+                     permissible_on: :project,
                      require: :member,
                      contract_actions: { projects: %i[copy] }
     end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -438,6 +438,7 @@ Rails.application.reloader.to_prepare do
     map.project_module :activity do
       map.permission :view_project_activity,
                      { activities: %i[index menu] },
+                     permissible_on: :project,
                      public: true,
                      contract_actions: { activities: %i[read] }
     end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -166,46 +166,54 @@ Rails.application.reloader.to_prepare do
                        work_packages_api: [:get],
                        'work_packages/reports': %i[report report_details]
                      },
+                     permissible_on: %i[work_package project],
                      contract_actions: { work_packages: %i[read] }
 
       wpt.permission :add_work_packages,
                      {},
+                     permissible_on: :project,
                      contract_actions: { work_packages: %i[create] }
 
       wpt.permission :edit_work_packages,
                      {
                        'work_packages/bulk': %i[edit update]
                      },
+                     permissible_on: %i[work_package project],
                      require: :member,
                      dependencies: :view_work_packages,
                      contract_actions: { work_packages: %i[update] }
 
       wpt.permission :move_work_packages,
                      { 'work_packages/moves': %i[new create] },
+                     permissible_on: :project,
                      require: :loggedin,
                      dependencies: :view_work_packages,
                      contract_actions: { work_packages: %i[move] }
 
       wpt.permission :copy_work_packages,
                      {},
-                     require: :loggedin,
                      permissible_on: %i[work_package project],
+                     require: :loggedin,
                      dependencies: :view_work_packages
+
       wpt.permission :add_work_package_notes,
                      {
                        # FIXME: Although the endpoint is removed, the code checking whether a user
                        # is eligible to add work packages through the API still seems to rely on this.
                        journals: [:new]
                      },
+                     permissible_on: %i[work_package project],
                      dependencies: :view_work_packages
 
       wpt.permission :edit_work_package_notes,
                      {},
+                     permissible_on: :project,
                      require: :loggedin,
                      dependencies: :view_work_packages
 
       wpt.permission :edit_own_work_package_notes,
                      {},
+                     permissible_on: %i[work_package project],
                      require: :loggedin,
                      dependencies: :view_work_packages
 
@@ -215,12 +223,14 @@ Rails.application.reloader.to_prepare do
                        'projects/settings/categories': [:show],
                        categories: %i[new create edit update destroy]
                      },
+                     permissible_on: :project,
                      require: :member
 
       wpt.permission :export_work_packages,
                      {
                        work_packages: %i[index all]
                      },
+                     permissible_on: %i[work_package project],
                      dependencies: :view_work_packages
 
       wpt.permission :delete_work_packages,
@@ -228,6 +238,7 @@ Rails.application.reloader.to_prepare do
                        work_packages: :destroy,
                        'work_packages/bulk': :destroy
                      },
+                     permissible_on: :project,
                      require: :member,
                      dependencies: :view_work_packages
 
@@ -235,35 +246,43 @@ Rails.application.reloader.to_prepare do
                      {
                        work_package_relations: %i[create destroy]
                      },
+                     permissible_on: %i[work_package project],
                      dependencies: :view_work_packages
 
       wpt.permission :manage_subtasks,
                      {},
+                     permissible_on: :project,
                      dependencies: :view_work_packages
       # Queries
       wpt.permission :manage_public_queries,
                      {},
+                     permissible_on: :project,
                      require: :member
 
       wpt.permission :save_queries,
                      {},
+                     permissible_on: :project,
                      require: :loggedin,
                      dependencies: :view_work_packages
       # Watchers
       wpt.permission :view_work_package_watchers,
                      {},
+                     permissible_on: :project,
                      dependencies: :view_work_packages
 
       wpt.permission :add_work_package_watchers,
                      {},
+                     permissible_on: :project,
                      dependencies: :view_work_packages
 
       wpt.permission :delete_work_package_watchers,
                      {},
+                     permissible_on: :project,
                      dependencies: :view_work_packages
 
       wpt.permission :assign_versions,
                      {},
+                     permissible_on: :project,
                      dependencies: :view_work_packages
 
       # A user having the following permission can become assignee and/or responsible of a work package.
@@ -271,6 +290,7 @@ Rails.application.reloader.to_prepare do
       # actions but rather to have actions taken together with him/her.
       wpt.permission :work_package_assigned,
                      {},
+                     permissible_on: %i[work_package project],
                      require: :member,
                      contract_actions: { work_packages: %i[assigned] },
                      grant_to_admin: false

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -401,30 +401,37 @@ Rails.application.reloader.to_prepare do
     map.project_module :forums do |forum|
       forum.permission :manage_forums,
                        { forums: %i[new create edit update move destroy] },
+                       permissible_on: :project,
                        require: :member
 
       forum.permission :view_messages,
                        { forums: %i[index show],
                          messages: [:show] },
+                       permissible_on: :project,
                        public: true
 
       forum.permission :add_messages,
-                       { messages: %i[new create reply quote preview] }
+                       { messages: %i[new create reply quote preview] },
+                       permissible_on: :project
 
       forum.permission :edit_messages,
                        { messages: %i[edit update preview] },
+                       permissible_on: :project,
                        require: :member
 
       forum.permission :edit_own_messages,
                        { messages: %i[edit update preview] },
+                       permissible_on: :project,
                        require: :loggedin
 
       forum.permission :delete_messages,
                        { messages: :destroy },
+                       permissible_on: :project,
                        require: :member
 
       forum.permission :delete_own_messages,
                        { messages: :destroy },
+                       permissible_on: :project,
                        require: :loggedin
     end
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -374,23 +374,28 @@ Rails.application.reloader.to_prepare do
 
     map.project_module :repository do |repo|
       repo.permission :browse_repository,
-                      { repositories: %i[show browse entry annotate changes diff stats graph] }
+                      { repositories: %i[show browse entry annotate changes diff stats graph] },
+                      permissible_on: :project
 
       repo.permission :commit_access,
-                      {}
+                      {},
+                      permissible_on: :project
 
       repo.permission :manage_repository,
                       {
                         repositories: %i[edit create update committers destroy_info destroy],
                         'projects/settings/repository': :show
                       },
+                      permissible_on: :project,
                       require: :member
 
       repo.permission :view_changesets,
-                      { repositories: %i[show revisions revision] }
+                      { repositories: %i[show revisions revision] },
+                      permissible_on: :project
 
       repo.permission :view_commit_author_statistics,
-                      {}
+                      {},
+                      permissible_on: :project
     end
 
     map.project_module :forums do |forum|

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -317,46 +317,58 @@ Rails.application.reloader.to_prepare do
 
     map.project_module :wiki do |wiki|
       wiki.permission :view_wiki_pages,
-                      { wiki: %i[index show special menu] }
+                      { wiki: %i[index show special menu] },
+                      permissible_on: :project
 
       wiki.permission :list_attachments,
                       { wiki: :list_attachments },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :manage_wiki,
                       { wikis: %i[edit destroy] },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :manage_wiki_menu,
                       { wiki_menu_items: %i[edit update select_main_menu_item replace_main_menu_item] },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :rename_wiki_pages,
                       { wiki: :rename },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :change_wiki_parent_page,
                       { wiki: %i[edit_parent_page update_parent_page] },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :delete_wiki_pages,
                       { wiki: :destroy },
+                      permissible_on: :project,
                       require: :member
 
       wiki.permission :export_wiki_pages,
-                      { wiki: [:export] }
+                      { wiki: [:export] },
+                      permissible_on: :project
 
       wiki.permission :view_wiki_edits,
-                      { wiki: %i[history diff annotate] }
+                      { wiki: %i[history diff annotate] },
+                      permissible_on: :project
 
       wiki.permission :edit_wiki_pages,
-                      { wiki: %i[edit update preview add_attachment new new_child create] }
+                      { wiki: %i[edit update preview add_attachment new new_child create] },
+                      permissible_on: :project
 
       wiki.permission :delete_wiki_pages_attachments,
-                      {}
+                      {},
+                      permissible_on: :project
 
       wiki.permission :protect_wiki_pages,
                       { wiki: :protect },
+                      permissible_on: :project,
                       require: :member
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2446,6 +2446,7 @@ en:
   permission_comment_news: "Comment news"
   permission_commit_access: "Read/write access to repository (commit)"
   permission_copy_projects: "Copy projects"
+  permission_copy_work_packages: "Copy work packages"
   permission_create_backup: "Create backup"
   permission_delete_work_package_watchers: "Delete watchers"
   permission_delete_work_packages: "Delete work packages"

--- a/db/migrate/20230829151629_add_copy_work_packages_permission_to_roles.rb
+++ b/db/migrate/20230829151629_add_copy_work_packages_permission_to_roles.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative 'migration_utils/permission_adder'
+
+class AddCopyWorkPackagesPermissionToRoles < ActiveRecord::Migration[7.0]
+  # Decouple ActiveRecord model from Migration
+  class MigrationRolePermission < ApplicationRecord
+    self.table_name = 'role_permissions'
+  end
+
+  def up
+    ::Migration::MigrationUtils::PermissionAdder
+      .add(:move_work_packages,
+           :copy_work_packages)
+  end
+
+  def down
+    MigrationRolePermission.where(permission: 'copy_work_packages').delete_all
+  end
+end

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -96,6 +96,10 @@ module OpenProject
         @loggedin_only_permissions ||= @mapped_permissions.select(&:require_loggedin?)
       end
 
+      def project_permissions
+        @project_permissions ||= @mapped_permissions.select(&:project?)
+      end
+
       def global_permissions
         @global_permissions ||= @mapped_permissions.select(&:global?)
       end
@@ -169,6 +173,7 @@ module OpenProject
         @members_only_permissions = nil
         @project_modules = nil
         @public_permissions = nil
+        @project_permissions = nil
         @global_permissions = nil
         @public_permissions = nil
         @permissions = nil

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -96,6 +96,10 @@ module OpenProject
         @loggedin_only_permissions ||= @mapped_permissions.select(&:require_loggedin?)
       end
 
+      def work_package_permissions
+        @work_package_permissions ||= @mapped_permissions.select(&:work_package?)
+      end
+
       def project_permissions
         @project_permissions ||= @mapped_permissions.select(&:project?)
       end
@@ -173,6 +177,7 @@ module OpenProject
         @members_only_permissions = nil
         @project_modules = nil
         @public_permissions = nil
+        @work_package_permissions = nil
         @project_permissions = nil
         @global_permissions = nil
         @public_permissions = nil

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -85,27 +85,27 @@ module OpenProject
       end
 
       def public_permissions
-        @public_permissions ||= @mapped_permissions.select(&:public?)
+        @public_permissions ||= permissions.select(&:public?)
       end
 
       def members_only_permissions
-        @members_only_permissions ||= @mapped_permissions.select(&:require_member?)
+        @members_only_permissions ||= permissions.select(&:require_member?)
       end
 
       def loggedin_only_permissions
-        @loggedin_only_permissions ||= @mapped_permissions.select(&:require_loggedin?)
+        @loggedin_only_permissions ||= permissions.select(&:require_loggedin?)
       end
 
       def work_package_permissions
-        @work_package_permissions ||= @mapped_permissions.select(&:work_package?)
+        @work_package_permissions ||= permissions.select(&:work_package?)
       end
 
       def project_permissions
-        @project_permissions ||= @mapped_permissions.select(&:project?)
+        @project_permissions ||= permissions.select(&:project?)
       end
 
       def global_permissions
-        @global_permissions ||= @mapped_permissions.select(&:global?)
+        @global_permissions ||= permissions.select(&:global?)
       end
 
       def available_project_modules
@@ -121,7 +121,7 @@ module OpenProject
 
       def project_modules
         @project_modules ||=
-          @mapped_permissions
+          permissions
             .reject(&:global?)
             .map(&:project_module)
             .including(@project_modules_without_permissions)
@@ -130,7 +130,7 @@ module OpenProject
       end
 
       def modules_permissions(modules)
-        @mapped_permissions.select { |p| p.project_module.nil? || modules.include?(p.project_module.to_s) }
+        permissions.select { |p| p.project_module.nil? || modules.include?(p.project_module.to_s) }
       end
 
       def module_enterprise_feature?(name)
@@ -162,13 +162,13 @@ module OpenProject
       end
 
       def remove_modules_permissions(module_name)
-        permissions = @mapped_permissions
+        original_permissions = permissions
 
-        module_permissions = permissions.select { |p| p.project_module.to_s == module_name.to_s }
+        module_permissions = original_permissions.select { |p| p.project_module.to_s == module_name.to_s }
 
         clear_caches
 
-        @mapped_permissions = permissions - module_permissions
+        @mapped_permissions = original_permissions - module_permissions
       end
 
       def clear_caches

--- a/lib/open_project/access_control/mapper.rb
+++ b/lib/open_project/access_control/mapper.rb
@@ -29,8 +29,8 @@
 module OpenProject
   module AccessControl
     class Mapper
-      def permission(name, hash, **options)
-        mapped_permissions << Permission.new(name, hash, project_module: @project_module, **options)
+      def permission(name, hash, **)
+        mapped_permissions << Permission.new(name, hash, project_module: @project_module, **)
       end
 
       def project_module(name, options = {})

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -40,9 +40,9 @@ module OpenProject
       # permissions.
       def initialize(name,
                      hash,
+                     permissible_on:,
                      public: false,
                      require: nil,
-                     global: false,
                      enabled: true,
                      project_module: nil,
                      contract_actions: [],
@@ -51,7 +51,7 @@ module OpenProject
         @name = name
         @public = public
         @require = require
-        @global = global
+        @permissible_on = Array(permissible_on)
         @enabled = enabled
         @project_module = project_module
         @contract_actions = contract_actions
@@ -71,8 +71,16 @@ module OpenProject
         @public
       end
 
+      def work_package?
+        @permissible_on.include? :work_package
+      end
+
+      def project?
+        @permissible_on.include? :project
+      end
+
       def global?
-        @global
+        @permissible_on.include? :global
       end
 
       def grant_to_admin?

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -67,30 +67,31 @@ module OpenProject::Backlogs
       end
 
       project_module :backlogs, dependencies: :work_package_tracking do
-        # SYNTAX: permission :name_of_permission, { :controller_name => [:action1, :action2] }
-
         # Master backlog permissions
         permission :view_master_backlog,
-                   rb_master_backlogs: :index,
-                   rb_sprints: %i[index show],
-                   rb_wikis: :show,
-                   rb_stories: %i[index show],
-                   rb_queries: :show,
-                   rb_burndown_charts: :show
+                   { rb_master_backlogs: :index,
+                     rb_sprints: %i[index show],
+                     rb_wikis: :show,
+                     rb_stories: %i[index show],
+                     rb_queries: :show,
+                     rb_burndown_charts: :show },
+                   permissible_on: :project
 
         permission :view_taskboards,
-                   rb_taskboards: :show,
-                   rb_sprints: :show,
-                   rb_stories: :show,
-                   rb_tasks: %i[index show],
-                   rb_impediments: %i[index show],
-                   rb_wikis: :show,
-                   rb_burndown_charts: :show
+                   { rb_taskboards: :show,
+                     rb_sprints: :show,
+                     rb_stories: :show,
+                     rb_tasks: %i[index show],
+                     rb_impediments: %i[index show],
+                     rb_wikis: :show,
+                     rb_burndown_charts: :show },
+                   permissible_on: :project
 
         permission :select_done_statuses,
                    {
                      'projects/settings/backlogs': %i[show update rebuild_positions]
                    },
+                   permissible_on: :project,
                    require: :member
 
         # Sprint permissions
@@ -100,6 +101,7 @@ module OpenProject::Backlogs
                      rb_sprints: %i[edit update],
                      rb_wikis: %i[edit update]
                    },
+                   permissible_on: :project,
                    require: :member
       end
 

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -31,6 +31,7 @@ module Bim
       [
         ::BasicData::BuiltinUsersSeeder,
         ::BasicData::ProjectRoleSeeder,
+        ::BasicData::WorkPackageRoleSeeder,
         ::BasicData::GlobalRoleSeeder,
         ::BasicData::TimeEntryActivitySeeder,
         ::BasicData::ColorSeeder,

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -47,17 +47,21 @@ module OpenProject::Bim
                      'bim/ifc_models/ifc_models': %i[index show defaults],
                      'bim/ifc_models/ifc_viewer': %i[show]
                    },
+                   permissible_on: :project,
                    contract_actions: { ifc_models: %i[read] }
         permission :manage_ifc_models,
                    { 'bim/ifc_models/ifc_models': %i[index show destroy edit update create new] },
+                   permissible_on: :project,
                    dependencies: %i[view_ifc_models],
                    contract_actions: { ifc_models: %i[create update destroy] }
         permission :view_linked_issues,
                    { 'bim/bcf/issues': %i[index] },
+                   permissible_on: :project,
                    dependencies: %i[view_work_packages],
                    contract_actions: { bcf: %i[read] }
         permission :manage_bcf,
                    { 'bim/bcf/issues': %i[index upload prepare_import configure_import perform_import] },
+                   permissible_on: :project,
                    dependencies: %i[view_linked_issues
                                     view_work_packages
                                     add_work_packages
@@ -65,6 +69,7 @@ module OpenProject::Bim
                    contract_actions: { bcf: %i[create update] }
         permission :delete_bcf,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[view_linked_issues
                                     manage_bcf
                                     view_work_packages
@@ -74,9 +79,11 @@ module OpenProject::Bim
                    contract_actions: { bcf: %i[destroy] }
         permission :save_bcf_queries,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[save_queries]
         permission :manage_public_bcf_queries,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[manage_public_queries save_bcf_queries]
       end
 

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -54,8 +54,8 @@ module OpenProject::Boards
            caption: :'boards.label_boards'
 
       should_render_global_menu_item = Proc.new do
-          (User.current.logged? || !Setting.login_required?) &&
-          User.current.allowed_to_globally?(:show_board_views)
+        (User.current.logged? || !Setting.login_required?) &&
+        User.current.allowed_to_globally?(:show_board_views)
       end
 
       menu :top_menu,

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -30,10 +30,12 @@ module OpenProject::Boards
       project_module :board_view, dependencies: :work_package_tracking, order: 80 do
         permission :show_board_views,
                    { 'boards/boards': %i[index show] },
+                   permissible_on: :project,
                    dependencies: :view_work_packages,
                    contract_actions: { boards: %i[read] }
         permission :manage_board_views,
                    { 'boards/boards': %i[index show new create destroy] },
+                   permissible_on: :project,
                    dependencies: :manage_public_queries,
                    contract_actions: { boards: %i[create update destroy] }
       end

--- a/modules/budgets/lib/budgets/engine.rb
+++ b/modules/budgets/lib/budgets/engine.rb
@@ -7,8 +7,12 @@ module Budgets
              bundled: true,
              name: 'Budgets' do
       project_module :budgets do
-        permission :view_budgets, { budgets: %i[index show] }
-        permission :edit_budgets, { budgets: %i[index show edit update destroy destroy_info new create copy] }
+        permission :view_budgets,
+                   { budgets: %i[index show] },
+                   permissible_on: :project
+        permission :edit_budgets,
+                   { budgets: %i[index show edit update destroy destroy_info new create copy] },
+                   permissible_on: :project
       end
 
       menu :project_menu,

--- a/modules/calendar/lib/open_project/calendar/engine.rb
+++ b/modules/calendar/lib/open_project/calendar/engine.rb
@@ -43,8 +43,8 @@ module OpenProject::Calendar
       end
 
       should_render = Proc.new do
-          (User.current.logged? || !Setting.login_required?) &&
-          User.current.allowed_to_globally?(:view_calendar)
+        (User.current.logged? || !Setting.login_required?) &&
+        User.current.allowed_to_globally?(:view_calendar)
       end
 
       menu :top_menu,

--- a/modules/calendar/lib/open_project/calendar/engine.rb
+++ b/modules/calendar/lib/open_project/calendar/engine.rb
@@ -30,14 +30,17 @@ module OpenProject::Calendar
       project_module :calendar_view, dependencies: :work_package_tracking do
         permission :view_calendar,
                    { 'calendar/calendars': %i[index show] },
+                   permissible_on: :project,
                    dependencies: %i[view_work_packages],
                    contract_actions: { calendar: %i[read] }
         permission :manage_calendars,
                    { 'calendar/calendars': %i[index show new create destroy] },
+                   permissible_on: :project,
                    dependencies: %i[view_calendar add_work_packages edit_work_packages save_queries manage_public_queries],
                    contract_actions: { calendar: %i[create update destroy] }
         permission :share_calendars,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[view_calendar],
                    contract_actions: { calendar: %i[read] }
       end

--- a/modules/costs/app/seeders/common.yml
+++ b/modules/costs/app/seeders/common.yml
@@ -36,3 +36,13 @@ modules_permissions:
     - :edit_own_cost_entries
     - :view_budgets
     - :view_own_cost_entries
+  - role: :default_role_work_package_editor
+    add:
+      - :view_own_time_entries
+      - :log_own_time
+      - :edit_own_time_entries
+  - role: :default_role_work_package_commenter
+    add:
+      - :view_own_time_entries
+      - :log_own_time
+      - :edit_own_time_entries

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -44,51 +44,80 @@ module Costs
              },
              name: :project_module_costs do
       project_module :costs do
-        permission :view_time_entries, {}
-        permission :view_own_time_entries, {}
+        permission :view_time_entries,
+                   {},
+                   permissible_on: :project
+        permission :view_own_time_entries,
+                   {},
+                   permissible_on: %i[work_package project]
 
         permission :log_own_time,
                    {},
+                   permissible_on: %i[work_package project],
                    require: :loggedin,
                    dependencies: :view_own_time_entries
 
         permission :log_time,
                    {},
+                   permissible_on: :project,
                    require: :loggedin,
                    dependencies: :view_time_entries
 
         permission :edit_own_time_entries,
                    {},
+                   permissible_on: %i[work_package project],
                    require: :loggedin
 
         permission :edit_time_entries,
                    {},
+                   permissible_on: :project,
                    require: :member
 
         permission :manage_project_activities,
                    { 'projects/settings/time_entry_activities': %i[show update] },
+                   permissible_on: :project,
                    require: :member
-        permission :view_own_hourly_rate, {}
-        permission :view_hourly_rates, {}
 
-        permission :edit_own_hourly_rate, { hourly_rates: %i[set_rate edit update] },
+        permission :view_own_hourly_rate,
+                   {},
+                   permissible_on: :project
+        permission :view_hourly_rates,
+                   {},
+                   permissible_on: :project
+
+        permission :edit_own_hourly_rate,
+                   { hourly_rates: %i[set_rate edit update] },
+                   permissible_on: :project,
                    require: :member
-        permission :edit_hourly_rates, { hourly_rates: %i[set_rate edit update] },
+
+        permission :edit_hourly_rates,
+                   { hourly_rates: %i[set_rate edit update] },
+                   permissible_on: :project,
                    require: :member
-        permission :view_cost_rates, {} # cost item values
+        permission :view_cost_rates, # cost item values
+                   {},
+                   permissible_on: :project
 
         permission :log_own_costs, { costlog: %i[new create] },
+                   permissible_on: :project,
                    require: :loggedin
         permission :log_costs, { costlog: %i[new create] },
+                   permissible_on: :project,
                    require: :member
 
         permission :edit_own_cost_entries, { costlog: %i[edit update destroy] },
+                   permissible_on: :project,
                    require: :loggedin
         permission :edit_cost_entries, { costlog: %i[edit update destroy] },
+                   permissible_on: :project,
                    require: :member
 
-        permission :view_cost_entries, { costlog: [:index] }
-        permission :view_own_cost_entries, { costlog: [:index] }
+        permission :view_cost_entries,
+                   { costlog: [:index] },
+                   permissible_on: :project
+        permission :view_own_cost_entries,
+                   { costlog: [:index] },
+                   permissible_on: :project
       end
 
       # Menu extensions

--- a/modules/dashboards/lib/dashboards/engine.rb
+++ b/modules/dashboards/lib/dashboards/engine.rb
@@ -26,8 +26,12 @@ module Dashboards
 
         OpenProject::AccessControl.map do |ac_map|
           ac_map.project_module(:dashboards) do |pm_map|
-            pm_map.permission(:view_dashboards, { 'dashboards/dashboards': ['show'] })
-            pm_map.permission(:manage_dashboards, { 'dashboards/dashboards': ['show'] })
+            pm_map.permission(:view_dashboards,
+                              { 'dashboards/dashboards': %i[show] },
+                              permissible_on: :project)
+            pm_map.permission(:manage_dashboards,
+                              { 'dashboards/dashboards': %i[show] },
+                              permissible_on: :project)
           end
         end
       end

--- a/modules/dashboards/lib/dashboards/engine.rb
+++ b/modules/dashboards/lib/dashboards/engine.rb
@@ -34,7 +34,7 @@ module Dashboards
     end
 
     initializer 'dashboards.conversion' do
-      require Rails.root.join('config', 'constants', 'ar_to_api_conversions')
+      require Rails.root.join('config/constants/ar_to_api_conversions')
 
       Constants::ARToAPIConversions.add('grids/dashboard': 'grid')
     end

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -43,10 +43,13 @@ module OpenProject::Documents
            icon: 'notes'
 
       project_module :documents do |_map|
-        permission :view_documents, documents: %i[index show download]
-        permission :manage_documents, {
-          documents: %i[new create edit update destroy]
-        }, require: :loggedin
+        permission :view_documents,
+                   { documents: %i[index show download] },
+                   permissible_on: :project
+        permission :manage_documents,
+                   { documents: %i[new create edit update destroy] },
+                   permissible_on: :project,
+                   require: :loggedin
       end
 
       Redmine::Search.register :documents

--- a/modules/github_integration/app/seeders/common.yml
+++ b/modules/github_integration/app/seeders/common.yml
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+modules_permissions:
+  github_integration:
+    - role: :default_role_work_package_editor
+      add:
+        - :show_github_content
+    - role: :default_role_work_package_commenter
+      add:
+        - :show_github_content
+    - role: :default_role_work_package_viewer
+      add:
+        - :show_github_content

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -27,7 +27,7 @@
 #++
 
 require 'open_project/plugins'
-require_relative './patches/api/work_package_representer'
+require_relative 'patches/api/work_package_representer'
 
 module OpenProject::GithubIntegration
   class Engine < ::Rails::Engine

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -39,7 +39,9 @@ module OpenProject::GithubIntegration
              author_url: 'https://www.openproject.org/',
              bundled: true do
       project_module(:github, dependencies: :work_package_tracking) do
-        permission(:show_github_content, {})
+        permission(:show_github_content,
+                   {},
+                   permissible_on: %i[work_package project])
       end
     end
 

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -38,21 +38,52 @@ module OpenProject::Meeting
              author_url: 'https://www.openproject.org',
              bundled: true do
       project_module :meetings do
-        permission :view_meetings, meetings: %i[index show], meeting_agendas: %i[history show diff],
-                                   meeting_minutes: %i[history show diff]
+        permission :view_meetings,
+                   { meetings: %i[index show],
+                     meeting_agendas: %i[history show diff],
+                     meeting_minutes: %i[history show diff] },
+                   permissible_on: :project
         permission :create_meetings,
                    { meetings: %i[new create copy] },
+                   permissible_on: :project,
                    require: :member,
                    contract_actions: { meetings: %i[create] }
-        permission :edit_meetings, { meetings: %i[edit update] }, require: :member
-        permission :delete_meetings, { meetings: [:destroy] }, require: :member
-        permission :meetings_send_invite, { meetings: [:icalendar] }, require: :member
-        permission :create_meeting_agendas, { meeting_agendas: %i[update preview] }, require: :member
-        permission :close_meeting_agendas, { meeting_agendas: %i[close open] }, require: :member
-        permission :send_meeting_agendas_notification, { meeting_agendas: [:notify] }, require: :member
-        permission :send_meeting_agendas_icalendar, { meeting_agendas: [:icalendar] }, require: :member
-        permission :create_meeting_minutes, { meeting_minutes: %i[update preview] }, require: :member
-        permission :send_meeting_minutes_notification, { meeting_minutes: [:notify] }, require: :member
+        permission :edit_meetings,
+                   { meetings: %i[edit update] },
+                   permissible_on: :project,
+                   require: :member
+        permission :delete_meetings,
+                   { meetings: [:destroy] },
+                   permissible_on: :project,
+                   require: :member
+        permission :meetings_send_invite,
+                   { meetings: [:icalendar] },
+                   permissible_on: :project,
+                   require: :member
+        permission :create_meeting_agendas,
+                   { meeting_agendas: %i[update preview] },
+                   permissible_on: :project,
+                   require: :member
+        permission :close_meeting_agendas,
+                   { meeting_agendas: %i[close open] },
+                   permissible_on: :project,
+                   require: :member
+        permission :send_meeting_agendas_notification,
+                   { meeting_agendas: [:notify] },
+                   permissible_on: :project,
+                   require: :member
+        permission :send_meeting_agendas_icalendar,
+                   { meeting_agendas: [:icalendar] },
+                   permissible_on: :project,
+                   require: :member
+        permission :create_meeting_minutes,
+                   { meeting_minutes: %i[update preview] },
+                   permissible_on: :project,
+                   require: :member
+        permission :send_meeting_minutes_notification,
+                   { meeting_minutes: [:notify] },
+                   permissible_on: :project,
+                   require: :member
       end
 
       Redmine::Search.map do |search|

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -72,8 +72,8 @@ module OpenProject::Meeting
            partial: 'meetings/menu_query_select'
 
       should_render_global_menu_item = Proc.new do
-          (User.current.logged? || !Setting.login_required?) &&
-          User.current.allowed_to_globally?(:view_meetings)
+        (User.current.logged? || !Setting.login_required?) &&
+        User.current.allowed_to_globally?(:view_meetings)
       end
 
       menu :top_menu,

--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -1,3 +1,31 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
 module Overviews
   class Engine < ::Rails::Engine
     engine_name :overviews

--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -52,6 +52,7 @@ module Overviews
           ac_map.project_module nil do |map|
             map.permission :manage_overview,
                            { 'overviews/overviews': ['show'] },
+                           permissible_on: :project,
                            require: :member
           end
         end

--- a/modules/overviews/spec/contracts/roles/base_contract_spec.rb
+++ b/modules/overviews/spec/contracts/roles/base_contract_spec.rb
@@ -27,6 +27,7 @@
 require 'spec_helper'
 
 RSpec.describe Roles::BaseContract do
+  let(:work_package_role) { build_stubbed(:work_package_role) }
   let(:member_role) { build_stubbed(:role) }
   let(:global_role) { build_stubbed(:global_role) }
   let(:anonymous_role) { build_stubbed(:anonymous_role) }
@@ -34,6 +35,15 @@ RSpec.describe Roles::BaseContract do
   let(:contract) { described_class.new(role, current_user) }
 
   describe 'assignable_permissions' do
+    context 'for a work package role' do
+      let(:role) { work_package_role }
+
+      it 'does not include manage_overview' do
+        expect(contract.assignable_permissions.map(&:name))
+          .not_to include :manage_overview
+      end
+    end
+
     context 'for a member role' do
       let(:role) { member_role }
 

--- a/modules/reporting/lib/open_project/reporting/engine.rb
+++ b/modules/reporting/lib/open_project/reporting/engine.rb
@@ -42,8 +42,12 @@ module OpenProject::Reporting
 
       # register reporting_module including permissions
       project_module :costs do
-        permission :save_cost_reports, { cost_reports: edit_actions }
-        permission :save_private_cost_reports, { cost_reports: edit_actions }
+        permission :save_cost_reports,
+                   { cost_reports: edit_actions },
+                   permissible_on: :project
+        permission :save_private_cost_reports,
+                   { cost_reports: edit_actions },
+                   permissible_on: :project
       end
 
       Rails.application.reloader.to_prepare do

--- a/modules/storages/app/seeders/common.yml
+++ b/modules/storages/app/seeders/common.yml
@@ -41,3 +41,9 @@ modules_permissions:
   - role: :default_role_reader
     add:
     - :view_file_links
+  - role: :default_role_work_package_editor
+    add:
+      - :view_file_links
+  - role: :default_role_work_package_commenter
+    add:
+      - :view_file_links

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -114,20 +114,24 @@ module OpenProject::Storages
                      dependencies: :work_package_tracking do
         permission :view_file_links,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[view_work_packages],
                    contract_actions: { file_links: %i[view] }
         permission :manage_file_links,
                    {},
+                   permissible_on: :project,
                    dependencies: %i[view_file_links],
                    contract_actions: { file_links: %i[manage] }
         permission :manage_storages_in_project,
-                   { 'storages/admin/project_storages': %i[index members new edit update create destroy destroy_info
-                                                           set_permissions],
+                   { 'storages/admin/project_storages': %i[index members new
+                                                           edit update create
+                                                           destroy destroy_info set_permissions],
                      'storages/project_settings/project_storage_members': %i[index] },
+                   permissible_on: :project,
                    dependencies: %i[]
 
         OpenProject::Storages::Engine.permissions.each do |p|
-          permission(p, {}, dependencies: %i[])
+          permission(p, {}, permissible_on: :project, dependencies: %i[])
         end
       end
 

--- a/modules/storages/spec/seeders/seeder_spec.rb
+++ b/modules/storages/spec/seeders/seeder_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RootSeeder, 'Storage module' do
   it 'seeds role permissions for Storages' do
     described_class.new.seed_data!
 
-    expect(RolePermission.where(permission: :view_file_links).count).to eq 5
+    expect(RolePermission.where(permission: :view_file_links).count).to eq 7
     expect(RolePermission.where(permission: :manage_file_links).count).to eq 2
     expect(RolePermission.where(permission: :manage_storages_in_project).count).to eq 1
   end

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -40,11 +40,17 @@ module OpenProject::TeamPlanner
       project_module :team_planner_view, dependencies: :work_package_tracking, enterprise_feature: true do
         permission :view_team_planner,
                    { 'team_planner/team_planner': %i[index show upsale overview] },
+                   permissible_on: :project,
                    dependencies: %i[view_work_packages],
                    contract_actions: { team_planner: %i[read] }
         permission :manage_team_planner,
                    { 'team_planner/team_planner': %i[index show new create destroy upsale] },
-                   dependencies: %i[view_team_planner add_work_packages edit_work_packages save_queries manage_public_queries],
+                   permissible_on: :project,
+                   dependencies: %i[view_team_planner
+                                    add_work_packages
+                                    edit_work_packages
+                                    save_queries
+                                    manage_public_queries],
                    contract_actions: { team_planner: %i[create update destroy] }
       end
 

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -39,8 +39,8 @@ module OpenProject::TeamPlanner
       end
 
       should_render_global_menu_item = Proc.new do
-          (User.current.logged? || !Setting.login_required?) &&
-          User.current.allowed_to_globally?(:view_team_planner)
+        (User.current.logged? || !Setting.login_required?) &&
+        User.current.allowed_to_globally?(:view_team_planner)
       end
 
       menu :global_menu,

--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -1,6 +1,13 @@
-# OpenProject Team Planner module
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2021-2023 the OpenProject GmbH
 #
-# Copyright (C) 2021 OpenProject GmbH
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,6 +22,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
 
 module OpenProject::TeamPlanner
   class Engine < ::Rails::Engine

--- a/spec/contracts/roles/create_contract_spec.rb
+++ b/spec/contracts/roles/create_contract_spec.rb
@@ -27,19 +27,26 @@
 #++
 
 require 'spec_helper'
-require_relative './shared_contract_examples'
+require_relative 'shared_contract_examples'
 
 RSpec.describe Roles::CreateContract do
   it_behaves_like 'roles contract' do
+    let(:work_package_role) do
+      build(:work_package_role) do |r|
+        r.name = role_name
+        r.permissions = role_permissions
+      end
+    end
+
     let(:role) do
-      Role.new.tap do |r|
+      build(:role) do |r|
         r.name = role_name
         r.permissions = role_permissions
       end
     end
 
     let(:global_role) do
-      GlobalRole.new.tap do |r|
+      build(:global_role) do |r|
         r.name = role_name
         r.permissions = role_permissions
       end

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -73,25 +73,31 @@ RSpec.shared_examples_for 'roles contract' do
   describe '#assignable_permissions' do
     let(:all_permissions) { %i[perm1 perm2 perm3] }
 
-    context 'for a standard role' do
-      let(:public_permissions) { [:perm1] }
-      let(:global_permissions) { [:perm3] }
+    context 'for a project role' do
+      before do
+        allow(OpenProject::AccessControl)
+          .to receive(:project_permissions)
+          .and_return(all_permissions)
+      end
+
+      it 'is all project permissions' do
+        expect(contract.assignable_permissions)
+          .to eql all_permissions
+      end
+    end
+
+    context 'for a work package role' do
+      let(:role) { work_package_role }
 
       before do
         allow(OpenProject::AccessControl)
-          .to receive(:permissions)
+          .to receive(:work_package_permissions)
           .and_return(all_permissions)
-        allow(OpenProject::AccessControl)
-          .to receive(:global_permissions)
-          .and_return(global_permissions)
-        allow(OpenProject::AccessControl)
-          .to receive(:public_permissions)
-          .and_return(public_permissions)
       end
 
-      it 'is all non public, non global permissions' do
+      it 'is all work package permissions' do
         expect(contract.assignable_permissions)
-          .to eql [:perm2]
+          .to eql all_permissions
       end
     end
 

--- a/spec/contracts/roles/update_contract_spec.rb
+++ b/spec/contracts/roles/update_contract_spec.rb
@@ -27,13 +27,21 @@
 #++
 
 require 'spec_helper'
-require_relative './shared_contract_examples'
+require_relative 'shared_contract_examples'
 
 RSpec.describe Roles::UpdateContract do
   it_behaves_like 'roles contract' do
+    let(:work_package_role) do
+      build_stubbed(:work_package_role,
+                    name: 'Some name') do |r|
+        r.name = role_name
+        r.permissions = role_permissions
+      end
+    end
+
     let(:role) do
       build_stubbed(:role,
-                    name: 'Some name').tap do |r|
+                    name: 'Some name') do |r|
         r.name = role_name
         r.permissions = role_permissions
       end
@@ -41,7 +49,7 @@ RSpec.describe Roles::UpdateContract do
 
     let(:global_role) do
       build_stubbed(:global_role,
-                    name: 'Some name').tap do |r|
+                    name: 'Some name') do |r|
         r.name = role_name
         r.permissions = role_permissions
       end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -250,9 +250,9 @@ RSpec.describe RolesController do
       [role0, role1, role2, role3]
     end
 
-    let!(:roles_scope) do
-      allow(Role)
-        .to receive(:order)
+    let!(:stub_roles_scope) do
+      allow(controller)
+        .to receive(:roles_scope)
         .and_return(roles)
     end
 
@@ -411,12 +411,13 @@ RSpec.describe RolesController do
   end
 
   describe '#report' do
+    let!(:stub_roles_scope) do
+      allow(controller)
+        .to receive(:roles_scope)
+              .and_return(roles)
+    end
     let!(:roles) do
-      [build_stubbed(:role)].tap do |roles|
-        allow(Role)
-          .to receive(:order)
-                .and_return(roles)
-      end
+      build_stubbed_list(:role, 1)
     end
 
     before do

--- a/spec/factories/work_package_role_factory.rb
+++ b/spec/factories/work_package_role_factory.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :work_package_role do
+    sequence(:name) { |n| "WorkPackage Role #{n}" }
+  end
+end

--- a/spec/features/global_roles/mock_global_permissions.rb
+++ b/spec/features/global_roles/mock_global_permissions.rb
@@ -1,6 +1,6 @@
 def mock_global_permissions(permissions)
   mapped = permissions.map do |name, options|
-    mock_permissions(name, options.merge(global: true))
+    mock_permissions(name, options.merge(permissible_on: :global))
   end
 
   mapped_modules = permissions.map do |_, options|
@@ -22,9 +22,9 @@ def mock_permissions(name, options = {})
   OpenProject::AccessControl::Permission.new(
     name,
     { does_not: :matter },
+    permissible_on: :project,
     project_module: 'Foo',
     public: false,
-    global: false,
     **options
   )
 end

--- a/spec/features/global_roles/no_module_spec.rb
+++ b/spec/features/global_roles/no_module_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require 'spec_helper'
-require_relative './mock_global_permissions'
+require_relative 'mock_global_permissions'
 
 RSpec.describe 'Global role: No module',
                js: true,

--- a/spec/features/members/roles_spec.rb
+++ b/spec/features/members/roles_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'members pagination', js: true do
+RSpec.describe 'Members Role CRUD', :js, :with_cuprite do
   shared_let(:admin) { create(:admin) }
   let(:project) do
     create(:project,

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -49,38 +49,57 @@ RSpec.describe OpenProject::AccessControl::Permission do
     end
   end
 
-  describe '#global?' do
-    context 'when it is marked as global' do
+  describe '#work_package?' do
+    context 'when marked as permissible on work package roles' do
       subject(:permission) do
-        described_class.new(:perm, { cont: [:action] }, global: true)
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :work_package)
+      end
+
+      it { expect(permission).to be_work_package }
+    end
+  end
+
+  describe '#project?' do
+    context 'when marked as permissible on project roles' do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :project)
+      end
+
+      it { expect(permission).to be_project }
+    end
+  end
+
+  describe '#global?' do
+    context 'when marked as permissible on global roles' do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :global)
       end
 
       it { expect(permission).to be_global }
     end
+  end
 
-    context 'when it is marked as non-global' do
-      subject(:permission) do
-        described_class.new :perm, { cont: [:action] }, global: false
-      end
-
-      it { expect(permission).not_to be_global }
+  describe 'marking it as permissible on multiple role types' do
+    subject(:permission) do
+      described_class.new(:perm, { cont: [:action] }, permissible_on: %i[work_package project])
     end
 
-    describe "without specifying whether the permission is global or not" do
-      subject(:permission) do
-        described_class.new :perm, { cont: [:action] }
-      end
+    it { expect(permission).to be_work_package }
+    it { expect(permission).to be_project }
+  end
 
-      it 'defaults to non-global' do
-        expect(permission).not_to be_global
-      end
+  context 'without :permissible_on as an argument' do
+    it do
+      expect do
+        described_class.new(:perm, { cont: [:action] })
+      end.to raise_error(ArgumentError)
     end
   end
 
   describe '#grant_to_admin?' do
     context 'when it is marked as grant-able to admin' do
       subject(:permission) do
-        described_class.new(:perm, {}, grant_to_admin: true)
+        described_class.new(:perm, {}, permissible_on: :project, grant_to_admin: true)
       end
 
       it { expect(permission).to be_grant_to_admin }
@@ -88,7 +107,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
 
     context 'when it is marked as non-grant-able to admin' do
       subject(:permission) do
-        described_class.new(:perm, {}, grant_to_admin: false)
+        described_class.new(:perm, {}, permissible_on: :project, grant_to_admin: false)
       end
 
       it { expect(permission).not_to be_grant_to_admin }
@@ -96,7 +115,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
 
     context 'without specifying whether the permissions is grant-able to admin or not' do
       subject(:permission) do
-        described_class.new(:perm, {})
+        described_class.new(:perm, {}, permissible_on: :project)
       end
 
       it 'defaults to grant-able to admin' do

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe OpenProject::AccessControl::Permission do
     context 'for a permission with a dependency' do
       subject { OpenProject::AccessControl.permission(:edit_work_packages) }
 
-      it 'denotes the prerequiresites' do
+      it 'denotes the pre-requisites' do
         expect(subject.dependencies)
-          .to match_array([:view_work_packages])
+          .to contain_exactly(:view_work_packages)
       end
     end
 
@@ -50,46 +50,58 @@ RSpec.describe OpenProject::AccessControl::Permission do
   end
 
   describe '#global?' do
-    describe 'setting global permission' do
-      let(:permission) { described_class.new(:perm, { cont: [:action] }, global: true) }
+    context 'when it is marked as global' do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, global: true)
+      end
 
       it { expect(permission).to be_global }
     end
 
-    describe 'setting non global permission' do
-      let(:permission) { described_class.new :perm, { cont: [:action] }, global: false }
-
-      it 'is false' do
-        expect(permission).not_to be_global
+    context 'when it is marked as non-global' do
+      subject(:permission) do
+        described_class.new :perm, { cont: [:action] }, global: false
       end
+
+      it { expect(permission).not_to be_global }
     end
 
-    describe 'not specifying -> default' do
-      let(:permission) { described_class.new :perm, { cont: [:action] } }
+    describe "without specifying whether the permission is global or not" do
+      subject(:permission) do
+        described_class.new :perm, { cont: [:action] }
+      end
 
-      it 'is false' do
+      it 'defaults to non-global' do
         expect(permission).not_to be_global
       end
     end
   end
 
   describe '#grant_to_admin?' do
-    context 'if explicitly specified' do
-      let(:permission) { described_class.new(:perm, {}, grant_to_admin: true) }
+    context 'when it is marked as grant-able to admin' do
+      subject(:permission) do
+        described_class.new(:perm, {}, grant_to_admin: true)
+      end
 
       it { expect(permission).to be_grant_to_admin }
     end
 
-    context 'as a default' do
-      let(:permission) { described_class.new(:perm, {}) }
-
-      it { expect(permission).to be_grant_to_admin }
-    end
-
-    context 'if explicitly specified not to' do
-      let(:permission) { described_class.new(:perm, {}, grant_to_admin: false) }
+    context 'when it is marked as non-grant-able to admin' do
+      subject(:permission) do
+        described_class.new(:perm, {}, grant_to_admin: false)
+      end
 
       it { expect(permission).not_to be_grant_to_admin }
+    end
+
+    context 'without specifying whether the permissions is grant-able to admin or not' do
+      subject(:permission) do
+        described_class.new(:perm, {})
+      end
+
+      it 'defaults to grant-able to admin' do
+        expect(permission).to be_grant_to_admin
+      end
     end
   end
 end

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -236,6 +236,29 @@ RSpec.describe OpenProject::AccessControl do
     end
   end
 
+  describe '.project_permissions' do
+    include_context 'with blank access control state'
+
+    before do
+      setup_permissions
+    end
+
+    subject(:project_permissions) do
+      described_class.project_permissions
+    end
+
+    it { expect(project_permissions.size).to eq(5) }
+
+    it do
+      expect(project_permissions.map(&:name))
+        .to contain_exactly(:no_module_project_permission_with_contract_actions,
+                            :no_module_project_permission,
+                            :project_module_project_permission_with_contract_actions,
+                            :mixed_module_project_permission_granted_to_admin,
+                            :dependent_module_project_permission_not_granted_to_admin)
+    end
+  end
+
   describe '.global_permissions' do
     include_context 'with blank access control state'
 

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe OpenProject::AccessControl do
       map.permission :no_module_project_permission,
                      { dont: :care },
                      permissible_on: :project
+      map.permission :no_module_work_package_permission,
+                     { dont: :care },
+                     permissible_on: :work_package
+      map.permission :no_module_mixed_permissible_on_permission,
+                     { dont: :care },
+                     permissible_on: %i[project work_package]
 
       map.project_module :global_module do |mod|
         mod.permission :global_module_global_permission,
@@ -236,6 +242,28 @@ RSpec.describe OpenProject::AccessControl do
     end
   end
 
+  describe '.work_package_permissions' do
+    include_context 'with blank access control state'
+
+    before do
+      setup_permissions
+    end
+
+    subject(:work_package_permissions) do
+      described_class.work_package_permissions
+    end
+
+    describe 'size' do
+      it { expect(work_package_permissions.size).to eq(2) }
+    end
+
+    it do
+      expect(work_package_permissions.map(&:name))
+        .to contain_exactly(:no_module_work_package_permission,
+                            :no_module_mixed_permissible_on_permission)
+    end
+  end
+
   describe '.project_permissions' do
     include_context 'with blank access control state'
 
@@ -248,7 +276,7 @@ RSpec.describe OpenProject::AccessControl do
     end
 
     describe 'size' do
-      it { expect(project_permissions.size).to eq(5) }
+      it { expect(project_permissions.size).to eq(6) }
     end
 
     it do
@@ -257,7 +285,8 @@ RSpec.describe OpenProject::AccessControl do
                             :no_module_project_permission,
                             :project_module_project_permission_with_contract_actions,
                             :mixed_module_project_permission_granted_to_admin,
-                            :dependent_module_project_permission_not_granted_to_admin)
+                            :dependent_module_project_permission_not_granted_to_admin,
+                            :no_module_mixed_permissible_on_permission)
     end
   end
 

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -247,7 +247,9 @@ RSpec.describe OpenProject::AccessControl do
       described_class.project_permissions
     end
 
-    it { expect(project_permissions.size).to eq(5) }
+    describe 'size' do
+      it { expect(project_permissions.size).to eq(5) }
+    end
 
     it do
       expect(project_permissions.map(&:name))
@@ -270,7 +272,9 @@ RSpec.describe OpenProject::AccessControl do
       described_class.global_permissions
     end
 
-    it { expect(global_permissions.size).to eq(3) }
+    describe 'size' do
+      it { expect(global_permissions.size).to eq(3) }
+    end
 
     it do
       expect(global_permissions.map(&:name))

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe OpenProject::AccessControl do
       before do
         described_class.map do |map|
           map.project_module :dynamic_module, if: if_proc do |mod|
-            mod.permission :perm_d1, { dont: :care }
+            mod.permission :perm_d1, { dont: :care }, permissible_on: :project
           end
         end
       end

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -33,18 +33,26 @@ RSpec.describe OpenProject::AccessControl do
     OpenProject::AccessControl.map do |map|
       map.permission :no_module_project_permission_with_contract_actions,
                      { dont: :care },
+                     permissible_on: :project,
                      require: :member,
                      contract_actions: { foo: :create }
-      map.permission :no_module_global_permission, { dont: :care }, global: true
-      map.permission :no_module_project_permission, { dont: :care }
+      map.permission :no_module_global_permission,
+                     { dont: :care },
+                     permissible_on: :global
+      map.permission :no_module_project_permission,
+                     { dont: :care },
+                     permissible_on: :project
 
       map.project_module :global_module do |mod|
-        mod.permission :global_module_global_permission, { dont: :care }, global: true
+        mod.permission :global_module_global_permission,
+                       { dont: :care },
+                       permissible_on: :global
       end
 
       map.project_module :project_module do |mod|
         mod.permission :project_module_project_permission_with_contract_actions,
                        { dont: :care },
+                       permissible_on: :project,
                        contract_actions: { bar: %i[create read] },
                        public: true
       end
@@ -52,16 +60,18 @@ RSpec.describe OpenProject::AccessControl do
       map.project_module :mixed_module do |mod|
         mod.permission :mixed_module_project_permission_granted_to_admin,
                        { dont: :care },
+                       permissible_on: :project,
                        grant_to_admin: true
         mod.permission :mixed_module_global_permission_with_contract_actions,
                        { dont: :care },
-                       global: true,
+                       permissible_on: :global,
                        contract_actions: { baz: %i[destroy] }
       end
 
       map.project_module :dependent_module, dependencies: :project_module do |mod|
         mod.permission :dependent_module_project_permission_not_granted_to_admin,
                        { dont: :care },
+                       permissible_on: :project,
                        grant_to_admin: false
       end
     end

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -29,27 +29,40 @@
 require 'spec_helper'
 
 RSpec.describe OpenProject::AccessControl do
-  def setup_global_permissions
+  def setup_permissions
     OpenProject::AccessControl.map do |map|
-      map.permission :proj0, { dont: :care }, require: :member, contract_actions: { foo: :create }
-      map.permission :global0, { dont: :care }, global: true
-      map.permission :proj1, { dont: :care }
+      map.permission :no_module_project_permission_with_contract_actions,
+                     { dont: :care },
+                     require: :member,
+                     contract_actions: { foo: :create }
+      map.permission :no_module_global_permission, { dont: :care }, global: true
+      map.permission :no_module_project_permission, { dont: :care }
 
       map.project_module :global_module do |mod|
-        mod.permission :global1, { dont: :care }, global: true
+        mod.permission :global_module_global_permission, { dont: :care }, global: true
       end
 
       map.project_module :project_module do |mod|
-        mod.permission :proj2, { dont: :care }, contract_actions: { bar: %i[create read] }, public: true
+        mod.permission :project_module_project_permission_with_contract_actions,
+                       { dont: :care },
+                       contract_actions: { bar: %i[create read] },
+                       public: true
       end
 
       map.project_module :mixed_module do |mod|
-        mod.permission :proj3, { dont: :care }, grant_to_admin: true
-        mod.permission :global2, { dont: :care }, global: true, contract_actions: { baz: %i[destroy] }
+        mod.permission :mixed_module_project_permission_granted_to_admin,
+                       { dont: :care },
+                       grant_to_admin: true
+        mod.permission :mixed_module_global_permission_with_contract_actions,
+                       { dont: :care },
+                       global: true,
+                       contract_actions: { baz: %i[destroy] }
       end
 
       map.project_module :dependent_module, dependencies: :project_module do |mod|
-        mod.permission :proj4, { dont: :care }, grant_to_admin: false
+        mod.permission :dependent_module_project_permission_not_granted_to_admin,
+                       { dont: :care },
+                       grant_to_admin: false
       end
     end
   end
@@ -57,55 +70,74 @@ RSpec.describe OpenProject::AccessControl do
   describe '.remove_modules_permissions' do
     let!(:all_former_permissions) { described_class.permissions }
     let!(:former_repository_permissions) do
-      module_permissions = described_class.modules_permissions(['repository'])
-
-      module_permissions.select do |permission|
-        permission.project_module == :repository
-      end
+      described_class.modules_permissions(%w[repository])
+                     .select { |permission| permission.project_module == :repository }
     end
 
     subject { described_class }
 
-    before do
-      described_class.remove_modules_permissions(:repository)
-    end
-
-    after do
-      raise 'Test outdated' unless described_class.instance_variable_defined?(:@mapped_permissions)
-
+    def reset_former_permissions_and_clear_caches
       described_class.instance_variable_set(:@mapped_permissions, all_former_permissions)
       described_class.clear_caches
     end
 
+    around do |example|
+      described_class.remove_modules_permissions(:repository)
+
+      example.run
+    ensure
+      raise 'Test outdated. @mapped_permissions is not defined after example run' unless
+        described_class.instance_variable_defined?(:@mapped_permissions)
+
+      reset_former_permissions_and_clear_caches
+    end
+
+    it 'removes from permissions' do
+      expect(subject.permissions)
+        .not_to include(former_repository_permissions)
+    end
+
     it 'removes from global permissions' do
-      expect(subject.permissions).not_to include(former_repository_permissions)
+      expect(subject.global_permissions)
+        .not_to include(former_repository_permissions)
     end
 
     it 'removes from public permissions' do
-      expect(subject.public_permissions).not_to include(former_repository_permissions)
+      expect(subject.public_permissions)
+        .not_to include(former_repository_permissions)
     end
 
-    it 'removes from members only permissions' do
-      expect(subject.members_only_permissions).not_to include(former_repository_permissions)
+    it 'removes from members-only permissions' do
+      expect(subject.members_only_permissions)
+        .not_to include(former_repository_permissions)
     end
 
-    it 'removes from loggedin only permissions' do
-      expect(subject.loggedin_only_permissions).not_to include(former_repository_permissions)
+    it 'removes from loggedin-only permissions' do
+      expect(subject.loggedin_only_permissions)
+        .not_to include(former_repository_permissions)
     end
 
     it 'disables repository module' do
-      expect(subject.available_project_modules).not_to include(:repository)
+      expect(subject.available_project_modules)
+        .not_to include(:repository)
     end
   end
 
-  describe '#permissions' do
-    it 'is an array of permissions' do
-      expect(described_class.permissions)
+  describe '.permissions' do
+    subject(:permissions) { described_class.permissions }
+
+    it 'returns an array permissions' do
+      expect(permissions)
         .to all(be_instance_of(OpenProject::AccessControl::Permission))
     end
+
+    it 'returns only enabled permissions' do
+      expect(permissions)
+        .to all(be_enabled)
+    end
   end
 
-  describe '#permission' do
+  describe '.permission' do
     context 'for a project module permission' do
       subject { described_class.permission(:view_work_packages) }
 
@@ -114,7 +146,7 @@ RSpec.describe OpenProject::AccessControl do
           .to be_a(OpenProject::AccessControl::Permission)
       end
 
-      it 'is the permission with the queried for name' do
+      it 'is the permission with the queried-for name' do
         expect(subject.name)
           .to eq(:view_work_packages)
       end
@@ -133,12 +165,12 @@ RSpec.describe OpenProject::AccessControl do
           .to be_a(OpenProject::AccessControl::Permission)
       end
 
-      it 'is the permission with the queried for name' do
+      it 'is the permission with the queried-for name' do
         expect(subject.name)
           .to eq(:edit_project)
       end
 
-      it 'belongs to a project module' do
+      it 'does not belong to a project module' do
         expect(subject.project_module)
           .to be_nil
       end
@@ -148,24 +180,30 @@ RSpec.describe OpenProject::AccessControl do
           .to include('projects/settings/general/show')
       end
     end
-  end
 
-  describe '#dependencies' do
-    context 'for a permission with a prerequisite' do
-      subject { described_class.permission(:edit_work_packages) }
+    describe '#dependencies' do
+      context 'for a permission with a pre-requisite' do
+        subject(:dependencies) do
+          described_class.permission(:edit_work_packages)
+                         .dependencies
+        end
 
-      it 'denotes the prerequisites' do
-        expect(subject.dependencies)
-          .to match_array([:view_work_packages])
+        it 'denotes the pre-requisites' do
+          expect(dependencies)
+            .to contain_exactly(:view_work_packages)
+        end
       end
-    end
 
-    context 'for a permission without a prerequisite' do
-      subject { described_class.permission(:view_work_packages) }
+      context 'for a permission without a pre-requisite' do
+        subject(:dependencies) do
+          described_class.permission(:view_work_packages)
+                         .dependencies
+        end
 
-      it 'denotes the prerequisites' do
-        expect(subject.dependencies)
-          .to be_empty
+        it 'denotes no pre-requisites' do
+          expect(dependencies)
+            .to be_empty
+        end
       end
     end
   end
@@ -174,37 +212,54 @@ RSpec.describe OpenProject::AccessControl do
     include_context 'with blank access control state'
 
     before do
-      setup_global_permissions
+      setup_permissions
     end
 
-    it 'can store dependencies' do
-      expect(described_class.modules.detect { |m| m[:name] == :dependent_module }[:dependencies])
-        .to match_array(%i[project_module])
+    subject(:dependencies) do
+      described_class.modules
+                     .find { _1[:name] == :dependent_module }[:dependencies]
+    end
+
+    it 'can store specified dependencies' do
+      expect(dependencies)
+        .to contain_exactly(:project_module)
     end
   end
 
-  describe '#global_permissions' do
+  describe '.global_permissions' do
     include_context 'with blank access control state'
 
     before do
-      setup_global_permissions
+      setup_permissions
     end
 
-    it { expect(described_class.global_permissions.size).to eq(3) }
-    it { expect(described_class.global_permissions.collect(&:name)).to include(:global0) }
-    it { expect(described_class.global_permissions.collect(&:name)).to include(:global1) }
-    it { expect(described_class.global_permissions.collect(&:name)).to include(:global2) }
+    subject(:global_permissions) do
+      described_class.global_permissions
+    end
+
+    it { expect(global_permissions.size).to eq(3) }
+
+    it do
+      expect(global_permissions.map(&:name))
+        .to contain_exactly(:no_module_global_permission,
+                            :global_module_global_permission,
+                            :mixed_module_global_permission_with_contract_actions)
+    end
   end
 
   describe '.available_project_modules' do
     include_context 'with blank access control state'
 
     before do
-      setup_global_permissions
+      setup_permissions
     end
 
-    it { expect(described_class.available_project_modules).not_to include(:global_module) }
-    it { expect(described_class.available_project_modules).to include(:mixed_module) }
+    subject(:available_project_modules) do
+      described_class.available_project_modules
+    end
+
+    it { expect(available_project_modules).to include(:project_module, :mixed_module, :dependent_module) }
+    it { expect(available_project_modules).not_to include(:global_module) }
 
     context 'when a module specifies :if' do
       before do
@@ -219,8 +274,7 @@ RSpec.describe OpenProject::AccessControl do
         let(:if_proc) { ->(*) { true } }
 
         it 'is considered available' do
-          described_class.available_project_modules
-          expect(described_class.available_project_modules).to include(:dynamic_module)
+          expect(available_project_modules).to include(:dynamic_module)
         end
       end
 
@@ -228,7 +282,7 @@ RSpec.describe OpenProject::AccessControl do
         let(:if_proc) { ->(*) { false } }
 
         it 'is not considered available anymore' do
-          expect(described_class.available_project_modules).not_to include(:dynamic_module)
+          expect(available_project_modules).not_to include(:dynamic_module)
         end
       end
 
@@ -236,7 +290,7 @@ RSpec.describe OpenProject::AccessControl do
         let(:if_proc) { ->(*) { if_state[:available] } }
         let(:if_state) { { available: true } }
 
-        it 'reevaluates module availability each time' do
+        it 'reevaluates module availability each time', :aggregate_failures do
           if_state[:available] = true
           expect(described_class.available_project_modules).to include(:dynamic_module)
 
@@ -247,30 +301,34 @@ RSpec.describe OpenProject::AccessControl do
     end
   end
 
-  describe '#contract_actions_map' do
+  describe '.contract_actions_map' do
     include_context 'with blank access control state'
 
     before do
-      setup_global_permissions
+      setup_permissions
     end
 
-    it 'contains all contract actions grouped by the permission' do
-      expect(subject.contract_actions_map)
-        .to eql(global2: {
+    subject(:contract_actions_map) do
+      described_class.contract_actions_map
+    end
+
+    it 'contains all contract actions grouped by the permission name' do
+      expect(contract_actions_map)
+        .to eql(mixed_module_global_permission_with_contract_actions: {
                   actions: { baz: [:destroy] },
                   global: true,
                   module_name: :mixed_module,
                   grant_to_admin: true,
                   public: false
                 },
-                proj0: {
+                no_module_project_permission_with_contract_actions: {
                   actions: { foo: :create },
                   global: false,
                   module_name: nil,
                   grant_to_admin: true,
                   public: false
                 },
-                proj2: {
+                project_module_project_permission_with_contract_actions: {
                   actions: { bar: %i[create read] },
                   global: false,
                   module_name: :project_module,
@@ -284,27 +342,27 @@ RSpec.describe OpenProject::AccessControl do
     include_context 'with blank access control state'
 
     before do
-      setup_global_permissions
+      setup_permissions
     end
 
-    context 'for a granted permission (default)' do
+    context 'without specifying whether the permission is granted to admins' do
       it 'is granted' do
         expect(described_class)
-          .to be_grant_to_admin(:proj0)
-      end
-    end
-
-    context 'for a non granted permission' do
-      it 'is granted' do
-        expect(described_class)
-          .not_to be_grant_to_admin(:proj4)
+          .to be_grant_to_admin(:no_module_project_permission_with_contract_actions)
       end
     end
 
     context 'for an explicitly granted permission' do
       it 'is granted' do
         expect(described_class)
-          .to be_grant_to_admin(:proj3)
+          .to be_grant_to_admin(:mixed_module_project_permission_granted_to_admin)
+      end
+    end
+
+    context 'for an explicitly non-granted permission' do
+      it 'is not granted' do
+        expect(described_class)
+          .not_to be_grant_to_admin(:dependent_module_project_permission_not_granted_to_admin)
       end
     end
 

--- a/spec/models/work_package_role_spec.rb
+++ b/spec/models/work_package_role_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe WorkPackageRole do
+  subject do
+    described_class.create(name: 'work_package_role',
+                           permissions: %w[permissions])
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_uniqueness_of :name }
+    it { is_expected.to validate_length_of(:name).is_at_most(256) }
+  end
+end

--- a/spec/seeders/basic_data/global_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/global_role_seeder_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe BasicData::GlobalRoleSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { Source::SeedData.new(data_hash) }
+
+  before do
+    seeder.seed!
+  end
+
+  context 'with some global roles defined' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        global_roles:
+          - reference: :role_staff_manager
+            name: Staff manager
+            permissions:
+            - :hire_people
+            - :give_feedback
+      SEEDING_DATA_YAML
+    end
+
+    it 'creates the corresponding global roles with the given attributes' do
+      expect(GlobalRole.count).to eq(1)
+      expect(GlobalRole.find_by(name: 'Staff manager')).to have_attributes(
+        builtin: Role::NON_BUILTIN,
+        permissions: %i[hire_people give_feedback]
+      )
+    end
+
+    it 'references the role in the seed data' do
+      role = GlobalRole.find_by(name: 'Staff manager')
+      expect(seed_data.find_reference(:role_staff_manager)).to eq(role)
+    end
+  end
+
+  context 'with permissions: :all_assignable_permissions' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        global_roles:
+          - reference: :role_project_admin
+            name: Project admin
+            global: true
+            position: 1
+            permissions: :all_assignable_permissions
+      SEEDING_DATA_YAML
+    end
+
+    it 'gives all assignable permissions to the role' do
+      expect(GlobalRole.find_by(name: 'Project admin').permissions)
+        .to match_array(Roles::CreateContract.new(GlobalRole.new, nil).assignable_permissions.map { _1.name.to_sym })
+    end
+  end
+end

--- a/spec/seeders/basic_data/project_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_role_seeder_spec.rb
@@ -30,7 +30,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BasicData::RoleSeeder do
+RSpec.describe BasicData::ProjectRoleSeeder do
   subject(:seeder) { described_class.new(seed_data) }
 
   let(:seed_data) { Source::SeedData.new(data_hash) }
@@ -42,18 +42,18 @@ RSpec.describe BasicData::RoleSeeder do
   context 'with some builtin roles defined' do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
-        roles:
-        - reference: :role_non_member
-          name: Non member
-          builtin: :non_member
-          permissions:
-          - :view_status
-          - :view_presentations
-        - reference: :role_anonymous
-          name: Anonymous
-          builtin: :anonymous
-          permissions:
-          - :read_information
+        project_roles:
+          - reference: :role_non_member
+            name: Non member
+            builtin: :non_member
+            permissions:
+            - :view_status
+            - :view_presentations
+          - reference: :role_anonymous
+            name: Anonymous
+            builtin: :anonymous
+            permissions:
+            - :read_information
       SEEDING_DATA_YAML
     end
 
@@ -78,13 +78,13 @@ RSpec.describe BasicData::RoleSeeder do
   context 'with some non-builtin roles defined' do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
-        roles:
-        - reference: :role_member
-          name: Member
-          position: 5
-          permissions:
-          - :view_movies
-          - :eat_popcorn
+        project_roles:
+          - reference: :role_member
+            name: Member
+            position: 5
+            permissions:
+            - :view_movies
+            - :eat_popcorn
       SEEDING_DATA_YAML
     end
 
@@ -103,42 +103,14 @@ RSpec.describe BasicData::RoleSeeder do
     end
   end
 
-  context 'with some global roles defined' do
-    let(:data_hash) do
-      YAML.load <<~SEEDING_DATA_YAML
-        roles:
-        - reference: :role_staff_manager
-          name: Staff manager
-          global: true
-          permissions:
-          - :hire_people
-          - :give_feedback
-      SEEDING_DATA_YAML
-    end
-
-    it 'creates the corresponding global roles with the given attributes' do
-      expect(GlobalRole.count).to eq(1)
-      expect(GlobalRole.find_by(name: 'Staff manager')).to have_attributes(
-        builtin: Role::NON_BUILTIN,
-        permissions: %i[hire_people give_feedback]
-      )
-    end
-
-    it 'references the role in the seed data' do
-      role = GlobalRole.find_by(name: 'Staff manager')
-      expect(seed_data.find_reference(:role_staff_manager)).to eq(role)
-    end
-  end
-
   context 'with permissions: :all_assignable_permissions' do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
-        roles:
-        - reference: :role_project_admin
-          name: Project admin
-          global: true
-          position: 1
-          permissions: :all_assignable_permissions
+        project_roles:
+          - reference: :role_project_admin
+            name: Project admin
+            position: 1
+            permissions: :all_assignable_permissions
       SEEDING_DATA_YAML
     end
 
@@ -151,13 +123,13 @@ RSpec.describe BasicData::RoleSeeder do
   context 'with some permissions added and removed by modules in a modules_permissions section' do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
-        roles:
-        - reference: :role_member
-          name: Member
-          position: 5
-          permissions:
-          - :view_movies
-          - :eat_popcorn
+        project_roles:
+          - reference: :role_member
+            name: Member
+            position: 5
+            permissions:
+            - :view_movies
+            - :eat_popcorn
         modules_permissions:
           ebooks:
           - role: :role_member

--- a/spec/seeders/basic_data/work_package_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/work_package_role_seeder_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe BasicData::WorkPackageRoleSeeder do
     end
   end
 
-  context 'with permissions: :all_assignable_permissions',
-          pending: 'Defining what `all_assignable_permissions` are for ' \
-                   'the `WorkPackageRole` type is still a TODO' do
+  context 'with permissions: :all_assignable_permissions' do
     let(:data_hash) do
       YAML.load <<~SEEDING_DATA_YAML
         work_package_roles:
@@ -91,11 +89,6 @@ RSpec.describe BasicData::WorkPackageRoleSeeder do
     end
 
     it 'gives all assignable permissions to the role' do
-      expect(Roles::CreateContract.new(WorkPackageRole.new, nil)
-                                  .assignable_permissions.map { _1.name.to_sym })
-        .not_to match_array(Roles::CreateContract.new(Role.new, nil)
-                                       .assignable_permissions.map { _1.name.to_sym })
-
       expect(Role.find_by(name: 'Edit work package').permissions)
         .to match_array(Roles::CreateContract.new(WorkPackageRole.new, nil)
                                              .assignable_permissions.map { _1.name.to_sym })

--- a/spec/seeders/basic_data/work_package_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/work_package_role_seeder_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe BasicData::WorkPackageRoleSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { Source::SeedData.new(data_hash) }
+
+  before do
+    seeder.seed!
+  end
+
+  context 'with some work package roles defined' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        work_package_roles:
+          - reference: :role_work_package_edit
+            name: Edit work package
+            position: 3
+            permissions:
+            - :become_assignee
+            - :log_time
+          - reference: :role_work_package_comment
+            name: Comment work package
+            position: 5
+            permissions:
+            - :add_comment
+      SEEDING_DATA_YAML
+    end
+
+    it 'creates the corresponding work package roles with the given attributes' do
+      expect(WorkPackageRole.count)
+        .to eq(2)
+      expect(WorkPackageRole.find_by(name: 'Edit work package'))
+        .to have_attributes(
+          builtin: Role::NON_BUILTIN,
+          permissions: %i[become_assignee log_time]
+        )
+      expect(WorkPackageRole.find_by(name: 'Comment work package'))
+        .to have_attributes(
+          builtin: Role::NON_BUILTIN,
+          permissions: %i[add_comment]
+        )
+    end
+
+    it 'references the role in the seed data' do
+      role = WorkPackageRole.find_by(name: 'Comment work package')
+      expect(seed_data.find_reference(:role_work_package_comment)).to eq(role)
+    end
+  end
+
+  context 'with permissions: :all_assignable_permissions',
+          pending: 'Defining what `all_assignable_permissions` are for ' \
+                   'the `WorkPackageRole` type is still a TODO' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        work_package_roles:
+          - reference: :role_work_package_edit
+            name: Edit work package
+            permissions: :all_assignable_permissions
+      SEEDING_DATA_YAML
+    end
+
+    it 'gives all assignable permissions to the role' do
+      expect(Roles::CreateContract.new(WorkPackageRole.new, nil)
+                                  .assignable_permissions.map { _1.name.to_sym })
+        .not_to match_array(Roles::CreateContract.new(Role.new, nil)
+                                       .assignable_permissions.map { _1.name.to_sym })
+
+      expect(Role.find_by(name: 'Edit work package').permissions)
+        .to match_array(Roles::CreateContract.new(WorkPackageRole.new, nil)
+                                             .assignable_permissions.map { _1.name.to_sym })
+    end
+  end
+
+  context 'with some permissions added and removed by modules in a modules_permissions section' do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        work_package_roles:
+          - reference: :role_work_package_edit
+            name: Edit work package
+            position: 5
+            permissions:
+            - :view_movies
+            - :eat_cheese
+        modules_permissions:
+          ebooks:
+          - role: :role_work_package_edit
+            add:
+            - :read_ebooks
+            - :rate_ebooks
+          music:
+          - role: :role_work_package_edit
+            add:
+            - :play_music
+            - :add_song
+          health_control:
+          - role: :role_work_package_edit
+            remove:
+            - :eat_cheese
+      SEEDING_DATA_YAML
+    end
+
+    it 'applies the permissions as specified' do
+      expect(Role.find_by(name: 'Edit work package').permissions)
+        .to match_array(
+          %i[
+            view_movies
+            read_ebooks
+            rate_ebooks
+            play_music
+            add_song
+          ]
+        )
+    end
+  end
+end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe RootSeeder,
       work_package_editor_role = root_seeder.seed_data.find_reference(:default_role_work_package_editor)
       expect(work_package_editor_role.permissions).to include(
         :view_work_packages, # from common basic data
-        :view_own_time_entries # from costs module
+        :view_own_time_entries, # from costs module
+        :view_file_links # from storages module
       )
       member_role = root_seeder.seed_data.find_reference(:default_role_member)
       expect(member_role.permissions).to include(

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe RootSeeder,
       expect(work_package_editor_role.permissions).to include(
         :view_work_packages, # from common basic data
         :view_own_time_entries, # from costs module
-        :view_file_links # from storages module
+        :view_file_links, # from storages module
+        :show_github_content # from github_integration module
       )
       member_role = root_seeder.seed_data.find_reference(:default_role_member)
       expect(member_role.permissions).to include(

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe RootSeeder,
       expect(View.where(type: 'team_planner').count).to eq 1
       expect(Query.count).to eq 26
       expect(Role.where(type: 'Role').count).to eq 5
+      expect(WorkPackageRole.count).to eq 3
       expect(GlobalRole.count).to eq 1
       expect(Grids::Overview.count).to eq 2
       expect(Version.count).to eq 4
@@ -80,6 +81,10 @@ RSpec.describe RootSeeder,
     it 'adds additional permissions from modules' do
       # do not test for all permissions but only some of them to ensure each
       # module got processed for a standard edition
+      work_package_role = root_seeder.seed_data.find_reference(:default_role_work_package_editor)
+      expect(work_package_role.permissions).to include(
+        :view_work_packages # from common basic data
+      )
       member_role = root_seeder.seed_data.find_reference(:default_role_member)
       expect(member_role.permissions).to include(
         :view_work_packages, # from common basic data
@@ -104,8 +109,9 @@ RSpec.describe RootSeeder,
     include_examples 'it creates records', model: Color, expected_count: 144
     include_examples 'it creates records', model: DocumentCategory, expected_count: 3
     include_examples 'it creates records', model: GlobalRole, expected_count: 1
+    include_examples 'it creates records', model: WorkPackageRole, expected_count: 3
+    include_examples 'it creates records', model: Role, expected_count: 9
     include_examples 'it creates records', model: IssuePriority, expected_count: 4
-    include_examples 'it creates records', model: Role, expected_count: 6
     include_examples 'it creates records', model: Status, expected_count: 14
     include_examples 'it creates records', model: TimeEntryActivity, expected_count: 6
     include_examples 'it creates records', model: Workflow, expected_count: 1172
@@ -138,6 +144,7 @@ RSpec.describe RootSeeder,
         expect(View.where(type: 'team_planner').count).to eq 1
         expect(Query.count).to eq 26
         expect(Role.where(type: 'Role').count).to eq 5
+        expect(WorkPackageRole.count).to eq 3
         expect(GlobalRole.count).to eq 1
         expect(Grids::Overview.count).to eq 2
         expect(Version.count).to eq 4

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -81,9 +81,10 @@ RSpec.describe RootSeeder,
     it 'adds additional permissions from modules' do
       # do not test for all permissions but only some of them to ensure each
       # module got processed for a standard edition
-      work_package_role = root_seeder.seed_data.find_reference(:default_role_work_package_editor)
-      expect(work_package_role.permissions).to include(
-        :view_work_packages # from common basic data
+      work_package_editor_role = root_seeder.seed_data.find_reference(:default_role_work_package_editor)
+      expect(work_package_editor_role.permissions).to include(
+        :view_work_packages, # from common basic data
+        :view_own_time_entries # from costs module
       )
       member_role = root_seeder.seed_data.find_reference(:default_role_member)
       expect(member_role.permissions).to include(

--- a/spec/support/shared/with_blank_access_control_state.rb
+++ b/spec/support/shared/with_blank_access_control_state.rb
@@ -36,7 +36,7 @@ RSpec.shared_context 'with blank access control state' do
     OpenProject::AccessControl.clear_caches
     example.run
   ensure
-    unstash_instance_variables(OpenProject::AccessControl, stash)
+    pop_instance_variables(OpenProject::AccessControl, stash)
     OpenProject::AccessControl.clear_caches
   end
 
@@ -47,7 +47,7 @@ RSpec.shared_context 'with blank access control state' do
     end
   end
 
-  def unstash_instance_variables(instance, stash)
+  def pop_instance_variables(instance, stash)
     stash.each do |instance_variable, value|
       instance.instance_variable_set(instance_variable, value)
     end


### PR DESCRIPTION
## Milestones
1. A new Role type will become available (`WorkPackageRole`) in order to capture/assign roles to users and groups appropriately for Work-Package-specific permissions in order to grant access to OpenProject on a Work-Package-specific basis.

2. Ability to specify/determine which role types permissions are assignable to. This will help simplify the form implementation for Role Creation.

3. Seed the three default Work Package roles and corresponding permissions that will come pre-packaged with OpenProject
  - Editor
  - Commenter
  - Viewer 

## Notes
Work Package: https://community.openproject.org/work_packages/49493