### PR TITLE
[#49836] Activate users upon successful password reset

### DIFF
--- a/app/services/users/change_password_service.rb
+++ b/app/services/users/change_password_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -40,9 +42,11 @@ module Users
         current_user.password = params[:new_password]
         current_user.password_confirmation = params[:new_password_confirmation]
         current_user.force_password_change = false
+        current_user.activate if current_user.invited?
 
         if current_user.save
           invalidate_recovery_tokens
+          invalidate_invitation_tokens
 
           log_success
           ::ServiceResult.new success: true,
@@ -62,6 +66,10 @@ module Users
 
     def invalidate_recovery_tokens
       Token::Recovery.where(user: current_user).delete_all
+    end
+
+    def invalidate_invitation_tokens
+      Token::Invitation.where(user: current_user).delete_all
     end
 
     def invalidate_session_result

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe AccountController,
       end
 
       it 'is not found' do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -519,7 +519,7 @@ RSpec.describe AccountController,
       end
 
       it 'renders 404' do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -559,7 +559,7 @@ RSpec.describe AccountController,
       end
 
       it 'is not found' do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -916,7 +916,7 @@ RSpec.describe AccountController,
           end
 
           it 'is not found' do
-            expect(response.status).to eq 404
+            expect(response).to have_http_status :not_found
           end
         end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -242,13 +242,12 @@ RSpec.describe AccountController,
       end
 
       context 'with a relative url root' do
-        before do
-          @old_relative_url_root = OpenProject::Configuration['rails_relative_url_root']
+        around do |example|
+          old_relative_url_root = OpenProject::Configuration['rails_relative_url_root']
           OpenProject::Configuration['rails_relative_url_root'] = '/openproject'
-        end
-
-        after do
-          OpenProject::Configuration['rails_relative_url_root'] = @old_relative_url_root
+          example.run
+        ensure
+          OpenProject::Configuration['rails_relative_url_root'] = old_relative_url_root
         end
 
         it 'redirects to the same subdirectory with an absolute path' do

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -30,24 +30,26 @@ require 'spec_helper'
 
 RSpec.describe AccountController,
                skip_2fa_stage: true do
-  class UserHook < OpenProject::Hook::ViewListener
-    attr_reader :registered_user, :first_login_user
+  let(:user_hook_class) do
+    Class.new(OpenProject::Hook::ViewListener) do
+      attr_reader :registered_user, :first_login_user
 
-    def user_registered(context)
-      @registered_user = context[:user]
-    end
+      def user_registered(context)
+        @registered_user = context[:user]
+      end
 
-    def user_first_login(context)
-      @first_login_user = context[:user]
-    end
+      def user_first_login(context)
+        @first_login_user = context[:user]
+      end
 
-    def reset!
-      @registered_user = nil
-      @first_login_user = nil
+      def reset!
+        @registered_user = nil
+        @first_login_user = nil
+      end
     end
   end
 
-  let(:hook) { UserHook.instance }
+  let(:hook) { user_hook_class.instance }
   let(:user) { build_stubbed(:user) }
 
   before do

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -566,6 +566,25 @@ RSpec.describe AccountController,
     end
   end
 
+  describe 'POST #lost_password' do
+    context 'when the user has been invited but not yet activated' do
+      shared_let(:admin) { create(:admin, status: :invited) }
+      shared_let(:token) { create(:recovery_token, user: admin) }
+
+      context 'with a valid token' do
+        before do
+          allow(controller).to receive(:allow_lost_password_recovery).and_return(true)
+
+          post :lost_password, params: { token: token.value }
+        end
+
+        it 'redirects to the login page' do
+          expect(response).to redirect_to '/login'
+        end
+      end
+    end
+  end
+
   shared_examples 'registration disabled' do
     it 'redirects to back the login page' do
       expect(response).to redirect_to signin_path

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -59,45 +59,46 @@ RSpec.describe AccountController,
   end
 
   describe 'GET #login' do
-    let(:setup) {}
     let(:params) { {} }
 
-    before do
-      setup
+    context 'when the user is not already logged in' do
+      before do
+        get :login, params:
+      end
 
-      get :login, params:
+      it 'renders the view' do
+        expect(response).to render_template 'login'
+        expect(response).to be_successful
+      end
     end
 
-    it 'renders the view' do
-      expect(response).to render_template 'login'
-      expect(response).to be_successful
-    end
+    context 'when the user is already logged in' do
+      before do
+        login_as user
 
-    context 'user already logged in' do
-      let(:setup) { login_as user }
+        get :login, params:
+      end
 
       it 'redirects to home' do
         expect(response)
           .to redirect_to my_page_path
       end
-    end
 
-    context 'user already logged in and back url present' do
-      let(:setup) { login_as user }
-      let(:params) { { back_url: "/projects" } }
+      context 'and a valid back url is present' do
+        let(:params) { { back_url: "/projects" } }
 
-      it 'redirects to back_url value' do
-        expect(response)
-          .to redirect_to projects_path
+        it 'redirects to back_url value' do
+          expect(response)
+            .to redirect_to projects_path
+        end
       end
-    end
 
-    context 'user already logged in and invalid back url present' do
-      let(:setup) { login_as user }
-      let(:params) { { back_url: 'http://test.foo/work_packages/show/1' } }
+      context 'and an invalid back url present' do
+        let(:params) { { back_url: 'http://test.foo/work_packages/show/1' } }
 
-      it 'redirects to home' do
-        expect(response).to redirect_to my_page_path
+        it 'redirects to home' do
+          expect(response).to redirect_to my_page_path
+        end
       end
     end
   end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -316,10 +316,12 @@ RSpec.describe AccountController,
       shared_let(:admin) { create(:admin) }
 
       it 'calls reset_session' do
-        expect(controller).to receive(:reset_session).once
-
+        allow(controller).to receive(:reset_session)
         login_as admin
+
         get :logout
+
+        expect(controller).to have_received(:reset_session).once
         expect(response).to be_redirect
       end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -719,7 +719,7 @@ RSpec.describe AccountController,
           it "notifies the admins about the issue" do
             perform_enqueued_jobs
 
-            mail = ActionMailer::Base.deliveries.detect { |mail| mail.to.first == admin.mail }
+            mail = ActionMailer::Base.deliveries.detect { |m| m.to.first == admin.mail }
             expect(mail).to be_present
             expect(mail.subject).to match /limit reached/
             expect(mail.body.parts.first.to_s).to match /new user \(#{params[:user][:mail]}\)/

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -418,7 +418,7 @@ RSpec.describe AccountController,
       end
 
       it 'does not login the user' do
-        expect(controller.send(:current_user).anonymous?).to be_truthy
+        expect(controller.send(:current_user)).to be_anonymous
       end
     end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe AccountController,
       shared_let(:admin) { create(:admin) }
 
       it 'calls reset_session' do
-        expect(@controller).to receive(:reset_session).once
+        expect(controller).to receive(:reset_session).once
 
         login_as admin
         get :logout
@@ -418,7 +418,7 @@ RSpec.describe AccountController,
       end
 
       it 'does not login the user' do
-        expect(@controller.send(:current_user).anonymous?).to be_truthy
+        expect(controller.send(:current_user).anonymous?).to be_truthy
       end
     end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe AccountController,
         allow(LdapAuthSource).to receive(:authenticate).and_return(authenticate ? user_attributes : nil)
 
         # required so that the register view can be rendered
-        allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false)
+        allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false) # rubocop:disable RSpec/AnyInstance
       end
 
       context 'with user limit reached' do
@@ -503,7 +503,7 @@ RSpec.describe AccountController,
     let(:admin) { create(:admin, force_password_change: true) }
 
     before do
-      allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false)
+      allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false) # rubocop:disable RSpec/AnyInstance
     end
 
     describe "Missing flash data for user initiated password change" do
@@ -767,7 +767,7 @@ RSpec.describe AccountController,
         end
 
         it "doesn't activate the user but sends out a token instead" do
-          expect(User.find_by_login('register')).not_to be_active
+          expect(User.find_by_login('register')).not_to be_active # rubocop:disable Rails/DynamicFindBy
           token = Token::Invitation.last
           expect(token.user.mail).to eq('register@example.com')
           expect(token).not_to be_expired
@@ -813,7 +813,7 @@ RSpec.describe AccountController,
         end
 
         it "doesn't activate the user" do
-          expect(User.find_by_login('register')).not_to be_active
+          expect(User.find_by_login('register')).not_to be_active # rubocop:disable Rails/DynamicFindBy
         end
 
         it 'calls the user_registered callback' do
@@ -874,7 +874,7 @@ RSpec.describe AccountController,
     context 'with on-the-fly registration',
             with_settings: { self_registration: Setting::SelfRegistration.disabled } do
       before do
-        allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false)
+        allow_any_instance_of(User).to receive(:change_password_allowed?).and_return(false) # rubocop:disable RSpec/AnyInstance
         allow(LdapAuthSource).to receive(:authenticate).and_return(login: 'foo',
                                                                    lastname: 'Smith',
                                                                    ldap_auth_source_id: 66)
@@ -899,7 +899,7 @@ RSpec.describe AccountController,
                }
           expect(response).to redirect_to home_path(first_time_user: true)
 
-          user = User.find_by_login('foo')
+          user = User.find_by_login('foo') # rubocop:disable Rails/DynamicFindBy
 
           expect(user).to be_an_instance_of(User)
           expect(user.ldap_auth_source_id).to be 66


### PR DESCRIPTION
## Description
When a user successfully resets their password via a token, it means they have proven to have access to the email address to which the activation link was sent to. It is quite common for a password reset to also activate the user (if not active), as this demonstrates they are who they say they are.

## Notes
Refactored and cleaned up the `account_controller_spec` to address all Rubocop warnings where possible.

See: https://community.openproject.org/work_packages/49836