### PR TITLE
check for toast after every query saving to fix flickering spec

### DIFF
--- a/spec/features/views/shared_examples.rb
+++ b/spec/features/views/shared_examples.rb
@@ -56,8 +56,6 @@ RSpec.shared_examples 'module specific query view management' do
       query_menu.expect_menu_entry 'My second query'
       query_menu.expect_menu_entry 'My first query'
 
-      module_page.expect_and_dismiss_toaster
-
       # Rename a query
       settings_menu.open_and_choose 'Rename view'
       expect(page).to have_focus_on('.editable-toolbar-title--input')

--- a/spec/support/components/work_packages/settings_menu.rb
+++ b/spec/support/components/work_packages/settings_menu.rb
@@ -26,12 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+require_relative '../../toasts/expectations'
+
 module Components
   module WorkPackages
     class SettingsMenu
       include Capybara::DSL
       include Capybara::RSpecMatchers
       include RSpec::Matchers
+      include Toasts::Expectations
 
       def open_and_save_query(name)
         open_and_choose('Save')
@@ -93,6 +96,7 @@ module Components
       end
 
       def wait_for_save_completion
+        expect_and_dismiss_toaster
         modal.expect_closed
       end
 

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -26,12 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+require_relative '../toasts/expectations'
+
 module Pages
   class Page
     include Capybara::DSL
     include Capybara::RSpecMatchers
     include RSpec::Matchers
     include OpenProject::StaticRouting::UrlHelpers
+    include Toasts::Expectations
 
     def current_page?
       URI.parse(current_url).path == path
@@ -91,36 +94,6 @@ module Pages
       expect(page).to have_current_path expected_path, wait: 10
     end
 
-    def expect_toast(message:, type: :success)
-      if toast_type == :angular
-        expect(page).to have_selector(".op-toast.-#{type}", text: message, wait: 20)
-      elsif type == :error
-        expect(page).to have_selector(".errorExplanation", text: message)
-      elsif type == :success
-        expect(page).to have_selector(".op-toast.-success", text: message)
-      else
-        raise NotImplementedError
-      end
-    end
-
-    def expect_and_dismiss_toaster(message: nil, type: :success)
-      expect_toast(type:, message:)
-      dismiss_toaster!
-      expect_no_toaster(type:, message:)
-    end
-
-    def dismiss_toaster!
-      page.find('.op-toast--close').click
-    end
-
-    def expect_no_toaster(type: :success, message: nil)
-      if type.nil?
-        expect(page).not_to have_selector(".op-toast")
-      else
-        expect(page).not_to have_selector(".op-toast.-#{type}", text: message)
-      end
-    end
-
     def click_to_sort_by(header_name)
       within '.generic-table thead' do
         click_link header_name
@@ -178,10 +151,6 @@ module Pages
 
     def path
       nil
-    end
-
-    def toast_type
-      :angular
     end
 
     def navigate_to_modules_menu_item(link_title)

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -1,0 +1,37 @@
+module Toasts
+  module Expectations
+    def expect_toast(message:, type: :success)
+      if toast_type == :angular
+        expect(page).to have_selector(".op-toast.-#{type}", text: message, wait: 20)
+      elsif type == :error
+        expect(page).to have_selector(".errorExplanation", text: message)
+      elsif type == :success
+        expect(page).to have_selector(".op-toast.-success", text: message)
+      else
+        raise NotImplementedError
+      end
+    end
+
+    def expect_and_dismiss_toaster(message: nil, type: :success)
+      expect_toast(type:, message:)
+      dismiss_toaster!
+      expect_no_toaster(type:, message:)
+    end
+
+    def dismiss_toaster!
+      page.find('.op-toast--close').click
+    end
+
+    def expect_no_toaster(type: :success, message: nil)
+      if type.nil?
+        expect(page).not_to have_selector(".op-toast")
+      else
+        expect(page).not_to have_selector(".op-toast.-#{type}", text: message)
+      end
+    end
+
+    def toast_type
+      :angular
+    end
+  end
+end


### PR DESCRIPTION
Test is flickering e.g. in https://github.com/opf/openproject/actions/runs/6021051577/job/16333278924?pr=13579 because the saving wasn't completed yet even though the modal was closed. Checking for the existence of the toast after every saving and removing it should stabilize the spec.