### PR TITLE
[#49989] Harmonize casing/pluralization of global permissions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2191,7 +2191,7 @@ en:
     zero: "no projects"
   label_yesterday: "yesterday"
   label_role_type: "Type"
-  label_member_role: "Project Role"
+  label_member_role: "Project role"
   label_global_role: "Global role"
   label_not_changeable: "(not changeable)"
   label_global: "Global"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2437,7 +2437,7 @@ en:
   permission_add_work_package_notes: "Add notes"
   permission_add_work_packages: "Add work packages"
   permission_add_messages: "Post messages"
-  permission_add_project: "Create project"
+  permission_add_project: "Create projects"
   permission_archive_project: "Archive project"
   permission_create_user: "Create users"
   permission_manage_user: "Edit users"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2450,7 +2450,7 @@ en:
   permission_comment_news: "Comment news"
   permission_commit_access: "Read/write access to repository (commit)"
   permission_copy_projects: "Copy projects"
-  permission_create_backup: "Create backup"
+  permission_create_backup: "Create backups"
   permission_delete_work_package_watchers: "Delete watchers"
   permission_delete_work_packages: "Delete work packages"
   permission_delete_messages: "Delete messages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2192,7 +2192,7 @@ en:
   label_yesterday: "yesterday"
   label_role_type: "Type"
   label_member_role: "Project Role"
-  label_global_role: "Global Role"
+  label_global_role: "Global role"
   label_not_changeable: "(not changeable)"
   label_global: "Global"
   label_seeded_from_env_warning: This record has been created through a setting / environment variable. It is not editable through UI.

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -461,7 +461,7 @@ en:
     label_filename: "File"
     label_filesize: "Size"
     label_general: "General"
-    label_global_roles: "Global Roles"
+    label_global_roles: "Global roles"
     label_greater_or_equal: ">="
     label_group: 'Group'
     label_group_by: "Group by"

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -31,18 +31,17 @@ require 'spec_helper'
 RSpec.describe 'Global role: Global Create project',
                js: true,
                with_cuprite: true do
-  let(:user) { create(:admin) }
-  let(:project) { create(:project) }
-
-  before do
-    login_as user
-  end
+  shared_let(:admin) { create(:admin) }
+  shared_let(:user) { create(:user) }
+  shared_let(:project) { create(:project) }
 
   describe 'Create project is not a member permission' do
     # Given there is a role "Member"
     let!(:role) { create(:role, name: 'Member') }
 
     # And I am already admin
+    current_user { admin }
+
     # When I go to the edit page of the role "Member"
     # Then I should not see "Create project"
     it 'does not show the global permission' do
@@ -55,7 +54,10 @@ RSpec.describe 'Global role: Global Create project',
   describe 'Create project is a global permission' do
     # Given there is a global role "Global"
     let!(:role) { create(:global_role, name: 'Global') }
+
     # And I am already admin
+    current_user { admin }
+
     # When I go to the edit page of the role "Global"
     # Then I should see "Create project"
 
@@ -70,7 +72,6 @@ RSpec.describe 'Global role: Global Create project',
     let!(:global_role) { create(:global_role, name: 'Global', permissions: %i[add_project]) }
     let!(:member_role) { create(:role, name: 'Member', permissions: %i[view_project]) }
 
-    let(:user) { create(:user) }
     let!(:global_member) do
       create(:global_member,
              principal: user,
@@ -78,6 +79,8 @@ RSpec.describe 'Global role: Global Create project',
     end
 
     let(:name_field) { FormFields::InputFormField.new :name }
+
+    current_user { user }
 
     it 'does show the global permission' do
       visit projects_path
@@ -100,7 +103,8 @@ RSpec.describe 'Global role: Global Create project',
     # | Firstname | Bob |
     # | Lastname | Bobbit |
     #   When I am already logged in as "bob"
-    let(:user) { create(:user) }
+
+    current_user { user }
 
     it 'does show the global permission' do
       # And I go to the overall projects page

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Global role: Global Create project',
     login_as user
   end
 
-  describe 'Create Project is not a member permission' do
+  describe 'Create project is not a member permission' do
     # Given there is a role "Member"
     let!(:role) { create(:role, name: 'Member') }
 
@@ -52,7 +52,7 @@ RSpec.describe 'Global role: Global Create project',
     end
   end
 
-  describe 'Create Project is a global permission' do
+  describe 'Create project is a global permission' do
     # Given there is a global role "Global"
     let!(:role) { create(:global_role, name: 'Global') }
     # And I am already admin
@@ -66,7 +66,7 @@ RSpec.describe 'Global role: Global Create project',
     end
   end
 
-  describe 'Create Project displayed to user' do
+  describe 'Create project displayed to user' do
     let!(:global_role) { create(:global_role, name: 'Global', permissions: %i[add_project]) }
     let!(:member_role) { create(:role, name: 'Member', permissions: %i[view_project]) }
 
@@ -94,7 +94,7 @@ RSpec.describe 'Global role: Global Create project',
     end
   end
 
-  describe 'Create Project not displayed to user without global role' do
+  describe 'Create project not displayed to user without global role' do
     # Given there is 1 User with:
     # | Login | bob |
     # | Firstname | Bob |

--- a/spec/features/global_roles/global_role_assignment_spec.rb
+++ b/spec/features/global_roles/global_role_assignment_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Global role: Global role assignment',
 
     it 'allows global roles management' do
       visit edit_user_path user
-      click_link 'Global Roles'
+      click_link 'Global roles'
 
       page.within('#table_principal_roles') do
         expect(page).to have_text 'global_role1'

--- a/spec/features/global_roles/global_role_crud_spec.rb
+++ b/spec/features/global_roles/global_role_crud_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'Global role: Global role CRUD',
     visit new_role_path
     # Then I should not see block with "#global_permissions"
     expect(page).not_to have_selector('.form--fieldset-legend', text: 'GLOBAL')
-    # When I check "Global Role"
-    check 'Global Role'
+    # When I check "Global role"
+    check 'Global role'
     # Then I should see block with "#global_permissions"
     expect(page).to have_selector('.form--fieldset-legend', text: 'GLOBAL')
     # And I should see "Global group"


### PR DESCRIPTION
## Description
* Harmonizes casing of Role type labels to "Global role" and "Project role"
* Harmonizes pluralization of global permissions

## Notes
See: https://community.openproject.org/work_packages/49989