### PR TITLE
[#50076] Add `view_shared_work_packages` permission

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -119,7 +119,12 @@ Rails.application.reloader.to_prepare do
       map.permission :share_work_packages,
                      {},
                      permissible_on: :project,
-                     dependencies: :edit_work_packages,
+                     dependencies: %i[edit_work_packages view_shared_work_packages],
+                     require: :member
+
+      map.permission :view_shared_work_packages,
+                     {},
+                     permissible_on: :project,
                      require: :member
 
       map.permission :view_members,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2508,6 +2508,7 @@ en:
   permission_view_news: "View news"
   permission_view_members: "View members"
   permission_view_reportings: "View reportings"
+  permission_view_shared_work_packages: "View shared work packages"
   permission_view_time_entries: "View spent time"
   permission_view_timelines: "View timelines"
   permission_view_wiki_edits: "View wiki history"

--- a/db/migrate/20230912185647_add_view_shared_work_packages_permission.rb
+++ b/db/migrate/20230912185647_add_view_shared_work_packages_permission.rb
@@ -1,0 +1,44 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require_relative 'migration_utils/permission_adder'
+
+class AddViewSharedWorkPackagesPermission < ActiveRecord::Migration[7.0]
+  # Decouple ActiveRecord model from Migration
+  class MigrationRolePermission < ApplicationRecord
+    self.table_name = 'role_permissions'
+  end
+
+  def up
+    ::Migration::MigrationUtils::PermissionAdder.add(:share_work_packages, :view_shared_work_packages)
+  end
+
+  def down
+    MigrationRolePermission.where(permission: 'share_work_packages').delete_all
+  end
+end


### PR DESCRIPTION
## Description
In tandem with `share_work_packages`, `view_shared_work_packages` is a new permission that is required for the Work Package Sharing feature.

This new permission is a dependency of `share_work_packages`
## Notes
See: https://community.openproject.org/work_packages/50076