### PR TITLE
[#50106] Remove link to permissions report from underneath roles index table

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -110,5 +110,3 @@ See COPYRIGHT and LICENSE files for more details.
 </div>
 
 <%= pagination_links_full @roles %>
-
-<p><%= link_to t(:label_permissions_report), :action => 'report' %></p>

--- a/docs/system-admin-guide/users-permissions/roles-permissions/README.md
+++ b/docs/system-admin-guide/users-permissions/roles-permissions/README.md
@@ -76,9 +76,7 @@ Administrators can add new roles with custom permissions or configure existing o
 
 ### Permissions report
 
-The permissions report is a good starting point to get an overview of the current configuration of roles and permissions. There are two ways to open the permissions report:
-1. Navigate to *Administration* > *Users and permissions* > *Permissions report*.
-2. Navigate to the overview table of existing *Roles* and click on the link *Permissions report* below the table.
+The permissions report is a good starting point to get an overview of the current configuration of roles and permissions. To open the permissions report, navigate to *Administration* > *Users and permissions* > *Permissions report*.
 
 ### Create a new project roles
 


### PR DESCRIPTION
## What was fixed?
![image](https://github.com/opf/openproject/assets/61627014/966badbf-849f-4ef3-969d-eede2430d7cd)

## Notes
https://community.openproject.org/work_packages/50106