### PR TITLE
Allow downloading ICS file of meeting by extracting meeting_mailer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ require:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
+  - rubocop-inflector
+  - ./config/initializers/inflections.rb
 
 <% if File.exist?('.rubocop-local.yml') %>
 inherit_from:

--- a/Gemfile
+++ b/Gemfile
@@ -312,6 +312,7 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-performance', require: false
+  gem 'rubocop-inflector', require: false
 
   # erb linting
   gem "erb_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -874,6 +874,10 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.24.0)
       rubocop (~> 1.33)
+    rubocop-inflector (0.2.1)
+      activesupport
+      rubocop
+      rubocop-rspec
     rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -1158,6 +1162,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.0)
   rspec-retry (~> 0.6.1)
   rubocop
+  rubocop-inflector
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -90,6 +90,7 @@ module Meetings
       render(Primer::Alpha::ActionMenu.new) do |menu|
         menu.with_show_button(icon: "kebab-horizontal", 'aria-label': t("label_meeting_actions"), test_selector: 'op-meetings-header-action-trigger')
         edit_action_item(menu) if edit_enabled?
+        download_ics_item(menu)
         delete_action_item(menu) if delete_enabled?
       end
     end
@@ -101,6 +102,13 @@ module Meetings
                        data: { 'turbo-stream': true }
                      }) do |item|
         item.with_leading_visual_icon(icon: :pencil)
+      end
+    end
+
+    def download_ics_item(menu)
+      menu.with_item(label: t(:label_icalendar_download),
+                     href: download_ics_meeting_path(@meeting)) do |item|
+        item.with_leading_visual_icon(icon: :download)
       end
     end
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -200,6 +200,16 @@ class MeetingsController < ApplicationController
     respond_with_turbo_streams
   end
 
+  def download_ics
+    ::Meetings::ICalService
+      .new(user: current_user, meeting: @meeting)
+      .call
+      .on_failure { |call| render_500(message: call.message) }
+      .on_success do |call|
+      send_data call.result, filename: filename_for_content_disposition("#{@meeting.title}.ics")
+    end
+  end
+
   private
 
   def load_query

--- a/modules/meeting/app/services/meetings/ical_service.rb
+++ b/modules/meeting/app/services/meetings/ical_service.rb
@@ -1,0 +1,92 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require 'icalendar'
+require 'icalendar/tzinfo'
+
+module Meetings
+  class ICalService
+    attr_reader :user, :meeting, :timezone, :url_helpers
+
+    def initialize(meeting:, user:)
+      @user = user
+      @meeting = meeting
+      @url_helpers = OpenProject::StaticRouting::StaticUrlHelpers.new
+    end
+
+    def call
+      User.execute_as(user) do
+        @timezone = Time.zone || Time.zone_default
+        ServiceResult.success(result: generate_ical)
+      end
+    rescue StandardError => e
+      Rails.logger.error("Failed to generate ICS for meeting #{@meeting.id}: #{e.message}")
+      ServiceResult.failure(message: e.message)
+    end
+
+    private
+
+    # rubocop:disable Metrics/AbcSize
+    def generate_ical
+      ical_event do |e|
+        tzinfo = timezone.tzinfo
+        tzid = tzinfo.canonical_identifier
+
+        e.dtstart = ical_datetime meeting.start_time, tzid
+        e.dtend = ical_datetime meeting.end_time, tzid
+        e.url = url_helpers.meeting_url(meeting)
+        e.summary = "[#{meeting.project.name}] #{meeting.title}"
+        e.description = ical_subject(meeting)
+        e.uid = "#{meeting.id}@#{meeting.project.identifier}"
+        e.organizer = ical_organizer meeting
+        e.location = meeting.location.presence
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def ical_event(&)
+      calendar = ::Icalendar::Calendar.new
+
+      calendar.event(&)
+
+      calendar.publish
+      calendar.to_ical
+    end
+
+    def ical_subject(meeting)
+      "[#{meeting.project.name}] #{I18n.t(:label_meeting)}: #{meeting.title}"
+    end
+
+    def ical_datetime(time, timezone_id)
+      Icalendar::Values::DateTime.new time.in_time_zone(timezone_id), 'tzid' => timezone_id
+    end
+
+    def ical_organizer(meeting)
+      Icalendar::Values::CalAddress.new("mailto:#{meeting.author.mail}", cn: meeting.author.name)
+    end
+  end
+end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -101,6 +101,7 @@ en:
   label_author: "Creator"
   label_notify: "Send for review"
   label_icalendar: "Send iCalendar"
+  label_icalendar_download: "Download iCalendar event"
   label_version: "Version"
   label_time_zone: "Time zone"
   label_start_date: "Start date"

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -47,6 +47,7 @@ OpenProject::Application.routes.draw do
   resources :meetings do
     member do
       get :cancel_edit
+      get :download_ics
       put :update_title
       put :update_details
       put :update_participants

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -39,7 +39,7 @@ module OpenProject::Meeting
              bundled: true do
       project_module :meetings do
         permission :view_meetings,
-                   { meetings: %i[index show],
+                   { meetings: %i[index show download_ics],
                      meeting_agendas: %i[history show diff],
                      meeting_minutes: %i[history show diff] },
                    permissible_on: :project

--- a/modules/meeting/spec/controllers/meeting_contents_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meeting_contents_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe MeetingContentsController do
         end
 
         it 'produces a flash message containing the mail addresses raising the error' do
-          put 'notify',  params: { meeting_id: meeting.id }
+          put 'notify', params: { meeting_id: meeting.id }
           meeting.participants.each do |participant|
             expect(flash[:error]).to include(participant.name)
           end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -174,6 +174,26 @@ RSpec.describe 'Structured meetings CRUD',
     expect(page).to have_current_path project_meetings_path(project)
   end
 
+  context 'exporting as ICS' do
+    before do
+      @download_list = DownloadList.new
+    end
+
+    after do
+      DownloadList.clear
+    end
+
+    subject { @download_list.refresh_from(page).latest_download.to_s }
+
+    it 'can export the meeting as ICS' do
+      click_button('op-meetings-header-action-trigger')
+
+      click_link I18n.t(:label_icalendar_download)
+
+      expect(subject).to end_with ".ics"
+    end
+  end
+
   context 'with a work package reference to another' do
     let!(:meeting) { create(:structured_meeting, project:, author: current_user) }
     let!(:other_project) { create(:project) }

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe MeetingMailer do
         expect(entry.dtstart.utc).to eq meeting.start_time
         expect(entry.dtend.utc).to eq meeting.start_time + 1.hour
         expect(entry.summary).to eq '[My project] Important meeting'
-        expect(entry.description).to eq "[My project] Agenda: Important meeting"
+        expect(entry.description).to eq "[My project] Meeting: Important meeting"
         expect(entry.location).to eq(meeting.location.presence)
       end
 

--- a/modules/meeting/spec/services/meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/ical_service_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe Meetings::ICalService, type: :model do
+  let(:user) { build_stubbed(:user, firstname: 'Bob', lastname: 'Barker') }
+  let(:project) { build_stubbed(:project, name: 'My Project') }
+
+  let(:meeting) do
+    build_stubbed(:meeting,
+                  author: user,
+                  project:,
+                  title: 'Important meeting',
+                  location: 'https://example.com/meet/important-meeting',
+                  start_time: Time.zone.parse("2021-01-19T10:00:00Z"),
+                  duration: 1.0)
+  end
+
+  let(:service) { described_class.new(user:, meeting:) }
+  let(:result) { service.call.result }
+
+  subject(:entry) { Icalendar::Event.parse(result).first }
+
+  describe '#call' do
+    it 'returns a success' do
+      expect(service.call).to be_success
+    end
+
+    context 'when exception is raised' do
+      subject { service.call }
+
+      before do
+        allow(service).to receive(:generate_ical).and_raise StandardError.new("Oh noes")
+      end
+
+      it 'returns a failure' do
+        expect(subject).to be_failure
+        expect(subject.message).to eq("Oh noes")
+      end
+    end
+
+    it 'renders the ICS file', :aggregate_failures do
+      expect(result).to be_a String
+
+      expect(entry.dtstart.utc).to eq meeting.start_time
+      expect(entry.dtend.utc).to eq meeting.start_time + 1.hour
+      expect(entry.summary).to eq '[My Project] Important meeting'
+      expect(entry.description).to eq "[My Project] Meeting: Important meeting"
+      expect(entry.location).to eq(meeting.location.presence)
+      expect(entry.dtstart).to eq Time.zone.parse("2021-01-19T10:00:00Z").in_time_zone("Europe/Berlin")
+      expect(entry.dtend).to eq (Time.zone.parse("2021-01-19T10:00:00Z") + 1.hour).in_time_zone("Europe/Berlin")
+    end
+  end
+end


### PR DESCRIPTION
We already had ICS generation capabilities to send out meeting agendas or minutes via email.
This PR extracts this to generate the ICS on the fly in order to download it, and also allow sending them to participants later.

https://community.openproject.org/work_packages/50180