### PR TITLE
Introduce test_selector finder and matcher to ease writing tests

### DIFF
--- a/app/components/enumerations/table_component.rb
+++ b/app/components/enumerations/table_component.rb
@@ -59,7 +59,7 @@ module Enumerations
       link_to new_enumeration_path(type: rows.name),
               aria: { label: t(:label_enumeration_new) },
               class: 'wp-inline-create--add-link',
-              data: { 'qa-selector': "create-enumeration-#{rows.name.underscore.dasherize}" },
+              data: { 'test-selector': "create-enumeration-#{rows.name.underscore.dasherize}" },
               title: t(:label_enumeration_new) do
         helpers.op_icon('icon icon-add')
       end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -50,7 +50,7 @@ module BreadcrumbHelper
       end
     end
 
-    content_tag(:ul, breadcrumb_elements.join.html_safe, class: 'op-breadcrumb', 'data-qa-selector': 'op-breadcrumb')
+    content_tag(:ul, breadcrumb_elements.join.html_safe, class: 'op-breadcrumb', 'data-test-selector': 'op-breadcrumb')
   end
 
   def breadcrumb_paths(*args)

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -31,9 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= toolbar title: t(:label_overview) %>
 
-<div class="menu-blocks--container" data-qa-selector="menu-blocks--container">
+<div class="menu-blocks--container" data-test-selector="menu-blocks--container">
   <% @menu_nodes.each do |menu_node| -%>
-    <%= link_to menu_node.url, { class: 'menu-block', 'data-qa-selector': 'menu-block' } do %>
+    <%= link_to menu_node.url, { class: 'menu-block', 'data-test-selector': 'menu-block' } do %>
       <%= op_icon("menu-block--icon icon3 icon-#{(menu_node.icon || '')}") %>
       <span class="menu-block--title"> <%= menu_node.caption %> </span>
     <% end %>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -76,7 +76,7 @@ See COPYRIGHT and LICENSE files for more details.
       </thead>
 
       <tbody
-        data-qa-selector="dragula-container"
+        data-test-selector="dragula-container"
         data-admin--custom-fields-target="dragContainer">
       <% custom_field.custom_options.each_with_index do |custom_option, i| %>
         <%= f.fields_for :custom_options, custom_option do |co_f| %>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -96,7 +96,7 @@ See COPYRIGHT and LICENSE files for more details.
           <button
             type="button"
             class="spot-link"
-            data-qa-selector="add-custom-option"
+            data-test-selector="add-custom-option"
             data-action="admin--custom-fields#addOption"
           >
             <span class="spot-icon spot-icon_1_25 spot-icon_add"></span>

--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -136,7 +136,7 @@ See COPYRIGHT and LICENSE files for more details.
                                       name: 'membership[project_id]'
                                     },
                                     data: {
-                                      'qa-selector': 'membership_project_id'
+                                      'test-selector': 'membership_project_id'
                                     },
                                     class: 'form--field'
           %>

--- a/app/views/homescreen/blocks/_header.html.erb
+++ b/app/views/homescreen/blocks/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="op-widget-box--header" data-qa-selector="op-widget-box--header">
+<div class="op-widget-box--header" data-test-selector="op-widget-box--header">
   <div class="op-widget-box--header-title title-container">
     <h2 class="editable-toolbar-title--fixed"><%= title %></h2>
   </div>

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -154,7 +154,7 @@ See COPYRIGHT and LICENSE files for more details.
                                       name: 'membership[project_id]'
                                     },
                                     data: {
-                                      'qa-selector': 'membership_project_id'
+                                      'test-selector': 'membership_project_id'
                                     },
                                     class: 'form--field'
           %>

--- a/app/views/my/access_token_partials/_api_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_api_tokens_section.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
               %>
               <tbody>
                 <tr>
-                  <td class="-w-rel-60" data-qa-selector="api-token-row-name"><%= t("my_account.access_tokens.api.static_token_name") %></td>
+                  <td class="-w-rel-60" data-test-selector="api-token-row-name"><%= t("my_account.access_tokens.api.static_token_name") %></td>
                   <td>
                     <span title="<%= format_time(api_token.created_at) %>">
                       <%= format_time(api_token.created_at.to_s) %>
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
                     <%= link_to "",
                                 { action: 'revoke_api_key' },
                                 method: :delete,
-                                data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), qa_selector: 'api-token-revoke' },
+                                data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), test_selector: 'api-token-revoke' },
                                 class: 'icon icon-delete' %>
                   </td>
                 </tr>
@@ -72,7 +72,7 @@ See COPYRIGHT and LICENSE files for more details.
           </div>
         </div>
       <% else %>
-        <%= link_to({ action: 'generate_api_key' }, method: :post, class: 'spot-link', data: { qa_selector: 'api-token-add' }) do %>
+        <%= link_to({ action: 'generate_api_key' }, method: :post, class: 'spot-link', data: { test_selector: 'api-token-add' }) do %>
           <span class="spot-icon spot-icon_add"></span>
           <span><%= t('my_account.access_tokens.api.static_token_name') %></span>
         <% end %>

--- a/app/views/my/access_token_partials/_icalendar_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_icalendar_tokens_section.html.erb
@@ -56,8 +56,8 @@ See COPYRIGHT and LICENSE files for more details.
                 <% ical_tokens_grouped_by_query.each do |query_id, tokens| %>
                   <% tokens.sort_by(&:created_at).each do |token| %>
                     <tr>
-                      <td class="-w-rel-20 -mw-abs-200" data-qa-selector="ical-token-row-<%= token.id %>-name"><%= token.ical_token_query_assignment.name %></td>
-                      <td class="-w-rel-20 -mw-abs-200" data-qa-selector="ical-token-row-<%= token.id %>-query-name">
+                      <td class="-w-rel-20 -mw-abs-200" data-test-selector="ical-token-row-<%= token.id %>-name"><%= token.ical_token_query_assignment.name %></td>
+                      <td class="-w-rel-20 -mw-abs-200" data-test-selector="ical-token-row-<%= token.id %>-query-name">
                         <%= link_to token.query.name,
                                     project_calendar_url(
                                       id: query_id,
@@ -65,7 +65,7 @@ See COPYRIGHT and LICENSE files for more details.
                                     )
                         %>
                       </td>
-                      <td class="-w-rel-20 -mw-abs-200" data-qa-selector="ical-token-row-<%= token.id %>-project-name">
+                      <td class="-w-rel-20 -mw-abs-200" data-test-selector="ical-token-row-<%= token.id %>-project-name">
                         <%= token.query.project.name %>
                       </td>
                       <td>
@@ -77,7 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
                       <td class="buttons">
                         <%= link_to "",
                                     { action: 'revoke_ical_token', id: token.id },
-                                    data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), qa_selector: "ical-token-row-#{token.id}-revoke" },
+                                    data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), test_selector: "ical-token-row-#{token.id}-revoke" },
                                     method: :delete,
                                     class: 'icon icon-delete' %>
                       </td>

--- a/app/views/my/access_token_partials/_oauth_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_oauth_tokens_section.html.erb
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
               <% granted_applications.each do |application, tokens| %>
                 <% latest = tokens.sort_by(&:created_at).last %>
                 <tr id="oauth-application-grant-<%= application.id %>">
-                  <td class="-w-rel-60" data-qa-selector="oauth-token-row-<%= application.id %>-name">
+                  <td class="-w-rel-60" data-test-selector="oauth-token-row-<%= application.id %>-name">
                     <%= t('oauth.application.named', name: application.name) %>
                     &nbsp;
                     (<%= t('oauth.x_active_tokens', count: tokens.count) %>)
@@ -69,7 +69,7 @@ See COPYRIGHT and LICENSE files for more details.
                                 revoke_my_oauth_application_path(application_id: application.id),
                                 data: { confirm: t('oauth.revoke_my_application_confirmation',
                                         token_count: t('oauth.x_active_tokens', count: tokens.count)),
-                                        qa_selector: "oauth-token-row-#{application.id}-revoke" },
+                                        test_selector: "oauth-token-row-#{application.id}-revoke" },
                                 method: :post,
                                 class: 'icon icon-delete' %>
                   </td>

--- a/app/views/my/access_token_partials/_rss_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_rss_tokens_section.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
               %>
               <tbody>
                 <tr>
-                  <td class="-w-rel-60" data-qa-selector="rss-token-row-name"><%= t("my_account.access_tokens.rss.static_token_name") %></td>
+                  <td class="-w-rel-60" data-test-selector="rss-token-row-name"><%= t("my_account.access_tokens.rss.static_token_name") %></td>
                   <td>
                     <span title="<%= format_time(rss_token.created_at) %>">
                       <%= format_time(rss_token.created_at.to_s) %>
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
                     <%= link_to "",
                                 { action: 'revoke_rss_key' },
                                 method: :delete,
-                                data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), qa_selector: 'rss-token-revoke' },
+                                data: { confirm: t('my_account.access_tokens.simple_revoke_confirmation'), test_selector: 'rss-token-revoke' },
                                 class: 'icon icon-delete' %>
                   </td>
                 </tr>
@@ -72,7 +72,7 @@ See COPYRIGHT and LICENSE files for more details.
           </div>
         </div>
       <% else %>
-        <%= link_to({ action: 'generate_rss_key' }, method: :post, class: 'spot-link', data: { qa_selector: 'rss-token-add' }) do %>
+        <%= link_to({ action: 'generate_rss_key' }, method: :post, class: 'spot-link', data: { test_selector: 'rss-token-add' }) do %>
           <span class="spot-icon spot-icon_add"></span>
           <span><%= t('my_account.access_tokens.rss.static_token_name') %></span>
         <% end %>

--- a/app/views/my/access_token_partials/_storage_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_storage_tokens_section.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
             <tbody>
             <% storage_tokens.each do |token| %>
               <tr id="storage-oauth-token-<%= token.id %>">
-                <td class="-w-rel-60" data-qa-selector="oauth-token-row-<%= token.oauth_client.integration.id %>-name">
+                <td class="-w-rel-60" data-test-selector="oauth-token-row-<%= token.oauth_client.integration.id %>-name">
                   <%= token.oauth_client.integration.name %>
                 </td>
                 <td>
@@ -65,7 +65,7 @@ See COPYRIGHT and LICENSE files for more details.
                   <%= link_to "",
                               storage_token_delete_path(token.id),
                               data: { confirm: t('my_account.access_tokens.storages.revoke_token', storage: token.oauth_client.integration.name),
-                                      qa_selector: "storages-token-row-#{token.id}-revoke" },
+                                      test_selector: "storages-token-row-#{token.id}-revoke" },
                               method: :delete,
                               class: 'icon icon-delete' %>
                 </td>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -71,7 +71,7 @@ See COPYRIGHT and LICENSE files for more details.
         aria-haspopup="true"
         title="<%= t(:label_more) %>"
         class="button"
-        data-qa-selector="project-more-dropdown-menu"
+        data-test-selector="project-more-dropdown-menu"
       >
         <%= op_icon('button--icon icon-show-more') %>
       </a>

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -74,7 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
                                               id: 'new_project_id',
                                               class: 'remote-field--input',
                                               data: {
-                                                'qa-selector': 'new_project_id'
+                                                'test-selector': 'new_project_id'
                                               }
                     %>
                   </div>

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -30,7 +30,7 @@ export function boardTourSteps(edition:'basic'|'enterprise', project:ProjectName
       },
     },
     {
-      'next [data-qa-selector="op-board-list"]': I18n.t(`js.onboarding.steps.boards.lists_${listExplanation}`),
+      'next [data-test-selector="op-board-list"]': I18n.t(`js.onboarding.steps.boards.lists_${listExplanation}`),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',
@@ -41,7 +41,7 @@ export function boardTourSteps(edition:'basic'|'enterprise', project:ProjectName
       }),
     },
     {
-      'next [data-qa-selector="op-board-list--card-dropdown-add-button"]': I18n.t('js.onboarding.steps.boards.add'),
+      'next [data-test-selector="op-board-list--card-dropdown-add-button"]': I18n.t('js.onboarding.steps.boards.add'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       condition: () => document.getElementsByClassName('op-board-list--add-button').length !== 0,

--- a/frontend/src/app/core/setup/globals/onboarding/tours/team_planners_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/team_planners_tour.ts
@@ -19,7 +19,7 @@ export function teamPlannerTourSteps():OnboardingStep[] {
       },
     },
     {
-      'next [data-qa-selector="op-team-planner--calendar-pane"]': I18n.t('js.onboarding.steps.team_planner.calendar'),
+      'next [data-test-selector="op-team-planner--calendar-pane"]': I18n.t('js.onboarding.steps.team_planner.calendar'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',
@@ -30,17 +30,17 @@ export function teamPlannerTourSteps():OnboardingStep[] {
       }),
     },
     {
-      'next [data-qa-selector="tp-assignee-add-button"]': I18n.t('js.onboarding.steps.team_planner.add_assignee'),
+      'next [data-test-selector="tp-assignee-add-button"]': I18n.t('js.onboarding.steps.team_planner.add_assignee'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
     },
     {
-      'next [data-qa-selector="op-team-planner--add-existing-toggle"]': I18n.t('js.onboarding.steps.team_planner.add_existing'),
+      'next [data-test-selector="op-team-planner--add-existing-toggle"]': I18n.t('js.onboarding.steps.team_planner.add_existing'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
     },
     {
-      'next [data-qa-selector="op-wp-single-card"]': I18n.t('js.onboarding.steps.team_planner.card'),
+      'next [data-test-selector="op-wp-single-card"]': I18n.t('js.onboarding.steps.team_planner.card'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       onNext() {

--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.html
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.html
@@ -18,12 +18,12 @@
   <div #viewerContainer
        *ngIf="modelCount"
        class="op-ifc-viewer--container xeokit-busy-modal-backdrop"
-       data-qa-selector="op-ifc-viewer--container">
+       data-test-selector="op-ifc-viewer--container">
 
     <div class="op-ifc-viewer--toolbar op-ifc-viewer--model-canvas-overlay">
       <div #toolbar
            class="op-ifc-viewer--toolbar-container"
-           data-qa-selector="op-ifc-viewer--toolbar-container">
+           data-test-selector="op-ifc-viewer--toolbar-container">
       </div>
 
       <div class="op-ifc-viewer--toolbar-info-button">
@@ -36,7 +36,7 @@
 
     <canvas #modelCanvas
             class="op-ifc-viewer--model-canvas"
-            data-qa-selector="op-ifc-viewer--model-canvas"
+            data-test-selector="op-ifc-viewer--model-canvas"
             tabindex="0">
     </canvas>
 
@@ -50,12 +50,12 @@
 
     <canvas #navCubeCanvas
             class="op-ifc-viewer--nav-cube-canvas op-ifc-viewer--model-canvas-overlay"
-            data-qa-selector="op-ifc-viewer--nav-cube-canvas"></canvas>
+            data-test-selector="op-ifc-viewer--nav-cube-canvas"></canvas>
   </div>
 
   <div #inspectorPane
        class="op-ifc-viewer--inspector-container"
        [class.op-ifc-viewer--inspector-container-hidden]="!(inspectorVisible$ | async)"
-       data-qa-selector="op-ifc-viewer--inspector-container">
+       data-test-selector="op-ifc-viewer--inspector-container">
   </div>
 </div>

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
@@ -49,14 +49,14 @@
     <div class="spot-action-bar--right">
       <button
         class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
-        data-qa-selector="confirmation-modal--cancel"
+        data-test-selector="confirmation-modal--cancel"
         (click)="closeMe($event)"
         [textContent]="text.button_cancel"
         [attr.title]="text.button_cancel"
       ></button>
       <button
         class="button button_no-margin -highlight spot-action-bar--action"
-        data-qa-selector="confirmation-modal--confirmed"
+        data-test-selector="confirmation-modal--confirmed"
         (click)="create()"
         [disabled]="!this.selectedAttribute || inFlight"
         [textContent]="text.button_add"

--- a/frontend/src/app/features/boards/board/board-actions/version/version-board-header.html
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-board-header.html
@@ -1,5 +1,5 @@
 <div class="op-version-board-header"
-      data-qa-selector="op-version-board-header"
+      data-test-selector="op-version-board-header"
      [ngClass]="{ '-closed': version.isClosed(), '-locked': version.isLocked() }"
      *ngIf="version">
   <h2 class="editable-toolbar-title--fixed">

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.html
@@ -1,7 +1,7 @@
 <div #loadingIndicator
      [attr.data-query-name]="listName"
      class="op-board-list loading-indicator--location"
-     data-qa-selector="op-board-list"
+     data-test-selector="op-board-list"
      [ngClass]="{ '-action-list': board.isAction }">
   <ng-container *ngIf="query">
 
@@ -11,7 +11,7 @@
     </div>
 
     <div class="op-board-list--header"
-          data-qa-selector="op-board-list--header">
+          data-test-selector="op-board-list--header">
       <ndc-dynamic *ngIf="headerComponent"
                    [ndcDynamicComponent]="headerComponent"
                    [ndcDynamicInputs]="{ resource: actionResource }">
@@ -27,7 +27,7 @@
       </editable-toolbar-title>
 
       <board-list-menu class="op-board-list--menu"
-                       data-qa-selector="op-board-list--menu"
+                       data-test-selector="op-board-list--menu"
                        [board]="board"
                        (onRemove)="deleteList()">
       </board-list-menu>
@@ -38,7 +38,7 @@
       <div class="op-board-list--button-container">
         <button [title]="text.addCard"
                 *ngIf="showAddButton"
-                data-qa-selector="op-board-list--card-dropdown-add-button"
+                data-test-selector="op-board-list--card-dropdown-add-button"
                 class="op-board-list--add-button op-board-list--card-dropdown-button button"
                 op-addCardDropdown>
           <op-icon icon-classes="icon-small icon-add"></op-icon>

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -14,7 +14,7 @@
     class="button -alt-highlight -expand"
     (click)="redirectToNewBoardForm()"
     [title]="text.create_new_board"
-    data-qa-selector="sidebar--create-board-button"
+    data-test-selector="sidebar--create-board-button"
   >
     <span class="spot-icon spot-icon_add"></span>
     <span [textContent]="text.board"></span>

--- a/frontend/src/app/features/boards/tile-view/tile-view.component.html
+++ b/frontend/src/app/features/boards/tile-view/tile-view.component.html
@@ -2,7 +2,7 @@
   <button
     *ngFor="let tile of tiles"
     class="op-tile-block--tile button button_no-margin"
-    data-qa-selector="op-tile-block"
+    data-test-selector="op-tile-block"
     type="button"
     [disabled]="tile.disabled || disable"
     (click)="created(tile.attribute)"
@@ -10,7 +10,7 @@
     <img [src]="tile.image" class="op-tile-block--image"/>
     <div>
       <span
-        data-qa-selector="op-tile-block-title"
+        data-test-selector="op-tile-block-title"
         class="op-tile-block--title"
       >{{ tile.text }}</span>
       <p class="op-tile-block--description" [textContent]="tile.description"></p>

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.template.html
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.template.html
@@ -1,5 +1,5 @@
 <div class="op-wp-calendar"
-     data-qa-selector="op-wp-calendar"
+     data-test-selector="op-wp-calendar"
      (contextmenu)="openContextMenu($event)"
      [attr.data-indicator-name]="'table'">
     <ng-container

--- a/frontend/src/app/features/enterprise/enterprise-active-trial/ee-active-trial.component.html
+++ b/frontend/src/app/features/enterprise/enterprise-active-trial/ee-active-trial.component.html
@@ -1,4 +1,4 @@
-<div data-qa-selector="op-enterprise--active-token" class="op-enterprise--active-token">
+<div data-test-selector="op-enterprise--active-token" class="op-enterprise--active-token">
   <div class="attributes-group">
     <div class="attributes-group--attributes">
       <div class="attributes-key-value">
@@ -13,7 +13,7 @@
         <div class="attributes-key-value--key" [textContent]="text.label_email"></div>
         <div
           class="attributes-key-value--value-container"
-          data-qa-selector="ee-active-trial-email"
+          data-test-selector="ee-active-trial-email"
         >
           <div class="attributes-key-value--value -text">
             <span [textContent]="email"></span>
@@ -32,7 +32,7 @@
         <div class="attributes-key-value--key" [textContent]="text.label_domain"></div>
         <div
           class="attributes-key-value--value-container"
-          data-qa-selector="ee-active-trial-domain"
+          data-test-selector="ee-active-trial-domain"
         >
           <div class="attributes-key-value--value -text">
             <span [textContent]="domain"></span>

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
@@ -39,14 +39,14 @@
            class="spot-action-bar--right">
         <button
           class="button button_no-margin spot-action-bar--action spot-modal--cancel-button"
-          data-qa-selector="confirmation-modal--cancel"
+          data-test-selector="confirmation-modal--cancel"
           (click)="closeModal($event)"
           [textContent]="text.button_cancel"
           [attr.title]="text.button_cancel"
         ></button>
         <button
           class="button button_no-margin -highlight spot-action-bar--action"
-          data-qa-selector="confirmation-modal--confirmed"
+          data-test-selector="confirmation-modal--confirmed"
           (click)="onSubmit()"
           [disabled]="!trialForm || trialForm.invalid"
           [textContent]="text.button_submit"
@@ -58,7 +58,7 @@
         <div class="spot-action-bar--right">
           <button
             class="button button_no-margin -highlight spot-action-bar--action"
-            data-qa-selector="confirmation-modal--confirmed"
+            data-test-selector="confirmation-modal--confirmed"
             (click)="startEnterpriseTrial()"
             [textContent]="text.button_continue"
             [attr.title]="text.button_continue"
@@ -68,7 +68,7 @@
           <button
             *ngIf="context.status === 'startTrial'"
             class="button button_no-margin -highlight spot-action-bar--action"
-            data-qa-selector="confirmation-modal--confirmed"
+            data-test-selector="confirmation-modal--confirmed"
             (click)="closeModal($event)"
             [textContent]="text.button_continue"
             [attr.title]="text.button_continue"

--- a/frontend/src/app/features/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.html
+++ b/frontend/src/app/features/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.html
@@ -8,14 +8,14 @@
   <p>
     <span>{{ text.status_label }} </span>
     <span *ngIf="!context.confirmed; else confirmedStatus" class="op-ee-trial-waiting-status--waiting"
-          data-qa-selector="op-ee-trial-waiting-status--waiting">
+          data-test-selector="op-ee-trial-waiting-status--waiting">
       {{ text.status_waiting }}
 
       <!-- <a id="op-ee-trial-waiting-resend-link"
-      data-qa-selector='op-ee-trial-waiting-resend-link' (click)="resendMail()">{{ text.resend }}</a> -->
+      data-test-selector='op-ee-trial-waiting-resend-link' (click)="resendMail()">{{ text.resend }}</a> -->
       <button
         class="spot-link op-ee-trial-waiting-resend-link"
-        data-qa-selector='op-ee-trial-waiting-resend-link'
+        data-test-selector='op-ee-trial-waiting-resend-link'
         (click)="resendMail()">
       {{ text.resend }}</button>
     </span>
@@ -24,7 +24,7 @@
     <ng-template #confirmedStatus>
         <span
           class="op-ee-trial-waiting-status--confirmed icon-yes"
-          data-qa-selector="op-ee-trial-waiting-status--confirmed"> {{ text.status_confirmed }}
+          data-test-selector="op-ee-trial-waiting-status--confirmed"> {{ text.status_confirmed }}
         </span>
     </ng-template>
   </p>

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
@@ -1,6 +1,6 @@
 <a
   class="op-ian-bell op-app-menu--item-action"
-  data-qa-selector="op-ian-bell"
+  data-test-selector="op-ian-bell"
   [href]="notificationsPath()"
 >
   <op-icon icon-classes="icon-bell"></op-icon>
@@ -8,7 +8,7 @@
     <span
       *ngIf="unreadCount !== 0"
       class="op-ian-bell--indicator"
-      data-qa-selector="op-ian-notifications-count"
+      data-test-selector="op-ian-notifications-count"
       [textContent]="unreadCountText$ | async"
     ></span>
   </ng-container>

--- a/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.html
@@ -1,6 +1,6 @@
 <div
         class="work-packages--details op-empty-state hidden-for-mobile"
-        data-qa-selector="op-empty-state"
+        data-test-selector="op-empty-state"
 >
     <div class="work-packages-tab-view--overflow op-empty-state--content">
       <ng-container *ngIf="(loading$ | async) === false; else loading">

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -17,7 +17,7 @@
               [class.op-ian-item_selected]="(stateChanged$ | async) === records[0]._links.resource.href"
               [notification]="records[0]"
               [aggregatedNotifications]="records"
-              attr.data-qa-selector="op-ian-notification-item-{{records[0].id}}"
+              attr.data-test-selector="op-ian-notification-item-{{records[0].id}}"
               [attr.data-qa-ian-read]="records[0].readIAN === true || undefined"
               [attr.data-qa-ian-selected]="(stateChanged$ | async) === records[0]._links.resource.href"
           ></op-in-app-notification-entry>
@@ -48,7 +48,7 @@
       <div class="op-ian-center--loading-indicator">
         <img [src]="image.loading"
           class="op-ian-center-loading-image"
-          data-qa-selector="op-ian-center--loading-indicator"/>
+          data-test-selector="op-ian-center--loading-indicator"/>
       </div>
     </ng-template>
   </div>

--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.html
@@ -1,4 +1,4 @@
 <op-sidemenu
   [items]="menuItems$ | async"
-  data-qa-selector="op-sidemenu"
+  data-test-selector="op-sidemenu"
 ></op-sidemenu>

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -54,7 +54,7 @@
       <div class="op-ian-item--buttons">
         <i
           *ngIf="!notification.readIAN"
-          data-qa-selector="mark-as-read-button"
+          data-test-selector="mark-as-read-button"
           class="op-ian-item--button icon-mark-read"
           [title]="text.mark_as_read"
           (click)="markAsRead($event, aggregatedNotifications)"

--- a/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
+++ b/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
@@ -3,7 +3,7 @@
 >
   <div
     class="spot-modal--header"
-    data-qa-selector="job-status--header"
+    data-test-selector="job-status--header"
   >{{ title }}</div>
 
   <div class="spot-divider"></div>

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
@@ -1,7 +1,7 @@
 <spot-text-field
   [ngModel]="searchString$ | async"
   (ngModelChange)="searchString$.next($event)"
-  data-qa-selector="op-add-existing-pane--search-input"
+  data-test-selector="op-add-existing-pane--search-input"
   [placeholder]="text.placeholder"
 >
   <span
@@ -28,7 +28,7 @@
           [disabledInfo]="showDisabledText(wp)"
           [attr.data-drag-helper-id]="wp.id"
           class="op-add-existing-pane--wp"
-          [attr.data-qa-selector]="'op-add-existing-pane--wp-' + wp.id"
+          [attr.data-test-selector]="'op-add-existing-pane--wp-' + wp.id"
           (stateLinkClicked)="openStateLink($event)"
           (cardClicked)="workPackagesCalendar.onCardClicked($event)"
           (cardDblClicked)="workPackagesCalendar.onCardDblClicked($event)"
@@ -40,7 +40,7 @@
   <ng-template #emptyTemplate>
     <div
       class="op-add-existing-pane--empty-state"
-      data-qa-selector="op-add-existing-pane--empty-state"
+      data-test-selector="op-add-existing-pane--empty-state"
     >
       <img
         *ngIf="(noResultsFound$ | async)?.showImage"

--- a/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.html
@@ -1,5 +1,5 @@
 <op-autocompleter
-  data-qa-selector="tp-add-assignee"
+  data-test-selector="tp-add-assignee"
   (change)="selectUser($event)"
   [fetchDataDirectly]="true"
   [getOptionsFn]="getOptionsFn"

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -10,7 +10,7 @@
       class="button op-team-planner--add-existing-toggle"
       [ngClass]="{'-active': (showAddExistingPane | async)}"
       [title]="text.add_existing_title"
-      data-qa-selector="op-team-planner--add-existing-toggle"
+      data-test-selector="op-team-planner--add-existing-toggle"
       (click)="toggleAddExistingPane()">
       <op-icon icon-classes="icon-add button--icon"></op-icon>
       <span
@@ -22,7 +22,7 @@
     <op-add-existing-pane
       *ngIf="(showAddExistingPane | async)"
       class="op-team-planner--add-existing-pane"
-      data-qa-selector="add-existing-pane"
+      data-test-selector="add-existing-pane"
     >
     </op-add-existing-pane>
 
@@ -33,7 +33,7 @@
       opTeamPlannerViewSelectDropdown
       [viewOptions]="viewOptions"
       (viewSelected)="switchView($event)"
-      data-qa-selector="op-team-planner--view-select-dropdown">
+      data-test-selector="op-team-planner--view-select-dropdown">
       <span class="button--text ellipsis"
             [textContent]="currentViewTitle"
             aria-hidden="true"></span>
@@ -43,7 +43,7 @@
 
   <div
     class="op-team-planner--calendar-pane"
-    data-qa-selector="op-team-planner--calendar-pane"
+    data-test-selector="op-team-planner--calendar-pane"
   >
     <ng-container
       *ngIf="(calendarOptions$ | async) as calendarOptions"
@@ -131,7 +131,7 @@
         <button
           type="button"
           class="op-team-planner--empty-state-button button -highlight"
-          data-qa-selector="op-team-planner--empty-state-button"
+          data-test-selector="op-team-planner--empty-state-button"
           (click)="showAssigneeAddRow()"
           [textContent]="text.add_assignee"
         >
@@ -139,7 +139,7 @@
       </div>
     </ng-container>
 
-    <div class="op-team-planner--footer" data-qa-selector="op-team-planner-footer">
+    <div class="op-team-planner--footer" data-test-selector="op-team-planner-footer">
       <div
         class="op-team-planner--add-assignee"
         *ngIf="!(showAddAssignee$ | async) && !(dropzone$ | async)?.dragging"
@@ -148,7 +148,7 @@
           type="button"
           class="spot-link"
           (click)="showAssigneeAddRow()"
-          data-qa-selector="tp-assignee-add-button"
+          data-test-selector="tp-assignee-add-button"
         >
           <span class="spot-icon spot-icon_user-plus"></span>
           <span [textContent]="text.add_assignee"></span>
@@ -162,7 +162,7 @@
           (mouseleave)="dropzoneHovered$.next(false)"
           (mouseup)="dropzone.canDrop && removeEvent(dropzone.dragging)"
           class="op-team-planner--remove-dropzone"
-          data-qa-selector="op-team-planner-dropzone"
+          data-test-selector="op-team-planner-dropzone"
           [class.op-team-planner--remove-dropzone_active]="dropzone.isHovering && dropzone.canDrop"
           [class.op-team-planner--remove-dropzone_forbidden]="!dropzone.canDrop"
         >

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -14,7 +14,7 @@
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
     [title]="createButton.title"
-    data-qa-selector="team-planner--create-button"
+    data-test-selector="team-planner--create-button"
   >
     <span class="spot-icon spot-icon_add"></span>
     <span [textContent]="createButton.text"></span>

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
@@ -253,5 +253,5 @@
   [userId]="userId"
   [settings]="settings"
   (selected)="addProjectSettings($event)"
-  data-qa-selector="notification-setting-inline-create"
+  data-test-selector="notification-setting-inline-create"
 ></op-notification-setting-inline-create>

--- a/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
@@ -29,7 +29,7 @@
       [ngModelOptions]="{standalone: true}"
       [disabled]="isDisabled(time, activeTimes)"
       class="op-reminder-settings-daily-time--active"
-      attr.data-qa-selector="op-settings-daily-time--active-{{i + 1}}">
+      attr.data-test-selector="op-settings-daily-time--active-{{i + 1}}">
     <label
       class="op-reminder-settings-daily-time--label"
       [textContent]="text.timeLabel(i + 1)"
@@ -55,7 +55,7 @@
       type="button"
       *ngIf="timeRemovable$ | async"
       (click)="removeTime(selectedTimes, i)"
-      attr.data-qa-selector="op-settings-daily-time--remove-{{i + 1}}">
+      attr.data-test-selector="op-settings-daily-time--remove-{{i + 1}}">
       <op-icon icon-classes="icon-small icon-remove icon4"></op-icon>
     </button>
   </div>

--- a/frontend/src/app/features/work-packages/components/back-routing/back-button.component.html
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-button.component.html
@@ -1,6 +1,6 @@
 <button
   class="op-back-button button hide-when-print"
-  data-qa-selector="op-back-button"
+  data-test-selector="op-back-button"
   [ngClass]="linkClass"
   [title]="text.goBack"
   (click)="goBack()"

--- a/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.html
@@ -9,7 +9,7 @@
     <span
       *ngIf="baselineIncompatibleFilter"
       [title]="text.incompatible_filter"
-      data-qa-selector="query-filter-baseline-incompatible"
+      data-test-selector="query-filter-baseline-incompatible"
       class="spot-icon spot-icon_warning"></span>
   </label>
 

--- a/frontend/src/app/features/work-packages/components/wp-activity/revision/revision-activity.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-activity/revision/revision-activity.component.html
@@ -7,7 +7,7 @@
     <span
       *ngIf="hasUnreadNotification"
       class="comments-number--bubble op-bubble op-bubble_mini"
-      data-qa-selector="revision-activity-bubble"
+      data-test-selector="revision-activity-bubble"
     ></span>
     <activity-link
       class="comments-number--link"

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
@@ -25,7 +25,7 @@
     <span
       *ngIf="hasUnreadNotification"
       class="comments-number--bubble op-bubble op-bubble_mini"
-      data-qa-selector="user-activity-bubble"
+      data-test-selector="user-activity-bubble"
     ></span>
     <activity-link
       class="comments-number--link"

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.html
@@ -3,7 +3,7 @@
   &ngsp;
   <span
     *ngIf="userOffset !== offset"
-    data-qa-selector="baseline-legend-time-offset"
+    data-test-selector="baseline-legend-time-offset"
     class="spot-icon spot-icon_1 spot-icon_info2"
     title="{{ text.in_your_timezone }} {{ localDate }}"
   ></span>

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
@@ -10,7 +10,7 @@
     [class.-active]="opened"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
-    data-qa-selector="baseline-button"
+    data-test-selector="baseline-button"
   >
   <span class="spot-icon spot-icon_baseline"></span>
     {{ text.toggle_title }}

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -4,7 +4,7 @@
     uiSref="work-packages.show"
     [uiParams]="{ workPackageId: parent.id }"
     class="op-wp-breadcrumb-parent nocut"
-    data-qa-selector="op-wp-breadcrumb-parent">
+    data-test-selector="op-wp-breadcrumb-parent">
     <span [textContent]="parent.name"></span>
   </a>
   <button

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
@@ -1,8 +1,8 @@
 <div class="op-wp-breadcrumb -show"
-      data-qa-selector="op-wp-breadcrumb"
+      data-test-selector="op-wp-breadcrumb"
      *ngIf="workPackage">
   <ul class="op-breadcrumb"
-      data-qa-selector="op-breadcrumb">
+      data-test-selector="op-breadcrumb">
     <ng-container *ngIf="!inputActive && hierarchyCount > 0">
       <li>
         <span>{{ hierarchyLabel }}: </span>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -7,7 +7,7 @@
   [disabled]="disabled"
   (click)="performAction($event)"
   [ngClass]="{ '-active': isActive }"
-  data-qa-selector="wp-filter-button"
+  data-test-selector="wp-filter-button"
 >
   <op-icon icon-classes="{{ iconClass }} button--icon"></op-icon>
   <span class="button--text">

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.html
@@ -1,7 +1,7 @@
 <div
   class="op-wp-status-button"
   [ngClass]="{'op-wp-status-button_small' : small}"
-  data-qa-selector="op-wp-status-button"
+  data-test-selector="op-wp-status-button"
   [attr.title]="buttonTitle"
   *ngIf="status"
 >

--- a/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/click-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/click-handler.ts
@@ -29,7 +29,7 @@ export class CardClickHandler implements CardEventHandler {
   }
 
   public get SELECTOR() {
-    return `[data-qa-selector="op-wp-single-card"]`;
+    return `[data-test-selector="op-wp-single-card"]`;
   }
 
   public eventScope(card:WorkPackageCardViewComponent) {

--- a/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/double-click-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/double-click-handler.ts
@@ -19,7 +19,7 @@ export class CardDblClickHandler implements CardEventHandler {
   }
 
   public get SELECTOR() {
-    return `[data-qa-selector="op-wp-single-card"]`;
+    return `[data-test-selector="op-wp-single-card"]`;
   }
 
   public eventScope(card:WorkPackageCardViewComponent) {

--- a/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/right-click-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/event-handler/right-click-handler.ts
@@ -26,7 +26,7 @@ export class CardRightClickHandler implements CardEventHandler {
   }
 
   public get SELECTOR() {
-    return `[data-qa-selector="op-wp-single-card"]`;
+    return `[data-test-selector="op-wp-single-card"]`;
   }
 
   public eventScope(card:WorkPackageCardViewComponent) {

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.html
@@ -1,5 +1,5 @@
 <div #container
-      data-qa-selector="op-wp-card-view" 
+      data-test-selector="op-wp-card-view"
      [ngClass]="classes()">
   <div *ngIf="inReference"
        class="wp-inline-create--reference-container">

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -1,6 +1,6 @@
 <div
   class="op-wp-single-card"
-  data-qa-selector="op-wp-single-card"
+  data-test-selector="op-wp-single-card"
   [attr.data-qa-draggable]="draggable || undefined"
   [attr.data-qa-selected]="selected || undefined"
   [ngClass]="cardClasses()"
@@ -16,11 +16,11 @@
 
   <div class="op-wp-single-card--card-actions">
     <div class="op-wp-single-card--inline-buttons hidden-for-mobile"
-         data-qa-selector="op-wp-single-card--inline-buttons">
+         data-test-selector="op-wp-single-card--inline-buttons">
       <button
         type="button"
         class="spot-link op-wp-single-card--details-button op-wp-single-card--card-action"
-        data-qa-selector="op-wp-single-card--details-button"
+        data-test-selector="op-wp-single-card--details-button"
         *ngIf="!isNewResource(workPackage) && showInfoButton"
         [title]="text.detailsView"
         (click)="emitStateLinkClicked($event, workPackage, true)">
@@ -29,7 +29,7 @@
 
       <button
         class="spot-link op-wp-single-card--inline-cancel-button op-wp-single-card--card-action"
-        data-qa-selector="op-wp-single-card--inline-cancel-button"
+        data-test-selector="op-wp-single-card--inline-cancel-button"
         *ngIf="isNewResource(workPackage) || showRemoveButton"
         [class.-show]="isNewResource(workPackage)"
         [title]="text.removeCard"
@@ -92,13 +92,13 @@
         *ngIf="!showAsInlineCard && highlightingMode !== 'type'"
         [textContent]="wpTypeAttribute(workPackage)"
         class="op-wp-single-card--content-type"
-        data-qa-selector="op-wp-single-card--content-type"
+        data-test-selector="op-wp-single-card--content-type"
         [ngClass]="typeHighlightingClass(workPackage)"
       ></span>
 
       <span
         class="op-wp-single-card--content-subject"
-        data-qa-selector="op-wp-single-card--content-subject"
+        data-test-selector="op-wp-single-card--content-subject"
         [textContent]="wpSubject(workPackage)"
       ></span>
 
@@ -136,7 +136,7 @@
       [link]="false"
       size="mini"
       class="op-wp-single-card--content-assignee"
-      data-qa-selector="op-wp-single-card--content-assignee"
+      data-test-selector="op-wp-single-card--content-assignee"
     ></op-principal>
     <span
       *ngIf="!showAsInlineCard"

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
@@ -7,7 +7,7 @@
     *ngIf="displayNotificationsButton"
     [workPackage]="workPackage"
     [showWithText]="true"
-    data-qa-selector="mark-notification-read-button"
+    data-test-selector="mark-notification-read-button"
   ></op-work-package-mark-notification-button>
 
   <button class="button dropdown-relative"

--- a/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.html
+++ b/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.html
@@ -2,6 +2,6 @@
   class="wp-replacement-label"
   (click)="activate($event)"
   tabindex="-1"
-  attr.data-qa-selector="{{fieldName}}">
+  attr.data-test-selector="{{fieldName}}">
   <ng-content></ng-content>
 </span>

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
@@ -43,7 +43,7 @@ export class GroupHeaderBuilder {
         <div class="expander icon-context ${togglerIconClass}">
           <span class="hidden-for-sighted">${_.escape(text)}</span>
         </div>
-        <div class="group--value" data-qa-selector="op-group--value">
+        <div class="group--value" data-test-selector="op-group--value">
           ${_.escape(groupName(group))}
           <span class="count">
             (${group.count})

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.html
@@ -16,7 +16,7 @@
         (click)="handleAddRowClick()"
         [attr.aria-label]="text.create"
         aria-haspopup="true"
-        data-qa-selector="op-wp-inline-create"
+        data-test-selector="op-wp-inline-create"
       >
         <span class="spot-icon spot-icon_add"></span>
         <span [textContent]="text.create"></span>
@@ -28,7 +28,7 @@
         (click)="handleReferenceClick()"
         [attr.aria-label]="text.create"
         aria-haspopup="true"
-        data-qa-selector="op-wp-inline-create-reference"
+        data-test-selector="op-wp-inline-create-reference"
       >
         <span class="spot-icon spot-icon_link"></span>
         <span [textContent]="text.reference"></span>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -10,7 +10,7 @@
       <button
         type="button"
         class="relation-row--type"
-        data-qa-selector="op-relation--row-type"
+        data-test-selector="op-relation--row-type"
         (click)="activateRelationTypeEdit()"
         *ngIf="!userInputs.showRelationTypesForm"
       >
@@ -48,14 +48,14 @@
 
     <a
       class="relation-row--grid-id"
-      data-qa-selector="op-relation--row-id"
+      data-test-selector="op-relation--row-id"
       uiSref="work-packages.show.tabs"
       [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
     >#{{relatedWorkPackage.id}}</a>
 
     <a
       class="relation-row--grid-subject"
-      data-qa-selector="op-relation--row-subject"
+      data-test-selector="op-relation--row-subject"
       uiSref="work-packages.show.tabs"
       [uiParams]="{ workPackageId: relatedWorkPackage.id, tabIdentifier: 'relations' }"
       [textContent]="relatedWorkPackage.subject"

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.html
@@ -1,6 +1,6 @@
 <op-autocompleter
   classes="wp-relations-autocomplete"
-  data-qa-selector="wp-relations-autocomplete"
+  data-test-selector="wp-relations-autocomplete"
   [appendTo]="appendToContainer"
   [placeholder]="inputPlaceholder"
   [resource]="autocompleterOptions.resource"

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
@@ -4,7 +4,7 @@
   <section
     class="op-tab-content--tab-section"
     [ngClass]="{ 'op-tab-content--tab-section_no-header': (showAttachmentHeader$ | async) === false }"
-    data-qa-selector="op-tab-content--tab-section"
+    data-test-selector="op-tab-content--tab-section"
   >
     <div
       *ngIf="showAttachmentHeader$ | async"
@@ -19,7 +19,7 @@
 
   <section
     *ngFor="let storage of projectStorages | async"
-    data-qa-selector="op-tab-content--tab-section"
+    data-test-selector="op-tab-content--tab-section"
     class="op-tab-content--tab-section"
   >
     <op-storage

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.html
@@ -4,7 +4,7 @@
       [principal]="watcher"
       [link]="true"
       size="mini"
-      data-qa-selector="op-wp-watcher-name"
+      data-test-selector="op-wp-watcher-name"
     ></op-principal>
   </span>
   <button

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
@@ -32,7 +32,7 @@
       </button>
       <button
         class="button button_no-margin -highlight spot-action-bar--action"
-        data-qa-selector="spot-modal-wp-table-configuration-save-button"
+        data-test-selector="spot-modal-wp-table-configuration-save-button"
         [textContent]="text.applyButton"
         (click)="saveChanges()"
       >

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -189,7 +189,7 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
     const day = date.toDate();
     if (this.weekdaysService.isNonWorkingDay(day) || this.wpTimeline.isNonWorkingDay(day)) {
       cell.classList.add('wp-timeline--non-working-day');
-      cell.dataset.qaSelector = `wp-timeline--non-working-day_${day.getDate()}-${day.getMonth() + 1}-${day.getFullYear()}`;
+      cell.dataset.testSelector = `wp-timeline--non-working-day_${day.getDate()}-${day.getMonth() + 1}-${day.getFullYear()}`;
     }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-timer-button/wp-timer-button.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-timer-button/wp-timer-button.component.html
@@ -3,7 +3,7 @@
     <button
       class="button button_flex"
       type="button"
-      data-qa-selector="timer-active"
+      data-test-selector="timer-active"
       [title]="text.stop_timer"
       (click)="stop()"
     >
@@ -16,7 +16,7 @@
   <button
     class="button"
     type="button"
-    data-qa-selector="timer-inactive"
+    data-test-selector="timer-inactive"
     *ngIf="!context.timer || !context.active"
     [title]="text.start_timer"
     (click)="start()"

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -39,7 +39,7 @@
         <li class="toolbar-item" *ngIf="(displayNotificationsButton$ | async)">
           <op-work-package-mark-notification-button
             [workPackage]="workPackage"
-            data-qa-selector="mark-notification-read-button"
+            data-test-selector="mark-notification-read-button"
           ></op-work-package-mark-notification-button>
         </li>
         <li class="toolbar-item hidden-for-tablet">

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
@@ -140,7 +140,7 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
     this.ngZone.runOutsideAngular(() => {
       setTimeout(() => {
         const selectedRow = this.elementRef.nativeElement.querySelector('.wp-table--row.-checked');
-        const selectedCard = this.elementRef.nativeElement.querySelector('[data-qa-selector="op-wp-single-card"].-checked');
+        const selectedCard = this.elementRef.nativeElement.querySelector('[data-test-selector="op-wp-single-card"].-checked');
 
         // The header of the table hides the scrolledIntoView element
         // so we scrollIntoView the previous element, if any

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
@@ -8,7 +8,7 @@
     <div
       [title]="attachment.fileName"
       class="spot-list--item-title op-file-list--item-title"
-      data-qa-selector="op-files-tab--file-list-item-title"
+      data-test-selector="op-files-tab--file-list-item-title"
     >
       <span
         class="spot-icon spot-icon_{{fileIcon.icon}} op-files-tab--icon op-files-tab--icon_{{fileIcon.clazz}}"

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
@@ -6,7 +6,7 @@
     *ngFor="let attachment of attachments; let i = index;"
     op-attachment-list-item
     class="spot-list--item op-file-list--item"
-    data-qa-selector="op-attachment-list-item"
+    data-test-selector="op-attachment-list-item"
     [attachment]="attachment"
     [index]="i"
     (removeAttachment)="removeAttachment(attachment)"

--- a/frontend/src/app/shared/components/attachments/attachments.component.html
+++ b/frontend/src/app/shared/components/attachments/attachments.component.html
@@ -22,7 +22,7 @@
 <button
   *ngIf="allowUploading && resource.canAddAttachments"
   [attr.aria-label]="text.uploadLabel"
-  data-qa-selector="op-attachments--drop-box"
+  data-test-selector="op-attachments--drop-box"
   [ngClass]="{
     'hide-when-print': true,
     'op-file-section--drop-box': true,
@@ -59,7 +59,7 @@
     type="button"
     class="spot-link"
     (click)="triggerFileInput()"
-    data-qa-selector="op-attachments--upload-button"
+    data-test-selector="op-attachments--upload-button"
   >
     <span class="spot-icon spot-icon_add-attachment"></span>
     <span [textContent]="text.uploadLabel"></span>

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -67,7 +67,7 @@ export const attachmentsSelector = 'op-attachments';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
-  @HostBinding('attr.data-qa-selector') public qaSelector = 'op-attachments';
+  @HostBinding('attr.data-test-selector') public testSelector = 'op-attachments';
 
   @HostBinding('class.op-file-section') public className = true;
 

--- a/frontend/src/app/shared/components/attribute-help-texts/help-text.modal.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/help-text.modal.html
@@ -4,7 +4,7 @@
 >
   <div
     class="spot-modal--header"
-    data-qa-selector="attribute-help-text--header"
+    data-test-selector="attribute-help-text--header"
   >
     <span class="spot-icon spot-icon_help1"></span>
     <span class="attribute-help-text--header-text" 

--- a/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.component.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.component.html
@@ -6,7 +6,7 @@
   (keydown.space)="handleClick($event)"
   role="button"
   tabindex="0"
-  data-qa-selector="static-attribute-help-text--icon"
+  data-test-selector="static-attribute-help-text--icon"
 >
   <span class="spot-icon spot-icon_help1"></span>
 </div>

--- a/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.html
@@ -1,7 +1,7 @@
 <div
   class="spot-modal"
   data-indicator-name="modal"
-  data-qa-selector="static-attribute-help-text--modal"
+  data-test-selector="static-attribute-help-text--modal"
 >
   <div
     class="spot-modal--header"

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -129,7 +129,7 @@
       ></op-principal>
       <span
         class="op-autocompleter--wp-subject"
-        data-qa-selector="op-autocompleter-item-subject"
+        data-test-selector="op-autocompleter-item-subject"
       >
         <span
           *ngIf="item.type"

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
@@ -3,7 +3,7 @@
   #input
   type="text"
   class="spot-input op-basic-range-datepicker--input"
-  data-qa-selector="op-basic-range-date-picker"
+  data-test-selector="op-basic-range-date-picker"
   [ngClass]="inputClassNames"
   [attr.data-value]="value"
   [id]="id"
@@ -18,7 +18,7 @@
   <input
     type="date"
     class="spot-input"
-    data-qa-selector="op-basic-range-date-picker-start"
+    data-test-selector="op-basic-range-date-picker-start"
     [ngClass]="inputClassNames"
     id="{{ id }}-start"
     name="{{ name }}-start"
@@ -31,7 +31,7 @@
   <input
     type="date"
     class="spot-input"
-    data-qa-selector="op-basic-range-date-picker-end"
+    data-test-selector="op-basic-range-date-picker-end"
     [ngClass]="inputClassNames"
     id="{{ id }}-end"
     name="{{ name }}-end"
@@ -42,7 +42,7 @@
   />
   <input
     type="hidden"
-    data-qa-selector="op-basic-range-date-picker--value"
+    data-test-selector="op-basic-range-date-picker--value"
     [attr.data-value]="stringValue"
     [id]="id"
     [name]="name"

--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.html
@@ -1,7 +1,7 @@
 <spot-drop-modal
   [opened]="opened"
   (closed)="opened = false"
-  data-qa-selector="op-modal-single-date-picker"
+  data-test-selector="op-modal-single-date-picker"
 >
   <ng-content
     slot="trigger"
@@ -23,7 +23,7 @@
   <ng-container slot="body">
     <form
       class="spot-container op-datepicker-modal"
-      data-qa-selector="op-datepicker-modal"
+      data-test-selector="op-datepicker-modal"
       tabindex="0"
       cdkFocusInitial
       cdkTrapFocus
@@ -40,7 +40,7 @@
           name="ignoreNonWorkingDays"
           [(ngModel)]="ignoreNonWorkingDays"
           (ngModelChange)="changeNonWorkingDays()"
-          data-qa-selector="op-datepicker-modal--include-non-working-days"
+          data-test-selector="op-datepicker-modal--include-non-working-days"
         ></spot-switch>
       </spot-selector-field>
 
@@ -76,13 +76,13 @@
             type="button"
             (click)="opened = false"
             class="button spot-action-bar--action"
-            data-qa-selector="op-datepicker-modal--action"
+            data-test-selector="op-datepicker-modal--action"
             [textContent]="text.cancel"
           ></button>
           <button
             type="submit"
             class="button -highlight spot-action-bar--action"
-            data-qa-selector="op-datepicker-modal--action"
+            data-test-selector="op-datepicker-modal--action"
             [textContent]="applyLabel"
           ></button>
         </div>

--- a/frontend/src/app/shared/components/datepicker/multi-date-picker/multi-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/multi-date-picker/multi-date-picker.component.html
@@ -1,7 +1,7 @@
 <spot-drop-modal
   [opened]="opened"
   (closed)="close()"
-  data-qa-selector="op-multi-date-picker"
+  data-test-selector="op-multi-date-picker"
 >
   <input
     slot="trigger"
@@ -17,7 +17,7 @@
   <form
     slot="body"
     class="op-datepicker-modal op-datepicker-modal_wide"
-    data-qa-selector="op-datepicker-modal"
+    data-test-selector="op-datepicker-modal"
     tabindex="0"
     cdkFocusInitial
     cdkTrapFocus
@@ -85,13 +85,13 @@
           type="button"
           (click)="close()"
           class="spot-modal--cancel-button button spot-action-bar--action"
-          data-qa-selector="op-datepicker-modal--action"
+          data-test-selector="op-datepicker-modal--action"
           [textContent]="text.cancel"
         ></button>
         <button
           type="submit"
           class="button -highlight spot-action-bar--action"
-          data-qa-selector="op-datepicker-modal--action"
+          data-test-selector="op-datepicker-modal--action"
           [textContent]="applyLabel"
         ></button>
       </div>

--- a/frontend/src/app/shared/components/datepicker/scheduling-mode/datepicker-scheduling-toggle.component.html
+++ b/frontend/src/app/shared/components/datepicker/scheduling-mode/datepicker-scheduling-toggle.component.html
@@ -7,6 +7,6 @@
     name="scheduling"
     [ngModel]="scheduleManually"
     (ngModelChange)="onToggle($event)"
-    data-qa-selector="op-datepicker-modal--scheduling-action"
+    data-test-selector="op-datepicker-modal--scheduling-action"
   ></spot-switch>
 </spot-selector-field>

--- a/frontend/src/app/shared/components/datepicker/toggle/datepicker-working-days-toggle.component.html
+++ b/frontend/src/app/shared/components/datepicker/toggle/datepicker-working-days-toggle.component.html
@@ -8,6 +8,6 @@
     [disabled]="disabled"
     [ngModel]="!ignoreNonWorkingDays"
     (ngModelChange)="onToggle($event)"
-    data-qa-selector="op-datepicker-modal--include-non-working-days"
+    data-test-selector="op-datepicker-modal--include-non-working-days"
   ></spot-switch>
 </spot-selector-field>

--- a/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.html
+++ b/frontend/src/app/shared/components/datepicker/wp-multi-date-form/wp-multi-date-form.component.html
@@ -1,5 +1,5 @@
 <form
-  data-qa-selector="op-datepicker-modal"
+  data-test-selector="op-datepicker-modal"
   [attr.id]="htmlId"
   class="op-datepicker-modal op-datepicker-modal_wide"
   #modalContainer
@@ -30,12 +30,12 @@
     <div class="op-datepicker-modal--dates-container">
       <spot-form-field
         [label]="text.startDate"
-        data-qa-selector="datepicker-start-date"
+        data-test-selector="datepicker-start-date"
       >
         <spot-text-field
           slot="input"
           name="startDate"
-          data-qa-selector="op-datepicker-modal--start-date-field"
+          data-test-selector="op-datepicker-modal--start-date-field"
           class="op-datepicker-modal--date-field"
           [attr.data-qa-highlighted]="showFieldAsActive('start') || undefined"
           [ngClass]="{'op-datepicker-modal--date-field_current' : showFieldAsActive('start')}"
@@ -56,12 +56,12 @@
       </spot-form-field>
       <spot-form-field
         [label]="text.endDate"
-        data-qa-selector="datepicker-end-date"
+        data-test-selector="datepicker-end-date"
       >
         <spot-text-field
           slot="input"
           name="endDate"
-          data-qa-selector="op-datepicker-modal--end-date-field"
+          data-test-selector="op-datepicker-modal--end-date-field"
           class="op-datepicker-modal--date-field"
           [attr.data-qa-highlighted]="showFieldAsActive('end') || undefined"
           [ngClass]="{'op-datepicker-modal--date-field_current' : showFieldAsActive('end')}"
@@ -82,13 +82,13 @@
       </spot-form-field>
       <spot-form-field
         [label]="text.duration"
-        data-qa-selector="datepicker-duration"
+        data-test-selector="datepicker-duration"
       >
         <spot-text-field
           #durationField
           slot="input"
           name="duration"
-          data-qa-selector="op-datepicker-modal--duration-field"
+          data-test-selector="op-datepicker-modal--duration-field"
           class="op-datepicker-modal--date-field"
           [attr.data-qa-highlighted]=" showFieldAsActive('duration') || undefined"
           [ngClass]="{'op-datepicker-modal--date-field_current' : showFieldAsActive('duration')}"
@@ -117,13 +117,13 @@
         type="button"
         (click)="doCancel()"
         class="spot-modal--cancel-button button spot-action-bar--action"
-        data-qa-selector="op-datepicker-modal--action"
+        data-test-selector="op-datepicker-modal--action"
         [textContent]="text.cancel"
       ></button>
       <button
         type="submit"
         class="button -highlight spot-action-bar--action"
-        data-qa-selector="op-datepicker-modal--action"
+        data-test-selector="op-datepicker-modal--action"
         [textContent]="text.save"
       ></button>
     </div>

--- a/frontend/src/app/shared/components/datepicker/wp-single-date-form/wp-single-date-form.component.html
+++ b/frontend/src/app/shared/components/datepicker/wp-single-date-form/wp-single-date-form.component.html
@@ -1,6 +1,6 @@
 <form
   class="spot-container op-datepicker-modal"
-  data-qa-selector="op-datepicker-modal"
+  data-test-selector="op-datepicker-modal"
   [attr.id]="htmlId"
   #modalContainer
   data-indicator-name="modal"
@@ -62,13 +62,13 @@
         type="button"
         (click)="doCancel()"
         class="spot-modal--cancel-button button spot-action-bar--action"
-        data-qa-selector="op-datepicker-modal--action"
+        data-test-selector="op-datepicker-modal--action"
         [textContent]="text.cancel"
       ></button>
       <button
         type="submit"
         class="button -highlight spot-action-bar--action"
-        data-qa-selector="op-datepicker-modal--action"
+        data-test-selector="op-datepicker-modal--action"
         [textContent]="text.save"
       ></button>
     </div>

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
@@ -1,6 +1,6 @@
 <div
   class="op-enterprise-banner"
-  data-qa-selector="op-enterprise-banner"
+  data-test-selector="op-enterprise-banner"
 >
   <div class="op-toast -ee-upsale"
        [ngClass]="{'-left-margin': leftMargin }">

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
@@ -21,7 +21,7 @@
       <li
         *ngFor="let widget of selectable;trackBy: trackWidgetBy"
         class="spot-list--item"
-        data-qa-selector="op-grid--addable-widget">
+        data-test-selector="op-grid--addable-widget">
         <button
           type="button"
           class="spot-list--item-action"

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.html
@@ -1,5 +1,5 @@
 <h3 class="op-widget-box--header"
-    data-qa-selector="op-widget-box--header"
+    data-test-selector="op-widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
 
   <ng-content select="[slot=prepend]"></ng-content>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -93,7 +93,7 @@
             <a *ngIf="item.entry && item.entry.updateImmediately"
                (click)="editTimeEntry(item.entry)"
                [title]="text.edit"
-               attr.data-qa-selector="edit-time-entry-{{ item.entry.id }}"
+               attr.data-test-selector="edit-time-entry-{{ item.entry.id }}"
             >
               <op-icon icon-classes="icon-context icon-edit"></op-icon>
             </a>

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -37,7 +37,7 @@
         [placeholder]="text.search_placeholder"
         [(ngModel)]="searchableProjectListService.searchText"
         [ngModelOptions]="{standalone: true}"
-        data-qa-selector="op-header-project-select--search"
+        data-test-selector="op-header-project-select--search"
         data-modal-focus-catcher-container="true"
         (keydown)="searchableProjectListService.onKeydown($event, projects)"
         (inputFocus)="textFieldFocused = true"
@@ -58,7 +58,7 @@
           [searchText]="searchableProjectListService.searchText"
           [root]="true"
           data-list-root="true"
-          data-qa-selector="op-header-project-select--list"
+          data-test-selector="op-header-project-select--list"
         ></ul>
 
         <ng-template #noResultsTemplate>

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -1,7 +1,7 @@
 <li
   class="spot-list--item"
   *ngFor="let project of projects; index as i; first as isFirst; last as isLast"
-  data-qa-selector="op-header-project-select--item"
+  data-test-selector="op-header-project-select--item"
   [attr.data-list-selector]="projectListItemIdentifier"
 >
   <a
@@ -18,7 +18,7 @@
   >
   <span
     class="spot-list--item-title spot-list--item-title_ellipse-text"
-    data-qa-selector="op-header-project-select--item-title"
+    data-test-selector="op-header-project-select--item-title"
     [opSearchHighlight]="searchText"
   >{{ project.name }}</span>
   </a>
@@ -31,7 +31,7 @@
   >
     <span
       class="spot-list--item-title spot-list--item-title_ellipse-text"
-      data-qa-selector="op-header-project-select--item-disabled-title"
+      data-test-selector="op-header-project-select--item-disabled-title"
     >{{ project.name }}</span>
   </span>
 

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -1,7 +1,7 @@
 <div
   class="op-modal-banner"
   ngClass="op-modal-banner_{{ type }}"
-  attr.data-qa-selector="op-modal-banner-{{ type }}"
+  attr.data-test-selector="op-modal-banner-{{ type }}"
 >
   <span
     *ngIf="type === 'info'"

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
@@ -47,7 +47,7 @@
       <button
         type="button"
         class="button spot-modal--cancel-button spot-action-bar--action"
-        data-qa-selector="confirmation-modal--cancel"
+        data-test-selector="confirmation-modal--cancel"
         (click)="close($event)"
       >
         <span *ngIf="icon.cancel as clazz" class="spot-icon spot-icon_{{clazz}}"></span>
@@ -56,7 +56,7 @@
       <button
         type="button"
         class="button spot-action-bar--action"
-        data-qa-selector="confirmation-modal--confirmed"
+        data-test-selector="confirmation-modal--confirmed"
         [ngClass]="dangerHighlighting ? '-danger': '-highlight'"
         (click)="confirmAndClose($event)"
       >

--- a/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
+++ b/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
@@ -41,7 +41,7 @@
         type="submit"
         class="button button_no-margin -highlight spot-action-bar--action"
         [textContent]="additionalText.confirm_button"
-        data-qa-selector="confirmation-modal--confirmed"
+        data-test-selector="confirmation-modal--confirmed"
         [disabled]="!passwordValuePresent()">
       </button>
     </div>

--- a/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
+++ b/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
@@ -1,7 +1,7 @@
 <li
   class="spot-list--item op-project-include-list--item"
   *ngFor="let project of projects"
-  data-qa-selector="op-project-include-list--item"
+  data-test-selector="op-project-include-list--item"
   [attr.data-list-selector]="projectListItemIdentifier"
 >
   <spot-tooltip
@@ -31,7 +31,7 @@
         ></spot-checkbox>
         <div
           class="spot-list--item-title spot-list--item-title_ellipse-text"
-          data-qa-selector="op-project-include-list--item-title"
+          data-test-selector="op-project-include-list--item-title"
           [opSearchHighlight]="searchText"
         >{{ project.name }}</div>
       </label>

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -9,7 +9,7 @@
     class="button"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
-    data-qa-selector="project-include-button"
+    data-test-selector="project-include-button"
   >
     {{ text.toggle_title }}
     <span
@@ -40,7 +40,7 @@
         name="project-include-search"
         [(ngModel)]="searchableProjectListService.searchText"
         [ngModelOptions]="{standalone: true}"
-        data-qa-selector="project-include-search"
+        data-test-selector="project-include-search"
         data-list-focus-catcher-container="true"
         data-modal-focus-catcher-container="true"
         (keydown)="searchableProjectListService.onKeydown($event, projects)"
@@ -65,7 +65,7 @@
           [searchText]="searchableProjectListService.searchText"
           [root]="true"
           (update)="selectedProjects = $event"
-          data-qa-selector="project-include-list"
+          data-test-selector="project-include-list"
           data-list-root="true"
         ></ul>
 
@@ -110,7 +110,7 @@
   <ng-template #loadingTemplate>
     <op-loading-project-list
       class="op-project-list-modal--loading"
-      data-qa-selector="op-project-include--loading"
+      data-test-selector="op-project-include--loading"
     ></op-loading-project-list>
   </ng-template>
 </spot-drop-modal>

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
@@ -25,7 +25,7 @@
   <li
     *ngFor="let item of items"
     class="op-sidemenu--item"
-    data-qa-selector="op-sidemenu--item"
+    data-test-selector="op-sidemenu--item"
   >
     <op-sidemenu
       *ngIf="item.children && item.children.length"
@@ -40,7 +40,7 @@
       [class]="{ 'op-sidemenu--item-action_with_icon': !!item.icon }"
       uiSrefActive="op-sidemenu--item-action_active-child"
       uiSrefActiveEq="op-sidemenu--item-action_active"
-      [attr.data-qa-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
+      [attr.data-test-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
       [uiSref]="item.uiSref"
       [uiParams]="item.uiParams"
       [uiOptions]="item.uiOptions"
@@ -52,7 +52,7 @@
       *ngIf="!item.children && item.href"
       class="op-sidemenu--item-action"
       [class]="{ 'op-sidemenu--item-action_with_icon': !!item.icon }"
-      [attr.data-qa-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
+      [attr.data-test-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
       [href]="item.href"
     >
       <ng-container *ngTemplateOutlet="itemTemplate; context: { item }"></ng-container>

--- a/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
+++ b/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
@@ -64,7 +64,7 @@
       <button
         *ngIf="allowEditing"
         class="spot-link"
-        data-qa-selector="file-list--item-remove-floating-action"
+        data-test-selector="file-list--item-remove-floating-action"
         [title]="text.title.removeFileLink"
         (click)="confirmRemoveFileLink()"
       >

--- a/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.html
+++ b/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.html
@@ -1,6 +1,6 @@
 <div
   class="spot-modal op-file-picker"
-  data-qa-selector="op-files-picker-modal"
+  data-test-selector="op-files-picker-modal"
 >
   <div class="spot-modal--header">
     <span class="spot-modal--header-title">{{text.header}}</span>
@@ -34,12 +34,12 @@
       <ul
         *ngIf="(listItems$ | async).length > 0; else emptyTemplate"
         class="spot-list spot-list_compact op-file-list op-file-picker--scrollable-content"
-        data-qa-selector="op-files-picker-modal--file-list"
+        data-test-selector="op-files-picker-modal--file-list"
       >
         <li
           *ngFor="let file of listItems$ | async; let i = index;"
           class="spot-list--item op-file-list--item"
-          data-qa-selector="op-file-list--item"
+          data-test-selector="op-file-list--item"
           op-storage-file-list-item
           [content]="file"
         ></li>
@@ -75,7 +75,7 @@
       <button
         type="button"
         class="spot-link spot-action-bar--action"
-        data-qa-selector="op-files-picker-modal--select-all"
+        data-test-selector="op-files-picker-modal--select-all"
         (click)="selectAllOfCurrentLevel()"
       >
         <span class="spot-icon spot-icon_select-all"></span>
@@ -92,7 +92,7 @@
       <button
         type="button"
         class="button spot-action-bar--action"
-        data-qa-selector="op-files-picker-modal--confirm"
+        data-test-selector="op-files-picker-modal--confirm"
         [ngClass]="{ '-highlight': selectedFileCount > 0 }"
         [disabled]="selectedFileCount === 0"
         (click)="createSelectedFileLinks()"

--- a/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.html
+++ b/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.html
@@ -1,6 +1,6 @@
 <div
   class="spot-modal op-file-picker"
-  data-qa-selector="op-files-picker-modal"
+  data-test-selector="op-files-picker-modal"
 >
   <div class="spot-modal--header">
     <span class="spot-modal--header-title">{{text.header}}</span>
@@ -34,12 +34,12 @@
       <ul
         *ngIf="(listItems$ | async).length > 0; else emptyTemplate"
         class="spot-list spot-list_compact op-file-list op-file-picker--scrollable-content"
-        data-qa-selector="op-files-picker-modal--file-list"
+        data-test-selector="op-files-picker-modal--file-list"
       >
         <li
           *ngFor="let file of listItems$ | async; let i = index;"
           class="spot-list--item op-file-list--item"
-          data-qa-selector="op-file-list--item"
+          data-test-selector="op-file-list--item"
           op-storage-file-list-item
           [content]="file"
         ></li>
@@ -49,7 +49,7 @@
     <ng-template #loadingTemplate>
       <op-loading-file-list
         class="spot-body-small"
-        data-qa-selector="op-file-list--loading-indicator"
+        data-test-selector="op-file-list--loading-indicator"
       ></op-loading-file-list>
     </ng-template>
 
@@ -82,7 +82,7 @@
       <button
         type="button"
         class="button spot-action-bar--action -highlight"
-        data-qa-selector="op-files-picker-modal--confirm"
+        data-test-selector="op-files-picker-modal--confirm"
         [disabled]="!canChooseLocation"
         [textContent]="text.buttons.submit"
         (click)="chooseLocation()"

--- a/frontend/src/app/shared/components/storages/storage-file-list-item/storage-file-list-item.html
+++ b/frontend/src/app/shared/components/storages/storage-file-list-item/storage-file-list-item.html
@@ -10,7 +10,7 @@
   <label
     slot="trigger"
     class="spot-list--item-action"
-    data-qa-selector="op-files-picker-modal--list-item"
+    data-test-selector="op-files-picker-modal--list-item"
     (click)="enterDirectoryOnLabel($event)"
     [ngClass]="{
       'spot-list--item-action_disabled': content.disabled,
@@ -52,7 +52,7 @@
     <button
       *ngIf="content.isDirectory"
       class="spot-link op-file-list--item-button"
-      data-qa-selector="op-files-picker-modal--list-item-caret"
+      data-test-selector="op-files-picker-modal--list-item-caret"
       (click)="content.enterDirectory()"
     >
       <span class="spot-icon spot-icon_arrow-right2"></span>

--- a/frontend/src/app/shared/components/storages/storage/storage.component.html
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.html
@@ -20,7 +20,7 @@
   <op-storage-information
     *ngFor="let infoBox of storageErrors | async"
     class="op-files-tab--storage-info-box"
-    data-qa-selector="op-storage--information"
+    data-test-selector="op-storage--information"
     [content]="infoBox"
   ></op-storage-information>
 
@@ -32,12 +32,12 @@
         'op-file-section': true,
         'op-file-section--list_dragging': dragging > 0
       }"
-      data-qa-selector="file-list"
+      data-test-selector="file-list"
     >
       <li
         *ngFor="let fileLink of fileLinks | async; let i = index;"
         class="spot-list--item op-file-list--item"
-        data-qa-selector="file-list--item"
+        data-test-selector="file-list--item"
         op-file-link-list-item
         [fileLink]="fileLink"
         [disabled]="disabled | async"
@@ -65,7 +65,7 @@
     <button
       *ngIf="allowUploading && (storageErrors | async)?.length === 0"
       [attr.aria-label]="text.dropBox.uploadLabel"
-      data-qa-selector="op-storage--drop-box"
+      data-test-selector="op-storage--drop-box"
       [ngClass]="{
         'hide-when-print': true,
         'op-file-section--drop-box': true,
@@ -102,7 +102,7 @@
         *ngIf="allowUploading"
         type="button"
         class="spot-link"
-        data-qa-selector="op-storage--upload-file-button"
+        data-test-selector="op-storage--upload-file-button"
         (click)="triggerFileInput()"
       >
         <span class="spot-icon spot-icon_upload-arrow"></span>
@@ -112,7 +112,7 @@
         *ngIf="allowLinking"
         type="button"
         class="spot-link"
-        data-qa-selector="op-storage--link-existing-file-button"
+        data-test-selector="op-storage--link-existing-file-button"
         (click)="openLinkFilesDialog()"
       >
         <span class="spot-icon spot-icon_add-link"></span>

--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.html
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.html
@@ -49,11 +49,11 @@
             <op-tab-count
               *ngIf="tab.showCountAsBubble"
               [count]="tabCounter"
-              [attr.data-qa-selector]="'tab-counter-' + tab.name"
+              [attr.data-test-selector]="'tab-counter-' + tab.name"
             ></op-tab-count>
             <span
               *ngIf="tabCounter > 0 && !tab.showCountAsBubble"
-              data-qa-selector="tab-count"
+              data-test-selector="tab-count"
             > ({{ tabCounter }})</span>
           </ng-container>
         </a>

--- a/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
@@ -1,6 +1,6 @@
 <div
   class="spot-modal"
-  data-qa-selector="op-stop-existing-timer-modal"
+  data-test-selector="op-stop-existing-timer-modal"
 >
   <div class="spot-modal--header">
     <span class="spot-modal--header-title">{{text.title}}</span>
@@ -37,7 +37,7 @@
       <button
         type="button"
         class="button -highlight spot-action-bar--action"
-        data-qa-selector="op-files-picker-modal--confirm"
+        data-test-selector="op-files-picker-modal--confirm"
         [textContent]="text.button_stop"
         (click)="saveAndClose()"
       >

--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
@@ -2,7 +2,7 @@
   <span class="op-timer-account-menu--timer"> {{text.tracking}}:  {{ elapsed$ | async }}
     <a
     class="op-timer-account-menu--timer-icon"
-    data-qa-selector="op-timer-account-menu-stop"
+    data-test-selector="op-timer-account-menu-stop"
     (click)="stopTimer()"
     >
       <span class="spot-icon spot-icon_inline spot-icon_time-tracking-stop spot-icon_1_25"> </span>

--- a/frontend/src/app/spot/components/breadcrumbs/breadcrumbs.component.html
+++ b/frontend/src/app/spot/components/breadcrumbs/breadcrumbs.component.html
@@ -4,7 +4,7 @@
   <div
     *ngIf="(first && !last) || i === content.crumbs.length - 2 || i === content.crumbs.length - 3"
     class="spot-breadcrumbs--crumb"
-    data-qa-selector="op-breadcrumb"
+    data-test-selector="op-breadcrumb"
     [ngClass]="{
       'spot-breadcrumbs--crumb_root': first,
       'spot-breadcrumbs--crumb_parent': i === content.crumbs.length - 2,
@@ -35,7 +35,7 @@
   <div
     *ngIf="last"
     class="spot-breadcrumbs--crumb spot-breadcrumbs--crumb_last"
-    data-qa-selector="op-breadcrumb"
+    data-test-selector="op-breadcrumb"
   >
     <span *ngIf="crumb.icon" class="spot-icon spot-icon_{{crumb.icon}}"></span>
     <span

--- a/frontend/src/app/spot/components/switch/switch.component.html
+++ b/frontend/src/app/spot/components/switch/switch.component.html
@@ -11,6 +11,6 @@
 />
 <span
   class="spot-switch--fake"
-  data-qa-selector="spot-switch-handle"
+  data-test-selector="spot-switch-handle"
   [attr.data-qa-active]="checked || undefined"
 ></span>

--- a/frontend/src/app/spot/components/toggle/toggle.component.html
+++ b/frontend/src/app/spot/components/toggle/toggle.component.html
@@ -1,7 +1,7 @@
 <label
   *ngFor="let option of options"
   [ngClass]="{ 'button': true, '-disabled': disabled, 'form--field-inline-button': true, '-active': value === option.value, 'spot-toggle--button': true }"
-  data-qa-selector="spot-toggle--option"
+  data-test-selector="spot-toggle--option"
   [attr.data-qa-disabled]="disabled || undefined"
   [attr.data-qa-active-toggle]="value === option.value"
 >

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -244,7 +244,7 @@ module Redmine::MenuManager::MenuHelper
     html_options = item.html_options(selected:)
     html_options[:title] ||= selected ? t(:description_current_position) + caption : caption
     html_options[:class] = "#{html_options[:class]} #{menu_class}--item-action"
-    html_options['data-qa-selector'] = "#{menu_class}--item-action"
+    html_options['data-test-selector'] = "#{menu_class}--item-action"
     html_options['target'] = '_blank' if item.icon_after.present? && item.icon_after == 'external-link'
 
     link_to link_text, url, html_options

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_panels.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_panels.html.erb
@@ -12,6 +12,6 @@
 
     <hr>
 
-    <div class="op-ifc-viewer--tree-panel active" data-qa-selector="op-ifc-viewer--tree-panel"></div>
+    <div class="op-ifc-viewer--tree-panel active" data-test-selector="op-ifc-viewer--tree-panel"></div>
   </div>
 </div>

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'BIM navigation spec',
         model_page.model_viewer_shows_a_toolbar true
         model_page.page_shows_a_toolbar true
         model_tree.sidebar_shows_viewer_menu true
-        expect(page).to have_selector('[data-qa-selector="op-wp-card-view"]')
+        expect(page).to have_test_selector('op-wp-card-view')
         card_view.expect_work_package_listed work_package
       end
 
@@ -104,13 +104,13 @@ RSpec.describe 'BIM navigation spec',
         model_page.switch_view 'Viewer'
 
         model_page.model_viewer_visible true
-        expect(page).not_to have_selector('[data-qa-selector="op-wp-card-view"]')
+        expect(page).not_to have_test_selector('op-wp-card-view')
 
         # Go to list only
         model_page.switch_view 'Cards'
 
         model_page.model_viewer_visible false
-        expect(page).to have_selector('[data-qa-selector="op-wp-card-view"]')
+        expect(page).to have_test_selector('op-wp-card-view')
         card_view.expect_work_package_listed work_package
 
         # Go to details view

--- a/modules/bim/spec/support/pages/ifc_models/index.rb
+++ b/modules/bim/spec/support/pages/ifc_models/index.rb
@@ -102,7 +102,7 @@ module Pages
       def show_model(model)
         click_model_link model.title
 
-        expect_correct_page_loaded '[data-qa-selector="op-ifc-viewer--container"]'
+        expect_correct_page_loaded '[data-test-selector="op-ifc-viewer--container"]'
 
         expect_model_active(model)
       end
@@ -114,7 +114,7 @@ module Pages
       def show_defaults(models = [])
         click_toolbar_button 'Show defaults'
 
-        expect_correct_page_loaded '[data-qa-selector="op-ifc-viewer--container"]'
+        expect_correct_page_loaded '[data-test-selector="op-ifc-viewer--container"]'
 
         models.each do |model|
           expect_model_active(model, model.is_default)

--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -74,12 +74,12 @@ module Pages
         selector = '.xeokit-btn'
 
         if visible
-          within('[data-qa-selector="op-ifc-viewer--toolbar-container"]') do
+          within('[data-test-selector="op-ifc-viewer--toolbar-container"]') do
             expect(page).to have_selector(selector, count: 8)
           end
         else
           expect(page).not_to have_selector(selector)
-          expect(page).not_to have_selector('[data-qa-selector="op-ifc-viewer--toolbar-container"]')
+          expect(page).not_to have_selector('[data-test-selector="op-ifc-viewer--toolbar-container"]')
         end
       end
 

--- a/modules/boards/app/components/boards/row_component.rb
+++ b/modules/boards/app/components/boards/row_component.rb
@@ -64,7 +64,7 @@ module Boards
           class: 'icon icon-delete',
           data: {
             confirm: I18n.t(:text_are_you_sure),
-            'qa-selector': "board-remove-#{model.id}"
+            'test-selector': "board-remove-#{model.id}"
           },
           title: t(:button_delete)
         )

--- a/modules/boards/app/views/boards/boards/_form.html.erb
+++ b/modules/boards/app/views/boards/boards/_form.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
                                   id: 'project_id',
                                   class: 'form--select-container -wide remote-field--input',
                                   data: {
-                                    'qa-selector': 'project_id'
+                                    'test-selector': 'project_id'
                                   }
         %>
       </div>
@@ -80,7 +80,7 @@ See COPYRIGHT and LICENSE files for more details.
         <% board_types.each_with_index do |board_type, tile_number| %>
           <label class="op-tile-block--tile form--radio-button-container -wide <%= '-disabled' if board_type.disabled? %>"
                  for="boards_grid_attribute_<%= board_type.radio_button_value %>"
-                 data-qa-selector="op-tile-block">
+                 data-test-selector="op-tile-block">
             <div class="op-tile-block--content">
               <%= styled_radio_button_tag 'boards_grid[attribute]',
                                           board_type.radio_button_value,
@@ -89,7 +89,7 @@ See COPYRIGHT and LICENSE files for more details.
                                           disabled: board_type.disabled?,
                                           class: 'radio-button' %>
               <div>
-                <span data-qa-selector="op-tile-block-title" class="op-tile-block--title">
+                <span data-test-selector="op-tile-block-title" class="op-tile-block--title">
                   <%= board_type.title %>
                 </span>
                 <p class="op-tile-block--description"><%= board_type.description %></p>

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -150,8 +150,9 @@ RSpec.describe 'Assignee action board',
       board_page.expect_card 'Bob Self', 'Some Task', present: false
 
       # Expect to have changed the avatar
-      expect(page).to have_selector('[data-qa-selector="op-wp-single-card--content-assignee"] .op-avatar_mini', text: 'FB',
-                                                                                                                wait: 10)
+      within_test_selector('op-wp-single-card--content-assignee') do
+        expect(page).to have_selector('.op-avatar_mini', text: 'FB', wait: 10)
+      end
 
       work_package.reload
       expect(work_package.assigned_to).to eq(foobar_user)
@@ -163,8 +164,9 @@ RSpec.describe 'Assignee action board',
       board_page.expect_card 'Bob Self', 'Some Task', present: false
 
       # Expect to have changed the avatar
-      expect(page).to have_selector('[data-qa-selector="op-wp-single-card--content-assignee"] .op-avatar_mini', text: 'GG',
-                                                                                                                wait: 10)
+      within_test_selector('op-wp-single-card--content-assignee') do
+        expect(page).to have_selector('.op-avatar_mini', text: 'GG', wait: 10)
+      end
 
       work_package.reload
       expect(work_package.assigned_to).to eq(group)

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -249,18 +249,18 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       end
 
       board_page.expect_list 'Closed version'
-      expect(page).to have_selector('[data-qa-selector="op-version-board-header"].-closed')
+      expect(page).to have_selector("#{test_selector('op-version-board-header')}.-closed")
 
       # Can open that version
       board_page.click_list_dropdown 'Closed version', 'Open version'
-      expect(page).not_to have_selector('[data-qa-selector="op-version-board-header"].-closed')
+      expect(page).not_to have_selector("#{test_selector('op-version-board-header')}.-closed")
 
       closed_version.reload
       expect(closed_version.status).to eq 'open'
 
       # Can lock that version
       board_page.click_list_dropdown 'Closed version', 'Lock version'
-      expect(page).to have_selector('[data-qa-selector="op-version-board-header"].-locked')
+      expect(page).to have_selector("#{test_selector('op-version-board-header')}.-locked")
 
       closed_version.reload
       expect(closed_version.status).to eq 'locked'
@@ -329,7 +329,7 @@ RSpec.describe 'Version action board', js: true, with_ee: %i[board_view] do
       board_page.expect_editable_board(true)
       board_page.expect_editable_list(false)
 
-      expect(page).not_to have_selector('[data-qa-selector="op-wp-single-card"].-draggable')
+      expect(page).not_to have_selector("#{test_selector('op-wp-single-card')}.-draggable")
     end
   end
 

--- a/modules/boards/spec/features/board_enterprise_spec.rb
+++ b/modules/boards/spec/features/board_enterprise_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe 'Boards enterprise spec', :js, :with_cuprite do
     it 'disabled all action boards' do
       page.find('.toolbar-item a', text: 'Board').click
 
-      expect(page).to have_selector('[data-qa-selector="op-tile-block"]:not(.-disabled)', text: 'Basic')
-      expect(page).to have_selector('[data-qa-selector="op-tile-block"].-disabled', count: 5)
+      expect(page).to have_selector("#{test_selector('op-tile-block')}:not(.-disabled)", text: 'Basic')
+      expect(page).to have_selector("#{test_selector('op-tile-block')}.-disabled", count: 5)
     end
 
     it 'shows a banner on the action board' do
@@ -67,12 +67,12 @@ RSpec.describe 'Boards enterprise spec', :js, :with_cuprite do
 
       board_page = board_index.open_board(manual_board)
       board_page.expect_query 'My board'
-      expect(page).not_to have_selector '[data-qa-selector="op-enterprise-banner"]'
+      expect(page).not_to have_test_selector 'op-enterprise-banner'
 
       board_index.visit!
       board_page = board_index.open_board(action_board)
       board_page.expect_query 'Subproject board'
-      expect(page).to have_selector '[data-qa-selector="op-enterprise-banner"]'
+      expect(page).to have_test_selector 'op-enterprise-banner'
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe 'Boards enterprise spec', :js, :with_cuprite do
     it 'enables all options' do
       page.find('.toolbar-item a', text: 'Board').click
 
-      expect(page).to have_selector('[data-qa-selector="op-tile-block"]:not(.-disabled)', count: 6)
+      expect(page).to have_selector("#{test_selector('op-tile-block')}:not(.-disabled)", count: 6)
     end
 
     it 'shows the action board' do
@@ -95,12 +95,12 @@ RSpec.describe 'Boards enterprise spec', :js, :with_cuprite do
 
       board_page = board_index.open_board(manual_board)
       board_page.expect_query 'My board'
-      expect(page).not_to have_selector '[data-qa-selector="op-enterprise-banner"]'
+      expect(page).not_to have_test_selector 'op-enterprise-banner'
 
       board_index.visit!
       board_page = board_index.open_board(action_board)
       board_page.expect_query 'Subproject board'
-      expect(page).not_to have_selector '[data-qa-selector="op-enterprise-banner"]'
+      expect(page).not_to have_test_selector 'op-enterprise-banner'
     end
   end
 end

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe 'Board management spec', js: true, with_ee: %i[board_view] do
 
       # Open in list 1
       board_page.within_list('List 1') do
-        page.find('[data-qa-selector="op-board-list--card-dropdown-add-button"]').click
+        page.find_test_selector('op-board-list--card-dropdown-add-button').click
       end
 
       page.find('.menu-item', text: 'Add new card').click
 
       # Open in list 2
       board_page.within_list('List 2') do
-        page.find('[data-qa-selector="op-board-list--card-dropdown-add-button"]').click
+        page.find_test_selector('op-board-list--card-dropdown-add-button').click
       end
 
       page.find('.menu-item', text: 'Add new card').click

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Work Package boards spec', js: true, with_ee: %i[board_view] do
     wp = WorkPackage.last
     expect(wp.subject).to eq 'Task 1'
     # Double click leads to the full view
-    click_target = board_page.find('[data-qa-selector="op-wp-single-card--content-type"]')
+    click_target = page.find_test_selector('op-wp-single-card--content-type')
     page.driver.browser.action.double_click(click_target.native).perform
 
     expect(page).to have_current_path project_work_package_path(project, wp.id, 'activity')
@@ -103,7 +103,7 @@ RSpec.describe 'Work Package boards spec', js: true, with_ee: %i[board_view] do
     item = page.find('#menu-sidebar li[data-name="boards"]', wait: 10)
     item.find('.toggler').click
 
-    subitem = page.find('[data-qa-selector="op-sidemenu--item-action--Myboard"]', wait: 10)
+    subitem = page.find_test_selector('op-sidemenu--item-action--Myboard', wait: 10)
     # Ends with boards due to lazy route
     expect(subitem[:href]).to end_with project_work_package_boards_path(project)
 

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -63,7 +63,7 @@ module Pages
           click_link 'Board'
         end
       else
-        find('[data-qa-selector="sidebar--create-board-button"]').click
+        find('[data-test-selector="sidebar--create-board-button"]').click
       end
 
       new_board_page = NewBoard.new

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -49,7 +49,7 @@ module Pages
     def expect_delete_buttons(*boards)
       within '#content-wrapper' do
         boards.each do |board|
-          expect(page).to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+          expect(page).to have_selector "[data-test-selector='board-remove-#{board.id}']"
         end
       end
     end
@@ -57,7 +57,7 @@ module Pages
     def expect_no_delete_buttons(*boards)
       within '#content-wrapper' do
         boards.each do |board|
-          expect(page).not_to have_selector "[data-qa-selector='board-remove-#{board.id}']"
+          expect(page).not_to have_selector "[data-test-selector='board-remove-#{board.id}']"
         end
       end
     end

--- a/modules/boards/spec/features/support/board_new_page.rb
+++ b/modules/boards/spec/features/support/board_new_page.rb
@@ -23,11 +23,11 @@ module Pages
     end
 
     def expect_project_dropdown
-      find "[data-qa-selector='project_id']"
+      find "[data-test-selector='project_id']"
     end
 
     def set_project(project)
-      select_autocomplete(find('[data-qa-selector="project_id"]'),
+      select_autocomplete(find('[data-test-selector="project_id"]'),
                           query: project,
                           results_selector: 'body',
                           wait_for_fetched_options: false)

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -68,7 +68,7 @@ module Pages
     end
 
     def list_count
-      page.all('[data-qa-selector="op-board-list"]').count
+      page.all('[data-test-selector="op-board-list"]').count
     end
 
     def within_list(name, &)
@@ -76,12 +76,12 @@ module Pages
     end
 
     def list_selector(name)
-      "[data-qa-selector='op-board-list'][data-query-name='#{name}']"
+      "[data-test-selector='op-board-list'][data-query-name='#{name}']"
     end
 
     def add_card(list_name, card_title)
       within_list(list_name) do
-        page.find('[data-qa-selector="op-board-list--card-dropdown-add-button"]').click
+        page.find('[data-test-selector="op-board-list--card-dropdown-add-button"]').click
       end
 
       # Add item in dropdown
@@ -97,16 +97,16 @@ module Pages
     end
 
     def remove_card(list_name, card_title, index)
-      source = page.all("#{list_selector(list_name)} [data-qa-selector='op-wp-single-card']")[index]
+      source = page.all("#{list_selector(list_name)} [data-test-selector='op-wp-single-card']")[index]
       source.hover
-      source.find('[data-qa-selector="op-wp-single-card--inline-cancel-button"]').click
+      source.find('[data-test-selector="op-wp-single-card--inline-cancel-button"]').click
 
       expect_card(list_name, card_title, present: false)
     end
 
     def reference(list_name, work_package)
       within_list(list_name) do
-        page.find('[data-qa-selector="op-board-list--card-dropdown-add-button"]').click
+        page.find('[data-test-selector="op-board-list--card-dropdown-add-button"]').click
       end
 
       page.find('.menu-item', text: 'Add existing').click
@@ -121,7 +121,7 @@ module Pages
 
     def expect_not_referencable(list_name, work_package)
       within_list(list_name) do
-        page.find('[data-qa-selector="op-board-list--card-dropdown-add-button"]').click
+        page.find('[data-test-selector="op-board-list--card-dropdown-add-button"]').click
       end
 
       page.find('.menu-item', text: 'Add existing').click
@@ -138,7 +138,7 @@ module Pages
     def expect_card(list_name, card_title, present: true)
       within_list(list_name) do
         expect(page).to have_conditional_selector(present,
-                                                  '[data-qa-selector="op-wp-single-card--content-subject"]',
+                                                  '[data-test-selector="op-wp-single-card--content-subject"]',
                                                   text: card_title)
       end
     end
@@ -148,7 +148,7 @@ module Pages
     # No non mentioned cards are allowed to be in the list.
     def expect_cards_in_order(list_name, *card_titles)
       within_list(list_name) do
-        found = all('[data-qa-selector="op-wp-single-card--content-subject"]')
+        found = all('[data-test-selector="op-wp-single-card--content-subject"]')
           .map(&:text)
         expected = card_titles.map { |title| title.is_a?(WorkPackage) ? title.subject : title.to_s }
 
@@ -159,15 +159,15 @@ module Pages
 
     def expect_movable(list_name, card_title, movable: true)
       within_list(list_name) do
-        expect(page).to have_selector('[data-qa-selector="op-wp-single-card"]', text: card_title)
+        expect(page).to have_selector('[data-test-selector="op-wp-single-card"]', text: card_title)
         expect(page).to have_conditional_selector(movable,
-                                                  '[data-qa-selector="op-wp-single-card"][data-qa-draggable]',
+                                                  '[data-test-selector="op-wp-single-card"][data-qa-draggable]',
                                                   text: card_title)
       end
     end
 
     def move_card(index, from:, to:)
-      source = page.all("#{list_selector(from)} [data-qa-selector='op-wp-single-card']")[index]
+      source = page.all("#{list_selector(from)} [data-test-selector='op-wp-single-card']")[index]
       target = page.find list_selector(to)
 
       drag_n_drop_element(from: source, to: target)
@@ -190,11 +190,11 @@ module Pages
 
       if option.nil?
         page.find('.boards-list--add-item').click
-        expect(page).to have_selector('[data-qa-selector="op-board-list"]', count: count + 1)
+        expect(page).to have_selector('[data-test-selector="op-board-list"]', count: count + 1)
       else
         open_and_fill_add_list_modal query
         page.find('.ng-option', text: option, wait: 10).click
-        page.find('[data-qa-selector="confirmation-modal--confirmed"]').click
+        page.find('[data-test-selector="confirmation-modal--confirmed"]').click
       end
     end
 
@@ -218,11 +218,11 @@ module Pages
     end
 
     def expect_list(name)
-      expect(page).to have_selector('[data-qa-selector="op-board-list--header"]', text: name, wait: 10)
+      expect(page).to have_selector('[data-test-selector="op-board-list--header"]', text: name, wait: 10)
     end
 
     def expect_no_list(name)
-      expect(page).not_to have_selector('[data-qa-selector="op-board-list--header"]', text: name)
+      expect(page).not_to have_selector('[data-test-selector="op-board-list--header"]', text: name)
     end
 
     def expect_empty
@@ -240,8 +240,8 @@ module Pages
 
     def click_list_dropdown(list_name, action)
       within_list(list_name) do
-        page.find('[data-qa-selector="op-board-list--header"]').hover
-        page.find('[data-qa-selector="op-board-list--menu"] a').click
+        page.find('[data-test-selector="op-board-list--header"]').hover
+        page.find('[data-test-selector="op-board-list--menu"] a').click
       end
 
       page.find('.dropdown-menu button', text: action).click
@@ -292,7 +292,7 @@ module Pages
     end
 
     def expect_editable_list(editable)
-      expect(page).to have_conditional_selector(editable, '[data-qa-selector="op-board-list--card-dropdown-add-button"]')
+      expect(page).to have_conditional_selector(editable, '[data-test-selector="op-board-list--card-dropdown-add-button"]')
     end
 
     def rename_board(new_name, through_dropdown: false)

--- a/modules/calendar/app/components/calendar/row_component.rb
+++ b/modules/calendar/app/components/calendar/row_component.rb
@@ -59,7 +59,7 @@ module Calendar
           class: 'icon icon-delete',
           data: {
             confirm: I18n.t(:text_are_you_sure),
-            'qa-selector': "calendar-remove-#{query.id}"
+            'test-selector': "calendar-remove-#{query.id}"
           },
           title: t(:button_delete)
         )

--- a/modules/calendar/app/views/calendar/calendars/_form.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/_form.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
                                 id: 'project_id',
                                 class: 'form--select-container -wide remote-field--input',
                                 data: {
-                                  'qa-selector': 'project_id'
+                                  'test-selector': 'project_id'
                                 }
       %>
     </div>

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -119,7 +119,7 @@ module Pages
     end
 
     def set_project(project)
-      select_autocomplete(find('[data-qa-selector="project_id"]'),
+      select_autocomplete(find('[data-test-selector="project_id"]'),
                           query: project,
                           results_selector: 'body',
                           wait_for_fetched_options: false)
@@ -156,11 +156,11 @@ module Pages
     end
 
     def expect_delete_button(query)
-      expect(page).to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
+      expect(page).to have_selector "[data-test-selector='calendar-remove-#{query.id}']"
     end
 
     def expect_no_delete_button(query)
-      expect(page).not_to have_selector "[data-qa-selector='calendar-remove-#{query.id}']"
+      expect(page).not_to have_selector "[data-test-selector='calendar-remove-#{query.id}']"
     end
 
     def expect_no_views_visible

--- a/modules/costs/spec/features/time_entry/activity_spec.rb
+++ b/modules/costs/spec/features/time_entry/activity_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Time entry activity' do
   it 'supports CRUD' do
     visit enumerations_path
 
-    page.find('[data-qa-selector="create-enumeration-time-entry-activity"]').click
+    page.find_test_selector('create-enumeration-time-entry-activity').click
 
     fill_in 'Name', with: 'A new activity'
     click_on('Create')

--- a/modules/costs/spec/features/timer_spec.rb
+++ b/modules/costs/spec/features/timer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Work Package timer', js: true do
       page.find('.op-top-menu-user').click
       expect(page).to have_selector('.op-timer-account-menu', wait: 10)
       expect(page).to have_selector('.op-timer-account-menu--wp-details', text: "##{work_package_a.id}: WP A")
-      page.find('[data-qa-selector="op-timer-account-menu-stop"]').click
+      page.find_test_selector('op-timer-account-menu-stop').click
 
       time_logging_modal.is_visible true
 

--- a/modules/dashboards/spec/features/custom_text_spec.rb
+++ b/modules/dashboards/spec/features/custom_text_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'Project description widget on dashboard', js: true do
       editor.drag_attachment image_fixture.path, 'Image uploaded'
 
       within custom_text_widget.area do
-        expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+        expect(page).to have_test_selector('op-attachment-list-item', text: 'image.png')
         expect(page).not_to have_selector('notifications-upload-progress')
 
         field.save!
@@ -149,7 +149,7 @@ RSpec.describe 'Project description widget on dashboard', js: true do
           .to have_selector('#content img', count: 1)
 
         expect(page)
-          .not_to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+          .not_to have_test_selector('op-attachment-list-item', text: 'image.png')
       end
     end
   end

--- a/modules/dashboards/spec/features/time_entries_spec.rb
+++ b/modules/dashboards/spec/features/time_entries_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Time entries widget on dashboard', js: true do
         .to have_selector('.hours', text: other_visible_time_entry.hours)
 
       # Allows to edit
-      page.find("[data-qa-selector='edit-time-entry-#{visible_time_entry.id}']").click
+      page.find_test_selector("edit-time-entry-#{visible_time_entry.id}").click
     end
 
     time_logging_modal.is_visible true

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Upload attachment to documents',
       fill_in "Title", with: 'New documentation'
 
       # adding an image via the attachments-list
-      find("[data-qa-selector='op-attachments--drop-box']").drop(image_fixture.path)
+      find_test_selector("op-attachments--drop-box").drop(image_fixture.path)
 
       editor.attachments_list.expect_attached('image.png')
 

--- a/modules/grids/spec/support/pages/grid.rb
+++ b/modules/grids/spec/support/pages/grid.rb
@@ -37,7 +37,7 @@ module Pages
 
         SeleniumHubWaiter.wait unless using_cuprite?
 
-        page.find('[data-qa-selector="op-grid--addable-widget"]', text: Regexp.new("^#{name}$")).click
+        page.find('[data-test-selector="op-grid--addable-widget"]', text: Regexp.new("^#{name}$")).click
       end
     end
 
@@ -108,7 +108,7 @@ module Pages
           .to have_content(I18n.t('js.grid.add_widget'))
 
         expect(page)
-          .not_to have_selector('[data-qa-selector="op-grid--addable-widget"]', text: Regexp.new("^#{name}$"))
+          .not_to have_selector('[data-test-selector="op-grid--addable-widget"]', text: Regexp.new("^#{name}$"))
       end
     end
   end

--- a/modules/meeting/app/views/meeting_contents/_show.html.erb
+++ b/modules/meeting/app/views/meeting_contents/_show.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div data-controller="meeting-content"
      data-application-target="dynamic"
      data-meeting-content-edit-state-value="<%= show_meeting_content_editor?(content, content_type) %>"
-     data-qa-selector="op-meeting--<%= content_type %>">
+     data-test-selector="op-meeting--<%= content_type %>">
   <div>
     <%= toolbar title: t(:"label_#{content_type}") do %>
       <%=raw meeting_content_context_menu content, content_type %>

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -50,7 +50,7 @@ See COPYRIGHT and LICENSE files for more details.
                                   id: 'project_id',
                                   class: 'form--select-container -wide remote-field--input',
                                   data: {
-                                    'qa-selector': 'project_id'
+                                    'test-selector': 'project_id'
                                   }
         %>
       </div>

--- a/modules/meeting/spec/features/meetings_attachments_spec.rb
+++ b/modules/meeting/spec/features/meetings_attachments_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Add an attachment to a meeting (agenda)', js: true, with_cuprite
 
         click_on "Save"
 
-        content = find('[data-qa-selector="op-meeting--meeting_agenda"]')
+        content = find_test_selector('op-meeting--meeting_agenda')
 
         expect(content).to have_selector('img')
         expect(content).to have_content('Some image caption')

--- a/modules/meeting/spec/features/meetings_locking_spec.rb
+++ b/modules/meeting/spec/features/meetings_locking_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Meetings locking', js: true do
   let(:agenda_field) do
     TextEditorField.new(page,
                         '',
-                        selector: '[data-qa-selector="op-meeting--meeting_agenda"]')
+                        selector: test_selector('op-meeting--meeting_agenda'))
   end
 
   before do

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe 'Meetings new', :js, with_cuprite: false do
       let(:field) do
         TextEditorField.new(page,
                             '',
-                            selector: '[data-qa-selector="op-meeting--meeting_agenda"]')
+                            selector: test_selector('op-meeting--meeting_agenda'))
       end
 
       it 'allows creating meeting in a project without members' do

--- a/modules/meeting/spec/features/meetings_show_spec.rb
+++ b/modules/meeting/spec/features/meetings_show_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Meetings', js: true do
       find('td.title a', text: 'Awesome meeting!', wait: 10).click
       expect(page).to have_selector('h2', text: 'Meeting: Awesome meeting!')
 
-      expect(page).to have_selector('[data-qa-selector="op-meeting--meeting_agenda"]',
+      expect(page).to have_test_selector('op-meeting--meeting_agenda',
                                     text: 'There is currently nothing to display')
     end
 
@@ -85,12 +85,12 @@ RSpec.describe 'Meetings', js: true do
 
       it 'shows the agenda' do
         visit meeting_path(meeting)
-        expect(page).to have_selector('[data-qa-selector="op-meeting--meeting_agenda"]',
+        expect(page).to have_test_selector('op-meeting--meeting_agenda',
                                       text: 'foo')
 
         # May not edit
         expect(page).not_to have_selector('.button--edit-agenda')
-        expect(page).not_to have_selector('[data-qa-selector="op-meeting--meeting_agenda"]',
+        expect(page).not_to have_test_selector('op-meeting--meeting_agenda',
                                           text: 'Edit')
       end
 
@@ -102,7 +102,7 @@ RSpec.describe 'Meetings', js: true do
         click_on 'History'
 
         find_by_id('version-1').click
-        expect(page).to have_selector('[data-qa-selector="op-meeting--meeting_agenda"]', text: 'foo')
+        expect(page).to have_test_selector('op-meeting--meeting_agenda', text: 'foo')
       end
 
       context 'and edit permissions' do
@@ -110,7 +110,7 @@ RSpec.describe 'Meetings', js: true do
         let(:field) do
           TextEditorField.new(page,
                               '',
-                              selector: '[data-qa-selector="op-meeting--meeting_agenda"]')
+                              selector: test_selector('op-meeting--meeting_agenda'))
         end
 
         it 'can edit the agenda' do
@@ -138,8 +138,8 @@ RSpec.describe 'Meetings', js: true do
         it 'can not edit the minutes' do
           visit meeting_path(meeting)
           click_link 'Minutes'
-          expect(page).not_to have_selector('[data-qa-selector="op-meeting--meeting_minutes"]', text: 'Edit')
-          expect(page).to have_selector('[data-qa-selector="op-meeting--meeting_minutes"]',
+          expect(page).not_to have_test_selector('op-meeting--meeting_minutes', text: 'Edit')
+          expect(page).to have_test_selector('op-meeting--meeting_minutes',
                                         text: 'There is currently nothing to display')
         end
       end
@@ -160,7 +160,7 @@ RSpec.describe 'Meetings', js: true do
         let(:field) do
           TextEditorField.new(page,
                               '',
-                              selector: '[data-qa-selector="op-meeting--meeting_minutes"]')
+                              selector: test_selector('op-meeting--meeting_minutes'))
         end
 
         it 'can edit the minutes' do

--- a/modules/meeting/spec/support/pages/meetings/new.rb
+++ b/modules/meeting/spec/support/pages/meetings/new.rb
@@ -54,11 +54,11 @@ module Pages::Meetings
     end
 
     def expect_project_dropdown
-      find "[data-qa-selector='project_id']"
+      find "[data-test-selector='project_id']"
     end
 
     def set_project(project)
-      select_autocomplete find("[data-qa-selector='project_id']"),
+      select_autocomplete find("[data-test-selector='project_id']"),
                           query: project.name,
                           results_selector: 'body'
     end

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Custom text widget on my page', js: true do
     editor.drag_attachment image_fixture.path, 'Image uploaded'
 
     within custom_text_widget.area do
-      expect(page).to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+      expect(page).to have_test_selector('op-attachment-list-item', text: 'image.png')
       expect(page).not_to have_selector('notifications-upload-progress')
 
       field.save!
@@ -108,7 +108,7 @@ RSpec.describe 'Custom text widget on my page', js: true do
         .to have_selector('#content img', count: 1)
 
       expect(page)
-        .not_to have_selector('[data-qa-selector="op-attachment-list-item"]', text: 'image.png')
+        .not_to have_test_selector('op-attachment-list-item', text: 'image.png')
     end
 
     # ensure no one but the page's user can see the uploaded attachment

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -201,8 +201,8 @@ RSpec.describe 'My page time entries current user widget spec', js: true do
     # Expect filtering works
     time_logging_modal.work_package_field.autocomplete work_package.subject, select: false
 
-    expect(page).to have_selector('[data-qa-selector="op-autocompleter-item-subject"]', text: work_package.subject)
-    expect(page).not_to have_selector('[data-qa-selector="op-autocompleter-item-subject"]', text: other_work_package.subject)
+    expect(page).to have_test_selector('op-autocompleter-item-subject', text: work_package.subject)
+    expect(page).not_to have_test_selector('op-autocompleter-item-subject', text: other_work_package.subject)
 
     time_logging_modal.update_work_package_field other_work_package.subject
 

--- a/modules/reporting/spec/features/menu_spec.rb
+++ b/modules/reporting/spec/features/menu_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'project menu' do
         end
 
         it 'leads to cost reports' do
-          find('#main-menu [data-qa-selector="op-menu--item-action"]', text: 'Time and costs').click
+          find("#main-menu #{test_selector('op-menu--item-action')}", text: 'Time and costs').click
 
           expect(page).to have_current_path("/projects/ponyo/cost_reports")
         end
@@ -95,7 +95,7 @@ RSpec.describe 'project menu' do
         it 'leads to cost reports' do
           # doing what no human can - click on invisible items.
           # This way, we avoid having to use selenium and by that increase stability.
-          find('#main-menu [data-qa-selector="op-menu--item-action"]', text: 'Time and costs').click
+          find("#main-menu #{test_selector('op-menu--item-action')}", text: 'Time and costs').click
 
           # to make sure we're not seeing the project cost reports:
           expect(page).not_to have_text('Ponyo')

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Admin storages', :storage_server_helpers, js: true do
     expect(page).to have_content("Password can't be blank.")
 
     # Switch off automatically managed project folders
-    page.find('[data-qa-selector="spot-switch-handle"]').click
+    page.find_test_selector('spot-switch-handle').click
     page.click_button('Save')
     expect(page).to have_text("Inactive")
     ######### End Edit Automatically managed project folders #########

--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe 'Managing file links in work package', js: true, webmock: true do
 
   describe 'create with the file picker and delete', with_flag: { storage_file_picking_select_all: true } do
     it 'must enable the user to manage existing files on the storage' do
-      expect(wp_page.all('[data-qa-selector="file-list--item"]').size).to eq 1
-      expect(wp_page).to have_selector('[data-qa-selector="file-list--item"]', text: file_link.name)
+      expect(wp_page.all(test_selector("file-list--item")).size).to eq 1
+      expect(wp_page).to have_test_selector('file-list--item', text: file_link.name)
 
-      wp_page.find('[data-qa-selector="op-storage--link-existing-file-button"]').click
+      page.find_test_selector('op-storage--link-existing-file-button').click
 
       file_picker.expect_open
       file_picker.confirm_button_state(selection_count: 0)
@@ -109,20 +109,20 @@ RSpec.describe 'Managing file links in work package', js: true, webmock: true do
 
       file_picker.confirm
 
-      expect(wp_page).to have_selector('[data-qa-selector="file-list--item"]', text: 'Manual.pdf')
-      expect(wp_page).to have_selector('[data-qa-selector="file-list--item"]', text: 'logo.png')
-      expect(wp_page).to have_selector('[data-qa-selector="file-list--item"]', text: file_link.name)
-      expect(wp_page.all('[data-qa-selector="file-list--item"]').size).to eq 3
+      expect(wp_page).to have_test_selector('file-list--item', text: 'Manual.pdf')
+      expect(wp_page).to have_test_selector('file-list--item', text: 'logo.png')
+      expect(wp_page).to have_test_selector('file-list--item', text: file_link.name)
+      expect(wp_page.all(test_selector("file-list--item")).size).to eq 3
 
-      wp_page.find('[data-qa-selector="file-list--item"]', text: 'logo.png').hover
-      wp_page.within('[data-qa-selector="file-list--item"]', text: 'logo.png') do
-        wp_page.find('[data-qa-selector="file-list--item-remove-floating-action"]').click
+      page.find_test_selector('file-list--item', text: 'logo.png').hover
+      within_test_selector('file-list--item', text: 'logo.png') do
+        page.find_test_selector('file-list--item-remove-floating-action').click
       end
 
       confirmation_dialog.confirm
 
-      expect(wp_page).not_to have_selector('[data-qa-selector="file-list--item"]', text: 'logo.png')
-      expect(wp_page.all('[data-qa-selector="file-list--item"]').size).to eq 2
+      expect(wp_page).not_to have_test_selector('file-list--item', text: 'logo.png')
+      expect(wp_page.all(test_selector("file-list--item")).size).to eq 2
     end
   end
 end

--- a/modules/storages/spec/features/show_file_links_spec.rb
+++ b/modules/storages/spec/features/show_file_links_spec.rb
@@ -73,9 +73,10 @@ RSpec.describe 'Showing of file links in work package', js: true do
 
   context 'if work package has associated file links' do
     it "must show associated file links" do
-      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 2)
-      expect(page.find('[data-qa-selector="file-list"]'))
-        .to have_selector('[data-qa-selector="file-list--item"]', text: file_link.origin_name, count: 1)
+      expect(page).to have_test_selector('op-tab-content--tab-section', count: 2)
+      within_test_selector('file-list') do
+        expect(page).to have_test_selector('file-list--item', text: file_link.origin_name, count: 1)
+      end
     end
   end
 
@@ -83,7 +84,7 @@ RSpec.describe 'Showing of file links in work package', js: true do
     let(:permissions) { %i(view_work_packages edit_work_packages) }
 
     it 'must not show a file links section' do
-      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 1)
+      expect(page).to have_test_selector('op-tab-content--tab-section', count: 1)
     end
   end
 
@@ -91,7 +92,7 @@ RSpec.describe 'Showing of file links in work package', js: true do
     let(:project_storage) { {} }
 
     it 'must not show a file links section' do
-      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 1)
+      expect(page).to have_test_selector('op-tab-content--tab-section', count: 1)
     end
   end
 
@@ -102,7 +103,7 @@ RSpec.describe 'Showing of file links in work package', js: true do
     end
 
     it 'must show storage information box with login button' do
-      expect(page.find('[data-qa-selector="op-storage--information"]')).to have_button(count: 1)
+      expect(page.find_test_selector('op-storage--information')).to have_button(count: 1)
     end
   end
 
@@ -112,7 +113,7 @@ RSpec.describe 'Showing of file links in work package', js: true do
     end
 
     it 'must show storage information box' do
-      expect(page).to have_selector('[data-qa-selector="op-storage--information"]', count: 1)
+      expect(page).to have_test_selector('op-storage--information', count: 1)
     end
   end
 end

--- a/modules/storages/spec/support/components/file_picker_dialog.rb
+++ b/modules/storages/spec/support/components/file_picker_dialog.rb
@@ -33,7 +33,7 @@ module Components
     include RSpec::Matchers
 
     def container
-      '[data-qa-selector="op-files-picker-modal"]'
+      '[data-test-selector="op-files-picker-modal"]'
     end
 
     def expect_open
@@ -55,46 +55,46 @@ module Components
 
     def wait_for_folder_loaded
       page.within(container) do
-        expect(page).not_to have_selector('[data-qa-selector="op-file-list--loading-indicator"]')
+        expect(page).not_to have_selector('[data-test-selector="op-file-list--loading-indicator"]')
       end
     end
 
     def confirm
       page.within(container) do
-        page.find('[data-qa-selector="op-files-picker-modal--confirm"]').click
+        page.find('[data-test-selector="op-files-picker-modal--confirm"]').click
       end
     end
 
     def select_file(text)
       page.within(container) do
-        page.find('[data-qa-selector="op-files-picker-modal--list-item"]', text:).click
+        page.find('[data-test-selector="op-files-picker-modal--list-item"]', text:).click
       end
     end
 
     def has_list_item?(text:, checked:, disabled:)
       page.within(container) do
-        expect(page.find('[data-qa-selector="op-files-picker-modal--list-item"]', text:))
+        expect(page.find('[data-test-selector="op-files-picker-modal--list-item"]', text:))
           .to have_field(type: 'checkbox', checked:, disabled:)
       end
     end
 
     def enter_folder(text)
       page.within(container) do
-        page.within('[data-qa-selector="op-files-picker-modal--list-item"]', text:) do
-          page.find('[data-qa-selector="op-files-picker-modal--list-item-caret"]').click
+        page.within('[data-test-selector="op-files-picker-modal--list-item"]', text:) do
+          page.find('[data-test-selector="op-files-picker-modal--list-item-caret"]').click
         end
       end
     end
 
     def select_all
       page.within(container) do
-        page.find('[data-qa-selector="op-files-picker-modal--select-all"]').click
+        page.find('[data-test-selector="op-files-picker-modal--select-all"]').click
       end
     end
 
     def use_breadcrumb(position: 'root' | 'grandparent' | 'parent')
       page.within(container) do
-        crumbs = page.all('[data-qa-selector="op-breadcrumb"]')
+        crumbs = page.all('[data-test-selector="op-breadcrumb"]')
         case position
         when 'root'
           expect(crumbs.size).to be > 1

--- a/modules/team_planner/app/components/team_planner/row_component.rb
+++ b/modules/team_planner/app/components/team_planner/row_component.rb
@@ -62,7 +62,7 @@ module TeamPlanner
           method: :delete,
           data: {
             confirm: I18n.t(:text_are_you_sure),
-            'qa-selector': "team-planner-remove-#{query.id}"
+            'test-selector': "team-planner-remove-#{query.id}"
           },
           title: t(:button_delete)
         )

--- a/modules/team_planner/app/views/team_planner/team_planner/_form.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/_form.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
                                 id: 'project_id',
                                 class: 'form--select-container -wide remote-field--input',
                                 data: {
-                                  'qa-selector': 'project_id'
+                                  'test-selector': 'project_id'
                                 }
       %>
     </div>

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'Team planner query handling', js: true, with_ee: %i[team_planner
   it 'shows only team planner queries' do
     # Go to team planner where no query is shown, only the create option
     query_menu.expect_no_menu_entry
-    expect(page).to have_selector('[data-qa-selector="team-planner--create-button"]')
+    expect(page).to have_test_selector('team-planner--create-button')
 
     # Change filter
     filters.open

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe 'Team planner add existing work packages', js: true do
     end
 
     it 'does not show the button to add existing work packages' do
-      expect(page).not_to have_selector('[data-qa-selector="op-team-planner--add-existing-toggle"]')
+      expect(page).not_to have_test_selector('op-team-planner--add-existing-toggle')
       add_existing_pane.expect_closed
     end
   end

--- a/modules/team_planner/spec/features/team_planner_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_create_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Team planner create new work package', js: true, with_ee: %i[tea
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
     end
@@ -123,19 +123,19 @@ RSpec.describe 'Team planner create new work package', js: true, with_ee: %i[tea
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add other_user.name
       end
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add third_user.name
       end
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
     end

--- a/modules/team_planner/spec/features/team_planner_dates_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_dates_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Team planner working days', js: true, with_ee: %i[team_planner_v
       team_planner.expect_empty_state
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
 

--- a/modules/team_planner/spec/features/team_planner_index_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Team planner index', :js, :with_cuprite, with_ee: %i[team_planne
   end
 
   it 'can create an action through the sidebar' do
-    find('[data-qa-selector="team-planner--create-button"]').click
+    find_test_selector('team-planner--create-button').click
 
     team_planner.expect_no_toaster
     team_planner.expect_title

--- a/modules/team_planner/spec/features/team_planner_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_menu_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Team planner Menu Item', :js, :with_cuprite do
             click_link 'Team planners'
           end
 
-          expect(page).not_to have_selector('[data-qa-selector="team-planner--create-button"]')
+          expect(page).not_to have_test_selector('team-planner--create-button')
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.describe 'Team planner Menu Item', :js, :with_cuprite do
             click_link 'Team planners'
           end
 
-          expect(page).not_to have_selector('[data-qa-selector="team-planner--create-button"]')
+          expect(page).not_to have_test_selector('team-planner--create-button')
         end
       end
     end
@@ -107,7 +107,7 @@ RSpec.describe 'Team planner Menu Item', :js, :with_cuprite do
             click_link 'Team planners'
           end
 
-          expect(page).not_to have_selector('[data-qa-selector="team-planner--create-button"]')
+          expect(page).not_to have_test_selector('team-planner--create-button')
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe 'Team planner Menu Item', :js, :with_cuprite do
             click_link 'Team planners'
           end
 
-          expect(page).to have_selector('[data-qa-selector="team-planner--create-button"]')
+          expect(page).to have_test_selector('team-planner--create-button')
         end
       end
     end

--- a/modules/team_planner/spec/features/team_planner_project_include_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_project_include_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe 'Team planner project include', js: true, with_ee: %i[team_planne
 
       retry_block do
         work_package_view.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         work_package_view.select_user_to_add user.name
       end
 
       retry_block do
         work_package_view.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         work_package_view.select_user_to_add other_user.name
       end
 

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
 
@@ -163,7 +163,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add other_user.name
       end
 
@@ -249,7 +249,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
 
@@ -259,7 +259,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add other_user.name
       end
 
@@ -280,7 +280,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
       # Try one more time to make sure deleting the full filter didn't kill the functionality
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
 
@@ -293,7 +293,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.search_user_to_add user_outside_project.name
       end
 
@@ -307,7 +307,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.search_user_to_add user.name
       end
 
@@ -337,7 +337,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
 
       retry_block do
         team_planner.click_add_user
-        page.find('[data-qa-selector="tp-add-assignee"] input')
+        page.find("#{test_selector('tp-add-assignee')} input")
         team_planner.select_user_to_add user.name
       end
 

--- a/modules/team_planner/spec/features/team_planner_split_view_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_split_view_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Team planner split view navigation', js: true, with_ee: %i[team_
     end
 
     # Expect clicking on a work package does not open the details
-    page.find('[data-qa-selector="op-wp-single-card--content-subject"]', text: work_package1.subject).click
+    page.find_test_selector('op-wp-single-card--content-subject', text: work_package1.subject).click
     expect(page).not_to have_current_path /team_planners\/new\/details\/#{work_package1.id}/
 
     # Open split view through info icon
@@ -76,7 +76,7 @@ RSpec.describe 'Team planner split view navigation', js: true, with_ee: %i[team_
     card1.expect_selected
 
     # now clicking on another card switches
-    page.find('[data-qa-selector="op-wp-single-card--content-subject"]', text: work_package2.subject).click
+    page.find_test_selector('op-wp-single-card--content-subject', text: work_package2.subject).click
     expect(page).to have_current_path /team_planners\/new\/details\/#{work_package2.id}/
 
     card2 = Pages::WorkPackageCard.new work_package2

--- a/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Team planner', js: true, with_ee: %i[team_planner_view] do
     team_planner.expect_empty_state
     retry_block do
       team_planner.click_add_user
-      page.find('[data-qa-selector="tp-add-assignee"] input')
+      page.find("#{test_selector('tp-add-assignee')} input")
       team_planner.select_user_to_add user.name
     end
 

--- a/modules/team_planner/spec/support/components/add_existing_pane.rb
+++ b/modules/team_planner/spec/support/components/add_existing_pane.rb
@@ -33,11 +33,11 @@ module Components
     include RSpec::Matchers
 
     def selector
-      "[data-qa-selector='add-existing-pane']"
+      "[data-test-selector='add-existing-pane']"
     end
 
     def open
-      page.find('[data-qa-selector="op-team-planner--add-existing-toggle"]').click
+      page.find('[data-test-selector="op-team-planner--add-existing-toggle"]').click
       expect_open
     end
 
@@ -50,26 +50,26 @@ module Components
     end
 
     def expect_empty
-      expect(page).to have_selector("[data-qa-selector='op-add-existing-pane--empty-state']")
+      expect(page).to have_selector("[data-test-selector='op-add-existing-pane--empty-state']")
     end
 
     def search(term)
-      page.find("[data-qa-selector='op-add-existing-pane--search-input'] input").set(term)
+      page.find("[data-test-selector='op-add-existing-pane--search-input'] input").set(term)
     end
 
     def expect_result(work_package, visible: true)
       if visible
         expect(page)
-          .to have_selector("[data-qa-selector='op-add-existing-pane--wp-#{work_package.id}']", wait: 10)
+          .to have_selector("[data-test-selector='op-add-existing-pane--wp-#{work_package.id}']", wait: 10)
       else
         expect(page)
-          .not_to have_selector("[data-qa-selector='op-add-existing-pane--wp-#{work_package.id}']")
+          .not_to have_selector("[data-test-selector='op-add-existing-pane--wp-#{work_package.id}']")
       end
     end
 
     def drag_wp_by_pixel(work_package, by_x, by_y)
       source = page
-                 .find("[data-qa-selector='op-add-existing-pane--wp-#{work_package.id}']")
+                 .find("[data-test-selector='op-add-existing-pane--wp-#{work_package.id}']")
 
       drag_by_pixel(element: source, by_x:, by_y:)
     end

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -72,7 +72,7 @@ module Pages
     end
 
     def expect_view_mode(text)
-      expect(page).to have_selector('[data-qa-selector="op-team-planner--view-select-dropdown"]', text:)
+      expect(page).to have_selector('[data-test-selector="op-team-planner--view-select-dropdown"]', text:)
 
       param = {
         'Work week' => :resourceTimelineWorkWeek,
@@ -85,7 +85,7 @@ module Pages
 
     def switch_view_mode(text)
       retry_block do
-        find('[data-qa-selector="op-team-planner--view-select-dropdown"]').click
+        find('[data-test-selector="op-team-planner--view-select-dropdown"]').click
 
         within('#op-team-planner--view-select-dropdown') do
           click_button(text)
@@ -157,13 +157,13 @@ module Pages
 
     def expect_delete_buttons_for(*queries)
       queries.each do |query|
-        expect(page).to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+        expect(page).to have_selector "[data-test-selector='team-planner-remove-#{query.id}']"
       end
     end
 
     def expect_no_delete_buttons_for(*queries)
       queries.each do |query|
-        expect(page).not_to have_selector "[data-qa-selector='team-planner-remove-#{query.id}']"
+        expect(page).not_to have_selector "[data-test-selector='team-planner-remove-#{query.id}']"
       end
     end
 
@@ -206,7 +206,7 @@ module Pages
     end
 
     def set_project(project)
-      select_autocomplete(find('[data-qa-selector="project_id"]'),
+      select_autocomplete(find('[data-test-selector="project_id"]'),
                           query: project,
                           results_selector: 'body',
                           wait_for_fetched_options: false)
@@ -226,25 +226,25 @@ module Pages
 
     def add_assignee(name)
       click_add_user
-      page.find('[data-qa-selector="tp-add-assignee"] input')
+      page.find("#{page.test_selector('tp-add-assignee')} input")
       select_user_to_add name
     end
 
     def click_add_user
-      is_open = page.has_selector?('[data-qa-selector="tp-add-assignee"] input', wait: 0)
+      is_open = page.has_selector?('[data-test-selector="tp-add-assignee"] input', wait: 0)
       return if is_open
 
-      page.find('[data-qa-selector="tp-assignee-add-button"]').click
+      page.find('[data-test-selector="tp-assignee-add-button"]').click
     end
 
     def select_user_to_add(name)
-      select_autocomplete page.find('[data-qa-selector="tp-add-assignee"]'),
+      select_autocomplete page.find('[data-test-selector="tp-add-assignee"]'),
                           query: name,
                           results_selector: 'body'
     end
 
     def search_user_to_add(name)
-      search_autocomplete page.find('[data-qa-selector="tp-add-assignee"]'),
+      search_autocomplete page.find('[data-test-selector="tp-add-assignee"]'),
                           query: name,
                           results_selector: 'body'
     end
@@ -284,12 +284,12 @@ module Pages
       end
 
       # Move the footer first to signal we're dragging something
-      footer = find('[data-qa-selector="op-team-planner-footer"]')
+      footer = find('[data-test-selector="op-team-planner-footer"]')
       drag_element_to(footer)
 
       sleep 1
 
-      dropzone = find('[data-qa-selector="op-team-planner-dropzone"]')
+      dropzone = find('[data-test-selector="op-team-planner-dropzone"]')
       drag_element_to(dropzone)
 
       if expect_removable

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe HomescreenController do
         end
 
         it 'renders the text' do
-          expect(response.body).to have_selector('[data-qa-selector="op-widget-box--header"]',
+          expect(response.body).to have_selector('[data-test-selector="op-widget-box--header"]',
                                                  text: 'Woohoo!')
         end
       end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Attribute help texts',
 
         # Expect files section to be present
         expect(modal.modal_container).to have_selector('.form--fieldset-legend', text: 'ATTACHMENTS')
-        expect(modal.modal_container).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]')
+        expect(modal.modal_container).to have_test_selector('op-files-tab--file-list-item-title')
 
         modal.close!
 

--- a/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe 'Multi-value custom fields creation', js: true do
     fill_in 'custom_field_custom_options_attributes_0_value', with: 'A'
 
     # Add new row
-    page.find('[data-qa-selector="add-custom-option"]').click
+    page.find_test_selector('add-custom-option').click
     SeleniumHubWaiter.wait
     expect(page).to have_selector('input#custom_field_custom_options_attributes_1_value')
     fill_in 'custom_field_custom_options_attributes_1_value', with: 'B'
 
     # Add new row
-    page.find('[data-qa-selector="add-custom-option"]').click
+    page.find_test_selector('add-custom-option').click
     SeleniumHubWaiter.wait
     expect(page).to have_selector('input#custom_field_custom_options_attributes_2_value')
     fill_in 'custom_field_custom_options_attributes_2_value', with: 'C'
@@ -77,7 +77,7 @@ RSpec.describe 'Multi-value custom fields creation', js: true do
 
     # We need to hack a target for where to drag the row to
     page.execute_script <<-JS
-      const container = document.querySelector('[data-qa-selector="dragula-container"]');
+      const container = document.querySelector('[data-test-selector="dragula-container"]');
       const element = document.createElement('tr')
       element.classList.add('__drag_and_drop_end_of_list');
       element.innerHTML = '<td colspan="4" style="height: 100px"></td>';

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Enterprise token',
         submit_button.click
 
         expect(page).to have_selector('.op-toast.-success', text: I18n.t(:notice_successful_update))
-        expect(page).to have_selector('[data-qa-selector="op-enterprise--active-token"]')
+        expect(page).to have_test_selector('op-enterprise--active-token')
 
         expect(page.all('.attributes-key-value--key').map(&:text))
           .to eq ['Subscriber', 'Email', 'Domain', 'Maximum active users', 'Starts at', 'Expires at']
@@ -113,7 +113,7 @@ RSpec.describe 'Enterprise token',
         click_on "Delete"
 
         # Expect modal
-        find('[data-qa-selector="confirmation-modal--confirmed"]').click
+        find_test_selector('confirmation-modal--confirmed').click
 
         wait_for_reload
 

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe 'Enterprise trial management',
     end
 
     it 'can confirm that trial regularly' do
-      find('.spot-modal--body [data-qa-selector="op-ee-trial-waiting-resend-link"]', text: 'Resend').click
+      find_test_selector('op-ee-trial-waiting-resend-link', text: 'Resend').click
       expect(page).to have_selector('.op-toast.-success', text: 'Email has been resent.', wait: 20)
 
       expect(page).to have_text 'foo@foocorp.example'
@@ -268,7 +268,7 @@ RSpec.describe 'Enterprise trial management',
         .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: confirmed_body.to_json)
 
       # Wait until the next request
-      expect(page).to have_selector '[data-qa-selector="op-ee-trial-waiting-status--confirmed"]', text: 'confirmed', wait: 20
+      expect(page).to have_test_selector 'op-ee-trial-waiting-status--confirmed', text: 'confirmed', wait: 20
 
       # advance to video
       click_on 'Continue'

--- a/spec/features/admin/enterprise/token_domain_spec.rb
+++ b/spec/features/admin/enterprise/token_domain_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Enterprise Edition token domain',
       it_behaves_like 'when uploading a token' do
         it 'saves the token' do
           expect(body).to have_text 'Successful update.'
-          expect(page).to have_selector('[data-qa-selector="ee-active-trial-email"]', text: 'operations@openproject.com')
+          expect(page).to have_test_selector('ee-active-trial-email', text: 'operations@openproject.com')
         end
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe 'Enterprise Edition token domain',
     end
 
     it 'shows the current token info' do
-      expect(page).to have_selector('[data-qa-selector="ee-active-trial-email"]', text: 'operations@openproject.com')
+      expect(page).to have_test_selector('ee-active-trial-email', text: 'operations@openproject.com')
     end
 
     describe 'replacing the token' do
@@ -113,7 +113,7 @@ RSpec.describe 'Enterprise Edition token domain',
           end
 
           it "shows the new token's info" do
-            expect(page).to have_selector('[data-qa-selector="ee-active-trial-domain"]', text: 'localhost:3000')
+            expect(page).to have_test_selector('ee-active-trial-domain', text: 'localhost:3000')
           end
 
           it "but doesn't save the new token" do

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -197,19 +197,19 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
       datepicker.expect_day '5'
 
       # It can cancel and reopen
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         click_on 'Cancel'
       end
       click_on 'Non-working day'
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         fill_in 'name', with: 'My holiday'
       end
 
       date1 = NonWorkingDay.maximum(:date).next_week(:monday).next_occurring(:monday)
       datepicker.set_date date1
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         click_on 'Add'
       end
 
@@ -218,14 +218,14 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
       # Add a second day
       click_on 'Non-working day'
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         fill_in 'name', with: 'Another important day'
       end
 
       date2 = NonWorkingDay.maximum(:date).next_week(:monday).next_occurring(:tuesday)
       datepicker.set_date date2
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         click_on 'Add'
       end
 
@@ -243,19 +243,19 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
       # Check if date and name are entered then close the datepicker
       click_on 'Non-working day'
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         click_on 'Add'
       end
       expect(page).to have_selector('.flatpickr-calendar')
       datepicker.expect_visible
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         fill_in 'name', with: 'Instance-wide NWD'
       end
 
       datepicker.set_date date2
 
-      page.within('[data-qa-selector="op-datepicker-modal"]') do
+      within_test_selector('op-datepicker-modal') do
         click_on 'Add'
       end
       expect(page).not_to have_selector('.flatpickr-calendar')

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe 'custom fields', js: true, with_cuprite: true do
         find(".custom-option-default-value input").set true
       end
 
-      page.find('[data-qa-selector="add-custom-option"]').click
+      page.find_test_selector('add-custom-option').click
 
       expect(page).to have_selector('.custom-option-row', count: 2)
       within all(".custom-option-row").last do
         find(".custom-option-value input").set "Linux"
       end
 
-      page.find('[data-qa-selector="add-custom-option"]').click
+      page.find_test_selector('add-custom-option').click
 
       expect(page).to have_selector('.custom-option-row', count: 3)
       within all(".custom-option-row").last do
@@ -89,7 +89,7 @@ RSpec.describe 'custom fields', js: true, with_cuprite: true do
     end
 
     it "adds new options" do
-      page.find('[data-qa-selector="add-custom-option"]').click
+      page.find_test_selector('add-custom-option').click
       wait_for_reload
 
       expect(page).to have_selector('.custom-option-row', count: 5)
@@ -97,7 +97,7 @@ RSpec.describe 'custom fields', js: true, with_cuprite: true do
         find(".custom-option-value input").set "Sega"
       end
 
-      page.find('[data-qa-selector="add-custom-option"]').click
+      page.find_test_selector('add-custom-option').click
       wait_for_reload
 
       expect(page).to have_selector('.custom-option-row', count: 6)

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe 'Admin menu items',
 
   context 'without having any menu items hidden in configuration' do
     it 'must display all menu items' do
-      expect(page).to have_selector('[data-qa-selector="menu-blocks--container"]')
-      expect(page).to have_selector('[data-qa-selector="menu-block"]', count: 20)
-      expect(page).to have_selector('[data-qa-selector="op-menu--item-action"]', count: 21) # All plus 'overview'
+      expect(page).to have_test_selector('menu-blocks--container')
+      expect(page).to have_test_selector('menu-block', count: 20)
+      expect(page).to have_test_selector('op-menu--item-action', count: 21) # All plus 'overview'
     end
   end
 
@@ -55,12 +55,12 @@ RSpec.describe 'Admin menu items',
             'hidden_menu_items' => { 'admin_menu' => ['colors'] }
           } do
     it 'must not display the hidden menu items and blocks' do
-      expect(page).to have_selector('[data-qa-selector="menu-blocks--container"]')
-      expect(page).to have_selector('[data-qa-selector="menu-block"]', count: 19)
-      expect(page).not_to have_selector('[data-qa-selector="menu-block"]', text: I18n.t(:label_color_plural))
+      expect(page).to have_test_selector('menu-blocks--container')
+      expect(page).to have_test_selector('menu-block', count: 19)
+      expect(page).not_to have_test_selector('menu-block', text: I18n.t(:label_color_plural))
 
-      expect(page).to have_selector('[data-qa-selector="op-menu--item-action"]', count: 20) # All plus 'overview'
-      expect(page).not_to have_selector('[data-qa-selector="op-menu--item-action"]', text: I18n.t(:label_color_plural))
+      expect(page).to have_test_selector('op-menu--item-action', count: 20) # All plus 'overview'
+      expect(page).not_to have_test_selector('op-menu--item-action', text: I18n.t(:label_color_plural))
     end
   end
 
@@ -68,10 +68,10 @@ RSpec.describe 'Admin menu items',
     shared_let(:user) { create(:user, global_permission: %i[manage_user create_backup]) }
 
     it 'must display only the actions allowed by global permissions' do
-      expect(page).to have_selector('[data-qa-selector="menu-block"]', text: I18n.t('label_user_plural'))
-      expect(page).to have_selector('[data-qa-selector="menu-block"]', text: I18n.t('label_backup'))
-      expect(page).to have_selector('[data-qa-selector="op-menu--item-action"]', text: I18n.t('label_user_plural'))
-      expect(page).to have_selector('[data-qa-selector="op-menu--item-action"]', text: I18n.t('label_backup'))
+      expect(page).to have_test_selector('menu-block', text: I18n.t('label_user_plural'))
+      expect(page).to have_test_selector('menu-block', text: I18n.t('label_backup'))
+      expect(page).to have_test_selector('op-menu--item-action', text: I18n.t('label_user_plural'))
+      expect(page).to have_test_selector('op-menu--item-action', text: I18n.t('label_backup'))
     end
   end
 end

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe "Notification center navigation", js: true, with_cuprite: true do
 
       split_screen.expect_open
 
-      expect(page).to have_selector('[data-qa-selector="op-wp-breadcrumb-parent"]', text: second_work_package.subject)
+      expect(page).to have_test_selector('op-wp-breadcrumb-parent', text: second_work_package.subject)
 
-      page.find('[data-qa-selector="op-wp-breadcrumb-parent"]').click
+      page.find_test_selector('op-wp-breadcrumb-parent').click
 
       expect(page).to have_current_path "/work_packages/#{second_work_package.id}/activity"
 
@@ -100,7 +100,7 @@ RSpec.describe "Notification center navigation", js: true, with_cuprite: true do
 
       expect(page).to have_current_path "/notifications/details/#{work_package.id}/relations"
 
-      page.find('[data-qa-selector="op-wp-breadcrumb-parent"]').click
+      page.find_test_selector('op-wp-breadcrumb-parent').click
 
       expect(page).to have_current_path "/work_packages/#{second_work_package.id}/relations"
     end

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'OAuth authorization code flow',
     # Revoke the application
     within("#oauth-application-grant-#{app.id}") do
       SeleniumHubWaiter.wait
-      find("[data-qa-selector='oauth-token-row-#{app.id}-revoke']").click
+      find_test_selector("oauth-token-row-#{app.id}-revoke").click
     end
 
     page.driver.browser.switch_to.alert.accept

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Project attribute help texts', js: true, with_cuprite: true do
         click_link "Overview"
       end
 
-      expect(page).to have_selector('[data-qa-selector="op-widget-box--header"] .help-text--entry', wait: 10)
+      expect(page).to have_selector("#{test_selector('op-widget-box--header')} .help-text--entry", wait: 10)
 
       # Open help text modal
       modal.open!

--- a/spec/features/statuses/read_only_statuses_spec.rb
+++ b/spec/features/statuses/read_only_statuses_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Read-only statuses affect work package editing',
 
   it 'locks the work package on a read only status' do
     wp_page.switch_to_tab(tab: 'FILES')
-    expect(page).to have_selector '[data-qa-selector="op-attachments--drop-box"]'
+    expect(page).to have_test_selector 'op-attachments--drop-box'
 
     subject_field = wp_page.edit_field :subject
     subject_field.activate!
@@ -95,7 +95,7 @@ RSpec.describe 'Read-only statuses affect work package editing',
     subject_field.expect_read_only
 
     # Expect attachments not available
-    expect(page).not_to have_selector '[data-qa-selector="op-attachments--drop-box"]'
+    expect(page).not_to have_test_selector 'op-attachments--drop-box'
 
     # Expect labels to not activate field editing (Regression#45032)
     assignee_field = wp_page.edit_field :assignee

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -54,7 +54,7 @@ module Components
     def open!
       SeleniumHubWaiter.wait
       container.find("[data-qa-help-text-for='#{help_text.attribute_name}']").click
-      expect(page).to have_selector('[data-qa-selector="attribute-help-text--header"]', text: help_text.attribute_caption)
+      expect(page).to have_selector('[data-test-selector="attribute-help-text--header"]', text: help_text.attribute_caption)
     end
 
     def close!
@@ -69,7 +69,7 @@ module Components
         end
         element.click(x: -((width / 2) - 10), y: -((height / 2) - 10))
       end
-      expect(page).not_to have_selector('[data-qa-selector="attribute-help-text--header"]', text: help_text.attribute_caption)
+      expect(page).not_to have_selector('[data-test-selector="attribute-help-text--header"]', text: help_text.attribute_caption)
     end
 
     def expect_edit(admin:)

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           within '#api-token-section' do
             expect(page).to have_content('API tokens are not enabled by the administrator.')
-            expect(page).not_to have_selector("[data-qa-selector='api-token-add']", text: 'API token')
+            expect(page).not_to have_test_selector('api-token-add', text: 'API token')
           end
         end
       end
@@ -143,8 +143,8 @@ RSpec.describe 'my', js: true, with_cuprite: true do
           expect(page).not_to have_content('API tokens are not enabled by the administrator.')
 
           within '#api-token-section' do
-            expect(page).to have_selector("[data-qa-selector='api-token-add']", text: 'API token')
-            find("[data-qa-selector='api-token-add']").click
+            expect(page).to have_test_selector('api-token-add', text: 'API token')
+            find_test_selector("api-token-add").click
           end
 
           expect(page).to have_content 'A new API token has been generated. Your access token is'
@@ -154,13 +154,13 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           # only one API token can be created
           within '#api-token-section' do
-            expect(page).not_to have_selector("[data-qa-selector='api-token-add']", text: 'API token')
+            expect(page).not_to have_test_selector('api-token-add', text: 'API token')
           end
 
           # revoke API token
           within '#api-token-section' do
             accept_confirm do
-              find("[data-qa-selector='api-token-revoke']").click
+              find_test_selector("api-token-revoke").click
             end
           end
 
@@ -171,7 +171,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           # API token can be created again
           within '#api-token-section' do
-            expect(page).to have_selector("[data-qa-selector='api-token-add']", text: 'API token')
+            expect(page).to have_test_selector('api-token-add', text: 'API token')
           end
         end
       end
@@ -184,7 +184,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           within '#rss-token-section' do
             expect(page).to have_content('RSS tokens are not enabled by the administrator.')
-            expect(page).not_to have_selector("[data-qa-selector='rss-token-add']", text: 'RSS token')
+            expect(page).not_to have_test_selector('rss-token-add', text: 'RSS token')
           end
         end
       end
@@ -196,8 +196,8 @@ RSpec.describe 'my', js: true, with_cuprite: true do
           expect(page).not_to have_content('RSS tokens are not enabled by the administrator.')
 
           within '#rss-token-section' do
-            expect(page).to have_selector("[data-qa-selector='rss-token-add']", text: 'RSS token')
-            find("[data-qa-selector='rss-token-add']").click
+            expect(page).to have_test_selector('rss-token-add', text: 'RSS token')
+            find_test_selector("rss-token-add").click
           end
 
           expect(page).to have_content 'A new RSS token has been generated. Your access token is'
@@ -207,13 +207,13 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           # only one RSS token can be created
           within '#rss-token-section' do
-            expect(page).not_to have_selector("[data-qa-selector='rss-token-add']", text: 'RSS token')
+            expect(page).not_to have_test_selector('rss-token-add', text: 'RSS token')
           end
 
           # revoke RSS token
           within '#rss-token-section' do
             accept_confirm do
-              find("[data-qa-selector='rss-token-revoke']").click
+              find_test_selector("rss-token-revoke").click
             end
           end
 
@@ -224,7 +224,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
           # RSS token can be created again
           within '#rss-token-section' do
-            expect(page).to have_selector("[data-qa-selector='rss-token-add']", text: 'RSS token')
+            expect(page).to have_test_selector('rss-token-add', text: 'RSS token')
           end
         end
       end
@@ -274,9 +274,9 @@ RSpec.describe 'my', js: true, with_cuprite: true do
                 token_name = ical_token.ical_token_query_assignment.name
                 query = ical_token.ical_token_query_assignment.query
 
-                expect(page).to have_selector("[data-qa-selector='ical-token-row-#{ical_token.id}-name']", text: token_name)
-                expect(page).to have_selector("[data-qa-selector='ical-token-row-#{ical_token.id}-query-name']", text: query.name)
-                expect(page).to have_selector("[data-qa-selector='ical-token-row-#{ical_token.id}-project-name']",
+                expect(page).to have_test_selector("ical-token-row-#{ical_token.id}-name", text: token_name)
+                expect(page).to have_test_selector("ical-token-row-#{ical_token.id}-query-name", text: query.name)
+                expect(page).to have_test_selector("ical-token-row-#{ical_token.id}-project-name",
                                               text: query.project.name)
               end
             end
@@ -287,7 +287,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
             within '#icalendar-token-section' do
               accept_confirm do
-                find("[data-qa-selector='ical-token-row-#{ical_token_for_query.id}-revoke']").click
+                find_test_selector("ical-token-row-#{ical_token_for_query.id}-revoke").click
               end
             end
 
@@ -297,7 +297,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
             visit my_access_token_path
 
             within '#icalendar-token-section' do
-              expect(page).not_to have_selector("[data-qa-selector='ical-token-row-#{ical_token_for_query.id}-revoke']")
+              expect(page).not_to have_test_selector('ical-token-row-#{ical_token_for_query.id}-revoke')
             end
           end
         end
@@ -344,8 +344,8 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
             [app, second_app].each do |app|
               within '#oauth-token-section' do
-                expect(page).to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-name']", text: app.name)
-                expect(page).to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-name']", text: '(one active token)')
+                expect(page).to have_test_selector("oauth-token-row-#{app.id}-name", text: app.name)
+                expect(page).to have_test_selector("oauth-token-row-#{app.id}-name", text: '(one active token)')
               end
             end
           end
@@ -356,7 +356,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
             [app, second_app].each do |app|
               within '#oauth-token-section' do
                 accept_confirm do
-                  find("[data-qa-selector='oauth-token-row-#{app.id}-revoke']").click
+                  find_test_selector("oauth-token-row-#{app.id}-revoke").click
                 end
               end
             end
@@ -366,7 +366,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
             [app, second_app].each do |app|
               within '#oauth-token-section' do
-                expect(page).not_to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-revoke']")
+                expect(page).not_to have_test_selector("oauth-token-row-#{app.id}-revoke")
               end
             end
           end
@@ -389,8 +389,8 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
             [app, second_app].each do |app|
               within '#oauth-token-section' do
-                expect(page).to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-name']", text: app.name)
-                expect(page).to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-name']", text: '(2 active token)')
+                expect(page).to have_test_selector("oauth-token-row-#{app.id}-name", text: app.name)
+                expect(page).to have_test_selector("oauth-token-row-#{app.id}-name", text: '(2 active token)')
               end
             end
           end
@@ -400,7 +400,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
 
             within '#oauth-token-section' do
               accept_confirm do
-                find("[data-qa-selector='oauth-token-row-#{app.id}-revoke']").click
+                find_test_selector("oauth-token-row-#{app.id}-revoke").click
               end
             end
 
@@ -408,7 +408,7 @@ RSpec.describe 'my', js: true, with_cuprite: true do
             visit my_access_token_path
 
             within '#oauth-token-section' do
-              expect(page).not_to have_selector("[data-qa-selector='oauth-token-row-#{app.id}-revoke']")
+              expect(page).not_to have_test_selector("oauth-token-row-#{app.id}-revoke")
             end
           end
         end

--- a/spec/features/users/notifications/shared_examples.rb
+++ b/spec/features/users/notifications/shared_examples.rb
@@ -109,7 +109,7 @@ RSpec.shared_examples 'notification settings workflow' do
 
       # Trying to add the same project again will not be possible (Regression #38072)
       click_button 'Add setting for project'
-      container = page.find('[data-qa-selector="notification-setting-inline-create"] ng-select')
+      container = page.find('[data-test-selector="notification-setting-inline-create"] ng-select')
       settings_page.search_autocomplete container, query: project.name, results_selector: 'body'
       expect(page).to have_text 'This project is already selected'
       expect(page).to have_selector('.ng-option-disabled', text: project.name)

--- a/spec/features/wiki/child_pages_spec.rb
+++ b/spec/features/wiki/child_pages_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'wiki child pages', js: true do
     click_button 'Save'
 
     # hierarchy displayed in the breadcrumb
-    expect(page).to have_selector('#breadcrumb [data-qa-selector="op-breadcrumb"]',
+    expect(page).to have_selector("#breadcrumb #{test_selector('op-breadcrumb')}",
                                   text: parent_page.title.to_s)
 
     # hierarchy displayed in the sidebar

--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -249,12 +249,12 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
   describe 'attachment dropzone' do
     it 'can drag something to the files tab and have it open' do
       wp_page.expect_tab 'Activity'
-      attachments.drag_and_drop_file '[data-qa-selector="op-attachments--drop-box"]',
+      attachments.drag_and_drop_file test_selector('op-attachments--drop-box'),
                                      image_fixture.path,
                                      :center,
                                      page.find('[data-qa-tab-id="files"]')
 
-      expect(page).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', wait: 10)
+      expect(page).to have_test_selector('op-files-tab--file-list-item-title', text: 'image.png', wait: 10)
       editor.wait_until_upload_progress_toaster_cleared
       wp_page.expect_tab 'Files'
     end
@@ -272,21 +272,21 @@ RSpec.describe 'Upload attachment to work package', js: true, with_cuprite: true
 
     it 'can upload an image via attaching and drag & drop' do
       wp_page.switch_to_tab(tab: 'files')
-      container = page.find('[data-qa-selector="op-attachments--drop-box"]')
+      container = page.find_test_selector('op-attachments--drop-box')
 
       ##
       # Attach file manually
-      expect(page).not_to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]')
+      expect(page).not_to have_test_selector('op-files-tab--file-list-item-title')
       attachments.attach_file_on_input(image_fixture.path)
       editor.wait_until_upload_progress_toaster_cleared
-      expect(page).to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', wait: 5)
+      expect(page).to have_test_selector('op-files-tab--file-list-item-title', text: 'image.png', wait: 5)
 
       ##
       # and via drag & drop
       attachments.drag_and_drop_file(container, image_fixture.path)
       editor.wait_until_upload_progress_toaster_cleared
       expect(page)
-        .to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'image.png', count: 2, wait: 5)
+        .to have_test_selector('op-files-tab--file-list-item-title', text: 'image.png', count: 2, wait: 5)
     end
   end
 end

--- a/spec/features/work_packages/bulk/copy_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/copy_work_package_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Copy work packages through Rails view', js: true do
 
         expect(page).to have_selector('#new_project_id')
         expect_page_reload do
-          select_autocomplete page.find('[data-qa-selector="new_project_id"]'),
+          select_autocomplete page.find_test_selector('new_project_id'),
                               query: project2.name,
                               select_text: project2.name,
                               results_selector: 'body'
@@ -293,7 +293,7 @@ RSpec.describe 'Copy work packages through Rails view', js: true do
       context_menu.choose 'Copy to other project'
 
       # On work packages move page
-      select_autocomplete page.find('[data-qa-selector="new_project_id"]'),
+      select_autocomplete page.find_test_selector('new_project_id'),
                           query: project2.name,
                           select_text: project2.name,
                           results_selector: 'body'

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
 
         # On work packages move page
         expect(page).to have_selector('#new_project_id')
-        select_autocomplete page.find('[data-qa-selector="new_project_id"]'),
+        select_autocomplete page.find_test_selector('new_project_id'),
                             query: 'Target',
                             select_text: 'Target',
                             results_selector: 'body'
@@ -101,7 +101,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
         it 'copies them in the background and shows a status page', :with_cuprite do
           click_on 'Move and follow'
           wait_for_reload
-          page.find('[data-qa-selector="job-status--header"]')
+          page.find_test_selector('job-status--header')
 
           expect(page).to have_text 'The job has been queued and will be processed shortly.'
 
@@ -217,7 +217,7 @@ RSpec.describe 'Moving a work package through Rails view', js: true do
       context_menu.choose 'Bulk change of project'
 
       # On work packages move page
-      select_autocomplete page.find('[data-qa-selector="new_project_id"]'),
+      select_autocomplete page.find_test_selector('new_project_id'),
                           query: project2.name,
                           select_text: project2.name,
                           results_selector: 'body'

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     work_package_page.visit_tab! :relations
     expect_angular_frontend_initialized
     expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
-    expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: original_work_package.subject)
+    expect(page).to have_test_selector('op-relation--row-subject', text: original_work_package.subject)
   end
 
   describe 'when source work package has an attachment' do
@@ -181,6 +181,6 @@ RSpec.describe 'Work package copy', js: true, selenium: true do
     work_package_page.visit_tab!('relations')
     expect_angular_frontend_initialized
     expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
-    expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: original_work_package.subject)
+    expect(page).to have_test_selector('op-relation--row-subject', text: original_work_package.subject)
   end
 end

--- a/spec/features/work_packages/details/closed_status_and_version_spec.rb
+++ b/spec/features/work_packages/details/closed_status_and_version_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe 'Closed status and version in full view', js: true do
 
   it 'shows a warning when trying to edit status' do
     # Should be initially editable (due to non specific schema)
-    status = page.find('[data-qa-selector="op-wp-status-button"] button:not([disabled])')
+    status = page.find("#{test_selector('op-wp-status-button')} button:not([disabled])")
     status.click
 
     wp_page.expect_and_dismiss_toaster type: :error,
                                        message: I18n.t('js.work_packages.message_work_package_status_blocked')
 
-    expect(page).to have_selector('[data-qa-selector="op-wp-status-button"] button[disabled]')
+    expect(page).to have_selector("#{test_selector('op-wp-status-button')} button[disabled]")
   end
 end

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -329,14 +329,14 @@ RSpec.describe 'date inplace editor',
     end
 
     it 'does not show a banner with or without manual scheduling' do
-      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-warning"]')
-      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-info"]')
+      expect(page).not_to have_test_selector('op-modal-banner-warning')
+      expect(page).not_to have_test_selector('op-modal-banner-info')
 
       # When toggling manually scheduled
       start_date.toggle_scheduling_mode
 
-      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-warning"]')
-      expect(page).not_to have_selector('[data-qa-selector="op-modal-banner-info"]')
+      expect(page).not_to have_test_selector('op-modal-banner-warning')
+      expect(page).not_to have_test_selector('op-modal-banner-info')
     end
   end
 
@@ -353,7 +353,7 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { true }
 
       it 'shows a banner that the relations are ignored' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.',
                                       wait: 5)
 
@@ -362,7 +362,7 @@ RSpec.describe 'date inplace editor',
 
         # Expect new banner info
         expect(page)
-          .to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+          .to have_selector("#{test_selector('op-modal-banner-warning')} span",
                             text: 'Changing these dates will affect dates of related work packages.')
 
         new_window = window_opened_by { click_on 'Show relations' }
@@ -381,14 +381,14 @@ RSpec.describe 'date inplace editor',
 
       it 'shows a banner that the start date is limited' do
         expect(page)
-          .to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+          .to have_selector("#{test_selector('op-modal-banner-warning')} span",
                             text: 'Changing these dates will affect dates of related work packages.',
                             wait: 5)
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
       end
     end
@@ -411,14 +411,14 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { true }
 
       it 'shows a banner that the relations are ignored' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
         # Expect banner to switch
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                       text: 'Automatically scheduled. Dates are derived from relations.')
 
         new_window = window_opened_by { click_on 'Show relations' }
@@ -434,13 +434,13 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { false }
 
       it 'shows a banner that the dates are not editable' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                       text: 'Automatically scheduled. Dates are derived from relations.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
 
         new_window = window_opened_by { click_on 'Show relations' }
@@ -461,7 +461,7 @@ RSpec.describe 'date inplace editor',
         end
 
         it 'allows switching to manual scheduling to set the ignore NWD (Regression #43933)' do
-          expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+          expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                         text: 'Automatically scheduled. Dates are derived from relations.')
 
           # Expect "Working days only" to be checked
@@ -474,7 +474,7 @@ RSpec.describe 'date inplace editor',
           datepicker.toggle_ignore_non_working_days
           datepicker.expect_ignore_non_working_days true
 
-          expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+          expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                         text: 'Manual scheduling enabled, all relations ignored.')
 
           # Reset when disabled
@@ -482,7 +482,7 @@ RSpec.describe 'date inplace editor',
           datepicker.expect_ignore_non_working_days_disabled
           datepicker.expect_ignore_non_working_days false, disabled: true
 
-          expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+          expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                         text: 'Automatically scheduled. Dates are derived from relations.')
         end
       end
@@ -509,14 +509,14 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { true }
 
       it 'shows a banner that the relations are ignored' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
         # Expect new banner info
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                       text: 'Available start and finish dates are limited by relations.')
 
         new_window = window_opened_by { click_on 'Show relations' }
@@ -532,13 +532,13 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { false }
 
       it 'shows a banner that the start date is limited' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-info')} span",
                                       text: 'Available start and finish dates are limited by relations.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
       end
     end
@@ -564,14 +564,14 @@ RSpec.describe 'date inplace editor',
       let(:schedule_manually) { true }
 
       it 'shows a banner that the relations are ignored' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
         expect(page)
-          .to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+          .to have_selector("#{test_selector('op-modal-banner-warning')} span",
                             text: 'Changing these dates will affect dates of related work packages.')
 
         new_window = window_opened_by { click_on 'Show relations' }
@@ -588,13 +588,13 @@ RSpec.describe 'date inplace editor',
 
       it 'shows a banner that the start date is limited' do
         expect(page)
-          .to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+          .to have_selector("#{test_selector('op-modal-banner-warning')} span",
                             text: 'Changing these dates will affect dates of related work packages.')
 
         # When toggling manually scheduled
         start_date.toggle_scheduling_mode
 
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
+        expect(page).to have_selector("#{test_selector('op-modal-banner-warning')} span",
                                       text: 'Manual scheduling enabled, all relations ignored.')
       end
     end

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe 'activity comments', js: true do
       comment_field.input_element.send_keys "I'm typing an important message here ..."
 
       wp_page.switch_to_tab tab: :files
-      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]')
+      expect(page).to have_test_selector('op-tab-content--tab-section')
 
       wp_page.switch_to_tab tab: :activity
 
@@ -273,7 +273,7 @@ RSpec.describe 'activity comments', js: true do
       # Has removed the draft now
 
       wp_page.switch_to_tab tab: :files
-      expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]')
+      expect(page).to have_test_selector('op-tab-content--tab-section')
 
       wp_page.switch_to_tab tab: :activity
       comment_field.expect_inactive!

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe 'Work package with relation query group', js: true, selenium: tru
     it 'add existing, remove it, add it from relations tab, remove from relations tab' do
       embedded_table.table_container.find('button', text: I18n.t('js.relation_buttons.add_existing')).click
       embedded_table.table_container.find('.wp-relations-create--form', wait: 10)
-      autocomplete = page.find("[data-qa-selector='wp-relations-autocomplete']")
+      autocomplete = page.find_test_selector("wp-relations-autocomplete")
       select_autocomplete autocomplete,
                           results_selector: '.ng-dropdown-panel-items',
                           query: independent_work_package.subject,

--- a/spec/features/work_packages/details/relations/hierarchy_custom_fields_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_custom_fields_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe 'creating a child directly after the wp itself was created', js: 
 
     # Add child
     scroll_to_and_click relations_tab
-    find('[data-qa-selector="op-wp-inline-create"]').click
+    find_test_selector('op-wp-inline-create').click
     fill_in 'wp-new-inline-edit--field-subject', with: 'A child WP'
     find_by_id('wp-new-inline-edit--field-subject').native.send_keys(:return)
 
     # Expect CF value to be still visible
     wp_page.expect_and_dismiss_toaster(message: 'Successful creation.')
-    expect(wp_page).to have_selector('[data-qa-selector="tab-count"]', text: "(1)")
+    expect(wp_page).to have_test_selector('tab-count', text: "(1)")
     wp_page.expect_attributes "customField#{custom_field.id}": '42'
   end
 end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -220,7 +220,7 @@ RSpec.shared_examples 'work package relations tab', js: true, selenium: true do
           expect(page).not_to have_selector('#hierarchy--add-new-child')
 
           # But it should show the linked parent
-          expect(page).to have_selector('[data-qa-selector="op-wp-breadcrumb-parent"]', text: parent.subject)
+          expect(page).to have_test_selector('op-wp-breadcrumb-parent', text: parent.subject)
 
           # And it should count the two relations
           tabs.expect_counter(relations_tab, 2)

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe 'Work package relations tab', js: true, selenium: true do
 
         # Wait for the relations table to be present
         sleep 2
-        expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']")
+        expect(page).to have_test_selector('op-relation--row-subject')
 
         scroll_to_element find('.detail-panel--relations')
 

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'work package export' do
                                  wait: 10
 
     # Expect title
-    expect(page).to have_selector '[data-qa-selector="job-status--header"]', text: I18n.t('export.your_work_packages_export')
+    expect(page).to have_test_selector 'job-status--header', text: I18n.t('export.your_work_packages_export')
 
     begin
       perform_enqueued_jobs

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe 'Work Package highlighting fields',
 
     # Expect highlighted fields in single view even when table disabled
     wp_table.open_full_screen_by_doubleclick wp_1
-    expect(page).to have_selector("[data-qa-selector='op-wp-status-button'] .__hl_background_status_#{status1.id}")
+    expect(page).to have_selector("#{test_selector('op-wp-status-button')} .__hl_background_status_#{status1.id}")
     expect(page).to have_selector(".__hl_inline_priority_#{priority1.id}")
   end
 

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe 'Work package navigation', js: true, selenium: true do
       full_view.ensure_page_loaded
       full_view.switch_to_tab(tab: 'FILES')
       expect(page)
-        .to have_selector('[data-qa-selector="op-files-tab--file-list-item-title"]', text: 'attachment-first.pdf', wait: 10)
+        .to have_test_selector('op-files-tab--file-list-item-title', text: 'attachment-first.pdf', wait: 10)
     end
   end
 

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -498,7 +498,7 @@ RSpec.describe 'new work package', js: true, with_cuprite: true do
 
       split_create_page.expect_attributes(combinedDate: "no start date - #{parent.due_date.strftime('%m/%d/%Y')}")
 
-      expect(split_create_page).to have_selector('[data-qa-selector="op-wp-breadcrumb"]', text: "Parent:\n#{parent.subject}")
+      expect(split_create_page).to have_test_selector('op-wp-breadcrumb', text: "Parent:\n#{parent.subject}")
     end
 
     it 'can navigate to the fullscreen page (Regression #49565)' do
@@ -533,7 +533,7 @@ RSpec.describe 'new work package', js: true, with_cuprite: true do
 
       wp_page.expect_attributes(combinedDate: "#{parent.start_date.strftime('%m/%d/%Y')} - #{parent.due_date.strftime('%m/%d/%Y')}")
 
-      expect(wp_page).to have_selector('[data-qa-selector="op-wp-breadcrumb"]', text: "Parent:\n#{parent.subject}")
+      expect(wp_page).to have_test_selector('op-wp-breadcrumb', text: "Parent:\n#{parent.subject}")
     end
   end
 end

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -459,6 +459,6 @@ RSpec.shared_examples 'has a project include dropdown', js: true, type: :feature
     dropdown.toggle!
     dropdown.expect_open
     dropdown.search 'Nonexistent'
-    expect(page).not_to have_selector("[data-qa-selector='op-project-include--loading']")
+    expect(page).not_to have_selector("[data-test-selector='op-project-include--loading']")
   end
 end

--- a/spec/features/work_packages/select/select_query_spec.rb
+++ b/spec/features/work_packages/select/select_query_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Query selection' do
       filters.expect_filter_by 'Assignee', 'is (OR)', ['me']
       filters.expect_filter_by 'Progress (%)', '>=', ['10'], 'percentageDone'
 
-      expect(page).to have_selector('[data-qa-selector="wp-filter-button"] .badge', text: '2')
+      expect(page).to have_selector("#{test_selector('wp-filter-button')} .badge", text: '2')
     end
   end
 

--- a/spec/features/work_packages/table/baseline/baseline_query_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_query_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'baseline query saving',
       text: 'Baseline mode is on but some of your active filters are not included in the comparison.'
     )
     page.within('#filter_watcher') do
-      expect(page).to have_selector('[data-qa-selector="query-filter-baseline-incompatible"]')
+      expect(page).to have_test_selector('query-filter-baseline-incompatible')
     end
   end
 

--- a/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
@@ -87,7 +87,7 @@ RSpec.shared_examples_for 'provides a single WP context menu' do
       subject.submit_by_enter
 
       split_view.expect_and_dismiss_toaster message: 'Successful creation.'
-      expect(page).to have_selector('[data-qa-selector="op-wp-breadcrumb"]', text: "Parent:\n#{work_package.subject}")
+      expect(page).to have_selector('[data-test-selector="op-wp-breadcrumb"]', text: "Parent:\n#{work_package.subject}")
       wp = WorkPackage.last
       expect(wp.parent).to eq work_package
     end

--- a/spec/features/work_packages/table/duration_field_spec.rb
+++ b/spec/features/work_packages/table/duration_field_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Duration field in the work package table',
     duration.activate!
 
     date_field.expect_duration_highlighted
-    expect(page).to have_focus_on('[data-qa-selector="op-datepicker-modal--duration-field"] input[name="duration"]')
+    expect(page).to have_focus_on("#{test_selector('op-datepicker-modal--duration-field')} input[name='duration']")
     expect(page).to have_field('duration', with: '4', wait: 10)
   end
 end

--- a/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Work Package table hierarchy and sorting', js: true do
     wp_table.expect_work_package_listed(wp_root, wp_child1, wp_child2, wp_child3)
 
     representation.switch_to_card_layout
-    expect(page).to have_selector('[data-qa-selector="op-wp-single-card"]', count: 4)
+    expect(page).to have_test_selector('op-wp-single-card', count: 4)
 
     # Expect indent-able for none
     hierarchy.expect_indent(wp_root, indent: false, outdent: false)

--- a/spec/features/work_packages/table/queries/bool_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/bool_cf_filter_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Work package filtering by bool custom field', js: true do
 
     # Turn the added filter to the "true" value.
     # Ideally this would be the default.
-    page.find("#div-values-customField#{bool_cf.id} [data-qa-selector='spot-switch-handle']").click
+    page.find("#div-values-customField#{bool_cf.id} #{test_selector('spot-switch-handle')}").click
 
     wp_table.ensure_work_package_not_listed!(work_package_false, work_package_without, work_package_other_type)
     wp_table.expect_work_package_listed(work_package_true)
@@ -103,7 +103,7 @@ RSpec.describe 'Work package filtering by bool custom field', js: true do
     filters.open
 
     # Inverting the filter
-    page.find("#div-values-customField#{bool_cf.id} [data-qa-selector='spot-switch-handle']").click
+    page.find("#div-values-customField#{bool_cf.id} #{test_selector('spot-switch-handle')}").click
 
     wp_table.ensure_work_package_not_listed!(work_package_true)
     wp_table.expect_work_package_listed(work_package_false, work_package_without, work_package_other_type)

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'mobile date filter work packages', :js, :with_cuprite do
       filters.add_filter('Finish date')
       filters.set_operator('Finish date', 'between', 'dueDate')
 
-      start_field = find('[data-qa-selector="op-basic-range-date-picker-start"]')
-      end_field = find('[data-qa-selector="op-basic-range-date-picker-end"]')
+      start_field = find_test_selector('op-basic-range-date-picker-start')
+      end_field = find_test_selector('op-basic-range-date-picker-end')
 
       clear_input_field_contents(start_field)
       clear_input_field_contents(end_field)

--- a/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
+++ b/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe 'Manual scheduling', js: true do
       start_date.within_modal do
         expect(page).to have_selector('input[name="startDate"][disabled]')
         expect(page).to have_selector('input[name="endDate"][disabled]')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Cancel')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Save')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Cancel')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Save')
       end
 
       start_date.toggle_scheduling_mode
@@ -67,8 +67,8 @@ RSpec.describe 'Manual scheduling', js: true do
       start_date.within_modal do
         expect(page).to have_selector('input[name="startDate"]:not([disabled])')
         expect(page).to have_selector('input[name="endDate"]:not([disabled])')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Cancel')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Save')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Cancel')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Save')
       end
 
       start_date.cancel_by_click
@@ -91,8 +91,8 @@ RSpec.describe 'Manual scheduling', js: true do
       start_date.within_modal do
         expect(page).to have_selector('input[name=startDate][disabled]')
         expect(page).to have_selector('input[name=endDate][disabled]')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Cancel')
-        expect(page).to have_selector('[data-qa-selector="op-datepicker-modal--action"]:not([disabled])', text: 'Save')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Cancel')
+        expect(page).to have_selector("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: 'Save')
       end
 
       start_date.toggle_scheduling_mode

--- a/spec/features/work_packages/tabs/activity_notifications_spec.rb
+++ b/spec/features/work_packages/tabs/activity_notifications_spec.rb
@@ -26,38 +26,38 @@ RSpec.describe 'Activity tab notifications', js: true, selenium: true do
              journal: work_package.journals.last)
     end
     it 'shows a notification bubble with the right number' do
-      expect(page).to have_selector('[data-qa-selector="tab-counter-Activity"]', text: '1')
+      expect(page).to have_test_selector('tab-counter-Activity', text: '1')
     end
 
     it 'shows a notification icon next to activities that have an unread notification' do
-      expect(page).to have_selector('[data-qa-selector="user-activity-bubble"]', count: 1)
-      expect(page).to have_selector('[data-qa-activity-number="4"] [data-qa-selector="user-activity-bubble"]')
+      expect(page).to have_test_selector('user-activity-bubble', count: 1)
+      expect(page).to have_selector("[data-qa-activity-number='4'] #{test_selector('user-activity-bubble')}")
     end
 
     it 'shows a button to mark the notifications as read' do
-      expect(page).to have_selector('[data-qa-selector="mark-notification-read-button"]')
+      expect(page).to have_test_selector('mark-notification-read-button')
 
       # A click marks the notification as read ...
-      page.find('[data-qa-selector="mark-notification-read-button"]').click
+      page.find_test_selector('mark-notification-read-button').click
 
       # ... and updates the view accordingly
-      expect(page).not_to have_selector('[data-qa-selector="mark-notification-read-button"]')
-      expect(page).not_to have_selector('[data-qa-selector="tab-counter-Activity"]')
-      expect(page).not_to have_selector('[data-qa-selector="user-activity-bubble"]')
+      expect(page).not_to have_test_selector('mark-notification-read-button')
+      expect(page).not_to have_test_selector('tab-counter-Activity')
+      expect(page).not_to have_test_selector('user-activity-bubble')
     end
   end
 
   shared_examples_for 'when there are no notifications for the work package' do
     it 'shows no notification bubble' do
-      expect(page).not_to have_selector('[data-qa-selector="tab-counter-Activity"]')
+      expect(page).not_to have_test_selector('tab-counter-Activity')
     end
 
     it 'does not show any notification icons next to activities' do
-      expect(page).not_to have_selector('[data-qa-selector="user-activity-bubble"]')
+      expect(page).not_to have_test_selector('user-activity-bubble')
     end
 
     it 'shows no button to mark the notifications as read' do
-      expect(page).not_to have_selector('[data-qa-selector="mark-notification-read-button"]')
+      expect(page).not_to have_test_selector('mark-notification-read-button')
     end
   end
 

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe 'Watcher tab', js: true, selenium: true do
     it 'watching the WP modifies the watcher list' do
       # Expect WP watch button is in not-watched state
       expect_button_is_not_watching
-      expect(page).not_to have_selector('[data-qa-selector="op-wp-watcher-name"]')
+      expect(page).not_to have_test_selector('op-wp-watcher-name')
       watch_button.click
 
       # Expect WP watch button causes watcher list to add user
       expect_button_is_watching
-      expect(page).to have_selector('[data-qa-selector="op-wp-watcher-name"]', count: 1, text: user.name)
+      expect(page).to have_test_selector('op-wp-watcher-name', count: 1, text: user.name)
 
       # Expect WP unwatch button causes watcher list to remove user
       watch_button.click
       expect_button_is_not_watching
-      expect(page).not_to have_selector('[data-qa-selector="op-wp-watcher-name"]')
+      expect(page).not_to have_test_selector('op-wp-watcher-name')
     end
   end
 
@@ -65,21 +65,21 @@ RSpec.describe 'Watcher tab', js: true, selenium: true do
                           results_selector: 'body'
 
       # Expect the addition of the user to toggle WP watch button
-      expect(page).to have_selector('[data-qa-selector="op-wp-watcher-name"]', count: 1, text: user.name)
+      expect(page).to have_test_selector('op-wp-watcher-name', count: 1, text: user.name)
       expect_button_is_watching
 
       # Expect watchers counter to increase
       tabs.expect_counter(watchers_tab, 1)
 
       # Remove watcher from list
-      page.find('[data-qa-selector="op-wp-watcher-name"]', text: user.name).hover
+      page.find_test_selector('op-wp-watcher-name', text: user.name).hover
       page.find('.form--selected-value--remover').click
 
       # Watchers counter should not be displayed
       tabs.expect_no_counter(watchers_tab)
 
       # Expect the removal of the user to toggle WP watch button
-      expect(page).not_to have_selector('[data-qa-selector="op-wp-watcher-name"]')
+      expect(page).not_to have_test_selector('op-wp-watcher-name')
       expect_button_is_not_watching
     end
 
@@ -138,7 +138,7 @@ RSpec.describe 'Watcher tab', js: true, selenium: true do
 
     it 'shows the number of watchers [#33685]' do
       wp_table.open_full_screen_by_doubleclick(work_package)
-      expect(page).to have_selector('[data-qa-selector="tab-count"]', text: "(1)")
+      expect(page).to have_test_selector('tab-count', text: "(1)")
     end
   end
 

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -132,14 +132,14 @@ RSpec.describe 'Work package timeline date formatting',
       it 'shows them as disabled' do
         expect_date_week work_package.start_date.iso8601, '01'
 
-        expect(page).to have_selector('[data-qa-selector="wp-timeline--non-working-day_27-12-2020"]')
-        expect(page).to have_selector('[data-qa-selector="wp-timeline--non-working-day_2-1-2021"]')
-        expect(page).to have_selector('[data-qa-selector="wp-timeline--non-working-day_28-12-2020"]')
+        expect(page).to have_test_selector('wp-timeline--non-working-day_27-12-2020')
+        expect(page).to have_test_selector('wp-timeline--non-working-day_2-1-2021')
+        expect(page).to have_test_selector('wp-timeline--non-working-day_28-12-2020')
 
-        expect(page).not_to have_selector('[data-qa-selector="wp-timeline--non-working-day_29-12-2020"]')
-        expect(page).not_to have_selector('[data-qa-selector="wp-timeline--non-working-day_30-12-2020"]')
-        expect(page).not_to have_selector('[data-qa-selector="wp-timeline--non-working-day_31-12-2020"]')
-        expect(page).not_to have_selector('[data-qa-selector="wp-timeline--non-working-day_1-1-2021"]')
+        expect(page).not_to have_test_selector('wp-timeline--non-working-day_29-12-2020')
+        expect(page).not_to have_test_selector('wp-timeline--non-working-day_30-12-2020')
+        expect(page).not_to have_test_selector('wp-timeline--non-working-day_31-12-2020')
+        expect(page).not_to have_test_selector('wp-timeline--non-working-day_1-1-2021')
       end
     end
   end

--- a/spec/helpers/angular_helper_spec.rb
+++ b/spec/helpers/angular_helper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AngularHelper do
   end
   let(:data) do
     {
-      'qa-selector': 'foo'
+      'test-selector': 'foo'
     }
   end
 
@@ -63,7 +63,7 @@ RSpec.describe AngularHelper do
           data-number="1"
           data-an-array="[1,2,3]"
           data-some-random-object="{&quot;complex&quot;:true,&quot;foo&quot;:&quot;bar&quot;}"
-          data-qa-selector="foo"
+          data-test-selector="foo"
         /></op-test>
       HTML
     end

--- a/spec/lib/redmine/menu_manager/menu_helper_spec.rb
+++ b/spec/lib/redmine/menu_manager/menu_helper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
     let(:item) { Redmine::MenuManager::MenuItem.new(:testing, '/test', caption: 'This is a test') }
     let(:expected) do
       <<~HTML
-        <a class="testing-menu-item op-menu--item-action" title="This is a test" data-qa-selector="op-menu--item-action" href="/test">
+        <a class="testing-menu-item op-menu--item-action" title="This is a test" data-test-selector="op-menu--item-action" href="/test">
           <span class="op-menu--item-title">
             <span class="ellipsis">This is a test</span>
           </span>
@@ -74,7 +74,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
       let(:expected) do
         <<~HTML.squish
           <li class="main-menu-item" data-name="single_node">
-            <a class="single-node-menu-item op-menu--item-action" title="Single node" data-qa-selector="op-menu--item-action" href="/test">
+            <a class="single-node-menu-item op-menu--item-action" title="Single node" data-test-selector="op-menu--item-action" href="/test">
               <span class="op-menu--item-title">
                 <span class="ellipsis">Single node</span>
               </span>
@@ -104,7 +104,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
         <<~HTML.squish
           <li data-name="parent_node" data-menus--main-target="item">
             <div class="main-item-wrapper" id="parent_node-wrapper">
-              <a class="parent-node-menu-item op-menu--item-action" title="Parent node" data-qa-selector="op-menu--item-action"
+              <a class="parent-node-menu-item op-menu--item-action" title="Parent node" data-test-selector="op-menu--item-action"
                  href="/test">
                 <span class="op-menu--item-title">
                 <span class="ellipsis">Parent node</span>
@@ -128,7 +128,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
               <li class="main-menu-item" data-name="child_one_node">
                 <a class="child-one-node-menu-item op-menu--item-action"
                    title="Child one node"
-                   data-qa-selector="op-menu--item-action" href="/test">
+                   data-test-selector="op-menu--item-action" href="/test">
                   <span class="op-menu--item-title">
                     <span class="ellipsis">Child one node</span>
                   </span>
@@ -137,7 +137,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
               <li class="main-menu-item" data-name="child_two_node">
                 <a class="child-two-node-menu-item op-menu--item-action"
                    title="Child two node"
-                   data-qa-selector="op-menu--item-action" href="/test">
+                   data-test-selector="op-menu--item-action" href="/test">
                   <span class="op-menu--item-title">
                     <span class="ellipsis">Child two node</span>
                   </span>
@@ -146,7 +146,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
               <li class="main-menu-item" data-name="child_three_node">
                 <a class="child-three-node-menu-item op-menu--item-action"
                    title="Child three node"
-                   data-qa-selector="op-menu--item-action"
+                   data-test-selector="op-menu--item-action"
                    href="/test">
                   <span class="op-menu--item-title">
                     <span class="ellipsis">Child three node</span>
@@ -155,7 +155,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
               </li>
               <li class="main-menu-item" data-name="child_three_inner_node">
                 <a class="child-three-inner-node-menu-item op-menu--item-action" title="Child three inner node"
-                   data-qa-selector="op-menu--item-action" href="/test">
+                   data-test-selector="op-menu--item-action" href="/test">
                   <span class="op-menu--item-title">
                     <span class="ellipsis">Child three inner node</span>
                   </span>
@@ -199,7 +199,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
           <li data-name="parent_node" data-menus--main-target="item">
             <div class="main-item-wrapper" id="parent_node-wrapper">
               <a class="parent-node-menu-item op-menu--item-action"
-                 title="Parent node" data-qa-selector="op-menu--item-action"
+                 title="Parent node" data-test-selector="op-menu--item-action"
                  href="/test">
                 <span class="op-menu--item-title">
                   <span class="ellipsis">Parent node</span>
@@ -276,7 +276,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
            <li data-name="parent_node" data-menus--main-target="item">
             <div class="main-item-wrapper" id="parent_node-wrapper">
               <a class="parent-node-menu-item op-menu--item-action"
-                 title="Parent node" data-qa-selector="op-menu--item-action"
+                 title="Parent node" data-test-selector="op-menu--item-action"
                  href="/test">
                 <span class="op-menu--item-title">
                   <span class="ellipsis">Parent node</span>
@@ -300,7 +300,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
                 <div class="main-item-wrapper" id="child_node-wrapper">
                   <a class="child-node-menu-item op-menu--item-action"
                      title="Child node"
-                     data-qa-selector="op-menu--item-action"
+                     data-test-selector="op-menu--item-action"
                      href="/test">
                     <span class="op-menu--item-title">
                       <span class="ellipsis">Child node</span>

--- a/spec/support/components/attachments_list.rb
+++ b/spec/support/components/attachments_list.rb
@@ -27,11 +27,11 @@ module Components
     end
 
     def expect_empty
-      expect(page).not_to have_selector("#{context_selector} [data-qa-selector='op-attachment-list-item']")
+      expect(page).not_to have_selector("#{context_selector} [data-test-selector='op-attachment-list-item']")
     end
 
     def expect_attached(name, count: 1)
-      expect(page).to have_selector("#{context_selector} [data-qa-selector='op-attachment-list-item']", text: name, count:)
+      expect(page).to have_selector("#{context_selector} [data-test-selector='op-attachment-list-item']", text: name, count:)
     end
 
     def wait_until_visible
@@ -39,11 +39,11 @@ module Components
     end
 
     def element
-      page.find("#{context_selector} [data-qa-selector='op-attachments']")
+      page.find("#{context_selector} [data-test-selector='op-attachments']")
     end
 
     def drop_box_element
-      find("#{context_selector} [data-qa-selector='op-attachments--drop-box']")
+      find("#{context_selector} [data-test-selector='op-attachments--drop-box']")
     end
   end
 end

--- a/spec/support/components/common/sidemenu.rb
+++ b/spec/support/components/common/sidemenu.rb
@@ -34,7 +34,7 @@ module Components
       include RSpec::Matchers
 
       def expect_open
-        expect(page).to have_selector('[data-qa-selector="op-sidemenu"]')
+        expect(page).to have_selector('[data-test-selector="op-sidemenu"]')
       end
 
       def expect_item_not_visible(item)
@@ -61,7 +61,7 @@ module Components
 
       def finished_loading
         wait_for_network_idle if using_cuprite?
-        expect(page).not_to have_selector('[data-qa-selector="op-ian-center--loading-indicator"]')
+        expect(page).not_to have_selector('[data-test-selector="op-ian-center--loading-indicator"]')
       end
 
       private
@@ -75,11 +75,11 @@ module Components
       end
 
       def item_action_selector(item)
-        "[data-qa-selector='op-sidemenu--item-action--#{item.delete(' ')}']"
+        "[data-test-selector='op-sidemenu--item-action--#{item.delete(' ')}']"
       end
 
       def item_selector
-        '[data-qa-selector="op-sidemenu--item"]'
+        '[data-test-selector="op-sidemenu--item"]'
       end
     end
   end

--- a/spec/support/components/confirmation_dialog.rb
+++ b/spec/support/components/confirmation_dialog.rb
@@ -42,13 +42,13 @@ module Components
 
     def confirm
       page.within(container) do
-        page.find('[data-qa-selector="confirmation-modal--confirmed"]').click
+        page.find('[data-test-selector="confirmation-modal--confirmed"]').click
       end
     end
 
     def cancel
       page.within(container) do
-        page.find('[data-qa-selector="confirmation-modal--cancel"]').click
+        page.find('[data-test-selector="confirmation-modal--cancel"]').click
       end
     end
   end

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -108,7 +108,7 @@ module Components
     end
 
     def save!(text: I18n.t(:button_apply))
-      container.find('[data-qa-selector="op-datepicker-modal"] .button', text:).click
+      container.find('[data-test-selector="op-datepicker-modal"] .button', text:).click
     end
 
     ##

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -87,11 +87,11 @@ module Components
     end
 
     def expect_start_highlighted
-      expect(container).to have_selector('[data-qa-selector="op-datepicker-modal--start-date-field"][data-qa-highlighted]')
+      expect(container).to have_selector('[data-test-selector="op-datepicker-modal--start-date-field"][data-qa-highlighted]')
     end
 
     def expect_due_highlighted
-      expect(container).to have_selector('[data-qa-selector="op-datepicker-modal--end-date-field"][data-qa-highlighted]')
+      expect(container).to have_selector('[data-test-selector="op-datepicker-modal--end-date-field"][data-qa-highlighted]')
     end
 
     def duration_field
@@ -111,7 +111,7 @@ module Components
           date
         end
 
-      page.within("[data-qa-selector='datepicker-#{key}-date']") do
+      page.within("[data-test-selector='datepicker-#{key}-date']") do
         find('button', text: 'Today').click
       end
     end
@@ -128,7 +128,7 @@ module Components
     end
 
     def expect_duration_highlighted
-      expect(container).to have_selector('[data-qa-selector="op-datepicker-modal--duration-field"][data-qa-highlighted]')
+      expect(container).to have_selector('[data-test-selector="op-datepicker-modal--duration-field"][data-qa-highlighted]')
     end
 
     def expect_scheduling_mode(manually)
@@ -179,7 +179,7 @@ module Components
       duration_field.click
 
       page
-        .find('[data-qa-selector="op-datepicker-modal--duration-field"] .spot-text-field--clear-button')
+        .find('[data-test-selector="op-datepicker-modal--duration-field"] .spot-text-field--clear-button')
         .click
     end
   end

--- a/spec/support/components/password_confirmation_dialog.rb
+++ b/spec/support/components/password_confirmation_dialog.rb
@@ -51,7 +51,7 @@ module Components
     end
 
     def submit_button
-      page.find('[data-qa-selector="confirmation-modal--confirmed"]')
+      page.find('[data-test-selector="confirmation-modal--confirmed"]')
     end
 
     private

--- a/spec/support/components/project_include_component.rb
+++ b/spec/support/components/project_include_component.rb
@@ -34,19 +34,19 @@ module Components
 
     def clear_tooltips
       # Just hover anything else
-      page.find("[data-qa-selector='project-include-search']").hover
+      page.find("[data-test-selector='project-include-search']").hover
     end
 
     def toggle!
-      page.find("[data-qa-selector='project-include-button']").click
+      page.find("[data-test-selector='project-include-button']").click
     end
 
     def expect_open
-      expect(page).to have_selector("[data-qa-selector='project-include-list']")
+      expect(page).to have_selector("[data-test-selector='project-include-list']")
     end
 
     def expect_count(count)
-      expect(page).to have_selector("[data-qa-selector='project-include-button'] .badge", text: count)
+      expect(page).to have_selector("[data-test-selector='project-include-button'] .badge", text: count)
     end
 
     def toggle_include_all_subprojects
@@ -60,7 +60,7 @@ module Components
 
     def set_filter_selected(filter)
       within_body do
-        page.find("[data-qa-selector='spot-toggle--option']", text: filter ? 'Only selected' : 'All projects').click
+        page.find("[data-test-selector='spot-toggle--option']", text: filter ? 'Only selected' : 'All projects').click
       end
     end
 
@@ -89,7 +89,7 @@ module Components
     end
 
     def expect_closed
-      expect(page).not_to have_selector("[data-qa-selector='project-include-list']")
+      expect(page).not_to have_selector("[data-test-selector='project-include-list']")
     end
 
     def click_button(text)
@@ -115,7 +115,7 @@ module Components
     end
 
     def no_loading_indicator
-      expect(page).not_to have_selector("[data-qa-selector='op-project-include--loading']")
+      expect(page).not_to have_selector("[data-test-selector='op-project-include--loading']")
     end
   end
 end

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -105,23 +105,23 @@ module Components
       end
 
       def autocompleter_item_selector
-        '[data-qa-selector="op-header-project-select--item"]'
+        '[data-test-selector="op-header-project-select--item"]'
       end
 
       def autocompleter_item_title_selector
-        '[data-qa-selector="op-header-project-select--item-title"]'
+        '[data-test-selector="op-header-project-select--item-title"]'
       end
 
       def autocompleter_item_disabled_title_selector
-        '[data-qa-selector="op-header-project-select--item-disabled-title"]'
+        '[data-test-selector="op-header-project-select--item-disabled-title"]'
       end
 
       def autocompleter_results_selector
-        '[data-qa-selector="op-header-project-select--list"]'
+        '[data-test-selector="op-header-project-select--list"]'
       end
 
       def autocompleter_selector
-        '[data-qa-selector="op-header-project-select--search"] input'
+        '[data-test-selector="op-header-project-select--search"] input'
       end
     end
   end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -47,11 +47,11 @@ module Components
       end
 
       def expect_notification_count(count)
-        expect(page).to have_selector('[data-qa-selector="tab-counter-Activity"] span', text: count)
+        expect(page).to have_selector('[data-test-selector="tab-counter-Activity"] span', text: count)
       end
 
       def expect_no_notification_badge
-        expect(page).not_to have_selector('[data-qa-selector="tab-counter-Activity"] span')
+        expect(page).not_to have_selector('[data-test-selector="tab-counter-Activity"] span')
       end
 
       def hover_action(journal_id, action)

--- a/spec/support/components/work_packages/baseline.rb
+++ b/spec/support/components/work_packages/baseline.rb
@@ -46,7 +46,7 @@ module Components
       end
 
       def expect_legend_tooltip(text)
-        expect(page).to have_selector('[data-qa-selector="baseline-legend-time-offset"]', visible: :all) { |node|
+        expect(page).to have_selector('[data-test-selector="baseline-legend-time-offset"]', visible: :all) { |node|
           node['title'] == text
         }
       end

--- a/spec/support/components/work_packages/baseline_modal.rb
+++ b/spec/support/components/work_packages/baseline_modal.rb
@@ -34,7 +34,7 @@ module Components
       include RSpec::Matchers
 
       def toggle_drop_modal
-        page.find('[data-qa-selector="baseline-button"]').click
+        page.find('[data-test-selector="baseline-button"]').click
       end
 
       def expect_closed

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -226,7 +226,7 @@ module Components
         retry_block do
           # wait for filter to be present
           filter_element = page.find("#filter_#{id}")
-          if filter_element.has_selector?("[data-qa-selector='op-basic-range-date-picker']", wait: false)
+          if filter_element.has_selector?("[data-test-selector='op-basic-range-date-picker']", wait: false)
             insert_date_range(filter_element, value)
           elsif operator == 'between'
             insert_two_single_dates(id, value)
@@ -264,7 +264,7 @@ module Components
       end
 
       def insert_date_range(filter_element, value)
-        date_input = filter_element.find("[data-qa-selector='op-basic-range-date-picker']")
+        date_input = filter_element.find("[data-test-selector='op-basic-range-date-picker']")
         ensure_value_is_input_correctly date_input, value: Array(value).join(' - ')
       end
 
@@ -296,7 +296,7 @@ module Components
             value.each do |v|
               expect(page).to have_selector("#values-#{id} .ng-value-label", text: v)
             end
-          elsif page.has_selector?("#filter_#{id} [data-qa-selector='op-basic-range-date-picker']", wait: false)
+          elsif page.has_selector?("#filter_#{id} [data-test-selector='op-basic-range-date-picker']", wait: false)
             expected_value =
               if value[1]
                 "#{value[0]} - #{value[1]}"
@@ -305,7 +305,7 @@ module Components
               else
                 "-"
               end
-            input = page.find("#filter_#{id} [data-qa-selector='op-basic-range-date-picker']")
+            input = page.find("#filter_#{id} [data-test-selector='op-basic-range-date-picker']")
             expect(input.value).to eql(expected_value)
           else
             page.all('input').each_with_index do |input, index|

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -56,15 +56,15 @@ module Components
       end
 
       def expect_number_of_groups(count)
-        expect(page).to have_selector('[data-qa-selector="op-group--value"] .count', count:)
+        expect(page).to have_selector('[data-test-selector="op-group--value"] .count', count:)
       end
 
       def expect_grouped_by_value(value_name, count)
-        expect(page).to have_selector('[data-qa-selector="op-group--value"]', text: "#{value_name} (#{count})")
+        expect(page).to have_selector('[data-test-selector="op-group--value"]', text: "#{value_name} (#{count})")
       end
 
       def expect_no_groups
-        expect(page).not_to have_selector('[data-qa-selector="op-group--value"]')
+        expect(page).not_to have_selector('[data-test-selector="op-group--value"]')
       end
 
       def expect_not_grouped_by(name)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -48,7 +48,7 @@ module Components
 
       def click_relation(relatable)
         SeleniumHubWaiter.wait
-        page.find(".relation-row-#{relatable.id} [data-qa-selector='op-relation--row-id']").click
+        page.find(".relation-row-#{relatable.id} [data-test-selector='op-relation--row-id']").click
       end
 
       def edit_relation_type(relatable, to_type:)
@@ -63,7 +63,7 @@ module Components
       def hover_action(relatable, action)
         retry_block do
           # Focus type edit to expose buttons
-          span = page.find(".relation-row-#{relatable.id} [data-qa-selector='op-relation--row-type']", wait: 20)
+          span = page.find(".relation-row-#{relatable.id} [data-test-selector='op-relation--row-type']", wait: 20)
           scroll_to_element(span)
           page.driver.browser.action.move_to(span.native).perform
 
@@ -101,7 +101,7 @@ module Components
         select relation_label, from: 'relation-type--select'
 
         # Enter the query and select the child
-        autocomplete = container.find("[data-qa-selector='wp-relations-autocomplete']")
+        autocomplete = container.find("[data-test-selector='wp-relations-autocomplete']")
         select_autocomplete autocomplete,
                             results_selector: '.ng-dropdown-panel-items',
                             query: to.subject,
@@ -111,9 +111,9 @@ module Components
                                       text: relation_label.upcase,
                                       wait: 10)
 
-        expect(page).to have_selector("[data-qa-selector='op-relation--row-type']", text: to.type.name.upcase)
+        expect(page).to have_selector("[data-test-selector='op-relation--row-type']", text: to.type.name.upcase)
 
-        expect(page).to have_selector("[data-qa-selector='op-relation--row-subject']", text: to.subject)
+        expect(page).to have_selector("[data-test-selector='op-relation--row-subject']", text: to.subject)
 
         ## Test if relation exist
         work_package.reload
@@ -123,15 +123,15 @@ module Components
       end
 
       def expect_relation(relatable)
-        expect(relations_group).to have_selector("[data-qa-selector='op-relation--row-subject']", text: relatable.subject)
+        expect(relations_group).to have_selector("[data-test-selector='op-relation--row-subject']", text: relatable.subject)
       end
 
       def expect_relation_by_text(text)
-        expect(relations_group).to have_selector("[data-qa-selector='op-relation--row-subject']", text:)
+        expect(relations_group).to have_selector("[data-test-selector='op-relation--row-subject']", text:)
       end
 
       def expect_no_relation(relatable)
-        expect(page).not_to have_selector("[data-qa-selector='op-relation--row-subject']", text: relatable.subject)
+        expect(page).not_to have_selector("[data-test-selector='op-relation--row-subject']", text: relatable.subject)
       end
 
       def add_parent(query, work_package)
@@ -141,7 +141,7 @@ module Components
 
         # Enter the query and select the child
         SeleniumHubWaiter.wait
-        autocomplete = find("[data-qa-selector='wp-relations-autocomplete']")
+        autocomplete = find("[data-test-selector='wp-relations-autocomplete']")
         select_autocomplete autocomplete,
                             query:,
                             results_selector: '.ng-dropdown-panel-items',
@@ -149,13 +149,13 @@ module Components
       end
 
       def expect_parent(work_package)
-        expect(page).to have_selector '[data-qa-selector="op-wp-breadcrumb-parent"]',
+        expect(page).to have_selector '[data-test-selector="op-wp-breadcrumb-parent"]',
                                       text: work_package.subject,
                                       wait: 10
       end
 
       def expect_no_parent
-        expect(page).not_to have_selector '[data-qa-selector="op-wp-breadcrumb-parent"]', wait: 10
+        expect(page).not_to have_selector '[data-test-selector="op-wp-breadcrumb-parent"]', wait: 10
       end
 
       def remove_parent
@@ -165,7 +165,7 @@ module Components
 
       def inline_create_child(subject_text)
         container = find('.wp-relations--children')
-        scroll_to_and_click(container.find('[data-qa-selector="op-wp-inline-create"]'))
+        scroll_to_and_click(container.find('[data-test-selector="op-wp-inline-create"]'))
 
         subject = ::EditField.new(container, 'subject')
         subject.expect_active!
@@ -177,7 +177,7 @@ module Components
           next if page.has_selector?('.wp-relations--children .ng-input input')
 
           SeleniumHubWaiter.wait
-          find('[data-qa-selector="op-wp-inline-create-reference"]', text: I18n.t('js.relation_buttons.add_existing_child')).click
+          find('[data-test-selector="op-wp-inline-create-reference"]', text: I18n.t('js.relation_buttons.add_existing_child')).click
 
           # Security check to be sure that the autocompleter has finished loading
           page.find '.wp-relations--children .ng-input input'
@@ -186,7 +186,7 @@ module Components
 
       def add_existing_child(work_package)
         # Enter the query and select the child
-        autocomplete = page.find(".wp-relations--add-form [data-qa-selector='wp-relations-autocomplete']")
+        autocomplete = page.find(".wp-relations--add-form [data-test-selector='wp-relations-autocomplete']")
         select_autocomplete autocomplete,
                             query: work_package.id,
                             results_selector: '.ng-dropdown-panel-items',

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -78,7 +78,7 @@ module Components
       end
 
       def save
-        find('[data-qa-selector="spot-modal-wp-table-configuration-save-button"]').click
+        find('[data-test-selector="spot-modal-wp-table-configuration-save-button"]').click
       end
 
       def cancel

--- a/spec/support/components/work_packages/tabs_counter.rb
+++ b/spec/support/components/work_packages/tabs_counter.rb
@@ -13,14 +13,14 @@ module Components
 
       # Check value of counter for the given tab
       def expect_counter(tab, content)
-        expect(tab).to have_selector('[data-qa-selector="tab-count"]')
+        expect(tab).to have_selector('[data-test-selector="tab-count"]')
 
-        expect(tab).to have_selector('[data-qa-selector="tab-count"]', text: "(#{content})")
+        expect(tab).to have_selector('[data-test-selector="tab-count"]', text: "(#{content})")
       end
 
       # Counter should not be displayed, if there are no relations or watchers
       def expect_no_counter(tab)
-        expect(tab).not_to have_selector('[data-qa-selector="tab-count"]', wait: 10)
+        expect(tab).not_to have_selector('[data-test-selector="tab-count"]', wait: 10)
       end
     end
   end

--- a/spec/support/components/work_packages/timer_button.rb
+++ b/spec/support/components/work_packages/timer_button.rb
@@ -34,15 +34,15 @@ module Components
       include RSpec::Matchers
 
       def expect_active
-        expect(page).to have_selector('[data-qa-selector="timer-active"]', wait: 10)
+        expect(page).to have_selector('[data-test-selector="timer-active"]', wait: 10)
       end
 
       def expect_inactive
-        expect(page).to have_selector('[data-qa-selector="timer-inactive"]', wait: 10)
+        expect(page).to have_selector('[data-test-selector="timer-inactive"]', wait: 10)
       end
 
       def expect_time(text)
-        expect(page).to have_selector('[data-qa-selector="timer-active"]', wait: 10, text:)
+        expect(page).to have_selector('[data-test-selector="timer-active"]', wait: 10, text:)
       end
 
       def expect_visible(visible: true)
@@ -56,13 +56,13 @@ module Components
       def start
         close_dropdown
         page.within('op-wp-timer-button') do
-          find('[data-qa-selector="timer-inactive"]').click
+          find('[data-test-selector="timer-inactive"]').click
         end
       end
 
       def stop
         page.within('op-wp-timer-button') do
-          find('[data-qa-selector="timer-active"]').click
+          find('[data-test-selector="timer-active"]').click
         end
       end
 

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -37,7 +37,7 @@ class DateEditField < EditField
            :toggle_scheduling_mode, to: :datepicker
 
   def modal_selector
-    '[data-qa-selector="op-datepicker-modal"]'
+    '[data-test-selector="op-datepicker-modal"]'
   end
 
   def input_selector
@@ -71,13 +71,13 @@ class DateEditField < EditField
 
   def activate_start_date_within_modal
     within_modal do
-      find('[data-qa-selector="op-datepicker-modal--start-date-field"]').click
+      find('[data-test-selector="op-datepicker-modal--start-date-field"]').click
     end
   end
 
   def activate_due_date_within_modal
     within_modal do
-      find('[data-qa-selector="op-datepicker-modal--end-date-field"]').click
+      find('[data-test-selector="op-datepicker-modal--end-date-field"]').click
     end
   end
 
@@ -170,6 +170,6 @@ class DateEditField < EditField
   end
 
   def action_button(text)
-    page.find("#{modal_selector} [data-qa-selector='op-datepicker-modal--action']", text:)
+    page.find("#{modal_selector} [data-test-selector='op-datepicker-modal--action']", text:)
   end
 end

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -38,7 +38,7 @@ class EditField
   end
 
   def label_element
-    context.find ".wp-replacement-label[data-qa-selector='#{property_name}']"
+    context.find ".wp-replacement-label[data-test-selector='#{property_name}']"
   end
 
   def clear(with_backspace: false)

--- a/spec/support/edit_fields/work_package_status_field.rb
+++ b/spec/support/edit_fields/work_package_status_field.rb
@@ -3,7 +3,7 @@ require_relative './edit_field'
 class WorkPackageStatusField < EditField
   def initialize(context)
     @context = context
-    @selector = "[data-qa-selector='op-wp-status-button']"
+    @selector = "[data-test-selector='op-wp-status-button']"
   end
 
   def input_selector

--- a/spec/support/finders/test_selector.rb
+++ b/spec/support/finders/test_selector.rb
@@ -1,0 +1,46 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module TestSelectorFinders
+  def test_selector(value)
+    "[data-test-selector=\"#{value}\"]"
+  end
+
+  def find_test_selector(value, **)
+    find(test_selector(value), **)
+  end
+
+  def within_test_selector(value, **, &block)
+    within(test_selector(value), **, &block)
+  end
+end
+
+RSpec.configure do |config|
+  Capybara::Session.include(TestSelectorFinders)
+  Capybara::DSL.extend(TestSelectorFinders)
+  config.include TestSelectorFinders, type: :feature
+end

--- a/spec/support/finders/test_selector.rb
+++ b/spec/support/finders/test_selector.rb
@@ -25,21 +25,30 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+require 'capybara/rspec'
+
 module TestSelectorFinders
   def test_selector(value)
     "[data-test-selector=\"#{value}\"]"
   end
 
   def find_test_selector(value, **)
-    find(test_selector(value), **)
+    find(:test_id, value, **)
   end
 
   def within_test_selector(value, **, &block)
-    within(test_selector(value), **, &block)
+    within(:test_id, value, **, &block)
   end
 end
 
 RSpec.configure do |config|
+  Capybara.test_id = 'data-test-selector'
+  Capybara.add_selector(:test_id) do
+    xpath do |locator|
+      XPath.descendant[XPath.attr(Capybara.test_id) == locator]
+    end
+  end
+
   Capybara::Session.include(TestSelectorFinders)
   Capybara::DSL.extend(TestSelectorFinders)
   config.include TestSelectorFinders, type: :feature

--- a/spec/support/matchers/has_test_selector.rb
+++ b/spec/support/matchers/has_test_selector.rb
@@ -1,0 +1,46 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+RSpec::Matchers.define :have_test_selector do |expected, **args|
+  include TestSelectorFinders
+
+  match do |page|
+    page.has_selector?(test_selector(expected), **args)
+  end
+
+  match_when_negated do |page|
+    page.has_no_selector?(test_selector(expected), **args)
+  end
+
+  failure_message do
+    "expected page to have test selector #{expected}"
+  end
+
+  failure_message_when_negated do
+    "expected page not to have test selector #{expected}"
+  end
+end

--- a/spec/support/pages/admin/individual_principals/edit.rb
+++ b/spec/support/pages/admin/individual_principals/edit.rb
@@ -105,7 +105,7 @@ module Pages
         end
 
         def select_project!(project_name)
-          select_autocomplete page.find('[data-qa-selector="membership_project_id"]'),
+          select_autocomplete page.find('[data-test-selector="membership_project_id"]'),
                               query: project_name,
                               select_text: project_name,
                               results_selector: 'body'

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -108,7 +108,7 @@ module Pages
     end
 
     def search_for_project(query)
-      autocomplete = page.find('[data-qa-selector="membership_project_id"]')
+      autocomplete = page.find('[data-test-selector="membership_project_id"]')
       search_autocomplete autocomplete,
                           query:,
                           results_selector: 'body'
@@ -123,7 +123,7 @@ module Pages
     end
 
     def select_project!(project_name)
-      select_autocomplete page.find('[data-qa-selector="membership_project_id"]'),
+      select_autocomplete page.find('[data-test-selector="membership_project_id"]'),
                           query: project_name,
                           select_text: project_name,
                           results_selector: 'body'

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -45,7 +45,7 @@ module Pages
 
       def mark_notification_as_read(notification)
         within_item(notification) do
-          page.find('[data-qa-selector="mark-as-read-button"]').click
+          page.find('[data-test-selector="mark-as-read-button"]').click
         end
       end
 
@@ -69,7 +69,7 @@ module Pages
       end
 
       def within_item(notification, &)
-        page.within("[data-qa-selector='op-ian-notification-item-#{notification.id}']", &)
+        page.within("[data-test-selector='op-ian-notification-item-#{notification.id}']", &)
       end
 
       def expect_item(notification, expected_text = notification.subject)
@@ -81,23 +81,23 @@ module Pages
       def expect_no_item(*notifications)
         notifications.each do |notification|
           expect(page)
-            .not_to have_selector("[data-qa-selector='op-ian-notification-item-#{notification.id}']")
+            .not_to have_selector("[data-test-selector='op-ian-notification-item-#{notification.id}']")
         end
       end
 
       def expect_read_item(notification)
         expect(page)
-          .to have_selector("[data-qa-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-read]")
+          .to have_selector("[data-test-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-read]")
       end
 
       def expect_item_not_read(notification)
         expect(page)
-          .not_to have_selector("[data-qa-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-read]")
+          .not_to have_selector("[data-test-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-read]")
       end
 
       def expect_item_selected(notification)
         expect(page)
-          .to have_selector("[data-qa-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-selected]")
+          .to have_selector("[data-test-selector='op-ian-notification-item-#{notification.id}'][data-qa-ian-selected]")
       end
 
       def expect_work_package_item(*notifications)
@@ -124,22 +124,22 @@ module Pages
 
       def expect_number_of_notifications(count)
         if count == 0
-          expect(page).not_to have_selector('[data-qa-selector^="op-ian-notification-item-"]')
+          expect(page).not_to have_selector('[data-test-selector^="op-ian-notification-item-"]')
         else
-          expect(page).to have_selector('[data-qa-selector^="op-ian-notification-item-"]', count:, wait: 10)
+          expect(page).to have_selector('[data-test-selector^="op-ian-notification-item-"]', count:, wait: 10)
         end
       end
 
       def expect_bell_count(count)
         if count == 0
-          expect(page).not_to have_selector('[data-qa-selector="op-ian-notifications-count"]')
+          expect(page).not_to have_selector('[data-test-selector="op-ian-notifications-count"]')
         else
-          expect(page).to have_selector('[data-qa-selector="op-ian-notifications-count"]', text: count, wait: 10)
+          expect(page).to have_selector('[data-test-selector="op-ian-notifications-count"]', text: count, wait: 10)
         end
       end
 
       def bell_element
-        page.find('op-in-app-notification-bell [data-qa-selector="op-ian-bell"]')
+        page.find('op-in-app-notification-bell [data-test-selector="op-ian-bell"]')
       end
 
       def expect_no_toaster

--- a/spec/support/pages/notifications/settings.rb
+++ b/spec/support/pages/notifications/settings.rb
@@ -73,7 +73,7 @@ module Pages
 
       def add_project(project)
         click_button 'Add setting for project'
-        container = page.find('[data-qa-selector="notification-setting-inline-create"] ng-select')
+        container = page.find('[data-test-selector="notification-setting-inline-create"] ng-select')
         select_autocomplete container, query: project.name, results_selector: 'body'
         wait_for_network_idle if using_cuprite?
         expect_project project

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -133,16 +133,16 @@ module Pages
 
       def set_toggle_filter(values)
         should_active = values.first == 'yes'
-        is_active = page.has_selector? '[data-qa-selector="spot-switch-handle"][data-qa-active]'
+        is_active = page.has_selector? '[data-test-selector="spot-switch-handle"][data-qa-active]'
 
         if should_active != is_active
-          page.find('[data-qa-selector="spot-switch-handle"]').click
+          page.find('[data-test-selector="spot-switch-handle"]').click
         end
 
         if should_active
-          expect(page).to have_selector('[data-qa-selector="spot-switch-handle"][data-qa-active]')
+          expect(page).to have_selector('[data-test-selector="spot-switch-handle"][data-qa-active]')
         else
-          expect(page).to have_selector('[data-qa-selector="spot-switch-handle"]:not([data-qa-active])')
+          expect(page).to have_selector('[data-test-selector="spot-switch-handle"]:not([data-qa-active])')
         end
       end
 
@@ -181,7 +181,7 @@ module Pages
       end
 
       def click_more_menu_item(item)
-        page.find('[data-qa-selector="project-more-dropdown-menu"]').click
+        page.find('[data-test-selector="project-more-dropdown-menu"]').click
         page.within('.menu-drop-down-container') do
           click_link(item)
         end

--- a/spec/support/pages/reminders/settings.rb
+++ b/spec/support/pages/reminders/settings.rb
@@ -51,17 +51,17 @@ module Pages
       end
 
       def deactivate_time(label)
-        find("[data-qa-selector='op-settings-daily-time--active-#{label.split[1]}']").click
+        find("[data-test-selector='op-settings-daily-time--active-#{label.split[1]}']").click
       end
 
       def remove_time(label)
-        find("[data-qa-selector='op-settings-daily-time--remove-#{label.split[1]}']").click
+        find("[data-test-selector='op-settings-daily-time--remove-#{label.split[1]}']").click
       end
 
       def expect_active_daily_times(*times)
         times.each_with_index do |time, index|
           expect(page)
-            .to have_css("input[data-qa-selector='op-settings-daily-time--active-#{index + 1}']:checked")
+            .to have_css("input[data-test-selector='op-settings-daily-time--active-#{index + 1}']:checked")
 
           expect(page)
             .to have_field("Time #{index + 1}", text: time)
@@ -116,7 +116,7 @@ module Pages
         end
 
         if first && last
-          expect(page).to have_selector('[data-qa-selector="op-basic-range-date-picker"]',
+          expect(page).to have_selector('[data-test-selector="op-basic-range-date-picker"]',
                                         value: "#{first.iso8601} - #{last.iso8601}")
         end
       end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -120,7 +120,7 @@ module Pages
       attribute_expectations.each do |label_name, value|
         label = label_name.to_s
         if label == 'status'
-          expect(page).to have_selector("[data-qa-selector='op-wp-status-button'] .button", text: value)
+          expect(page).to have_selector("[data-test-selector='op-wp-status-button'] .button", text: value)
         else
           expect(page).to have_selector(".inline-edit--container.#{label.camelize(:lower)}", text: value)
         end
@@ -147,7 +147,7 @@ module Pages
     def expect_no_parent
       visit_tab!('relations')
 
-      expect(page).not_to have_selector('[data-qa-selector="op-wp-breadcrumb-parent"]')
+      expect(page).not_to have_selector('[data-test-selector="op-wp-breadcrumb-parent"]')
     end
 
     def expect_zen_mode
@@ -303,7 +303,7 @@ module Pages
     end
 
     def mark_notifications_as_read
-      find('[data-qa-selector="mark-notification-read-button"]').click
+      find('[data-test-selector="mark-notification-read-button"]').click
     end
 
     private

--- a/spec/support/pages/work_packages/embedded_work_packages_table.rb
+++ b/spec/support/pages/work_packages/embedded_work_packages_table.rb
@@ -46,16 +46,16 @@ module Pages
     end
 
     def click_reference_inline_create
-      container.find('[data-qa-selector="op-wp-inline-create-reference"]').click
+      container.find('[data-test-selector="op-wp-inline-create-reference"]').click
 
       # Returns the autocomplete container
-      container.find('[data-qa-selector="wp-relations-autocomplete"]')
+      container.find('[data-test-selector="wp-relations-autocomplete"]')
     end
 
     def reference_work_package(work_package, query: work_package.subject)
       click_reference_inline_create
 
-      autocomplete_container = container.find('[data-qa-selector="wp-relations-autocomplete"]')
+      autocomplete_container = container.find('[data-test-selector="wp-relations-autocomplete"]')
       select_autocomplete autocomplete_container,
                           query:,
                           results_selector: '.ng-dropdown-panel-items',

--- a/spec/support/pages/work_packages/work_package_card.rb
+++ b/spec/support/pages/work_packages/work_package_card.rb
@@ -51,19 +51,19 @@ module Pages
 
     def expect_type(name)
       page.within(card_element) do
-        expect(page).to have_selector('[data-qa-selector="op-wp-single-card--content-type"]', text: name.upcase)
+        expect(page).to have_selector('[data-test-selector="op-wp-single-card--content-type"]', text: name.upcase)
       end
     end
 
     def expect_subject(subject)
       page.within(card_element) do
-        expect(page).to have_selector('[data-qa-selector="op-wp-single-card--content-subject"]', text: subject)
+        expect(page).to have_selector('[data-test-selector="op-wp-single-card--content-subject"]', text: subject)
       end
     end
 
     def open_details_view
       card_element.hover
-      card_element.find('[data-qa-selector="op-wp-single-card--details-button"]').click
+      card_element.find('[data-test-selector="op-wp-single-card--details-button"]').click
 
       ::Pages::SplitWorkPackage.new work_package
     end

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -78,7 +78,7 @@ module Pages
       element = card(work_package)
       scroll_to_element(element)
       element.hover
-      element.find('[data-qa-selector="op-wp-single-card--details-button"]').click
+      element.find('[data-test-selector="op-wp-single-card--details-button"]').click
 
       ::Pages::SplitWorkPackage.new(work_package, project)
     end
@@ -94,7 +94,7 @@ module Pages
     def click_info_icon(work_package)
       card_element = card(work_package)
       card_element.hover
-      card_element.find('[data-qa-selector="op-wp-single-card--details-button"]').click
+      card_element.find('[data-test-selector="op-wp-single-card--details-button"]').click
     end
 
     def click_id_link(work_package)

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -152,7 +152,7 @@ module Pages
       # there is a delay on travis where inline create can be clicked.
       sleep 3
 
-      container.find('[data-qa-selector="op-wp-inline-create"]').click
+      container.find('[data-test-selector="op-wp-inline-create"]').click
       expect(container).to have_selector('.wp-inline-create-row', wait: 10)
     end
 


### PR DESCRIPTION
Instead of doing 

```ruby
expect(page).to have_selector('[data-test-selector="some-value"]')
```

do this:

```ruby
expect(page).to have_test_selector('some-value')
```

and some other helpers to improve testing with test-selectors. This PR also changes the previous `qa-selector` to match the primer key.
