### PR TITLE
🏎️ Make Cuprite the default driver 🏎️ 

### DIFF
--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Backlogs', js: true do
     end
 
     # the order is kept even after a page refresh -> it is persisted in the db
-    page.driver.refresh
+    refresh
 
     expect(page)
       .not_to have_content 'Another story'

--- a/modules/bim/spec/features/bcf/api_authorization_spec.rb
+++ b/modules/bim/spec/features/bcf/api_authorization_spec.rb
@@ -29,7 +29,9 @@
 require 'spec_helper'
 
 RSpec.describe 'authorization for BCF api',
-               js: true, with_config: { edition: 'bim' } do
+               js: true,
+               with_config: { edition: 'bim' },
+               with_cuprite: false do
   let!(:user) { create(:admin) }
   let(:client_secret) { app.plaintext_secret }
   let(:scope) { 'bcf_v2_1' }

--- a/modules/bim/spec/features/bcf_view_management_spec.rb
+++ b/modules/bim/spec/features/bcf_view_management_spec.rb
@@ -32,7 +32,9 @@ require_relative '../support/pages/ifc_models/show_default'
 require_relative '../../../../spec/features/views/shared_examples'
 
 RSpec.describe 'bcf view management',
-               js: true, with_config: { edition: 'bim' } do
+               js: true,
+               with_config: { edition: 'bim' },
+               with_cuprite: false do
   let(:project) { create(:project, enabled_module_names: %i[bim work_package_tracking]) }
   let(:bcf_page) { Pages::IfcModels::ShowDefault.new(project) }
   let(:role) do

--- a/modules/bim/spec/features/bim_filter_spec.rb
+++ b/modules/bim/spec/features/bim_filter_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'BIM filter spec',
       card_view.expect_work_package_not_listed wp2
     end
 
-    it 'the filter is applied even after reload' do
+    it 'the filter is applied even after reload', with_cuprite: false do
       # Change filter
       filters.set_operator('Status', 'closed', nil)
       filters.expect_filter_count 1

--- a/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
+++ b/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
@@ -29,7 +29,11 @@
 require 'spec_helper'
 require_relative './ifc_upload_shared_examples'
 
-RSpec.describe 'direct IFC upload', js: true, with_config: { edition: 'bim' }, with_direct_uploads: :redirect do
+RSpec.describe 'direct IFC upload',
+               js: true,
+               with_config: { edition: 'bim' },
+               with_cuprite: false,
+               with_direct_uploads: :redirect do
   it_behaves_like 'can upload an IFC file' do
     # with direct upload, we don't get the model name
     let(:model_name) { 'model.ifc' }

--- a/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
@@ -29,7 +29,9 @@
 require_relative '../../spec_helper'
 
 RSpec.describe 'Create viewpoint from BCF details page',
-               js: true, with_config: { edition: 'bim' } do
+               js: true,
+               with_config: { edition: 'bim' },
+               with_cuprite: false do
   let(:project) { create(:project, enabled_module_names: %i[bim work_package_tracking]) }
   let(:user) { create(:admin) }
 

--- a/modules/bim/spec/features/viewer/delete_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/delete_viewpoint_spec.rb
@@ -29,7 +29,9 @@
 require_relative '../../spec_helper'
 
 RSpec.describe 'Delete viewpoint in model viewer',
-               js: true, with_config: { edition: 'bim' } do
+               js: true,
+               with_config: { edition: 'bim' },
+               with_cuprite: false do
   let(:project) { create(:project, enabled_module_names: %i[bim work_package_tracking]) }
   let(:user) { create(:admin) }
 

--- a/modules/bim/spec/support/pages/ifc_models/index.rb
+++ b/modules/bim/spec/support/pages/ifc_models/index.rb
@@ -91,9 +91,9 @@ module Pages
       end
 
       def delete_model(model_name)
-        click_table_icon model_name, '.icon-delete'
-
-        page.driver.browser.switch_to.alert.accept
+        accept_alert do
+          click_table_icon model_name, '.icon-delete'
+        end
 
         model_listed false, model_name
         expect(page).to have_current_path bcf_project_ifc_models_path(project), ignore_query: true

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Assignee action board',
       login_as(bobself_user)
     end
 
-    it 'allows to move a task between two assignees' do
+    it 'allows to move a task between two assignees', with_cuprite: false do
       # Move to the board index page
       board_index.visit!
 

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -30,7 +30,10 @@ require 'spec_helper'
 require_relative './../support//board_index_page'
 require_relative './../support/board_page'
 
-RSpec.describe 'Custom field filter in boards', js: true, with_ee: %i[board_view] do
+RSpec.describe 'Custom field filter in boards',
+               js: true,
+               with_cuprite: false,
+               with_ee: %i[board_view] do
   let(:user) do
     create(:user,
            member_in_project: project,

--- a/modules/boards/spec/features/action_boards/status_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_board_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Status action board', js: true, with_ee: %i[board_view] do
       board_page.expect_list 'Closed'
     end
 
-    it 'does not change moving card project when filtering on projects (Bug #44895)' do
+    it 'does not change moving card project when filtering on projects (Bug #44895)', with_cuprite: false do
       other_project = create(:project,
                              types: [type],
                              enabled_module_names: %i[work_package_tracking board_view],
@@ -148,7 +148,7 @@ RSpec.describe 'Status action board', js: true, with_ee: %i[board_view] do
       expect(wp_task.project).to eq(project), 'Moving the card should not change the project'
     end
 
-    it 'allows management of boards' do
+    it 'allows management of boards', with_cuprite: false do
       board_index.visit!
 
       # Create new board

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -30,7 +30,10 @@ require 'spec_helper'
 require_relative './../support//board_index_page'
 require_relative './../support/board_page'
 
-RSpec.describe 'Status action board', js: true, with_ee: %i[board_view] do
+RSpec.describe 'Status action board',
+               js: true,
+               with_cuprite: false,
+               with_ee: %i[board_view] do
   let(:user) do
     create(:user,
            member_in_project: project,

--- a/modules/boards/spec/features/action_boards/subproject_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subproject_board_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'Subproject action board', js: true, with_ee: %i[board_view] do
              member_through_role: role)
     end
 
-    it 'allows management of subproject work packages' do
+    it 'allows management of subproject work packages', with_cuprite: false do
       board_index.visit!
 
       # Create new board

--- a/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Subtasks action board', js: true, with_ee: %i[board_view] do
          edit_work_packages view_work_packages manage_public_queries manage_subtasks]
     end
 
-    it 'allows management of subtasks work packages' do
+    it 'allows management of subtasks work packages', with_cuprite: false do
       board_index.visit!
 
       # Create new board
@@ -157,7 +157,7 @@ RSpec.describe 'Subtasks action board', js: true, with_ee: %i[board_view] do
       board_page.expect_card('Other WP', 'Second child', present: false)
     end
 
-    it 'prevents adding a work package to its own column' do
+    it 'prevents adding a work package to its own column', with_cuprite: false do
       board_index.visit!
       board_page = board_index.create_board action: 'Parent-child', expect_empty: true
       board_page.add_list option: 'Parent WP'

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       login_as(user)
     end
 
-    it 'allows management of boards' do
+    it 'allows management of boards', with_cuprite: false do
       board_page = create_new_version_board
 
       board_page.expect_card 'Open version', work_package.subject, present: true
@@ -222,7 +222,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       board_page.expect_card('A second version', 'Task 1', present: false)
     end
 
-    it 'allows adding new and closed versions from within the board' do
+    it 'allows adding new and closed versions from within the board', with_cuprite: false do
       board_page = create_new_version_board
 
       # Add new version (and list)

--- a/modules/boards/spec/features/board_enterprise_spec.rb
+++ b/modules/boards/spec/features/board_enterprise_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 require_relative 'support/board_index_page'
 require_relative 'support/board_page'
 
-RSpec.describe 'Boards enterprise spec', :js, :with_cuprite do
+RSpec.describe 'Boards enterprise spec', :js do
   shared_let(:admin) { create(:admin) }
 
   shared_let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/board_index_spec.rb
+++ b/modules/boards/spec/features/board_index_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 require_relative 'support/board_index_page'
 
 RSpec.describe 'Work Package Project Boards Index Page',
-               :with_cuprite,
                with_ee: %i[board_view] do
   # The identifier is important to test https://community.openproject.com/wp/29754
   shared_let(:project) { create(:project, identifier: 'boards', enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Board management spec', js: true, with_ee: %i[board_view] do
     end
     let(:board_view) { create(:board_grid_with_query, project:) }
 
-    it 'allows parallel creation of cards (Regression #30842)' do
+    it 'allows parallel creation of cards (Regression #30842)', with_cuprite: false do
       board_view
       board_index.visit!
 
@@ -103,7 +103,7 @@ RSpec.describe 'Board management spec', js: true, with_ee: %i[board_view] do
       board_page.expect_card('List 2', 'New card 1')
     end
 
-    it 'allows management of boards' do
+    it 'allows management of boards', with_cuprite: false do
       board_view
       board_index.visit!
 
@@ -241,7 +241,7 @@ RSpec.describe 'Board management spec', js: true, with_ee: %i[board_view] do
     let(:permissions) { %i[show_board_views view_work_packages add_work_packages edit_work_packages] }
     let(:board_view) { create(:board_grid_with_queries, project:) }
 
-    it 'allows viewing boards index and moving items around' do
+    it 'allows viewing boards index and moving items around', with_cuprite: false do
       board_view
       board_index.visit!
 

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Work Package boards spec', js: true, with_ee: %i[board_view] do
     login_as(admin)
   end
 
-  it 'navigates from boards to the WP full view and back' do
+  it 'navigates from boards to the WP full view and back', with_cuprite: false do
     board_index.visit!
 
     # Add a new WP on the board
@@ -161,7 +161,7 @@ RSpec.describe 'Work Package boards spec', js: true, with_ee: %i[board_view] do
     split_view.ensure_page_loaded
     split_view.expect_subject
 
-    page.driver.refresh
+    refresh
 
     split_view.ensure_page_loaded
     split_view.expect_subject

--- a/modules/boards/spec/features/board_overview_spec.rb
+++ b/modules/boards/spec/features/board_overview_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 require_relative 'support/board_overview_page'
 
 RSpec.describe 'Work Package Boards Overview',
-               :with_cuprite,
                with_ee: %i[board_view] do
   # The identifier is important to test https://community.openproject.com/wp/29754
   shared_let(:project) do

--- a/modules/boards/spec/features/boards_global_create_spec.rb
+++ b/modules/boards/spec/features/boards_global_create_spec.rb
@@ -6,7 +6,6 @@ require_relative 'support/board_new_page'
 RSpec.describe 'Boards',
                'Creating a view from a Global Context',
                :js,
-               :with_cuprite,
                with_ee: %i[board_view] do
   shared_let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   shared_let(:other_project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Global menu item for boards', :js, :with_cuprite do
+RSpec.describe 'Global menu item for boards', :js do
   let(:boards_label) { I18n.t('boards.label_boards') }
 
   before do

--- a/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Top menu item for boards', :js, :with_cuprite do
+RSpec.describe 'Top menu item for boards', :js do
   let(:user) { create(:admin) }
 
   let(:menu) { find(".op-app-menu a[title='#{I18n.t('label_modules')}']") }

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -27,10 +27,11 @@
 #++
 
 require 'spec_helper'
-require_relative './../support/onboarding_steps'
+require_relative '../support/onboarding_steps'
 
 RSpec.describe 'boards onboarding tour',
-               js: true do
+               js: true,
+               with_cuprite: false do
   let(:next_button) { find('.enjoyhint_next_btn') }
   let(:user) do
     create(:admin,

--- a/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
+++ b/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Upload attachment to budget', js: true do
     attachments_list.expect_attached('image.png', count: 2)
   end
 
-  it 'can upload an image to new and existing budgets via drag & drop on attachment list' do
+  it 'can upload an image to new and existing budgets via drag & drop on attachment list', with_cuprite: false do
     visit projects_budgets_path(project)
 
     within '.toolbar-items' do

--- a/modules/budgets/spec/features/costs_edit_fields_spec.rb
+++ b/modules/budgets/spec/features/costs_edit_fields_spec.rb
@@ -28,7 +28,9 @@
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
-RSpec.describe 'Work Package budget fields', js: true do
+RSpec.describe 'Work Package budget fields',
+               js: true,
+               with_cuprite: false do
   let(:type_task) { create(:type_task) }
   let!(:status) { create(:status, is_default: true) }
   let!(:priority) { create(:priority, is_default: true) }

--- a/modules/calendar/spec/features/calendar_create_work_package_spec.rb
+++ b/modules/calendar/spec/features/calendar_create_work_package_spec.rb
@@ -27,9 +27,11 @@
 #++
 
 require 'spec_helper'
-require_relative './shared_context'
+require_relative 'shared_context'
 
-RSpec.describe 'Calendar create new work package', js: true do
+RSpec.describe 'Calendar create new work package',
+               js: true,
+               with_cuprite: false do
   include_context 'with calendar full access'
 
   let(:type_task) { create(:type_task) }

--- a/modules/calendar/spec/features/calendar_dates_spec.rb
+++ b/modules/calendar/spec/features/calendar_dates_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative './shared_context'
 
-RSpec.describe 'Calendar non working days', :js, :with_cuprite do
+RSpec.describe 'Calendar non working days', :js do
   include_context 'with calendar full access'
 
   let!(:other_user) do

--- a/modules/calendar/spec/features/calendar_project_include_spec.rb
+++ b/modules/calendar/spec/features/calendar_project_include_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 require 'features/work_packages/project_include/project_include_shared_examples'
 require_relative '../support/pages/calendar'
 
-RSpec.describe 'Calendar project include', js: true do
+RSpec.describe 'Calendar project include',
+               js: true do
   shared_let(:enabled_modules) { %w[work_package_tracking calendar_view] }
   shared_let(:permissions) do
     %i[view_work_packages view_calendar edit_work_packages add_work_packages save_queries manage_public_queries]
@@ -71,7 +72,7 @@ RSpec.describe 'Calendar project include', js: true do
       work_package_view.expect_event other_task
       work_package_view.expect_event other_other_task
 
-      page.refresh
+      refresh
 
       work_package_view.expect_event task
       work_package_view.expect_event sub_bug, present: true

--- a/modules/calendar/spec/features/calendar_user_interaction_spec.rb
+++ b/modules/calendar/spec/features/calendar_user_interaction_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Calendar drag&dop and resizing', js: true do
     calendar.expect_event work_package
   end
 
-  context 'with full permissions' do
+  context 'with full permissions', with_cuprite: false do
     it 'allows to resize to change the dates of a wp' do
       target = work_package.due_date + 1.day
       current_start = work_package.start_date

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative '../../../overviews/spec/support/pages/overview'
 
-RSpec.describe 'Calendar Widget', :js, :with_cuprite do
+RSpec.describe 'Calendar Widget', :js do
   let(:project) do
     create(:project, enabled_module_names: %w[work_package_tracking calendar_view])
   end

--- a/modules/calendar/spec/features/calendars_global_create_spec.rb
+++ b/modules/calendar/spec/features/calendars_global_create_spec.rb
@@ -34,8 +34,7 @@ require_relative 'shared_context'
 
 RSpec.describe 'Calendar',
                'Creating a view from a Global Context',
-               :js,
-               :with_cuprite do
+               :js do
   include_context 'with calendar full access'
 
   let(:calendars_page) { Pages::Calendar.new nil }

--- a/modules/calendar/spec/features/calendars_index_spec.rb
+++ b/modules/calendar/spec/features/calendars_index_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative '../support/pages/calendar'
 
-RSpec.describe 'Calendars', 'index', :with_cuprite do
+RSpec.describe 'Calendars', 'index' do
   # The order the Projects are created in is important. By naming `project` alphanumerically
   # after `other_project`, we can ensure that subsequent specs that assert sorting is
   # correct for the right reasons (sorting by Project name and not id)

--- a/modules/dashboards/spec/features/project_status_spec.rb
+++ b/modules/dashboards/spec/features/project_status_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Project status widget on dashboard', js: true do
   context 'with editing permissions' do
     let(:current_user) { editing_user }
 
-    it 'can edit the status and its explanation' do
+    it 'can edit the status and its explanation', with_cuprite: false do
       # As the user lacks the manage_public_queries and save_queries permission, no other widget is present
       status_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
 

--- a/modules/dashboards/spec/features/work_package_graph_overview_spec.rb
+++ b/modules/dashboards/spec/features/work_package_graph_overview_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Work package overview graph widget on dashboard',
   end
 
   # As a graph is rendered as a canvas, we have limited abilities to test the widget
-  it 'can add the widget' do
+  it 'can add the widget', with_cuprite: false do
     sleep(0.1)
 
     dashboard.add_widget(1, 1, :within, "Work packages overview")

--- a/modules/dashboards/spec/features/work_package_graph_spec.rb
+++ b/modules/dashboards/spec/features/work_package_graph_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Arbitrary WorkPackage query graph widget dashboard',
   end
 
   context 'with the permission to save queries' do
-    it 'can add the widget and see the work packages of the filtered for types' do
+    it 'can add the widget and see the work packages of the filtered for types', with_cuprite: false do
       expect(page)
         .to have_content(type_work_package.subject)
 

--- a/modules/dashboards/spec/features/work_package_table_spec.rb
+++ b/modules/dashboards/spec/features/work_package_table_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Arbitrary WorkPackage query table widget dashboard', js: true do
   end
 
   context 'with the permission to save queries' do
-    it 'can add the widget and see the work packages of the filtered for types' do
+    it 'can add the widget and see the work packages of the filtered for types', with_cuprite: false do
       # This one always exists by default.
       # Using it here as a safeguard to govern speed.
       wp_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -30,10 +30,11 @@ require 'spec_helper'
 require 'features/page_objects/notification'
 
 RSpec.describe 'Upload attachment to documents',
-         js: true,
-         with_settings: {
-           journal_aggregation_time_minutes: 0
-         } do
+               js: true,
+               with_cuprite: false,
+               with_settings: {
+                 journal_aggregation_time_minutes: 0
+               } do
   let!(:user) do
     create(:user,
            member_in_project: project,

--- a/modules/github_integration/spec/features/work_package_activity_spec.rb
+++ b/modules/github_integration/spec/features/work_package_activity_spec.rb
@@ -4,8 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Work Package Activity Tab',
                'Comments by Github',
-               :js,
-               :with_cuprite do
+               :js do
   shared_let(:github_system_user) { create(:admin, firstname: 'Github', lastname: 'System User') }
   shared_let(:admin) { create(:admin) }
 

--- a/modules/github_integration/spec/features/work_package_github_tab_spec.rb
+++ b/modules/github_integration/spec/features/work_package_github_tab_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Open the GitHub tab', js: true do
       work_package_page.switch_to_tab(tab: 'github')
     end
 
-    it 'shows the github tab when the user is allowed to see it' do
+    it 'shows the github tab when the user is allowed to see it', with_cuprite: false do
       work_package_page.visit!
       work_package_page.switch_to_tab(tab: 'github')
 
@@ -88,7 +88,7 @@ RSpec.describe 'Open the GitHub tab', js: true do
       let(:check_run) {}
       let(:pull_request) {}
 
-      it 'shows the github tab with an empty-pull-requests message' do
+      it 'shows the github tab with an empty-pull-requests message', with_cuprite: false do
         work_package_page.visit!
         work_package_page.switch_to_tab(tab: 'github')
         tabs.expect_no_counter(github_tab_element)

--- a/modules/meeting/spec/features/meetings_copy_spec.rb
+++ b/modules/meeting/spec/features/meetings_copy_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Meetings copy', :js, :with_cuprite do
+RSpec.describe 'Meetings copy', :js do
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   shared_let(:permissions) { %i[view_meetings create_meetings] }
   shared_let(:user) do

--- a/modules/meeting/spec/features/meetings_global_menu_item_spec.rb
+++ b/modules/meeting/spec/features/meetings_global_menu_item_spec.rb
@@ -32,8 +32,7 @@
 require 'spec_helper'
 require_relative '../support/pages/meetings/index'
 
-RSpec.describe 'Meetings global menu item',
-               :with_cuprite do
+RSpec.describe 'Meetings global menu item' do
   shared_let(:user_without_permissions) { create(:user) }
   shared_let(:admin) { create(:admin) }
   shared_let(:meetings_label) { I18n.t(:label_meeting_plural) }

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 require_relative '../support/pages/meetings/index'
 
-RSpec.describe 'Meetings', 'Index', :with_cuprite do
+RSpec.describe 'Meetings', 'Index' do
   # The order the Projects are created in is important. By naming `project` alphanumerically
   # after `other_project`, we can ensure that subsequent specs that assert sorting is
   # correct for the right reasons (sorting by Project name and not id)

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
     let(:new_page) { Pages::Meetings::New.new(nil) }
 
     context 'with permission to create meetings' do
-      it 'does not render menus', :with_cuprite do
+      it 'does not render menus' do
         new_page.visit!
         new_page.expect_no_main_menu
       end
 
-      describe 'clicking on the create new meeting button', :with_cuprite do
+      describe 'clicking on the create new meeting button' do
         it 'navigates to the global create form' do
           index_page.visit!
           index_page.click_create_new
@@ -151,7 +151,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
       end
     end
 
-    context 'without permission to create meetings', :with_cuprite do
+    context 'without permission to create meetings' do
       let(:permissions) { %i[view_meetings] }
 
       it 'shows no edit link' do
@@ -161,7 +161,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
       end
     end
 
-    context 'as an admin', :with_cuprite do
+    context 'as an admin' do
       let(:current_user) { admin }
 
       it 'allows creating meeting in a project without members' do
@@ -227,7 +227,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
         other_user
       end
 
-      describe 'clicking on the create new meeting button', :with_cuprite do
+      describe 'clicking on the create new meeting button' do
         it 'navigates to the project-specific create form' do
           index_page.visit!
           index_page.click_create_new
@@ -277,7 +277,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
       end
     end
 
-    context 'without permission to create meetings', :with_cuprite do
+    context 'without permission to create meetings' do
       let(:permissions) { %i[view_meetings] }
 
       it 'shows no edit link' do
@@ -287,7 +287,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
       end
     end
 
-    context 'as an admin', :with_cuprite do
+    context 'as an admin' do
       let(:current_user) { admin }
       let(:field) do
         TextEditorField.new(page,

--- a/modules/my_page/spec/features/my/accountable_spec.rb
+++ b/modules/my_page/spec/features/my/accountable_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Accountable widget on my page', js: true do
     my_page.visit!
   end
 
-  it 'can add the widget and see the work packages the user is accountable for' do
+  it 'can add the widget and see the work packages the user is accountable for', with_cuprite: false do
     # Added to ensure the page has finished loading.
     # The page starts with a "wp created widget".
     created_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')

--- a/modules/my_page/spec/features/my/assigned_to_me_spec.rb
+++ b/modules/my_page/spec/features/my/assigned_to_me_spec.rb
@@ -170,7 +170,9 @@ RSpec.describe 'Assigned to me embedded query on my page', js: true do
     embedded_table.expect_work_package_listed wp
   end
 
-  it 'can paginate in embedded tables (Regression test #29845)', with_settings: { per_page_options: '1' } do
+  it 'can paginate in embedded tables (Regression test #29845)',
+     with_cuprite: false,
+     with_settings: { per_page_options: '1' } do
     my_page.visit!
 
     # exists as default

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Custom text widget on my page', js: true do
     my_page.visit!
   end
 
-  it 'can add the widget set custom text and upload attachments' do
+  it 'can add the widget set custom text and upload attachments', with_cuprite: false do
     my_page.add_widget(1, 1, :within, "Custom text")
 
     sleep(0.1)

--- a/modules/my_page/spec/features/my/documents_spec.rb
+++ b/modules/my_page/spec/features/my/documents_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'My page documents widget', js: true do
     my_page.visit!
   end
 
-  it 'can add the widget and see the visible documents' do
+  it 'can add the widget and see the visible documents', with_cuprite: false do
     # within top-right area, add an additional widget
     my_page.add_widget(1, 1, :within, 'Documents')
 

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'My page', js: true do
     Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(#{index + 1})")
   end
 
-  it 'renders the default view, allows altering and saving' do
+  it 'renders the default view, allows altering and saving', with_cuprite: false do
     sleep(0.5)
 
     assigned_area.expect_to_exist

--- a/modules/my_page/spec/features/my/news_spec.rb
+++ b/modules/my_page/spec/features/my/news_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'My page news widget spec', js: true do
     my_page.visit!
   end
 
-  it 'can add the widget and see the visible news' do
+  it 'can add the widget and see the visible news', with_cuprite: false do
     # No other widgets exist as the user lacks the permissions for the default widgets
     # add widget in top right corner
     my_page.add_widget(1, 1, :within, 'News')

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'My page time entries current user widget spec', js: true do
     my_page.visit!
   end
 
-  it 'adds the widget which then displays time entries and allows manipulating them' do
+  it 'adds the widget which then displays time entries and allows manipulating them', with_cuprite: false do
     # within top-right area, add an additional widget
     my_page.add_widget(1, 1, :within, 'My spent time')
 

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Arbitrary WorkPackage query table widget on my page', js: true d
   end
 
   context 'with the permission to save queries' do
-    it 'can add the widget and see the work packages of the filtered for types' do
+    it 'can add the widget and see the work packages of the filtered for types', with_cuprite: false do
       # This one always exists by default.
       # Using it here as a safeguard to govern speed.
       created_by_me_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Overview page managing', js: true do
     overview_page.visit!
   end
 
-  it 'renders the default view, allows altering and saving' do
+  it 'renders the default view, allows altering and saving', with_cuprite: false do
     description_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
     status_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')
     details_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(3)')

--- a/modules/reporting/spec/features/calculations_spec.rb
+++ b/modules/reporting/spec/features/calculations_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Cost Report', 'calculations', :js, :with_cuprite do
+RSpec.describe 'Cost Report', 'calculations', :js do
   let(:project) { create(:project) }
   let(:user) { create(:admin) }
   let(:work_package) { create(:work_package, project:) }

--- a/modules/reporting/spec/features/filter_spec.rb
+++ b/modules/reporting/spec/features/filter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Cost report calculations', :js, :with_cuprite do
+RSpec.describe 'Cost report calculations', :js do
   let(:project) { create(:project) }
   let(:user) { create(:admin) }
 

--- a/modules/reporting/spec/features/group_by_spec.rb
+++ b/modules/reporting/spec/features/group_by_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative 'support/pages/cost_report_page'
 
-RSpec.describe 'Cost report calculations', 'grouping', :js, :with_cuprite do
+RSpec.describe 'Cost report calculations', 'grouping', :js do
   let(:project) { create(:project) }
   let(:user) { create(:admin) }
   let(:work_package) { create(:work_package, project:) }

--- a/modules/reporting/spec/features/main_menu_item_spec.rb
+++ b/modules/reporting/spec/features/main_menu_item_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Cost and Reports Main Menu Item', :js, :with_cuprite do
+RSpec.describe 'Cost and Reports Main Menu Item', :js do
   shared_let(:admin) { create(:admin) }
   shared_let(:user_with_permissions) { create(:user, global_permissions: %i[view_time_entries]) }
   shared_let(:user_without_permissions) { create(:user) }

--- a/modules/reporting/spec/features/menu_spec.rb
+++ b/modules/reporting/spec/features/menu_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'project menu' do
           visit current_path
         end
 
-        it 'leads to cost reports' do
+        it 'leads to cost reports', with_cuprite: false do
           find('#main-menu [data-qa-selector="op-menu--item-action"]', text: 'Time and costs').click
 
           expect(page).to have_current_path("/projects/ponyo/cost_reports")
@@ -92,7 +92,7 @@ RSpec.describe 'project menu' do
           visit current_path
         end
 
-        it 'leads to cost reports' do
+        it 'leads to cost reports', with_cuprite: false do
           # doing what no human can - click on invisible items.
           # This way, we avoid having to use selenium and by that increase stability.
           find('#main-menu [data-qa-selector="op-menu--item-action"]', text: 'Time and costs').click

--- a/modules/reporting/spec/features/support/components/cost_reports_base_table.rb
+++ b/modules/reporting/spec/features/support/components/cost_reports_base_table.rb
@@ -83,9 +83,9 @@ module Components
 
     def delete_entry(row)
       SeleniumHubWaiter.wait
-      page.find("#{row_selector(row)} .icon-delete").click
-
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        page.find("#{row_selector(row)} .icon-delete").click
+      end
     end
 
     private

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Admin storages', :storage_server_helpers, js: true do
 
   before { login_as admin }
 
-  it 'creates, edits and deletes storages', webmock: true do
+  it 'creates, edits and deletes storages', webmock: true, with_cuprite: false do
     visit admin_settings_storages_path
 
     ######### Step 1: Begin Create a storage #########

--- a/modules/storages/spec/features/storages_menu_links_spec.rb
+++ b/modules/storages/spec/features/storages_menu_links_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe 'Project menu', js: true, with_cuprite: true do
+RSpec.describe 'Project menu', js: true do
   let(:storage) { create(:storage, name: "Storage 1") }
   let(:another_storage) { create(:storage, name: "Storage 2") }
   let(:unlinked_storage) { create(:storage, name: "Storage 3") }

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -30,7 +30,10 @@ require 'spec_helper'
 require_relative '../support/pages/team_planner'
 require_relative '../../../../spec/features/views/shared_examples'
 
-RSpec.describe 'Team planner query handling', js: true, with_ee: %i[team_planner_view] do
+RSpec.describe 'Team planner query handling',
+               js: true,
+               with_cuprite: false,
+               with_ee: %i[team_planner_view] do
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
                due_date: 12.days.from_now)
       end
 
-      it 'shows work packages removed from the team planner' do
+      it 'shows work packages removed from the team planner', with_cuprite: false do
         team_planner.within_lane(user) do
           team_planner.expect_event first_wp
         end
@@ -116,7 +116,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
       end
     end
 
-    it 'allows to click cards to open split view when open' do
+    it 'allows to click cards to open split view when open', with_cuprite: false do
       # Search for a work package
       add_existing_pane.search 'Task'
       add_existing_pane.expect_result second_wp
@@ -133,7 +133,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
       expect(page).to have_current_path /\/details\/#{second_wp.id}/
     end
 
-    it 'allows to add work packages via drag&drop from the left hand shortlist' do
+    it 'allows to add work packages via drag&drop from the left hand shortlist', with_cuprite: false do
       # Search for a work package
       add_existing_pane.search 'Task'
       add_existing_pane.expect_result second_wp
@@ -173,7 +173,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
       split_view.expect_open
     end
 
-    it 'the search applies the filter from the team planner' do
+    it 'the search applies the filter from the team planner', with_cuprite: false do
       # Search for a work package
       add_existing_pane.search 'Task'
       add_existing_pane.expect_result second_wp
@@ -215,7 +215,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
 
       let(:dropdown) { Components::ProjectIncludeComponent.new }
 
-      it 'applies the project include filter' do
+      it 'applies the project include filter', with_cuprite: false do
         # Search for the work package in the child project
         add_existing_pane.search 'Subtask'
         add_existing_pane.expect_empty

--- a/modules/team_planner/spec/features/team_planner_context_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_context_menu_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 require_relative 'shared_context'
 require 'features/work_packages/table/context_menu/context_menu_shared_examples'
 
-RSpec.describe 'Work package table context menu', js: true, with_ee: %i[team_planner_view] do
+RSpec.describe 'Work package table context menu',
+               js: true,
+               with_cuprite: false,
+               with_ee: %i[team_planner_view] do
   include_context 'with team planner full access'
 
   let!(:work_package) do

--- a/modules/team_planner/spec/features/team_planner_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_create_spec.rb
@@ -29,7 +29,10 @@
 require 'spec_helper'
 require_relative './shared_context'
 
-RSpec.describe 'Team planner create new work package', js: true, with_ee: %i[team_planner_view] do
+RSpec.describe 'Team planner create new work package',
+               js: true,
+               with_cuprite: false,
+               with_ee: %i[team_planner_view] do
   include_context 'with team planner full access'
 
   let(:type_task) { create(:type_task) }

--- a/modules/team_planner/spec/features/team_planner_dates_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_dates_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'Team planner working days', js: true, with_ee: %i[team_planner_v
   context 'with week days defined' do
     let!(:week_days) { week_with_saturday_and_sunday_as_weekend }
 
-    it 'hides sat and sun in the "Work week" view andd renders sat and sun as non working in the "1-week" view' do
+    it 'hides sat and sun in the "Work week" view andd renders sat and sun as non working in the "1-week" view',
+       with_cuprite: false do
       team_planner.visit!
 
       team_planner.expect_empty_state

--- a/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Team planner error handling', js: true do
       end
     end
 
-    it 'cannot change the wp because of required fields not being set' do
+    it 'cannot change the wp because of required fields not being set', with_cuprite: false do
       custom_field.is_required = true
       custom_field.save!
 
@@ -79,7 +79,7 @@ RSpec.describe 'Team planner error handling', js: true do
       end
     end
 
-    it 'cannot change the wp because of conflicting modifications' do
+    it 'cannot change the wp because of conflicting modifications', with_cuprite: false do
       # Try to move the wp
       retry_block do
         wp_strip = page.find('.fc-event', text: work_package.subject)

--- a/modules/team_planner/spec/features/team_planner_global_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_global_create_spec.rb
@@ -34,7 +34,6 @@ require_relative 'shared_context'
 RSpec.describe 'Team Planner',
                'Creating a view from a Global Context',
                :js,
-               :with_cuprite,
                with_ee: %i[team_planner_view] do
   include_context 'with team planner full access'
 

--- a/modules/team_planner/spec/features/team_planner_index_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_index_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative 'shared_context'
 
-RSpec.describe 'Team planner index', :js, :with_cuprite, with_ee: %i[team_planner_view] do
+RSpec.describe 'Team planner index', :js, with_ee: %i[team_planner_view] do
   shared_let(:project) do
     create(:project)
   end

--- a/modules/team_planner/spec/features/team_planner_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_menu_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Team planner Menu Item', :js, :with_cuprite do
+RSpec.describe 'Team planner Menu Item', :js do
   shared_let(:project) do
     create(:project, enabled_module_names: %w[work_package_tracking team_planner_view])
   end

--- a/modules/team_planner/spec/features/team_planner_overview_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_overview_spec.rb
@@ -33,7 +33,6 @@ require 'spec_helper'
 require_relative 'shared_context'
 
 RSpec.describe 'Team planner overview',
-               :with_cuprite,
                with_ee: %i[team_planner_view] do
   # The order the Projects are created in is important. By naming `project` alphanumerically
   # after `other_project`, we can ensure that subsequent specs that assert sorting is

--- a/modules/team_planner/spec/features/team_planner_project_include_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_project_include_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Team planner project include', js: true, with_ee: %i[team_planne
     let(:work_package_view) { Pages::TeamPlanner.new(project) }
     let(:dropdown) { Components::ProjectIncludeComponent.new }
 
-    it 'correctly filters work packages by project' do
+    it 'correctly filters work packages by project', with_cuprite: false do
       dropdown.expect_count 1
 
       # Make sure the filter gets set once
@@ -102,7 +102,7 @@ RSpec.describe 'Team planner project include', js: true, with_ee: %i[team_planne
         work_package_view.expect_event other_other_task
       end
 
-      page.refresh
+      refresh
 
       work_package_view.within_lane(other_user) do
         work_package_view.expect_event other_task

--- a/modules/team_planner/spec/features/team_planner_remove_event_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_remove_event_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Team planner remove event', js: true, with_ee: %i[team_planner_v
     sleep 2
   end
 
-  it 'can remove one of the work packages' do
+  it 'can remove one of the work packages', with_cuprite: false do
     team_planner.drag_to_remove_dropzone non_removable_wp, expect_removable: false
     team_planner.drag_to_remove_dropzone removable_wp, expect_removable: true
   end
@@ -93,7 +93,7 @@ RSpec.describe 'Team planner remove event', js: true, with_ee: %i[team_planner_v
   context 'with the add existing open searching for the task' do
     let(:add_existing_pane) { Components::AddExistingPane.new }
 
-    it 'the removed task shows up again' do
+    it 'the removed task shows up again', with_cuprite: false do
       # Open the left hand pane
       add_existing_pane.open
       add_existing_pane.expect_empty

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
       team_planner.expect_empty_state(present: false)
     end
 
-    it 'can add and remove assignees' do
+    it 'can add and remove assignees', with_cuprite: false do
       team_planner.visit!
 
       team_planner.expect_empty_state
@@ -288,7 +288,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
       team_planner.expect_assignee(other_user, present: false)
     end
 
-    it 'filters possible assignees correctly' do
+    it 'filters possible assignees correctly', with_cuprite: false do
       team_planner.visit!
 
       retry_block do
@@ -328,7 +328,9 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
              subject: 'A blocked task')
     end
 
-    it 'disables editing on readonly tasks', with_ee: %i[team_planner_view readonly_work_packages] do
+    it 'disables editing on readonly tasks',
+       with_cuprite: false,
+       with_ee: %i[team_planner_view readonly_work_packages] do
       team_planner.visit!
 
       team_planner.wait_for_loaded

--- a/modules/team_planner/spec/features/team_planner_split_view_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_split_view_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Team planner split view navigation', js: true, with_ee: %i[team_
            due_date: start_of_week.next_occurring(:thursday))
   end
 
-  it 'allows to navigate to the split view' do
+  it 'allows to navigate to the split view', with_cuprite: false do
     team_planner.visit!
 
     team_planner.add_assignee user

--- a/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Team planner constraints for a subproject', js: true, with_ee: %
            due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday))
   end
 
-  it 'shows a visual aid that the other user cannot be assigned' do
+  it 'shows a visual aid that the other user cannot be assigned', with_cuprite: false do
     team_planner.visit!
 
     team_planner.add_assignee user

--- a/modules/team_planner/spec/features/team_planner_upsale_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_upsale_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative './shared_context'
 
-RSpec.describe 'Team planner index', :js, :with_cuprite do
+RSpec.describe 'Team planner index', :js do
   include_context 'with team planner full access'
 
   let(:current_user) { user }

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Team planner drag&dop and resizing', js: true, with_ee: %i[team_
       end
     end
 
-    it 'allows to drag&drop between the lanes to change the assignee' do
+    it 'allows to drag&drop between the lanes to change the assignee', with_cuprite: false do
       # Move first wp to the user
       retry_block do
         team_planner.drag_wp_to_lane(first_wp, user)
@@ -180,7 +180,7 @@ RSpec.describe 'Team planner drag&dop and resizing', js: true, with_ee: %i[team_
       end
     end
 
-    it 'allows to resize to change the dates of a wp' do
+    it 'allows to resize to change the dates of a wp', with_cuprite: false do
       retry_block do
         # Change date of second_wp by resizing it
         team_planner.change_wp_date_by_resizing(second_wp, number_of_days: 1, is_start_date: true)
@@ -252,7 +252,7 @@ RSpec.describe 'Team planner drag&dop and resizing', js: true, with_ee: %i[team_
       end
     end
 
-    it 'allows neither dragging nor resizing any wp' do
+    it 'allows neither dragging nor resizing any wp', with_cuprite: false do
       team_planner.expect_wp_not_resizable(first_wp)
       team_planner.expect_wp_not_resizable(second_wp)
       team_planner.expect_wp_not_resizable(third_wp)

--- a/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
@@ -32,7 +32,9 @@ require_relative './shared_context'
 RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
   include_context 'with team planner full access'
 
-  it 'allows switching of view modes', with_settings: { working_days: [1, 2, 3, 4, 5] } do
+  it 'allows switching of view modes',
+     with_cuprite: false,
+     with_settings: { working_days: [1, 2, 3, 4, 5] } do
     team_planner.visit!
 
     team_planner.expect_empty_state

--- a/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
@@ -73,9 +73,10 @@ RSpec.describe 'Admin 2FA management',
       visit edit_user_path(other_user, tab: :two_factor_authentication)
       expect(page).to have_selector('.mobile-otp--two-factor-device-row', count: 2)
       expect(page).to have_selector('.on-off-status.-enabled')
-      find('.button', text: I18n.t('two_factor_authentication.admin.button_delete_all_devices')).click
 
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        find('.button', text: I18n.t('two_factor_authentication.admin.button_delete_all_devices')).click
+      end
 
       expect(page).to have_selector('.generic-table--empty-row',
                                     text: I18n.t('two_factor_authentication.admin.no_devices_for_user'), wait: 20)

--- a/modules/two_factor_authentication/spec/features/remember_cookie/login_with_remember_cookie_spec.rb
+++ b/modules/two_factor_authentication/spec/features/remember_cookie/login_with_remember_cookie_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Login with 2FA remember cookie',
     end
   end
 
-  context 'when user has no remember cookie' do
+  context 'when user has no remember cookie', with_cuprite: false do
     it 'can remove the autologin cookie after login' do
       login_with_cookie
       visit my_2fa_devices_path

--- a/modules/webhooks/spec/features/manage_webhooks_spec.rb
+++ b/modules/webhooks/spec/features/manage_webhooks_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe 'Manage webhooks through UI', js: true do
 
       SeleniumHubWaiter.wait
       # Delete webhook
-      find(".webhooks--outgoing-webhook-row-#{webhook.id} .icon-delete").click
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        find(".webhooks--outgoing-webhook-row-#{webhook.id} .icon-delete").click
+      end
 
       expect(page).to have_selector('.op-toast.-success', text: I18n.t(:notice_successful_delete))
       expect(page).to have_selector('.generic-table--empty-row')

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -179,10 +179,10 @@ RSpec.describe 'Work package index accessibility', selenium: true do
         expect(page).to have_focus_on(first_row_selector)
 
         # Avoid sending keys on body since that resets focus
-        page.driver.browser.switch_to.active_element.send_keys('j')
+        find(first_row_selector).native.send_keys('j')
         expect(page).to have_focus_on(second_row_selector)
 
-        page.driver.browser.switch_to.active_element.send_keys('k')
+        find(second_row_selector).native.send_keys('k')
         expect(page).to have_focus_on(first_row_selector)
       end
     end
@@ -225,7 +225,7 @@ RSpec.describe 'Work package index accessibility', selenium: true do
       end
     end
 
-    describe 'work package context menu', js: true do
+    describe 'work package context menu', js: true, with_cuprite: false do
       it_behaves_like 'context menu' do
         let(:target_link) { '#work-package-context-menu a.detailsViewMenuItem' }
         let(:source_link) { '.work-package-table--container tr.issue td.id a' }

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Activity page navigation', :js, :with_cuprite do
+RSpec.describe 'Activity page navigation', :js do
   include ActiveSupport::Testing::TimeHelpers
 
   shared_let(:project) { create(:project, enabled_module_names: Setting.default_projects_modules + ['activity']) }

--- a/spec/features/activities/disabled_activity_spec.rb
+++ b/spec/features/activities/disabled_activity_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Disabled activity', :js, :with_cuprite do
+RSpec.describe 'Disabled activity', :js do
   shared_let(:admin) { create(:admin) }
 
   let(:project1) do

--- a/spec/features/activities/project_attributes_activity_spec.rb
+++ b/spec/features/activities/project_attributes_activity_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Project attributes activity', :js, :with_cuprite do
+RSpec.describe 'Project attributes activity', :js do
   let(:user) { create(:user, member_in_project: project) }
   let(:parent_project) { create(:project, name: 'parent') }
   let(:project) { create(:project, parent: parent_project, active: false) }

--- a/spec/features/activities/time_entry_activity_spec.rb
+++ b/spec/features/activities/time_entry_activity_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'TimeEntry activity',
                :js,
-               :with_cuprite,
                with_settings: { journal_aggregation_time_minutes: 0 } do
   let(:user) do
     create(:user,

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Wiki Activity', :js, :with_cuprite do
+RSpec.describe 'Wiki Activity', :js do
   let(:user) do
     create(:user,
            member_in_project: project,

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Attribute help texts',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
 
   let(:instance) { AttributeHelpText.last }

--- a/spec/features/admin/custom_fields/list_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/list_custom_field_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'List custom fields edit',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
 
   before do

--- a/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Multi-value custom fields creation', js: true do
+RSpec.describe 'Multi-value custom fields creation', js: true, with_cuprite: false do
   shared_let(:admin) { create(:admin) }
 
   before do

--- a/spec/features/admin/custom_fields/user_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/user_custom_field_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'User custom fields edit',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Enterprise token',
-               js: true,
-               with_cuprite: true do
+               js: true do
   include Redmine::I18n
 
   shared_let(:admin) { create(:admin) }

--- a/spec/features/admin/enterprise/token_domain_spec.rb
+++ b/spec/features/admin/enterprise/token_domain_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Enterprise Edition token domain',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:current_user) { create(:admin) }
   let(:ee_token) { Rails.root.join("spec/fixtures/ee_tokens/v2_1_user_localhost_3001.token").read }
 

--- a/spec/features/admin/menu_item_traversal_spec.rb
+++ b/spec/features/admin/menu_item_traversal_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Menu item traversal' do
       visit admin_index_path
     end
 
-    it 'correctly maps the menu items for controllers in their namespace (Regression #30859)' do
+    it 'correctly maps the menu items for controllers in their namespace (Regression #30859)', with_cuprite: false do
       expect(page).to have_selector('.admin-overview-menu-item.selected', text: 'Overview')
 
       find('.plugin-webhooks-menu-item').click

--- a/spec/features/admin/oauth/oauth_applications_management_spec.rb
+++ b/spec/features/admin/oauth/oauth_applications_management_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'OAuth applications management',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:admin) { create(:admin) }
 
   before do

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Test mail notification', js: true, with_cuprite: true do
+RSpec.describe 'Test mail notification', js: true do
   shared_let(:admin) { create(:admin) }
 
   before do

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Working Days', js: true, with_cuprite: true do
+RSpec.describe 'Working Days', js: true do
   create_shared_association_defaults_for_work_package_factory
 
   shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }

--- a/spec/features/api_docs/index_spec.rb
+++ b/spec/features/api_docs/index_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'REST API docs index page', js: true do
   context 'with authenticated user' do
     current_user { create(:user) }
 
-    it 'displays the docs rendered by openapi-explorer' do
+    it 'displays the docs rendered by openapi-explorer', with_cuprite: false do
       visit_docs_page
 
       # web component are harder to test with capybara

--- a/spec/features/auth/consent_auth_stage_spec.rb
+++ b/spec/features/auth/consent_auth_stage_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Authentication Stages' do
+RSpec.describe 'Authentication Stages', with_cuprite: false do
   let(:language) { 'en' }
   let(:user_password) { 'bob' * 4 }
   let(:user) do

--- a/spec/features/categories/delete_spec.rb
+++ b/spec/features/categories/delete_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/categories/categories_page'
 
-RSpec.describe 'Deletion', js: true, with_cuprite: true do
+RSpec.describe 'Deletion', js: true do
   let(:current_user) do
     create(:user,
            member_in_project: category.project,

--- a/spec/features/custom_fields/activate_in_project_spec.rb
+++ b/spec/features/custom_fields/activate_in_project_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
   let(:for_all_cf) { create(:list_wp_custom_field, is_for_all: true) }

--- a/spec/features/custom_fields/create_bool_spec.rb
+++ b/spec/features/custom_fields/create_bool_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/custom_fields/create_date_spec.rb
+++ b/spec/features/custom_fields/create_date_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/custom_fields/create_float_spec.rb
+++ b/spec/features/custom_fields/create_float_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/custom_fields/create_int_spec.rb
+++ b/spec/features/custom_fields/create_int_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'custom fields', js: true, with_cuprite: true do
+RSpec.describe 'custom fields', js: true do
   let(:user) { create(:admin) }
   let(:cf_page) { Pages::CustomFields.new }
 

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -2,8 +2,7 @@ require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
 RSpec.describe "multi select custom values",
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -2,8 +2,7 @@ require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
 RSpec.describe "multi select custom values",
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:type) { create(:type) }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
   let(:wp_table) { Pages::WorkPackagesTable.new project }

--- a/spec/features/forums/attachment_upload_spec.rb
+++ b/spec/features/forums/attachment_upload_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Upload attachment to forum message', js: true do
     attachments_list.expect_attached('image.png', count: 2)
   end
 
-  it 'can upload an image to new and existing messages via drag & drop on attachments' do
+  it 'can upload an image to new and existing messages via drag & drop on attachments', with_cuprite: false do
     index_page.visit!
     click_link forum.name
 

--- a/spec/features/forums/message_spec.rb
+++ b/spec/features/forums/message_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'messages', js: true do
     login_as user
   end
 
-  it 'adding, checking replies, replying' do
+  it 'adding, checking replies, replying', with_cuprite: false do
     index_page.visit!
     click_link forum.name
 

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Global role: Global Create project',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
 

--- a/spec/features/global_roles/global_role_assignment_spec.rb
+++ b/spec/features/global_roles/global_role_assignment_spec.rb
@@ -30,8 +30,7 @@ require 'spec_helper'
 require_relative './mock_global_permissions'
 
 RSpec.describe 'Global role: Global role assignment',
-               js: true,
-               with_cuprite: true do
+               js: true do
   before do
     login_as current_user
   end

--- a/spec/features/global_roles/global_role_crud_spec.rb
+++ b/spec/features/global_roles/global_role_crud_spec.rb
@@ -30,8 +30,7 @@ require 'spec_helper'
 require_relative './mock_global_permissions'
 
 RSpec.describe 'Global role: Global role CRUD',
-               js: true,
-               with_cuprite: true do
+               js: true do
   # Scenario: Global Role creation
   # Given there is the global permission "glob_test" of the module "global_group"
   before do

--- a/spec/features/global_roles/global_role_update_spec.rb
+++ b/spec/features/global_roles/global_role_update_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Role updating', js: true, with_cuprite: true do
+RSpec.describe 'Role updating', js: true do
   let!(:admin) { create(:admin) }
 
   before do

--- a/spec/features/global_roles/member_roles_spec.rb
+++ b/spec/features/global_roles/member_roles_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Global role: Unchanged Member Roles',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:admin) { create(:admin) }
   let(:project) { create(:project) }
   let!(:role) { create(:role, name: 'MemberRole1') }

--- a/spec/features/global_roles/no_module_spec.rb
+++ b/spec/features/global_roles/no_module_spec.rb
@@ -30,8 +30,7 @@ require 'spec_helper'
 require_relative './mock_global_permissions'
 
 RSpec.describe 'Global role: No module',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:admin) { create(:admin) }
   let(:project) { create(:project) }
   let!(:role) { create(:role) }

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'group memberships through groups page',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
   let!(:project) do
     create(:project, name: 'Project 1', identifier: 'project1', members: project_members)

--- a/spec/features/groups/groups_spec.rb
+++ b/spec/features/groups/groups_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'group memberships through groups page',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
   let!(:group) { create(:group, lastname: "Bob's Team") }
 

--- a/spec/features/groups/membership_spec.rb
+++ b/spec/features/groups/membership_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'group memberships through project members page',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:admin) { create(:admin) }
   let(:project) { create(:project, name: 'Project 1', identifier: 'project1', members: project_member) }
 

--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Homescreen', 'index', :with_cuprite do
+RSpec.describe 'Homescreen', 'index' do
   let(:admin) { create(:admin) }
   let(:user) { build_stubbed(:user) }
   let!(:project) { create(:public_project, identifier: 'public-project') }

--- a/spec/features/ldap_auth_sources/crud_spec.rb
+++ b/spec/features/ldap_auth_sources/crud_spec.rb
@@ -28,9 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'CRUD LDAP connections',
-               js: true,
-               with_cuprite: true do
+RSpec.describe 'CRUD LDAP connections', js: true do
   shared_let(:admin) { create(:admin) }
   let(:ldap_page) { Pages::Admin::LdapAuthSources::Index.new }
 

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -28,9 +28,11 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Localization', with_settings: { login_required?: false,
-                                                available_languages: %w[de en],
-                                                default_language: 'en' } do
+RSpec.describe 'Localization',
+               with_cuprite: false,
+               with_settings: { login_required?: false,
+                                available_languages: %w[de en],
+                                default_language: 'en' } do
   context 'with a HTTP header Accept-Language having a valid supported language' do
     before do
       Capybara.current_session.driver.header('Accept-Language', 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3')

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Admin menu items',
-               :js,
-               :with_cuprite do
+               :js do
   shared_let(:user) { create(:admin) }
 
   before do

--- a/spec/features/menu_items/help_menu_spec.rb
+++ b/spec/features/menu_items/help_menu_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Help menu items',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:user) { create(:admin) }
   let(:help_item) { find('.op-app-help .op-app-menu--item-action') }
   let(:help_menu_dropdown_selector) { '.op-app-menu--dropdown.op-menu' }

--- a/spec/features/menu_items/menu_permissions_spec.rb
+++ b/spec/features/menu_items/menu_permissions_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'menu permissions',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:user) do
     create(:user,
            member_in_project: project,

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -32,8 +32,7 @@ require 'features/work_packages/shared_contexts'
 require 'features/work_packages/work_packages_page'
 
 RSpec.describe 'Query menu items',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:work_packages_page) { WorkPackagesPage.new(project) }

--- a/spec/features/menu_items/quick_add_menu_spec.rb
+++ b/spec/features/menu_items/quick_add_menu_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Quick-add menu', js: true, with_cuprite: true do
+RSpec.describe 'Quick-add menu', js: true do
   let(:quick_add) { Components::QuickAddMenu.new }
 
   context 'as a logged in user with add_project permission' do

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Top menu items', :js, :with_cuprite do
+RSpec.describe 'Top menu items', :js do
   let(:user) { create(:user) }
   let(:open_menu) { true }
 

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Wiki menu items' do
     end
   end
 
-  it 'allows managing the menu item of a wiki page', js: true, with_cuprite: true do
+  it 'allows managing the menu item of a wiki page', js: true do
     other_wiki_page
     another_wiki_page
 

--- a/spec/features/my/sessions_management_spec.rb
+++ b/spec/features/my/sessions_management_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'My account session management', js: true do
+RSpec.describe 'My account session management', js: true, with_cuprite: false do
   include Redmine::I18n
   let(:user) { create(:user) }
 
@@ -63,8 +63,9 @@ RSpec.describe 'My account session management', js: true do
     expect(trs[1]).to have_text format_time(old_session_time)
     expect(trs[1]).to have_selector('.buttons a')
 
-    trs[1].find('.buttons a').click
-    page.driver.browser.switch_to.alert.accept
+    accept_alert do
+      trs[1].find('.buttons a').click
+    end
 
     expect(page).to have_selector('.generic-table tbody tr', count: 1)
 

--- a/spec/features/news/creation_and_commenting_spec.rb
+++ b/spec/features/news/creation_and_commenting_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'News creation and commenting', :js, :with_cuprite do
+RSpec.describe 'News creation and commenting', :js do
   let(:project) { create(:project) }
   let!(:other_user) do
     create(:user,

--- a/spec/features/news/global_menu_item_spec.rb
+++ b/spec/features/news/global_menu_item_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'News global menu item spec', :js, :with_cuprite do
+RSpec.describe 'News global menu item spec', :js do
   shared_let(:admin) { create(:admin) }
   shared_let(:user_without_permissions) { create(:user) }
 

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "Notification center navigation", js: true, with_cuprite: true do
+RSpec.describe "Notification center navigation", js: true do
   shared_association_default(:project) { create(:project) }
 
   shared_let(:work_package) { create(:work_package, project:) }

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Notification center date alerts",
 
       # When a work package is updated to a different date
       wp_double_notification.update_column(:due_date, time_zone.now + 5.days)
-      page.driver.refresh
+      refresh
       wait_for_reload
 
       center.expect_item(notification_wp_double_date_alert, 'Finish date is in 5 days')

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -4,7 +4,6 @@ require 'features/page_objects/notification'
 # rubocop:disable RSpec/ScatteredLet
 RSpec.describe "Notification center date alerts",
                js: true,
-               with_cuprite: true,
                with_settings: { journal_aggregation_time_minutes: 0 } do
   include ActiveSupport::Testing::TimeHelpers
 

--- a/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe "Notification center sidemenu",
                js: true,
-               with_cuprite: true,
                with_ee: %i[date_alerts] do
   shared_let(:project) { create(:project) }
   shared_let(:project2) { create(:project) }

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe "Notification center",
                js: true,
-               with_cuprite: true,
                with_ee: %i[date_alerts],
                with_settings: { journal_aggregation_time_minutes: 0 } do
   # Notice that the setup in this file here is not following the normal rules as

--- a/spec/features/notifications/notification_center/split_screen_spec.rb
+++ b/spec/features/notifications/notification_center/split_screen_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "Split screen in the notification center",
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:global_html_title) { Components::HtmlTitle.new }
   let(:center) { Pages::Notifications::Center.new }
   let(:split_screen) { Pages::Notifications::SplitScreen.new work_package }

--- a/spec/features/notifications/reminder_mail_spec.rb
+++ b/spec/features/notifications/reminder_mail_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../users/notifications/shared_examples'
 
-RSpec.describe "Reminder email sending", js: true, with_cuprite: true do
+RSpec.describe "Reminder email sending", js: true do
   let!(:project) { create(:project, members: { current_user => role }) }
   let!(:mute_project) { create(:project, members: { current_user => role }) }
   let(:role) { create(:role, permissions: %i[view_work_packages]) }

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "Immediate reminder settings",
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_examples 'immediate reminder settings' do
     it 'allows to configure the reminder settings' do
       # Save prefs so we can reload them later

--- a/spec/features/notifications/settings/my_notifications_settings_spec.rb
+++ b/spec/features/notifications/settings/my_notifications_settings_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require_relative '../../users/notifications/shared_examples'
 require 'support/pages/my/notifications'
 
-RSpec.describe "My notifications settings", js: true, with_cuprite: true do
+RSpec.describe "My notifications settings", js: true do
   shared_let(:user) { create(:user) }
 
   let(:settings_page) { Pages::My::Notifications.new(user) }

--- a/spec/features/notifications/settings/pause_reminder_settings_spec.rb
+++ b/spec/features/notifications/settings/pause_reminder_settings_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "Pause reminder settings",
-               js: true,
-               with_cuprite: true do
+RSpec.describe "Pause reminder settings", js: true do
   shared_examples 'pause reminder settings' do
     let(:first) { Time.zone.today.beginning_of_month }
     let(:last) { (Time.zone.today.beginning_of_month + 10.days) }

--- a/spec/features/notifications/settings/reminder_email_settings_spec.rb
+++ b/spec/features/notifications/settings/reminder_email_settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../users/notifications/shared_examples'
 
-RSpec.describe "Reminder email", js: true, with_cuprite: true do
+RSpec.describe "Reminder email", js: true do
   shared_examples 'reminder settings' do
     it 'allows to configure the reminder settings' do
       # Configure the digest

--- a/spec/features/notifications/settings/workdays_settings_spec.rb
+++ b/spec/features/notifications/settings/workdays_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "Workday notification settings", js: true, with_cuprite: true do
+RSpec.describe "Workday notification settings", js: true do
   shared_examples 'workday settings' do
     before do
       current_user.language = locale

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'OAuth authorization code flow',
     expect(body['scope']).to eq 'api_v3'
   end
 
-  it 'can authorize and manage an OAuth application grant' do
+  it 'can authorize and manage an OAuth application grant', with_cuprite: false do
     visit oauth_path app.uid, redirect_uri
 
     # Expect we're guided to the login screen
@@ -137,7 +137,7 @@ RSpec.describe 'OAuth authorization code flow',
       let!(:redirect_uri) { "https://foo.com/foo" }
       let!(:allowed_redirect_uri) { "#{redirect_uri} https://bar.com/bar" }
 
-      it 'can authorize and manage an OAuth application grant' do
+      it 'can authorize and manage an OAuth application grant', with_cuprite: false do
         visit oauth_path app.uid, redirect_uri
 
         # Check that the hosts of allowed redirection urls are present in the content security policy

--- a/spec/features/onboarding/onboarding_tour_spec.rb
+++ b/spec/features/onboarding/onboarding_tour_spec.rb
@@ -28,7 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'onboarding tour for new users', js: true do
+RSpec.describe 'onboarding tour for new users',
+               js: true,
+               with_cuprite: false do
   let(:user) { create(:admin) }
   let(:project) do
     create(:project, name: 'Demo project', identifier: 'demo-project', public: true,

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Project attribute help texts', js: true, with_cuprite: true do
+RSpec.describe 'Project attribute help texts', js: true do
   let(:project) { create(:project) }
 
   let(:instance) do

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects copy', :with_cuprite, js: true do
+RSpec.describe 'Projects copy', js: true do
   describe 'with a full copy example' do
     let!(:project) do
       create(:project,

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects', 'creation',
-               :js,
-               :with_cuprite do
+               :js do
   shared_let(:name_field) { FormFields::InputFormField.new :name }
 
   current_user { create(:admin) }

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects#destroy',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let!(:project) { create(:project, name: 'foo', identifier: 'foo') }
   let(:project_page) { Pages::Projects::Destroy.new(project) }
   let(:danger_zone) { DangerZone.new(page) }

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects', 'editing settings',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:name_field) { FormFields::InputFormField.new :name }
   let(:parent_field) { FormFields::SelectFormField.new :parent }
   let(:permissions) { %i(edit_project) }

--- a/spec/features/projects/export_spec.rb
+++ b/spec/features/projects/export_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'project export', js: true, with_cuprite: true do
+RSpec.describe 'project export', js: true do
   shared_let(:important_project) { create(:project, name: 'Important schedule plan') }
   shared_let(:party_project) { create(:project, name: 'Christmas party') }
   shared_let(:user) do

--- a/spec/features/projects/global_menu_item_spec.rb
+++ b/spec/features/projects/global_menu_item_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects global menu item', :js, :with_cuprite do
+RSpec.describe 'Projects global menu item', :js do
   let(:user) { create(:user) }
 
   before do

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Projects autocomplete page', js: true, with_cuprite: true do
+RSpec.describe 'Projects autocomplete page', js: true do
   let!(:user) { create(:user) }
   let(:top_menu) { Components::Projects::TopMenu.new }
 

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects status administration',
-               js: true,
-               with_cuprite: true do
+               js: true do
   include_context 'ng-select-autocomplete helpers'
 
   let(:current_user) do

--- a/spec/features/projects/projects_custom_fields_spec.rb
+++ b/spec/features/projects/projects_custom_fields_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects custom fields',
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:current_user) { create(:admin) }
   shared_let(:project) { create(:project, name: 'Foo project', identifier: 'foo-project') }
   let(:name_field) { FormFields::InputFormField.new :name }
@@ -163,8 +162,7 @@ RSpec.describe 'Projects custom fields',
     end
 
     context 'with german locale',
-            driver: :firefox_de,
-            with_cuprite: false do
+            driver: :firefox_de do
       let(:current_user) { create(:admin, language: 'de') }
 
       it 'displays the float with german locale' do

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'Projects index page',
                js: true,
-               with_cuprite: true,
                with_settings: { login_required?: false } do
   shared_let(:admin) { create(:admin) }
 

--- a/spec/features/projects/projects_portfolio_spec.rb
+++ b/spec/features/projects/projects_portfolio_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'Projects index page',
                js: true,
-               with_cuprite: true,
                with_ee: %i[custom_fields_in_projects_list], with_settings: { login_required?: false } do
   shared_let(:admin) { create(:admin) }
 

--- a/spec/features/projects/subproject_creation_spec.rb
+++ b/spec/features/projects/subproject_creation_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Subproject creation', js: true, with_cuprite: true do
+RSpec.describe 'Subproject creation', js: true do
   let(:name_field) { FormFields::InputFormField.new :name }
   let(:parent_field) { FormFields::SelectFormField.new :parent }
   let(:add_subproject_role) { create(:role, permissions: %i[edit_project add_subprojects]) }

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Project templates', js: true, with_cuprite: true do
+RSpec.describe 'Project templates', js: true do
   describe 'making project a template' do
     let(:project) { create(:project) }
 

--- a/spec/features/projects/work_package_type_mgmt_spec.rb
+++ b/spec/features/projects/work_package_type_mgmt_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Projects', 'work package type mgmt',
-               js: true,
-               with_cuprite: true do
+               js: true do
   current_user { create(:user, member_in_project: project, member_with_permissions: %i[edit_project manage_types]) }
 
   let(:phase_type)     { create(:type, name: 'Phase', is_default: true) }

--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Create repository', js: true, selenium: true do
     shared_examples 'has hidden type' do |type, vendor|
       let(:selector) { find("input[name='scm_type'][value='#{type}']") }
 
-      it 'displays a collapsed type' do
+      it 'displays a collapsed type', with_cuprite: false do
         expect(selector).not_to be_nil
         expect(selector[:selected]).to be_falsey
         expect(selector).not_to be_disabled
@@ -124,7 +124,7 @@ RSpec.describe 'Create repository', js: true, selenium: true do
       it_behaves_like 'has hidden type', type, vendor
       it_behaves_like 'has hidden type', 'managed', vendor
 
-      it 'can toggle between the two' do
+      it 'can toggle between the two', with_cuprite: false do
         find("input[name='scm_type'][value='#{type}']").set(true)
         content = find("#attributes-group--content-#{type}")
         expect(content).not_to be_nil

--- a/spec/features/roles/create_spec.rb
+++ b/spec/features/roles/create_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Role creation',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let!(:admin) { create(:admin) }
   let!(:existing_role) { create(:role) }
   let!(:existing_workflow) { create(:workflow_with_default_status, role: existing_role, type:) }

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe 'Search', js: true, with_settings: { per_page_options: '5' } do
       let(:columns) { Components::WorkPackages::Columns.new }
       let(:top_menu) { Components::Projects::TopMenu.new }
 
-      it 'shows a work package table with correct results' do
+      it 'shows a work package table with correct results', with_cuprite: false do
         # Search without subprojects
         global_search.search query
         global_search.submit_in_current_project

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -60,7 +60,7 @@ module Components
     def close!
       # make backdrop click an the pixel x:10,y:10
       page.find('.spot-modal-overlay').tap do |element|
-        if RSpec.current_example.metadata[:with_cuprite]
+        if using_cuprite?
           width = element.style('width')["width"].to_i
           height = element.style('height')["height"].to_i
         else

--- a/spec/features/types/activate_in_project_spec.rb
+++ b/spec/features/types/activate_in_project_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'support/pages/custom_fields'
 
-RSpec.describe 'types', js: true, with_cuprite: true do
+RSpec.describe 'types', js: true do
   let(:user) do
     create(:user,
            member_in_project: project,

--- a/spec/features/types/crud_spec.rb
+++ b/spec/features/types/crud_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Types', js: true, with_cuprite: true do
+RSpec.describe 'Types', js: true do
   shared_let(:admin) { create(:admin) }
 
   shared_let(:existing_role) { create(:role) }

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'form query configuration', js: true, with_cuprite: true do
+RSpec.describe 'form query configuration', js: true do
   shared_let(:admin) { create(:admin) }
   let(:type_bug) { create(:type_bug) }
   let(:type_task) { create(:type_task) }

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'form configuration', js: true do
         visit edit_type_tab_path(id: type.id, tab: "form_configuration")
       end
 
-      it 'resets the form properly after changes' do
+      it 'resets the form properly after changes', with_cuprite: false do
         form.rename_group('Details', 'Whatever')
         form.expect_attribute(key: :assignee)
 
@@ -119,7 +119,7 @@ RSpec.describe 'form configuration', js: true do
           .to have_selector('.work-packages--details--description', text: work_package.description)
       end
 
-      it 'allows modification of the form configuration' do
+      it 'allows modification of the form configuration', with_cuprite: false do
         #
         # Test default set of groups
         #
@@ -256,7 +256,7 @@ RSpec.describe 'form configuration', js: true do
         visit edit_type_tab_path(id: type.id, tab: "form_configuration")
       end
 
-      it 'shows the field' do
+      it 'shows the field', with_cuprite: false do
         # Should be initially disabled
         form.expect_inactive(cf_identifier)
 
@@ -300,7 +300,7 @@ RSpec.describe 'form configuration', js: true do
       end
 
       context 'if inactive in project' do
-        it 'can be added to the type, but is not shown' do
+        it 'can be added to the type, but is not shown', with_cuprite: false do
           add_cf_to_group
           # Disable in project, should be invisible
           # This step is necessary, since we auto-activate custom fields
@@ -353,7 +353,7 @@ RSpec.describe 'form configuration', js: true do
                  work_package_custom_fields: custom_fields)
         end
 
-        it 'can be added to type and is visible' do
+        it 'can be added to type and is visible', with_cuprite: false do
           add_cf_to_group
 
           # Visit work package with that type

--- a/spec/features/types/reset_form_configuration_spec.rb
+++ b/spec/features/types/reset_form_configuration_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Reset form configuration', js: true do
       visit edit_type_tab_path(id: type.id, tab: "form_configuration")
     end
 
-    it 'resets the form properly after changes with CFs (Regression test #27487)' do
+    it 'resets the form properly after changes with CFs (Regression test #27487)', with_cuprite: false do
       # Should be initially disabled
       form.expect_inactive(cf_identifier)
 

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'create users', with_cuprite: true do
+RSpec.describe 'create users' do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let!(:auth_source) { create(:ldap_auth_source) }

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'user deletion:', js: true, with_cuprite: true do
+RSpec.describe 'user deletion:', js: true do
   let(:dialog) { Components::PasswordConfirmationDialog.new }
 
   before do

--- a/spec/features/users/edit_users_spec.rb
+++ b/spec/features/users/edit_users_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'edit users', js: true, with_cuprite: true do
+RSpec.describe 'edit users', js: true do
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let(:user) { create(:user, mail: 'foo@example.com') }

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'index users', js: true, with_cuprite: true do
+RSpec.describe 'index users', js: true do
   shared_let(:current_user) { create(:admin, firstname: 'admin', lastname: 'admin', created_at: 1.hour.ago) }
   let(:index_page) { Pages::Admin::Users::Index.new }
 

--- a/spec/features/users/invitation_spec.rb
+++ b/spec/features/users/invitation_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'invitations', js: true, with_cuprite: true do
+RSpec.describe 'invitations', js: true do
   let(:user) { create(:invited_user, mail: 'holly@openproject.com') }
 
   before do

--- a/spec/features/users/invite_user_modal/custom_fields_spec.rb
+++ b/spec/features/users/invite_user_modal/custom_fields_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal custom fields', :js, :with_cuprite do
+RSpec.describe 'Invite user modal custom fields', :js do
   shared_let(:project) { create(:project) }
 
   let(:permissions) { %i[view_project manage_members] }

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal', js: true, with_cuprite: true do
+RSpec.describe 'Invite user modal', js: true do
   shared_let(:project) { create(:project) }
   shared_let(:work_package) { create(:work_package, project:) }
 

--- a/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
+++ b/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Inviting user in project the current user is lacking permission in',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:modal) do
     Components::Users::InviteUserModal.new project: invite_project,
                                            principal: other_user,

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Invite user modal subprojects', js: true, with_cuprite: true do
+RSpec.describe 'Invite user modal subprojects', js: true do
   shared_let(:project) { create(:project, name: 'Parent project') }
   shared_let(:subproject) { create(:project, name: 'Subproject', parent: project) }
   shared_let(:work_package) { create(:work_package, project: subproject) }

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'my', js: true, with_cuprite: true do
+RSpec.describe 'my', js: true do
   let(:user_password) { 'bob' * 4 }
   let(:user) do
     create(:user,

--- a/spec/features/users/notifications/user_notifications_settings_spec.rb
+++ b/spec/features/users/notifications/user_notifications_settings_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 require_relative './shared_examples'
 
 RSpec.describe "user notifications settings",
-               js: true,
-               with_cuprite: true do
+               js: true do
   shared_let(:user) { create(:user) }
 
   let(:settings_page) { Pages::Notifications::Settings.new(user) }

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'random password generation', js: true, with_cuprite: true do
+RSpec.describe 'random password generation', js: true do
   shared_let(:admin) { create(:admin) }
 
   let(:old_password) { 'old_Password!123' }

--- a/spec/features/users/self_registration_spec.rb
+++ b/spec/features/users/self_registration_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'user self registration', js: true, with_cuprite: true do
+RSpec.describe 'user self registration', js: true do
   let(:admin_password) { 'Test123Test123' }
   let(:admin) { create(:admin, password: admin_password, password_confirmation: admin_password) }
   let(:home_page) { Pages::Home.new }

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'index users', js: true, with_cuprite: true do
+RSpec.describe 'index users', js: true do
   current_user { create(:admin) }
 
   let(:index_page) { Pages::Admin::Users::Index.new }

--- a/spec/features/users/user_memberships_spec.rb
+++ b/spec/features/users/user_memberships_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative '../principals/shared_memberships_examples'
 
-RSpec.describe 'user memberships through user page', js: true, with_cuprite: true do
+RSpec.describe 'user memberships through user page', js: true do
   include_context 'principal membership management context'
 
   shared_let(:principal) { create(:user, firstname: 'Foobar', lastname: 'Blabla') }

--- a/spec/features/versions/delete_spec.rb
+++ b/spec/features/versions/delete_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'version delete', js: true, with_cuprite: true do
+RSpec.describe 'version delete', js: true do
   let!(:project) { create(:project, name: 'Parent') }
   let!(:archived_child) { create(:project, name: 'Archived child', parent: project, active: false) }
 

--- a/spec/features/versions/roadmap_filtering_spec.rb
+++ b/spec/features/versions/roadmap_filtering_spec.rb
@@ -30,7 +30,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Roadmap Filtering', :js, :with_cuprite do
+RSpec.describe 'Roadmap Filtering', :js do
   shared_let(:project) { create(:project) }
   shared_let(:sub_project) { create(:project, parent: project) }
 

--- a/spec/features/views/shared_examples.rb
+++ b/spec/features/views/shared_examples.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples 'module specific query view management' do
     let(:settings_menu) { Components::WorkPackages::SettingsMenu.new }
     let(:filters) { module_page.filters }
 
-    it 'allows to save, rename and delete a query' do
+    it 'allows to save, rename and delete a query', with_cuprite: false do
       # Change the query
       filters.open
       filters.add_filter_by 'Subject', 'contains', ['Test']

--- a/spec/features/wiki/adding_editing_history_spec.rb
+++ b/spec/features/wiki/adding_editing_history_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'wiki pages', js: true, with_settings: { journal_aggregation_time
     login_as user
   end
 
-  it 'adding, editing and history' do
+  it 'adding, editing and history', with_cuprite: false do
     visit project_settings_modules_path(project)
 
     expect(page).not_to have_selector('.menu-sidebar .main-item-wrapper', text: 'Wiki')

--- a/spec/features/wiki/attachment_upload_spec.rb
+++ b/spec/features/wiki/attachment_upload_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Upload attachment to wiki page', js: true do
     login_as(user)
   end
 
-  it 'can upload an image to new and existing wiki page via drag & drop in editor' do
+  it 'can upload an image to new and existing wiki page via drag & drop in editor', with_cuprite: false do
     visit project_wiki_path(project, 'test')
 
     # adding an image
@@ -104,7 +104,7 @@ RSpec.describe 'Upload attachment to wiki page', js: true do
     expect(wiki_page_content).to have_selector '.op-uc-image[src^="/api/v3/attachments"]'
   end
 
-  it 'can upload an image to new and existing wiki page via drag & drop on attachments' do
+  it 'can upload an image to new and existing wiki page via drag & drop on attachments', with_cuprite: false do
     visit project_wiki_path(project, 'test')
 
     editor.attachments_list.expect_empty

--- a/spec/features/wiki/child_pages_spec.rb
+++ b/spec/features/wiki/child_pages_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'wiki child pages', js: true do
     login_as user
   end
 
-  it 'adding a childpage' do
+  it 'adding a childpage', with_cuprite: false do
     visit project_wiki_path(project, parent_page.title)
 
     click_on 'Wiki page'

--- a/spec/features/wiki/wiki_page_external_link_spec.rb
+++ b/spec/features/wiki/wiki_page_external_link_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Wiki page external link', js: true do
            text: 'A link to <a href="http://0.0.0.0:3001/">OpenProject</a>.')
   end
 
-  it 'opens that link in a new window or tab' do
+  it 'opens that link in a new window or tab', with_cuprite: false do
     visit project_wiki_path(project, wiki_page)
 
     link = page.find('a[href^="http://0.0.0.0:3001/"]')

--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/page_objects/notification'
 
-RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true do
+RSpec.describe 'Upload attachment to work package', js: true do
   let(:role) do
     create(:role,
            permissions: %i[view_work_packages add_work_packages edit_work_packages add_work_package_notes])
@@ -113,7 +113,7 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
       end
       let!(:table) { Pages::WorkPackagesTable.new project }
 
-      it 'can add two work packages in a row when uploading (Regression #42933)' do |example|
+      it 'can add two work packages in a row when uploading (Regression #42933)' do
         table.visit!
         new_page = table.create_wp_by_button type
         subject = new_page.edit_field :subject
@@ -122,7 +122,7 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
         target = find('.ck-content')
         attachments.drag_and_drop_file(target, image_fixture.path)
 
-        sleep 2 unless example.metadata[:with_cuprite]
+        sleep 2 unless using_cuprite?
         editor.wait_until_upload_progress_toaster_cleared
 
         editor.in_editor do |_container, editable|
@@ -130,7 +130,7 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
           expect(editable).not_to have_selector('.ck-upload-placeholder-loader')
         end
 
-        sleep 2 unless example.metadata[:with_cuprite]
+        sleep 2 unless using_cuprite?
 
         scroll_to_and_click find_by_id('work-packages--edit-actions-save')
 
@@ -183,14 +183,14 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
           visit new_project_work_packages_path(project.identifier, type: type.id)
         end
 
-        it 'can upload an image via drag & drop (Regression #28189)' do |example|
+        it 'can upload an image via drag & drop (Regression #28189)' do
           subject = new_page.edit_field :subject
           subject.set_value 'My subject'
 
           target = find('.ck-content')
           attachments.drag_and_drop_file(target, image_fixture.path)
 
-          sleep 2 unless example.metadata[:with_cuprite]
+          sleep 2 unless using_cuprite?
           editor.wait_until_upload_progress_toaster_cleared
 
           editor.in_editor do |_container, editable|
@@ -198,7 +198,7 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
             expect(editable).not_to have_selector('.ck-upload-placeholder-loader')
           end
 
-          sleep 2 unless example.metadata[:with_cuprite]
+          sleep 2 unless using_cuprite?
 
           scroll_to_and_click find_by_id('work-packages--edit-actions-save')
 

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
 
       context 'when the limit to move in the frontend is 1',
               with_settings: { work_packages_bulk_request_limit: 1 } do
-        it 'copies them in the background and shows a status page', :with_cuprite do
+        it 'copies them in the background and shows a status page' do
           click_on 'Move and follow'
           wait_for_reload
           page.find('[data-qa-selector="job-status--header"]')
@@ -115,7 +115,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
         end
       end
 
-      it 'moves parent and child wp to a new project', :with_cuprite do
+      it 'moves parent and child wp to a new project' do
         click_on 'Move and follow'
         wait_for_reload
         page.find('.inline-edit--container.subject', text: work_package.subject)
@@ -129,7 +129,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
       context 'when the target project does not have the type' do
         let!(:project2) { create(:project, name: 'Target', types: [type2]) }
 
-        it 'does moves the work package and changes the type', :with_cuprite do
+        it 'does moves the work package and changes the type' do
           click_on 'Move and follow'
           wait_for_reload
           page.find('.inline-edit--container.subject', text: work_package.subject)

--- a/spec/features/work_packages/bulk/update_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/update_work_package_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'features/page_objects/notification'
 
-RSpec.describe 'Bulk update work packages through Rails view', js: true, with_cuprite: true do
+RSpec.describe 'Bulk update work packages through Rails view', js: true do
   shared_let(:type) { create(:type, name: 'Bug') }
   shared_let(:project) { create(:project, name: 'Source', types: [type]) }
   shared_let(:status) { create(:status) }

--- a/spec/features/work_packages/cancel_editing_spec.rb
+++ b/spec/features/work_packages/cancel_editing_spec.rb
@@ -89,8 +89,9 @@ RSpec.describe 'Cancel editing work package', js: true do
     loading_indicator_saveguard
     wp_table.expect_work_package_listed(work_package2)
 
-    wp_table.open_split_view(work_package2)
-    page.driver.browser.switch_to.alert.dismiss
+    dismiss_prompt do
+      wp_table.open_split_view(work_package2)
+    end
 
     expect(page).to have_selector('#wp-new-inline-edit--field-subject')
     expect(wp_page).not_to have_alert_dialog
@@ -106,15 +107,15 @@ RSpec.describe 'Cancel editing work package', js: true do
     version.activate!
 
     # Decline move, expect field still active
-    wp_table.open_split_view(work_package2)
-    page.driver.browser.switch_to.alert.dismiss
+    dismiss_prompt do
+      wp_table.open_split_view(work_package2)
+    end
     version.expect_active!
 
-    sleep 1
-
     # Now accept to move to the second page
-    split_page = wp_table.open_split_view(work_package2)
-    page.driver.browser.switch_to.alert.accept
+    accept_alert do
+      split_page = wp_table.open_split_view(work_package2)
+    end
     version = split_page.edit_field :version
     version.expect_inactive!
   end
@@ -168,8 +169,9 @@ RSpec.describe 'Cancel editing work package', js: true do
     description.click_and_type_slowly 'foobar'
 
     # Try to move back to list, expect warning
-    wp_page.go_back
-    wp_page.dismiss_alert_dialog!
+    dismiss_prompt do
+      wp_page.go_back
+    end
 
     # Now cancel the field
     description.cancel_by_click

--- a/spec/features/work_packages/cards/wp_card_status_spec.rb
+++ b/spec/features/work_packages/cards/wp_card_status_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Update status from WP card', js: true, with_cuprite: true do
+RSpec.describe 'Update status from WP card', js: true do
   let(:manager_role) do
     create(:role, permissions: %i[view_work_packages edit_work_packages])
   end

--- a/spec/features/work_packages/custom_actions/custom_actions_me_value_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_me_value_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Custom actions me value', js: true, with_cuprite: true, with_ee: %i[custom_actions] do
+RSpec.describe 'Custom actions me value', js: true, with_ee: %i[custom_actions] do
   shared_let(:admin) { create(:admin) }
 
   let(:permissions) { %i(view_work_packages edit_work_packages) }

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'Custom actions',
                js: true,
-               with_cuprite: true,
                with_ee: %i[custom_actions] do
   shared_let(:admin) { create(:admin) }
 

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -31,7 +31,6 @@ require 'support/edit_fields/edit_field'
 
 RSpec.describe 'Datepicker logic on follow relationships',
                js: true,
-               with_cuprite: true,
                with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:user) { create(:admin) }
 

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -31,7 +31,7 @@ require 'support/edit_fields/edit_field'
 
 RSpec.describe 'Datepicker modal logic test cases (WP #43539)',
                js: true,
-               with_cuprite: true, with_settings: { date_format: '%Y-%m-%d' } do
+               with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:user) { create(:admin) }
 
   shared_let(:type_bug) { create(:type_bug) }

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -31,6 +31,7 @@ require 'support/edit_fields/edit_field'
 
 RSpec.describe 'Datepicker modal individual non working days (WP #44453)',
                js: true,
+               with_cuprite: false,
                with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:user) { create(:admin) }
   shared_let(:project) { create(:project) }

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe 'date inplace editor',
     expect(work_package.start_date).to be_nil
   end
 
-  it 'closes the date picker when moving away' do
+  it 'closes the date picker when moving away', with_cuprite: false do
     wp_table.visit!
     wp_table.open_full_screen_by_doubleclick work_package
 

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'as an accessible inplace editor' do
     field.cancel_by_escape
   end
 
-  it 'triggers edit mode on RETURN key' do
+  it 'triggers edit mode on RETURN key', with_cuprite: false do
     scroll_to_element(field.display_element)
 
     field.display_element.native.send_keys(:return)

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -4,7 +4,7 @@ require 'features/work_packages/shared_contexts'
 require 'support/edit_fields/edit_field'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'subject inplace editor', js: true, selenium: true do
+RSpec.describe 'subject inplace editor', js: true do
   let(:project) { create(:project_with_types, name: 'Root', public: true) }
   let(:subproject1) { create(:project_with_types, name: 'Child', parent: project) }
   let(:subproject2) { create(:project_with_types, name: 'Aunt', parent: project) }
@@ -57,7 +57,7 @@ RSpec.describe 'subject inplace editor', js: true, selenium: true do
       login_as(user)
     end
 
-    it 'renders hierarchical versions' do
+    it 'renders hierarchical versions', with_cuprite: false do
       work_package_page.visit!
       work_package_page.ensure_page_loaded
 

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'activity comments', js: true do
       end
 
       describe 'with an existing comment' do
-        it 'allows to edit an existing comment' do
+        it 'allows to edit an existing comment', with_cuprite: false do
           # Insert new text, need to do this separately.''
           ['Comment with', ' ', '*', '*', 'bold text', '*', '*', ' ', 'in it'].each do |key|
             comment_field.input_element.send_keys key

--- a/spec/features/work_packages/details/markdown/todolist_spec.rb
+++ b/spec/features/work_packages/details/markdown/todolist_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Todolists in CKEditor', js: true do
       ckeditor.clear
     end
 
-    it 'can add a task list with links in them (Regression #30920)' do
+    it 'can add a task list with links in them (Regression #30920)', with_cuprite: false do
       ckeditor.click_toolbar_button 'To-do List'
       ckeditor.type_slowly 'Todo item 1'
       ckeditor.type_slowly :enter

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Work package with relation query group', js: true, selenium: tru
   end
 
   context 'children table' do
-    it 'creates and removes across all tables' do
+    it 'creates and removes across all tables', with_cuprite: false do
       embedded_table.expect_work_package_count 1
       relations_tab.click
       relations.expect_child(related_work_package)
@@ -198,7 +198,7 @@ RSpec.describe 'Work package with relation query group', js: true, selenium: tru
       relations.expect_relation(related_work_package)
     end
 
-    it 'creates and removes across all tables' do
+    it 'creates and removes across all tables', with_cuprite: false do
       embedded_table.table_container.find('button', text: I18n.t('js.relation_buttons.create_new')).click
       subject_field = embedded_table.edit_field(nil, :subject)
 
@@ -209,7 +209,7 @@ RSpec.describe 'Work package with relation query group', js: true, selenium: tru
       relations.expect_relation_by_text('Fresh WP')
     end
 
-    it 'add existing, remove it, add it from relations tab, remove from relations tab' do
+    it 'add existing, remove it, add it from relations tab, remove from relations tab', with_cuprite: false do
       embedded_table.table_container.find('button', text: I18n.t('js.relation_buttons.add_existing')).click
       embedded_table.table_container.find('.wp-relations-create--form', wait: 10)
       autocomplete = page.find("[data-qa-selector='wp-relations-autocomplete']")

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Work package relations tab', js: true, selenium: true do
+RSpec.describe 'Work package relations tab', js: true, with_cuprite: false do
   include_context 'ng-select-autocomplete helpers'
 
   let(:user) { create(:admin) }

--- a/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Switching work package view',
 
     it 'saves the representation in the query' do
       # After refresh the WP are still disaplyed as cards
-      page.driver.browser.navigate.refresh
+      refresh
       cards.expect_work_package_listed wp_1, wp_2
     end
   end
@@ -128,15 +128,15 @@ RSpec.describe 'Switching work package view',
       expect(url).not_to match(/query_props=.+/)
 
       # Since the query is unchanged, the WPs will be displayed as list on larger screens again
-      page.driver.browser.manage.window.resize_to(700, 1080)
-      page.driver.browser.navigate.refresh
+      page.driver.resize(700, 1080)
+      refresh
       wp_table.expect_work_package_listed wp_1, wp_2
       wp_table.expect_work_package_order wp_1, wp_2
     end
   end
 
   context 'when reordering an unsaved query' do
-    it 'retains that order' do
+    it 'retains that order', with_cuprite: false do
       wp_table.expect_work_package_order wp_1, wp_2
 
       wp_table.drag_and_drop_work_package from: 1, to: 0

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Work Package highlighting fields',
     wp_table.expect_work_package_listed wp_1, wp_2
   end
 
-  it 'provides highlighting through css classes' do
+  it 'provides highlighting through css classes', with_cuprite: false do
     # Default inline highlight
     wp1_row = wp_table.row(wp_1)
     wp2_row = wp_table.row(wp_2)

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'Work Package highlighting fields',
     expect(page).to have_selector(".__hl_inline_priority_#{priority1.id}")
   end
 
-  it 'correctly parses custom selected inline attributes', :with_cuprite do
+  it 'correctly parses custom selected inline attributes' do
     # Highlight only one attribute
     highlighting.switch_inline_attribute_highlight "Priority"
 

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Work package navigation', js: true, selenium: true do
     login_as(user)
   end
 
-  it 'all different angular based work package views' do
+  it 'all different angular based work package views', with_cuprite: false do
     work_package.save!
 
     # deep link global work package index
@@ -168,7 +168,7 @@ RSpec.describe 'Work package navigation', js: true, selenium: true do
     expect(page).to have_field('editable-toolbar-title', with: query.name)
   end
 
-  it 'double clicking search result row (Regression #30247)' do
+  it 'double clicking search result row (Regression #30247)', with_cuprite: false do
     work_package.subject = 'Foobar'
     work_package.save!
     visit search_path(q: 'Foo', work_packages: 1, scope: :all)

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -3,7 +3,7 @@ require 'support/edit_fields/edit_field'
 require 'features/work_packages/work_packages_page'
 require 'features/page_objects/notification'
 
-RSpec.describe 'new work package', js: true, with_cuprite: true do
+RSpec.describe 'new work package', js: true do
   shared_let(:status) { create(:status, is_default: true) }
   shared_let(:priority) { create(:priority, is_default: true) }
   shared_let(:type_task) { create(:type_task) }

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'new work package', js: true do
   end
 
   describe 'global work package create' do
-    it 'shows the template after selection of project and type' do
+    it 'shows the template after selection of project and type', with_cuprite: false do
       visit '/work_packages/new'
       wp_page.expect_fully_loaded
 

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -227,7 +227,7 @@ RSpec.shared_examples 'has a project include dropdown', js: true, type: :feature
     dropdown.expect_closed
     dropdown.expect_count 3
 
-    page.refresh
+    refresh
 
     dropdown.expect_count 3
 
@@ -327,7 +327,7 @@ RSpec.shared_examples 'has a project include dropdown', js: true, type: :feature
     dropdown.expect_count 1
   end
 
-  it 'filter projects in the list' do
+  it 'filter projects in the list', with_cuprite: false do
     dropdown.expect_count 1
     dropdown.toggle!
     dropdown.expect_open

--- a/spec/features/work_packages/select/select_card_view_spec.rb
+++ b/spec/features/work_packages/select/select_card_view_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Selecting cards in the card view (regression #31962)', js: true 
       cards.expect_work_package_selected work_package3, false
     end
 
-    it 'can select and deselect single cards' do
+    it 'can select and deselect single cards', with_cuprite: false do
       # Select a card
       cards.select_work_package work_package1
       cards.expect_work_package_selected work_package1, true
@@ -84,7 +84,7 @@ RSpec.describe 'Selecting cards in the card view (regression #31962)', js: true 
       cards.expect_work_package_selected work_package3, false
     end
 
-    it 'can select and deselect range of cards' do
+    it 'can select and deselect range of cards', with_cuprite: false do
       # Select the first WP
       cards.select_work_package work_package1
       cards.expect_work_package_selected work_package1, true

--- a/spec/features/work_packages/select/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select/select_work_package_row_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Select work package row', js: true, selenium: true do
+RSpec.describe 'Select work package row', js: true, with_cuprite: false do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:work_package_1) { create(:work_package, project:) }

--- a/spec/features/work_packages/select/select_wp_card_spec.rb
+++ b/spec/features/work_packages/select/select_wp_card_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Select work package card', js: true, selenium: true do
+RSpec.describe 'Select work package card', js: true do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:work_package_1) { create(:work_package, project:) }
@@ -52,7 +52,7 @@ RSpec.describe 'Select work package card', js: true, selenium: true do
   end
 
   describe 'opening' do
-    it 'the full screen view via double click' do
+    it 'the full screen view via double click', with_cuprite: false do
       wp_card_view.open_full_screen_by_doubleclick(work_package_1)
       expect(page).to have_selector('.work-packages--details--subject',
                                     text: work_package_1.subject)

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'Manual sorting of WP table', js: true do
+RSpec.describe 'Manual sorting of WP table', js: true, with_cuprite: false do
   let(:user) { create(:admin) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
 

--- a/spec/features/work_packages/sorting/table_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/table_sorting_spec.rb
@@ -72,9 +72,11 @@ RSpec.describe 'Select work package row', js: true do
       end
 
       it 'sorts by version although version is not selected as a column' do
-        sort_by.open_modal
-        sort_by.update_nth_criteria(0, 'Version')
-        expect_work_packages_to_be_in_order([work_package_1, work_package_2])
+        ignore_ferrum_javascript_error do
+          sort_by.open_modal
+          sort_by.update_nth_criteria(0, 'Version')
+          expect_work_packages_to_be_in_order([work_package_1, work_package_2])
+        end
       end
     end
   end
@@ -85,9 +87,11 @@ RSpec.describe 'Select work package row', js: true do
     before do
       login_as user
       wp_table.visit!
+      expect_angular_frontend_initialized
     end
 
-    it 'provides the default sortation and allows using the value at another level (Regression WP#26792)' do
+    it 'provides the default sorting and allows using the value at another level (Regression WP#26792)',
+       with_cuprite: false do
       # Expect current criteria
       sort_by.expect_criteria(['-', 'asc'])
 

--- a/spec/features/work_packages/table/baseline/baseline_query_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_query_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'baseline query saving',
                :js,
-               :with_cuprite,
                with_ee: %i[baseline_comparison],
                with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:project) { create(:project) }

--- a/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_rendering_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 RSpec.describe 'baseline rendering',
                :js,
-               :with_cuprite,
                with_settings: { date_format: '%Y-%m-%d' } do
   shared_let(:list_wp_custom_field) { create(:list_wp_custom_field) }
   shared_let(:multi_list_wp_custom_field) { create(:list_wp_custom_field, multi_value: true) }

--- a/spec/features/work_packages/table/context_menu/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative 'context_menu_shared_examples'
 
-RSpec.describe 'Work package table context menu', js: true, with_cuprite: true do
+RSpec.describe 'Work package table context menu', js: true do
   shared_let(:user) { create(:admin) }
   shared_let(:work_package) { create(:work_package) }
 

--- a/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Work Package group by progress', js: true do
       group_by.expect_no_groups
 
       # Expect disabled group by to be kept after reload
-      page.driver.browser.navigate.refresh
+      refresh
       group_by.expect_no_groups
 
       # But query has not been changed

--- a/spec/features/work_packages/table/hierarchy/hierarchy_sorting_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_sorting_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Work Package table hierarchy and sorting', js: true do
     login_as(user)
   end
 
-  it 'can show hierarchies and sort by start_date' do
+  it 'can show hierarchies and sort by start_date', with_cuprite: false do
     wp_table.visit!
     wp_table.expect_work_package_listed(wp_root, wp_child1, wp_child2, wp_child3)
     hierarchy.expect_hierarchy_at(wp_root)

--- a/spec/features/work_packages/table/hierarchy/parent_column_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/parent_column_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Work Package table parent column', js: true do
     end
   end
 
-  it 'can edit the parent work package (Regression #43647)' do
+  it 'can edit the parent work package (Regression #43647)', with_cuprite: false do
     wp_table.visit_query query
     wp_table.expect_work_package_listed(parent, child)
 

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe 'inline create work package', js: true do
+RSpec.describe 'inline create work package',
+               js: true,
+               with_cuprite: false do
   let(:type) { create(:type) }
   let(:types) { [type] }
 

--- a/spec/features/work_packages/table/milestones_spec.rb
+++ b/spec/features/work_packages/table/milestones_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Inline editing milestones', js: true do
     wp_table.expect_work_package_listed work_package
   end
 
-  it 'mapping for start and finish date in the table (regression #26044)' do
+  it 'mapping for start and finish date in the table (regression #26044)', with_cuprite: false do
     start_date = wp_table.edit_field(work_package, :startDate)
     due_date = wp_table.edit_field(work_package, :dueDate)
 

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -550,7 +550,7 @@ RSpec.describe 'filter work packages', js: true do
       wp_table.ensure_work_package_not_listed! wp_updated_3d_ago, wp_updated_5d_ago
     end
 
-    it 'filters between date by updated_at', :with_cuprite do
+    it 'filters between date by updated_at' do
       wp_table.visit!
       loading_indicator_saveguard
       wp_table.expect_work_package_listed wp_updated_today, wp_updated_3d_ago, wp_updated_5d_ago

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'mobile date filter work packages', :js, :with_cuprite do
+RSpec.describe 'mobile date filter work packages', :js do
   shared_let(:user) { create(:admin) }
   shared_let(:project) { create(:project) }
   shared_let(:wp_table) { Pages::WorkPackagesTable.new(project) }

--- a/spec/features/work_packages/table/queries/query_history_spec.rb
+++ b/spec/features/work_packages/table/queries/query_history_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Going back and forth through the browser history', js: true do
     version_query
   end
 
-  it 'updates the filters and query results on history back and forth', retry: 1 do
+  it 'updates the filters and query results on history back and forth', retry: 1, with_cuprite: false do
     wp_table.visit!
     wp_table.expect_title('All open', editable: true)
 

--- a/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
+++ b/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Query name inline edit', js: true do
     wp_table.visit_query assignee_query
   end
 
-  it 'allows renaming the query and shows changed state' do
+  it 'allows renaming the query and shows changed state', with_cuprite: false do
     wp_table.expect_work_package_listed work_package
     query_title.expect_not_changed
 

--- a/spec/features/work_packages/tabs/activity_revisions_spec.rb
+++ b/spec/features/work_packages/tabs/activity_revisions_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 require 'support/edit_fields/edit_field'
 
-RSpec.describe 'Activity tab', js: true, with_cuprite: true do
+RSpec.describe 'Activity tab', js: true do
   let(:project) { create(:project_with_types, public: true) }
 
   let(:creation_time) { 5.days.ago }

--- a/spec/features/work_packages/tabs/activity_tab_spec.rb
+++ b/spec/features/work_packages/tabs/activity_tab_spec.rb
@@ -32,8 +32,7 @@ require 'features/work_packages/work_packages_page'
 require 'support/edit_fields/edit_field'
 
 RSpec.describe 'Activity tab',
-               js: true,
-               with_cuprite: true do
+               js: true do
   let(:project) do
     create(:project_with_types,
            types: [type_with_cf],

--- a/spec/features/work_packages/tabs/keep_tab_spec.rb
+++ b/spec/features/work_packages/tabs/keep_tab_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Keep current details tab', js: true, selenium: true do
+RSpec.describe 'Keep current details tab', js: true, with_cuprite: false do
   let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let!(:wp1) { create(:work_package, project:) }

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'Watcher tab', js: true, selenium: true do
       wp_table.expect_work_package_listed work_package
     end
 
-    it 'shows the number of watchers [#33685]' do
+    it 'shows the number of watchers [#33685]', with_cuprite: false do
       wp_table.open_full_screen_by_doubleclick(work_package)
       expect(page).to have_selector('[data-qa-selector="tab-count"]', text: "(1)")
     end

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe 'Work package timeline date formatting',
     end
 
     shared_examples "sets dates, duration and displays bar" do
-      it 'sets dates, duration and duration bar' do
+      it 'sets dates, duration and duration bar', with_cuprite: false do
         subject
 
         row.expect_bar(duration: expected_bar_duration)
@@ -219,7 +219,7 @@ RSpec.describe 'Work package timeline date formatting',
         work_package_with_non_working_days.update({ start_date: nil, due_date: nil, duration: 5 })
       end
 
-      it 'displays the hover bar correctly' do
+      it 'displays the hover bar correctly', with_cuprite: false do
         # Expect no hover bar when hovering over a non working day
         row.hover_bar(offset_days: -1)
         row.expect_no_hovered_bar
@@ -303,7 +303,7 @@ RSpec.describe 'Work package timeline date formatting',
         end
       end
 
-      it 'cancels when the drag starts or finishes on a weekend' do
+      it 'cancels when the drag starts or finishes on a weekend', with_cuprite: false do
         # Finish on the weekend
         row.drag_and_drop(offset_days: 1, days: 5)
 

--- a/spec/features/work_packages/timeline/timeline_navigation_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_navigation_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe 'Work package timeline navigation', js: true, selenium: true do
       wp_timeline.expect_no_timeline_relation(wp_cat1, wp_cat2)
     end
 
-    it 'removes the relation element when removed in split screen' do
+    it 'removes the relation element when removed in split screen', with_cuprite: false do
       wp_table.visit_query(query)
       wp_table.expect_work_package_listed(wp_cat1, wp_cat2, wp_none)
 

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Work Packages', 'index view', :js, :with_cuprite do
+RSpec.describe 'Work Packages', 'index view', :js do
   let(:user) { create(:admin) }
   let(:project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }

--- a/spec/features/wysiwyg/bold_behavior_spec.rb
+++ b/spec/features/wysiwyg/bold_behavior_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Wysiwyg bold behavior',
-               js: true,
-               with_cuprite: true do
+               js: true do
   current_user { create(:admin) }
 
   let(:project) { create(:project, enabled_module_names: %w[wiki]) }

--- a/spec/features/wysiwyg/macros/code_block_macro_spec.rb
+++ b/spec/features/wysiwyg/macros/code_block_macro_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Wysiwyg code block macro',
         end
       end
 
-      it 'can add and edit a code block widget' do
+      it 'can add and edit a code block widget', with_cuprite: false do
         editor.in_editor do |container,|
           editor.click_toolbar_button 'Insert code snippet'
 

--- a/spec/features/wysiwyg/macros/embedded_tables_spec.rb
+++ b/spec/features/wysiwyg/macros/embedded_tables_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Wysiwyg embedded work package tables',
         visit project_wiki_path(project, :wiki)
       end
 
-      it 'can add and edit an embedded table widget' do
+      it 'can add and edit an embedded table widget', with_cuprite: false do
         editor.in_editor do |_container, editable|
           editor.insert_macro 'Embed work package table'
 

--- a/spec/features/wysiwyg/mentions_spec.rb
+++ b/spec/features/wysiwyg/mentions_spec.rb
@@ -29,8 +29,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Wysiwyg work package mentions',
-               :js,
-               :with_cuprite do
+               :js do
   let!(:user) { create(:admin, firstname: 'MeMyself', lastname: 'AndI', member_in_project: project) }
   let!(:user2) { create(:user, firstname: 'Foo', lastname: 'Bar', member_in_project: project) }
   let!(:group) { create(:group, firstname: 'Foogroup', lastname: 'Foogroup') }

--- a/spec/features/wysiwyg/work_package_linking_spec.rb
+++ b/spec/features/wysiwyg/work_package_linking_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Wysiwyg work package linking',
       visit project_wiki_path(project, :wiki)
     end
 
-    it 'can reference work packages' do
+    it 'can reference work packages', with_cuprite: false do
       # single hash autocomplete
       editor.click_and_type_slowly "##{work_package.id}"
       editor.click_autocomplete work_package.subject

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -39,7 +39,7 @@ module AuthenticationHelpers
       # we must set the user_id in rack.session accordingly
       # Otherwise e.g. calls to Warden will behave unexpectantly
       # as they will login AnonymousUser
-      if using_cuprite? && js_enabled?
+      if using_cuprite?
         page.driver.set_cookie(
           OpenProject::Configuration['session_cookie_name'],
           session_value_for(user).to_s
@@ -75,12 +75,8 @@ module AuthenticationHelpers
 
   private
 
-  def js_enabled?
-    RSpec.current_example.metadata[:js]
-  end
-
   def using_cuprite?
-    RSpec.current_example.metadata[:with_cuprite]
+    Capybara.default_driver == :better_cuprite_en
   end
 
   def session_value_for(user)

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -76,7 +76,9 @@ module AuthenticationHelpers
   private
 
   def using_cuprite?
-    Capybara.default_driver == :better_cuprite_en
+    metadata = RSpec.current_example.metadata
+
+    metadata[:javascript_driver] == :better_cuprite_en && metadata[:js]
   end
 
   def session_value_for(user)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -23,7 +23,7 @@ end
 
 RSpec.configure do |config|
   Capybara.default_max_wait_time = 4
-  Capybara.javascript_driver = :chrome_en
+  Capybara.javascript_driver = :better_cuprite_en
 
   port = ENV.fetch('CAPYBARA_SERVER_PORT', ParallelHelper.port_for_app).to_i
   if port > 0

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -85,26 +85,8 @@ end
 
 register_better_cuprite 'en'
 
-def reset_drivers_to_cuprite_if_changed
-  unless Capybara.javascript_driver == :better_cuprite_en
-    Capybara.javascript_driver = :better_cuprite_en
-  end
-end
-
 RSpec.configure do |config|
-  config.around(:each, type: :feature) do |example|
-    disable_cuprite = example.metadata.key?(:with_cuprite) && example.metadata[:with_cuprite] == false
-    other_driver_registered = example.metadata.key?(:driver)
-
-    if disable_cuprite || other_driver_registered
-      driver = example.metadata[:driver] || :chrome_en
-      Capybara.javascript_driver = driver
-    end
-
-    begin
-      example.run
-    ensure
-      reset_drivers_to_cuprite_if_changed
-    end
+  config.define_derived_metadata(with_cuprite: false) do |metadata|
+    metadata[:javascript_driver] = :chrome_en
   end
 end

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -157,7 +157,7 @@ module Pages
       visit root_path
 
       within '#more-menu', visible: false do
-        click_on link_title, visible: false
+        click_link link_title, visible: false
       end
     end
   end

--- a/spec/support/selenium_hub_waiter.rb
+++ b/spec/support/selenium_hub_waiter.rb
@@ -4,6 +4,6 @@ module SeleniumHubWaiter
   # frontend not fast enough to bind click handlers on buttons?
   # only happens when using the Selenium Hub
   def wait
-    sleep 1 if ENV.fetch("SELENIUM_GRID_URL", "").present?
+    sleep 1 unless ENV.fetch("SELENIUM_GRID_URL", "").blank? && using_cuprite?
   end
 end

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -45,6 +45,14 @@ def wait_for_reload
   page.driver.wait_for_reload
 end
 
+def refresh
+  if using_cuprite?
+    page.driver.refresh
+  else
+    page.refresh
+  end
+end
+
 # Ferrum is yet support `fill_options` as a Hash
 def clear_input_field_contents(input_element)
   if input_element.is_a? String
@@ -58,5 +66,5 @@ def clear_input_field_contents(input_element)
 end
 
 def using_cuprite?
-  Capybara.javascript_driver == :better_cuprite_en
+  RSpec.current_example.metadata[:javascript_driver] == :better_cuprite_en
 end

--- a/spec/support/shared/with_mobile_screen.rb
+++ b/spec/support/shared/with_mobile_screen.rb
@@ -46,11 +46,11 @@ RSpec.shared_context 'with mobile screen size' do |width, height|
     # and refresh the page
     if using_cuprite?
       page.driver.resize(width || 500, height || 1000)
-      page.driver.refresh
     else
       page.driver.browser.manage.window.resize_to(width || 500, height || 1000)
-      page.driver.browser.navigate.refresh
     end
+
+    refresh
   end
 
   after do


### PR DESCRIPTION
In order to improve the developer experience (and CI/test performance), I would like to not have to remember to add a `:with_cuprite => true` tag to my examples. I should only be caring about opting-out of cuprite if need be. Hence, the reason for this PR. I know this is also something you were looking forward to @oliverguenther 

* Sets `:better_cuprite_en` as the default javascript driver for
  Capybara.

  If the example has `:with_cuprite => false` as metadata but doesn't
  specify a driver, it defaults to using `:chrome_en` (the previous
  default).

**NOTES:** 
* A lot of specs should fail in this PR's CI right now. This is intended so that we can see all specs that DO pass and like cuprite, and then opt-out of those that don't out-of-the-box.

* Just opting-out of Cuprite might not be enough. The CI run in general is slower, this might due to:
  * Excessive retries: Since the specs are running quite fast now and were written tailored for Selenium, we might have wrong or inappropriate expectations that aren't okay with Cuprite.