### PR TITLE
Linking all the pieces of the Sharepoint Integration into the FilePicker/Workpackage view

### DIFF
--- a/frontend/src/app/core/upload/convert-http-event.ts
+++ b/frontend/src/app/core/upload/convert-http-event.ts
@@ -26,14 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Observable } from 'rxjs';
 import { HttpEvent } from '@angular/common/http';
+import isHttpResponse from 'core-app/core/upload/is-http-response';
 
-export interface IUploadFile {
-  file:File;
-  overwrite?:boolean;
-}
+export default function convertHttpEvent<T, K>(event:HttpEvent<T>, convert:(body:T) => K):HttpEvent<K> {
+  if (isHttpResponse(event) && event.body !== null) {
+    return event.clone({ body: convert(event.body) });
+  }
 
-export abstract class OpUploadService {
-  public abstract upload<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
+  return event as HttpEvent<K>;
 }

--- a/frontend/src/app/shared/components/storages/storages-constants.const.ts
+++ b/frontend/src/app/shared/components/storages/storages-constants.const.ts
@@ -1,5 +1,6 @@
 // Storage types
 export const nextcloud = 'urn:openproject-org:api:v3:storages:Nextcloud';
+export const oneDrive = 'urn:openproject-org:api:v3:storages:OneDrive';
 
 // Storage authorization state
 export const storageConnected = 'urn:openproject-org:api:v3:storages:authorization:Connected';

--- a/frontend/src/app/shared/components/storages/upload/nextcloud-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/nextcloud-upload.strategy.ts
@@ -1,0 +1,82 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Observable } from 'rxjs';
+import { map, share } from 'rxjs/operators';
+import { HttpClient, HttpEvent } from '@angular/common/http';
+
+import { IUploadFile } from 'core-app/core/upload/upload.service';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
+import { IUploadStrategy } from 'core-app/shared/components/storages/upload/upload-strategy';
+import convertHttpEvent from 'core-app/core/upload/convert-http-event';
+
+export interface NextcloudFileUploadResponse {
+  file_name:string;
+  file_id:number;
+}
+
+export class NextcloudUploadStrategy implements IUploadStrategy {
+  constructor(private readonly http:HttpClient) { }
+
+  public execute<T>(
+    href:string,
+    uploadFiles:IUploadFile[],
+  ):Observable<HttpEvent<T>>[] {
+    return uploadFiles.map((file) => this.uploadSingle(href, file));
+  }
+
+  private uploadSingle<T>(href:string, uploadFile:IUploadFile):Observable<HttpEvent<T>> {
+    const body = new FormData();
+    body.append('file', uploadFile.file, uploadFile.file.name);
+
+    if (uploadFile.overwrite !== undefined) {
+      body.append('overwrite', String(uploadFile.overwrite));
+    }
+
+    return this.http.request<NextcloudFileUploadResponse>(
+      'post',
+      href,
+      {
+        body,
+        headers: { [EXTERNAL_REQUEST_HEADER]: 'true' },
+        observe: 'events',
+        reportProgress: true,
+        responseType: 'json',
+      },
+    ).pipe(
+      share(),
+      map((event) =>
+        convertHttpEvent(event, (responseBody) => ({
+          id: responseBody.file_id,
+          name: responseBody.file_name,
+          size: uploadFile.file.size,
+          mimeType: uploadFile.file.type,
+        } as T))),
+    );
+  }
+}

--- a/frontend/src/app/shared/components/storages/upload/one-drive-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/one-drive-upload.strategy.ts
@@ -38,7 +38,7 @@ import convertHttpEvent from 'core-app/core/upload/convert-http-event';
 export interface OneDriveFileUploadResponse {
   id:string;
   name:string;
-  mimeType:string;
+  file:{ mimeType:string };
   size:number;
 }
 
@@ -75,7 +75,7 @@ export class OneDriveUploadStrategy implements IUploadStrategy {
           id: responseBody.id,
           name: responseBody.name,
           size: responseBody.size,
-          mimeType: responseBody.mimeType,
+          mimeType: responseBody.file.mimeType,
         } as T))),
     );
   }

--- a/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
+++ b/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
@@ -1,0 +1,80 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Observable } from 'rxjs';
+import { ID } from '@datorama/akita';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpEvent } from '@angular/common/http';
+
+import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
+import { IUploadStrategy } from 'core-app/shared/components/storages/upload/upload-strategy';
+import { NextcloudUploadStrategy } from 'core-app/shared/components/storages/upload/nextcloud-upload.strategy';
+import { nextcloud, oneDrive } from 'core-app/shared/components/storages/storages-constants.const';
+import { OneDriveUploadStrategy } from 'core-app/shared/components/storages/upload/one-drive-upload.strategy';
+
+export interface IStorageFileUploadResponse {
+  id:ID;
+  name:string;
+  mimeType:string;
+  size:number;
+}
+
+@Injectable()
+export class StorageUploadService extends OpUploadService {
+  private uploadStrategy:IUploadStrategy;
+
+  constructor(
+    private readonly http:HttpClient,
+  ) {
+    super();
+  }
+
+  public upload<T>(
+    href:string,
+    uploadFiles:IUploadFile[],
+  ):Observable<HttpEvent<T>>[] {
+    if (!this.uploadStrategy) {
+      throw new Error('missing strategy');
+    }
+
+    return this.uploadStrategy.execute(href, uploadFiles);
+  }
+
+  public setUploadStrategy(storageType:string):void {
+    switch (storageType) {
+      case nextcloud:
+        this.uploadStrategy = new NextcloudUploadStrategy(this.http);
+        break;
+      case oneDrive:
+        this.uploadStrategy = new OneDriveUploadStrategy(this.http);
+        break;
+      default:
+        throw new Error('unknown storage type');
+    }
+  }
+}

--- a/frontend/src/app/shared/components/storages/upload/upload-strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/upload-strategy.ts
@@ -29,11 +29,8 @@
 import { Observable } from 'rxjs';
 import { HttpEvent } from '@angular/common/http';
 
-export interface IUploadFile {
-  file:File;
-  overwrite?:boolean;
-}
+import { IUploadFile } from 'core-app/core/upload/upload.service';
 
-export abstract class OpUploadService {
-  public abstract upload<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
+export interface IUploadStrategy {
+  execute<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
 }

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/upload_link_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/upload_link_query.rb
@@ -66,7 +66,7 @@ module Storages
             case response
             when Net::HTTPSuccess
               upload_url = MultiJson.load(response.body, symbolize_keys: true)[:uploadUrl]
-              ServiceResult.success(result: ::Storages::UploadLink.new(URI(upload_url)))
+              ServiceResult.success(result: ::Storages::UploadLink.new(URI(upload_url), :put))
             when Net::HTTPNotFound
               ServiceResult.failure(result: :not_found, errors: ::Storages::StorageError.new(code: :not_found))
             when Net::HTTPUnauthorized
@@ -77,7 +77,7 @@ module Storages
           end
 
           def uri_path_for(folder, filename)
-            "/v1.0/drives/#{@storage.drive_id}/items/#{folder}:/#{filename}:/createUploadSession"
+            "/v1.0/drives/#{@storage.drive_id}/items/#{folder}:/#{URI.encode_uri_component(filename)}:/createUploadSession"
           end
         end
       end

--- a/modules/storages/app/contracts/storages/file_links/create_contract.rb
+++ b/modules/storages/app/contracts/storages/file_links/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -34,8 +36,7 @@ class Storages::FileLinks::CreateContract < ModelContract
   attribute :container_type
 
   attribute :origin_id
-  validates :origin_id, length: { maximum: 100 },
-                        format: { with: /\A[-0-9a-f]*\z/i, message: :only_numeric_or_uuid }
+  validates :origin_id, length: 1..100
   attribute :origin_name
   validates :origin_name, presence: true
   attribute :origin_created_by_name

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -44,7 +44,7 @@ module Storages
     end
 
     def uri
-      URI('https://graph.microsoft.com').normalize
+      @uri ||= URI('https://graph.microsoft.com').normalize
     end
 
     def connect_src

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -47,6 +47,10 @@ module Storages
       URI('https://graph.microsoft.com').normalize
     end
 
+    def connect_src
+      %w[https://*.sharepoint.com https://*.up.1drv.com]
+    end
+
     def open_link
       ::Storages::Peripherals::Registry.resolve("queries.one_drive.open_drive_link")
                                        .call(storage: self, user: User.current)

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -107,7 +107,11 @@ module Storages
     end
 
     def uri
-      URI(host).normalize
+      @uri ||= URI(host).normalize
+    end
+
+    def connect_src
+      ["#{uri.scheme}://#{uri.host}"]
     end
 
     def open_link

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -107,6 +107,8 @@ module Storages
     end
 
     def uri
+      return unless host
+
       @uri ||= URI(host).normalize
     end
 

--- a/modules/storages/lib/api/v3/file_links/create_endpoint.rb
+++ b/modules/storages/lib/api/v3/file_links/create_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -59,6 +61,7 @@ class API::V3::FileLinks::CreateEndpoint < API::Utilities::Endpoints::Create
       # rollback records created if an error occurred (validation failed)
       raise ActiveRecord::Rollback if global_result.failure?
     end
+
     global_result
   end
 

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -38,13 +38,16 @@ module API::V3::Storages
   URN_CONNECTION_ERROR = "#{::API::V3::URN_PREFIX}storages:authorization:Error".freeze
 
   URN_STORAGE_TYPE_NEXTCLOUD = "#{::API::V3::URN_PREFIX}storages:Nextcloud".freeze
+  URN_STORAGE_TYPE_ONE_DRIVE = "#{::API::V3::URN_PREFIX}storages:OneDrive".freeze
 
   STORAGE_TYPE_MAP = {
-    URN_STORAGE_TYPE_NEXTCLOUD => Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
+    URN_STORAGE_TYPE_NEXTCLOUD => Storages::Storage::PROVIDER_TYPE_NEXTCLOUD,
+    URN_STORAGE_TYPE_ONE_DRIVE => Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
   }.freeze
 
   STORAGE_TYPE_URN_MAP = {
-    Storages::Storage::PROVIDER_TYPE_NEXTCLOUD => URN_STORAGE_TYPE_NEXTCLOUD
+    Storages::Storage::PROVIDER_TYPE_NEXTCLOUD => URN_STORAGE_TYPE_NEXTCLOUD,
+    Storages::Storage::PROVIDER_TYPE_ONE_DRIVE => URN_STORAGE_TYPE_ONE_DRIVE
   }.freeze
 
   class StorageRepresenter < ::API::Decorators::Single

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/upload_link_query_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::UploadLinkQu
     link = upload_query.call(user:, data: query_payload).result
 
     expect(link.destination).not_to be_nil
-    expect(link.method).to eq(:post)
+    expect(link.method).to eq(:put)
   end
 
   shared_examples_for 'outbound is failing' do |code, symbol|

--- a/modules/storages/spec/contracts/storages/file_links/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/file_links/shared_contract_examples.rb
@@ -67,13 +67,13 @@ RSpec.shared_examples_for 'file_link contract' do
       context 'when empty' do
         let(:file_link_attributes) { { origin_id: '' } }
 
-        include_examples 'contract is invalid', origin_id: :blank
+        include_examples 'contract is invalid', origin_id: %i[blank too_short]
       end
 
       context 'when nil' do
         let(:file_link_attributes) { { origin_id: nil } }
 
-        include_examples 'contract is invalid', origin_id: :blank
+        include_examples 'contract is invalid', origin_id: %i[blank too_short]
       end
 
       context 'when numeric' do
@@ -91,11 +91,11 @@ RSpec.shared_examples_for 'file_link contract' do
       context 'when having non ascii characters' do
         let(:file_link_attributes) { { origin_id: 'Hëllò Wôrłd!' } }
 
-        include_examples 'contract is invalid', origin_id: :invalid
+        include_examples 'contract is valid'
       end
 
       context 'when longer than 100 characters' do
-        let(:file_link_attributes) { { origin_id: '1' * 101 } }
+        let(:file_link_attributes) { { origin_id: '1' * 201 } }
 
         include_examples 'contract is invalid', origin_id: :too_long
       end

--- a/modules/storages/spec/factories/file_link_element_factory.rb
+++ b/modules/storages/spec/factories/file_link_element_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -39,7 +41,7 @@ FactoryBot.define do
     storage_url { "https://nextcloud.example.com" }
 
     trait :invalid do
-      origin_id { "I'm invalid" }
+      origin_id { ' ' }
     end
 
     initialize_with do

--- a/modules/storages/spec/support/payloads/empty_folder.json
+++ b/modules/storages/spec/support/payloads/empty_folder.json
@@ -1,0 +1,4 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#drives('b%21-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd')/root/children",
+  "value": []
+}


### PR DESCRIPTION
##### Related Work Package: [OP#49128](https://community.openproject.org/projects/openproject/work_packages/49128), [OP#49127](https://community.openproject.org/projects/openproject/work_packages/49127), [OP#49126](https://community.openproject.org/projects/openproject/work_packages/49126), [OP#49125](https://community.openproject.org/projects/openproject/work_packages/49125)

On this PR, we link all the Sharepoint/OneDrive pieces for actual usage.

This meant changing the behaviour of the `FilesQuery` - in order to accommodate the inner workings of the File Picker - so that it can use a path based approach, plus some changes to our contract validators.


This also prepares for upload (it needs more changes on the FilePicker and is being handled by @Kharonus) by allowing connection to OneDrive and Sharepoint for uploads.

![image](https://github.com/opf/openproject/assets/10281/b0c73fdd-7284-4c18-8bbb-5679cfa006d9)
![image](https://github.com/opf/openproject/assets/10281/73d69e5d-b3ab-4da9-8bdf-9f83688c9c8f)
![image](https://github.com/opf/openproject/assets/10281/c269d1e1-e96d-437d-93cb-ce7832dc546f)
