### PR TITLE
Raise selenium log level to find why it fails

### DIFF
--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -69,6 +69,10 @@ setup_tests() {
 
 	# create test database "app" and dump schema because db/structure.sql is not checked in
 	execute_quiet "time bundle exec rails db:migrate db:schema:dump zeitwerk:check"
+
+	# pre-cache browsers and their drivers binaries
+	execute "$(bundle show selenium)/bin/linux/selenium-manager --browser chrome --debug"
+	execute "$(bundle show selenium)/bin/linux/selenium-manager --browser firefox --debug"
 }
 
 run_units() {


### PR DESCRIPTION
On CI, a lot of runs fail recently. For instance https://github.com/opf/openproject/actions/runs/5951589226/job/16141701715

Error is `Failed to open TCP connection to 127.0.0.1:9515`.
Scrolling to the top, 2 other errors message are visible:
* `Text file busy - /app/.cache/selenium/chromedriver/linux64/115.0.5790.170/chromedriver`
* `Unable to obtain chromedriver using Selenium Manager; not executable: "/app/.cache/selenium/chromedriver/linux64/115.0.5790.170/chromedriver"; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location`

First one, `Text file busy`, is like the file is being written to by another process while trying to read it.

This PR adds a step to the CI build that downloads the binaries before the tests are run.