### PR TITLE
Enable "Nate Heckler" mode when using Factory Profiler tool 🔬

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ require 'shoulda/matchers'
 require 'test_prof/recipes/rspec/before_all'
 require 'test_prof/recipes/rspec/let_it_be'
 require "test_prof/recipes/rspec/factory_default"
+# Encourages fixing factories as soon as possible
+require "test_prof/factory_prof/nate_heckler"
 
 # Add PaperTrail integration so that it is disabled by default
 # https://github.com/paper-trail-gem/paper_trail#7b-rspec


### PR DESCRIPTION
By requiring `nate_heckler` as a test-prof dependency in our `rails_helper`, when using the Factory Profiler tool, we'll get how much time is spent in factory creation as a percentage of the total time in the suite.

https://test-prof.evilmartians.io/#/profilers/factory_prof

I've been personally using this in a custom spec_helper file for my local development and want to add it to the core repo as anyone actively using Factory Profiler would benefit from it.

I'd also soon like to add some of Test Prof's Profilers to our CI and keep a running tab on bottlenecks in our test suite, but that's for another time/PR :)