### PR TITLE
hide public permissions from role administration

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -62,6 +62,8 @@ module Roles
                                 []
                               end
 
+      permissions_to_remove += OpenProject::AccessControl.public_permissions
+
       OpenProject::AccessControl.project_permissions -
         permissions_to_remove
     end

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -72,17 +72,17 @@ RSpec.shared_examples_for 'roles contract' do
 
   describe '#assignable_permissions' do
     let(:all_permissions) { %i[perm1 perm2 perm3] }
+    let(:public_permissions) { %i[perm2] }
 
     context 'for a project role' do
       before do
         allow(OpenProject::AccessControl)
-          .to receive(:project_permissions)
-          .and_return(all_permissions)
+          .to receive_messages(project_permissions: all_permissions, public_permissions:)
       end
 
-      it 'is all project permissions' do
+      it 'is all project permissions excluding public ones' do
         expect(contract.assignable_permissions)
-          .to eql all_permissions
+          .to eql(all_permissions - public_permissions)
       end
     end
 


### PR DESCRIPTION
Public permissions should never be manageable in the role administration. They are granted as soon as a project membership is created and therefore need to be hidden in the administration.

https://community.openproject.org/wp/50392

