### PR TITLE
Remove debug statement in the middle of the case statement of RDM Mailhandler

### DIFF
--- a/extra/mail_handler/rdm-mailhandler.rb
+++ b/extra/mail_handler/rdm-mailhandler.rb
@@ -163,7 +163,6 @@ class RedmineMailHandler
     debug "Response received: #{response.code}"
 
     case response.code.to_i
-        debug "Processed successfully"
     when 403
       warn "Request was denied by your Redmine server. " +
            "Make sure that 'WS for incoming emails' is enabled in application settings and that you provided the correct API key."


### PR DESCRIPTION
There is a debug statement in the middle of the case statement, that makes the code invalid (at least in Ruby 3.2). It was introduced in 2ae53bd which was fixing typos. Looks like it landed there by accident.

File seems not to be in use, but it is causing problems when running rubocop on the entire project