### PR TITLE
Fix flaky Team Planner feature spec

### DIFF
--- a/modules/bim/spec/features/bcf_view_management_spec.rb
+++ b/modules/bim/spec/features/bcf_view_management_spec.rb
@@ -68,5 +68,6 @@ RSpec.describe 'bcf view management',
   it_behaves_like 'module specific query view management' do
     let(:module_page) { bcf_page }
     let(:default_name) { 'All open' }
+    let(:initial_filter_count) { 0 }
   end
 end

--- a/modules/calendar/spec/features/query_handling_spec.rb
+++ b/modules/calendar/spec/features/query_handling_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe 'Calendar query handling', js: true do
     it_behaves_like 'module specific query view management' do
       let(:module_page) { calendar_page }
       let(:default_name) { 'Unnamed calendar' }
+      let(:initial_filter_count) { 1 }
     end
   end
 end

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe 'Team planner query handling', :js, with_ee: %i[team_planner_view
   current_user { user }
 
   before do
-    login_as user
     team_planner.visit!
 
     team_planner.add_assignee user

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -32,7 +32,7 @@ require 'spec_helper'
 require_relative '../support/pages/team_planner'
 require_relative '../../../../spec/features/views/shared_examples'
 
-RSpec.describe 'Team planner query handling', js: true, with_ee: %i[team_planner_view] do
+RSpec.describe 'Team planner query handling', :js, with_ee: %i[team_planner_view] do
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -139,5 +139,6 @@ RSpec.describe 'Team planner query handling', :js, with_ee: %i[team_planner_view
   it_behaves_like 'module specific query view management' do
     let(:module_page) { team_planner }
     let(:default_name) { 'Unnamed team planner' }
+    let(:initial_filter_count) { 1 }
   end
 end

--- a/spec/features/views/shared_examples.rb
+++ b/spec/features/views/shared_examples.rb
@@ -37,6 +37,7 @@ RSpec.shared_examples 'module specific query view management' do
       # Change the query
       filters.open
       filters.add_filter_by 'Subject', 'contains', ['Test']
+      filters.expect_filter_count(initial_filter_count + 1)
 
       # Save it
       query_title.expect_changed
@@ -47,6 +48,7 @@ RSpec.shared_examples 'module specific query view management' do
 
       # Change the filter again
       filters.add_filter_by 'Progress (%)', 'is', ['25'], 'percentageDone'
+      filters.expect_filter_count(initial_filter_count + 2)
 
       # Save as another query
       query_title.expect_changed


### PR DESCRIPTION
There was a race-condition where the saving of the query was happening
as the update request for the added filter was also happening, causing
the frontend to not register the save as a successful creation but
as a successful update (from the added filter), causing the spec to
fail under conditions where it's execution was too fast.

**NOTE**: This is only a patch to aid in the flakiness that everyone
is experiencing but ultimately I would expect the "Save" button and
the "Save as" button to be disabled until every already performed
request is done (which would prevent this from happening to some users
just performing things at Capybara speed, or for some users under high
latency regions).