### PR TITLE
Fix/improve project allowed to scope performance

### DIFF
--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -50,9 +50,14 @@ class PlaceholderUsersController < ApplicationController
   end
 
   def show
-    # show projects based on current user visibility
-    @memberships = @placeholder_user.memberships
-      .visible(current_user)
+    # show projects based on current user visibility.
+    # But don't simply concatenate the .visible scope to the memberships
+    # as .memberships has an include and an order which for whatever reason
+    # also gets applied to the Project.allowed_to parts concatenated by a UNION
+    # and an order inside a UNION is not allowed in postgres.
+    @memberships = @placeholder_user
+                     .memberships
+                     .where(id: Member.visible(current_user))
 
     respond_to do |format|
       format.html { render layout: 'no_menu' }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,10 +65,14 @@ class UsersController < ApplicationController
   end
 
   def show
-    # show projects based on current user visibility
+    # show projects based on current user visibility.
+    # But don't simply concatenate the .visible scope to the memberships
+    # as .memberships has an include and an order which for whatever reason
+    # also gets applied to the Project.allowed_to parts concatenated by a UNION
+    # and an order inside a UNION is not allowed in postgres.
     @memberships = @user.memberships
                         .where.not(project_id: nil)
-                        .visible(current_user)
+                        .where(id: Member.visible(current_user))
 
     if can_show_user?
       @events = events

--- a/app/models/members/scopes/visible.rb
+++ b/app/models/members/scopes/visible.rb
@@ -43,16 +43,16 @@ module Members::Scopes
       private
 
       def visible_for_non_admins(user)
-        view_members = Project.where(id: Project.allowed_to(user, :view_members))
-        manage_members = Project.where(id: Project.allowed_to(user, :manage_members))
+        view_members = Project.allowed_to(user, :view_members)
+        manage_members = Project.allowed_to(user, :manage_members)
 
         project_scope = view_members.or(manage_members)
 
-        Member.where(project_id: project_scope.select(:id))
+        where(project_id: project_scope.select(:id))
       end
 
       def visible_for_admins
-        Member.all
+        all
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -150,6 +150,9 @@ class Project < ApplicationRecord
 
   friendly_id :identifier, use: :finders
 
+  include ::Scopes::Scoped
+  scopes :allowed_to
+
   scope :has_module, ->(mod) {
     where(["#{Project.table_name}.id IN (SELECT em.project_id FROM #{EnabledModule.table_name} em WHERE em.name=?)", mod.to_s])
   }
@@ -206,12 +209,6 @@ class Project < ApplicationRecord
   # role's permissions.
   def self.visible_by(user = User.current)
     allowed_to(user, :view_project)
-  end
-
-  # Returns a ActiveRecord::Relation to find all projects for which
-  # +user+ has the given +permission+
-  def self.allowed_to(user, permission)
-    Authorization.projects(permission, user)
   end
 
   # Returns a :conditions SQL string that can be used to find the issues associated with this project.

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -1,0 +1,140 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects::Scopes
+  module AllowedTo
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns a ActiveRecord::Relation to find all projects for which
+      # +user+ has the given +permission+
+      def allowed_to(user, permission)
+        permissions = if permission.is_a?(Hash)
+                        OpenProject::AccessControl.allow_actions(permission)
+                      else
+                        [OpenProject::AccessControl.permission(permission)].compact
+                      end
+
+        if user.admin?
+          Project
+            .joins(:enabled_modules)
+            .where(active: true)
+            .where(enabled_modules: { name: permissions.map(&:project_module).compact.uniq })
+        elsif user.anonymous?
+          Project.find_by_sql(allowed_to_non_member_sql(user, permissions))
+        else
+          Project.find_by_sql("#{allowed_to_member_sql(user, permissions)} UNION #{allowed_to_non_member_sql(user, permissions)}")
+        end
+      end
+
+      private
+
+      def allowed_to_non_member_sql(user, permissions)
+        sql = <<~SQL.squish
+          SELECT "projects".*
+          FROM "projects"
+          #{allowed_to_enabled_module_join(permissions)}
+          INNER JOIN "roles"
+              ON "roles"."builtin" IN (#{Role::BUILTIN_ANONYMOUS}, #{Role::BUILTIN_NON_MEMBER})
+              AND "projects"."active" = TRUE
+              AND "projects"."public" = TRUE
+              AND NOT EXISTS (SELECT 1
+                              FROM members
+                              WHERE members.project_id = projects.id
+                              AND members.user_id = :user_id
+                              AND members.entity_type IS NULL
+                              AND members.entity_id IS NULL
+                              LIMIT 1)
+          #{allowed_to_role_permission_join(permissions)}
+        SQL
+
+        OpenProject::SqlSanitization.sanitize(sql,
+                                              user_id: user.id,
+                                              permission: permissions.map(&:name))
+      end
+
+      def allowed_to_member_sql(user, permissions)
+        sql = <<~SQL.squish
+          SELECT "projects".*
+          FROM "projects"
+          #{allowed_to_enabled_module_join(permissions)}
+          LEFT OUTER JOIN "members"
+              ON "projects"."id" = "members"."project_id"
+              AND "members"."user_id" = :user_id
+              AND "members"."entity_type" IS NULL
+              AND "members"."entity_id" IS NULL
+              AND "projects"."active" = TRUE
+          LEFT OUTER JOIN "member_roles"
+              ON "members"."id" = "member_roles"."member_id"
+          LEFT OUTER JOIN "roles"
+              ON "projects"."active" = TRUE
+              AND ("roles"."id" = "member_roles"."role_id" OR
+                  ("projects"."public" = TRUE AND "roles"."builtin" = #{Role::BUILTIN_NON_MEMBER} AND "roles"."id" IS NULL))
+          #{allowed_to_role_permission_join(permissions)}
+          WHERE "roles"."id" IS NOT NULL
+        SQL
+
+        OpenProject::SqlSanitization.sanitize(sql,
+                                              user_id: user.id,
+                                              permission: permissions.map(&:name))
+      end
+
+      def allowed_to_enabled_module_join(permissions)
+        project_module = permissions.map(&:project_module).compact.uniq
+
+        if project_module.any?
+          sql = <<~SQL.squish
+            INNER JOIN "enabled_modules"
+              ON "projects"."id" = "enabled_modules"."project_id"
+              AND "enabled_modules"."name" IN (:enabled_module_names)
+              AND "projects"."active" = TRUE
+          SQL
+
+          OpenProject::SqlSanitization.sanitize(sql,
+                                                enabled_module_names: project_module)
+        end
+      end
+
+      def allowed_to_role_permission_join(permissions)
+        return if permissions.all?(&:public?)
+
+        condition = permissions.map do |permission|
+          <<~SQL.squish
+            (enabled_modules.name = '#{permission.project_module}' AND "role_permissions"."permission" = '#{permission.name}')
+          SQL
+        end.join(' OR ')
+
+        <<~SQL.squish
+          JOIN "role_permissions"
+              ON roles.id = role_permissions.role_id
+              AND (#{condition})
+        SQL
+      end
+    end
+  end
+end

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -41,9 +41,9 @@ module Projects::Scopes
         elsif user.anonymous?
           where(id: allowed_to_non_member_relation(user, permissions))
         else
-          where(arel_table[:id].in(allowed_to_member_relation(user, permissions).arel.union(
-                                     allowed_to_non_member_relation(user, permissions).arel
-                                   )))
+          where(arel_table[:id].in(allowed_to_member_relation(user, permissions)
+                                     .arel
+                                     .union(:all, allowed_to_non_member_relation(user, permissions).arel)))
         end
       end
 
@@ -55,41 +55,15 @@ module Projects::Scopes
       end
 
       def allowed_to_non_member_relation(user, permissions)
-        builtin = if user.logged?
-                    Role::BUILTIN_NON_MEMBER
-                  else
-                    Role::BUILTIN_ANONYMOUS
-                  end
-
-        member_permission = if user.logged?
-                              <<~SQL.squish
-                                AND NOT EXISTS (SELECT 1
-                                                FROM members
-                                                WHERE #{allowed_to_members_condition(user)})
-                              SQL
-                            end
-
         joins(allowed_to_enabled_module_join(permissions))
-          .joins(<<~SQL.squish
-            INNER JOIN "roles"
-              ON "roles"."builtin" = #{builtin}
-              AND "projects"."active" = TRUE
-              AND "projects"."public" = TRUE
-              #{member_permission}
-          SQL
-                )
+          .joins(allowed_to_builtin_roles_in_active_project_join(user))
           .joins(allowed_to_role_permission_join(permissions))
           .select(:id)
       end
 
       def allowed_to_member_relation(user, permissions)
         Member
-          .joins(<<~SQL.squish
-            JOIN "projects"
-              ON "projects"."active" = TRUE
-              AND #{allowed_to_members_condition(user)}
-          SQL
-                )
+          .joins(allowed_to_member_in_active_project_join(user))
           .joins(allowed_to_enabled_module_join(permissions))
           .joins(:roles, :member_roles)
           .joins(allowed_to_role_permission_join(permissions))
@@ -98,40 +72,39 @@ module Projects::Scopes
 
       def allowed_to_enabled_module_join(permissions)
         project_module = permissions.filter_map(&:project_module).uniq
+        enabled_module_table = EnabledModule.arel_table
 
         if project_module.any?
-          sql = <<~SQL.squish
-            INNER JOIN "enabled_modules"
-              ON "projects"."id" = "enabled_modules"."project_id"
-              AND "enabled_modules"."name" IN (:enabled_module_names)
-              AND "projects"."active" = TRUE
-          SQL
-
-          OpenProject::SqlSanitization.sanitize(sql,
-                                                enabled_module_names: project_module)
+          arel_table.join(enabled_module_table, Arel::Nodes::InnerJoin)
+                    .on(arel_table[:id].eq(enabled_module_table[:project_id])
+                          .and(enabled_module_table[:name].in(project_module))
+                          .and(arel_table[:active].eq(true)))
+                    .join_sources
         end
       end
 
       def allowed_to_role_permission_join(permissions)
         return if permissions.all?(&:public?)
 
-        condition = permissions.map do |permission|
-          if permission.public?
-            <<~SQL.squish
-              "role_permissions"."permission" = '#{permission.name}'
-            SQL
-          else
-            <<~SQL.squish
-              (enabled_modules.name = '#{permission.project_module}' AND "role_permissions"."permission" = '#{permission.name}')
-            SQL
-          end
-        end.join(' OR ')
+        role_permissions_table = RolePermission.arel_table
+        enabled_modules_table = EnabledModule.arel_table
+        roles_table = Role.arel_table
 
-        <<~SQL.squish
-          JOIN "role_permissions"
-            ON roles.id = role_permissions.role_id
-            AND (#{condition})
-        SQL
+        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
+          permission_condition = role_permissions_table[:permission].eq(permission.name)
+
+          unless permission.public?
+            permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
+          end
+
+          or_condition.or(permission_condition)
+        end
+
+        arel_table
+          .join(role_permissions_table, Arel::Nodes::InnerJoin)
+          .on(roles_table[:id].eq(role_permissions_table[:role_id])
+                              .and(condition))
+          .join_sources
       end
 
       def allowed_to_permissions(permission)
@@ -143,12 +116,56 @@ module Projects::Scopes
       end
 
       def allowed_to_members_condition(user)
-        <<~SQL.squish
-          members.project_id = projects.id
-          AND members.user_id = #{user.id}
-          AND members.entity_type IS NULL
-          AND members.entity_id IS NULL
-        SQL
+        members_table = Member.arel_table
+
+        members_table[:project_id].eq(arel_table[:id])
+                                  .and(members_table[:user_id].eq(user.id))
+                                  .and(members_table[:entity_type].eq(nil))
+                                  .and(members_table[:entity_id].eq(nil))
+      end
+
+      def allowed_to_builtin_roles_in_active_project_join(user)
+        condition = allowed_to_built_roles_in_active_project_condition(user)
+
+        if user.logged?
+          condition = condition.and(allowed_to_no_member_exists_condition(user))
+        end
+
+        roles_table = Role.arel_table
+
+        arel_table.join(roles_table)
+                  .on(condition)
+                  .join_sources
+      end
+
+      def allowed_to_member_in_active_project_join(user)
+        arel_table.join(arel_table)
+                  .on(arel_table[:active].eq(true)
+                                         .and(allowed_to_members_condition(user)))
+                  .join_sources
+      end
+
+      def allowed_to_built_roles_in_active_project_condition(user)
+        builtin = if user.logged?
+                    Role::BUILTIN_NON_MEMBER
+                  else
+                    Role::BUILTIN_ANONYMOUS
+                  end
+
+        roles_table = Role.arel_table
+
+        roles_table[:builtin].eq(builtin)
+                             .and(arel_table[:active])
+                             .and(arel_table[:public])
+      end
+
+      def allowed_to_no_member_exists_condition(user)
+        Member
+          .select(1)
+          .where(allowed_to_members_condition(user))
+          .arel
+          .exists
+          .not
       end
     end
   end

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -36,7 +36,7 @@ module Projects::Scopes
       def allowed_to(user, permission)
         permissions = allowed_to_permissions(permission)
 
-        if user.admin?
+        if user.admin? && permissions.all?(&:grant_to_admin?)
           where(id: allowed_to_admin_relation(permissions))
         elsif user.anonymous?
           where(id: allowed_to_non_member_relation(user, permissions))

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -51,7 +51,7 @@ module Projects::Scopes
 
       def allowed_to_admin_relation(permissions)
         joins(allowed_to_enabled_module_join(permissions))
-          .where(active: true)
+          .where(arel_table[:active].eq(true))
       end
 
       def allowed_to_non_member_relation(user, permissions)
@@ -93,7 +93,7 @@ module Projects::Scopes
         condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
           permission_condition = role_permissions_table[:permission].eq(permission.name)
 
-          unless permission.public?
+          if permission.project_module.present?
             permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
           end
 

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -83,20 +83,18 @@ module Projects::Scopes
           SELECT "projects".*
           FROM "projects"
           #{allowed_to_enabled_module_join(permissions)}
-          LEFT OUTER JOIN "members"
+          JOIN "members"
               ON "projects"."id" = "members"."project_id"
               AND "members"."user_id" = :user_id
               AND "members"."entity_type" IS NULL
               AND "members"."entity_id" IS NULL
               AND "projects"."active" = TRUE
-          LEFT OUTER JOIN "member_roles"
+          JOIN "member_roles"
               ON "members"."id" = "member_roles"."member_id"
-          LEFT OUTER JOIN "roles"
+          JOIN "roles"
               ON "projects"."active" = TRUE
-              AND ("roles"."id" = "member_roles"."role_id" OR
-                  ("projects"."public" = TRUE AND "roles"."builtin" = #{Role::BUILTIN_NON_MEMBER} AND "roles"."id" IS NULL))
+              AND ("roles"."id" = "member_roles"."role_id")
           #{allowed_to_role_permission_join(permissions)}
-          WHERE "roles"."id" IS NOT NULL
         SQL
 
         OpenProject::SqlSanitization.sanitize(sql,

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -36,7 +36,7 @@ module Authorization
 
   # Returns all projects a user has a certain permission in
   def projects(action, user)
-    Authorization::ProjectQuery.query(user, action)
+    Project.allowed_to(action, user)
   end
 
   # Returns all roles a user has in a certain project, for a specific entity or globally

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   .new(@individual_principal.memberships.build, current_user)
   .assignable_projects
   .order(Arel.sql('lft')) %>
-<% memberships = @individual_principal.memberships.visible(current_user) %>
+<% memberships = @individual_principal.memberships.where(id: Member.visible(current_user)) %>
 
 <div class="grid-block">
   <div class="grid-content">

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe Project, 'allowed to' do
 
   shared_examples_for 'includes the project' do
     it 'includes the project' do
-      expect(Project.allowed_to(user, action)).to match_array [project]
+      expect(described_class.allowed_to(user, action)).to contain_exactly(project)
     end
   end
 
   shared_examples_for 'is empty' do
     it 'is empty' do
-      expect(Project.allowed_to(user, action)).to be_empty
+      expect(described_class.allowed_to(user, action)).to be_empty
     end
   end
 
@@ -88,8 +88,8 @@ RSpec.describe Project, 'allowed to' do
       user.save!
     end
 
-    context 'w/ the user being member
-             w/ the role having the permission' do
+    context 'with the user being member
+             with the role having the permission' do
       before do
         non_member_role.save!
         member.save!
@@ -98,9 +98,9 @@ RSpec.describe Project, 'allowed to' do
       it_behaves_like 'includes the project'
     end
 
-    context 'w/ the user being member
-             w/ the role having the permission
-             w/o the project being active' do
+    context 'with the user being member
+             with the role having the permission
+             without the project being active' do
       let(:project_status) { false }
 
       before do
@@ -110,8 +110,8 @@ RSpec.describe Project, 'allowed to' do
       it_behaves_like 'is empty'
     end
 
-    context 'w/ the user being member
-             w/o the role having the permission' do
+    context 'with the user being member
+             without the role having the permission' do
       let(:permissions) { [] }
 
       before do
@@ -121,14 +121,14 @@ RSpec.describe Project, 'allowed to' do
       it_behaves_like 'is empty'
     end
 
-    context 'w/o the user being member
-             w/ the role having the permission' do
+    context 'without the user being member
+             with the role having the permission' do
       it_behaves_like 'is empty'
     end
 
-    context 'w/ the user being member
-             w/ the role having the permission
-             w/o the associated module being active' do
+    context 'with the user being member
+             with the role having the permission
+             without the associated module being active' do
       before do
         member.save!
         project.enabled_modules = []
@@ -137,45 +137,45 @@ RSpec.describe Project, 'allowed to' do
       it_behaves_like 'is empty'
     end
 
-    context 'w/ the user being member
-             w/ the permission being public' do
+    context 'with the user being member
+             with the permission being public' do
       before do
         member.save!
       end
 
       it 'includes the project' do
-        expect(Project.allowed_to(user, public_action)).to match_array [project]
+        expect(described_class.allowed_to(user, public_action)).to contain_exactly(project)
       end
     end
 
-    context 'w/ the user being member
-             w/ the permission being public
-             w/o the associated module being active' do
+    context 'with the user being member
+             with the permission being public
+             without the associated module being active' do
       before do
         member.save!
         project.enabled_modules = []
       end
 
       it 'is empty' do
-        expect(Project.allowed_to(user, public_action)).to be_empty
+        expect(described_class.allowed_to(user, public_action)).to be_empty
       end
     end
 
-    context 'w/ the user being member
-             w/ the permission being public and not module bound
-             w/ no module bing active' do
+    context 'with the user being member
+             with the permission being public and not module bound
+             with no module bing active' do
       before do
         member.save!
         project.enabled_modules = []
       end
 
       it 'includes the project' do
-        expect(Project.allowed_to(user, public_non_module_action)).to match_array [project]
+        expect(described_class.allowed_to(user, public_non_module_action)).to contain_exactly(project)
       end
     end
   end
 
-  shared_examples_for 'w/ an admin user' do
+  shared_examples_for 'with an admin user' do
     let(:user) { admin }
 
     before do
@@ -183,26 +183,32 @@ RSpec.describe Project, 'allowed to' do
       user.save!
     end
 
-    context 'w/o the user being a member' do
+    context 'without the user being a member' do
       it_behaves_like 'includes the project'
     end
 
-    context 'w/o the project being active' do
+    context 'without the project being active' do
       let(:project_status) { false }
 
       it_behaves_like 'is empty'
     end
 
-    context 'w/o the project being active
-             w/ the permission being public' do
+    context 'without the project being active
+             with the permission being public' do
       let(:project_status) { false }
 
       it 'is empty' do
-        expect(Project.allowed_to(user, public_action)).to be_empty
+        expect(described_class.allowed_to(user, public_action)).to be_empty
       end
     end
 
-    context 'w/o the project module being active' do
+    context 'with the project being active with the permission being public' do
+      it 'includes the project' do
+        expect(described_class.allowed_to(user, public_action)).to contain_exactly(project)
+      end
+    end
+
+    context 'without the project module being active' do
       before do
         project.enabled_modules = []
       end
@@ -211,99 +217,99 @@ RSpec.describe Project, 'allowed to' do
     end
   end
 
-  context 'w/ the project being private' do
+  context 'with the project being private' do
     let(:project) { private_project }
 
     it_behaves_like 'member based allowed to check'
-    it_behaves_like 'w/ an admin user'
+    it_behaves_like 'with an admin user'
 
-    context 'w/ the user not being logged in' do
+    context 'with the user not being logged in' do
       before do
         project.save!
         anonymous.save!
         anonymous_role.save!
       end
 
-      context 'w/ the anonymous role having the permission' do
+      context 'with the anonymous role having the permission' do
         it 'is empty' do
-          expect(Project.allowed_to(anonymous, action)).to be_empty
+          expect(described_class.allowed_to(anonymous, action)).to be_empty
         end
       end
 
-      context 'w/ the permission being public' do
+      context 'with the permission being public' do
         it 'is empty' do
-          expect(Project.allowed_to(anonymous, public_action)).to be_empty
+          expect(described_class.allowed_to(anonymous, public_action)).to be_empty
         end
       end
     end
   end
 
-  context 'w/ the project being public' do
+  context 'with the project being public' do
     let(:project) { public_project }
 
     it_behaves_like 'member based allowed to check'
-    it_behaves_like 'w/ an admin user'
+    it_behaves_like 'with an admin user'
 
-    context 'w/ the user not being logged in' do
+    context 'with the user not being logged in' do
       before do
         project.save!
         anonymous.save!
         anonymous_role.save!
       end
 
-      context 'w/ the anonymous role having the permission' do
+      context 'with the anonymous role having the permission' do
         it 'includes the project' do
-          expect(Project.allowed_to(anonymous, action)).to match_array [project]
+          expect(described_class.allowed_to(anonymous, action)).to contain_exactly(project)
         end
       end
 
-      context 'w/ the anonymous role having the permission
-               w/o the project being active' do
+      context 'with the anonymous role having the permission
+               without the project being active' do
         let(:project_status) { false }
 
         it 'is empty' do
-          expect(Project.allowed_to(anonymous, action)).to be_empty
+          expect(described_class.allowed_to(anonymous, action)).to be_empty
         end
       end
 
-      context 'w/o the anonymous role having the permission' do
+      context 'without the anonymous role having the permission' do
         let(:anonymous_permissions) { [] }
 
         it 'is empty' do
-          expect(Project.allowed_to(anonymous, action)).to be_empty
+          expect(described_class.allowed_to(anonymous, action)).to be_empty
         end
       end
 
-      context 'w/ the permission being public' do
+      context 'with the permission being public' do
         it 'includes the project' do
-          expect(Project.allowed_to(anonymous, public_action)).to match_array [project]
+          expect(described_class.allowed_to(anonymous, public_action)).to contain_exactly(project)
         end
       end
 
-      context 'w/ the permission being public
-               w/ the associated module not being active' do
+      context 'with the permission being public
+               with the associated module not being active' do
         before do
           project.enabled_modules = []
         end
 
         it 'is empty' do
-          expect(Project.allowed_to(anonymous, public_action)).to be_empty
+          expect(described_class.allowed_to(anonymous, public_action)).to be_empty
         end
       end
 
-      context 'w/ the permission being public and not module bound
-               w/ no module being active' do
+      context 'with the permission being public and not module bound
+               with no module being active' do
         before do
           project.enabled_modules = []
         end
 
         it 'includes the project' do
-          expect(Project.allowed_to(anonymous, public_non_module_action)).to match_array [project]
+          expect(described_class.allowed_to(anonymous, public_non_module_action)).to contain_exactly(project)
         end
       end
     end
 
-    context 'w/ the user being member' do
+    context 'with the user being member' do
       before do
         project.save!
         user.save!
@@ -311,8 +317,8 @@ RSpec.describe Project, 'allowed to' do
         member.save!
       end
 
-      context 'w/ the role not having the permission
-               w/ non member having the permission' do
+      context 'with the role not having the permission
+               with non member having the permission' do
         let(:permissions) { [] }
         let(:non_member_permissions) { [action] }
 
@@ -320,64 +326,64 @@ RSpec.describe Project, 'allowed to' do
       end
     end
 
-    context 'w/o the user being member' do
+    context 'without the user being member' do
       before do
         project.save!
         user.save!
         non_member_role.save!
       end
 
-      context 'w/ the non member role having the permission' do
+      context 'with the non member role having the permission' do
         it_behaves_like 'includes the project'
       end
 
-      context 'w/ the non member role having the permission
-               w/o the project being active' do
+      context 'with the non member role having the permission
+               without the project being active' do
         let(:project_status) { false }
 
         it_behaves_like 'is empty'
       end
 
-      context 'w/ the permission being public and not module bound
-               w/o the project being active' do
+      context 'with the permission being public and not module bound
+               without the project being active' do
         let(:project_status) { false }
 
         it 'is empty' do
-          expect(Project.allowed_to(user, public_non_module_action)).to be_empty
+          expect(described_class.allowed_to(user, public_non_module_action)).to be_empty
         end
       end
 
-      context 'w/o the non member role having the permission' do
+      context 'without the non member role having the permission' do
         let(:non_member_permissions) { [] }
 
         it_behaves_like 'is empty'
       end
 
-      context 'w/ the permission being public' do
+      context 'with the permission being public' do
         it 'includes the project' do
-          expect(Project.allowed_to(user, public_action)).to match_array [project]
+          expect(described_class.allowed_to(user, public_action)).to contain_exactly(project)
         end
       end
 
-      context 'w/ the permission being public
-               w/ the module not being active' do
+      context 'with the permission being public
+               with the module not being active' do
         before do
           project.enabled_modules = []
         end
 
         it 'is empty' do
-          expect(Project.allowed_to(user, public_action)).to be_empty
+          expect(described_class.allowed_to(user, public_action)).to be_empty
         end
       end
 
-      context 'w/ the permission being public and not module bound
-               w/ no module active' do
+      context 'with the permission being public and not module bound
+               with no module active' do
         before do
           project.enabled_modules = []
         end
 
         it 'includes the project' do
-          expect(Project.allowed_to(user, public_non_module_action)).to match_array [project]
+          expect(described_class.allowed_to(user, public_non_module_action)).to contain_exactly(project)
         end
       end
     end

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Project, 'allowed to' do
   let(:action) { :view_work_packages }
   let(:public_action) { :view_news }
   let(:public_non_module_action) { :view_project }
+  let(:non_module_action) { :edit_project }
   let(:member) do
     build(:member,
           user:,
@@ -163,7 +164,7 @@ RSpec.describe Project, 'allowed to' do
 
     context 'with the user being member
              with the permission being public and not module bound
-             with no module bing active' do
+             with no module being active' do
       before do
         member.save!
         project.enabled_modules = []
@@ -171,6 +172,36 @@ RSpec.describe Project, 'allowed to' do
 
       it 'includes the project' do
         expect(described_class.allowed_to(user, public_non_module_action)).to contain_exactly(project)
+      end
+    end
+
+    context 'with the user being member
+             with the permission being module bound
+             with the role having the permission
+             with no module active' do
+      let(:permissions) { [non_module_action] }
+
+      before do
+        member.save!
+      end
+
+      it 'includes the project' do
+        expect(described_class.allowed_to(user, non_module_action)).to contain_exactly(project)
+      end
+    end
+
+    context 'with the user being member
+             with the permission being module bound
+             without the role having the permission
+             with no module active' do
+      let(:permissions) { [] }
+
+      before do
+        member.save!
+      end
+
+      it 'is empty' do
+        expect(described_class.allowed_to(user, non_module_action)).to be_empty
       end
     end
   end

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Project, 'allowed to' do
     end
 
     context 'with the user being member
-             with the permission being module bound
+             without the permission being module bound
              with the role having the permission
              with no module active' do
       let(:permissions) { [non_module_action] }
@@ -191,7 +191,7 @@ RSpec.describe Project, 'allowed to' do
     end
 
     context 'with the user being member
-             with the permission being module bound
+             without the permission being module bound
              without the role having the permission
              with no module active' do
       let(:permissions) { [] }

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe User, 'allowed_to?' do
           it { expect(user).not_to be_allowed_to(permission, project) }
         end
 
-        context 'and the permission being assigend to the non-member role' do
+        context 'and the permission being assigned to the non-member role' do
           before do
             non_member = Role.non_member
             non_member.add_permission! permission


### PR DESCRIPTION
Reworks the SQL statement underlying

`Project.allowed_to?(some_user, :some_permission)`

that showed poor performance in some datasets. 

### Background

The problem manifests in statements where the aforementioned statement takes part as a subquery in combination with a `LIMIT`, as e.g. in 

```sql

SELECT "work_packages"."id"                      AS t0_r0,
       "work_packages"."type_id"                 AS t0_r1,
       "work_packages"."project_id"              AS t0_r2,
       "work_packages"."subject"                 AS t0_r3,
       "work_packages"."description"             AS t0_r4,
       "work_packages"."due_date"                AS t0_r5,
       "work_packages"."category_id"             AS t0_r6,
       "work_packages"."status_id"               AS t0_r7,
       "work_packages"."assigned_to_id"          AS t0_r8,
       "work_packages"."priority_id"             AS t0_r9,
       "work_packages"."version_id"              AS t0_r10,
       "work_packages"."author_id"               AS t0_r11,
       "work_packages"."lock_version"            AS t0_r12,
       "work_packages"."done_ratio"              AS t0_r13,
       "work_packages"."estimated_hours"         AS t0_r14,
       "work_packages"."created_at"              AS t0_r15,
       "work_packages"."updated_at"              AS t0_r16,
       "work_packages"."start_date"              AS t0_r17,
       "work_packages"."responsible_id"          AS t0_r18,
       "work_packages"."position"                AS t0_r19,
       "work_packages"."story_points"            AS t0_r20,
       "work_packages"."remaining_hours"         AS t0_r21,
       "work_packages"."budget_id"               AS t0_r22,
       "work_packages"."derived_estimated_hours" AS t0_r23,
       "work_packages"."schedule_manually"       AS t0_r24,
       "work_packages"."parent_id"               AS t0_r25,
       "work_packages"."duration"                AS t0_r26,
       "work_packages"."ignore_non_working_days" AS t0_r27,
       "work_packages"."derived_remaining_hours" AS t0_r28,
       "projects"."id"                           AS t1_r0,
       "projects"."name"                         AS t1_r1,
       "projects"."description"                  AS t1_r2,
       "projects"."public"                       AS t1_r3,
       "projects"."parent_id"                    AS t1_r4,
       "projects"."created_at"                   AS t1_r5,
       "projects"."updated_at"                   AS t1_r6,
       "projects"."identifier"                   AS t1_r7,
       "projects"."lft"                          AS t1_r8,
       "projects"."rgt"                          AS t1_r9,
       "projects"."active"                       AS t1_r10,
       "projects"."templated"                    AS t1_r11,
       "projects"."status_code"                  AS t1_r12,
       "projects"."status_explanation"           AS t1_r13
FROM "work_packages"
         LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
WHERE "work_packages"."project_id" IN (
	SELECT "projects"."id"
                                       FROM "projects"
                                                LEFT OUTER JOIN "members"
                                                                ON "projects"."id" = "members"."project_id" AND
                                                                   "members"."user_id" = 60026 AND
                                                                   "members"."entity_type" IS NULL AND
                                                                   "members"."entity_id" IS NULL AND
                                                                   "projects"."active" = TRUE
                                                INNER JOIN "enabled_modules"
                                                           ON "projects"."id" = "enabled_modules"."project_id" AND
                                                              "enabled_modules"."name" IN ('work_package_tracking') AND
                                                              "projects"."active" = TRUE
                                                INNER JOIN "role_permissions"
                                                           ON "role_permissions"."permission" IN ('view_work_packages')
                                                INNER JOIN "roles" "permission_roles"
                                                           ON "permission_roles"."id" = "role_permissions"."role_id"
                                                LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id"
                                                LEFT OUTER JOIN "roles" "assigned_roles"
                                                                ON "assigned_roles"."id" = "permission_roles"."id" AND
                                                                   "projects"."active" = TRUE AND
                                                                   ("assigned_roles"."id" = "member_roles"."role_id" OR (
                                                                    "projects"."public" = TRUE AND
                                                                    "assigned_roles"."builtin" = 1 AND
                                                                    "member_roles"."id" IS NULL))
                                       WHERE "assigned_roles"."id" IS NOT NULL
)
  AND (((work_packages.subject ILIKE '%6%' OR projects.name ILIKE '%6%')))
ORDER BY work_packages.updated_at, work_packages.id DESC
LIMIT 10 
```

A statement like this is issued when using the work package autocompleter inside text fields (i.e. typing `#6` in a comment field) but similar requests are issued e.g. on
* /api/v3/work_packages
* /api/v3/queries/default

As such, in the problematic datasets, central parts of the application are affected for non admin users.

The reason for the poor performance is the query planner assuming that it will be faster to go over the work packages from the top and find those that match the filtered for (`work_packages.subject ILIKE '%6%' OR projects.name ILIKE '%6%'`) and afterwards check if they are in a project the user is allowed to see. This is true even though only one project might be returned by the subselect and in the dataset in a lot of cases is. Running `ANALYZE` on the tables does not help in this case. 

This behaviour is a known shortcoming of PostgreSQL in some scenarios (see https://www.postgresql.org/message-id/flat/CA%2BU5nMLbXfUT9cWDHJ3tpxjC3bTWqizBKqTwDgzebCB5bAGCgg%40mail.gmail.com and https://stackoverflow.com/questions/60115419/postgres-slower-when-a-limit-is-set-how-to-fix-besides-adding-a-dummy-order-by/60118336#60118336)

Since PostgreSQL does not support query hints, the query planner cannot be coerced into first running the subselect.

The subselect has a shortcoming of itself, though in that it needs to have a LEFT JOIN for the members and an OR when joining the roles to support both actual project members and their roles as well as the builtin roles on public projects.

## Solution

For those two reasons, it seems prudent to rewrite the subselect. In the PR, a UNION ALL based approach is chosen to separate the two cases (actual project member roles vs builtin roles). Then then also leads to improved performance as the query planner choses a better execution plan.

The resulting query looks like this

```SQL
SELECT "work_packages"."id" AS T0_R0,
	"work_packages"."type_id" AS T0_R1,
	"work_packages"."project_id" AS T0_R2,
	"work_packages"."subject" AS T0_R3,
	"work_packages"."description" AS T0_R4,
	"work_packages"."due_date" AS T0_R5,
	"work_packages"."category_id" AS T0_R6,
	"work_packages"."status_id" AS T0_R7,
	"work_packages"."assigned_to_id" AS T0_R8,
	"work_packages"."priority_id" AS T0_R9,
	"work_packages"."version_id" AS T0_R10,
	"work_packages"."author_id" AS T0_R11,
	"work_packages"."lock_version" AS T0_R12,
	"work_packages"."done_ratio" AS T0_R13,
	"work_packages"."estimated_hours" AS T0_R14,
	"work_packages"."created_at" AS T0_R15,
	"work_packages"."updated_at" AS T0_R16,
	"work_packages"."start_date" AS T0_R17,
	"work_packages"."responsible_id" AS T0_R18,
	"work_packages"."position" AS T0_R19,
	"work_packages"."story_points" AS T0_R20,
	"work_packages"."remaining_hours" AS T0_R21,
	"work_packages"."budget_id" AS T0_R22,
	"work_packages"."derived_estimated_hours" AS T0_R23,
	"work_packages"."schedule_manually" AS T0_R24,
	"work_packages"."parent_id" AS T0_R25,
	"work_packages"."duration" AS T0_R26,
	"work_packages"."ignore_non_working_days" AS T0_R27,
	"work_packages"."derived_remaining_hours" AS T0_R28,
	"projects"."id" AS T1_R0,
	"projects"."name" AS T1_R1,
	"projects"."description" AS T1_R2,
	"projects"."public" AS T1_R3,
	"projects"."parent_id" AS T1_R4,
	"projects"."created_at" AS T1_R5,
	"projects"."updated_at" AS T1_R6,
	"projects"."identifier" AS T1_R7,
	"projects"."lft" AS T1_R8,
	"projects"."rgt" AS T1_R9,
	"projects"."active" AS T1_R10,
	"projects"."templated" AS T1_R11,
	"projects"."status_code" AS T1_R12,
	"projects"."status_explanation" AS T1_R13
FROM "work_packages"
LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
WHERE "work_packages"."project_id" IN
		(SELECT "projects"."id"
			FROM "projects"
			WHERE "projects"."id" IN (
							(SELECT "projects"."id"
								FROM "members"
								INNER JOIN "projects" ON "projects"."active" = TRUE
								AND "members"."project_id" = "projects"."id"
								AND "members"."user_id" = 60026
								AND "members"."entity_type" IS NULL
								AND "members"."entity_id" IS NULL
								INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
								AND "enabled_modules"."name" IN ('work_package_tracking')
								AND "projects"."active" = TRUE
								INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
								INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
								INNER JOIN "member_roles" "member_roles_members" ON "member_roles_members"."member_id" = "members"."id"
								INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
								AND (FALSE
									 OR "role_permissions"."permission" = 'view_work_packages'
									 AND "enabled_modules"."name" = 'work_package_tracking')
								
                                                                UNION ALL
 
                                                                SELECT "projects"."id"
								FROM "projects"
								INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
								AND "enabled_modules"."name" IN ('work_package_tracking')
								AND "projects"."active" = TRUE
								INNER JOIN "roles" ON "roles"."builtin" = 1
								AND "projects"."active"
								AND "projects"."public"
								AND NOT (EXISTS
									(SELECT 1
										FROM "members"
										WHERE "members"."project_id" = "projects"."id"
											AND "members"."user_id" = 60026
											AND "members"."entity_type" IS NULL
											AND "members"."entity_id" IS NULL))
								INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
								AND (FALSE
									 OR "role_permissions"."permission" = 'view_work_packages'
									 AND "enabled_modules"."name" = 'work_package_tracking'))))
	AND (((WORK_PACKAGES.SUBJECT ILIKE '%6%' OR PROJECTS.NAME ILIKE '%6%')))
ORDER BY WORK_PACKAGES.UPDATED_AT,
	WORK_PACKAGES.ID DESC
LIMIT 10

``` 

## Result

All results are measured on the same dataset for the same non admin user and with a hot cache.

* WorkPackage autocompleter: 
  * before: 7.5s
  * after: ~40 ms
* /api/v3/work_packages?pageSize=100 
  * before: 3.5s
  * after: 330ms
* /api/v3/queries/default?pageSize=100
  * before: 3.5s
  * after: 370ms  

## Observations

The performance for administrator users does not change which isn't surprising as the statement for those users isn't altered. But interestingly, of the roughly 600ms spent for e.g. `/api/v3/work_packages?pageSize=100` over 300ms are spent calculating the overall number of work packages visible to the admin `SELECT COUNT(DISTINCT "work_packages"."id") FROM "work_packages"...`. While COUNT is notoriously slow, it might be beneficial to at least remove the `DISTINCT "work_packages"."id"` part in favour of a `*` but this is out of scope for this PR. 

## Work package

https://community.openproject.org/wp/50102