### PR TITLE
[chore] added one drive upload strategy for frontend

### DIFF
--- a/frontend/src/app/core/upload/convert-http-event.ts
+++ b/frontend/src/app/core/upload/convert-http-event.ts
@@ -26,14 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Observable } from 'rxjs';
 import { HttpEvent } from '@angular/common/http';
+import isHttpResponse from 'core-app/core/upload/is-http-response';
 
-export interface IUploadFile {
-  file:File;
-  overwrite?:boolean;
-}
+export default function convertHttpEvent<T, K>(event:HttpEvent<T>, convert:(body:T) => K):HttpEvent<K> {
+  if (isHttpResponse(event) && event.body !== null) {
+    return event.clone({ body: convert(event.body) });
+  }
 
-export abstract class OpUploadService {
-  public abstract upload<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
+  return event as HttpEvent<K>;
 }

--- a/frontend/src/app/shared/components/storages/storages-constants.const.ts
+++ b/frontend/src/app/shared/components/storages/storages-constants.const.ts
@@ -1,5 +1,6 @@
 // Storage types
 export const nextcloud = 'urn:openproject-org:api:v3:storages:Nextcloud';
+export const oneDrive = 'urn:openproject-org:api:v3:storages:OneDrive';
 
 // Storage authorization state
 export const storageConnected = 'urn:openproject-org:api:v3:storages:authorization:Connected';

--- a/frontend/src/app/shared/components/storages/upload/nextcloud-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/nextcloud-upload.strategy.ts
@@ -1,0 +1,82 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Observable } from 'rxjs';
+import { map, share } from 'rxjs/operators';
+import { HttpClient, HttpEvent } from '@angular/common/http';
+
+import { IUploadFile } from 'core-app/core/upload/upload.service';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
+import { IUploadStrategy } from 'core-app/shared/components/storages/upload/upload-strategy';
+import convertHttpEvent from 'core-app/core/upload/convert-http-event';
+
+export interface NextcloudFileUploadResponse {
+  file_name:string;
+  file_id:number;
+}
+
+export class NextcloudUploadStrategy implements IUploadStrategy {
+  constructor(private readonly http:HttpClient) { }
+
+  public execute<T>(
+    href:string,
+    uploadFiles:IUploadFile[],
+  ):Observable<HttpEvent<T>>[] {
+    return uploadFiles.map((file) => this.uploadSingle(href, file));
+  }
+
+  private uploadSingle<T>(href:string, uploadFile:IUploadFile):Observable<HttpEvent<T>> {
+    const body = new FormData();
+    body.append('file', uploadFile.file, uploadFile.file.name);
+
+    if (uploadFile.overwrite !== undefined) {
+      body.append('overwrite', String(uploadFile.overwrite));
+    }
+
+    return this.http.request<NextcloudFileUploadResponse>(
+      'post',
+      href,
+      {
+        body,
+        headers: { [EXTERNAL_REQUEST_HEADER]: 'true' },
+        observe: 'events',
+        reportProgress: true,
+        responseType: 'json',
+      },
+    ).pipe(
+      share(),
+      map((event) =>
+        convertHttpEvent(event, (responseBody) => ({
+          id: responseBody.file_id,
+          name: responseBody.file_name,
+          size: uploadFile.file.size,
+          mimeType: uploadFile.file.type,
+        } as T))),
+    );
+  }
+}

--- a/frontend/src/app/shared/components/storages/upload/one-drive-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/one-drive-upload.strategy.ts
@@ -38,7 +38,7 @@ import convertHttpEvent from 'core-app/core/upload/convert-http-event';
 export interface OneDriveFileUploadResponse {
   id:string;
   name:string;
-  mimeType:string;
+  file:{ mimeType:string };
   size:number;
 }
 
@@ -75,7 +75,7 @@ export class OneDriveUploadStrategy implements IUploadStrategy {
           id: responseBody.id,
           name: responseBody.name,
           size: responseBody.size,
-          mimeType: responseBody.mimeType,
+          mimeType: responseBody.file.mimeType,
         } as T))),
     );
   }

--- a/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
+++ b/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
@@ -1,0 +1,80 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Observable } from 'rxjs';
+import { ID } from '@datorama/akita';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpEvent } from '@angular/common/http';
+
+import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
+import { IUploadStrategy } from 'core-app/shared/components/storages/upload/upload-strategy';
+import { NextcloudUploadStrategy } from 'core-app/shared/components/storages/upload/nextcloud-upload.strategy';
+import { nextcloud, oneDrive } from 'core-app/shared/components/storages/storages-constants.const';
+import { OneDriveUploadStrategy } from 'core-app/shared/components/storages/upload/one-drive-upload.strategy';
+
+export interface IStorageFileUploadResponse {
+  id:ID;
+  name:string;
+  mimeType:string;
+  size:number;
+}
+
+@Injectable()
+export class StorageUploadService extends OpUploadService {
+  private uploadStrategy:IUploadStrategy;
+
+  constructor(
+    private readonly http:HttpClient,
+  ) {
+    super();
+  }
+
+  public upload<T>(
+    href:string,
+    uploadFiles:IUploadFile[],
+  ):Observable<HttpEvent<T>>[] {
+    if (!this.uploadStrategy) {
+      throw new Error('missing strategy');
+    }
+
+    return this.uploadStrategy.execute(href, uploadFiles);
+  }
+
+  public setUploadStrategy(storageType:string):void {
+    switch (storageType) {
+      case nextcloud:
+        this.uploadStrategy = new NextcloudUploadStrategy(this.http);
+        break;
+      case oneDrive:
+        this.uploadStrategy = new OneDriveUploadStrategy(this.http);
+        break;
+      default:
+        throw new Error('unknown storage type');
+    }
+  }
+}

--- a/frontend/src/app/shared/components/storages/upload/upload-strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/upload-strategy.ts
@@ -29,11 +29,8 @@
 import { Observable } from 'rxjs';
 import { HttpEvent } from '@angular/common/http';
 
-export interface IUploadFile {
-  file:File;
-  overwrite?:boolean;
-}
+import { IUploadFile } from 'core-app/core/upload/upload.service';
 
-export abstract class OpUploadService {
-  public abstract upload<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
+export interface IUploadStrategy {
+  execute<T>(href:string, uploadFiles:IUploadFile[]):Observable<HttpEvent<T>>[];
 }

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -38,13 +38,16 @@ module API::V3::Storages
   URN_CONNECTION_ERROR = "#{::API::V3::URN_PREFIX}storages:authorization:Error".freeze
 
   URN_STORAGE_TYPE_NEXTCLOUD = "#{::API::V3::URN_PREFIX}storages:Nextcloud".freeze
+  URN_STORAGE_TYPE_ONE_DRIVE = "#{::API::V3::URN_PREFIX}storages:OneDrive".freeze
 
   STORAGE_TYPE_MAP = {
-    URN_STORAGE_TYPE_NEXTCLOUD => Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
+    URN_STORAGE_TYPE_NEXTCLOUD => Storages::Storage::PROVIDER_TYPE_NEXTCLOUD,
+    URN_STORAGE_TYPE_ONE_DRIVE => Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
   }.freeze
 
   STORAGE_TYPE_URN_MAP = {
-    Storages::Storage::PROVIDER_TYPE_NEXTCLOUD => URN_STORAGE_TYPE_NEXTCLOUD
+    Storages::Storage::PROVIDER_TYPE_NEXTCLOUD => URN_STORAGE_TYPE_NEXTCLOUD,
+    Storages::Storage::PROVIDER_TYPE_ONE_DRIVE => URN_STORAGE_TYPE_ONE_DRIVE
   }.freeze
 
   class StorageRepresenter < ::API::Decorators::Single


### PR DESCRIPTION
### What?

- refactored nextcloud upload service to storage upload service using different strategies for each provider type
- fixed type urn in storage representer
- amended storage component to seed correct strategy

### Why?

- there was an idea of adding one upload service for each provider type, but I couldn't get it to work with angular DI

### ⚠️ IMPORTANT 

This PR currently points to a feature branch from @mereghost , as it is directly tight to the changes there. You can find the PR here: #13854