### PR TITLE
Use meeting duration from seed data

### DIFF
--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_seeder.rb
@@ -43,8 +43,13 @@ module Meetings
         {
           title: meeting_data['title'],
           author: seed_data.find_reference(meeting_data['author']),
+          duration: minutes_to_hours(meeting_data['duration']),
           project:
         }
+      end
+
+      def minutes_to_hours(duration)
+        duration && (duration / 60.0)
       end
     end
   end

--- a/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe DemoData::ProjectSeeder do
       meetings:
         - title: Weekly
           reference: :weekly_meeting
+          duration: 30
+          author: :openproject_user
+        - title: Implicit 1h duration
           author: :openproject_user
       meeting_agenda_items:
         - title: First topic
@@ -74,10 +77,14 @@ RSpec.describe DemoData::ProjectSeeder do
     SEEDING_DATA_YAML
   end
 
-  it 'creates an associated meeting' do
+  before do
     project_seeder.seed!
+  end
+
+  it 'creates an associated meeting' do
     meeting = Meeting.find_by(title: 'Weekly')
     expect(meeting.author).to eq user
+    expect(meeting.duration).to eq 0.5
 
     expect(meeting.agenda_items.count).to eq 2
 
@@ -91,5 +98,10 @@ RSpec.describe DemoData::ProjectSeeder do
     expect(second.author).to eq user
     expect(second.notes).to eq 'Some **markdown**'
     expect(second.work_package).to eq work_package
+  end
+
+  it 'uses default duration of 1h if not specified' do
+    meeting = Meeting.find_by(title: 'Implicit 1h duration')
+    expect(meeting.duration).to eq 1
   end
 end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe RootSeeder,
     include_examples 'it creates records', model: Status, expected_count: 14
     include_examples 'it creates records', model: TimeEntryActivity, expected_count: 6
     include_examples 'it creates records', model: Workflow, expected_count: 1172
+    include_examples 'it creates records', model: Meeting, expected_count: 1
   end
 
   describe 'demo data' do


### PR DESCRIPTION
Related to #13768 Create a StructuredMeeting seeder for the demo project.