### PR TITLE
Remove duplicate import of primer/css

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -57,8 +57,7 @@
               "node_modules/jquery-ui/themes/base/core.css",
               "node_modules/jquery-ui/themes/base/datepicker.css",
               "node_modules/jquery-ui/themes/base/dialog.css",
-              "node_modules/flatpickr/dist/flatpickr.min.css",
-              "node_modules/@primer/css/core/index.scss"
+              "node_modules/flatpickr/dist/flatpickr.min.css"
             ],
             "stylePreprocessorOptions": {
               "includePaths": [


### PR DESCRIPTION
primer/css was imported in angular.json as a global asset as well as in the styles import