### PR TITLE
[#50219] Custom export cover background overlay color won't return to…

### DIFF
--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -66,13 +66,8 @@ class CustomStylesController < ApplicationController
   end
 
   def update_export_cover_text_color
+    @custom_style = get_or_create_custom_style
     color = params[:export_cover_text_color]
-
-    @custom_style = CustomStyle.current
-    if @custom_style.nil?
-      return render_404
-    end
-
     color_hexcode_regex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
     color = nil if color.blank?
     if color.nil? || color.match(color_hexcode_regex)

--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -74,7 +74,8 @@ class CustomStylesController < ApplicationController
     end
 
     color_hexcode_regex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
-    if !color.nil? && color.match(color_hexcode_regex)
+    color = nil if color.blank?
+    if color.nil? || color.match(color_hexcode_regex)
       @custom_style.export_cover_text_color = color
       @custom_style.save
     end

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -489,6 +489,23 @@ RSpec.describe CustomStylesController do
           end
         end
 
+        context 'with valid empty parameter' do
+          let(:params) do
+            { export_cover_text_color: '' }
+          end
+
+          before do
+            custom_style.export_cover_text_color = "#990000"
+            custom_style.save
+            post :update_export_cover_text_color, params:
+          end
+
+          it "removes the color" do
+            expect(custom_style.export_cover_text_color).to be_nil
+            expect(response).to redirect_to action: :show
+          end
+        end
+
         context 'with invalid parameter' do
           let(:params) do
             { export_cover_text_color: "red" } # we only accept hexcodes

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -528,8 +528,8 @@ RSpec.describe CustomStylesController do
           post :update_export_cover_text_color, params:
         end
 
-        it 'renders 404' do
-          expect(response).to have_http_status :not_found
+        it 'it is created' do
+          expect(response).to redirect_to action: :show
         end
       end
     end


### PR DESCRIPTION
… the default one after deleting

This PR:
* allows blank parameter to remove the stored color
* adds a test for this

https://community.openproject.org/work_packages/50219