### PR TITLE
Permission Rework [1/x]: `.allowed_to` scope for WorkPackages

### DIFF
--- a/app/models/authorization/scopes/allowed_to.rb
+++ b/app/models/authorization/scopes/allowed_to.rb
@@ -1,0 +1,143 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Authorization::Scopes
+  module AllowedTo
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns an ActiveRecord::Relation to find all entries for which
+      # +user+ has the given +permission+.
+      def allowed_to(user, permission)
+        permissions = allowed_to_permissions(permission)
+
+        return none if user.locked?
+
+        if user.admin? && permissions.all?(&:grant_to_admin?)
+          allowed_to_admin(permissions)
+        elsif user.anonymous?
+          allowed_to_anonymous(user, permission)
+        else
+          allowed_to_member(user, permission)
+        end
+      end
+
+      private
+
+      def allowed_to_admin(permissions)
+        where(id: allowed_to_admin_relation(permissions))
+      end
+
+      def allowed_to_anonymous(user, permission)
+        where(id: allowed_to_non_member_relation(user, allowed_to_permissions(permission)))
+      end
+
+      def allowed_to_member(user, permission)
+        where(arel_table[:id].in(allowed_to_member_relation(user, permission)
+                                   .select(arel_table[:id])
+                                   .arel
+                                   .union(:all, allowed_to_non_member_relation(user, permission).select(:id).arel)))
+      end
+
+      def allowed_to_admin_relation(permissions)
+        joins(allowed_to_enabled_module_join(permissions))
+          .where(Project.arel_table[:active].eq(true))
+      end
+
+      def allowed_to_member_relation(user, permission)
+        permissions = allowed_to_permissions(permission)
+
+        Member
+          .joins(allowed_to_member_in_active_project_join(user))
+          .joins(allowed_to_enabled_module_join(permissions))
+          .joins(:roles)
+          .joins(allowed_to_role_permission_join(permissions))
+      end
+
+      def allowed_to_non_member_relation(_user, _permission)
+        raise NotImplementedError
+      end
+
+      def allowed_to_enabled_module_join(permissions) # rubocop:disable Metrics/AbcSize
+        project_module = permissions.filter_map(&:project_module).uniq
+        enabled_module_table = EnabledModule.arel_table
+        projects_table = Project.arel_table
+
+        if project_module.any?
+          arel_table.join(enabled_module_table, Arel::Nodes::InnerJoin)
+                    .on(projects_table[:id].eq(enabled_module_table[:project_id])
+                                           .and(enabled_module_table[:name].in(project_module))
+                                           .and(projects_table[:active].eq(true)))
+                    .join_sources
+        end
+      end
+
+      def allowed_to_role_permission_join(permissions) # rubocop:disable Metrics/AbcSize
+        return if permissions.all?(&:public?)
+
+        role_permissions_table = RolePermission.arel_table
+        enabled_modules_table = EnabledModule.arel_table
+        roles_table = Role.arel_table
+
+        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
+          permission_condition = role_permissions_table[:permission].eq(permission.name)
+
+          if permission.project_module.present?
+            permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
+          end
+
+          or_condition.or(permission_condition)
+        end
+
+        arel_table
+          .join(role_permissions_table, Arel::Nodes::InnerJoin)
+          .on(roles_table[:id].eq(role_permissions_table[:role_id])
+                              .and(condition))
+          .join_sources
+      end
+
+      def allowed_to_members_condition(_user)
+        raise NotImplementedError
+      end
+
+      def allowed_to_member_in_active_project_join(user)
+        Project.arel_table
+               .join(Project.arel_table)
+               .on(Project.arel_table[:active].eq(true)
+                          .and(allowed_to_members_condition(user)))
+               .join_sources
+      end
+
+      def allowed_to_permissions(permission)
+        Authorization.contextual_permissions(permission,
+                                             to_s.underscore.to_sym,
+                                             raise_on_unknown: true)
+      end
+    end
+  end
+end

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -29,82 +29,17 @@
 module Projects::Scopes
   module AllowedTo
     extend ActiveSupport::Concern
+    include Authorization::Scopes::AllowedTo
 
     class_methods do
-      # Returns an ActiveRecord::Relation to find all projects for which
-      # +user+ has the given +permission+
-      def allowed_to(user, permission)
-        permissions = Authorization.contextual_permissions(permission, :project, raise_on_unknown: true)
-
-        if user.admin? && permissions.all?(&:grant_to_admin?)
-          where(id: allowed_to_admin_relation(permissions))
-        elsif user.anonymous?
-          where(id: allowed_to_non_member_relation(user, permissions))
-        else
-          where(arel_table[:id].in(allowed_to_member_relation(user, permissions)
-                                     .arel
-                                     .union(:all, allowed_to_non_member_relation(user, permissions).arel)))
-        end
-      end
-
       private
 
-      def allowed_to_admin_relation(permissions)
-        joins(allowed_to_enabled_module_join(permissions))
-          .where(arel_table[:active].eq(true))
-      end
+      def allowed_to_non_member_relation(user, permission)
+        permissions = allowed_to_permissions(permission)
 
-      def allowed_to_non_member_relation(user, permissions)
         joins(allowed_to_enabled_module_join(permissions))
           .joins(allowed_to_builtin_roles_in_active_project_join(user))
           .joins(allowed_to_role_permission_join(permissions))
-          .select(:id)
-      end
-
-      def allowed_to_member_relation(user, permissions)
-        Member
-          .joins(allowed_to_member_in_active_project_join(user))
-          .joins(allowed_to_enabled_module_join(permissions))
-          .joins(:roles, :member_roles)
-          .joins(allowed_to_role_permission_join(permissions))
-          .select('projects.id')
-      end
-
-      def allowed_to_enabled_module_join(permissions)
-        project_module = permissions.filter_map(&:project_module).uniq
-        enabled_module_table = EnabledModule.arel_table
-
-        if project_module.any?
-          arel_table.join(enabled_module_table, Arel::Nodes::InnerJoin)
-                    .on(arel_table[:id].eq(enabled_module_table[:project_id])
-                          .and(enabled_module_table[:name].in(project_module))
-                          .and(arel_table[:active].eq(true)))
-                    .join_sources
-        end
-      end
-
-      def allowed_to_role_permission_join(permissions)
-        return if permissions.all?(&:public?)
-
-        role_permissions_table = RolePermission.arel_table
-        enabled_modules_table = EnabledModule.arel_table
-        roles_table = Role.arel_table
-
-        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
-          permission_condition = role_permissions_table[:permission].eq(permission.name)
-
-          if permission.project_module.present?
-            permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
-          end
-
-          or_condition.or(permission_condition)
-        end
-
-        arel_table
-          .join(role_permissions_table, Arel::Nodes::InnerJoin)
-          .on(roles_table[:id].eq(role_permissions_table[:role_id])
-                              .and(condition))
-          .join_sources
       end
 
       def allowed_to_members_condition(user)
@@ -127,13 +62,6 @@ module Projects::Scopes
 
         arel_table.join(roles_table)
                   .on(condition)
-                  .join_sources
-      end
-
-      def allowed_to_member_in_active_project_join(user)
-        arel_table.join(arel_table)
-                  .on(arel_table[:active].eq(true)
-                                         .and(allowed_to_members_condition(user)))
                   .join_sources
       end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -126,6 +126,7 @@ class WorkPackage < ApplicationRecord
   }
 
   scopes :covering_dates_and_days_of_week,
+         :allowed_to,
          :for_scheduling,
          :include_derived_dates,
          :include_spent_time,

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -26,64 +26,75 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Projects::Scopes
+module WorkPackages::Scopes
   module AllowedTo
     extend ActiveSupport::Concern
 
     class_methods do
-      # Returns an ActiveRecord::Relation to find all projects for which
-      # +user+ has the given +permission+
-      def allowed_to(user, permission)
-        permissions = Authorization.contextual_permissions(permission, :project, raise_on_unknown: true)
+      # Returns an ActiveRecord::Relation to find all work packages for which
+      # +user+ has the given +permission+ either directly on the work package
+      # or by the linked project
+      def allowed_to(user, permission) # rubocop:disable Metrics/AbcSize
+        permissions = Authorization.contextual_permissions(permission, :work_package, raise_on_unknown: true)
 
         if user.admin? && permissions.all?(&:grant_to_admin?)
           where(id: allowed_to_admin_relation(permissions))
         elsif user.anonymous?
           where(id: allowed_to_non_member_relation(user, permissions))
         else
-          where(arel_table[:id].in(allowed_to_member_relation(user, permissions)
-                                     .arel
-                                     .union(:all, allowed_to_non_member_relation(user, permissions).arel)))
+          union = Arel::Nodes::UnionAll.new(
+            Arel::Nodes::UnionAll.new(
+              allowed_to_member_relation(user, permissions).select(arel_table[:id]).arel,
+              allowed_to_non_member_relation(user, permissions).select(arel_table[:id]).arel
+            ),
+            where(project_id: Project.allowed_to(user, permission).select(:id)).select(arel_table[:id]).arel
+          )
+
+          where(arel_table[:id].in(union))
         end
       end
 
       private
 
       def allowed_to_admin_relation(permissions)
-        joins(allowed_to_enabled_module_join(permissions))
-          .where(arel_table[:active].eq(true))
+        joins(:project)
+        .joins(allowed_to_enabled_module_join(permissions))
+          .where(Project.arel_table[:active].eq(true))
       end
 
       def allowed_to_non_member_relation(user, permissions)
-        joins(allowed_to_enabled_module_join(permissions))
+        joins(:project)
+          .joins(allowed_to_enabled_module_join(permissions))
           .joins(allowed_to_builtin_roles_in_active_project_join(user))
           .joins(allowed_to_role_permission_join(permissions))
-          .select(:id)
+          .select(arel_table[:id])
       end
 
       def allowed_to_member_relation(user, permissions)
         Member
           .joins(allowed_to_member_in_active_project_join(user))
+          .joins(allowed_to_member_in_work_package_join)
           .joins(allowed_to_enabled_module_join(permissions))
           .joins(:roles, :member_roles)
           .joins(allowed_to_role_permission_join(permissions))
-          .select('projects.id')
+          .select(arel_table[:id])
       end
 
-      def allowed_to_enabled_module_join(permissions)
+      def allowed_to_enabled_module_join(permissions) # rubocop:disable Metrics/AbcSize
         project_module = permissions.filter_map(&:project_module).uniq
         enabled_module_table = EnabledModule.arel_table
+        projects_table = Project.arel_table
 
         if project_module.any?
           arel_table.join(enabled_module_table, Arel::Nodes::InnerJoin)
-                    .on(arel_table[:id].eq(enabled_module_table[:project_id])
+                    .on(projects_table[:id].eq(enabled_module_table[:project_id])
                           .and(enabled_module_table[:name].in(project_module))
-                          .and(arel_table[:active].eq(true)))
+                          .and(projects_table[:active].eq(true)))
                     .join_sources
         end
       end
 
-      def allowed_to_role_permission_join(permissions)
+      def allowed_to_role_permission_join(permissions) # rubocop:disable Metrics/AbcSize
         return if permissions.all?(&:public?)
 
         role_permissions_table = RolePermission.arel_table
@@ -110,10 +121,9 @@ module Projects::Scopes
       def allowed_to_members_condition(user)
         members_table = Member.arel_table
 
-        members_table[:project_id].eq(arel_table[:id])
+        members_table[:project_id].eq(arel_table[:project_id])
                                   .and(members_table[:user_id].eq(user.id))
-                                  .and(members_table[:entity_type].eq(nil))
-                                  .and(members_table[:entity_id].eq(nil))
+                                  .and(members_table[:entity_type].eq(model_name.name))
       end
 
       def allowed_to_builtin_roles_in_active_project_join(user)
@@ -131,13 +141,23 @@ module Projects::Scopes
       end
 
       def allowed_to_member_in_active_project_join(user)
-        arel_table.join(arel_table)
-                  .on(arel_table[:active].eq(true)
-                                         .and(allowed_to_members_condition(user)))
+        Project.arel_table
+          .join(Project.arel_table)
+                  .on(Project.arel_table[:active].eq(true)
+                   .and(allowed_to_members_condition(user)))
                   .join_sources
       end
 
+      def allowed_to_member_in_work_package_join
+        members_table = Member.arel_table
+        arel_table.join(arel_table)
+        .on(members_table[:entity_id].eq(arel_table[:id]))
+        .join_sources
+      end
+
       def allowed_to_built_roles_in_active_project_condition(user)
+        projects_table = Project.arel_table
+
         builtin = if user.logged?
                     Role::BUILTIN_NON_MEMBER
                   else
@@ -147,8 +167,8 @@ module Projects::Scopes
         roles_table = Role.arel_table
 
         roles_table[:builtin].eq(builtin)
-                             .and(arel_table[:active])
-                             .and(arel_table[:public])
+                             .and(projects_table[:active])
+                             .and(projects_table[:public])
       end
 
       def allowed_to_no_member_exists_condition(user)

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -29,82 +29,26 @@
 module WorkPackages::Scopes
   module AllowedTo
     extend ActiveSupport::Concern
+    include Authorization::Scopes::AllowedTo
 
     class_methods do
-      # Returns an ActiveRecord::Relation to find all work packages for which
-      # +user+ has the given +permission+ either directly on the work package
-      # or by the linked project
-      def allowed_to(user, permission) # rubocop:disable Metrics/AbcSize
-        permissions = Authorization.contextual_permissions(permission, :work_package, raise_on_unknown: true)
+      private
 
-        if user.admin? && permissions.all?(&:grant_to_admin?)
-          where(id: allowed_to_admin_relation(permissions))
-        elsif user.anonymous?
-          where(project_id: Project.allowed_to(user, permission).select(:id))
-        else
-          union = Arel::Nodes::UnionAll.new(
-            allowed_to_member_relation(user, permissions).select(arel_table[:id]).arel,
-            where(project_id: Project.allowed_to(user, permission).select(:id)).select(arel_table[:id]).arel
-          )
-
-          where(arel_table[:id].in(union))
-        end
+      def allowed_to_anonymous(user, permissions)
+        where(project_id: Project.allowed_to(user, permissions).select(:id))
       end
 
-      private
+      alias_method :allowed_to_non_member_relation, :allowed_to_anonymous
 
       def allowed_to_admin_relation(permissions)
         joins(:project)
-        .joins(allowed_to_enabled_module_join(permissions))
+          .joins(allowed_to_enabled_module_join(permissions))
           .where(Project.arel_table[:active].eq(true))
       end
 
-      def allowed_to_member_relation(user, permissions)
-        Member
-          .joins(allowed_to_member_in_active_project_join(user))
+      def allowed_to_member_relation(user, permission)
+        super
           .joins(allowed_to_member_in_work_package_join)
-          .joins(allowed_to_enabled_module_join(permissions))
-          .joins(:roles, :member_roles)
-          .joins(allowed_to_role_permission_join(permissions))
-          .select(arel_table[:id])
-      end
-
-      def allowed_to_enabled_module_join(permissions) # rubocop:disable Metrics/AbcSize
-        project_module = permissions.filter_map(&:project_module).uniq
-        enabled_module_table = EnabledModule.arel_table
-        projects_table = Project.arel_table
-
-        if project_module.any?
-          arel_table.join(enabled_module_table, Arel::Nodes::InnerJoin)
-                    .on(projects_table[:id].eq(enabled_module_table[:project_id])
-                          .and(enabled_module_table[:name].in(project_module))
-                          .and(projects_table[:active].eq(true)))
-                    .join_sources
-        end
-      end
-
-      def allowed_to_role_permission_join(permissions) # rubocop:disable Metrics/AbcSize
-        return if permissions.all?(&:public?)
-
-        role_permissions_table = RolePermission.arel_table
-        enabled_modules_table = EnabledModule.arel_table
-        roles_table = Role.arel_table
-
-        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
-          permission_condition = role_permissions_table[:permission].eq(permission.name)
-
-          if permission.project_module.present?
-            permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
-          end
-
-          or_condition.or(permission_condition)
-        end
-
-        arel_table
-          .join(role_permissions_table, Arel::Nodes::InnerJoin)
-          .on(roles_table[:id].eq(role_permissions_table[:role_id])
-                              .and(condition))
-          .join_sources
       end
 
       def allowed_to_members_condition(user)
@@ -115,19 +59,12 @@ module WorkPackages::Scopes
                                   .and(members_table[:entity_type].eq(model_name.name))
       end
 
-      def allowed_to_member_in_active_project_join(user)
-        Project.arel_table
-          .join(Project.arel_table)
-                  .on(Project.arel_table[:active].eq(true)
-                   .and(allowed_to_members_condition(user)))
-                  .join_sources
-      end
-
       def allowed_to_member_in_work_package_join
         members_table = Member.arel_table
+
         arel_table.join(arel_table)
-        .on(members_table[:entity_id].eq(arel_table[:id]).and(members_table[:entity_type].eq(model_name.name)))
-        .join_sources
+                  .on(members_table[:entity_id].eq(arel_table[:id]).and(members_table[:entity_type].eq(model_name.name)))
+                  .join_sources
       end
     end
   end

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -151,7 +151,7 @@ module WorkPackages::Scopes
       def allowed_to_member_in_work_package_join
         members_table = Member.arel_table
         arel_table.join(arel_table)
-        .on(members_table[:entity_id].eq(arel_table[:id]))
+        .on(members_table[:entity_id].eq(arel_table[:id]).and(members_table[:entity_type].eq(model_name.name)))
         .join_sources
       end
 

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -36,7 +36,12 @@ module Authorization
 
   # Returns all projects a user has a certain permission in
   def projects(action, user)
-    Project.allowed_to(action, user)
+    Project.allowed_to(user, action)
+  end
+
+  # Returns all work packages a user has a certain permission in (or in the project it belongs to)
+  def work_packages(action, user)
+    WorkPackage.allowed_to(user, action)
   end
 
   # Returns all roles a user has in a certain project, for a specific entity or globally
@@ -48,5 +53,46 @@ module Authorization
     else
       Authorization::UserGlobalRolesQuery.query(user)
     end
+  end
+
+  # Normalizes the different types of permission arguments into Permission objects.
+  # Possible arguments
+  #  - Symbol permission names (e.g. :view_work_packages)
+  #  - Hash with :controller and :action (e.g. { controller: 'work_packages', action: 'show' })
+  def permissions_for(action) # rubocop:disable Metrics/PerceivedComplexity
+    return [action] if action.is_a?(OpenProject::AccessControl::Permission)
+    return action if action.is_a?(Array) && action.all?(OpenProject::AccessControl::Permission)
+
+    if action.is_a?(Hash)
+      if action[:controller]&.to_s&.starts_with?('/')
+        action = action.dup
+        action[:controller] = action[:controller][1..]
+      end
+
+      OpenProject::AccessControl.allow_actions(action)
+    else
+      [OpenProject::AccessControl.permission(action)].compact
+    end
+  end
+
+  # Returns a set of normalized permissions filtered for a given context
+  #  - When there is no permission matching the +permission+ parameter, either an empty array is returned
+  #    or an +UnknownPermissionError+ is raised (depending on the raise_on_unknown parameter)
+  #  - When there are no permissions available for the given context (based on +permissible_on+
+  #    attribute of the permission), an +IllegalPermissionContextError+ is raised
+  def contextual_permissions(action, context, raise_on_unknown: false)
+    perms = permissions_for(action)
+
+    if perms.blank?
+      Rails.logger.warn "Used permission \"#{action}\" that is not defined. It will never return true."
+      raise UnknownPermissionError.new(action) if raise_on_unknown
+
+      return []
+    end
+
+    context_perms = perms.select { |p| p.permissible_on?(context) }
+    raise IllegalPermissionContextError.new(action, perms, context) if context_perms.blank?
+
+    context_perms
   end
 end

--- a/app/services/authorization/illegal_permission_context_error.rb
+++ b/app/services/authorization/illegal_permission_context_error.rb
@@ -26,52 +26,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Authorization::AbstractQuery
-  class_attribute :model
-  class_attribute :base_table
-
-  def self.query(*)
-    arel = transformed_query(*)
-
-    model.unscoped
-         .joins(joins(arel))
-         .where(wheres(arel))
-  end
-
-  def self.base_query
-    Arel::SelectManager
-      .new(nil)
-      .from(base_table || model.arel_table)
-  end
-
-  def self.transformed_query(*)
-    run_transformations(*)
-  end
-
-  class_attribute :transformations
-
-  self.transformations = ::Authorization::QueryTransformations.new
-
-  def self.inherited(subclass)
-    subclass.transformations = transformations.copy
-  end
-
-  def self.run_transformations(*args)
-    query = base_query
-
-    transformator = Authorization::QueryTransformationVisitor.new(transformations:,
-                                                                  args:)
-
-    transformator.accept(query)
-
-    query
-  end
-
-  def self.wheres(arel)
-    arel.ast.cores.last.wheres.last
-  end
-
-  def self.joins(arel)
-    arel.join_sources
+module Authorization
+  class IllegalPermissionContextError < StandardError
+    def initialize(permission, mapped_permissions, context)
+      super("Used permission \"#{permission}\" which maps to #{mapped_permissions.map(&:name).join(', ')} in #{context} context. Correct contexts for this permission are: #{mapped_permissions.flat_map(&:permissible_on).uniq.join(', ')}.")
+    end
   end
 end

--- a/app/services/authorization/unknown_permission_error.rb
+++ b/app/services/authorization/unknown_permission_error.rb
@@ -26,52 +26,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Authorization::AbstractQuery
-  class_attribute :model
-  class_attribute :base_table
-
-  def self.query(*)
-    arel = transformed_query(*)
-
-    model.unscoped
-         .joins(joins(arel))
-         .where(wheres(arel))
-  end
-
-  def self.base_query
-    Arel::SelectManager
-      .new(nil)
-      .from(base_table || model.arel_table)
-  end
-
-  def self.transformed_query(*)
-    run_transformations(*)
-  end
-
-  class_attribute :transformations
-
-  self.transformations = ::Authorization::QueryTransformations.new
-
-  def self.inherited(subclass)
-    subclass.transformations = transformations.copy
-  end
-
-  def self.run_transformations(*args)
-    query = base_query
-
-    transformator = Authorization::QueryTransformationVisitor.new(transformations:,
-                                                                  args:)
-
-    transformator.accept(query)
-
-    query
-  end
-
-  def self.wheres(arel)
-    arel.ast.cores.last.wheres.last
-  end
-
-  def self.joins(arel)
-    arel.join_sources
+module Authorization
+  class UnknownPermissionError < StandardError
+    def initialize(permission_name)
+      super("Used permission \"#{permission_name}\" that is not defined. It will never return true.")
+    end
   end
 end

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -33,7 +33,8 @@ module OpenProject
                   :controller_actions,
                   :contract_actions,
                   :project_module,
-                  :dependencies
+                  :dependencies,
+                  :permissible_on
 
       # @param public [Boolean] when true, the permission is granted to anybody
       # having at least one role in a project, regardless of the role's
@@ -72,15 +73,19 @@ module OpenProject
       end
 
       def work_package?
-        @permissible_on.include? :work_package
+        permissible_on? :work_package
       end
 
       def project?
-        @permissible_on.include? :project
+        permissible_on? :project
       end
 
       def global?
-        @permissible_on.include? :global
+        permissible_on? :global
+      end
+
+      def permissible_on?(context_type)
+        @permissible_on.include?(context_type)
       end
 
       def grant_to_admin?

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -246,6 +246,14 @@ RSpec.describe Project, 'allowed to' do
 
       it_behaves_like 'is empty'
     end
+
+    context 'with the user being locked' do
+      before do
+        user.update!(status: Principal.statuses[:locked])
+      end
+
+      it_behaves_like 'is empty'
+    end
   end
 
   context 'with the project being private' do

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -1,0 +1,129 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe WorkPackage, '.allowed_to' do
+  let!(:private_project) { create(:project, public: false, active: project_status) }
+  let!(:public_project) { create(:project, public: true, active: project_status) }
+  let(:project_status) { true }
+
+  let!(:work_package_in_public_project) { create(:work_package, project: public_project) }
+  let!(:work_package_in_private_project) { create(:work_package, project: private_project) }
+  let!(:other_work_package_in_private_project) { create(:work_package, project: private_project) }
+
+  let(:project_permissions) { [] }
+  let(:project_role) { create(:role, permissions: project_permissions) }
+
+  let(:work_package_permissions) { [] }
+  let(:work_package_role) { create(:work_package_role, permissions: work_package_permissions) }
+
+  let(:anonymous_permissions) { [] }
+  let(:anonymous_role) { create(:anonymous_role, permissions: anonymous_permissions) }
+
+  let(:non_member_permissions) { [] }
+  let!(:non_member_role) { create(:non_member, permissions: non_member_permissions) }
+
+  let!(:user_without_membership) { create(:user) }
+  let!(:user_with_private_project_membership) { create(:user, member_with_roles: { private_project => project_role }) }
+  let!(:user_with_private_work_package_membership) do
+    create(:user, member_with_roles: { work_package_in_private_project => work_package_role })
+  end
+
+  let(:action) { project_or_work_package_action }
+  let(:project_or_work_package_action) { :view_work_packages }
+  let(:public_action) { :view_news }
+  let(:public_non_module_action) { :view_project }
+  let(:non_module_action) { :edit_project }
+
+  context 'when querying for a permission that does not exist' do
+    it 'raises an error' do
+      expect do
+        described_class.allowed_to(build(:user), :non_existing_permission)
+      end.to raise_error(Authorization::UnknownPermissionError)
+    end
+  end
+
+  context 'when the user is an admin' do
+    let(:user) { create(:admin) }
+
+    subject { described_class.allowed_to(user, action) }
+
+    it 'returns all work packages' do
+      expect(subject).to contain_exactly(
+        work_package_in_public_project,
+        work_package_in_private_project,
+        other_work_package_in_private_project
+      )
+    end
+  end
+
+  context 'when the user has the permission directly on the work package' do
+    let(:work_package_permissions) { [action] }
+    let!(:user) do
+      create(:user, member_with_roles: { work_package_in_private_project => work_package_role })
+    end
+
+    subject { described_class.allowed_to(user, action) }
+
+    it 'returns the authorized work package' do
+      expect(subject).to contain_exactly(work_package_in_private_project)
+    end
+  end
+
+  context 'when the user has the permission on the project the work package belongs to' do
+    let(:project_permissions) { [action] }
+
+    let!(:user) do
+      create(:user, member_with_roles: { private_project => project_role })
+    end
+
+    subject { described_class.allowed_to(user, action) }
+
+    it 'returns the authorized work packages' do
+      expect(subject).to contain_exactly(work_package_in_private_project, other_work_package_in_private_project)
+    end
+  end
+
+  context 'when the user has a different permission on the project, but the requested one on a specific work package' do
+    let(:project_permissions) { [:view_work_packages] }
+    let(:work_package_permissions) { %i[view_work_packages edit_work_packages] }
+
+    let(:user) do
+      create(:user, member_with_roles: { private_project => project_role, work_package_in_private_project => work_package_role })
+    end
+
+    subject { described_class.allowed_to(user, :edit_work_packages) }
+
+    it 'returns the authorized work packages' do
+      expect(subject).to contain_exactly(work_package_in_private_project)
+    end
+  end
+
+  # TODO: Add more tests that check anonymous and non-member permissions
+end

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe WorkPackage, '.allowed_to' do
     end
   end
 
+  context 'when querying for a permission that does not apply to the context' do
+    it 'raises an error' do
+      expect do
+        described_class.allowed_to(build(:user), public_action)
+      end.to raise_error(Authorization::IllegalPermissionContextError)
+    end
+  end
+
   context 'when the user is an admin' do
     let(:user) { create(:admin) }
 
@@ -76,6 +84,27 @@ RSpec.describe WorkPackage, '.allowed_to' do
         work_package_in_private_project,
         other_work_package_in_private_project
       )
+    end
+
+    context 'when the project is archived' do
+      before do
+        public_project.update!(active: false)
+        private_project.update!(active: false)
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the user is locked' do
+      before do
+        user.locked!
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
     end
   end
 
@@ -92,6 +121,27 @@ RSpec.describe WorkPackage, '.allowed_to' do
     it 'returns the authorized work package' do
       expect(subject).to contain_exactly(work_package_in_private_project)
     end
+
+    context 'when the project is archived' do
+      before do
+        public_project.update!(active: false)
+        private_project.update!(active: false)
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the user is locked' do
+      before do
+        user.locked!
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
+    end
   end
 
   context 'when the user has the permission on the project the work package belongs to' do
@@ -105,6 +155,27 @@ RSpec.describe WorkPackage, '.allowed_to' do
 
     it 'returns the authorized work packages' do
       expect(subject).to contain_exactly(work_package_in_private_project, other_work_package_in_private_project)
+    end
+
+    context 'when the project is archived' do
+      before do
+        public_project.update!(active: false)
+        private_project.update!(active: false)
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the user is locked' do
+      before do
+        user.locked!
+      end
+
+      it 'returns no work packages' do
+        expect(subject).to be_empty
+      end
     end
   end
 
@@ -134,5 +205,57 @@ RSpec.describe WorkPackage, '.allowed_to' do
     end
   end
 
-  # TODO: Add more tests that check anonymous and non-member permissions
+  context 'when the user is not logged in (anonymous)' do
+    let(:user) { User.anonymous }
+    let(:action) { :view_work_packages }
+
+    before do
+      anonymous_role.save!
+    end
+
+    subject { described_class.allowed_to(user, action) }
+
+    context 'with the anonymous role having the permission' do
+      let(:anonymous_permissions) { [action] }
+
+      it 'returns work packages in the public project' do
+        expect(subject).to contain_exactly(work_package_in_public_project)
+      end
+    end
+
+    context 'with the anonymous role lacking the permission' do
+      let(:anonymous_permissions) { [] }
+
+      it 'is empty' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+
+  context 'when the user isn`t member in the project' do
+    let(:user) { create(:user) }
+    let(:action) { :view_work_packages }
+
+    before do
+      non_member_role.save!
+    end
+
+    subject { described_class.allowed_to(user, action) }
+
+    context 'with the non member role having the permission' do
+      let(:non_member_permissions) { [action] }
+
+      it 'returns work packages in the public project' do
+        expect(subject).to contain_exactly(work_package_in_public_project)
+      end
+    end
+
+    context 'with the non member role lacking the permission' do
+      let(:non_member_permissions) { [] }
+
+      it 'is empty' do
+        expect(subject).to be_empty
+      end
+    end
+  end
 end

--- a/spec/services/authorization_spec.rb
+++ b/spec/services/authorization_spec.rb
@@ -1,0 +1,246 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe Authorization do
+  let(:user) { build_stubbed(:user) }
+  let(:action) { :view_work_packages }
+
+  describe '.users' do
+    it 'calls Authorization::UserAllowedQuery' do
+      expect(Authorization::UserAllowedQuery).to receive(:query).with(action, user)
+      described_class.users(action, user)
+    end
+  end
+
+  describe '.projects' do
+    it 'uses the .allowed_to scope on Project' do
+      expect(Project).to receive(:allowed_to).with(user, action)
+      described_class.projects(action, user)
+    end
+  end
+
+  describe '.work_packages' do
+    it 'uses the .allowed_to scope on WorkPackage' do
+      expect(WorkPackage).to receive(:allowed_to).with(user, action)
+      described_class.work_packages(action, user)
+    end
+  end
+
+  describe '.roles' do
+    context 'with a project' do
+      let(:context) { build_stubbed(:project) }
+
+      it 'calls Authorization::UserProjectRolesQuery' do
+        expect(Authorization::UserProjectRolesQuery).to receive(:query).with(user, context)
+        described_class.roles(user, context)
+      end
+    end
+
+    context 'with a WorkPackage' do
+      let(:context) { build_stubbed(:work_package) }
+
+      it 'calls Authorization::UserEntityRolesQuery' do
+        expect(Authorization::UserEntityRolesQuery).to receive(:query).with(user, context)
+        described_class.roles(user, context)
+      end
+    end
+
+    context 'without a context' do
+      let(:context) { nil }
+
+      it 'calls Authorization::UserGlobalRolesQuery' do
+        expect(Authorization::UserGlobalRolesQuery).to receive(:query).with(user)
+        described_class.roles(user, context)
+      end
+    end
+  end
+
+  describe '.permissions_for' do
+    subject { described_class.permissions_for(action) }
+
+    context 'when called with a Permission object' do
+      let(:action) { OpenProject::AccessControl.permission(:view_work_packages) }
+
+      it 'returns the Permission object wrapped in an array' do
+        expect(subject).to eq([action])
+      end
+    end
+
+    context 'when called with an array of Permission objects' do
+      let(:action) do
+        [
+          OpenProject::AccessControl.permission(:view_work_packages),
+          OpenProject::AccessControl.permission(:edit_work_packages)
+        ]
+      end
+
+      it 'returns the Permission array' do
+        expect(subject).to eq(action)
+      end
+    end
+
+    context 'when action is a Hash where controller starts with a slash' do
+      let(:action) do
+        { controller: '/work_packages', action: 'show' }
+      end
+
+      it 'returns all permissions that grant the permission to this URL' do
+        # there might be more permissions granting access to this URL, we check for a known one
+        expect(subject).to include(OpenProject::AccessControl.permission(:view_work_packages))
+      end
+    end
+
+    context 'when action is a Hash where controller does not start with a slash' do
+      let(:action) do
+        { controller: 'work_packages', action: 'show' }
+      end
+
+      it 'returns all permissions that grant the permission to this URL' do
+        # there might be more permissions granting access to this URL, we check for a known one
+        expect(subject).to include(OpenProject::AccessControl.permission(:view_work_packages))
+      end
+    end
+
+    context 'when action is a permission name' do
+      let(:action) { :view_work_packages }
+
+      it 'returns the Permission object wrapped in an array' do
+        expect(subject).to eq([OpenProject::AccessControl.permission(:view_work_packages)])
+      end
+    end
+
+    context 'when action is a permission name that does not exist' do
+      let(:action) { :this_permission_does_not_exist }
+
+      it 'returns the Permission object wrapped in an array' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+
+  describe '.contextual_permissions' do
+    subject { described_class.contextual_permissions(action, context, raise_on_unknown:) }
+
+    let(:raise_on_unknown) { false }
+    let(:context) { nil }
+
+    let(:global_permission) { OpenProject::AccessControl.permission(:manage_user) }
+    let(:project_permission) { OpenProject::AccessControl.permission(:manage_members) }
+    let(:project_and_work_package_permission) { OpenProject::AccessControl.permission(:view_work_packages) }
+
+    let(:returned_permissions) do
+      [
+        global_permission,
+        project_permission,
+        project_and_work_package_permission
+      ]
+    end
+
+    before do
+      allow(described_class).to receive(:permissions_for).and_return(returned_permissions)
+    end
+
+    context 'when there is no permission' do
+      let(:returned_permissions) { [] }
+
+      context 'and raise_on_unknown is false' do
+        let(:raise_on_unknown) { false }
+
+        it 'warns and returns an empty array' do
+          expect(Rails.logger).to receive(:warn).with(/Used permission "#{action}" that is not defined./)
+          expect(subject).to be_empty
+        end
+      end
+
+      context 'and raise_on_unknown is true' do
+        let(:raise_on_unknown) { true }
+
+        it 'warns and raises' do
+          expect(Rails.logger).to receive(:warn).with(/Used permission "#{action}" that is not defined./)
+          expect { subject }.to raise_error(Authorization::UnknownPermissionError)
+        end
+      end
+    end
+
+    context 'with global context' do
+      let(:context) { :global }
+
+      context 'when a global permission is part of the returned permissions' do
+        it 'returns only the global permission' do
+          expect(subject).to eq([global_permission])
+        end
+      end
+
+      context 'when no global permission is part of the returned permissions' do
+        let(:returned_permissions) { [project_permission, project_and_work_package_permission] }
+
+        it 'raises an IllegalPermissionContextError' do
+          expect { subject }.to raise_error(Authorization::IllegalPermissionContextError)
+        end
+      end
+    end
+
+    context 'with project context' do
+      let(:context) { :project }
+
+      context 'when a project permission is part of the returned permissions' do
+        it 'returns only the project permissions' do
+          expect(subject).to eq([project_permission, project_and_work_package_permission])
+        end
+      end
+
+      context 'when no project permission is part of the returned permissions' do
+        let(:returned_permissions) { [global_permission] }
+
+        it 'raises an IllegalPermissionContextError' do
+          expect { subject }.to raise_error(Authorization::IllegalPermissionContextError)
+        end
+      end
+    end
+
+    context 'with work package context' do
+      let(:context) { :work_package }
+
+      context 'when a work package permission is part of the returned permissions' do
+        it 'returns only the work package permission' do
+          expect(subject).to eq([project_and_work_package_permission])
+        end
+      end
+
+      context 'when no work package permission is part of the returned permissions' do
+        let(:returned_permissions) { [global_permission, project_permission] }
+
+        it 'raises an IllegalPermissionContextError' do
+          expect { subject }.to raise_error(Authorization::IllegalPermissionContextError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on the work that @ulferts did in #13683, this PR adds a similiar `.allowed_to` scope to the `WorkPackage` model. It already optimizes by also including WorkPackages if

- the requested permission is allowed on the WorkPackage
- the requested permission is allowed on the Project the Work Package belongs to

Also, I have extracted the `allowed_to_permissions` method out of the scope into the `Authorization` module. We will be using the method a lot more in the future, so there's a good place to park it.

Also, we added the `Authorization.contextual_permissions` method that allows filtering permissions for a given context. This helps us when checking permissions or mocking permissions, that we don't accidentally try to check i.e. a global permission (like `:create_user` in a project context).

--- 

This PR has been extracted from #13658 for easier reviewing