### PR TITLE
[49831] Description in a box having too little height when the browser window's width is decreased 

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -145,7 +145,7 @@
       .detailsViewMenuItem
         display: block
 
-@media only screen and (max-width: $breakpoint-lg)
+@media only screen and (max-width: $breakpoint-xl)
   .work-packages--show-view
     // Important for Safari
     height: initial


### PR DESCRIPTION
The layout of WP pages is changed from one-column to two-columns when the screen width is greater than 1279px (xl), so flex-basis of 530px for tabs should be applied only when the screen is larger than xl size. 

https://community.openproject.org/work_packages/49831/activity