### PR TITLE
Remove cron jobs from db with old handler names.

### DIFF
--- a/modules/storages/db/migrate/20231009135807_remove_renamed_cronjobs.rb
+++ b/modules/storages/db/migrate/20231009135807_remove_renamed_cronjobs.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class RemoveRenamedCronjobs < ActiveRecord::Migration[7.0]
+  def up
+    Delayed::Job.where("handler LIKE '%job_class: CleanupUncontaineredFileLinksJob%'").delete_all
+    Delayed::Job.where("handler LIKE '%job_class: ManageNextcloudIntegrationJob%'").delete_all
+  end
+
+  def down; end
+end


### PR DESCRIPTION
After renaming some cron jobs records with old handler class name can be left in the database which produce unnecessary noise.

It resolves errors like:
https://appsignal.com/openproject-gmbh/sites/62bf0cc2d2a5e4832c923ff0/exceptions/incidents/119
https://appsignal.com/openproject-gmbh/sites/62d6c55083eb673480474bf9/exceptions/incidents/6543