### PR TITLE
Add `./bin/rubocop` Spring binstub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -275,6 +275,7 @@ group :development do
 
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'spring-commands-rubocop'
 
   gem 'colored2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -913,6 +913,8 @@ GEM
     spring (4.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-commands-rubocop (0.4.0)
+      spring (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -1155,6 +1157,7 @@ DEPENDENCIES
   shoulda-matchers (~> 5.0)
   spring
   spring-commands-rspec
+  spring-commands-rubocop
   sprockets (~> 3.7.2)
   sprockets-rails (~> 3.4.2)
   stackprof

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
+require 'bundler/setup'
+load Gem.bin_path('rubocop', 'rubocop')


### PR DESCRIPTION
Adds the `./bin/rubocop` binstub which allows using the preloaded Rails application by Spring in development.

Total execution time is similar, however CPU consumption is way lower as compared to using `bundle exec rubocop`

```bash
-> % time bundle exec rubocop spec/seeders/basic_data/role_seeder_spec.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
bundle exec rubocop spec/seeders/basic_data/role_seeder_spec.rb  0.92s user 0.44s system 94% cpu 1.438 total

-> % time bin/rubocop spec/seeders/basic_data/role_seeder_spec.rb
Running via Spring preloader in process 62643
Inspecting 1 file
.

1 file inspected, no offenses detected
bin/rubocop spec/seeders/basic_data/role_seeder_spec.rb  0.08s user 0.04s system 8% cpu 1.441 total
```