### PR TITLE
[chore] added redirect uri to oauth clients for auth requests

### DIFF
--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -56,8 +56,4 @@ module OAuthHelper
     tokens = ::Doorkeeper::AccessToken.active_for(user).includes(:application)
     tokens.group_by(&:application)
   end
-
-  def oauth_client_redirect_uri(oauth_client)
-    "#{request.protocol}#{request.host_with_port}/oauth_clients/#{oauth_client.client_id}/callback"
-  end
 end

--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -28,4 +28,8 @@
 
 class OAuthClient < ApplicationRecord
   belongs_to :integration, polymorphic: true
+
+  def redirect_uri
+    File.join(OpenProject::Application.root_url, 'oauth_clients', client_id, 'callback')
+  end
 end

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/nextcloud_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/nextcloud_configuration.rb
@@ -37,6 +37,7 @@ module Storages
         def initialize(storage)
           @uri = storage.uri
           @oauth_client = storage.oauth_client.freeze
+          super()
         end
 
         def authorization_state_check(token)
@@ -64,6 +65,7 @@ module Storages
           Rack::OAuth2::Client.new(
             identifier: @oauth_client.client_id,
             secret: @oauth_client.client_secret,
+            redirect_uri: @oauth_client.redirect_uri,
             scheme: @uri.scheme,
             host: @uri.host,
             port: @uri.port,

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
@@ -41,6 +41,7 @@ module Storages
           @uri = storage.uri
           @oauth_client = storage.oauth_client
           @oauth_uri = URI('https://login.microsoftonline.com/').normalize
+          super()
         end
 
         def authorization_state_check(access_token)
@@ -58,6 +59,7 @@ module Storages
         def basic_rack_oauth_client
           Rack::OAuth2::Client.new(
             identifier: @oauth_client.client_id,
+            redirect_uri: @oauth_client.redirect_uri,
             secret: @oauth_client.client_secret,
             scheme: @oauth_uri.scheme,
             host: @oauth_uri.host,

--- a/modules/storages/app/views/storages/admin/storages/one_drive/_oauth_client_section.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/one_drive/_oauth_client_section.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
                                    { key: "#{t("storages.provider_types.#{@storage.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}",
                                      value: short_secret(@storage.oauth_client.client_secret) },
                                    { key: "#{t("storages.provider_types.#{@storage.short_provider_type}.name")} #{Storages::Admin::LABEL_OAUTH_REDIRECT_URI}",
-                                     value: oauth_client_redirect_uri(@storage.oauth_client) }
+                                     value: @storage.oauth_client.redirect_uri }
                                  ]) %>
 
     <%= link_to(t("storages.buttons.replace_provider_type_oauth", provider_type: t("storages.provider_types.#{@storage.short_provider_type}.name")),


### PR DESCRIPTION
### What did you do????!!

I added the redirect uri query param to all oauth authorization requests.

### But, why??

This way an OAuth Application can savely handle multiple redirect URIs of different clients. It is optional for a client to send it, but if you want to be sure, that the authorize request comes back to your app, you should send it.