### PR TITLE
Visit response in case frame is missing

### DIFF
--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -3,3 +3,10 @@ import * as Turbo from '@hotwired/turbo';
 Turbo.session.drive = false;
 // Start turbo
 Turbo.start();
+
+// Error handling when "Content missing" returned
+document.addEventListener('turbo:frame-missing', (event:CustomEvent) => {
+  const { detail: { response, visit } } = event as { detail:{ response:Response, visit:(url:string) => void } };
+  event.preventDefault();
+  visit(response.url);
+});


### PR DESCRIPTION
If you're setting up the wrong frame response, you get "Content missing" by default. This is not very helpful for identifying the error.

We can listen to the turbo frame-missing event and promote it to a full visit instead

https://community.openproject.org/work_packages/50210