### PR TITLE
[#49935] Fix flaky create meeting spec

### DIFF
--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -173,6 +173,8 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
 
         new_page.set_project project
 
+        wait_for_network_idle # Wait for participant section to be fetched
+
         show_page = new_page.click_create
 
         show_page.expect_toast(message: 'Successful creation')


### PR DESCRIPTION
## Flakiness description
`./modules/meeting/spec/features/meetings_new_spec.rb:167` has been failing quite frequently on CI runs lately. 

After some inspection to it and attempting to reproduce it locally, using the `stress` tool, I found that it was caused by the participant section (which is fetched via a turbo stream) not loaded in time before the form submission occurred while under heavy load.

By using `wait_for_network_idle` we can ensure that the participant section is loaded and therefore, its params also bundled in the form submission when clicking create.

## Notes
See: https://community.openproject.org/work_packages/49935