### PR TITLE
[50258] Add description to selectable permissions in the share WP modal

### DIFF
--- a/app/components/work_packages/share/permission_button_component.html.erb
+++ b/app/components/work_packages/share/permission_button_component.html.erb
@@ -17,7 +17,9 @@
                        method: :patch,
                        name: 'role_ids[]',
                        value: option[:value]
-                     })
+                     }) do |item|
+        item.with_description.with_content(option[:description])
+      end
     end
   end
 %>

--- a/app/components/work_packages/share/permission_button_component.rb
+++ b/app/components/work_packages/share/permission_button_component.rb
@@ -57,9 +57,15 @@ module WorkPackages
 
       def options
         [
-          { label: I18n.t('work_package.sharing.permissions.edit'), value: Role::BUILTIN_WORK_PACKAGE_EDITOR },
-          { label: I18n.t('work_package.sharing.permissions.comment'), value: Role::BUILTIN_WORK_PACKAGE_COMMENTER },
-          { label: I18n.t('work_package.sharing.permissions.view'), value: Role::BUILTIN_WORK_PACKAGE_VIEWER }
+          { label: I18n.t('work_package.sharing.permissions.edit'),
+            value: Role::BUILTIN_WORK_PACKAGE_EDITOR,
+            description: I18n.t('work_package.sharing.permissions.edit_description') },
+          { label: I18n.t('work_package.sharing.permissions.comment'),
+            value: Role::BUILTIN_WORK_PACKAGE_COMMENTER,
+            description: I18n.t('work_package.sharing.permissions.comment_description') },
+          { label: I18n.t('work_package.sharing.permissions.view'),
+            value: Role::BUILTIN_WORK_PACKAGE_VIEWER,
+            description: I18n.t('work_package.sharing.permissions.view_description') }
         ]
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3199,9 +3199,12 @@ en:
       label_search_placeholder: "Search by user or email address"
       permissions:
         comment: "Comment"
+        comment_description: "Can view and comment this work package."
         denied: "You don't have permissions to share work packages."
         edit: "Edit"
+        edit_description: "Can view, comment and edit this work package."
         view: "View"
+        view_description: "Can view this work package."
       remove: "Remove"
       text_empty_state_description: "The work package has not been shared with anyone yet."
       text_empty_state_header: "No shared users"


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/50258/activity

<img width="338" alt="Bildschirmfoto 2023-10-09 um 08 47 36" src="https://github.com/opf/openproject/assets/7457313/f2154715-854e-40e6-8b7d-28cec8f7aa01">
