### PR TITLE
Address "implicit block expectation syntax" deprecation warning

### DIFF
--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe User do
     context "when the uploaded file is a good image" do
       subject { lambda { user.local_avatar_attachment = avatar_file } }
 
-      it { expect { subject.call }.not_to raise_error }
-      it { expect { subject.call }.to change(user, :local_avatar_attachment) }
+      specify { expect { subject.call }.not_to raise_error }
+      specify { expect { subject.call }.to change(user, :local_avatar_attachment) }
     end
   end
 end

--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../shared_examples')
+require File.expand_path("#{File.dirname(__FILE__)}/../spec_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/../shared_examples")
 
 RSpec.describe User do
   let(:user) { build(:user) }

--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe User do
   describe "#local_avatar_attachment" do
     subject { user.local_avatar_attachment }
 
-    context "WHEN user has an avatar" do
+    context "when user has an avatar" do
       let(:user) { user_with_avatar }
 
       it { is_expected.to be_a Attachment }
     end
 
-    context "WHEN user has no avatar" do
+    context "when user has no avatar" do
       let(:user) { user_without_avatar }
 
       it { is_expected.to be_blank }
@@ -25,7 +25,7 @@ RSpec.describe User do
   end
 
   describe "#local_avatar_attachment=" do
-    context "WHEN the uploaded file is a good image" do
+    context "when the uploaded file is a good image" do
       subject { lambda { user.local_avatar_attachment = avatar_file } }
 
       it { expect { subject.call }.not_to raise_error }

--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe User do
     context "WHEN the uploaded file is a good image" do
       subject { lambda { user.local_avatar_attachment = avatar_file } }
 
-      it { is_expected.not_to raise_error }
-      specify { is_expected.to change(user, :local_avatar_attachment) }
+      it { expect { subject.call }.not_to raise_error }
+      it { expect { subject.call }.to change(user, :local_avatar_attachment) }
     end
   end
 end


### PR DESCRIPTION
Fixes

```
The implicit block expectation syntax is deprecated, you should pass
a block rather than an argument to `expect` to use the provided block
expectation matcher or the matcher must implement
`supports_value_expectations?`.

e.g  `expect { value }.to change `User#local_avatar_attachment``
not `expect(value).to change `User#local_avatar_attachment``
```

and

```
The implicit block expectation syntax is deprecated, you should
pass a block rather than an argument to `expect` to use the provided
block expectation matcher or the matcher must implement
`supports_value_expectations?`.

e.g  `expect { value }.to raise Exception`
not `expect(value).to raise Exception`
```