### PR TITLE
Apply skip metadata to `svnadmin`-dependent specs

### DIFF
--- a/spec/services/scm/create_managed_repository_service_spec.rb
+++ b/spec/services/scm/create_managed_repository_service_spec.rb
@@ -27,7 +27,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SCM::CreateManagedRepositoryService do
+RSpec.describe SCM::CreateManagedRepositoryService, skip_if_command_unavailable: 'svnadmin' do
   let(:user) { build(:user) }
   let(:config) { {} }
   let(:project) { build(:project) }

--- a/spec/services/scm/delete_managed_repository_service_spec.rb
+++ b/spec/services/scm/delete_managed_repository_service_spec.rb
@@ -27,7 +27,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SCM::DeleteManagedRepositoryService do
+RSpec.describe SCM::DeleteManagedRepositoryService, skip_if_command_unavailable: 'svnadmin' do
   let(:user) { build(:user) }
   let(:config) { {} }
   let(:project) { build(:project) }


### PR DESCRIPTION
As is the pattern with other specs that require native commands (specifically `svnadmin`), skipping the remaining service specs that required it.