### PR TITLE
Fix Lookbook `define_param_input` deprecation warning

### DIFF
--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -37,7 +37,7 @@ OpenProject::Application.configure do
   # rubocop:enable Lint/ConstantDefinitionInBlock
 
   Rails.application.reloader.to_prepare do
-    Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
+    Lookbook.add_input_type(:octicon, "lookbook/previews/inputs/octicon")
 
     [
       Lookbook::ApplicationController,


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: define_param_input is deprecated and will
be removed from Lookbook 3.0 (use add_input_type instead)
```