### PR TITLE
Fix flickering test

### DIFF
--- a/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
@@ -224,6 +224,7 @@ class Storages::GroupFolderPropertiesSyncService
                      .where(oauth_client: @storage.oauth_client)
                      .where.not(id: @admin_tokens_query)
                      .includes(:user)
+                     .order(:id)
     # The user scope is required in all cases except one:
     #   when the project is public and non member has at least one storage permission
     #   then all non memebers should have access to the project folder


### PR DESCRIPTION
When committing 8c7e03931e, I had an unrelated test failure in `modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb:735`. It appears to be a flickering one. This PR fixes it

the test could fail because the order of the users returned by database is not deterministic, making the expected ACL list order incorrect. In the failing test:
* The ACL request sent is "group:OpenProject, user:OpenProject, user:Darth Vader, user:Yoda, user:Obi-Wan"
* The ACL request stubbed is "group:OpenProject, user:OpenProject, user:Darth Vader, user:Obi-Wan, user:Yoda"

By sorting by id, the order is assured to be deterministic.

Here is the output of the failed test:

<details><summary>Test failure output</summary>
<p>

```
  1) Storages::GroupFolderPropertiesSyncService#call when remove_user_from_group_command fails unexpectedly sets project folders properties, but does not remove inactive user from group
     Failure/Error: described_class.new(storage).call
     
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: PROPPATCH https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(172) with body '<?xml version="1.0"?>
       <d:propertyupdate xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
         <d:set>
           <d:prop>
             <nc:acl-list>
               <nc:acl>
                 <nc:acl-mapping-type>group</nc:acl-mapping-type>
                 <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>
                 <nc:acl-mask>31</nc:acl-mask>
                 <nc:acl-permissions>0</nc:acl-permissions>
               </nc:acl>
               <nc:acl>
                 <nc:acl-mapping-type>user</nc:acl-mapping-type>
                 <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>
                 <nc:acl-mask>31</nc:acl-mask>
                 <nc:acl-permissions>31</nc:acl-permissions>
               </nc:acl>
               <nc:acl>
                 <nc:acl-mapping-type>user</nc:acl-mapping-type>
                 <nc:acl-mapping-id>Darth Vader</nc:acl-mapping-id>
                 <nc:acl-mask>31</nc:acl-mask>
                 <nc:acl-permissions>31</nc:acl-permissions>
               </nc:acl>
               <nc:acl>
                 <nc:acl-mapping-type>user</nc:acl-mapping-type>
                 <nc:acl-mapping-id>Yoda</nc:acl-mapping-id>
                 <nc:acl-mask>31</nc:acl-mask>
                 <nc:acl-permissions>3</nc:acl-permissions>
               </nc:acl>
               <nc:acl>
                 <nc:acl-mapping-type>user</nc:acl-mapping-type>
                 <nc:acl-mapping-id>Obi-Wan</nc:acl-mapping-id>
                 <nc:acl-mask>31</nc:acl-mask>
                 <nc:acl-permissions>3</nc:acl-permissions>
               </nc:acl>
             </nc:acl-list>
           </d:prop>
         </d:set>
       </d:propertyupdate>
       ' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=', 'User-Agent'=>'Ruby'}
     
       You can stub this request with the following snippet:
     
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(172)").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Darth Vader</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Yoda</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>3</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Obi-Wan</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>3</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Accept'=>'*/*',
       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'User-Agent'=>'Ruby'
           }).
         to_return(status: 200, body: "", headers: {})
     
       registered request stubs:
     
       stub_request(:delete, "https://host2.example.com/ocs/v1.php/cloud/users/Darth%20Maul/groups?groupid=OpenProject").
         with(
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Ocs-Apirequest'=>'true'
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20(175)").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Darth Vader</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Obi-Wan</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>1</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Yoda</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>1</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/NOT%20ACTIVE%20PROJECT").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/Jedi%20Project%20Folder%20%7C%7C%7C%20(173)").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Darth Vader</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Obi-Wan</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>3</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%232").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:move, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%233").
         with(
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Destination'=>'/remote.php/dav/files/OpenProject/OpenProject/Jedi%20Project%20Folder%20%7C%7C%7C%20%28173%29'
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(172)").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>0</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Darth Vader</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Obi-Wan</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>3</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>Yoda</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>3</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:post, "https://host2.example.com/ocs/v1.php/cloud/users/Darth%20Vader/groups").
         with(
           body: "groupid=OpenProject",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Ocs-Apirequest'=>'true'
           })
       stub_request(:post, "https://host2.example.com/ocs/v1.php/cloud/users/Yoda/groups").
         with(
           body: "groupid=OpenProject",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Ocs-Apirequest'=>'true'
           })
       stub_request(:post, "https://host2.example.com/ocs/v1.php/cloud/users/Obi-Wan/groups").
         with(
           body: "groupid=OpenProject",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Ocs-Apirequest'=>'true'
           })
       stub_request(:propfind, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(172)").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propfind xmlns:d=\"DAV:\" xmlns:oc=\"http://owncloud.org/ns\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:prop>\n    <oc:fileid/>\n  </d:prop>\n</d:propfind>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Depth'=>'1'
           })
       stub_request(:mkcol, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject/%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(172)").
         with(
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:propfind, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propfind xmlns:d=\"DAV:\" xmlns:oc=\"http://owncloud.org/ns\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:prop>\n    <oc:fileid/>\n  </d:prop>\n</d:propfind>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Depth'=>'1'
           })
       stub_request(:proppatch, "https://host2.example.com/remote.php/dav/files/OpenProject/OpenProject").
         with(
           body: "<?xml version=\"1.0\"?>\n<d:propertyupdate xmlns:d=\"DAV:\" xmlns:nc=\"http://nextcloud.org/ns\">\n  <d:set>\n    <d:prop>\n      <nc:acl-list>\n        <nc:acl>\n          <nc:acl-mapping-type>group</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>1</nc:acl-permissions>\n        </nc:acl>\n        <nc:acl>\n          <nc:acl-mapping-type>user</nc:acl-mapping-type>\n          <nc:acl-mapping-id>OpenProject</nc:acl-mapping-id>\n          <nc:acl-mask>31</nc:acl-mask>\n          <nc:acl-permissions>31</nc:acl-permissions>\n        </nc:acl>\n      </nc:acl-list>\n    </d:prop>\n  </d:set>\n</d:propertyupdate>\n",
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
           })
       stub_request(:get, "https://host2.example.com/ocs/v1.php/cloud/groups/OpenProject").
         with(
           headers: {
       	  'Authorization'=>'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
       	  'Ocs-Apirequest'=>'true'
           })
     
       ============================================================
     # ./modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb:80:in `call'
     # ./modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb:40:in `call'
     # ./modules/storages/app/services/storages/group_folder_properties_sync_service.rb:185:in `set_project_folder_permissions'
     # ./modules/storages/app/services/storages/group_folder_properties_sync_service.rb:76:in `block in call'
     # ./modules/storages/app/services/storages/group_folder_properties_sync_service.rb:71:in `call'
     # ./modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb:740:in `block (4 levels) in <top (required)>'
     # ./spec/support/webmock.rb:49:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'

```

</p>
</details> 