### PR TITLE
Fix command to clear angular cache

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -70,7 +70,9 @@ ENV BUNDLE_WITHOUT="development:production:docker"
 
 RUN --mount=type=cache,target=/app/frontend/.angular/cache,uid=1000,gid=1000 DATABASE_URL=nulldb://db bin/rails openproject:plugins:register_frontend assets:precompile && \
 	# only keep most current angular cache since webpack is unable to cleanup after itself
-	find frontend/.angular/cache -type d -exec sh -c 'ls -dt "$1"/*/ | tail -n +2 | xargs rm -r' sh {} \;
+  ls -1 --directory --sort=time frontend/.angular/cache/*/angular-webpack/* \
+    | tail --lines=+2 \
+    | xargs --no-run-if-empty rm -r
 RUN cp -rp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json
 RUN cp docker/ci/database.yml config/
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -60,7 +60,9 @@ RUN --mount=type=cache,target=/app/frontend/.angular/cache,uid=1000,gid=1000 \
   SECRET_KEY_BASE=1 RAILS_ENV=production DATABASE_URL=nulldb://db \
   bin/rails openproject:plugins:register_frontend assets:precompile && \
   # only keep most current angular cache since webpack is unable to cleanup after itself
-	find frontend/.angular/cache -type d -exec sh -c 'ls -dt "$1"/*/ | tail -n +2 | xargs rm -r' sh {} \;
+  ls -1 --directory --sort=time frontend/.angular/cache/*/angular-webpack/* \
+    | tail --lines=+2 \
+    | xargs --no-run-if-empty rm -r
 
 # -------------------------------------
 # base (private)


### PR DESCRIPTION
The original command `find frontend/.angular/cache -type d -exec sh -c 'ls -dt "$1"/*/ | tail -n +2 | xargs rm -r' sh {} \;` executes a command for each directory found under `frontend/.angular/cache`. It fails in two cases:

* when the directory has no subdirectories, it fails with something like: ``` ls: cannot access 'frontend/.angular/cache/16.2.2/babel-webpack/*/': No such file or directory ```

* when the directory has only one subdirectory, it's removed by `tail -n +2` and the rm command is called without any argument. The error looks like ``` rm: missing operand Try 'rm --help' for more information ```

Another issue: `angular/cache/x.y.z/` contains 2 subdirectories: `babel-webpack` and `angular-webpack`. The command could delete the oldest of both directories, making the cache less effective. But this is mitigated by the lack of `-1` argument for `ls`, so the directories may end up on the same line, in which case both are kept, or not, in which case the oldest one is deleted.

The failures were silent when building the docker image as it's in the `-exec` of `find`. They can be seen on the CI build step:
```
[...]
#35 90.63 I, [2023-09-15T07:06:56.075299 #7]  INFO -- : Writing /app/public/assets/doorkeeper/application-c93dac2ad9d65e3393e0e2c958481e86ef7a5e5b0f6ce406842a7b99b25a4850.css.gz
#35 90.70 rm: missing operand
#35 90.70 Try 'rm --help' for more information.
#35 90.74 rm: missing operand
#35 90.74 Try 'rm --help' for more information.
#35 90.74 ls: cannot access 'frontend/.angular/cache/16.2.2/angular-webpack/0ea266da3d3c181b43a429d7115d6f6d5a3aa68c/*/': No such file or directory
#35 90.74 rm: missing operand
#35 90.74 Try 'rm --help' for more information.

#36 [final 18/20] RUN cp -rp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json
[...]
```

This commit replaces the command by a simpler one caring only about keeping latest subdirectory of `angular-webpack`.