### PR TITLE
[49781] Allow trial creation in development mode

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -420,7 +420,7 @@ module Settings
       # Allow connections for trial creation and booking
       enterprise_trial_creation_host: {
         description: 'Host for EE trial service',
-        default: 'https://augur.openproject.com',
+        default: 'https://start.openproject.com',
         writable: false
       },
       enterprise_chargebee_site: {

--- a/lib_static/open_project/configuration/helpers.rb
+++ b/lib_static/open_project/configuration/helpers.rb
@@ -78,7 +78,7 @@ module OpenProject
         if Rails.env.production?
           self['enterprise_trial_creation_host']
         else
-          'https://augur.openproject-edge.com'
+          'https://start.openproject-edge.com'
         end
       end
 

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe 'Enterprise trial management',
         {
           self:
             {
-              href: "https://augur.openproject-edge.com/public/v1/trials/#{trial_id}"
+              href: "https://start.openproject-edge.com/public/v1/trials/#{trial_id}"
             },
           details:
             {
-              href: "https://augur.openproject-edge.com/public/v1/trials/#{trial_id}/details"
+              href: "https://start.openproject-edge.com/public/v1/trials/#{trial_id}/details"
             }
         }
     }
@@ -59,11 +59,11 @@ RSpec.describe 'Enterprise trial management',
       description: "User has to confirm their email address",
       _links: {
         resend: {
-          href: "https://augur.openproject-edge.com/public/v1/trials/#{trial_id}/resend",
+          href: "https://start.openproject-edge.com/public/v1/trials/#{trial_id}/resend",
           method: "POST"
         },
         details: {
-          href: "https://augur.openproject-edge.com/public/v1/trials/#{trial_id}/details"
+          href: "https://start.openproject-edge.com/public/v1/trials/#{trial_id}/details"
         }
       }
     }
@@ -122,7 +122,7 @@ RSpec.describe 'Enterprise trial management',
       token_retrieved: false,
       _links: {
         self: {
-          href: "https://augur.openproject-edge.com/public/v1/trials/#{trial_id}"
+          href: "https://start.openproject-edge.com/public/v1/trials/#{trial_id}"
         }
       }
     }
@@ -175,7 +175,7 @@ RSpec.describe 'Enterprise trial management',
   end
 
   it 'blocks the request assuming the mail was used' do
-    proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
+    proxy.stub('https://start.openproject-edge.com:443/public/v1/trials', method: 'post')
       .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: mail_in_use_body.to_json)
 
     find('.button', text: 'Start free trial').click
@@ -188,7 +188,7 @@ RSpec.describe 'Enterprise trial management',
   end
 
   it 'blocks the request assuming the domain was used' do
-    proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
+    proxy.stub('https://start.openproject-edge.com:443/public/v1/trials', method: 'post')
       .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: domain_in_use_body.to_json)
 
     find('.button', text: 'Start free trial').click
@@ -201,7 +201,7 @@ RSpec.describe 'Enterprise trial management',
   end
 
   it 'shows an error in case of other errors' do
-    proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
+    proxy.stub('https://start.openproject-edge.com:443/public/v1/trials', method: 'post')
       .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 409, body: other_error_body.to_json)
 
     find('.button', text: 'Start free trial').click
@@ -214,13 +214,13 @@ RSpec.describe 'Enterprise trial management',
 
   context 'with a waiting request pending' do
     before do
-      proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
+      proxy.stub('https://start.openproject-edge.com:443/public/v1/trials', method: 'post')
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: created_body.to_json)
 
-      proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
+      proxy.stub("https://start.openproject-edge.com:443/public/v1/trials/#{trial_id}")
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: waiting_body.to_json)
 
-      proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}/resend", method: 'post')
+      proxy.stub("https://start.openproject-edge.com:443/public/v1/trials/#{trial_id}/resend", method: 'post')
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: waiting_body.to_json)
 
       find('.button', text: 'Start free trial').click
@@ -238,11 +238,11 @@ RSpec.describe 'Enterprise trial management',
       # Stub with successful body
       # Stub the proxy to a successful return
       # which marks the user has confirmed the mail link
-      proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
+      proxy.stub("https://start.openproject-edge.com:443/public/v1/trials/#{trial_id}")
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: confirmed_body.to_json)
 
       # Stub the details URL to still return 403
-      proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}/details")
+      proxy.stub("https://start.openproject-edge.com:443/public/v1/trials/#{trial_id}/details")
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 403)
 
       visit enterprise_path
@@ -264,7 +264,7 @@ RSpec.describe 'Enterprise trial management',
 
       # Stub the proxy to a successful return
       # which marks the user has confirmed the mail link
-      proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
+      proxy.stub("https://start.openproject-edge.com:443/public/v1/trials/#{trial_id}")
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: confirmed_body.to_json)
 
       # Wait until the next request


### PR DESCRIPTION
The augur URL has changed. This PR fixes that for the development environment. However, for production the `enterprise_trial_creation_host` has to be changed. Further, augur needs to be configured to allow get requests to collect the current information about a token (such as subscriber or company). Otherwise the overview page of the trial remains empty.

https://community.openproject.org/projects/openproject/work_packages/49781/activity