### PR TITLE
[#50234] add storage filter to project and project storage collection

### DIFF
--- a/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
@@ -1,0 +1,57 @@
+# Example: Simple storage collection
+---
+value:
+  _type: Collection
+  count: 2
+  total: 2
+  offset: 1
+  pageSize: 20
+  _embedded:
+    elements:
+      - id: 1337
+        _type: Storage
+        name: It's no moon
+        hasApplicationPassword: true
+        createdAt: '2021-12-20T13:37:00.211Z'
+        updatedAt: '2021-12-20T13:37:00.211Z'
+        _links:
+          self:
+            href: /api/v3/storages/1337
+            title: It's no moon
+          type:
+            href: urn:openproject-org:api:v3:storages:nextcloud
+            title: Nextcloud
+          origin:
+            href: https://nextcloud.deathstar.rocks/
+          open:
+            href: https://nextcloud.deathstar.rocks/apps/files
+          authorizationState:
+            href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
+            title: Failed Authorization
+          authorize:
+            href: https://nextcloud.deathstar.rocks/authorize/
+            title: Authorize
+          oauthApplication:
+            href: /api/v3/oauth_application/42
+            title: It's no moon (Nextcloud)
+          oauthClientCredentials:
+            href: /api/v3/oauth_client_credentials/42
+      - id: 1338
+        _type: Storage
+        name: EmpireSharepoint
+        createdAt: '2022-12-21T13:37:00Z'
+        updatedAt: '2022-12-21T13:37:00Z'
+        _links:
+          self:
+            href: /api/v3/storages/1338
+            title: EmpireSharepoint
+          type:
+            href: urn:openproject-org:api:v3:storages:one-drive
+            title: OneDrive
+          open:
+            href: https://empire.sharepoint.com/sites/Documents
+          authorizationState:
+            href: urn:openproject-org:api:v3:storages:authorization:Connected
+            title: Connected
+          oauthClientCredentials:
+            href: /api/v3/oauth_client_credentials/44

--- a/docs/api/apiv3/components/schemas/storage_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_collection_model.yml
@@ -1,0 +1,30 @@
+# Schema: StorageCollectionModel
+---
+allOf:
+  - $ref: './collection_model.yml'
+  - type: object
+    required:
+      - _links
+      - _embedded
+    properties:
+      _links:
+        type: object
+        required:
+          - self
+        properties:
+          self:
+            allOf:
+              - $ref: './link.yml'
+              - description: |-
+                  This storage collection
+                  
+                  **Resource**: StorageCollectionReadModel
+      _embedded:
+        type: object
+        required:
+          - elements
+        properties:
+          elements:
+            type: array
+            items:
+              $ref: './storage_read_model.yml'

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -483,6 +483,8 @@ components:
       "$ref": "./components/examples/query.yml"
     QuerySchemaModel:
       "$ref": "./components/examples/query_schema.yml"
+    StoragesSimpleCollectionModel:
+      "$ref": "./components/examples/storages-simple-collection-response.yml"
     ValuesPropertyStartDateSchema:
       "$ref": "./components/examples/values_property_start_date_schema.yml"
     ValuesPropertyDueDateSchema:
@@ -705,6 +707,8 @@ components:
       "$ref": "./components/schemas/status_model.yml"
     StatusesModel:
       "$ref": "./components/schemas/statuses_model.yml"
+    StorageCollectionModel:
+      "$ref": "./components/schemas/storage_collection_model.yml"
     StorageFileModel:
       "$ref": "./components/schemas/storage_file_model.yml"
     StorageFilesModel:

--- a/docs/api/apiv3/paths/project_storages.yml
+++ b/docs/api/apiv3/paths/project_storages.yml
@@ -21,6 +21,7 @@ get:
 
         - project_id
         - storage_id
+        - storage_url
       example: '[{ "project_id": { "operator": "=", "values": ["42"] }}, { "storage_id": { "operator": "=", "values": ["1337"] }}]'
   responses:
     '200':

--- a/docs/api/apiv3/paths/projects.yml
+++ b/docs/api/apiv3/paths/projects.yml
@@ -1,198 +1,120 @@
 # /api/v3/projects
 ---
 get:
-  parameters:
-  - description: |-
-      JSON specifying filter conditions.
-      Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/) endpoint.
-      Currently supported filters are:
-
-      + active: based on the active property of the project
-
-      + ancestor: filters projects by their ancestor. A project is not considered to be it's own ancestor.
-
-      + created_at: based on the time the project was created
-
-      + latest_activity_at: based on the time the last activity was registered on a project.
-
-      + name_and_identifier: based on both the name and the identifier.
-
-      + parent_id: filters projects by their parent.
-
-      + principal: based on members of the project.
-
-      + type_id: based on the types active in a project.
-
-      + user_action: based on the actions the current user has in the project.
-
-      + id: based on projects' id.
-
-      + visible: based on the visibility for the user (id) provided as the filter value. This filter is useful for admins to identify the projects visible to a user.
-      There might also be additional filters based on the custom fields that have been configured.
-    example: '[{ "ancestor": { "operator": "=", "values": [''1''] }" }]'
-    in: query
-    name: filters
-    required: false
-    schema:
-      type: string
-  - description: |-
-      JSON specifying sort criteria.
-      Currently supported orders are:
-
-      + id
-
-      + name
-
-      + typeahead (sorting by hierarchy and name)
-
-      + created_at
-
-      + public
-
-      + latest_activity_at
-
-      + required_disk_space
-      There might also be additional orders based on the custom fields that have been configured.
-    example: '[["id", "asc"]]'
-    in: query
-    name: sortBy
-    required: false
-    schema:
-      type: string
-  - description: |-
-      Comma separated list of properties to include.
-    example: 'total,elements/identifier,elements/name'
-    in: query
-    name: select
-    required: false
-    schema:
-      type: string
-  responses:
-    '200':
-      content:
-        application/hal+json:
-          examples:
-            response:
-              value:
-                _embedded:
-                  elements:
-                  - _links:
-                      categories:
-                        href: "/api/v3/projects/6/categories"
-                      createWorkPackage:
-                        href: "/api/v3/projects/6/work_packages/form"
-                        method: post
-                      createWorkPackageImmediate:
-                        href: "/api/v3/projects/6/work_packages"
-                        method: post
-                      projects:
-                        href: "/api/v3/projects/123"
-                      self:
-                        href: "/api/v3/projects/6"
-                        title: A project
-                      status:
-                        href: "/api/v3/project_statuses/on_track"
-                        title: On track
-                      versions:
-                        href: "/api/v3/projects/6/versions"
-                    _type: Project
-                    active: true
-                    createdAt: '2015-07-06T13:28:14+00:00'
-                    description:
-                      format: markdown
-                      html: "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
-                      raw: Lorem **ipsum** dolor sit amet
-                    id: 6
-                    identifier: a_project
-                    name: A project
-                    public: false
-                    statusExplanation:
-                      format: markdown
-                      html: "<p>Everything <strong>fine</strong></p>"
-                      raw: Everything **fine**
-                    type: Customer Project
-                    updatedAt: '2015-10-01T09:55:02+00:00'
-                  - _links:
-                      categories:
-                        href: "/api/v3/projects/14/categories"
-                      createWorkPackage:
-                        href: "/api/v3/projects/14/work_packages/form"
-                        method: post
-                      createWorkPackageImmediate:
-                        href: "/api/v3/projects/14/work_packages"
-                        method: post
-                      projects:
-                        href: 
-                      self:
-                        href: "/api/v3/projects/14"
-                        title: Another project
-                      status:
-                        href: "/api/v3/project_statuses/off_track"
-                        title: Off track
-                      versions:
-                        href: "/api/v3/projects/14/versions"
-                    _type: Project
-                    active: false
-                    createdAt: '2016-02-29T12:50:20+00:00'
-                    description:
-                      format: markdown
-                      html: ''
-                      raw: ''
-                    id: 14
-                    identifier: another_project
-                    name: Another project
-                    public: true
-                    statusExplanation:
-                      format: markdown
-                      html: "<p>Uh <strong>oh</strong></p>"
-                      raw: Uh **oh**
-                    type: 
-                    updatedAt: '2016-02-29T12:50:20+00:00'
-                _links:
-                  self:
-                    href: "/api/v3/projects"
-                _type: Collection
-                count: 2
-                total: 2
-          schema:
-            "$ref": "../components/schemas/list_projects_model.yml"
-      description: OK
-      headers: {}
+  summary: List projects
+  operationId: list_projects
   tags:
-  - Projects
+    - Projects
   description: Returns a collection of projects. The collection can be filtered via
     query parameters similar to how work packages are filtered. In addition to the
     provided filter, the result set is always limited to only contain projects the
     client is allowed to see.
-  operationId: List_projects
-  summary: List projects
+  parameters:
+    - name: filters
+      schema:
+        type: string
+      in: query
+      required: false
+      description: |-
+        JSON specifying filter conditions.
+        Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/) endpoint.
+        Currently supported filters are:
+        
+        + active: based on the active property of the project
+        + ancestor: filters projects by their ancestor. A project is not considered to be it's own ancestor.
+        + created_at: based on the time the project was created
+        + latest_activity_at: based on the time the last activity was registered on a project.
+        + name_and_identifier: based on both the name and the identifier.
+        + parent_id: filters projects by their parent.
+        + principal: based on members of the project.
+        + storage_id: filters projects by linked storages
+        + storage_url: filters projects by linked storages identified by the host url
+        + type_id: based on the types active in a project.
+        + user_action: based on the actions the current user has in the project.
+        + id: based on projects' id.
+        + visible: based on the visibility for the user (id) provided as the filter value. This filter is useful for admins to identify the projects visible to a user.
+        
+        There might also be additional filters based on the custom fields that have been configured.
+      example: '[{ "ancestor": { "operator": "=", "values": ["1"] }" }]'
+    - name: sortBy
+      schema:
+        type: string
+      in: query
+      required: false
+      description: |-
+        JSON specifying sort criteria.
+        Currently supported orders are:
+        
+        + id
+        + name
+        + typeahead (sorting by hierarchy and name)
+        + created_at
+        + public
+        + latest_activity_at
+        + required_disk_space
+        
+        There might also be additional orders based on the custom fields that have been configured.
+      example: '[["id", "asc"]]'
+    - name: select
+      schema:
+        type: string
+      in: query
+      required: false
+      description: |-
+        Comma separated list of properties to include.
+      example: 'total,elements/identifier,elements/name'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/list_projects_model.yml'
+    '400':
+      description: Returned if the client sends invalid request parameters e.g. filters
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
+            message: Filters Invalid filter does not exist.
+
 post:
+  summary: Create project
+  operationId: create_project
+  tags:
+    - Projects
+  description: |-
+    Creates a new project, applying the attributes provided in the body.
+
+    You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
   requestBody:
     content:
       application/json:
         schema:
           type: object
         examples:
-          "with custom fields":
-            "$ref": "../components/examples/project_body.yml"
+          'with custom fields':
+            $ref: '../components/examples/project_body.yml'
   responses:
     '201':
+      description: Created
       content:
         application/hal+json:
           schema:
-            "$ref": "../components/schemas/project_model.yml"
+            $ref: '../components/schemas/project_model.yml'
           examples:
-            "with custom fields":
-              "$ref": "../components/examples/project.yml"
-      description: Created
-      headers: {}
+            'with custom fields':
+              $ref: '../components/examples/project.yml'
     '400':
-      $ref: "../components/responses/invalid_request_body.yml"
+      $ref: '../components/responses/invalid_request_body.yml'
     '403':
       content:
         application/hal+json:
           schema:
-            $ref: "../components/schemas/error_response.yml"
+            $ref: '../components/schemas/error_response.yml'
           examples:
             response:
               value:
@@ -203,35 +125,23 @@ post:
         Returned if the client does not have sufficient permissions.
 
         **Required permission:** add project which is a global permission
-      headers: {}
     '406':
-      $ref: "../components/responses/missing_content_type.yml"
+      $ref: '../components/responses/missing_content_type.yml'
     '415':
-      $ref: "../components/responses/unsupported_media_type.yml"
+      $ref: '../components/responses/unsupported_media_type.yml'
     '422':
       content:
         application/hal+json:
           schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _embedded:
-                  details:
-                    attribute: name
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:PropertyConstraintViolation
-                message: Name can't be blank.
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _embedded:
+              details:
+                attribute: name
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:PropertyConstraintViolation
+            message: Name can't be blank.
       description: |-
         Returned if:
 
         * a constraint for a property was violated (`PropertyConstraintViolation`)
-      headers: {}
-  tags:
-  - Projects
-  description: |-
-    Creates a new project, applying the attributes provided in the body.
-
-    You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
-  operationId: Create_project
-  summary: Create project

--- a/docs/api/apiv3/paths/storages.yml
+++ b/docs/api/apiv3/paths/storages.yml
@@ -1,5 +1,32 @@
 # /api/v3/storages
 ---
+get:
+  summary: Get Storages
+  operationId: list_storages
+  tags:
+    - File links
+  description: Returns a collection of storages.
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/storage_collection_model.yml'
+          examples:
+            'Simple storage collection':
+              $ref: '../components/examples/storages-simple-collection-response.yml'
+    '400':
+      description: Returned if the client sends invalid request parameters e.g. filters
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
+            message: Filters Invalid filter does not exist.
+
 post:
   summary: Creates a storage.
   operationId: create_storage
@@ -27,3 +54,27 @@ post:
         application/hal+json:
           schema:
             $ref: '../components/schemas/storage_read_model.yml'
+    '400':
+      $ref: '../components/responses/invalid_request_body.yml'
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+            message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** Depends on the page the grid is defined for.
+    '406':
+      $ref: '../components/responses/missing_content_type.yml'
+    '415':
+      $ref: '../components/responses/unsupported_media_type.yml'
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/modules/storages/app/models/queries/storages/project_storages/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/project_storages/filter/storage_url_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -27,7 +29,7 @@
 #++
 
 module Queries::Storages::ProjectStorages::Filter
-  class StorageIdFilter < ::Queries::Filters::Base
+  class StorageUrlFilter < ::Queries::Filters::Base
     self.model = Storages::ProjectStorage
 
     def type
@@ -40,6 +42,20 @@ module Queries::Storages::ProjectStorages::Filter
 
     def allowed_values
       values.map { |value| [nil, value] }
+    end
+
+    def joins
+      [:storage]
+    end
+
+    def where
+      operator_strategy.sql_for_field(unescape_hosts(values), Storages::Storage.table_name, 'host')
+    end
+
+    private
+
+    def unescape_hosts(hosts)
+      hosts.map { |host| CGI.unescape(host).gsub(/\/+$/, '') }
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/projects/filter/storage_id_filter.rb
+++ b/modules/storages/app/models/queries/storages/projects/filter/storage_id_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -25,21 +27,22 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
-module Queries::Storages::ProjectStorages::Filter
-  class StorageIdFilter < ::Queries::Filters::Base
-    self.model = Storages::ProjectStorage
-
+module Queries::Storages::Projects::Filter
+  class StorageIdFilter < ::Queries::Projects::Filters::ProjectFilter
     def type
       :list
     end
 
-    def human_name
-      ::Storages::ProjectStorage.human_attribute_name(name)
-    end
-
     def allowed_values
       values.map { |value| [nil, value] }
+    end
+
+    def joins
+      [:storages]
+    end
+
+    def where
+      operator_strategy.sql_for_field(values, Storages::Storage.table_name, 'id')
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -25,21 +27,28 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
-module Queries::Storages::ProjectStorages::Filter
-  class StorageIdFilter < ::Queries::Filters::Base
-    self.model = Storages::ProjectStorage
-
+module Queries::Storages::Projects::Filter
+  class StorageUrlFilter < ::Queries::Projects::Filters::ProjectFilter
     def type
       :list
     end
 
-    def human_name
-      ::Storages::ProjectStorage.human_attribute_name(name)
-    end
-
     def allowed_values
       values.map { |value| [nil, value] }
+    end
+
+    def joins
+      [:storages]
+    end
+
+    def where
+      operator_strategy.sql_for_field(unescape_hosts(values), Storages::Storage.table_name, 'host')
+    end
+
+    private
+
+    def unescape_hosts(hosts)
+      hosts.map { |host| CGI.unescape(host).gsub(/\/+$/, '') }
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
@@ -29,26 +29,16 @@
 #++
 module Queries::Storages::Projects::Filter
   class StorageUrlFilter < ::Queries::Projects::Filters::ProjectFilter
-    def type
-      :list
-    end
-
-    def allowed_values
-      values.map { |value| [nil, value] }
-    end
-
-    def joins
-      [:storages]
-    end
-
-    def where
-      operator_strategy.sql_for_field(unescape_hosts(values), Storages::Storage.table_name, 'host')
-    end
+    include StorageFilterMixin
 
     private
 
-    def unescape_hosts(hosts)
-      hosts.map { |host| CGI.unescape(host).gsub(/\/+$/, '') }
+    def filter_column
+      'host'
+    end
+
+    def where_values
+      values.map { |host| CGI.unescape(host).gsub(/\/+$/, '') }
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/storages/storage_query.rb
+++ b/modules/storages/app/models/queries/storages/storages/storage_query.rb
@@ -28,27 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class API::V3::Storages::StoragesAPI < API::OpenProjectAPI
-  helpers Storages::Peripherals::Scopes
-
-  resources :storages do
-    post &API::V3::Utilities::Endpoints::Create.new(model: Storages::Storage).mount
-
-    get &API::V3::Utilities::Endpoints::Index.new(model: Storages::Storage, scope: -> { visible_storages }).mount
-
-    route_param :storage_id, type: Integer, desc: 'Storage id' do
-      after_validation do
-        @storage = visible_storages.find(params[:storage_id])
+module Queries::Storages::Storages
+  class StorageQuery < Queries::BaseQuery
+    class << self
+      def model
+        @model ||= ::Storages::Storage
       end
-
-      get &API::V3::Utilities::Endpoints::Show.new(model: Storages::Storage).mount
-
-      patch &API::V3::Utilities::Endpoints::Update.new(model: Storages::Storage).mount
-
-      delete &API::V3::Utilities::Endpoints::Delete.new(model: Storages::Storage).mount
-
-      mount API::V3::StorageFiles::StorageFilesAPI
-      mount API::V3::OAuthClient::OAuthClientCredentialsAPI
     end
   end
 end

--- a/modules/storages/lib/api/v3/storages/storage_collection_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_collection_representer.rb
@@ -28,27 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class API::V3::Storages::StoragesAPI < API::OpenProjectAPI
-  helpers Storages::Peripherals::Scopes
-
-  resources :storages do
-    post &API::V3::Utilities::Endpoints::Create.new(model: Storages::Storage).mount
-
-    get &API::V3::Utilities::Endpoints::Index.new(model: Storages::Storage, scope: -> { visible_storages }).mount
-
-    route_param :storage_id, type: Integer, desc: 'Storage id' do
-      after_validation do
-        @storage = visible_storages.find(params[:storage_id])
+module API
+  module V3
+    module Storages
+      class StorageCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
       end
-
-      get &API::V3::Utilities::Endpoints::Show.new(model: Storages::Storage).mount
-
-      patch &API::V3::Utilities::Endpoints::Update.new(model: Storages::Storage).mount
-
-      delete &API::V3::Utilities::Endpoints::Delete.new(model: Storages::Storage).mount
-
-      mount API::V3::StorageFiles::StorageFilesAPI
-      mount API::V3::OAuthClient::OAuthClientCredentialsAPI
     end
   end
 end

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -182,12 +182,14 @@ module API::V3::Storages
     associated_resource :oauth_application,
                         skip_render: ->(*) { !represent_oauth_application? },
                         getter: ->(*) {
-                          next unless represent_oauth_application?
+                          next unless represent_oauth_application? && represented.oauth_application.present?
 
                           ::API::V3::OAuth::OAuthApplicationsRepresenter.create(represented.oauth_application, current_user:)
                         },
                         link: ->(*) {
                           next unless represent_oauth_application?
+
+                          return { href: nil } if represented.oauth_application.blank?
 
                           {
                             href: api_v3_paths.oauth_application(represented.oauth_application.id),

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -200,12 +200,18 @@ module OpenProject::Storages
           exclude filter
         end
 
+        ::Queries::Register.register(::Queries::Projects::ProjectQuery) do
+          filter ::Queries::Storages::Projects::Filter::StorageIdFilter
+          filter ::Queries::Storages::Projects::Filter::StorageUrlFilter
+        end
+
         ::Queries::Register.register(::Queries::Storages::FileLinks::FileLinkQuery) do
           filter ::Queries::Storages::FileLinks::Filter::StorageFilter
         end
 
         ::Queries::Register.register(::Queries::Storages::ProjectStorages::ProjectStoragesQuery) do
           filter ::Queries::Storages::ProjectStorages::Filter::StorageIdFilter
+          filter ::Queries::Storages::ProjectStorages::Filter::StorageUrlFilter
           filter ::Queries::Storages::ProjectStorages::Filter::ProjectIdFilter
         end
       end

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe API::V3::Storages::StorageRepresenter, 'rendering' do
           let(:href) { "/api/v3/oauth_applications/#{oauth_application.id}" }
           let(:title) { oauth_application.name }
         end
+
+        context 'with invalid configured storage with missing oauth application' do
+          let(:oauth_application) { nil }
+
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'oauthApplication' }
+            let(:href) { nil }
+          end
+        end
       end
     end
 

--- a/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
@@ -1,0 +1,118 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_module_spec_helper
+
+RSpec.describe 'API v3 projects resource with filters for the linked storages',
+               content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  let(:user) { create(:user) }
+  let(:role) { create(:role, permissions: %i[view_work_packages]) }
+
+  # rubocop:disable RSpec/IndexedLet
+  let!(:project1) { create(:project, members: { user => role }) }
+  let!(:project2) { create(:project, members: { user => role }) }
+  let!(:project3) { create(:project, members: { user => role }) }
+  let!(:project4) { create(:project, members: { user => role }) }
+  let!(:storage1) { create(:nextcloud_storage) }
+  let!(:storage2) { create(:one_drive_storage) }
+  let!(:storage3) { create(:one_drive_storage) }
+  let!(:project_storage11) { create(:project_storage, project: project1, storage: storage1) }
+  let!(:project_storage12) { create(:project_storage, project: project1, storage: storage2) }
+  let!(:project_storage13) { create(:project_storage, project: project1, storage: storage3) }
+  let!(:project_storage23) { create(:project_storage, project: project2, storage: storage3) }
+  let!(:project_storage21) { create(:project_storage, project: project2, storage: storage1) }
+  let!(:project_storage31) { create(:project_storage, project: project3, storage: storage1) }
+  # rubocop:enable RSpec/IndexedLet
+
+  subject(:response) { last_response }
+
+  before do
+    login_as user
+  end
+
+  describe 'GET /api/v3/projects' do
+    let(:path) { api_v3_paths.path_for :projects, filters: }
+
+    before do
+      get path
+    end
+
+    context 'with filter for storage id' do
+      let(:storage_id) { storage1.id }
+      let(:filters) { [{ storageId: { operator: '=', values: [storage_id] } }] }
+
+      it_behaves_like 'API V3 collection response', 3, 3, 'Project', 'Collection' do
+        let(:elements) { [project3, project2, project1] }
+      end
+
+      context 'if a project has the storages module deactivated' do
+        let(:project1) { create(:project, disable_modules: :storages) }
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'Project', 'Collection' do
+          let(:elements) { [project3, project2] }
+        end
+      end
+
+      context 'if the filter is set to an unknown storage id' do
+        let(:storage_id) { '1337' }
+
+        it_behaves_like 'API V3 collection response', 0, 0, 'Project', 'Collection' do
+          let(:elements) { [] }
+        end
+      end
+    end
+
+    context 'with filter for storage url' do
+      let(:storage_url) { CGI.escape(storage1.host) }
+      let(:filters) { [{ storageUrl: { operator: '=', values: [storage_url] } }] }
+
+      it_behaves_like 'API V3 collection response', 3, 3, 'Project', 'Collection' do
+        let(:elements) { [project3, project2, project1] }
+      end
+
+      context 'if a project has the storages module deactivated' do
+        let(:project1) { create(:project, disable_modules: :storages) }
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'Project', 'Collection' do
+          let(:elements) { [project3, project2] }
+        end
+      end
+
+      context 'if the filter is set to an unknown storage url' do
+        let(:storage_url) { CGI.escape("https://not.my-domain.org") }
+
+        it_behaves_like 'API V3 collection response', 0, 0, 'Project', 'Collection' do
+          let(:elements) { [] }
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'API v3 projects resource with filters for the linked storages',
   end
 
   shared_let(:user) { create(:user) }
-  shared_let(:role) { create(:role, permissions: %i[view_work_packages]) }
+  shared_let(:role) { create(:role, permissions: %i[view_work_packages view_file_links]) }
 
   shared_let(:project1) { create(:project, members: { user => role }) }
   shared_let(:project2) { create(:project, members: { user => role }) }


### PR DESCRIPTION
[OP#50234](https://community.openproject.org/work_packages/50234)

### What is here?

- add storage_id and storage_url filter to project collection
- add storage_url to project storage collection
- added storage collection endpoint
- added requests tests
- refactored projects api specification as I touched it

### But... why??

- the storage filters are very handy when fetching a project list from a storage context, e.g. a specific nextcloud.