### PR TITLE
Fix bootstrap on top of custom element, re-enable custom action spec

### DIFF
--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -130,7 +130,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% group_project_ids = @group.projects.ids  %>
           <% filters = [['active', '=', ['t']]] %>
           <% filters << ['id', '!', group_project_ids.map(&:to_s)] if group_project_ids.any? %>
-          <%= angular_component_tag 'op-project-autocompleter',
+          <%= angular_component_tag 'opce-project-autocompleter',
                                     inputs: {
                                       apiFilters: filters,
                                       name: 'membership[project_id]'

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -148,7 +148,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% principal_project_ids = @individual_principal.projects.ids  %>
           <% filter = [['active', '=', 't']] %>
           <% filter << ['id', '!', principal_project_ids.map(&:to_s)] if principal_project_ids.any? %>
-          <%= angular_component_tag 'op-project-autocompleter',
+          <%= angular_component_tag 'opce-project-autocompleter',
                                     inputs: {
                                       apiFilters: filter,
                                       name: 'membership[project_id]'

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -62,7 +62,7 @@ See COPYRIGHT and LICENSE files for more details.
               <div class="form--field">
                 <label class="form--label" for="new_project_id"><%= WorkPackage.human_attribute_name(:project) %>:</label>
                   <div class="form--field-container">
-                    <%= angular_component_tag 'op-project-autocompleter',
+                    <%= angular_component_tag 'opce-project-autocompleter',
                                               inputs: {
                                                 apiFilters: [['user_action', '=', ['work_packages/move']]],
                                                 name: 'new_project_id',

--- a/frontend/src/app/core/setup/global-dynamic-components.const.ts
+++ b/frontend/src/app/core/setup/global-dynamic-components.const.ts
@@ -79,10 +79,6 @@ import {
   OpHeaderProjectSelectComponent,
 } from 'core-app/shared/components/header-project-select/header-project-select.component';
 import {
-  ProjectAutocompleterComponent,
-  projectsAutocompleterSelector,
-} from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component';
-import {
   RemoteFieldUpdaterComponent,
   remoteFieldUpdaterSelector,
 } from 'core-app/shared/components/remote-field-updater/remote-field-updater.component';
@@ -255,7 +251,6 @@ export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: freeTrialButtonSelector, cls: FreeTrialButtonComponent },
   { selector: enterpriseActiveSavedTrialSelector, cls: EEActiveSavedTrialComponent },
   { selector: headerProjectSelectSelector, cls: OpHeaderProjectSelectComponent },
-  { selector: projectsAutocompleterSelector, cls: ProjectAutocompleterComponent },
   { selector: wpOverviewGraphSelector, cls: WorkPackageOverviewGraphComponent },
   { selector: opViewSelectSelector, cls: ViewSelectComponent },
   { selector: opTeamPlannerSidemenuSelector, cls: TeamPlannerSidemenuComponent },

--- a/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
+++ b/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
@@ -1,9 +1,6 @@
 import { Injector, NgModule } from '@angular/core';
 import { NgSelectModule } from '@ng-select/ng-select';
-import {
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DynamicModule } from 'ng-dynamic-component';
 import { CommonModule } from '@angular/common';
 import { DragulaModule } from 'ng2-dragula';
@@ -11,20 +8,46 @@ import { DragulaModule } from 'ng2-dragula';
 import { InviteUserButtonModule } from 'core-app/features/invite-user-modal/button/invite-user-button.module';
 import { OpenprojectPrincipalRenderingModule } from 'core-app/shared/components/principal/principal-rendering.module';
 
-import { DraggableAutocompleteComponent } from 'core-app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component';
+import {
+  DraggableAutocompleteComponent,
+} from 'core-app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component';
 import { ColorsAutocompleterComponent } from 'core-app/shared/components/colors/colors-autocompleter.component';
-import { WorkPackageAutocompleterComponent } from 'core-app/shared/components/autocompleter/work-package-autocompleter/wp-autocompleter.component';
-import { TimeEntryWorkPackageAutocompleterComponent } from 'core-app/shared/components/autocompleter/te-work-package-autocompleter/te-work-package-autocompleter.component';
-import { AutocompleteSelectDecorationComponent } from 'core-app/shared/components/autocompleter/autocomplete-select-decoration/autocomplete-select-decoration.component';
-import { VersionAutocompleterComponent } from 'core-app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component';
-import { UserAutocompleterComponent } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
-import { ProjectAutocompleterComponent } from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component';
-import { OpAutocompleterComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
-import { OpAutocompleterOptionTemplateDirective } from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-option-template.directive';
-import { OpAutocompleterLabelTemplateDirective } from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-label-template.directive';
-import { OpAutocompleterHeaderTemplateDirective } from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-header-template.directive';
-import { CreateAutocompleterComponent } from 'core-app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component';
-import { OpAutocompleterFooterTemplateDirective } from 'core-app/shared/components/autocompleter/autocompleter-footer-template/op-autocompleter-footer-template.directive';
+import {
+  WorkPackageAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/work-package-autocompleter/wp-autocompleter.component';
+import {
+  TimeEntryWorkPackageAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/te-work-package-autocompleter/te-work-package-autocompleter.component';
+import {
+  AutocompleteSelectDecorationComponent,
+} from 'core-app/shared/components/autocompleter/autocomplete-select-decoration/autocomplete-select-decoration.component';
+import {
+  VersionAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component';
+import {
+  UserAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
+import {
+  ProjectAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component';
+import {
+  OpAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
+import {
+  OpAutocompleterOptionTemplateDirective,
+} from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-option-template.directive';
+import {
+  OpAutocompleterLabelTemplateDirective,
+} from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-label-template.directive';
+import {
+  OpAutocompleterHeaderTemplateDirective,
+} from 'core-app/shared/components/autocompleter/op-autocompleter/directives/op-autocompleter-header-template.directive';
+import {
+  CreateAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component';
+import {
+  OpAutocompleterFooterTemplateDirective,
+} from 'core-app/shared/components/autocompleter/autocompleter-footer-template/op-autocompleter-footer-template.directive';
 import { OpSearchHighlightDirective } from 'core-app/shared/directives/search-highlight.directive';
 import { registerCustomElement } from 'core-app/shared/helpers/angular/custom-elements.helper';
 
@@ -64,6 +87,7 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
 export class OpenprojectAutocompleterModule {
   constructor(injector:Injector) {
     registerCustomElement('opce-autocompleter', OpAutocompleterComponent, { injector });
+    registerCustomElement('opce-project-autocompleter', ProjectAutocompleterComponent, { injector });
     registerCustomElement('opce-select-decoration', AutocompleteSelectDecorationComponent, { injector });
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.html
@@ -15,7 +15,7 @@
 
   [appendTo]="appendTo"
 
-  (change)="writeValue($event)"
+  (change)="projectSelected($event)"
   (keydown.escape)="cancel.emit()"
 >
   <ng-template

--- a/modules/boards/app/views/boards/boards/_form.html.erb
+++ b/modules/boards/app/views/boards/boards/_form.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field -required">
       <label class="form--label" for="project_id"><%= Query.human_attribute_name(:project) %>:</label>
       <div class="form--field-container">
-        <%= angular_component_tag 'op-project-autocompleter',
+        <%= angular_component_tag 'opce-project-autocompleter',
                                   inputs: {
                                     apiFilters: [['user_action', '=', ['boards/create']]],
                                     name: 'project_id',

--- a/modules/calendar/app/views/calendar/calendars/_form.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/_form.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="form--field -required">
     <label class="form--label" for="project_id"><%= Query.human_attribute_name(:project) %>:</label>
     <div class="form--field-container">
-      <%= angular_component_tag 'op-project-autocompleter',
+      <%= angular_component_tag 'opce-project-autocompleter',
                                 inputs: {
                                   apiFilters: [['user_action', '=', ['calendars/create']]],
                                   name: 'project_id',

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -85,7 +85,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field -required">
       <label class="form--label" for="project_id"><%= Meeting.human_attribute_name(:project) %>:</label>
       <div class="form--field-container">
-        <%= angular_component_tag 'op-project-autocompleter',
+        <%= angular_component_tag 'opce-project-autocompleter',
                                   inputs: {
                                     apiFilters: [['user_action', '=', ['meetings/create']]],
                                     name: 'project_id',

--- a/modules/reporting/lib/widget/filters/project.rb
+++ b/modules/reporting/lib/widget/filters/project.rb
@@ -35,7 +35,7 @@ class Widget::Filters::Project < Widget::Filters::Base
 
       selected_values = map_filter_values
 
-      box = angular_component_tag 'op-project-autocompleter',
+      box = angular_component_tag 'opce-project-autocompleter',
                                   inputs: {
                                     apiFilters: [],
                                     name: "values[#{filter_class.underscore_name}][]",

--- a/modules/team_planner/app/views/team_planner/team_planner/_form.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/_form.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="form--field -required">
     <label class="form--label" for="project_id"><%= Query.human_attribute_name(:project) %>:</label>
     <div class="form--field-container">
-      <%= angular_component_tag 'op-project-autocompleter',
+      <%= angular_component_tag 'opce-project-autocompleter',
                                 inputs: {
                                   apiFilters: [['user_action', '=', ['team_planners/create']]],
                                   name: 'project_id',

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -147,8 +147,6 @@ RSpec.describe 'Custom actions',
   end
 
   it 'viewing workflow buttons' do
-    skip("The autocompleter for projects is currently broken. See https://community.openproject.org/wp/50281")
-
     # create custom action 'Unassign'
     index_ca_page.visit!
 


### PR DESCRIPTION
The opce-select-decoration is now rendered on page load, which results in the project-autocompleter being incorrectly bootstrapped dynamically and the instance losing all inputs.

The error manifests itself in the field no longer being identifiable by its "Project" label, as the `labelForId` is lost due to the re-bootstrapping.

By ensuring we only use custom elements instead of boostrapping, we can avoid this error. In the short term, I want to remove all embeddable bootstrapped components and turn them into custom elements.

https://community.openproject.org/work_packages/50281