### PR TITLE
Fix/reenable specifying eager loading in endpoints

### DIFF
--- a/lib/api/v3/memberships/membership_representer.rb
+++ b/lib/api/v3/memberships/membership_representer.rb
@@ -92,9 +92,9 @@ module API
         date_time_property :created_at
         date_time_property :updated_at
 
-        self.to_eager_load = %i[principal
-                                project
-                                roles]
+        self.to_eager_load = [:principal,
+                              { project: :enabled_modules },
+                              { member_roles: :role }]
 
         def _type
           'Membership'

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -222,10 +222,7 @@ module API
           'Project'
         end
 
-        self.to_eager_load = [:status,
-                              :parent,
-                              :enabled_modules,
-                              { custom_values: :custom_field }]
+        self.to_eager_load = [:enabled_modules]
 
         self.checked_permissions = [:add_work_packages]
       end

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -162,7 +162,9 @@ module API
             if constraint.is_a?(Class)
               result_scope
             else
-              result_scope.where id: constraint.select(:id)
+              result_scope
+                .includes(constraint.includes_values)
+                .where id: constraint.select(:id)
             end
           end
         end


### PR DESCRIPTION
Eager loading for the base scopes specified in the API endpoints was disabled by a [change done to the default index action](https://github.com/opf/openproject/commit/f83d4f0b47a971dffa10fa79253ceca013f6823a). Because of that, the performance of some endpoints, e.g. /api/v3/principals degraded.

https://community.openproject.org/wp/49915