### PR TITLE
[#49833] Fix `share_calendars` permission definition   

### DIFF
--- a/modules/calendar/lib/open_project/calendar/engine.rb
+++ b/modules/calendar/lib/open_project/calendar/engine.rb
@@ -37,6 +37,7 @@ module OpenProject::Calendar
                    dependencies: %i[view_calendar add_work_packages edit_work_packages save_queries manage_public_queries],
                    contract_actions: { calendar: %i[create update destroy] }
         permission :share_calendars,
+                   {},
                    dependencies: %i[view_calendar],
                    contract_actions: { calendar: %i[read] }
       end


### PR DESCRIPTION
## Bug description
The `controller_actions` hash was missing as a second argument, causing `:dependencies` and `:contract_actions` to be picked up as the second hash argument and interpreted as controller actions.

### Before
```ruby
[1] pry(main)> OpenProject::AccessControl.permission(:share_calendars)
=> #<OpenProject::AccessControl::Permission:0x00000001236b5b60
 @contract_actions=[],
 @controller_actions=["permissible_on/project", "dependencies/view_calendar", "contract_actions/{:calendar=>[:read]}"],
 @dependencies=[],
 @enabled=true,
 @global=false,
 @grant_to_admin=true,
 @name=:share_calendars,
 @permissible_on=[],
 @project_module=:calendar_view,
 @public=false,
 @require=nil>
```

### After
```ruby
[1] pry(main)> OpenProject::AccessControl.permission(:share_calendars)
=> #<OpenProject::AccessControl::Permission:0x0000000120615640
 @contract_actions={:calendar=>[:read]},
 @controller_actions=[],
 @dependencies=[:view_calendar],
 @enabled=true,
 @global=false,
 @grant_to_admin=true,
 @name=:share_calendars,
 @project_module=:calendar_view,
 @public=false,
 @require=nil>
```

## Notes
See: https://community.openproject.org/work_packages/49833