### PR TITLE
Correctly create default values for multi-value list custom field

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -80,7 +80,7 @@ class CustomField < ApplicationRecord
 
   def default_value
     if list?
-      ids = custom_options.select(&:default_value).map(&:id)
+      ids = custom_options.where(default_value: true).pluck(:id).map(&:to_s)
 
       if multi_value?
         ids
@@ -181,24 +181,26 @@ class CustomField < ApplicationRecord
   end
 
   def cast_value(value)
-    casted = nil
-    if value.present?
-      case field_format
-      when 'string', 'text', 'list'
-        casted = value
-      when 'date'
-        casted = begin; value.to_date; rescue StandardError; nil end
-      when 'bool'
-        casted = ActiveRecord::Type::Boolean.new.cast(value)
-      when 'int'
-        casted = value.to_i
-      when 'float'
-        casted = value.to_f
-      when 'user', 'version'
-        casted = (value.blank? ? nil : field_format.classify.constantize.find_by(id: value.to_i))
+    return if value.blank?
+
+    case field_format
+    when 'string', 'text', 'list'
+      value
+    when 'date'
+      begin
+        value.to_date
+      rescue StandardError
+        nil
       end
+    when 'bool'
+      ActiveRecord::Type::Boolean.new.cast(value)
+    when 'int'
+      value.to_i
+    when 'float'
+      value.to_f
+    when 'user', 'version'
+      field_format.classify.constantize.find_by(id: value.to_i)
     end
-    casted
   end
 
   def <=>(other)

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -117,13 +117,10 @@ module Redmine
               existing_cvs = custom_values.select { |v| v.custom_field_id == custom_field.id }
 
               if existing_cvs.empty?
-                new_value = custom_values.build(customized: self,
-                                                custom_field:,
-                                                value: custom_field.default_value)
-                existing_cvs.push new_value
+                build_default_custom_values(custom_field)
+              else
+                existing_cvs
               end
-
-              existing_cvs
             end
         end
 
@@ -283,10 +280,10 @@ module Redmine
           end
         end
 
-        def method_missing(method, *args)
+        def method_missing(method, *)
           for_custom_field_accessor(method) do |custom_field|
             add_custom_field_accessors(custom_field)
-            return send method, *args
+            return send(method, *)
           end
 
           super
@@ -311,6 +308,24 @@ module Redmine
         attr_accessor :custom_value_destroyed
 
         private
+
+        def build_default_custom_values(custom_field)
+          if custom_field.multi_value? && custom_field.default_value.present?
+            custom_field.default_value.map do |value|
+              build_custom_value(custom_field, value:)
+            end
+          elsif custom_field.multi_value? && custom_field.default_value.blank?
+            build_custom_value(custom_field, value: nil)
+          else
+            build_custom_value(custom_field, value: custom_field.default_value)
+          end
+        end
+
+        def build_custom_value(custom_field, value:)
+          custom_values.build(customized: self,
+                              custom_field:,
+                              value:)
+        end
 
         def for_custom_field_accessor(method_symbol)
           match = /\Acustom_field_(?<id>\d+)=?\z/.match(method_symbol.to_s)

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "multi select custom values",
     wait_for_reload
   end
 
-  describe 'with mixed users, group, and placeholdders' do
+  describe 'with mixed users, group, and placeholders' do
     let(:work_package) { create(:work_package, project:, type:) }
 
     let!(:user) do

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -192,11 +192,11 @@ RSpec.describe CustomFieldFormBuilder do
 
     context 'for a list custom field' do
       let(:custom_field) do
-        build_stubbed(:list_wp_custom_field,
-                      custom_options: [custom_option])
+        create(:list_wp_custom_field,
+               custom_options: [custom_option])
       end
       let(:custom_option) do
-        build_stubbed(:custom_option, value: 'my_option')
+        create(:custom_option, value: 'my_option')
       end
 
       it_behaves_like 'wrapped in container', 'select-container' do
@@ -216,7 +216,7 @@ RSpec.describe CustomFieldFormBuilder do
 
       context 'which is required and has no default value' do
         before do
-          custom_field.is_required = true
+          custom_field.update(is_required: true)
         end
 
         it 'outputs element' do
@@ -233,8 +233,8 @@ RSpec.describe CustomFieldFormBuilder do
 
       context 'which is required and a default value' do
         before do
-          custom_field.is_required = true
-          custom_option.default_value = true
+          custom_field.update(is_required: true)
+          custom_option.update(default_value: true)
         end
 
         it 'outputs element' do

--- a/spec/models/custom_value_spec.rb
+++ b/spec/models/custom_value_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CustomValue do
   shared_let(:version) { create(:version) }
 
   let(:format) { 'bool' }
-  let(:custom_field) { create(:custom_field, field_format: format) }
+  let(:custom_field) { create(:version_custom_field, field_format: format) }
   let(:custom_value) { create(:custom_value, custom_field:, value:, customized: version) }
 
   describe '#typed_value' do
@@ -94,6 +94,287 @@ RSpec.describe CustomValue do
 
       context 'for a date format', with_settings: { date_format: '%Y/%m/%d' } do
         it { expect(subject.formatted_value).to eq('2016/12/01') }
+      end
+    end
+  end
+
+  describe '#default?' do
+    shared_let(:project) { create(:project) }
+
+    RSpec::Matchers.define_negated_matcher :not_be_default, :be_default
+
+    shared_examples 'returns true for generated custom value' do
+      describe "for a generated custom value" do
+        it 'returns true' do
+          custom_values = project.custom_field_values
+
+          expect(custom_values.count).to eq(1)
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    shared_examples 'returns false for custom value with value' do |value:|
+      describe "for a custom value with #{value.inspect} value" do
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, value)
+          custom_value = project.custom_values.last
+
+          expect(custom_value).to not_be_default
+        end
+      end
+    end
+
+    context 'for a boolean custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :boolean) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: false
+      include_examples 'returns false for custom value with value', value: true
+    end
+
+    context 'for a boolean custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :boolean, default_value: true)
+          create(:project_custom_field, :boolean, default_value: false)
+          # the admin interface saves default value as "1" (checked) or "0" (unchecked)
+          create(:project_custom_field, :boolean, default_value: '1')
+          create(:project_custom_field, :boolean, default_value: '0')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context "for a string custom field without default value" do
+      shared_let(:custom_field) { create(:project_custom_field, :string) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: 'Hello world!'
+    end
+
+    context 'for a string custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :string, default_value: 'Hello world!')
+          create(:project_custom_field, :string, default_value: '')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for a text custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :text) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: "Hello world!"
+      include_examples 'returns false for custom value with value', value: "Hello world!\nHello world!\nHello world!"
+    end
+
+    context 'for a text custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :text, default_value: 'Hello world!')
+          create(:project_custom_field, :text, default_value: '')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for an integer custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :int) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: 123
+      include_examples 'returns false for custom value with value', value: 0
+      include_examples 'returns false for custom value with value', value: -12
+    end
+
+    context 'for an integer custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :int, default_value: 0)
+          create(:project_custom_field, :int, default_value: 123)
+          create(:project_custom_field, :int, default_value: '456')
+          create(:project_custom_field, :int, default_value: -987)
+          create(:project_custom_field, :int, default_value: '-678')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for a float custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :float) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: 3.14
+      include_examples 'returns false for custom value with value', value: 0
+      include_examples 'returns false for custom value with value', value: -12
+    end
+
+    context 'for a float custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :float, default_value: 0.0)
+          create(:project_custom_field, :float, default_value: 12.3)
+          create(:project_custom_field, :float, default_value: '45.6')
+          create(:project_custom_field, :float, default_value: -98.7)
+          create(:project_custom_field, :float, default_value: '-67')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for a date custom field' do
+      shared_let(:custom_field) { create(:project_custom_field, :date) }
+
+      include_examples 'returns true for generated custom value'
+      include_examples 'returns false for custom value with value', value: "2023-08-08"
+      include_examples 'returns false for custom value with value', value: Date.current
+    end
+
+    context 'for a list custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :list) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe "for a custom value with option 'B' selected" do
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, custom_field.value_of('B'))
+          custom_value = project.custom_values.last
+
+          expect(custom_value).to not_be_default
+        end
+      end
+    end
+
+    context 'for a list custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :list, default_option: 'B')
+
+          custom_values = project.custom_field_values
+
+          expect(custom_values.count).to eq(ProjectCustomField.count)
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for a multi-value list custom field without default value' do
+      shared_let(:custom_field) { create(:project_custom_field, :multi_list) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe "for a custom value with option 'B' and 'D' selected" do
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, [custom_field.value_of('B'), custom_field.value_of('D')])
+          project.save!
+
+          expect(project.custom_values).to all(not_be_default)
+        end
+      end
+    end
+
+    context 'for a multi-value list custom field with default value' do
+      describe 'for a generated custom value' do
+        it 'returns true' do
+          create(:project_custom_field, :multi_list, default_options: ['B'])
+          create(:project_custom_field, :multi_list, default_options: ['G', 'B', 'C'])
+
+          custom_values = project.custom_field_values
+
+          # 1 CustomValue for each of the default options
+          expect(custom_values.count).to eq(4)
+          expect(custom_values).to all(be_default)
+        end
+      end
+    end
+
+    context 'for a version custom field' do
+      shared_let(:custom_field) { create(:project_custom_field, :version) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe 'for a custom value with a version selected' do
+        let!(:version_turfu) { create(:version, name: 'turfu', project:) }
+
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, version_turfu.id)
+          project.save!
+          custom_value = project.custom_values.last
+
+          expect(custom_value).to not_be_default
+        end
+      end
+    end
+
+    context 'for a multi version custom field' do
+      shared_let(:custom_field) { create(:project_custom_field, :multi_version) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe 'for a custom value with multiple versions selected' do
+        let!(:version_ringbo) { create(:version, name: 'ringbo', project:) }
+        let!(:version_turfu) { create(:version, name: 'turfu', project:) }
+
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, [version_ringbo.id, version_turfu.id])
+          project.save!
+
+          expect(project.custom_values).to all(not_be_default)
+        end
+      end
+    end
+
+    context 'for a user custom field' do
+      shared_let(:custom_field) { create(:project_custom_field, :user) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe 'for a custom value with a user selected' do
+        let!(:alice) { create(:user, firstname: 'Alice', member_in_project: project) }
+
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, alice.id)
+          project.save!
+          custom_value = project.custom_values.last
+
+          expect(custom_value).to not_be_default
+        end
+      end
+    end
+
+    context 'for a multi user custom field' do
+      shared_let(:custom_field) { create(:project_custom_field, :multi_user) }
+
+      include_examples 'returns true for generated custom value'
+
+      describe 'for a custom value with multiple users selected' do
+        let!(:alice) { create(:user, firstname: 'Alice', member_in_project: project) }
+        let!(:bob) { create(:user, firstname: 'Bob', member_in_project: project) }
+
+        it 'returns false' do
+          project.send(custom_field.attribute_setter, [alice.id, bob.id])
+          project.save!
+
+          expect(project.custom_values).to all(not_be_default)
+        end
       end
     end
   end

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -75,6 +75,56 @@ RSpec.describe WorkPackage, 'acts_as_customizable' do
     end
   end
 
+  describe '#custom_field_values' do
+    subject(:work_package) do
+      setup_custom_field(custom_field)
+      new_work_package
+    end
+
+    context 'with a multi-value list custom field without default value' do
+      let(:custom_field) { create(:wp_custom_field, :multi_list) }
+
+      it 'returns an array with a CustomValue with nil value' do
+        expect(work_package.custom_field_values)
+          .to match([
+                      an_instance_of(CustomValue).and(having_attributes(value: nil, custom_field_id: custom_field.id))
+                    ])
+      end
+    end
+
+    context 'with a multi-value list custom field with default value of 1 option' do
+      let(:custom_field) { create(:wp_custom_field, :multi_list, default_options: ['B']) }
+
+      it 'returns an array with a CustomValue whose value is the stringified id of the default custom option' do
+        option_b = custom_field.custom_options.find_by(value: 'B')
+        expect(work_package.custom_field_values)
+          .to match([
+                      an_instance_of(CustomValue).and(having_attributes(value: option_b.id.to_s,
+                                                                        custom_field_id: custom_field.id))
+                    ])
+      end
+    end
+
+    context 'with a multi-value list custom field with default value of multiple options' do
+      let(:custom_field) { create(:wp_custom_field, :multi_list, default_options: ['D', 'B', 'F']) }
+
+      it 'returns an array with CustomValues whose values are the stringified ids of the default custom options' do
+        option_d = custom_field.custom_options.find_by(value: 'D')
+        option_b = custom_field.custom_options.find_by(value: 'B')
+        option_f = custom_field.custom_options.find_by(value: 'F')
+        expect(work_package.custom_field_values)
+          .to match([
+                      an_instance_of(CustomValue).and(having_attributes(value: option_b.id.to_s,
+                                                                        custom_field_id: custom_field.id)),
+                      an_instance_of(CustomValue).and(having_attributes(value: option_d.id.to_s,
+                                                                        custom_field_id: custom_field.id)),
+                      an_instance_of(CustomValue).and(having_attributes(value: option_f.id.to_s,
+                                                                        custom_field_id: custom_field.id))
+                    ])
+      end
+    end
+  end
+
   describe '#custom_field_:id' do
     let(:included_cf) { build(:work_package_custom_field) }
     let(:other_cf) { build(:work_package_custom_field) }


### PR DESCRIPTION
## Bug description

Two bugs

https://community.openproject.org/wp/49765

Creating a new list custom field and then adding a comment to an existing work package would be impossible: an error "<custom field> was attempted to be written but is not writable" was displayed and the comment was not saved.

https://community.openproject.org/wp/49784

In a project with a multi-value list custom field with multiple default values, the work package new form would not preselect the default values. Instead it would preselect a "-" value.

## Analysis

In `ModelContract`, it checks that readonly attributes are not changed. If there are some `unauthenticated_changes`, then some readonly attributes have been changed. To see what has been changed by the user, for custom fields, it checks that the given value is different from the custom field default value, in which case it has not been changed by the user. This check is done in `CustomValue#default?`.

Custom values are populated by `Redmine::Acts::Customizable#custom_field_values` using the `#available_custom_fields`. This ensure there is at least one `CustomValue` for each `CustomField` of the work package.

This check is flawed for list custom field:
* for non-multi-value list, `CustomField#default_value` returns an integer, and `CustomValue#value` returns a string. Checking something like `367 == "367"` always returns false. So the field is considered changed by the user.
* for multi-value list, `CustomField#default_value` returns an array of integers, and `CustomValue#value` returns a stringified array of integers. Checking something like `[367, 368] == "[367, 368]"` always returns false as well. So the field is considered changed by the user.

Also the behavior is wrong for multi-value list: when creating value, it should create as many `CustomValue` instances as there are default options for the multi-value list custom field. For instance if the default options are `367` and `368`, then two `CustomValue`s must be created: one with value 367, second with value 368. This is why the values were not preselected in the new work package form (bug #49784). The value returned by the work package form api was actually `"[367, 368] not found"`, which was then displayed by the frontend as the value `"-"`.

## Fix

* Return strings for default value of list custom fields in `CustomField#default_value` and check inclusiveness instead of equality for multi-value custom field in `CustomValue#default?` (bug #49765).
* Create multiple CustomValue for multi-value list custom fields in `Redmine::Acts::Customizable#custom_field_values` (bug #49784).