### PR TITLE
Fix incorrect execution order of `OpenProject::AccessControl` spec setup

### DIFF
--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe OpenProject::AccessControl do
   end
 
   describe '.remove_modules_permissions' do
-    let!(:all_former_permissions) { described_class.permissions }
-    let!(:former_repository_permissions) do
+    shared_let(:all_former_permissions) { described_class.permissions }
+    shared_let(:former_repository_permissions) do
       described_class.modules_permissions(%w[repository])
-                     .select { |permission| permission.project_module == :repository }
+                     .filter { _1.project_module == :repository }
     end
 
     subject { described_class }

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -84,53 +84,52 @@ RSpec.describe OpenProject::AccessControl do
   end
 
   describe '.remove_modules_permissions' do
-    shared_let(:all_former_permissions) { described_class.permissions }
-    shared_let(:former_repository_permissions) do
-      described_class.modules_permissions(%w[repository])
-                     .filter { _1.project_module == :repository }
-    end
-
-    subject { described_class }
-
-    def reset_former_permissions_and_clear_caches
-      described_class.instance_variable_set(:@mapped_permissions, all_former_permissions)
-      described_class.clear_caches
+    RSpec::Matchers.define :not_belong_to_project_module do |project_module|
+      match do |actual|
+        actual.project_module != project_module
+      end
     end
 
     around do |example|
-      described_class.remove_modules_permissions(:repository)
+      raise 'Test outdated. @mapped_permissions is not defined' unless
+        described_class.instance_variable_defined?(:@mapped_permissions)
+
+      previous_permissions = described_class.instance_variable_get(:@mapped_permissions)
 
       example.run
     ensure
-      raise 'Test outdated. @mapped_permissions is not defined after example run' unless
-        described_class.instance_variable_defined?(:@mapped_permissions)
+      described_class.instance_variable_set(:@mapped_permissions, previous_permissions)
+      described_class.clear_caches
+    end
 
-      reset_former_permissions_and_clear_caches
+    subject do
+      described_class.remove_modules_permissions(:repository)
+      described_class
     end
 
     it 'removes from permissions' do
       expect(subject.permissions)
-        .not_to include(former_repository_permissions)
+        .to all(not_belong_to_project_module(:repository))
     end
 
     it 'removes from global permissions' do
       expect(subject.global_permissions)
-        .not_to include(former_repository_permissions)
+        .to all(not_belong_to_project_module(:repository))
     end
 
     it 'removes from public permissions' do
       expect(subject.public_permissions)
-        .not_to include(former_repository_permissions)
+        .to all(not_belong_to_project_module(:repository))
     end
 
     it 'removes from members-only permissions' do
       expect(subject.members_only_permissions)
-        .not_to include(former_repository_permissions)
+        .to all(not_belong_to_project_module(:repository))
     end
 
     it 'removes from loggedin-only permissions' do
       expect(subject.loggedin_only_permissions)
-        .not_to include(former_repository_permissions)
+        .to all(not_belong_to_project_module(:repository))
     end
 
     it 'disables repository module' do


### PR DESCRIPTION
Given that `:all_former_permissions` and
`:former_repository_permissions` were memoized with a `let!` construct their execution was happening after the

```
described_class.remove_modules_permissions(:repository)
```

call in the around hook. Therefore `:all_former_permissions` would lack the repository permissions when resetting it back after `example.run` in `reset_former_permissions_and_clear_caches`.

This caused other specs that required repository permissions down the line in the test suite to fail due to there being no permissions for the `:repository` project module. (and false positives for this spec file).

This order dependency was detected and reproducible by the following `rspec --bisect`s output

```
rspec './spec/lib/open_project/access_control_spec.rb[1:1:3]' \
'./spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb[1:1:3:2:1:2]' \
 --seed 44936
```