### PR TITLE
Add unit test to ensure every permission has an english translation

### DIFF
--- a/spec/permissions/translations_spec.rb
+++ b/spec/permissions/translations_spec.rb
@@ -1,0 +1,42 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Permissions', 'I18n' do
+  subject(:permissions) do
+    OpenProject::AccessControl.instance_variable_get(:@mapped_permissions)
+  end
+
+  it 'has an english translation for every permission', :aggregate_failures do
+    permissions.each do |permission|
+      expect(I18n.exists?("permission_#{permission.name}", :en))
+        .to be(true), "English translation for #{permission.name} is missing"
+    end
+  end
+end


### PR DESCRIPTION
## Notes
* Uses `@mapped_permissions` as the source of permissions since `.permissions` only includes permissions that are currently enabled and we don't want to leave any out.

* Raises a helpful error message for the developer running the spec.

## Fabricated failure Demo

```
Failures:

  1) Permissions I18n has an english translation for every permission
     Got 2 failures:

     1.1) Failure/Error:
            expect(I18n.exists?("permission_#{permission.name}", :en))
              .to be(true), "English translation for #{permission.name} is missing"

            English translation for search_project is missing
          # ./spec/permissions/translations_spec.rb:38:in `block (3 levels) in <top (required)>'
          # ./spec/permissions/translations_spec.rb:37:in `each'
          # ./spec/permissions/translations_spec.rb:37:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'

     1.2) Failure/Error:
            expect(I18n.exists?("permission_#{permission.name}", :en))
              .to be(true), "English translation for #{permission.name} is missing"

            English translation for save_queries is missing
          # ./spec/permissions/translations_spec.rb:38:in `block (3 levels) in <top (required)>'
          # ./spec/permissions/translations_spec.rb:37:in `each'
          # ./spec/permissions/translations_spec.rb:37:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'
```