### PR TITLE
Implementation/49112 enable login to microsoft graph api

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -151,7 +151,7 @@ class OAuthClientsController < ApplicationController
 
   def redirect_user_or_admin(redirect_uri = nil)
     # This needs to be modified as soon as we support more integration types.
-    if User.current.admin && redirect_uri && nextcloud?
+    if User.current.admin && redirect_uri && (nextcloud? || one_drive?)
       yield
     elsif redirect_uri
       flash[:error] = [t(:'oauth_client.errors.oauth_issue_contact_admin')]
@@ -163,6 +163,10 @@ class OAuthClientsController < ApplicationController
 
   def nextcloud?
     @oauth_client&.integration&.provider_type == ::Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
+  end
+
+  def one_drive?
+    @oauth_client&.integration&.provider_type == ::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
   end
 
   def get_redirect_uri

--- a/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
@@ -73,7 +73,11 @@ class Storages::Admin::ProjectStoragesController < Projects::SettingsController
                          .result
     @last_project_folders = {}
 
-    render template: '/storages/project_settings/new'
+    if @project_storage.storage.present? && @project_storage.storage.provider_type_one_drive?
+      create
+    else
+      render template: '/storages/project_settings/new'
+    end
   end
 
   # Create a new ProjectStorage object.

--- a/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
+++ b/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
@@ -30,10 +30,13 @@
 module Storages::ProjectStorages
   class SetAttributesService < ::BaseServices::SetAttributes
     def set_default_attributes(_params)
-      model.creator ||= user
+      project_storage = model
+      storage = project_storage.storage
 
-      model.project_folder_mode ||=
-        if model.storage.present? && model.storage.automatically_managed?
+      project_storage.creator ||= user
+
+      project_storage.project_folder_mode ||=
+        if storage.present? && storage.provider_type_nextcloud? && storage.automatically_managed?
           "automatic"
         else
           "inactive"

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -178,12 +178,14 @@ module API::V3::Storages
     end
 
     associated_resource :oauth_application,
-                        skip_render: ->(*) { !current_user.admin? },
+                        skip_render: ->(*) { !current_user.admin? || !represented.provider_type_nextcloud? },
                         getter: ->(*) {
+                          next unless current_user.admin? && represented.provider_type_nextcloud?
+
                           ::API::V3::OAuth::OAuthApplicationsRepresenter.create(represented.oauth_application, current_user:)
                         },
                         link: ->(*) {
-                          next unless current_user.admin?
+                          next unless current_user.admin? && represented.provider_type_nextcloud?
 
                           {
                             href: api_v3_paths.oauth_application(represented.oauth_application.id),

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -178,14 +178,14 @@ module API::V3::Storages
     end
 
     associated_resource :oauth_application,
-                        skip_render: ->(*) { !current_user.admin? || !represented.provider_type_nextcloud? },
+                        skip_render: ->(*) { !represent_oauth_application? },
                         getter: ->(*) {
-                          next unless current_user.admin? && represented.provider_type_nextcloud?
+                          next unless represent_oauth_application?
 
                           ::API::V3::OAuth::OAuthApplicationsRepresenter.create(represented.oauth_application, current_user:)
                         },
                         link: ->(*) {
-                          next unless current_user.admin? && represented.provider_type_nextcloud?
+                          next unless represent_oauth_application?
 
                           {
                             href: api_v3_paths.oauth_application(represented.oauth_application.id),
@@ -210,6 +210,10 @@ module API::V3::Storages
     end
 
     private
+
+    def represent_oauth_application?
+      current_user.admin? && represented.provider_type_nextcloud?
+    end
 
     def storage_projects(storage)
       storage.projects.merge(Project.allowed_to(current_user, :manage_file_links))

--- a/modules/storages/lib/open_project/storages/append_storages_hosts_to_csp_hook.rb
+++ b/modules/storages/lib/open_project/storages/append_storages_hosts_to_csp_hook.rb
@@ -46,9 +46,9 @@ class ::OpenProject::Storages::AppendStoragesHostsToCspHook < OpenProject::Hook:
     controller = context[:controller]
 
     active_nextcloud_storages_hosts = ::Storages::NextcloudStorage
-      .where(id: ::Storages::ProjectStorage.select(:storage_id))
-      .pluck(:host)
-      .map(&method(:remove_uri_path))
+                                        .where(id: ::Storages::ProjectStorage.select(:storage_id))
+                                        .pluck(:host)
+                                        .map(&method(:remove_uri_path))
 
     if active_nextcloud_storages_hosts.present?
       controller.append_content_security_policy_directives(
@@ -60,9 +60,10 @@ class ::OpenProject::Storages::AppendStoragesHostsToCspHook < OpenProject::Hook:
       project_id: Project.allowed_to(User.current, :manage_file_links)
     ).select(:storage_id)
     storages_hosts = ::Storages::Storage
-      .where(id: storage_ids)
-      .pluck(:host)
-      .map(&method(:remove_uri_path))
+                       .where(id: storage_ids)
+                       .where.not(host: nil)
+                       .pluck(:host)
+                       .map(&method(:remove_uri_path))
 
     if storages_hosts.present?
       # secure_headers gem provides this helper method to append to the current content security policy


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/49112/activity

This PR implements to parts that are needed to login to Azure for gaining access to the OneDrive/SharePoint API.

What was done?

- Storage representer no longer returns an oauth application for a OneDrive storage
- Adding a OneDrive storage to a project now skips the `project folder` configuration, as it's not available for OneDrive
- `folder_mode` is set to `inactive` on default for OneDrive storages
- CSP configuration filters out OneDrive as they have not `host`