### PR TITLE
fix(lookbook): remove closing collapsible-section wrapper tag

### DIFF
--- a/lookbook/previews/collapsible_section_preview/default.html.erb
+++ b/lookbook/previews/collapsible_section_preview/default.html.erb
@@ -11,4 +11,3 @@
 <div class="collapsible-section-augment--body" hidden>
   <p><strong>Initially closed</strong></p>
 </div>
-</collapsible-section>


### PR DESCRIPTION
In the lookbook preview there is a `</collapsible-section>` without an opening tag. 
This PR removes the seemingly not used & not necessary wrapper closing tag.