### PR TITLE
add eager loading to time entries api

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
@@ -33,7 +33,9 @@ module API
         helpers ::API::Utilities::UrlPropsParsingHelper
 
         resources :time_entries do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: TimeEntry).mount
+          get &::API::V3::Utilities::Endpoints::Index.new(model: TimeEntry,
+                                                          scope: -> { TimeEntry.includes(TimeEntryRepresenter.to_eager_load) })
+                                                     .mount
           post &::API::V3::Utilities::Endpoints::Create.new(model: TimeEntry).mount
 
           mount ::API::V3::TimeEntries::CreateFormAPI

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -132,6 +132,11 @@ module API
                                                                          'hours',
                                                                          allow_nil: true)
         end
+
+        self.to_eager_load = [:work_package,
+                              :user,
+                              :activity,
+                              { project: :enabled_modules }]
       end
     end
   end


### PR DESCRIPTION
Adds eager loading to the `api/v3/time_entries` to remove n+1 queries. n+1 queries for custom fields are not removed in this PR but having the rest should cover the most important cases.

https://community.openproject.org/wp/50130

