### PR TITLE
Address deprecation warning for Firefox Driver's `:capabilities` parameter

### DIFF
--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -26,7 +26,7 @@ def register_firefox(language, name: :"firefox_#{language}")
 
     options = Selenium::WebDriver::Firefox::Options.new(profile:)
 
-    yield(profile, options, capabilities) if block_given?
+    yield(profile, options) if block_given?
 
     unless ActiveRecord::Type::Boolean.new.cast(ENV.fetch('OPENPROJECT_TESTING_NO_HEADLESS', nil))
       options.args << "--headless"
@@ -42,7 +42,7 @@ def register_firefox(language, name: :"firefox_#{language}")
       browser: is_grid ? :remote : :firefox,
       url: ENV.fetch('SELENIUM_GRID_URL', nil),
       http_client: client,
-      capabilities: options
+      options:
     }
 
     if is_grid

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -45,10 +45,6 @@ def register_firefox(language, name: :"firefox_#{language}")
       options:
     }
 
-    if is_grid
-      driver_opts[:url] = ENV.fetch('SELENIUM_GRID_URL', nil)
-    end
-
     driver = Capybara::Selenium::Driver.new app, **driver_opts
 
     Capybara::Screenshot.register_driver(name) do |driver, path|


### PR DESCRIPTION
Fixes:

```
WARN Selenium [:capabilities] [DEPRECATION] The :capabilities parameter
for Selenium::WebDriver::Firefox::Driver is deprecated. Use :options
argument with an instance of Selenium::WebDriver::Firefox::Driver
instead.
```