### PR TITLE
Fixes for meeting agenda items

### DIFF
--- a/app/components/users/avatar_component.rb
+++ b/app/components/users/avatar_component.rb
@@ -32,7 +32,7 @@ module Users
     include AvatarHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(user:, show_name: true, link: true, size: 'default', title: nil)
+    def initialize(user:, show_name: true, link: true, size: 'default', classes: '', title: nil)
       super
 
       @user = user
@@ -40,6 +40,7 @@ module Users
       @link = link
       @size = size
       @title = title
+      @classes = classes
     end
 
     def render?
@@ -52,7 +53,8 @@ module Users
         size: @size,
         link: @link,
         hide_name: !@show_name,
-        title: @title
+        title: @title,
+        class: @classes
       )
     end
   end

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -4,7 +4,7 @@
   justify-content: center
   vertical-align: middle
 
-  &--flex
+  &_flex
     display: flex
 
   &--avatar

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -4,6 +4,9 @@
   justify-content: center
   vertical-align: middle
 
+  &--flex
+    display: flex
+
   &--avatar
     flex-grow: 0
     flex-shrink: 0

--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -30,11 +30,13 @@
 // as the OpenProject form styles override them.
 
 .Box
-  ul
+  ul:not(.op-uc-list)
     margin-left: 0
+
 segmented-control
   ul
     margin-left: 0
+
 .FormControl
   label
     margin-bottom: 0

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -31,14 +31,14 @@
           I18n.t(:label_agenda_item_undisclosed_wp, id: @meeting_agenda_item.work_package_id)
         end
       else
-        render(Primer::Beta::Text.new(font_size: :normal, mr: 1, font_weight: :bold, test_selector: 'op-meeting-agenda-title')) do
+        render(Primer::Beta::Text.new(font_size: :normal, mr: 2, font_weight: :bold, test_selector: 'op-meeting-agenda-title')) do
           @meeting_agenda_item.title
         end
       end
     end
 
     if @meeting_agenda_item.duration_in_minutes.present? && @meeting_agenda_item.duration_in_minutes > 0
-      grid.with_area(:duration, Primer::Beta::Text, font_size: :small, color: :subtle, mr: 1) do
+      grid.with_area(:duration, Primer::Beta::Text, color: :subtle, mr: 1) do
         I18n.t('datetime.distance_in_words.x_min_abbreviated', count: @meeting_agenda_item.duration_in_minutes)
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   grid_layout('op-meeting-agenda-item', tag: :div) do |grid|
     if drag_and_drop_enabled?
-      grid.with_area(:drag_handle, tag: :div) do
+      grid.with_area(:'drag-handle', tag: :div) do
         render(Primer::OpenProject::DragHandle.new(classes: 'handle'))
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -43,7 +43,7 @@
       end
     end
 
-    grid.with_area(:author, tag: :div) do
+    grid.with_area(:author, tag: :div, classes: 'ellipsis') do
       title = I18n.t(:label_added_time_by,
                      author: @meeting_agenda_item.author.name,
                      age: helpers.distance_of_time_in_words(Time.zone.now, @meeting_agenda_item.created_at))

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -47,7 +47,7 @@
       title = I18n.t(:label_added_time_by,
                      author: @meeting_agenda_item.author.name,
                      age: helpers.distance_of_time_in_words(Time.zone.now, @meeting_agenda_item.created_at))
-      render(Users::AvatarComponent.new(user: @meeting_agenda_item.author, size: 'mini', title:, classes: 'op-principal--flex'))
+      render(Users::AvatarComponent.new(user: @meeting_agenda_item.author, size: 'mini', title:, classes: 'op-principal_flex'))
     end
 
     grid.with_area(:actions, tag: :div, justify_self: :end) do

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -47,7 +47,7 @@
       title = I18n.t(:label_added_time_by,
                      author: @meeting_agenda_item.author.name,
                      age: helpers.distance_of_time_in_words(Time.zone.now, @meeting_agenda_item.created_at))
-      render(Users::AvatarComponent.new(user: @meeting_agenda_item.author, size: 'mini', title:))
+      render(Users::AvatarComponent.new(user: @meeting_agenda_item.author, size: 'mini', title:, classes: 'op-principal--flex'))
     end
 
     grid.with_area(:actions, tag: :div, justify_self: :end) do

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -9,14 +9,10 @@
     grid.with_area(:content, tag: :span) do
       if @meeting_agenda_item.visible_work_package?
         flex_layout(align_items: :center) do |flex|
-          flex.with_column(mr: 2) do
+          flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
             render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
                                           font_size: :normal, font_weight: :bold, target: "_blank")) do
-              render(Primer::Beta::Truncate.new) do |component|
-                component.with_item(max_width: 300, expandable: true) do
-                  @meeting_agenda_item.work_package.subject
-                end
-              end
+              @meeting_agenda_item.work_package.subject
             end
           end
           flex.with_column(mr: 2, classes: 'hidden-for-mobile') do
@@ -42,7 +38,7 @@
     end
 
     if @meeting_agenda_item.duration_in_minutes.present? && @meeting_agenda_item.duration_in_minutes > 0
-      grid.with_area(:duration, Primer::Beta::Text, font_size: :small, color: :subtle,  mr: 1) do
+      grid.with_area(:duration, Primer::Beta::Text, font_size: :small, color: :subtle, mr: 1) do
         I18n.t('datetime.distance_in_words.x_min_abbreviated', count: @meeting_agenda_item.duration_in_minutes)
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -3,9 +3,9 @@
 .op-meeting-agenda-item
   display: grid
   grid-template-columns: 20px auto 1fr minmax(auto, 200px) 40px
-  grid-template-areas: "drag_handle content duration author actions" ". notes notes notes notes"
+  grid-template-areas: "drag-handle content duration author actions" ". notes notes notes notes"
 
-  &--drag_handle,
+  &--drag-handle,
   &--duration,
   &--content,
   &--author
@@ -22,7 +22,7 @@
 
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr 50px
-    grid-template-areas: "drag_handle content content actions" ". author author duration" ". notes notes notes"
+    grid-template-areas: "drag-handle content content actions" ". author author duration" ". notes notes notes"
 
     &--duration
       justify-self: end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -2,7 +2,7 @@
 
 .op-meeting-agenda-item
   display: grid
-  grid-template-columns: 20px fit-content(70%) auto max-content 40px
+  grid-template-columns: 20px auto 1fr minmax(auto, 200px) 40px
   grid-template-areas: "drag_handle content duration author actions" ". notes notes notes notes"
 
   &--drag_handle,
@@ -10,6 +10,9 @@
   &--content,
   &--author
     align-self: center
+
+  &--duration
+    white-space: nowrap
 
   &--actions
     justify-self: end
@@ -22,8 +25,4 @@
     grid-template-areas: "drag_handle content content actions" ". author author duration" ". notes notes notes"
 
     &--duration
-      justify-self: end
-
-  @media screen and (min-width: $breakpoint-lg)
-    &--author
       justify-self: end

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -52,10 +52,6 @@ module Meetings
 
     private
 
-    def edit_enabled?
-      User.current.allowed_to?(:edit_meetings, @meeting.project)
-    end
-
     def delete_enabled?
       User.current.allowed_to?(:delete_meetings, @meeting.project)
     end
@@ -89,7 +85,7 @@ module Meetings
     def actions_partial
       render(Primer::Alpha::ActionMenu.new) do |menu|
         menu.with_show_button(icon: "kebab-horizontal", 'aria-label': t("label_meeting_actions"), test_selector: 'op-meetings-header-action-trigger')
-        edit_action_item(menu) if edit_enabled?
+        edit_action_item(menu) if @meeting.editable?
         download_ics_item(menu)
         delete_action_item(menu) if delete_enabled?
       end

--- a/modules/meeting/app/components/meetings/sidebar/details_component.rb
+++ b/modules/meeting/app/components/meetings/sidebar/details_component.rb
@@ -53,16 +53,12 @@ module Meetings
 
     private
 
-    def edit_enabled?
-      User.current.allowed_to?(:edit_meetings, @meeting.project)
-    end
-
     def heading_partial
       flex_layout(align_items: :center, justify_content: :space_between) do |flex|
         flex.with_column(flex: 1) do
           render(Primer::Beta::Heading.new(tag: :h4)) { t("label_meeting_details") }
         end
-        if edit_enabled?
+        if @meeting.editable?
           flex.with_column do
             dialog_wrapper_partial
           end

--- a/modules/meeting/app/components/meetings/sidebar/participants_component.rb
+++ b/modules/meeting/app/components/meetings/sidebar/participants_component.rb
@@ -157,9 +157,10 @@ module Meetings
 
     def participant_partial(participant)
       flex_layout(align_items: :center) do |flex|
-        flex.with_column do
+        flex.with_column(style: 'flex-shrink: 1; min-width: 0') do
           render(Users::AvatarComponent.new(user: participant.user,
-                                            size: :medium))
+                                            size: :medium,
+                                            classes: 'op-principal--flex'))
         end
         participant_state_partial(participant, flex)
       end

--- a/modules/meeting/app/components/meetings/sidebar/participants_component.rb
+++ b/modules/meeting/app/components/meetings/sidebar/participants_component.rb
@@ -47,7 +47,7 @@ module Meetings
           flex.with_row(mt: 2) do
             participant_list_partial(5)
           end
-          if edit_enabled?
+          if @meeting.editable?
             flex.with_row(mt: 3) do
               manage_button_partial
             end
@@ -58,16 +58,12 @@ module Meetings
 
     private
 
-    def edit_enabled?
-      User.current.allowed_to?(:edit_meetings, @meeting.project)
-    end
-
     def heading_partial
       flex_layout(align_items: :center, justify_content: :space_between) do |flex|
         flex.with_column(flex: 1) do
           title_partial
         end
-        if edit_enabled?
+        if @meeting.editable?
           flex.with_column do
             dialog_wrapper_partial
           end

--- a/modules/meeting/app/components/meetings/sidebar/participants_component.rb
+++ b/modules/meeting/app/components/meetings/sidebar/participants_component.rb
@@ -157,10 +157,10 @@ module Meetings
 
     def participant_partial(participant)
       flex_layout(align_items: :center) do |flex|
-        flex.with_column(style: 'flex-shrink: 1; min-width: 0') do
+        flex.with_column(classes: 'ellipsis') do
           render(Users::AvatarComponent.new(user: participant.user,
                                             size: :medium,
-                                            classes: 'op-principal--flex'))
+                                            classes: 'op-principal_flex'))
         end
         participant_state_partial(participant, flex)
       end

--- a/modules/meeting/app/components/meetings/sidebar/participants_form_component.rb
+++ b/modules/meeting/app/components/meetings/sidebar/participants_form_component.rb
@@ -120,9 +120,10 @@ module Meetings
 
     def exisiting_participant_form_checkboxes_partial(participant)
       flex_layout(align_items: :center) do |flex|
-        flex.with_column(flex: 1) do
+        flex.with_column(flex: 1, classes: 'ellipsis') do
           render(Users::AvatarComponent.new(
                    user: participant.user,
+                   classes: 'op-principal_flex'
                  ))
         end
         flex.with_column(style: "width: 90px;", text_align: :center) do
@@ -170,9 +171,10 @@ module Meetings
 
     def new_participant_form_partial(user)
       flex_layout(align_items: :center) do |flex|
-        flex.with_column(flex: 1) do
+        flex.with_column(flex: 1, classes: 'ellipsis') do
           render(Users::AvatarComponent.new(
                    user:,
+                   classes: 'op-principal_flex'
                  ))
         end
         flex.with_column(style: "width: 90px;", text_align: :center) do

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -142,8 +142,12 @@ class Meeting < ApplicationRecord
   end
 
   # Returns true if user or current user is allowed to view the meeting
-  def visible?(user = nil)
-    (user || User.current).allowed_to?(:view_meetings, project)
+  def visible?(user = User.current)
+    user.allowed_to?(:view_meetings, project)
+  end
+
+  def editable?(user = User.current)
+    open? && user.allowed_to?(:edit_meetings, project)
   end
 
   def invited_or_attended_participants


### PR DESCRIPTION
- [x] Author is not being truncated correctly
  - [x] At the meeting agenda item
  - [x] At the participants list
- [x] Alignment duration / title is slightly off
- [x] Truncation of work package is wrong
- [x] CKEditor notes bullet points misaligned
- [x] Wrapping duration
- [x] Rename class `...drag_handle` to `...drag-handle`
- [x] When duration for an agenda item is not specified, that information should not be displayed in non-edit mode (vs. "0 min" right now).
- In the Meeting details overlay:
  - [x] ~~make text input fields shorter (except place)~~
         **Note Oliver**: Primer currently does not offer form sizes, extracted into https://community.openproject.org/work_packages/50211
  - [x] ~~time and date fields have an icon to the right on some browsers (but not in others); this might be because they are native HTML elements. Any way to suppress the browser-set icons on the right edge?~~
        **Note Oliver**: Browser native. We'll not hide browser default behavior.
  - [x] In closed mode, hide "Add participants", "Edit meeting" and "Edit meeting name" actions.