### PR TITLE
Fix: `@component_wrapper_used` should be set on component and not target

### DIFF
--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -28,6 +28,10 @@
 
 module OpTurbo
   module Streamable
+    # rubocop:disable OpenProject/AddPreviewForViewComponent
+    class MissingComponentWrapper < StandardError; end
+    # rubocop:enable OpenProject/AddPreviewForViewComponent
+
     extend ActiveSupport::Concern
 
     class_methods do
@@ -49,11 +53,12 @@ module OpTurbo
           render_in(view_context)
           template = nil
         else
-          raise "Unsupported action #{action}"
+          raise ArgumentError, "Unsupported action #{action}"
         end
 
         unless wrapped?
-          raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
+          raise MissingComponentWrapper,
+                "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
         end
 
         OpTurbo::StreamWrapperComponent.new(
@@ -70,7 +75,8 @@ module OpTurbo
         # needs wrapping, not the target since it isn't the one
         # that needs to be rendered to perform this turbo stream action.
         unless component.wrapped?
-          raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
+          raise MissingComponentWrapper,
+                "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
         end
 
         OpTurbo::StreamWrapperComponent.new(
@@ -125,7 +131,8 @@ module OpTurbo
 
       def insert_target_container(tag: "div", class: nil, data: nil, style: nil, &block)
         unless insert_target_modified?
-          raise "`insert_target_modified?` needs to be implemented and return true if `insert_target_container` is " \
+          raise NotImplementedError,
+                "#insert_target_modified? needs to be implemented and return true if #insert_target_container is " \
                 "used in this component"
         end
 

--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -52,7 +52,7 @@ module OpTurbo
           raise "Unsupported action #{action}"
         end
 
-        unless @component_wrapper_used
+        unless wrapped?
           raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
         end
 
@@ -66,7 +66,7 @@ module OpTurbo
       def insert_as_turbo_stream(component:, view_context:, action: :append)
         template = component.render_in(view_context)
 
-        unless component.instance_variable_get(:@component_wrapper_used)
+        unless component.wrapped?
           raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
         end
 
@@ -78,7 +78,8 @@ module OpTurbo
       end
 
       def component_wrapper(tag: "div", class: nil, data: nil, style: nil, &block)
-        @component_wrapper_used = true
+        @wrapped = true
+
         if inner_html_only?
           capture(&block)
         elsif wrapper_only?
@@ -86,6 +87,10 @@ module OpTurbo
         else
           content_tag(tag, id: wrapper_key, class:, data:, style:, &block)
         end
+      end
+
+      def wrapped?
+        !!@wrapped
       end
 
       def inner_html_only?

--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -66,6 +66,9 @@ module OpTurbo
       def insert_as_turbo_stream(component:, view_context:, action: :append)
         template = component.render_in(view_context)
 
+        # The component being inserted into the target component
+        # needs wrapping, not the target since it isn't the one
+        # that needs to be rendered to perform this turbo stream action.
         unless component.wrapped?
           raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
         end

--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -66,7 +66,7 @@ module OpTurbo
       def insert_as_turbo_stream(component:, view_context:, action: :append)
         template = component.render_in(view_context)
 
-        unless @component_wrapper_used
+        unless component.instance_variable_get(:@component_wrapper_used)
           raise "You need to wrap your component in a `component_wrapper` block in order to use the turbo-stream methods"
         end
 


### PR DESCRIPTION
The purpose of `@component_wrapper_used` in this scenario is to check if the component that is to be inserted into the target has used a `component_wrapper` in its template rendering.

This PR both:
* Fixes the issue where this will always raise an error as the target component is not being rendered (and doesn't need to be).

* Ensures that there is a unique ID set at the top-most level of the turbo stream response and turbo can de-duplicate any existing components that match the current ID of the component before appending/prepending.