### PR TITLE
Improve wording of journal entry of migration step adding existing file links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1528,8 +1528,8 @@ en:
           non_working: "%{date} is now non-working"
       system_update:
         file_links_journal: >
-          From now on you will see links to files that are stored in external file storages mentioned here in the
-          Activity tab. The following additions of links actually already existed before this system migration:
+          From now on, activity related to file links (files stored in external storages) will appear here in the
+          Activity tab. The following represent activity concerning links that already existed:
 
 
   links:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1510,7 +1510,7 @@ en:
 
     caused_changes:
       dates_changed: "Dates changed"
-      system_update: "OpenProject update"
+      system_update: "OpenProject system update:"
 
     cause_descriptions:
       work_package_predecessor_changed_times: by changes to predecessor %{link}
@@ -1527,7 +1527,9 @@ en:
           working: "%{date} is now working"
           non_working: "%{date} is now non-working"
       system_update:
-        file_links_journal: 'added File links to Activities'
+        file_links_journal: >
+          From now on you will see links to files that are stored in external file storages mentioned here in the
+          Activity tab. The following additions of links actually already existed before this system migration:
 
 
   links:


### PR DESCRIPTION
https://community.openproject.org/work_packages/49770

With the release of 13.0 we had to create a journal entry for all those file links that were already there. Unfortunately that journal entry is not understandable. The information value is very low. The complexity is high. It would be best to not show it. However, the cost for hiding it appear very high in development, maintenance and run time. And it is not likely that we will run into a similar issue. Also, I don't believe that so many installations already use the Nextcloud integration. That is why I opt for simply improving the texts within the activity entry and live with it.

Before:
![image](https://github.com/opf/openproject/assets/327272/9031ca89-6dc3-4c9a-a990-6d171e2f652a)

After:

![image](https://github.com/opf/openproject/assets/327272/23027c37-9ca9-4c93-8e61-05fd2ec42993)
