### PR TITLE
[#50295] copying projects with nextcloud project folders does not recreate file links to folders

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
@@ -138,6 +138,8 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
       return '/' if idx == nil
 
       idx += prefix.length - 1
+      # Remove the following when /filesinfo starts responding with a trailing slash for directory paths
+      # in all supported versions of OpenProjectIntegation Nextcloud App.
       file_path << '/' if mimetype == 'application/x-op-directory' && file_path[-1] != '/'
       Util.escape_path(file_path[idx..])
     end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
@@ -116,7 +116,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
                 last_modified_by_name: value.modifier_name,
                 last_modified_by_id: value.modifier_id,
                 permissions: value.dav_permissions,
-                location: location(value.path)
+                location: location(value.path, value.mimetype)
               )
             else
               ::Storages::StorageFileInfo.new(
@@ -132,13 +132,13 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
 
     # rubocop:enable Metrics/AbcSize
 
-    def location(file_path)
+    def location(file_path, mimetype)
       prefix = 'files/'
       idx = file_path.rindex(prefix)
       return '/' if idx == nil
 
       idx += prefix.length - 1
-
+      file_path << '/' if mimetype == 'application/x-op-directory' && file_path[-1] != '/'
       Util.escape_path(file_path[idx..])
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
@@ -31,7 +31,9 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Util
 
   class << self
     def escape_path(path)
-      path.split('/').map { |i| CGI.escapeURIComponent(i) }.join('/')
+      escaped_path = path.split('/').map { |i| CGI.escapeURIComponent(i) }.join('/')
+      escaped_path << '/' if path[-1] == '/'
+      escaped_path
     end
 
     def basic_auth_header(username, password)
@@ -47,12 +49,12 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Util
       )
     end
 
-    def join_uri_path(uri, *parts)
+    def join_uri_path(uri, *)
       # We use `File.join` to ensure single `/` in between every part. This API will break if executed on a
       # Windows context, as it used `\` as file separators. But we anticipate that OpenProject
       # Server is not run on a Windows context.
       # URI::join cannot be used, as it behaves very different for the path parts depending on trailing slashes.
-      File.join(uri.to_s, *parts)
+      File.join(uri.to_s, *)
     end
 
     def token(user:, oauth_client:, &block)

--- a/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
+++ b/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
@@ -118,12 +118,26 @@ module Projects::Copy
         .result
     end
 
+    def remove_trailing_slashes_from_hash_keys(original_hash)
+      # Remove trailing slashes of directory paths.
+      # Nextcloud WebDAV PROPFIND requests for return for forlders location paths with trailing slashes.
+      # The `filesinfo` endpoint of the `OpenProject integration` Nextcloud app does not have those
+      # trailing slashes for folder paths. For matching both types of paths, we need to remove the trailing slashes.
+      clean_hash = {}
+      original_hash.each do |key, value|
+        clean_hash[key.chomp('/')] = value
+      end
+
+      clean_hash
+    end
+
     def folder_files_file_ids_deep_query(storage_requests:, path:)
-      storage_requests
-        .folder_files_file_ids_deep_query
-        .call(path:)
-        .on_failure { |r| add_error!("folder_files_file_ids_deep_query", r.to_active_model_errors) }
-        .result
+      result = storage_requests
+                 .folder_files_file_ids_deep_query
+                 .call(path:)
+                 .on_failure { |r| add_error!("folder_files_file_ids_deep_query", r.to_active_model_errors) }
+                 .result
+      remove_trailing_slashes_from_hash_keys(result)
     end
   end
 end

--- a/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
+++ b/modules/storages/app/services/projects/copy/file_links_dependent_service.rb
@@ -118,26 +118,12 @@ module Projects::Copy
         .result
     end
 
-    def remove_trailing_slashes_from_hash_keys(original_hash)
-      # Remove trailing slashes of directory paths.
-      # Nextcloud WebDAV PROPFIND requests for return for forlders location paths with trailing slashes.
-      # The `filesinfo` endpoint of the `OpenProject integration` Nextcloud app does not have those
-      # trailing slashes for folder paths. For matching both types of paths, we need to remove the trailing slashes.
-      clean_hash = {}
-      original_hash.each do |key, value|
-        clean_hash[key.chomp('/')] = value
-      end
-
-      clean_hash
-    end
-
     def folder_files_file_ids_deep_query(storage_requests:, path:)
-      result = storage_requests
-                 .folder_files_file_ids_deep_query
-                 .call(path:)
-                 .on_failure { |r| add_error!("folder_files_file_ids_deep_query", r.to_active_model_errors) }
-                 .result
-      remove_trailing_slashes_from_hash_keys(result)
+      storage_requests
+        .folder_files_file_ids_deep_query
+        .call(path:)
+        .on_failure { |r| add_error!("folder_files_file_ids_deep_query", r.to_active_model_errors) }
+        .result
     end
   end
 end

--- a/modules/storages/spec/common/peripherals/files_info_query_spec.rb
+++ b/modules/storages/spec/common/peripherals/files_info_query_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesInfoQuery, webmock: true do
+RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesInfoQuery, :webmock do
   using Storages::Peripherals::ServiceResultRefinements
 
   let(:user) { create(:user) }
@@ -134,6 +134,40 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesInfoQu
             on_success: ->(file_infos) do
               expect(file_infos.size).to eq(2)
               expect(file_infos).to all(be_a(Storages::StorageFileInfo))
+              expect(file_infos.map(&:to_h)).to eq(
+                [
+                  { status: "OK",
+                    status_code: 200,
+                    id: 354,
+                    name: "Demo project (1)",
+                    last_modified_at: Time.parse("Wed, 12 Jul 2023 11:43:41.000000000 UTC +00:00"),
+                    created_at: Time.parse("Thu, 01 Jan 1970 00:00:00.000000000 UTC +00:00"),
+                    mime_type: "application/x-op-directory",
+                    size: 989752,
+                    owner_name: "admin",
+                    owner_id: "admin",
+                    trashed: false,
+                    last_modified_by_name: nil,
+                    last_modified_by_id: nil,
+                    permissions: "RMGDNVCK",
+                    location: "/OpenProject/Demo%20project%20%281%29/" },
+                  { status: "OK",
+                    status_code: 200,
+                    id: 355,
+                    name: "minecraft.jpg",
+                    last_modified_at: Time.parse("Wed, 12 Jul 2023 11:43:41.000000000 UTC +00:00"),
+                    created_at: Time.parse("Thu, 01 Jan 1970 00:00:00.000000000 UTC +00:00"),
+                    mime_type: "image/jpeg",
+                    size: 989752,
+                    owner_name: "admin",
+                    owner_id: "admin",
+                    trashed: false,
+                    last_modified_by_name: nil,
+                    last_modified_by_id: nil,
+                    permissions: "RMGDNVW",
+                    location: "/OpenProject/Demo%20project%20%281%29/minecraft.jpg" }
+                ]
+              )
             end,
             on_failure: ->(error) { fail "Expected success, got #{error}" }
           )

--- a/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
+++ b/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Delete ProjectStorage with FileLinks', js: true, webmock: true d
   let(:file_link) { create(:file_link, storage:, container: work_package) }
   let(:second_file_link) { create(:file_link, container: work_package, storage:) }
   let(:delete_folder_url) do
-    "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+    "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}/"
   end
 
   before do

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe(
     stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/user").to_return(status: 200, body: "{}")
     stub_request(
       :delete,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project%20name%20without%20sequence%20(#{project.id})"
+      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project%20name%20without%20sequence%20(#{project.id})/"
     ).to_return(status: 200, body: "", headers: {})
 
     storage

--- a/modules/storages/spec/requests/api/v3/storages/storages_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storages_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe 'API v3 storages resource', content_type: :json, webmock: true do
   describe 'DELETE /api/v3/storages/:storage_id' do
     let(:path) { api_v3_paths.storage(storage.id) }
     let(:delete_folder_url) do
-      "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+      "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}/"
     end
     let(:deletion_request_stub) do
       stub_request(:delete, delete_folder_url).to_return(status: 204, body: nil, headers: {})

--- a/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :mkcol,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
+        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})/"
       ).with(
         headers: {
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
@@ -656,7 +656,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :propfind,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
+        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})/"
       ).with(
         body: propfind_request_body,
         headers: {
@@ -695,7 +695,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
+        "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})/"
       ).with(
         body: set_permissions_request_body2,
         headers: {
@@ -706,19 +706,19 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :move,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "Lost%20Jedi%20Project%20Folder%20%233"
+        "Lost%20Jedi%20Project%20Folder%20%233/"
       ).with(
         headers: {
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=',
           'Destination' => "/remote.php/dav/files/OpenProject/OpenProject/" \
-                           "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29"
+                           "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29/"
         }
       ).to_return(status: 201, body: "", headers: {})
 
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "Lost%20Jedi%20Project%20Folder%20%232"
+        "Lost%20Jedi%20Project%20Folder%20%232/"
       ).with(
         body: set_permissions_request_body3,
         headers: {
@@ -729,7 +729,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29"
+        "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29/"
       ).with(
         body: set_permissions_request_body4,
         headers: {
@@ -740,7 +740,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "NOT%20ACTIVE%20PROJECT"
+        "NOT%20ACTIVE%20PROJECT/"
       ).with(
         body: set_permissions_request_body5,
         headers: {
@@ -751,7 +751,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "PUBLIC%20PROJECT%20%28#{project_public.id}%29"
+        "PUBLIC%20PROJECT%20%28#{project_public.id}%29/"
       ).with(
         body: set_permissions_request_body6,
         headers: {
@@ -762,7 +762,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
       request_stubs << stub_request(
         :proppatch,
         "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
-        "Project3%20%28#{project3.id}%29"
+        "Project3%20%28#{project3.id}%29/"
       ).with(
         body: set_permissions_request_body4,
         headers: {
@@ -790,7 +790,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
 
       request_stubs << stub_request(
         :mkcol,
-        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})"
+        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})/"
       ).with(
         headers: {
           'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg='
@@ -805,7 +805,7 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
 
       request_stubs << stub_request(
         :propfind,
-        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})"
+        "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20(#{project3.id})/"
       ).with(
         headers: { 'Authorization' => 'Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=' },
         body: propfind_request_body

--- a/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Storages::ProjectStorages::DeleteService, type: :model, webmock: 
     let(:file_link) { create(:file_link, container: work_package, storage:) }
     let(:other_file_link) { create(:file_link, container: other_work_package, storage:) }
     let(:delete_folder_url) do
-      "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+      "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}/"
     end
 
     it 'destroys the record' do
@@ -67,7 +67,7 @@ RSpec.describe Storages::ProjectStorages::DeleteService, type: :model, webmock: 
     context 'with Nextcloud storage' do
       let(:storage) { create(:nextcloud_storage) }
       let(:delete_folder_url) do
-        "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+        "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}/"
       end
       let(:delete_folder_stub) do
         stub_request(:delete, delete_folder_url).to_return(status: 204, body: nil, headers: {})

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -235,6 +235,13 @@ RSpec.describe(
                container: source_wp,
                storage: storage1)
       end
+      let!(:folder_inside_automatic_project_folder_link) do
+        create(:file_link,
+               origin_id: "103",
+               origin_name: "This is a folder",
+               container: source_wp,
+               storage: storage1)
+      end
       let!(:file_inside_manual_project_folder_link) do
         create(:file_link,
                origin_id: "102",
@@ -324,6 +331,21 @@ RSpec.describe(
                   <d:status>HTTP/1.1 404 Not Found</d:status>
                 </d:propstat>
               </d:response>
+              <d:response>
+                <d:href>/remote.php/dav/files/OpenProject/OpenProject/Target%20Project%20Name%20(#{project_id})/#{folder_inside_automatic_project_folder_link.origin_name}/</d:href>
+                <d:propstat>
+                  <d:prop>
+                    <oc:fileid>431</oc:fileid>
+                  </d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status>
+                </d:propstat>
+                <d:propstat>
+                  <d:prop>
+                    <nc:acl-list/>
+                  </d:prop>
+                  <d:status>HTTP/1.1 404 Not Found</d:status>
+                </d:propstat>
+              </d:response>
             </d:multistatus>
           XML
           { status: 200, body:, headers: {} }
@@ -373,13 +395,30 @@ RSpec.describe(
                   "modifier_id": null,
                   "dav_permissions": "RMGDNVW",
                   "path": "files\\/OpenProject\\/Source Project Name (#{source.id})\\/#{file_inside_automatic_project_folder_link.origin_name}"
+                },
+                "#{folder_inside_automatic_project_folder_link.origin_id}": {
+                  "status": "OK",
+                  "statuscode": 200,
+                  "id": #{folder_inside_automatic_project_folder_link.origin_id},
+                  "name": "#{folder_inside_automatic_project_folder_link.origin_name}",
+                  "mtime": 1689687111,
+                  "ctime": 0,
+                  "mimetype": "image\\/jpeg",
+                  "size": 94064,
+                  "owner_name": "admin",
+                  "owner_id": "admin",
+                  "trashed": false,
+                  "modifier_name": null,
+                  "modifier_id": null,
+                  "dav_permissions": "RMGDNVW",
+                  "path": "files\\/OpenProject\\/Source Project Name (#{source.id})\\/#{folder_inside_automatic_project_folder_link.origin_name}"
                 }
               }
             }
           }
         JSON
         stub_request(:post, "#{host}/ocs/v1.php/apps/integration_openproject/filesinfo")
-          .with(body: '{"fileIds":["100","101"]}')
+          .with(body: '{"fileIds":["100","101","103"]}')
           .to_return(status: 200, body: filesinfo_response_body, headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -438,10 +477,11 @@ RSpec.describe(
         expect(manual_project_storage_copy.project_folder_mode).to eq('manual')
 
         wp_copy = project_copy.work_packages.where(subject: "source wp").first
-        expect(wp_copy.file_links.count).to eq(3)
+        expect(wp_copy.file_links.count).to eq(4)
         file_outside_project_folder_link_copy = wp_copy.file_links.find_by(origin_name: "file_name1.txt")
         file_inside_automatic_project_folder_link_copy = wp_copy.file_links.find_by(origin_name: "file_name2.txt")
         file_inside_manual_project_folder_link_copy = wp_copy.file_links.find_by(origin_name: "file_name3.txt")
+        folder_inside_automatic_project_folder_link_copy = wp_copy.file_links.find_by(origin_name: "This is a folder")
         expect(file_outside_project_folder_link_copy.id).not_to eq(file_outside_project_folder_link.id)
         expect(file_outside_project_folder_link_copy.origin_id).to eq(file_outside_project_folder_link.origin_id)
         expect(file_outside_project_folder_link_copy.storage_id).to eq(file_outside_project_folder_link.storage_id)
@@ -449,6 +489,10 @@ RSpec.describe(
         expect(file_inside_automatic_project_folder_link_copy.origin_id).to eq("430")
         expect(file_inside_automatic_project_folder_link_copy.storage_id)
           .to eq(file_inside_automatic_project_folder_link.storage_id)
+        expect(folder_inside_automatic_project_folder_link_copy.id).not_to eq(folder_inside_automatic_project_folder_link.id)
+        expect(folder_inside_automatic_project_folder_link_copy.origin_id).to eq("431")
+        expect(folder_inside_automatic_project_folder_link_copy.storage_id)
+          .to eq(folder_inside_automatic_project_folder_link.storage_id)
         expect(file_inside_manual_project_folder_link_copy.id).not_to eq(file_inside_manual_project_folder_link.id)
         expect(file_inside_manual_project_folder_link_copy.origin_id).to eq("102")
         expect(file_inside_manual_project_folder_link_copy.storage_id).to eq(file_inside_manual_project_folder_link.storage_id)

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -30,9 +30,8 @@ require 'spec_helper'
 
 RSpec.describe(
   Projects::CopyService,
-  'integration',
+  'integration', :webmock,
   type: :model,
-  webmock: true,
   with_ee: %i[readonly_work_packages]
 ) do
   shared_let(:status_locked) { create(:status, is_readonly: true) }
@@ -403,14 +402,14 @@ RSpec.describe(
                   "name": "#{folder_inside_automatic_project_folder_link.origin_name}",
                   "mtime": 1689687111,
                   "ctime": 0,
-                  "mimetype": "image\\/jpeg",
-                  "size": 94064,
+                  "mimetype": "application\\/x-op-directory",
+                  "size": 0,
                   "owner_name": "admin",
                   "owner_id": "admin",
                   "trashed": false,
                   "modifier_name": null,
                   "modifier_id": null,
-                  "dav_permissions": "RMGDNVW",
+                  "dav_permissions": "RMGDNVCK",
                   "path": "files\\/OpenProject\\/Source Project Name (#{source.id})\\/#{folder_inside_automatic_project_folder_link.origin_name}"
                 }
               }

--- a/spec/services/projects/delete_service_spec.rb
+++ b/spec/services/projects/delete_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Projects::DeleteService, type: :model do
           work_package = create(:work_package, project:)
           create(:file_link, container: work_package, storage:)
           delete_folder_url =
-            "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}"
+            "#{storage.host}/remote.php/dav/files/#{storage.username}/#{project_storage.project_folder_path.chop}/"
 
           stub_request(:delete, delete_folder_url).to_return(status: 204, body: nil, headers: {})
 


### PR DESCRIPTION
https://community.openproject.org/wp/50295

The filesinfo endpoint returns folder location paths without trailing slashes, but the WebDAV PROPFIND does. Thus, the paths are not directly mappable. This leads to a situation where one cannot be mapped on the other.
