### PR TITLE
[#50235] Granularly update Share Modal's components on CRUD actions

### DIFF
--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -86,15 +86,17 @@ module OpTurbo
         ).render_in(view_context)
       end
 
-      def component_wrapper(tag: "div", class: nil, data: nil, style: nil, &block)
+      def component_wrapper(method = nil, tag: "div", class: nil, data: nil, style: nil, &block)
         @wrapped = true
+
+        wrapper_arguments = { id: wrapper_key, class:, data:, style: }
 
         if inner_html_only?
           capture(&block)
         elsif wrapper_only?
-          content_tag(tag, id: wrapper_key, class:, data:, style:)
+          method ? send(method, wrapper_arguments) : content_tag(tag, wrapper_arguments)
         else
-          content_tag(tag, id: wrapper_key, class:, data:, style:, &block)
+          method ? send(method, wrapper_arguments, &block) : content_tag(tag, wrapper_arguments, &block)
         end
       end
 

--- a/app/components/work_packages/share/concerns/authorization.rb
+++ b/app/components/work_packages/share/concerns/authorization.rb
@@ -30,44 +30,15 @@
 
 module WorkPackages
   module Share
-    class ShareRowComponent < ApplicationComponent
-      include ApplicationHelper
-      include OpTurbo::Streamable
-      include OpPrimer::ComponentHelpers
-      include WorkPackages::Share::Concerns::Authorization
+    module Concerns
+      module Authorization
+        extend ActiveSupport::Concern
 
-      def initialize(share:,
-                     container: nil)
-        super
-
-        @share = share
-        @work_package = share.entity
-        @user = share.principal
-        @container = container
-      end
-
-      def wrapper_uniq_by
-        share.id
-      end
-
-      def border_box_row(wrapper_arguments, &)
-        if container
-          container.with_row(**wrapper_arguments, &)
-        else
-          container = Primer::Beta::BorderBox.new
-          row = container.registered_slots[:rows][:renderable_function]
-                         .bind_call(container, **wrapper_arguments)
-
-          render(row, &)
+        included do
+          def sharing_manageable?
+            User.current.allowed_to?(:share_work_packages, @work_package.project)
+          end
         end
-      end
-
-      private
-
-      attr_reader :share, :work_package, :user, :container
-
-      def share_editable?
-        @share_editable ||= User.current != share.principal && sharing_manageable?
       end
     end
   end

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -1,22 +1,28 @@
 <%=
-  primer_form_with(
-    model: new_share,
-    url: work_package_shares_path(@work_package)
-  ) do |form|
-    flex_layout do |new_user_row|
-      new_user_row.with_column(flex: :auto, mr: 2) do
-        render(WorkPackages::Share::Invitee.new(form))
-      end
+  component_wrapper do
+    if sharing_manageable?
+      primer_form_with(
+        model: new_share,
+        url: work_package_shares_path(@work_package)
+      ) do |form|
+        flex_layout do |new_user_row|
+          new_user_row.with_column(flex: :auto, mr: 2) do
+            render(WorkPackages::Share::Invitee.new(form))
+          end
 
-      new_user_row.with_column(mr: 2) do
-        render(WorkPackages::Share::PermissionButtonComponent.new(share: new_share,
-                                                                  form_arguments: { builder: form, name: "role_id" },
-                                                                  data: { 'test-selector': 'op-share-wp-invite-role' }))
-      end
+          new_user_row.with_column(mr: 2) do
+            render(WorkPackages::Share::PermissionButtonComponent.new(share: new_share,
+                                                                      form_arguments: { builder: form, name: "role_id" },
+                                                                      data: { 'test-selector': 'op-share-wp-invite-role' }))
+          end
 
-      new_user_row.with_column do
-        render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { I18n.t('work_package.sharing.invite') }
+          new_user_row.with_column do
+            render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { I18n.t('work_package.sharing.invite') }
+          end
+        end
       end
+    else
+      render(Primer::Beta::Flash.new(icon: :info)) { I18n.t('work_package.sharing.permissions.denied') }
     end
   end
 %>

--- a/app/components/work_packages/share/invite_user_form_component.rb
+++ b/app/components/work_packages/share/invite_user_form_component.rb
@@ -32,6 +32,7 @@ module WorkPackages
       include ApplicationHelper
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
+      include WorkPackages::Share::Concerns::Authorization
 
       def initialize(work_package:)
         super

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -9,15 +9,16 @@
         end
       end
 
-      if shared_users.empty?
-        modal_content.with_row(mt: 3) do
-          render(Primer::Beta::Blankslate.new(border: true)) do |component|
-            component.with_visual_icon(icon: :people, size: :medium)
-            component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
-            component.with_description do
-              flex_layout do |flex|
-                flex.with_row(mb: 2) do
-                  render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
+        if shared_users.none?
+          modal_content.with_row(mt: 3) do
+            render(Primer::Beta::Blankslate.new(border: true)) do |component|
+              component.with_visual_icon(icon: :people, size: :medium)
+              component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
+              component.with_description do
+                flex_layout do |flex|
+                  flex.with_row(mb: 2) do
+                    render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
+                  end
                 end
               end
             end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -9,16 +9,15 @@
         end
       end
 
-        if shared_users.none?
-          modal_content.with_row(mt: 3) do
-            render(Primer::Beta::Blankslate.new(border: true)) do |component|
-              component.with_visual_icon(icon: :people, size: :medium)
-              component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
-              component.with_description do
-                flex_layout do |flex|
-                  flex.with_row(mb: 2) do
-                    render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
-                  end
+      if shared_users.none?
+        modal_content.with_row(mt: 3) do
+          render(Primer::Beta::Blankslate.new(border: true)) do |component|
+            component.with_visual_icon(icon: :people, size: :medium)
+            component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
+            component.with_description do
+              flex_layout do |flex|
+                flex.with_row(mb: 2) do
+                  render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
                 end
               end
             end
@@ -34,28 +33,10 @@
             shared_users.each do |user|
               share = user.work_package_shares.where(entity: @work_package).first
 
-              invited_user_list.with_row(data: { 'test-selector': "op-share-wp-active-user-#{user.id}" }) do
-                grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
-                  user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
-                    render(Users::AvatarComponent.new(user: user, size: :medium))
-                  end
-
-                  if share_editable?(share)
-                    user_row_grid.with_area(:button, tag: :div, color: :subtle) do
-                      render(WorkPackages::Share::PermissionButtonComponent.new(share:,
-                                                                                data: { 'test-selector': 'op-share-wp-update-role' }))
-                    end
-                  end
-
-                  if share_editable?(share)
-                    user_row_grid.with_area(:remove, tag: :div) do
-                      form_with url: work_packages_share_path(share), method: :delete do
-                        render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
-                      end
-                    end
-                  end
-                end
-              end
+              render(WorkPackages::Share::ShareRowComponent.new(user:,
+                                                                share:,
+                                                                container: invited_user_list,
+                                                                render_controls: share_editable?(share)))
             end
           end
         end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -25,18 +25,16 @@
         end
       else
         modal_content.with_row(mt: 3, data: { 'test-selector': 'op-share-wp-active-list'}) do
-          render(Primer::Beta::BorderBox.new) do |invited_user_list|
-            invited_user_list.with_header(color: :subtle, data: { 'test-selector': 'op-share-wp-active-count' }) do
+          invited_user_list do |border_box|
+            border_box.with_header(color: :subtle, data: { 'test-selector': 'op-share-wp-active-count' }) do
               render(WorkPackages::Share::ShareCounterComponent.new(count: shared_users.count))
             end
 
             shared_users.each do |user|
               share = user.work_package_shares.where(entity: @work_package).first
 
-              render(WorkPackages::Share::ShareRowComponent.new(user:,
-                                                                share:,
-                                                                container: invited_user_list,
-                                                                render_controls: share_editable?(share)))
+              render(WorkPackages::Share::ShareRowComponent.new(share:,
+                                                                container: border_box))
             end
           end
         end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -27,7 +27,7 @@
         modal_content.with_row(mt: 3, data: { 'test-selector': 'op-share-wp-active-list'}) do
           render(Primer::Beta::BorderBox.new) do |invited_user_list|
             invited_user_list.with_header(color: :subtle, data: { 'test-selector': 'op-share-wp-active-count' }) do
-              I18n.t('work_package.sharing.count', count: shared_users.count)
+              render(WorkPackages::Share::ShareCounterComponent.new(count: shared_users.count))
             end
 
             shared_users.each do |user|

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -2,11 +2,7 @@
   component_wrapper(tag: 'turbo-frame') do
     flex_layout(data: { turbo: true }) do |modal_content|
       modal_content.with_row do
-        if sharing_manageable?
-          render(WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package))
-        else
-          render(Primer::Beta::Flash.new(icon: :info)) { I18n.t('work_package.sharing.permissions.denied') }
-        end
+        render(WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package))
       end
 
       if shared_users.none?

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -38,7 +38,6 @@ module WorkPackages
         super
 
         @work_package = work_package
-        @shared_users = find_shared_users
       end
 
       def self.wrapper_key
@@ -46,8 +45,6 @@ module WorkPackages
       end
 
       private
-
-      attr_reader :shared_users
 
       def insert_target_modified?
         true
@@ -76,8 +73,8 @@ module WorkPackages
         list_container.instance_variable_set(:@list_arguments, new_list_arguments)
       end
 
-      def find_shared_users
-        @shared_users = User
+      def shared_users
+        @shared_users ||= User
                           .having_entity_membership(@work_package)
                           .includes(work_package_shares: :roles)
                           .where(work_package_shares: { entity: @work_package })

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -53,6 +53,10 @@ module WorkPackages
         true
       end
 
+      def insert_target_modifier_id
+        'op-share-wp-active-shares'
+      end
+
       # There is currently no available system argument for setting an id on the
       # rendered <ul> tag that houses the row slots on Primer::Beta::BorderBox components.
       def invited_user_list(&)

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -75,7 +75,7 @@ module WorkPackages
                           .having_entity_membership(@work_package)
                           .includes(work_package_shares: :roles)
                           .where(work_package_shares: { entity: @work_package })
-                          .order('work_package_shares.created_at DESC')
+                          .ordered_by_name
       end
     end
   end

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -59,6 +59,8 @@ module WorkPackages
 
       # There is currently no available system argument for setting an id on the
       # rendered <ul> tag that houses the row slots on Primer::Beta::BorderBox components.
+      # Setting an id is required to be able to uniquely identify a target for
+      # TurboStream +insert+ actions and being able to prepend and append to it.
       def invited_user_list(&)
         border_box = Primer::Beta::BorderBox.new
 

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -32,6 +32,7 @@ module WorkPackages
       include ApplicationHelper
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
+      include WorkPackages::Share::Concerns::Authorization
 
       def initialize(work_package:)
         super
@@ -75,10 +76,6 @@ module WorkPackages
                           .includes(work_package_shares: :roles)
                           .where(work_package_shares: { entity: @work_package })
                           .order('work_package_shares.created_at DESC')
-      end
-
-      def sharing_manageable?
-        User.current.allowed_to?(:share_work_packages, @work_package.project)
       end
     end
   end

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -32,7 +32,6 @@ module WorkPackages
       include ApplicationHelper
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
-      include WorkPackages::Share::Concerns::Authorization
 
       def initialize(work_package:)
         super

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -33,10 +33,11 @@ module WorkPackages
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      def initialize(work_package:)
+      def initialize(work_package:, shared_users: nil)
         super
 
         @work_package = work_package
+        @shared_users = shared_users || find_shared_users
       end
 
       def self.wrapper_key
@@ -45,12 +46,14 @@ module WorkPackages
 
       private
 
-      def shared_users
-        @shared_users ||= User
-                            .having_entity_membership(@work_package)
-                            .includes(work_package_shares: :roles)
-                            .where(work_package_shares: { entity: @work_package })
-                            .order('work_package_shares.created_at DESC')
+      attr_reader :shared_users
+
+      def find_shared_users
+        User
+          .having_entity_membership(@work_package)
+          .includes(work_package_shares: :roles)
+          .where(work_package_shares: { entity: @work_package })
+          .order('work_package_shares.created_at DESC')
       end
 
       def sharing_manageable?

--- a/app/components/work_packages/share/share_counter_component.html.erb
+++ b/app/components/work_packages/share/share_counter_component.html.erb
@@ -1,0 +1,5 @@
+<%=
+  component_wrapper do
+    I18n.t('work_package.sharing.count', count:)
+  end
+%>

--- a/app/components/work_packages/share/share_counter_component.rb
+++ b/app/components/work_packages/share/share_counter_component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages
+  module Share
+    class ShareCounterComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpTurbo::Streamable
+
+      def initialize(count:)
+        super
+
+        @count = count
+      end
+
+      private
+
+      attr_reader :count
+    end
+  end
+end

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -1,21 +1,20 @@
 <%=
-  component_wrapper do
-    border_box_row do
-      grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
-        user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
-          render(Users::AvatarComponent.new(user: user, size: :medium))
+  component_wrapper(:border_box_row, data: { 'test-selector': "op-share-wp-active-user-#{user.id}" }) do
+    grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
+      user_row_grid.with_area(:user, tag: :div, classes: '  ellipsis') do
+        render(Users::AvatarComponent.new(user: user, size: :medium))
+      end
+
+
+      if share_editable?
+        user_row_grid.with_area(:button, tag: :div, color: :subtle) do
+          render(WorkPackages::Share::PermissionButtonComponent.new(share:,
+                                                                    data: { 'test-selector': 'op-share-wp-update-role' }))
         end
 
-        if share_editable?
-          user_row_grid.with_area(:button, tag: :div, color: :subtle) do
-            render(WorkPackages::Share::PermissionButtonComponent.new(share:,
-                                                                      data: { 'test-selector': 'op-share-wp-update-role' }))
-          end
-
-          user_row_grid.with_area(:remove, tag: :div) do
-            form_with url: work_packages_share_path(share), method: :delete do
-              render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
-            end
+        user_row_grid.with_area(:remove, tag: :div) do
+          form_with url: work_packages_share_path(share), method: :delete do
+            render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
           end
         end
       end

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -1,0 +1,24 @@
+<%=
+  component_wrapper do
+    container.with_row(id: wrapper_key, data: { 'test-selector': "op-share-wp-active-user-#{user.id}" }) do
+      grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
+        user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
+          render(Users::AvatarComponent.new(user: user, size: :medium))
+        end
+
+        if render_controls?
+          user_row_grid.with_area(:button, tag: :div, color: :subtle) do
+            render(WorkPackages::Share::PermissionButtonComponent.new(share:,
+                                                                      data: { 'test-selector': 'op-share-wp-update-role' }))
+          end
+
+          user_row_grid.with_area(:remove, tag: :div) do
+            form_with url: work_packages_share_path(share), method: :delete do
+              render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -1,12 +1,12 @@
 <%=
   component_wrapper do
-    container.with_row(id: wrapper_key, data: { 'test-selector': "op-share-wp-active-user-#{user.id}" }) do
+    border_box_row do
       grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
         user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
           render(Users::AvatarComponent.new(user: user, size: :medium))
         end
 
-        if render_controls?
+        if share_editable?
           user_row_grid.with_area(:button, tag: :div, color: :subtle) do
             render(WorkPackages::Share::PermissionButtonComponent.new(share:,
                                                                       data: { 'test-selector': 'op-share-wp-update-role' }))

--- a/app/components/work_packages/share/share_row_component.rb
+++ b/app/components/work_packages/share/share_row_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages
+  module Share
+    class ShareRowComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpTurbo::Streamable
+      include OpPrimer::ComponentHelpers
+
+      def initialize(share:,
+                     user: share.principal,
+                     render_controls: false,
+                     container: nil)
+        super
+
+        @share = share
+        @user = user
+        @render_controls = render_controls
+        @container = container
+      end
+
+      def wrapper_uniq_by
+        share.id
+      end
+
+      private
+
+      attr_reader :user, :share, :container
+
+      def render_controls?
+        !!@render_controls
+      end
+    end
+  end
+end

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -53,7 +53,7 @@ class WorkPackages::SharesController < ApplicationController
       .new(user: current_user, model: @share)
       .call(role_ids: find_role_ids(params[:role_ids]))
 
-    respond_with_update_modal
+    head :no_content
   end
 
   def destroy

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -84,13 +84,17 @@ class WorkPackages::SharesController < ApplicationController
   end
 
   def respond_with_prepend_share
-    prepend_via_turbo_stream(
-      component: WorkPackages::Share::ShareRowComponent.new(share: @share),
-      target_component: WorkPackages::Share::ModalBodyComponent.new(work_package: @work_package)
+    replace_via_turbo_stream(
+      component: WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package)
     )
 
     update_via_turbo_stream(
       component: WorkPackages::Share::ShareCounterComponent.new(count: current_member_count)
+    )
+
+    prepend_via_turbo_stream(
+      component: WorkPackages::Share::ShareRowComponent.new(share: @share),
+      target_component: WorkPackages::Share::ModalBodyComponent.new(work_package: @work_package)
     )
 
     respond_with_turbo_streams

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -134,6 +134,6 @@ class WorkPackages::SharesController < ApplicationController
                       .having_entity_membership(@work_package)
                       .includes(work_package_shares: :roles)
                       .where(work_package_shares: { entity: @work_package })
-                      .order('work_package_shares.created_at DESC')
+                      .ordered_by_name
   end
 end

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Work package sharing',
   let!(:shared_project_user) { create(:user, firstname: 'Shared Project', lastname: 'User') }
   let!(:not_shared_yet_with_user) { create(:user, firstname: 'Not shared Yet', lastname: 'User') }
 
-  current_user { create(:user) }
+  current_user { create(:user, firstname: 'Signed in', lastname: 'User') }
 
   context 'when having share permission' do
     it 'allows seeing and administrating sharing' do
@@ -83,36 +83,32 @@ RSpec.describe 'Work package sharing',
       click_button 'Share'
 
       share_modal.expect_open
-      share_modal.expect_shared_with(view_user, 'View')
-      share_modal.expect_shared_with(comment_user, 'Comment')
-      share_modal.expect_shared_with(edit_user, 'Edit')
-      share_modal.expect_shared_with(shared_project_user, 'Edit')
+      share_modal.expect_shared_with(comment_user, 'Comment', position: 1)
+      share_modal.expect_shared_with(edit_user, 'Edit', position: 2)
+      share_modal.expect_shared_with(shared_project_user, 'Edit', position: 3)
       # The current users share is also displayed but not editable
-      share_modal.expect_shared_with(current_user, editable: false)
+      share_modal.expect_shared_with(current_user, position: 4, editable: false)
+      share_modal.expect_shared_with(view_user, 'View', position: 5)
 
       share_modal.expect_not_shared_with(non_shared_project_user)
       share_modal.expect_not_shared_with(not_shared_yet_with_user)
 
       share_modal.expect_shared_count_of(5)
 
-      # Inviting a user will lead to that user being listed together with the rest of the shared with users.
+      # Inviting a user will lead to that user being prepended to the list together with the rest of the shared with users.
       share_modal.invite_user(not_shared_yet_with_user, 'View')
 
-      share_modal.expect_shared_with(not_shared_yet_with_user, 'View')
-
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'View', position: 1)
       share_modal.expect_shared_count_of(6)
 
       # Removing a share will lead to that user being removed from the list of shared with users.
       share_modal.remove_user(edit_user)
-
       share_modal.expect_not_shared_with(edit_user)
-
       share_modal.expect_shared_count_of(5)
 
       # Adding a user multiple times will lead to the user's role being updated.
       share_modal.invite_user(not_shared_yet_with_user, 'Edit')
-
-      share_modal.expect_shared_with(not_shared_yet_with_user, 'Edit')
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'Edit', position: 1)
 
       # Sent out email only on first share and not again when updating.
       perform_enqueued_jobs
@@ -120,8 +116,7 @@ RSpec.describe 'Work package sharing',
 
       # Updating the share
       share_modal.change_role(not_shared_yet_with_user, 'Comment')
-
-      share_modal.expect_shared_with(not_shared_yet_with_user, 'Comment')
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'Comment', position: 1)
 
       # Sent out email only on first share and not again when updating so the
       # count should still be 1.
@@ -134,15 +129,15 @@ RSpec.describe 'Work package sharing',
       click_button 'Share'
 
       # These users were not changed
-      share_modal.expect_shared_with(view_user, 'View')
-      share_modal.expect_shared_with(comment_user, 'Comment')
-      share_modal.expect_shared_with(shared_project_user, 'Edit')
-      share_modal.expect_shared_with(current_user, editable: false)
+      share_modal.expect_shared_with(comment_user, 'Comment', position: 1)
       # This user's role was updated
-      share_modal.expect_shared_with(not_shared_yet_with_user, 'Comment')
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'Comment', position: 2)
+      share_modal.expect_shared_with(shared_project_user, 'Edit', position: 3)
+      share_modal.expect_shared_with(current_user, position: 4, editable: false)
+      share_modal.expect_shared_with(view_user, 'View', position: 5)
+
       # This user's share was revoked
       share_modal.expect_not_shared_with(edit_user)
-
       # This user has never been added
       share_modal.expect_not_shared_with(non_shared_project_user)
 

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -82,10 +82,18 @@ module Components
         modal_element.send_keys(:escape)
       end
 
-      def expect_shared_with(user, role_name = nil, editable: true)
-        within active_list do
+      def expect_shared_with(user, role_name = nil, position: nil, editable: true)
+        within shares_list do
           expect(page)
             .to have_text(user.name)
+        end
+
+        if position
+          within shares_list do
+            expect(page)
+              .to have_selector("li:nth-child(#{position})", text: user.name),
+                  "Expected #{user.name} to be ##{position} on the shares list."
+          end
         end
 
         if role_name
@@ -104,7 +112,7 @@ module Components
       end
 
       def expect_not_shared_with(user)
-        within active_list do
+        within shares_list do
           expect(page)
             .not_to have_text(user.name)
         end
@@ -130,6 +138,10 @@ module Components
       def active_list
         modal_element
           .find('[data-test-selector="op-share-wp-active-list"]')
+      end
+
+      def shares_list
+        active_list.find_by_id('op-share-wp-active-shares')
       end
     end
   end


### PR DESCRIPTION
## Description
Instead of re-rendering the whole modal on every CRUD action, we can perform more granular turbo stream responses:
### Create
1. New shares are prepended to the list, while preserving the alphabetical order of all initially rendered shares.
2. Updating a share via the invite form, removes the original share on the list and prepends the updated share to the the list.
![Kapture 2023-10-05 at 10 37 34](https://github.com/opf/openproject/assets/61627014/1f78bf49-7e0b-475d-81f1-4d753030e98a)

### Update
1. Ability to respond with a `head :ok`, meaning no re-rendering is needed.
2. Tab indexes are preserved (big on accessibility)
![Kapture 2023-10-05 at 10 44 47](https://github.com/opf/openproject/assets/61627014/017a66d5-f223-48d4-9870-5d4af3b4efb8)

### Destroy
1. Performs a `:remove` turbo stream action on the removed share
2. Preserves tab index (big on accessibility again)
![Kapture 2023-10-05 at 10 47 14](https://github.com/opf/openproject/assets/61627014/8dbdb116-c30e-41f4-9ee8-da383b44c3f1)

## Notes
### Noteworthy commits
https://github.com/opf/openproject/pull/13845/commits/ecc7d4d360475f9cfb63c7ecfe85572ad94bab8e: When performing a turbo stream response for a View Component slot, we need a way to specify the `with_*` call or whatever slot invocation mechanism is used as the `component_wrapper` and not only be able to provide a tag name as it stood before this PR (e.g. plain `div` with the wrapper key as its ID and some attributes).

This commit extends `component_wrapper` which can optionally take a method name as a symbol, which should render the custom component_wrapper you would like (e.g. a view component slot call to `box.with_row`) and adds the `wrapper_key` as its `id`.
### Work Package
https://community.openproject.org/work_packages/50235

### TODO
When https://github.com/opf/openproject/pull/13843 is merged this should be ready to review, as this commit is based off that PR and not based on dev