### PR TITLE
[#49752] Not enough spacing between the information box and the heading on LDAP page

### DIFF
--- a/app/views/admin/settings/working_days_settings/show.html.erb
+++ b/app/views/admin/settings/working_days_settings/show.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="op-toast--content">
     <p>
     <%= t("working_days.warning").html_safe %>
-  </p>
+    </p>
   </div>
 </div>
 

--- a/frontend/src/global_styles/layout/_admin.sass
+++ b/frontend/src/global_styles/layout/_admin.sass
@@ -27,4 +27,5 @@
 //++
 
 .admin--edit-section
+  margin-top: 1rem
   margin-bottom: 1.5rem


### PR DESCRIPTION
https://community.openproject.org/work_packages/49752

Old:

![image](https://github.com/opf/openproject/assets/7458152/20c3607d-af00-4ac6-ae1f-95ae1ff8b0bc)

New:

![image](https://github.com/opf/openproject/assets/7458152/b6c11032-c2f1-455e-bb74-a5a11c1482c9)
