### PR TITLE
Add concurency setting for test-core workflow.

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -70,3 +70,7 @@ jobs:
       with:
         node-version: '14'
     - run: ./script/api/validate_spec
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -71,6 +71,10 @@ jobs:
         node-version: '14'
     - run: ./script/api/validate_spec
 
+# github.head_ref is only availabe in PR context and if it is absent then github.run_id
+# is used . And github.run_id is unique for each workflow run. So, this option makes
+# sure that there is only one build running for a pull request and the build is attached
+# to the last commit of the PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/spec/lib/representable_spec.rb
+++ b/spec/lib/representable_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Representable do
       property :title
     end
 
-    it { expect(UpcaseRepresenter.new(object).to_json).to eql("{\"TITLE\":\"test\"}") }
+    it { expect(UpcaseRepresenter.new(object).to_json).to eql('{"TITLE":"test"}') }
   end
 
   describe 'as_strategy with class responding to #call?' do
@@ -58,7 +58,7 @@ RSpec.describe Representable do
       property :title
     end
 
-    it { expect(ReverseRepresenter.new(object).to_json).to eql("{\"eltit\":\"test\"}") }
+    it { expect(ReverseRepresenter.new(object).to_json).to eql('{"eltit":"test"}') }
   end
 
   describe 'as_strategy with class not responding to #call?' do


### PR DESCRIPTION
Expected behavior:
  - all pending and in-progress workflow runs are canceled on the PR update.
  - it should not change the behavior of workflow runs on push to dev/release branches, because `github.head_ref` is only availabe in PR context and if it is absent then `github.run_id` is used as building block for concurency group value. And `github.run_id` is unique for each workflow run.