### PR TITLE
Default to target=_top for all links rendered in CKEditor

### DIFF
--- a/lib/open_project/text_formatting/filters/link_attribute_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_attribute_filter.rb
@@ -31,7 +31,7 @@ module OpenProject::TextFormatting
     class LinkAttributeFilter < HTML::Pipeline::Filter
       def call
         links.each do |node|
-          node['target'] = context[:target] if context[:target].present?
+          node['target'] = context.fetch(:target, '_top')
         end
 
         doc

--- a/modules/documents/spec/application_helper_spec.rb
+++ b/modules/documents/spec/application_helper_spec.rb
@@ -65,31 +65,32 @@ RSpec.describe ApplicationHelper do
       let(:document_link) do
         link_to('Test document',
                 { controller: 'documents', action: 'show', id: document.id },
-                class: 'document op-uc-link')
+                class: 'document op-uc-link',
+                target: '_top')
       end
 
       context "Plain link" do
         subject { format_text("document##{document.id}") }
 
-        it { is_expected.to eq("<p class=\"op-uc-p\">#{document_link}</p>") }
+        it { is_expected.to be_html_eql("<p class=\"op-uc-p\">#{document_link}</p>") }
       end
 
       context "Link with document name" do
         subject { format_text("document##{document.id}") }
 
-        it { is_expected.to eq("<p class=\"op-uc-p\">#{document_link}</p>") }
+        it { is_expected.to be_html_eql("<p class=\"op-uc-p\">#{document_link}</p>") }
       end
 
       context "Escaping plain link" do
         subject { format_text("!document##{document.id}") }
 
-        it { is_expected.to eq("<p class=\"op-uc-p\">document##{document.id}</p>") }
+        it { is_expected.to be_html_eql("<p class=\"op-uc-p\">document##{document.id}</p>") }
       end
 
       context "Escaping link with document name" do
         subject { format_text('!document:"Test document"') }
 
-        it { is_expected.to eq('<p class="op-uc-p">document:"Test document"</p>') }
+        it { is_expected.to be_html_eql('<p class="op-uc-p">document:"Test document"</p>') }
       end
     end
 
@@ -99,14 +100,14 @@ RSpec.describe ApplicationHelper do
       context "By name without project" do
         subject { format_text("document:\"#{document.title}\"", project: the_other_project) }
 
-        it { is_expected.to eq('<p class="op-uc-p">document:"Test document"</p>') }
+        it { is_expected.to be_html_eql('<p class="op-uc-p">document:"Test document"</p>') }
       end
 
       context "By id and given project" do
         subject { format_text("#{identifier}:document##{document.id}", project: the_other_project) }
 
         it {
-          expect(subject).to eq("<p class=\"op-uc-p\"><a class=\"document op-uc-link\" href=\"/documents/#{document.id}\">Test document</a></p>")
+          expect(subject).to be_html_eql("<p class=\"op-uc-p\"><a class=\"document op-uc-link\" href=\"/documents/#{document.id}\" target=\"_top\">Test document</a></p>")
         }
       end
 
@@ -114,14 +115,14 @@ RSpec.describe ApplicationHelper do
         subject { format_text("#{identifier}:document:\"#{document.title}\"", project: the_other_project) }
 
         it {
-          expect(subject).to eq("<p class=\"op-uc-p\"><a class=\"document op-uc-link\" href=\"/documents/#{document.id}\">Test document</a></p>")
+          expect(subject).to be_html_eql("<p class=\"op-uc-p\"><a class=\"document op-uc-link\" href=\"/documents/#{document.id}\" target=\"_top\">Test document</a></p>")
         }
       end
 
       context "Invalid link" do
         subject { format_text("invalid:document:\"Test document\"", project: the_other_project) }
 
-        it { is_expected.to eq('<p class="op-uc-p">invalid:document:"Test document"</p>') }
+        it { is_expected.to be_html_eql('<p class="op-uc-p">invalid:document:"Test document"</p>') }
       end
     end
   end

--- a/modules/documents/spec/lib/open_project/markdown_formatting_spec.rb
+++ b/modules/documents/spec/lib/open_project/markdown_formatting_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe OpenProject::TextFormatting,
       link_to(
         'My document',
         { controller: '/documents', action: 'show', id: document.id, only_path: true },
-        class: 'document op-uc-link'
+        class: 'document op-uc-link',
+        target: '_top'
       )
     end
 

--- a/modules/meeting/spec/lib/open_project/markdown_formatting_spec.rb
+++ b/modules/meeting/spec/lib/open_project/markdown_formatting_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe OpenProject::TextFormatting,
       link_to(
         'Monthly coordination',
         { controller: '/meetings', action: 'show', id: meeting.id, only_path: true },
-        class: 'meeting op-uc-link'
+        class: 'meeting op-uc-link',
+        target: '_top'
       )
     end
 

--- a/spec/features/forums/attachment_upload_spec.rb
+++ b/spec/features/forums/attachment_upload_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe 'Upload attachment to forum message', js: true do
     show_page = create_page.click_save
 
     attachments_list.expect_attached('image.png')
-
     within '.toolbar-items' do
       click_on "Edit"
     end

--- a/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
@@ -82,12 +82,12 @@ RSpec.describe OpenProject::TextFormatting,
       let(:changeset_link) do
         link_to("r#{changeset1.revision}",
                 { controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset1.revision },
-                class: 'changeset op-uc-link', title: 'My very first commit')
+                class: 'changeset op-uc-link', title: 'My very first commit', target: '_top')
       end
       let(:changeset_link2) do
         link_to("r#{changeset2.revision}",
                 { controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset2.revision },
-                class: 'changeset op-uc-link', title: 'This commit fixes #1, #2 and references #1 & #3')
+                class: 'changeset op-uc-link', title: 'This commit fixes #1, #2 and references #1 & #3', target: '_top')
       end
 
       before do
@@ -137,7 +137,7 @@ RSpec.describe OpenProject::TextFormatting,
       let(:version_link) do
         link_to('1.0',
                 { controller: 'versions', action: 'show', id: version.id },
-                class: 'version op-uc-link')
+                class: 'version op-uc-link', target: '_top')
       end
 
       context 'Link with version id' do
@@ -187,7 +187,8 @@ RSpec.describe OpenProject::TextFormatting,
         link_to(
           'project plan with milestones',
           project_work_packages_path([query.project.id], query_id: query.id),
-          class: 'query op-uc-link'
+          class: 'query op-uc-link',
+          target: '_top'
         )
       end
 
@@ -209,7 +210,8 @@ RSpec.describe OpenProject::TextFormatting,
         link_to(
           'Work packages',
           project_work_packages_path([project.id]),
-          class: 'query op-uc-link'
+          class: 'query op-uc-link',
+          target: '_top'
         )
       end
 
@@ -244,7 +246,8 @@ RSpec.describe OpenProject::TextFormatting,
 
         it {
           expect(subject).to be_html_eql("<p class='op-uc-p'>#{link_to(message1.subject, topic_path(message1),
-                                                                       class: 'message op-uc-link')}</p>")
+                                                                       class: 'message op-uc-link',
+                                                                       target: '_top')}</p>")
         }
       end
 
@@ -252,8 +255,11 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text("message##{message2.id}") }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'>#{link_to(message2.subject,
-                                                                       topic_path(message1, anchor: "message-#{message2.id}", r: message2.id), class: 'message op-uc-link')}</p>")
+          link = link_to(message2.subject,
+                         topic_path(message1, anchor: "message-#{message2.id}", r: message2.id),
+                         class: 'message op-uc-link',
+                         target: '_top')
+          expect(subject).to be_html_eql("<p class='op-uc-p'>#{link}</p>")
         }
       end
     end
@@ -262,7 +268,8 @@ RSpec.describe OpenProject::TextFormatting,
       let(:work_package_link) do
         link_to("##{work_package.id}",
                 work_package_path(work_package),
-                class: 'issue work_package preview-trigger op-uc-link')
+                class: 'issue work_package preview-trigger op-uc-link',
+                target: '_top')
       end
 
       context 'Plain work_package link' do
@@ -333,7 +340,8 @@ RSpec.describe OpenProject::TextFormatting,
         let(:work_package_link) do
           link_to("##{work_package.id}",
                   work_package_path(work_package),
-                  class: 'issue work_package preview-trigger op-uc-link')
+                  class: 'issue work_package preview-trigger op-uc-link',
+                  target: '_top')
         end
 
         subject { format_text("##{work_package.id}") }
@@ -359,7 +367,8 @@ RSpec.describe OpenProject::TextFormatting,
 
         it {
           expect(subject).to be_html_eql("<p class='op-uc-p'>#{link_to(subproject.name, project_url,
-                                                                       class: 'project op-uc-link')}</p>")
+                                                                       target: '_top',
+                                                                       class: 'project op-uc-link',)}</p>")
         }
       end
 
@@ -368,6 +377,7 @@ RSpec.describe OpenProject::TextFormatting,
 
         it {
           expect(subject).to be_html_eql("<p class='op-uc-p'>#{link_to(subproject.name, project_url,
+                                                                       target: '_top',
                                                                        class: 'project op-uc-link')}</p>")
         }
       end
@@ -377,6 +387,7 @@ RSpec.describe OpenProject::TextFormatting,
 
         it {
           expect(subject).to be_html_eql("<p class='op-uc-p'>#{link_to(subproject.name, project_url,
+                                                                       target: '_top',
                                                                        class: 'project op-uc-link')}</p>")
         }
       end
@@ -430,7 +441,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[CookBook documentation]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/cookbook-documentation\">CookBook documentation</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/cookbook-documentation\">CookBook documentation</a></p>")
         }
       end
 
@@ -439,7 +450,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text("[[#{title}]]") }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/alert-foo\">#{h(title)}</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/alert-foo\">#{h(title)}</a></p>")
         }
       end
 
@@ -447,7 +458,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[Another page|Page]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></p>")
         }
       end
 
@@ -455,7 +466,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[CookBook documentation#One-section]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/cookbook-documentation#One-section\">CookBook documentation</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\"  href=\"/projects/#{project.identifier}/wiki/cookbook-documentation#One-section\">CookBook documentation</a></p>")
         }
       end
 
@@ -463,7 +474,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[Another page#anchor|Page]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/another-page#anchor\">Page</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/another-page#anchor\">Page</a></p>")
         }
       end
 
@@ -471,7 +482,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[Unknown page]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>")
         }
       end
 
@@ -479,7 +490,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[Unknown page|404]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=404\">404</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=404\">404</a></p>")
         }
       end
 
@@ -487,7 +498,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[onlinestore:]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/onlinestore/wiki/start-page\">onlinestore</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/onlinestore/wiki/start-page\">onlinestore</a></p>")
         }
       end
 
@@ -495,7 +506,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[onlinestore:|Wiki]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/onlinestore/wiki/start-page\">Wiki</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/onlinestore/wiki/start-page\">Wiki</a></p>")
         }
       end
 
@@ -503,7 +514,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[onlinestore:Start page]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/onlinestore/wiki/start-page\">Start Page</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/onlinestore/wiki/start-page\">Start Page</a></p>")
         }
       end
 
@@ -511,7 +522,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[onlinestore:Start page|Text]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" href=\"/projects/onlinestore/wiki/start-page\">Text</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/onlinestore/wiki/start-page\">Text</a></p>")
         }
       end
 
@@ -519,7 +530,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('[[onlinestore:Unknown page]]') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" href=\"/projects/onlinestore/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><a class=\"wiki-page new op-uc-link\" target=\"_top\" href=\"/projects/onlinestore/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>")
         }
       end
 
@@ -527,7 +538,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('~~[[Another page|Page]]~~') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><del><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></del></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><del><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></del></p>")
         }
       end
 
@@ -535,7 +546,7 @@ RSpec.describe OpenProject::TextFormatting,
         subject { format_text('~~[[Another page|Page]] link~~') }
 
         it {
-          expect(subject).to be_html_eql("<p class='op-uc-p'><del><a class=\"wiki-page op-uc-link\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a> link</del></p>")
+          expect(subject).to be_html_eql("<p class='op-uc-p'><del><a class=\"wiki-page op-uc-link\" target=\"_top\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a> link</del></p>")
         }
       end
 
@@ -581,21 +592,26 @@ RSpec.describe OpenProject::TextFormatting,
 
         @to_test = {
           # source
-          'source:/some/file' => link_to('source:/some/file', source_url, class: 'source op-uc-link'),
-          'source:/some/file.' => link_to('source:/some/file', source_url, class: 'source op-uc-link') + '.',
-          'source:"/some/file.ext".' => link_to('source:/some/file.ext', source_url_with_ext, class: 'source op-uc-link') + '.',
-          'source:/some/file. ' => link_to('source:/some/file', source_url, class: 'source op-uc-link') + '.',
-          'source:"/some/file.ext". ' => link_to('source:/some/file.ext', source_url_with_ext, class: 'source op-uc-link') + '.',
-          'source:/some/file, ' => link_to('source:/some/file', source_url, class: 'source op-uc-link') + ',',
-          'source:/some/file@52' => link_to('source:/some/file@52', source_url(rev: 52), class: 'source op-uc-link'),
+          'source:/some/file' => link_to('source:/some/file', source_url, class: 'source op-uc-link', target: '_top'),
+          'source:/some/file.' => link_to('source:/some/file', source_url, class: 'source op-uc-link', target: '_top') + '.',
+          'source:"/some/file.ext".' => link_to('source:/some/file.ext', source_url_with_ext, class: 'source op-uc-link', target: '_top') + '.',
+          'source:/some/file. ' => link_to('source:/some/file', source_url, class: 'source op-uc-link', target: '_top') + '.',
+          'source:"/some/file.ext". ' => link_to('source:/some/file.ext', source_url_with_ext, class: 'source op-uc-link', target: '_top') + '.',
+          'source:/some/file, ' => link_to('source:/some/file', source_url, class: 'source op-uc-link', target: '_top') + ',',
+          'source:/some/file@52' => link_to('source:/some/file@52', source_url(rev: 52), class: 'source op-uc-link', target: '_top'),
           'source:"/some/file.ext@52"' => link_to('source:/some/file.ext@52', source_url_with_ext(rev: 52),
-                                                  class: 'source op-uc-link'),
-          'source:"/some/file#L110"' => link_to('source:/some/file#L110', source_url(anchor: 'L110'), class: 'source op-uc-link'),
+                                                  class: 'source op-uc-link',
+                                                  target: '_top'),
+          'source:"/some/file#L110"' => link_to('source:/some/file#L110', source_url(anchor: 'L110'), class: 'source op-uc-link', target: '_top'),
           'source:"/some/file.ext#L110"' => link_to('source:/some/file.ext#L110', source_url_with_ext(anchor: 'L110'),
-                                                    class: 'source op-uc-link'),
+                                                    class: 'source op-uc-link',
+                                                    target: '_top'),
           'source:"/some/file@52#L110"' => link_to('source:/some/file@52#L110', source_url(rev: 52, anchor: 'L110'),
-                                                   class: 'source op-uc-link'),
-          'export:/some/file' => link_to('export:/some/file', source_url(format: 'raw'), class: 'source download op-uc-link'),
+                                                   class: 'source op-uc-link',
+                                                   target: '_top'),
+          'export:/some/file' => link_to('export:/some/file', source_url(format: 'raw'),
+                                         class: 'source download op-uc-link',
+                                         target: '_top'),
           # escaping
           '!source:/some/file' => 'source:/some/file',
           # invalid expressions
@@ -638,8 +654,8 @@ RSpec.describe OpenProject::TextFormatting,
 
       let(:expected) do
         <<~EXPECTED
-          <p class='op-uc-p'><a class="wiki-page op-uc-link" href="/projects/#{project.identifier}/wiki/cookbook-documentation">CookBook documentation</a></p>
-          <p class='op-uc-p'><a class="issue work_package preview-trigger op-uc-link" href="/work_packages/#{work_package.id}">##{work_package.id}</a></p>
+          <p class='op-uc-p'><a class="wiki-page op-uc-link" target="_top" href="/projects/#{project.identifier}/wiki/cookbook-documentation">CookBook documentation</a></p>
+          <p class='op-uc-p'><a class="issue work_package preview-trigger op-uc-link" target="_top" href="/work_packages/#{work_package.id}">##{work_package.id}</a></p>
           <pre class="op-uc-code-block">
           [[CookBook documentation]]
 

--- a/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe OpenProject::TextFormatting,
                   <td>
                     <ul class="op-uc-list_task-list op-uc-list">
                       <li>
-                        <a class="op-uc-link" href="https://example.com/">
+                        <a class="op-uc-link" target="_top" href="https://example.com/">
                           <label class="op-uc-list__label">
                             <input type="checkbox" disabled="disabled">
                             <span class="op-uc-list__label__description">asdfasd</span>
@@ -217,7 +217,7 @@ RSpec.describe OpenProject::TextFormatting,
                         <ul class="op-uc-list_task-list op-uc-list">
                           <li class="op-uc-list--item">
                             <input type="checkbox" class="op-uc-list--task-checkbox" disabled>
-                            <a class="op-uc-link" href="https://example.com/" rel="noopener noreferrer">
+                            <a class="op-uc-link" target="_top" href="https://example.com/" rel="noopener noreferrer">
                               <span>asdfasd</span>
                               <span> asdf</span>
                             </a>
@@ -316,7 +316,7 @@ RSpec.describe OpenProject::TextFormatting,
                           <li class="op-uc-list--item">
                             <input type="checkbox" class="op-uc-list--task-checkbox" disabled>
                             <span>asdfasdfasdf </span>
-                            <a class="op-uc-link" href="https://example.com/" rel="noopener noreferrer">
+                            <a class="op-uc-link" target="_top" href="https://example.com/" rel="noopener noreferrer">
                               <span>foobar</span>
                             </a>
                           </li>

--- a/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe OpenProject::TextFormatting,
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
                             title: "User #{linked_project_member.name}",
-                            class: 'user-mention op-uc-link')}
+                            class: 'user-mention op-uc-link',
+                            target: '_top')}
                 </p>
               EXPECTED
             end
@@ -133,7 +134,8 @@ RSpec.describe OpenProject::TextFormatting,
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
                             title: "User #{linked_project_member.name}",
-                            class: 'user-mention op-uc-link')}
+                            class: 'user-mention op-uc-link',
+                            target: '_top')}
                 </p>
               EXPECTED
             end
@@ -156,7 +158,8 @@ RSpec.describe OpenProject::TextFormatting,
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
                             title: "User #{linked_project_member.name}",
-                            class: 'user-mention op-uc-link')}
+                            class: 'user-mention op-uc-link',
+                            target: '_top')}
                 </p>
               EXPECTED
             end
@@ -180,7 +183,8 @@ RSpec.describe OpenProject::TextFormatting,
                     #{link_to(linked_project_member.name,
                               { controller: :users, action: :show, id: linked_project_member.id },
                               title: "User #{linked_project_member.name}",
-                              class: 'user-mention op-uc-link')}
+                              class: 'user-mention op-uc-link',
+                              target: '_top')}
                   </p>
                 EXPECTED
               end
@@ -208,7 +212,8 @@ RSpec.describe OpenProject::TextFormatting,
                     #{link_to(linked_project_member.name,
                               { controller: :users, action: :show, id: linked_project_member.id },
                               title: "User #{linked_project_member.name}",
-                              class: 'user-mention op-uc-link')}
+                              class: 'user-mention op-uc-link',
+                              target: '_top')}
                   </p>
                 EXPECTED
               end
@@ -232,7 +237,8 @@ RSpec.describe OpenProject::TextFormatting,
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
                             title: "User #{linked_project_member.name}",
-                            class: 'user-mention op-uc-link')}
+                            class: 'user-mention op-uc-link',
+                            target: '_top')}
                 </p>
               EXPECTED
             end
@@ -292,7 +298,7 @@ RSpec.describe OpenProject::TextFormatting,
               let(:expected) do
                 <<~EXPECTED
                   <p class="op-uc-p">
-                    Link to <a class="user-mention op-uc-link" href="/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
+                    Link to <a class="user-mention op-uc-link" target="_top" href="/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
                   </p>
                 EXPECTED
               end
@@ -312,7 +318,7 @@ RSpec.describe OpenProject::TextFormatting,
               let(:expected) do
                 <<~EXPECTED
                   <p class="op-uc-p">
-                    Link to <a class="user-mention op-uc-link" href="http://openproject.org/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
+                    Link to <a class="user-mention op-uc-link" target="_top" href="http://openproject.org/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
                   </p>
                 EXPECTED
               end
@@ -351,6 +357,7 @@ RSpec.describe OpenProject::TextFormatting,
                 <p class="op-uc-p">
                   Link to
                   <a class="user-mention op-uc-link"
+                     target="_top"
                      href="/groups/#{linked_project_member_group.id}"
                      title="Group #{linked_project_member_group.name}">
                     #{linked_project_member_group.name}
@@ -396,6 +403,7 @@ RSpec.describe OpenProject::TextFormatting,
               <<~EXPECTED
                 <p class="op-uc-p">
                   <a class="user-mention op-uc-link"
+                     target="_top"
                      href="/groups/#{linked_project_member_group.id}"
                      title="Group #{linked_project_member_group.name}">
                     #{linked_project_member_group.name}

--- a/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
@@ -61,10 +61,12 @@ RSpec.describe OpenProject::TextFormatting,
           </p>
           <p class="op-uc-p">
             <a href="#{OpenProject::Application.root_url}/foo/bar" rel="noopener noreferrer"
+               target="_top"
                class="op-uc-link">Link with setting</a>
           </p>
           <p class="op-uc-p">
             <a href="#{OpenProject::Application.root_url}/foo/bar" rel="noopener noreferrer"
+               target="_top"
                class="op-uc-link">Saved and transformed link with setting</a>
           </p>
           <p class="op-uc-p">

--- a/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe OpenProject::TextFormatting,
     it_behaves_like 'format_text produces' do
       let(:raw) do
         <<~RAW
-          this is a <a style="display:none;" href="http://malicious">
+          this is a <a style="display:none;" target="_top" href="http://malicious">
         RAW
       end
 
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            this is a <a href="http://malicious" rel="noopener noreferrer" class="op-uc-link">
+            this is a <a href="http://malicious" target="_top" rel="noopener noreferrer" class="op-uc-link">
           </p>
         EXPECTED
       end
@@ -101,7 +101,7 @@ RSpec.describe OpenProject::TextFormatting,
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Link to <a href="/foo/bar" class="op-uc-link" rel="noopener noreferrer">relative path</a>
+              Link to <a href="/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer">relative path</a>
             </p>
           EXPECTED
         end
@@ -121,7 +121,7 @@ RSpec.describe OpenProject::TextFormatting,
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Link to <a href="http://openproject.org/foo/bar" class="op-uc-link" rel="noopener noreferrer">relative path</a>
+              Link to <a href="http://openproject.org/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer">relative path</a>
             </p>
           EXPECTED
         end

--- a/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe OpenProject::TextFormatting,
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            <a class="op-uc-link" href="/projects/my-project/work_packages/new">New work package</a>
+            <a class="op-uc-link" target="_top" href="/projects/my-project/work_packages/new">New work package</a>
           </p>
         EXPECTED
       end
@@ -106,7 +106,7 @@ RSpec.describe OpenProject::TextFormatting,
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            <a class="op-uc-link" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
+            <a class="op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
           </p>
         EXPECTED
       end
@@ -123,7 +123,7 @@ RSpec.describe OpenProject::TextFormatting,
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              <a class="button op-uc-link" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
+              <a class="button op-uc-link" target="_top" href="/projects/my-project/work_packages/new?type=#{type.id}">New MyTaskName</a>
             </p>
           EXPECTED
         end

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -69,9 +69,15 @@ RSpec.describe 'API v3 Render resource' do
 
             it_behaves_like 'valid response' do
               let(:text) do
-                '<p class="op-uc-p">Hello World! This <em>is</em> markdown with a ' +
-                  '<a href="http://community.openproject.org" rel="noopener noreferrer" class="op-uc-link">link</a> ' +
-                  'and ümläutß.</p>'
+                <<~HTML
+                  <p class="op-uc-p">
+                    Hello World! This <em>is</em> markdown with a
+                    <a target="_top"
+                       href="http://community.openproject.org"
+                       rel="noopener noreferrer"
+                       class="op-uc-link">link</a>
+                    and ümläutß.</p>
+                HTML
               end
             end
           end
@@ -81,9 +87,14 @@ RSpec.describe 'API v3 Render resource' do
             let(:id) { work_package.id }
             let(:href) { "/work_packages/#{id}" }
             let(:text) do
-              '<p class="op-uc-p">Hello World! Have a look at <a ' \
-                "class=\"issue work_package preview-trigger op-uc-link\" " \
-                "href=\"#{href}\">##{id}</a></p>"
+              <<~HTML
+                <p class="op-uc-p">
+                  Hello World! Have a look at
+                  <a class="issue work_package preview-trigger op-uc-link"
+                     target="_top"
+                     href="#{href}">##{id}</a>
+                </p>
+              HTML
             end
 
             context 'with work package context' do


### PR DESCRIPTION
When we gradually enable `data-turbo=true`, links rendered within a frame will target that frame by default. This results in links rendered from CKEditor breaking. I see two solutions for that:

1. We add a link catcher that looks for links without a target, and ensures turbo does not handle them. This would mean we need to target frames directly for all links. 

2. Set all links that do not have a target set to _top

The PR tries to do 2)