### PR TITLE
Make GroupFolderPropertiesSync more stable.

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/add_user_to_group_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/add_user_to_group_command.rb
@@ -38,7 +38,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
     # rubocop:disable Metrics/AbcSize
     def call(user:, group: @group)
       response = Util.http(@uri).post(
-        Util.join_uri_path(@uri, 'ocs/v1.php/cloud/users', CGI.escapeURIComponent(user), 'groups'),
+        Util.join_uri_path(@uri.path, 'ocs/v1.php/cloud/users', CGI.escapeURIComponent(user), 'groups'),
         "groupid=#{CGI.escapeURIComponent(group)}",
         Util
           .basic_auth_header(@username, @password)

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/copy_template_folder_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/copy_template_folder_command.rb
@@ -56,14 +56,14 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
         escaped_username = CGI.escapeURIComponent(@username)
 
         source = Util.join_uri_path(
-          @uri,
+          @uri.path,
           "remote.php/dav/files",
           escaped_username,
           Util.escape_path(input[:source_path])
         )
 
         destination = Util.join_uri_path(
-          @uri,
+          @uri.path,
           "remote.php/dav/files",
           escaped_username,
           Util.escape_path(input[:destination_path])

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/group_users_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/group_users_query.rb
@@ -40,7 +40,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
     # rubocop:disable Metrics/AbcSize
     def call(group: @group)
       response = Util.http(@uri).get(
-        Util.join_uri_path(@uri, "ocs/v1.php/cloud/groups", CGI.escapeURIComponent(group)),
+        Util.join_uri_path(@uri.path, "ocs/v1.php/cloud/groups", CGI.escapeURIComponent(group)),
         Util.basic_auth_header(@username, @password).merge('OCS-APIRequest' => 'true')
       )
       case response

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
@@ -86,7 +86,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Internal
 
       response = UTIL.http(@uri).propfind(
         UTIL.join_uri_path(
-          @uri,
+          @uri.path,
           'remote.php/dav/files',
           CGI.escapeURIComponent(@username),
           UTIL.escape_path(path)

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/remove_user_from_group_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/remove_user_from_group_command.rb
@@ -38,7 +38,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
     # rubocop:disable Metrics/AbcSize
     def call(user:, group: @group)
       response = Util.http(@uri).delete(
-        Util.join_uri_path(@uri,
+        Util.join_uri_path(@uri.path,
                            "ocs/v1.php/cloud/users",
                            CGI.escapeURIComponent(user),
                            "groups?groupid=#{CGI.escapeURIComponent(group)}"),

--- a/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
@@ -67,7 +67,7 @@ class Storages::GroupFolderPropertiesSyncService
             .automatic
             .includes(project: :enabled_modules)
             .where(projects: { active: true })
-            .each do |project_storage|
+            .find_each do |project_storage|
       project = project_storage.project
       project_folder_path = project_storage.project_folder_path
       @project_folder_ids_used_in_openproject << ensure_project_folder(project_storage:, project_folder_path:)

--- a/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
@@ -625,6 +625,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
              origin_user_id: 'Darth Vader',
              user: admin,
              oauth_client:)
+
       request_stubs << stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
                          .with(
                            body: set_permissions_request_body1,
@@ -632,6 +633,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
                            }
                          ).to_return(status: 207, body: set_permissions_response_body1, headers: {})
+
       request_stubs << stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
                          .with(
                            body: propfind_request_body,
@@ -640,6 +642,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'Depth' => '1'
                            }
                          ).to_return(status: 207, body: propfind_response_body1, headers: {})
+
       request_stubs << stub_request(
         :mkcol,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -649,6 +652,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 201, body: "", headers: {})
+
       request_stubs << stub_request(
         :propfind,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -660,6 +664,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Depth' => '1'
         }
       ).to_return(status: 207, body: propfind_response_body2, headers: {})
+
       request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Obi-Wan/groups")
                          .with(
                            body: "groupid=OpenProject",
@@ -668,6 +673,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'Ocs-Apirequest' => 'true'
                            }
                          ).to_return(status: 200, body: add_user_to_group_response_body, headers: {})
+
       request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Yoda/groups")
                          .with(
                            body: "groupid=OpenProject",
@@ -676,6 +682,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'Ocs-Apirequest' => 'true'
                            }
                          ).to_return(status: 200, body: add_user_to_group_response_body, headers: {})
+
       request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Vader/groups")
                          .with(
                            body: "groupid=OpenProject",
@@ -684,6 +691,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'Ocs-Apirequest' => 'true'
                            }
                          ).to_return(status: 200, body: add_user_to_group_response_body, headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -694,6 +702,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body2, headers: {})
+
       request_stubs << stub_request(
         :move,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -705,6 +714,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                            "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29"
         }
       ).to_return(status: 201, body: "", headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -715,6 +725,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body3, headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -725,6 +736,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body4, headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -735,6 +747,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body5, headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -745,6 +758,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body6, headers: {})
+
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
@@ -755,6 +769,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body7, headers: {})
+
       request_stubs << stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/groups/#{storage.group}")
                          .with(
                            headers: {
@@ -762,6 +777,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
                              'OCS-APIRequest' => 'true'
                            }
                          ).to_return(status: 200, body: group_users_response_body, headers: {})
+
       request_stubs << stub_request(
         :delete,
         "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Maul/groups?groupid=OpenProject"
@@ -771,23 +787,29 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           'Ocs-Apirequest' => 'true'
         }
       ).to_return(status: 200, body: remove_user_from_group_response, headers: {})
-      request_stubs << stub_request(:mkcol, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})")
-        .with(
-          headers: {
-            'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
-          }
-        ).to_return(status: 405, body: <<~XML, headers: {})
-          <?xml version="1.0" encoding="utf-8"?>
-          <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
-            <s:exception>Sabre\\DAV\\Exception\\MethodNotAllowed</s:exception>
-            <s:message>The resource you tried to create already exists</s:message>
-          </d:error>
-        XML
-      request_stubs << stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})")
-        .with(
-          headers: { 'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=' },
-          body: propfind_request_body
-        ).to_return(status: 200, body: propfind_response_body3, headers: {})
+
+      request_stubs << stub_request(
+        :mkcol,
+        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})"
+      ).with(
+        headers: {
+          'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
+        }
+      ).to_return(status: 405, body: <<~XML, headers: {})
+        <?xml version="1.0" encoding="utf-8"?>
+        <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+          <s:exception>Sabre\\DAV\\Exception\\MethodNotAllowed</s:exception>
+          <s:message>The resource you tried to create already exists</s:message>
+        </d:error>
+      XML
+
+      request_stubs << stub_request(
+        :propfind,
+        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})"
+      ).with(
+        headers: { 'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=' },
+        body: propfind_request_body
+      ).to_return(status: 200, body: propfind_response_body3, headers: {})
     end
 
     it 'sets project folders properties' do

--- a/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
+RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
   describe '#call' do
     # rubocop:disable RSpec/IndexedLet
     let(:group_users_response_body) do
@@ -151,10 +151,19 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
             </d:propstat>
           </d:response>
           <d:response>
-            <d:href>/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{public_project.id}%29/</d:href>
+            <d:href>/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{project_public.id}%29/</d:href>
             <d:propstat>
               <d:prop>
                 <oc:fileid>999</oc:fileid>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+          <d:response>
+            <d:href>/remote.php/dav/files/OpenProject/OpenProject/Project3%20%28#{project3.id}%29/</d:href>
+            <d:propstat>
+              <d:prop>
+                <oc:fileid>2600003</oc:fileid>
               </d:prop>
               <d:status>HTTP/1.1 200 OK</d:status>
             </d:propstat>
@@ -474,7 +483,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
           xmlns:oc="http://owncloud.org/ns"
           xmlns:nc="http://nextcloud.org/ns">
           <d:response>
-            <d:href>/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{public_project.id}%29/</d:href>
+            <d:href>/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{project_public.id}%29/</d:href>
             <d:propstat>
               <d:prop>
                 <nc:acl-list/>
@@ -485,6 +494,47 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
         </d:multistatus>
       XML
     end
+    let(:set_permissions_response_body7) do
+      <<~XML
+        <?xml version="1.0"?>
+        <d:multistatus
+          xmlns:d="DAV:"
+          xmlns:s="http://sabredav.org/ns"
+          xmlns:oc="http://owncloud.org/ns"
+          xmlns:nc="http://nextcloud.org/ns">
+          <d:response>
+            <d:href>/remote.php/dav/files/OpenProject/OpenProject/Project3%20%28#{project3.id}%29/</d:href>
+            <d:propstat>
+              <d:prop>
+                <nc:acl-list/>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+      XML
+    end
+    let(:propfind_response_body3) do
+      <<~XML
+        <?xml version="1.0"?>
+        <d:multistatus
+          xmlns:d="DAV:"
+          xmlns:s="http://sabredav.org/ns"
+          xmlns:oc="http://owncloud.org/ns"
+          xmlns:nc="http://nextcloud.org/ns">
+          <d:response>
+            <d:href>/remote.php/dav/files/OpenProject/OpenProject/Project3%20%28#{project3.id}%29/</d:href>
+            <d:propstat>
+              <d:prop>
+                <oc:fileid>2600003</oc:fileid>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+      XML
+    end
+
     let(:request_stubs) { [] }
 
     let(:project1) do
@@ -499,11 +549,16 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
     end
     let(:project3) do
       create(:project,
+             name: 'Project3',
+             members: { multiple_projects_user => ordinary_role })
+    end
+    let(:project_not_active) do
+      create(:project,
              name: 'NOT ACTIVE PROJECT',
              active: false,
              members: { multiple_projects_user => ordinary_role })
     end
-    let(:public_project) do
+    let(:project_public) do
       create(:public_project,
              name: 'PUBLIC PROJECT',
              active: true)
@@ -537,12 +592,19 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
              project_folder_mode: 'automatic',
              project: project3,
              storage:,
-             project_folder_id: '778')
+             project_folder_id: nil)
     end
     let!(:project_storage4) do
       create(:project_storage,
              project_folder_mode: 'automatic',
-             project: public_project,
+             project: project_not_active,
+             storage:,
+             project_folder_id: '778')
+    end
+    let!(:project_storage5) do
+      create(:project_storage,
+             project_folder_mode: 'automatic',
+             project: project_public,
              storage:,
              project_folder_id: '999')
     end
@@ -563,13 +625,6 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
              origin_user_id: 'Darth Vader',
              user: admin,
              oauth_client:)
-      request_stubs << stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/groups/#{storage.group}")
-                         .with(
-                           headers: {
-                             'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
-                             'OCS-APIRequest' => 'true'
-                           }
-                         ).to_return(status: 200, body: group_users_response_body, headers: {})
       request_stubs << stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
                          .with(
                            body: set_permissions_request_body1,
@@ -683,13 +738,30 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "PUBLIC%20PROJECT%20%28#{public_project.id}%29"
+        "PUBLIC%20PROJECT%20%28#{project_public.id}%29"
       ).with(
         body: set_permissions_request_body6,
         headers: {
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
         }
       ).to_return(status: 207, body: set_permissions_response_body6, headers: {})
+      request_stubs << stub_request(
+        :proppatch,
+        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+        "Project3%20%28#{project3.id}%29"
+      ).with(
+        body: set_permissions_request_body4,
+        headers: {
+          'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
+        }
+      ).to_return(status: 207, body: set_permissions_response_body7, headers: {})
+      request_stubs << stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/groups/#{storage.group}")
+                         .with(
+                           headers: {
+                             'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
+                             'OCS-APIRequest' => 'true'
+                           }
+                         ).to_return(status: 200, body: group_users_response_body, headers: {})
       request_stubs << stub_request(
         :delete,
         "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Maul/groups?groupid=OpenProject"
@@ -699,19 +771,39 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, webmock: true do
           'Ocs-Apirequest' => 'true'
         }
       ).to_return(status: 200, body: remove_user_from_group_response, headers: {})
+      request_stubs << stub_request(:mkcol, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})")
+        .with(
+          headers: {
+            'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
+          }
+        ).to_return(status: 405, body: <<~XML, headers: {})
+          <?xml version="1.0" encoding="utf-8"?>
+          <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+            <s:exception>Sabre\\DAV\\Exception\\MethodNotAllowed</s:exception>
+            <s:message>The resource you tried to create already exists</s:message>
+          </d:error>
+        XML
+      request_stubs << stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})")
+        .with(
+          headers: { 'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=' },
+          body: propfind_request_body
+        ).to_return(status: 200, body: propfind_response_body3, headers: {})
     end
 
     it 'sets project folders properties' do
       expect(project_storage1.project_folder_id).to be_nil
       expect(project_storage2.project_folder_id).to eq('123')
+      expect(project_storage3.project_folder_id).to be_nil
 
       described_class.new(storage).call
 
       expect(request_stubs).to all have_been_requested
       project_storage1.reload
       project_storage2.reload
+      project_storage3.reload
       expect(project_storage1.project_folder_id).to eq('819')
       expect(project_storage2.project_folder_id).to eq('123')
+      expect(project_storage3.project_folder_id).to eq('2600003')
     end
 
     context 'when remove_user_from_group_command fails unexpectedly' do


### PR DESCRIPTION
https://community.openproject.org/wp/50117

[Cover a special NC sync case with a test.](https://github.com/opf/openproject/pull/13824/commits/e641a8a5307979e604ee63627f6f596088b6f96a)

The test case is a follows:
1. The sync job creates a project folder on NC side.
2. The sync process fails/crashes (network issue, for instance). So, the
   project folder id has not been saved to the database.
3. On next synchronization try we get to the earlier created folder and
   try to create it again. We receive 405 with 'The resource you tried
   to create already exists', but the job does not fail at this point
   and asks for the `fileid` of the project folder as usual.
4. The `fileid` has been saved to the database as expected.

[Use relative paths when issuing HTTP requests.](https://github.com/opf/openproject/pull/13824/commits/dac4622f27d1d05cddf50ae213ed3b6a524128a2)

In some requests to NC we used the following format of HTTP requests:
```
"POST https://nextcloud.local/ocs/v1.php/cloud/users/rhboltaev/groups ..."
"GET https://nextcloud.local/ocs/v1.php/cloud/groups/OpenProject ..."
"COPY https://nextcloud.local/remote.php/dav/files/OpenProject/OpenProject/%5Bdev%5D%20Large%20%285%29 HTTP/1.1\r\nAuthorization: Basic XXXXXXX\r\nDestination: https://nextcloud.local/remote.php/dav/files/OpenProject/OpenProject/DEV%20LARGE%20COPY%202%20%2853%29 ..."
```
Instead of:
```
"POST /ocs/v1.php/cloud/users/rhboltaev/groups ..."
"GET /ocs/v1.php/cloud/groups/OpenProject ..."
"COPY /remote.php/dav/files/OpenProject/OpenProject/%5Bdev%5D%20Large%20%285%29 HTTP/1.1\r\nAuthorization: Basic XXXXXXX\r\nDestination: https://nextcloud.local/remote.php/dav/files/OpenProject/OpenProject/DEV%20LARGE%20COPY%202%20%2853%29 ..."
```
The former format caused issues on NC side on some setups.
The issues are:
1. 200 OK with HTML with "App not installed: " has been received instead
  of expected WebDAV XML response.
2. 200 OK with the following XML:
```
 "<?xml version=\"1.0\"?>\n<ocs>\n <meta>\n  <status>failure</status>\n  <statuscode>996</statuscode>\n  <message>Internal Server Error\n</message>\n </meta>\n <data/>\n</ocs>\n"
 ```