### PR TITLE
Fix/incorrect non member permission signaling

### DIFF
--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -108,11 +108,11 @@ module Capabilities::Scopes
             ON 1 = 1
           JOIN "projects"
             ON "projects".active = true
-            AND ("projects".public = true OR EXISTS (SELECT 1
-                                                     FROM members
-                                                     WHERE members.project_id = projects.id
-                                                     AND members.user_id = users.id
-                                                     LIMIT 1))
+            AND ("projects".public = true AND NOT EXISTS (SELECT 1
+                                                          FROM members
+                                                          WHERE members.project_id = projects.id
+                                                          AND members.user_id = users.id
+                                                          LIMIT 1))
           LEFT OUTER JOIN enabled_modules
             ON enabled_modules.project_id = projects.id
             AND actions.module = enabled_modules.name

--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -60,10 +60,16 @@ module Capabilities::Scopes
             users.id principal_id,
             projects.id context_id
           FROM (#{Action.default.to_sql}) actions
-          LEFT OUTER JOIN "role_permissions" ON "role_permissions"."permission" = "actions"."permission"
-          LEFT OUTER JOIN "roles" ON "roles".id = "role_permissions".role_id OR "actions"."public"
-          LEFT OUTER JOIN "member_roles" ON "member_roles".role_id = "roles".id
-          LEFT OUTER JOIN "members" ON members.id = member_roles.member_id AND members.entity_type IS NULL AND members.entity_id IS NULL
+          LEFT OUTER JOIN "role_permissions"
+            ON "role_permissions"."permission" = "actions"."permission"
+          LEFT OUTER JOIN "roles"
+            ON "roles".id = "role_permissions".role_id OR "actions"."public"
+          LEFT OUTER JOIN "member_roles"
+            ON "member_roles".role_id = "roles".id
+          LEFT OUTER JOIN "members"
+            ON members.id = member_roles.member_id
+            AND members.entity_type IS NULL
+            AND members.entity_id IS NULL
           JOIN (#{Principal.visible.not_builtin.not_locked.to_sql}) users
             ON "users".id = members.user_id
           LEFT OUTER JOIN "projects"
@@ -102,8 +108,11 @@ module Capabilities::Scopes
             users.id principal_id,
             projects.id context_id
           FROM (#{Action.default.to_sql}) actions
-          LEFT JOIN "role_permissions" ON "role_permissions"."permission" = "actions"."permission"
-          JOIN "roles" ON ("roles".id = "role_permissions".role_id OR "actions"."public") AND roles.builtin = #{Role::BUILTIN_NON_MEMBER}
+          LEFT JOIN "role_permissions"
+            ON "role_permissions"."permission" = "actions"."permission"
+          JOIN "roles"
+            ON ("roles".id = "role_permissions".role_id OR "actions"."public")
+            AND roles.builtin = #{Role::BUILTIN_NON_MEMBER}
           JOIN (#{Principal.visible.not_builtin.not_locked.to_sql}) users
             ON 1 = 1
           JOIN "projects"
@@ -130,8 +139,11 @@ module Capabilities::Scopes
             users.id principal_id,
             projects.id context_id
           FROM (#{Action.default.to_sql}) actions
-          LEFT JOIN "role_permissions" ON "role_permissions"."permission" = "actions"."permission"
-          JOIN "roles" ON ("roles".id = "role_permissions".role_id OR "actions"."public") AND roles.builtin = #{Role::BUILTIN_ANONYMOUS}
+          LEFT JOIN "role_permissions"
+            ON "role_permissions"."permission" = "actions"."permission"
+          JOIN "roles"
+            ON ("roles".id = "role_permissions".role_id OR "actions"."public")
+            AND roles.builtin = #{Role::BUILTIN_ANONYMOUS}
           JOIN users ON users.type = '#{AnonymousUser.name}'
           JOIN "projects"
             ON "projects".active = true

--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -112,6 +112,8 @@ module Capabilities::Scopes
                                                           FROM members
                                                           WHERE members.project_id = projects.id
                                                           AND members.user_id = users.id
+                                                          AND members.entity_type IS NULL
+                                                          AND members.entity_id IS NULL
                                                           LIMIT 1))
           LEFT OUTER JOIN enabled_modules
             ON enabled_modules.project_id = projects.id

--- a/spec/models/capabilities/scopes/default_spec.rb
+++ b/spec/models/capabilities/scopes/default_spec.rb
@@ -503,6 +503,23 @@ RSpec.describe Capabilities::Scopes::Default do
 
         include_examples 'is empty'
       end
+
+      context 'for a public project' do
+        let(:non_member_permissions) { %i[view_members] }
+        let(:members) { [work_package_member, non_member_role] }
+
+        before do
+          project.update(public: true)
+        end
+
+        include_examples 'consists of contract actions', with: 'the actions of the non member role`s permission' do
+          let(:expected) do
+            [
+              ['memberships/read', user.id, project.id]
+            ]
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up on #13432. In that PR it was established (had been the case all along) that the permissions granted to the non member role in fact do not constitute the minimal set of permissions granted to members of any project (public or private). 

This PR now reflects that behaviour in the capabilities. 

Since the change leads to users being member in a public project being exempt from receiving permissions from the non member roles via a `WHERE NOT EXISTS (SELECT 1 FROM members ...)` that subselect needs to not consider entity memberships which is also part of the PR.