### PR TITLE
[#49782] Fix out-of-bounds widgets error when creating Version Boards

### DIFF
--- a/modules/boards/app/services/boards/version_board_create_service.rb
+++ b/modules/boards/app/services/boards/version_board_create_service.rb
@@ -15,7 +15,7 @@ module Boards
     private
 
     def column_count_for_board
-      versions(params).count
+      [super, versions(params).count].max
     end
 
     def create_queries(params)

--- a/modules/boards/app/services/boards/version_board_create_service.rb
+++ b/modules/boards/app/services/boards/version_board_create_service.rb
@@ -14,6 +14,10 @@ module Boards
 
     private
 
+    def column_count_for_board
+      versions(params).count
+    end
+
     def create_queries(params)
       versions(params).map do |version|
         Queries::CreateService.new(user: User.current)

--- a/modules/boards/spec/services/version_board_create_service_spec.rb
+++ b/modules/boards/spec/services/version_board_create_service_spec.rb
@@ -71,6 +71,25 @@ RSpec.describe Boards::VersionBoardCreateService do
       expect(board.options[:type]).to eq('action')
     end
 
+    describe 'column_count' do
+      it 'matches the column_count to the version count' do
+        board = subject.result
+
+        expect(board.column_count).to eq(versions.count)
+      end
+
+      context 'when there are no versions that apply for the project' do
+        before do
+          versions.each { _1.update!(status: 'closed') }
+        end
+
+        it 'sets the column_count to the default value' do
+          board = subject.result
+          expect(board.column_count).to eq(4)
+        end
+      end
+    end
+
     describe 'widgets and queries' do
       let(:board) { subject.result }
       let(:widgets) { board.widgets }

--- a/modules/boards/spec/services/version_board_create_service_spec.rb
+++ b/modules/boards/spec/services/version_board_create_service_spec.rb
@@ -34,7 +34,10 @@ require_relative 'base_create_service_shared_examples'
 RSpec.describe Boards::VersionBoardCreateService do
   shared_let(:project) { create(:project) }
   shared_let(:other_project) { create(:project) }
-  shared_let(:versions) { create_list(:version, 3, project:) }
+  # Amount of versions is important to test that the right column count is
+  # set by the service. It should set the column count to the number of versions
+  # and avoid out of bounds errors.
+  shared_let(:versions) { create_list(:version, 5, project:) }
   shared_let(:excluded_versions) do
     [
       create(:version, project:, status: 'closed'),


### PR DESCRIPTION
## Bug description
An ["out-of-bounds" validation](https://github.com/opf/openproject/blob/21a696ef9b170e14ad2daf53364a4c2113822c2f/modules/grids/app/contracts/grids/base_contract.rb#L139-L144) was rightfully raising an error since when a Project had more than 4 versions which applied for being a column on a version board, the amount of columns being set on the board was 4 (as done in the original implementation of Board creation).

Version boards however, are a special case, as the number of columns to be created initially with it is varying based on the amount of open versions for the project at the moment of creating the board.

## Fix
The `VersionBoardCreateService` now sets the `column_count_for_board` dynamically based on the versions that a widget will be created for; this ensures they're mapped 1-to-1 (or the default if no versions apply) and we don't run into out-of-bounds widgets for them anymore.

Added a modification to the setup code in the `VersionBoardCreateService` spec file demonstrates the failing behavior and success behavior after the override.
## Notes
See Bug Work Package: https://community.openproject.org/work_packages/49782