### PR TITLE
Fix default language setting value zh -> zh-CN

### DIFF
--- a/db/migrate/20231002141527_fix_default_language_value_for_chinese_simplified.rb
+++ b/db/migrate/20231002141527_fix_default_language_value_for_chinese_simplified.rb
@@ -1,0 +1,5 @@
+class FixDefaultLanguageValueForChineseSimplified < ActiveRecord::Migration[7.0]
+  def up
+    Setting.where(name: 'default_language', value: 'zh').update_all(value: 'zh-CN')
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/50216
https://community.openproject.org/wp/40500

`db/migrate/20190618115620_fix_available_languages.rb` fixes available languages setting and user languages where zh was used instead of zh-CN.

This migration also fixes the default language setting value.