### PR TITLE
[#50106] Add menu item for Permissions report

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -33,6 +33,9 @@ class RolesController < ApplicationController
 
   before_action :require_admin, except: [:autocomplete_for_role]
 
+  menu_item :roles, except: :report
+  menu_item :permissions_report, only: :report
+
   def index
     @roles = roles_scope
              .page(page_param)

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -290,6 +290,12 @@ Redmine::MenuManager.map :admin_menu do |menu|
             caption: :label_role_and_permissions,
             parent: :users_and_permissions
 
+  menu.push :permissions_report,
+            { controller: '/roles', action: 'report' },
+            if: Proc.new { User.current.admin? },
+            caption: :label_permissions_report,
+            parent: :users_and_permissions
+
   menu.push :user_avatars,
             { controller: '/admin/settings', action: 'show_plugin', id: :openproject_avatars },
             if: Proc.new { User.current.admin? },

--- a/spec/features/menu_items/users_and_permissions_menu_item_spec.rb
+++ b/spec/features/menu_items/users_and_permissions_menu_item_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Menu items',
+               'User and permissions' do
+  shared_current_user { create(:admin) }
+
+  context "when I visit the /users path" do
+    before do
+      visit(users_path)
+    end
+
+    it 'renders the "Users and permissions" menu with its children entries', :aggregate_failures do
+      within '#menu-sidebar' do
+        expect(page)
+          .to have_link(I18n.t(:label_user_and_permission))
+
+        expect(page)
+          .to have_link(I18n.t(:label_users_settings))
+
+        expect(page)
+          .to have_link(I18n.t(:label_placeholder_user_plural))
+
+        expect(page)
+          .to have_link(I18n.t(:label_group_plural))
+
+        expect(page)
+          .to have_link(I18n.t(:label_role_and_permissions))
+
+        expect(page)
+          .to have_link(I18n.t(:label_permissions_report))
+
+        expect(page)
+          .to have_link(I18n.t(:label_avatar_plural))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
The goal is to improve the discoverability of the Permissions report.

Currently it's solely a tiny link below the Roles index table. By adding a dedicated menu item for it, it should become more visible and discoverable.
## Notes
See: https://community.openproject.org/work_packages/50106