### PR TITLE
[#49113] ensure to display file links for one drive storages

### DIFF
--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -60,6 +60,8 @@ module OAuthClients
       ServiceResult.failure(result: @redirect_url)
     end
 
+    # rubocop:disable Metrics/AbcSize
+
     # The bearer/access token has expired or is due for renew for other reasons.
     # Talk to OAuth2 Authorization Server to exchange the renew_token for a new bearer token.
     def refresh_token
@@ -79,10 +81,16 @@ module OAuthClients
             ServiceResult.success(result: oauth_client_token)
           end
         else
-          service_result_with_error(I18n.t('oauth_client.errors.refresh_token_called_without_existing_token'))
+          storage_error = ::Storages::StorageError.new(
+            code: :error,
+            log_message: I18n.t('oauth_client.errors.refresh_token_called_without_existing_token')
+          )
+          ServiceResult.failure(result: :error, errors: storage_error)
         end
       end
     end
+
+    # rubocop:enable Metrics/AbcSize
 
     # Returns the URI of the "authorize" endpoint of the OAuth2 Authorization Server.
     # @param state (OAuth2 RFC) is a nonce referencing a cookie containing the calling page (URL + params) to which to
@@ -92,6 +100,8 @@ module OAuthClients
       client = rack_oauth_client # Configure and start the rack-oauth2 client
       client.authorization_uri(scope: @config.scope, state:)
     end
+
+    # rubocop:disable Metrics/AbcSize
 
     # Called by callback_page with a cryptographic "code" that indicates
     # that the user has successfully authorized the OAuth2 Authorization Server.
@@ -127,6 +137,8 @@ module OAuthClients
 
       ServiceResult.success(result: oauth_client_token)
     end
+
+    # rubocop:enable Metrics/AbcSize
 
     # Called by StorageRepresenter to inquire about the status of the OAuth2
     # authentication server.
@@ -167,11 +179,7 @@ module OAuthClients
 
       if yield_service_result.failure? && yield_service_result.result == :unauthorized
         refresh_service_result = refresh_token
-        if refresh_service_result.failure?
-          failed_service_result = ServiceResult.failure(result: :error)
-          failed_service_result.merge!(refresh_service_result)
-          return failed_service_result
-        end
+        return refresh_service_result if refresh_service_result.failure?
 
         oauth_client_token.reload
         yield_service_result = yield(oauth_client_token) # Should contain result=<data> in case of success
@@ -189,27 +197,27 @@ module OAuthClients
       OAuthClientToken.find_by(user_id: @user, oauth_client_id: @oauth_client.id)
     end
 
-    # Calls client.access_token!
-    # Convert the various exceptions into user-friendly error strings.
+    # rubocop:disable Metrics/AbcSize
     def request_new_token(options = {})
       rack_access_token = rack_oauth_client(options).access_token!(:body)
 
       ServiceResult.success(result: rack_access_token)
     rescue Rack::OAuth2::Client::Error => e
-      service_result_with_error(i18n_rack_oauth2_error_message(e), e.message)
+      service_result_with_error(e.response, i18n_rack_oauth2_error_message(e))
     rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::ParsingError, Faraday::SSLError => e
       service_result_with_error(
-        "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}",
-        e.message
+        e.response,
+        "#{I18n.t('oauth_client.errors.oauth_returned_http_error')}: #{e.class}: #{e.message.to_html}"
       )
     rescue StandardError => e
       service_result_with_error(
-        "#{I18n.t('oauth_client.errors.oauth_returned_standard_error')}: #{e.class}: #{e.message.to_html}",
-        e.message
+        e.response,
+        "#{I18n.t('oauth_client.errors.oauth_returned_standard_error')}: #{e.class}: #{e.message.to_html}"
       )
     end
 
-    # Localize the error message
+    # rubocop:enable Metrics/AbcSize
+
     def i18n_rack_oauth2_error_message(rack_oauth2_client_exception)
       i18n_key = "oauth_client.errors.rack_oauth2.#{rack_oauth2_client_exception.message}"
       if I18n.exists? i18n_key
@@ -250,12 +258,10 @@ module OAuthClients
       end
     end
 
-    # Shortcut method to convert an error message into an unsuccessful
-    # ServiceResult with that error message
-    def service_result_with_error(message, result = nil)
-      ServiceResult.failure(result:).tap do |r|
-        r.errors.add(:base, message)
-      end
+    def service_result_with_error(data, log_message = nil)
+      error_data = ::Storages::StorageErrorData.new(source: self, payload: data)
+      ServiceResult.failure(result: :bad_request,
+                            errors: ::Storages::StorageError.new(code: :bad_request, data: error_data, log_message:))
     end
   end
 end

--- a/modules/storages/app/common/storages/peripherals/service_result_refinements.rb
+++ b/modules/storages/app/common/storages/peripherals/service_result_refinements.rb
@@ -27,6 +27,11 @@
 #++
 
 module Storages::Peripherals
+  # rubocop:disable Lint/EmptyClass
+  class UnknownSource; end
+
+  # rubocop:enable Lint/EmptyClass
+
   module ServiceResultRefinements
     refine ServiceResult do
       def match(on_success:, on_failure:)
@@ -49,6 +54,18 @@ module Storages::Peripherals
         end
 
         bind(&other)
+      end
+
+      def error_source
+        if errors.is_a?(::Storages::StorageError) && errors.data&.source.present?
+          errors.data.source
+        else
+          UnknownSource
+        end
+      end
+
+      def error_payload
+        errors.data&.payload
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
@@ -55,7 +55,14 @@ module Storages
             end
 
             result = file_ids.map do |file_id|
-              wrap_storage_file_error(file_id, FileInfoQuery.call(storage: @storage, user:, file_id:))
+              file_info_result = FileInfoQuery.call(storage: @storage, user:, file_id:)
+              if file_info_result.failure? &&
+                file_info_result.errors.data.source.is_a?(::OAuthClients::ConnectionManager)
+                # errors in the connection manager must short circuit the query and return the error
+                return file_info_result
+              end
+
+              wrap_storage_file_error(file_id, file_info_result)
             end
 
             ServiceResult.success(result:)
@@ -70,7 +77,7 @@ module Storages
               storage_error = query_result.errors
               StorageFileInfo.new(
                 id: file_id,
-                status: storage_error.data.dig(:error, :code),
+                status: storage_error.data.payload.dig(:error, :code),
                 status_code: Rack::Utils::SYMBOL_TO_STATUS_CODE[storage_error.code]
               )
             end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
@@ -57,7 +57,7 @@ module Storages
             result = file_ids.map do |file_id|
               file_info_result = FileInfoQuery.call(storage: @storage, user:, file_id:)
               if file_info_result.failure? &&
-                file_info_result.errors.data.source.is_a?(::OAuthClients::ConnectionManager)
+                file_info_result.error_source.is_a?(::OAuthClients::ConnectionManager)
                 # errors in the connection manager must short circuit the query and return the error
                 return file_info_result
               end
@@ -74,11 +74,10 @@ module Storages
             if query_result.success?
               query_result.result
             else
-              storage_error = query_result.errors
               StorageFileInfo.new(
                 id: file_id,
-                status: storage_error.data.payload.dig(:error, :code),
-                status_code: Rack::Utils::SYMBOL_TO_STATUS_CODE[storage_error.code]
+                status: query_result.error_payload.dig(:error, :code),
+                status_code: Rack::Utils::SYMBOL_TO_STATUS_CODE[query_result.errors.code]
               )
             end
           end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/internal/drive_item_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/internal/drive_item_query.rb
@@ -41,22 +41,23 @@ module Storages
 
             def handle_responses(response)
               json = MultiJson.load(response.body, symbolize_keys: true)
+              error_data = ::Storages::StorageErrorData.new(source: self, payload: json)
 
               case response
               when Net::HTTPSuccess
                 ServiceResult.success(result: json)
               when Net::HTTPNotFound
                 ServiceResult.failure(result: :not_found,
-                                      errors: ::Storages::StorageError.new(code: :not_found, data: json))
+                                      errors: ::Storages::StorageError.new(code: :not_found, data: error_data))
               when Net::HTTPForbidden
                 ServiceResult.failure(result: :forbidden,
-                                      errors: ::Storages::StorageError.new(code: :forbidden, data: json))
+                                      errors: ::Storages::StorageError.new(code: :forbidden, data: error_data))
               when Net::HTTPUnauthorized
                 ServiceResult.failure(result: :unauthorized,
-                                      errors: ::Storages::StorageError.new(code: :unauthorized, data: json))
+                                      errors: ::Storages::StorageError.new(code: :unauthorized, data: error_data))
               else
                 ServiceResult.failure(result: :error,
-                                      errors: ::Storages::StorageError.new(code: :error, data: json))
+                                      errors: ::Storages::StorageError.new(code: :error, data: error_data))
               end
             end
 

--- a/modules/storages/app/models/storages/storage_error.rb
+++ b/modules/storages/app/models/storages/storage_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH

--- a/modules/storages/app/models/storages/storage_error_data.rb
+++ b/modules/storages/app/models/storages/storage_error_data.rb
@@ -28,35 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Storages::Peripherals::StorageInteraction::OneDrive::Util
-  using Storages::Peripherals::ServiceResultRefinements
+module Storages
+  class StorageErrorData
+    attr_reader :source, :payload
 
-  class << self
-    def mime_type(json)
-      json.dig(:file, :mimeType) || (json.key?(:folder) ? 'application/x-op-directory' : nil)
-    end
-
-    def using_user_token(storage, user, &)
-      connection_manager = ::OAuthClients::ConnectionManager
-                             .new(user:, configuration: storage.oauth_configuration)
-
-      connection_manager
-        .get_access_token
-        .match(
-          on_success: ->(token) do
-            connection_manager.request_with_token_refresh(token) { yield token }
-          end,
-          on_failure: ->(_) do
-            ServiceResult.failure(
-              result: :unauthorized,
-              errors: ::Storages::StorageError.new(
-                code: :unauthorized,
-                data: ::Storages::StorageErrorData.new(source: connection_manager),
-                log_message: 'Query could not be created! No access token found!'
-              )
-            )
-          end
-        )
+    def initialize(source:, payload: nil)
+      @source = source
+      @payload = payload
     end
   end
 end

--- a/modules/storages/app/services/storages/file_link_sync_service.rb
+++ b/modules/storages/app/services/storages/file_link_sync_service.rb
@@ -38,7 +38,7 @@ class Storages::FileLinkSyncService
   def call(file_links)
     resulting_file_links = file_links
       .group_by(&:storage_id)
-      .map { |storage_id, storage_file_links| sync_nextcloud(storage_id, storage_file_links) }
+      .map { |storage_id, storage_file_links| sync_storage_data(storage_id, storage_file_links) }
       .reduce([]) do |state, sync_result|
         sync_result.match(
           on_success: ->(sr) { state + sr },
@@ -51,7 +51,7 @@ class Storages::FileLinkSyncService
 
   private
 
-  def sync_nextcloud(storage_id, file_links)
+  def sync_storage_data(storage_id, file_links)
     storage = ::Storages::Storage.find(storage_id)
     ::Storages::Peripherals::Registry
       .resolve("queries.#{storage.short_provider_type}.files_info")

--- a/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
+++ b/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -26,16 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# This class provides definitions for API routes and endpoints for the file_links namespace. It inherits the
-# functionality from the Grape REST API framework. It is mounted in lib/api/v3/work_packages/work_packages_api.rb,
-# which puts the file_links namespace behind the provided namespace of the work packages api
-# -> /api/v3/work_packages/:id/file_links/...
 class API::V3::FileLinks::WorkPackagesFileLinksAPI < API::OpenProjectAPI
   # The `:resources` keyword defines the API namespace -> /api/v3/work_packages/:id/file_links/...
   resources :file_links do
-    # Get the list of FileLinks related to a work package, with updated information from Nextcloud.
     get do
-      # API supports query filters on storages, for example { storage: { operator: '=', values: [storage_id] }
       query = ParamsToQueryService
                 .new(::Storages::Storage,
                      current_user,
@@ -48,12 +44,9 @@ class API::V3::FileLinks::WorkPackagesFileLinksAPI < API::OpenProjectAPI
       end
 
       result = if current_user.allowed_to?(:view_file_links, @work_package.project)
-                 # Get a (potentially huge...) list of all FileLinks for the work package.
                  file_links = query.results.where(container_id: @work_package.id,
                                                   container_type: 'WorkPackage',
                                                   storage: @work_package.project.storages)
-                 # Synchronize with Nextcloud. StorageAPI has handled OAuth2 for us before.
-                 # We ignore the result, because partial errors (storage network issues) are written to each FileLink
                  ::Storages::FileLinkSyncService
                    .new(user: current_user)
                    .call(file_links)

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/file_info_query_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FileInfoQuer
 
       expect(storage_files).to be_failure
       expect(storage_files.result).to eq(:not_found)
-      expect(storage_files.errors.data.to_json).to eq(not_found_json)
+      expect(storage_files.errors.data.payload.to_json).to eq(not_found_json)
     end
 
     it 'returns a forbidden error if the API call returns a 403' do
@@ -102,7 +102,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FileInfoQuer
 
       expect(storage_files).to be_failure
       expect(storage_files.result).to eq(:forbidden)
-      expect(storage_files.errors.data.to_json).to eq(forbidden_json)
+      expect(storage_files.errors.data.payload.to_json).to eq(forbidden_json)
     end
   end
 end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_link_query_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenLinkQuer
 
       expect(open_link_result).to be_failure
       expect(open_link_result.result).to eq(:not_found)
-      expect(open_link_result.errors.data.to_json).to eq(not_found_json)
+      expect(open_link_result.errors.data.payload.to_json).to eq(not_found_json)
     end
 
     it 'returns a forbidden error if the API call returns a 403' do
@@ -96,7 +96,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenLinkQuer
 
       expect(open_link_result).to be_failure
       expect(open_link_result.result).to eq(:forbidden)
-      expect(open_link_result.errors.data.to_json).to eq(forbidden_json)
+      expect(open_link_result.errors.data.payload.to_json).to eq(forbidden_json)
     end
   end
 end

--- a/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
+++ b/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
@@ -30,7 +30,7 @@
 
 require 'spec_helper'
 
-RSpec.describe OAuthClients::ConnectionManager, type: :model, webmock: true do
+RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
   let(:user) { create(:user) }
   let(:storage) { create(:one_drive_storage, :with_oauth_client, tenant_id: 'consumers') }
   let(:token) { create(:oauth_client_token, oauth_client: storage.oauth_client, user:) }
@@ -82,7 +82,7 @@ RSpec.describe OAuthClients::ConnectionManager, type: :model, webmock: true do
       end
     end
 
-    context 'with access token present', webmock: true do
+    context 'with access token present', :webmock do
       before { token }
 
       context 'with access token valid' do


### PR DESCRIPTION
- https://community.openproject.org/wp/49113
- refactored errors returned by connection manager to be storage errors
- added source indicator to storage error data
- removed nextcloud specific method names from sync service
- check all three states of the file link list
  - not logged in
  - with auth error
  - happy case