### PR TITLE
Do not set statement timeout if already set to 0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -217,8 +217,8 @@ RSpec/DescribeMethod:
 
 # Don't force the second argument of describe
 # to match the exact file name
-RSpec/FilePath:
-  SpecSuffixOnly: true
+RSpec/SpecFilePathFormat:
+  IgnoreMethods: true
 
 # Prevent  "fit" or similar to be committed
 RSpec/Focus:

--- a/lib_static/open_project/migration_statement_timeout/manager.rb
+++ b/lib_static/open_project/migration_statement_timeout/manager.rb
@@ -93,7 +93,7 @@ module MigrationStatementTimeout
         when /\A\d+h\z/
           timeout.to_i * 1000 * 60 * 60
         else
-          raise "Unrecognized statement timeout duration #{timeout.inspect}"
+          raise ArgumentError, "Unrecognized statement timeout duration #{timeout.inspect}"
         end
       end
     end


### PR DESCRIPTION
A statement_timeout of 0 disables the statement timeout. So when setting the minimum to `15min`, it should do nothing as `15min` is less than infinite.
The reverse is true: when setting the minimum statement timeout to `0`, it should always apply it (unless it is already 0).