### PR TITLE
[50020] Remove db string length constraint on news_journals.title

### DIFF
--- a/db/migrate/20230911093530_remove_news_journals_title_length_constraint.rb
+++ b/db/migrate/20230911093530_remove_news_journals_title_length_constraint.rb
@@ -1,0 +1,9 @@
+class RemoveNewsJournalsTitleLengthConstraint < ActiveRecord::Migration[7.0]
+  def up
+    change_column(:news_journals, :title, :string, limit: nil)
+  end
+
+  def down
+    change_column(:news_journals, :title, :string, limit: 60)
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/50020

It is a leftover from 0c2b7ce. The length constraint on title field was removed for `news` table, but not for `news_journals`.