### PR TITLE
Add erb-lint with GitHub a11y linters

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,35 @@
+---
+EnableDefaultLinters: true
+inherit_gem:
+  erblint-github:
+    - config/accessibility.yml
+exclude:
+  - '**/frontend/**/*'
+  - '**/node_modules/**/*'
+  - '**/vendor/**/*'
+linters:
+  ErbSafety:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false

--- a/.erb-linters/erblint-github.rb
+++ b/.erb-linters/erblint-github.rb
@@ -1,0 +1,1 @@
+require "erblint-github/linters"

--- a/Gemfile
+++ b/Gemfile
@@ -312,6 +312,10 @@ group :development, :test do
   gem 'rubocop-rspec', require: false
   gem 'rubocop-performance', require: false
 
+  # erb linting
+  gem "erb_lint", require: false
+  gem "erblint-github", require: false
+
   # Brakeman scanner
   gem 'brakeman', '~> 6.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,13 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindata (2.4.15)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -436,6 +443,14 @@ GEM
       activemodel
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
+    erblint-github (0.4.1)
     erubi (1.12.0)
     escape_utils (1.3.0)
     et-orbi (1.2.7)
@@ -903,6 +918,7 @@ GEM
       multi_json (~> 1.10)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
+    smart_properties (1.17.0)
     spreadsheet (1.3.0)
       ruby-ole
     spring (4.1.1)
@@ -1039,6 +1055,8 @@ DEPENDENCIES
   dry-container
   email_validator (~> 2.2.3)
   equivalent-xml (~> 0.6)
+  erb_lint
+  erblint-github
   escape_utils (~> 1.3)
   factory_bot (~> 6.2.0)
   factory_bot_rails (~> 6.2.0)


### PR DESCRIPTION
After having seen [the talk from RailsConf 2023 "Accessible by default" by Joel Hawksley](https://www.youtube.com/watch?v=4j2zlvE_Yj8), I'd like to experiment locally with erb-lint and the accessibility linters that GitHub developed.

This PR adds erb-lint in our Gemfile with a basic configuration.