### PR TITLE
remove entity members from global roles query

### DIFF
--- a/app/services/authorization/user_global_roles_query.rb
+++ b/app/services/authorization/user_global_roles_query.rb
@@ -44,4 +44,10 @@ class Authorization::UserGlobalRolesQuery < Authorization::UserRolesQuery
     statement.group(roles_table[:id])
              .where(users_table[:id].eq(user.id))
   end
+
+  transformations.register users_members_join, :entity_restriction do |statement, _|
+    statement
+      .and(members_table[:entity_type].eq(nil))
+      .and(members_table[:entity_id].eq(nil))
+  end
 end

--- a/app/services/authorization/user_roles_query.rb
+++ b/app/services/authorization/user_roles_query.rb
@@ -30,8 +30,8 @@ class Authorization::UserRolesQuery < Authorization::AbstractUserQuery
   self.model = Role
   self.base_table = users_table
 
-  def self.query(*args)
-    arel = transformed_query(*args)
+  def self.query(*)
+    arel = transformed_query(*)
 
     model.where(roles_table[:id].in(arel))
   end

--- a/spec/services/authorization/user_global_roles_query_spec.rb
+++ b/spec/services/authorization/user_global_roles_query_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         global_member.save!
       end
 
-      it 'is the global role and non member role' do
+      it 'is the global role, member role and non member role' do
         expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
       end
     end
@@ -137,7 +137,7 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         work_package_member.save!
       end
 
-      it 'is the global role and non member role' do
+      it 'is the global role, member role and non member role' do
         expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
       end
     end

--- a/spec/services/authorization/user_global_roles_query_spec.rb
+++ b/spec/services/authorization/user_global_roles_query_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
                    roles: [role2],
                    principal: user)
   end
-  let(:global_permission) { OpenProject::AccessControl.permissions.find { |p| p.global? } }
+  let(:global_permission) { OpenProject::AccessControl.permissions.find(&:global?) }
   let(:global_role) do
     build(:global_role,
           permissions: [global_permission.name])
@@ -57,6 +57,12 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
     build(:global_member,
           principal: user,
           roles: [global_role])
+  end
+  let(:work_package_permission) { [:edit_work_packages] }
+  let(:work_package_editor_role) { create(:work_package_role, permissions: work_package_permission) }
+  let(:work_package) { create(:work_package, project:) }
+  let(:work_package_member) do
+    build(:member, entity: work_package, project: work_package.project, roles: [work_package_editor_role], principal: user)
   end
 
   describe '.query' do
@@ -70,57 +76,69 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
       expect(described_class.query(user, project)).to be_a ActiveRecord::Relation
     end
 
-    context 'w/ the user being a member in a project' do
+    context 'with the user being a member in a project' do
       before do
         member.save!
       end
 
       it 'is the member and non member role' do
-        expect(described_class.query(user)).to match_array [role, non_member]
+        expect(described_class.query(user)).to contain_exactly(role, non_member)
       end
     end
 
-    context 'w/ the user being a member in two projects' do
+    context 'with the user being a member in two projects' do
       before do
         member.save!
         member2.save!
       end
 
       it 'is both member and the non member role' do
-        expect(described_class.query(user)).to match_array [role, role2, non_member]
+        expect(described_class.query(user)).to contain_exactly(role, role2, non_member)
       end
     end
 
-    context 'w/o the user being a member in a project' do
+    context 'without the user being a member in a project' do
       it 'is the non member role' do
-        expect(described_class.query(user)).to match_array [non_member]
+        expect(described_class.query(user)).to contain_exactly(non_member)
       end
     end
 
-    context 'w/ the user being anonymous' do
+    context 'with the user being anonymous' do
       it 'is the anonymous role' do
-        expect(described_class.query(anonymous)).to match_array [anonymous_role]
+        expect(described_class.query(anonymous)).to contain_exactly(anonymous_role)
       end
     end
 
-    context 'w/ the user having a global role' do
+    context 'with the user having a global role' do
       before do
         global_member.save!
       end
 
       it 'is the global role and non member role' do
-        expect(described_class.query(user)).to match_array [global_role, non_member]
+        expect(described_class.query(user)).to contain_exactly(global_role, non_member)
       end
     end
 
-    context 'w/ the user having a global role and a member role' do
+    context 'with the user having a global role and a member role' do
       before do
         member.save!
         global_member.save!
       end
 
       it 'is the global role and non member role' do
-        expect(described_class.query(user)).to match_array [global_role, role, non_member]
+        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
+      end
+    end
+
+    context 'with the user having a global role, a member role and a work package role' do
+      before do
+        member.save!
+        global_member.save!
+        work_package_member.save!
+      end
+
+      it 'is the global role and non member role' do
+        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
       end
     end
   end


### PR DESCRIPTION
Avoids returning members on entities (e.g. WorkPackage) on the `Authorization::UserGlobalRolesQuery`, so when `Authorization.roles(some_user)` is called.

To reproduce, first create such a member:
```Member.create(entity: WorkPackage.first, project: WorkPackage.first.project, roles: [WorkPackageRole.first], principal: User.active.first)```

Then fetch the global roles for the user:
`Authorization.roles(User.active.first)`

https://community.openproject.org/wp/50287