### PR TITLE
[#49774] Change browserlist support for safari to last 2 MAJOR versions, don't count minor versions

### DIFF
--- a/frontend/browserslist
+++ b/frontend/browserslist
@@ -2,7 +2,7 @@
 # https://www.openproject.org/systemrequirements/
 #
 last 2 Chrome versions
-last 2 Safari versions
+last 2 Safari major versions
 last 2 Edge versions
 last 2 Firefox versions
 Firefox esr


### PR DESCRIPTION
##### https://community.openproject.org/work_packages/49774

Without the MAJOR statement browserlist will count minor versions which removed support for < 16.3

Instead, support last 2 major versions: 16, 15 for now- coming up is 17 (in Beta) See [Safari Release Notes](https://developer.apple.com/documentation/safari-release-notes/)

<details><summary>Bug ScreenShots</summary>

![Screenshot 2023-08-23 at 6 35 53 PM](https://github.com/opf/openproject/assets/17295175/d856402f-64e9-4d09-a264-9e937514183b)
![Screenshot 2023-08-23 at 6 26 26 PM](https://github.com/opf/openproject/assets/17295175/37ff1991-1acd-4354-90cf-3f511f914adc)
![Screenshot 2023-08-23 at 6 21 33 PM](https://github.com/opf/openproject/assets/17295175/32b25f6d-bae6-49a3-82d4-da06d1152991)
![Screenshot 2023-08-23 at 6 20 03 PM](https://github.com/opf/openproject/assets/17295175/faa631b4-a161-4951-9e7c-a32c7002011b)
![Screenshot 2023-08-23 at 6 15 01 PM](https://github.com/opf/openproject/assets/17295175/7b4a3197-9775-4991-9028-3a3bdd5f5a2b)

</details>

Fix:

![Screenshot 2023-08-23 at 7 01 14 PM](https://github.com/opf/openproject/assets/17295175/f9308464-0aa4-41c5-bb20-db067024aed6)
