### PR TITLE
[49771] Set statement timeout to 15 minutes for the validity period migration

### DIFF
--- a/config/initializers/migration_statement_timeout.rb
+++ b/config/initializers/migration_statement_timeout.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative '../../lib_static/open_project/migration_statement_timeout/manager'
+require_relative '../../lib_static/open_project/migration_statement_timeout/migration_extensions'
+
+ActiveRecord::Migration.prepend(MigrationStatementTimeout::Manager)
+ActiveRecord::Migration.extend(MigrationStatementTimeout::MigrationExtensions)

--- a/db/migrate/20230608151123_add_validity_period_to_journals.rb
+++ b/db/migrate/20230608151123_add_validity_period_to_journals.rb
@@ -1,4 +1,6 @@
 class AddValidityPeriodToJournals < ActiveRecord::Migration[7.0]
+  set_minimum_statement_timeout('15min')
+
   def change
     add_column :journals, :validity_period, :tstzrange
 

--- a/lib_static/open_project/migration_statement_timeout/manager.rb
+++ b/lib_static/open_project/migration_statement_timeout/manager.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module MigrationStatementTimeout
+  module Manager
+    def exec_migration(conn, direction)
+      min_timeout = self.class.minimum_statement_timeout
+      return super unless min_timeout
+      return super unless direction == :up
+
+      if disable_ddl_transaction
+        raise 'Cannot set local statement_timeout outside of a transaction. ' \
+              'Try removing disable_ddl_transaction! from your migration.'
+      end
+
+      set_statement_timeout_at_least_at(conn, min_timeout)
+
+      super
+    end
+
+    def set_statement_timeout_at_least_at(conn, min_timeout)
+      current_timeout = get_timeout(conn)
+      if in_ms(min_timeout) > in_ms(current_timeout)
+        set_timeout(conn, min_timeout)
+        say "set statement_timeout to #{min_timeout} (was #{current_timeout} before)"
+      else
+        say "ignore set statement_timeout to #{min_timeout}: it would be lower than current value #{current_timeout}"
+      end
+    end
+
+    def set_timeout(conn, timeout)
+      conn.execute("SET LOCAL statement_timeout = '#{timeout}'")
+    end
+
+    def get_timeout(conn)
+      conn.execute('SHOW statement_timeout').first['statement_timeout']
+    end
+
+    def in_ms(timeout)
+      case timeout
+      when Integer
+        timeout
+      when /\A\d+(ms)?\z/
+        timeout.to_i
+      when /\A\d+s\z/
+        timeout.to_i * 1000
+      when /\A\d+min\z/
+        timeout.to_i * 1000 * 60
+      when /\A\d+h\z/
+        timeout.to_i * 1000 * 60 * 60
+      else
+        raise "Unrecognized statement timeout duration #{timeout.inspect}"
+      end
+    end
+  end
+end

--- a/lib_static/open_project/migration_statement_timeout/migration_extensions.rb
+++ b/lib_static/open_project/migration_statement_timeout/migration_extensions.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module MigrationStatementTimeout
+  module MigrationExtensions
+    attr_accessor :minimum_statement_timeout
+
+    # Sets the minimum statement timeout for this migration.
+    #
+    # If the current statement timeout is lower than the given value, it will be
+    # set to this value. It does nothing if the statement timeout is already set
+    # to a higher value.
+    #
+    # When the given value is an integer or a string without units, it is
+    # interpreted as milliseconds.
+    #
+    # When the given value is a string with units, it is interpreted
+    # accordingly. Valid units for this parameter are "ms", "s", "min", and "h".
+    # Examples: "15min", "90s", "2h".
+    #
+    # @param [Integer|String] timeout duration
+    def set_minimum_statement_timeout(timeout)
+      self.minimum_statement_timeout = timeout
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/49771

Introduce a `set_minimum_statement_timeout` helper to be used in a migration. It sets the statement timeout to a minimum value for the migration. It will do nothing if the statement timeout is already set to a higher value.