### PR TITLE
fix font-size of ng-value in wp type status row

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -61,6 +61,7 @@ div.autocomplete
 // -------------------------- ng-select --------------------------
 .ng-select
   width: 100%
+  font-size: var(--body-font-size)
 
   .ng-value-container
     min-height: 2rem
@@ -92,7 +93,6 @@ div.autocomplete
   .ng-value
     @include text-shortener
     line-height: 22px
-    font-size: var(--body-font-size)
 
 .ng-select.ng-select-multiple .ng-select-container
   height: initial !important
@@ -116,6 +116,7 @@ div.autocomplete
 
 .ng-option
   line-height: 22px
+  font-size: var(--body-font-size)
 
   .op-avatar
     margin-right: 8px

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -92,6 +92,7 @@ div.autocomplete
   .ng-value
     @include text-shortener
     line-height: 22px
+    font-size: var(--body-font-size)
 
 .ng-select.ng-select-multiple .ng-select-container
   height: initial !important


### PR DESCRIPTION
Before:

<img width="337" alt="image" src="https://github.com/opf/openproject/assets/617519/f0e16468-a821-4394-bb4c-40036cfa3526">



After:

<img width="322" alt="image" src="https://github.com/opf/openproject/assets/617519/f353773e-1c7b-4561-b5fc-2097aaad24fe">

This fix could have been applied to both the generic `_autocomplete.sass` or the specific `_type_status_row.sass` and I am not sure about where to place it best. It seems prudent to have the font-size of inputs governed generally throughout the system as it is done in `_forms.sass` for all the normal input fields. On the other hand, d26b76f63a5 removed the font-size statements explicitly so I am unsure.

https://community.openproject.org/wp/49858