### PR TITLE
Implementation/50263 prevent users from administrating their own share

### DIFF
--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -2,7 +2,7 @@
   component_wrapper(tag: 'turbo-frame') do
     flex_layout(data: { turbo: true }) do |modal_content|
       modal_content.with_row do
-        if sharing_enabled?
+        if sharing_manageable?
           render(WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package))
         else
           render(Primer::Beta::Flash.new(icon: :info)) { I18n.t('work_package.sharing.permissions.denied') }
@@ -39,14 +39,14 @@
                     render(Users::AvatarComponent.new(user: user, size: :medium))
                   end
 
-                  if sharing_enabled?
+                  if share_editable?(share)
                     user_row_grid.with_area(:button, tag: :div, color: :subtle) do
                       render(WorkPackages::Share::PermissionButtonComponent.new(share:,
                                                                                 data: { 'test-selector': 'op-share-wp-update-role' }))
                     end
                   end
 
-                  if sharing_enabled?
+                  if share_editable?(share)
                     user_row_grid.with_area(:remove, tag: :div) do
                       form_with url: work_packages_share_path(share), method: :delete do
                         render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -53,8 +53,12 @@ module WorkPackages
                             .order('work_package_shares.created_at DESC')
       end
 
-      def sharing_enabled?
+      def sharing_manageable?
         User.current.allowed_to?(:share_work_packages, @work_package.project)
+      end
+
+      def share_editable?(share)
+        User.current != share.principal && sharing_manageable?
       end
     end
   end

--- a/app/contracts/work_package_members/base_contract.rb
+++ b/app/contracts/work_package_members/base_contract.rb
@@ -44,7 +44,9 @@ module WorkPackageMembers
     private
 
     def user_allowed_to_manage
-      errors.add :base, :error_unauthorized unless user_allowed_to_manage?
+      return if user_allowed_to_manage? && (!model.principal || model.principal != user)
+
+      errors.add :base, :error_unauthorized
     end
 
     def user_allowed_to_manage?

--- a/app/forms/work_packages/share/invitee.rb
+++ b/app/forms/work_packages/share/invitee.rb
@@ -25,7 +25,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module  WorkPackages::Share
+module WorkPackages::Share
   class Invitee < ApplicationForm
     form do |user_invite_form|
       user_invite_form.autocompleter(
@@ -42,7 +42,8 @@ module  WorkPackages::Share
           # but restrict the type of the principal to users only. Subject to change
           # as we want to support groups soon.
           resource: 'principals',
-          filters: [{ name: 'type', operator: '=', values: ['User'] }],
+          filters: [{ name: 'type', operator: '=', values: ['User'] },
+                    { name: 'id', operator: '!', values: [::Queries::Filters::MeValue::KEY] }],
           searchKey: 'any_name_attribute',
           focusDirectly: true,
           appendTo: 'body',

--- a/spec/contracts/work_package_members/shared_contract_examples.rb
+++ b/spec/contracts/work_package_members/shared_contract_examples.rb
@@ -73,6 +73,12 @@ RSpec.shared_examples_for 'work package member contract' do
       it_behaves_like 'contract is invalid', roles: :ungrantable
     end
 
+    context 'if the principal is the current user' do
+      let(:member_principal) { current_user }
+
+      it_behaves_like 'contract is invalid', base: :error_unauthorized
+    end
+
     # Needs to be changed once groups are introduced
     context 'if more than one role is assigned' do
       let(:member_roles) do

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'Work package sharing',
       create(:work_package_member, entity: wp, user: comment_user, roles: [comment_work_package_role])
       create(:work_package_member, entity: wp, user: edit_user, roles: [edit_work_package_role])
       create(:work_package_member, entity: wp, user: shared_project_user, roles: [edit_work_package_role])
+      create(:work_package_member, entity: wp, user: current_user, roles: [view_work_package_role])
     end
   end
 
@@ -86,25 +87,27 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(comment_user, 'Comment')
       share_modal.expect_shared_with(edit_user, 'Edit')
       share_modal.expect_shared_with(shared_project_user, 'Edit')
+      # The current users share is also displayed but not editable
+      share_modal.expect_shared_with(current_user, editable: false)
 
       share_modal.expect_not_shared_with(non_shared_project_user)
       share_modal.expect_not_shared_with(not_shared_yet_with_user)
 
-      share_modal.expect_shared_count_of(4)
+      share_modal.expect_shared_count_of(5)
 
       # Inviting a user will lead to that user being listed together with the rest of the shared with users.
       share_modal.invite_user(not_shared_yet_with_user, 'View')
 
       share_modal.expect_shared_with(not_shared_yet_with_user, 'View')
 
-      share_modal.expect_shared_count_of(5)
+      share_modal.expect_shared_count_of(6)
 
       # Removing a share will lead to that user being removed from the list of shared with users.
       share_modal.remove_user(edit_user)
 
       share_modal.expect_not_shared_with(edit_user)
 
-      share_modal.expect_shared_count_of(4)
+      share_modal.expect_shared_count_of(5)
 
       # Adding a user multiple times will lead to the user's role being updated.
       share_modal.invite_user(not_shared_yet_with_user, 'Edit')
@@ -134,6 +137,7 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(view_user, 'View')
       share_modal.expect_shared_with(comment_user, 'Comment')
       share_modal.expect_shared_with(shared_project_user, 'Edit')
+      share_modal.expect_shared_with(current_user, editable: false)
       # This user's role was updated
       share_modal.expect_shared_with(not_shared_yet_with_user, 'Comment')
       # This user's share was revoked
@@ -142,7 +146,7 @@ RSpec.describe 'Work package sharing',
       # This user has never been added
       share_modal.expect_not_shared_with(non_shared_project_user)
 
-      share_modal.expect_shared_count_of(4)
+      share_modal.expect_shared_count_of(5)
     end
   end
 
@@ -166,11 +170,12 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(comment_user, editable: false)
       share_modal.expect_shared_with(edit_user, editable: false)
       share_modal.expect_shared_with(shared_project_user, editable: false)
+      share_modal.expect_shared_with(current_user, editable: false)
 
       share_modal.expect_not_shared_with(non_shared_project_user)
       share_modal.expect_not_shared_with(not_shared_yet_with_user)
 
-      share_modal.expect_shared_count_of(4)
+      share_modal.expect_shared_count_of(5)
 
       share_modal.expect_no_invite_option
     end


### PR DESCRIPTION
Prevents the current user from adding a share to a work package for themselves via:

* Removing the user from the autocompleter
* Enforcing the limitation in the contract

If the current user is already added when opening the modal, their entry will be displayed same as if the current user would lack edit permission:

<img width="750" alt="image" src="https://github.com/opf/openproject/assets/617519/e4e83c94-df04-455b-8c06-ab6f1637295c">

https://community.openproject.org/wp/50263