### PR TITLE
[chore] added vcr data to one drive files query spec

### DIFF
--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
@@ -31,155 +31,203 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, :webmock do
-  include JsonResponseHelper
+RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, :vcr, :webmock do
+  using Storages::Peripherals::ServiceResultRefinements
 
-  let(:storage) do
-    create(:one_drive_storage,
-           :with_oauth_client,
-           drive_id: 'b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd')
-  end
   let(:user) { create(:user) }
-  let(:json) { read_json('root_drive_children') }
-  let(:token) { create(:oauth_client_token, user:, oauth_client: storage.oauth_client) }
+  let(:storage) { create(:sharepoint_dev_drive_storage, oauth_client_token_user: user) }
 
-  it 'responds to .call' do
-    expect(described_class).to respond_to(:call)
+  describe '#call' do
+    it 'responds with correct parameters' do
+      expect(described_class).to respond_to(:call)
 
-    method = described_class.method(:call)
-    expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq folder])
-  end
-
-  it 'returns a StorageFiles object' do
-    stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root/children#{described_class::FIELDS}")
-      .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .to_return(status: 200, body: json, headers: {})
-
-    storage_files = described_class.call(storage:, user:, folder: nil).result
-
-    expect(storage_files).to be_a(Storages::StorageFiles)
-    expect(storage_files.ancestors).to be_empty
-    expect(storage_files.parent.name).to eq("Root")
-
-    one_file = storage_files.files[10]
-
-    expect(one_file.to_h).to eq({ id: '01BYE5RZZ6FUE5272C5JCY3L7CLZ7XOUYM',
-                                  name: "All Japan Revenues By City.xlsx",
-                                  size: 20051,
-                                  mime_type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                                  created_at: Time.parse("2017-08-07T16:07:10Z"),
-                                  last_modified_at: Time.parse("2017-08-07T16:07:10Z"),
-                                  created_by_name: "Megan Bowen",
-                                  last_modified_by_name: "Megan Bowen",
-                                  location: "/All Japan Revenues By City.xlsx",
-                                  permissions: %i[readable writeable] })
-  end
-
-  it 'when the argument folder is nil, gets information from that users root folder' do
-    stub_request(
-      :get,
-      "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root/children#{described_class::FIELDS}"
-    )
-      .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .to_return(status: 200, body: json, headers: {})
-
-    storage_files = described_class.call(storage:, user:, folder: nil).result
-
-    expect(storage_files.files.size).to eq(38)
-    expect(storage_files.parent.name).to eq("Root")
-    expect(storage_files.ancestors).to be_empty
-  end
-
-  context 'when accessing an empty folder' do
-    let(:json) { read_json('empty_folder') }
-
-    before do
-      stub_request(
-        :get,
-        "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root:/TestBatchingFolder:/children#{described_class::FIELDS}"
-      )
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 200, body: json, headers: {})
+      method = described_class.method(:call)
+      expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq folder])
     end
 
-    it 'returns an empty storage files' do
-      storage_files = described_class.call(storage:, user:, folder: '/TestBatchingFolder').result
+    context 'with outbound requests successful' do
+      context 'with parent folder being nil', vcr: 'one_drive/files_query_root' do
+        # rubocop:disable RSpec/ExampleLength
+        it 'returns a StorageFiles object for root' do
+          storage_files = described_class.call(storage:, user:, folder: nil).result
 
-      expect(storage_files.files).to be_empty
+          expect(storage_files).to be_a(Storages::StorageFiles)
+          expect(storage_files.ancestors).to be_empty
+          expect(storage_files.parent.name).to eq("Root")
+
+          expect(storage_files.files.map(&:to_h))
+            .to eq([
+                     {
+                       id: '01AZJL5PMAXGDWAAKMEBALX4Q6GSN5BSBR',
+                       name: 'Folder',
+                       size: 257394,
+                       created_at: '2023-09-26T14:38:50Z',
+                       created_by_name: 'Eric Schubert',
+                       last_modified_at: '2023-09-26T14:38:50Z',
+                       last_modified_by_name: 'Eric Schubert',
+                       location: '/Folder',
+                       mime_type: 'application/x-op-directory',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU',
+                       name: 'Folder with spaces',
+                       size: 35141,
+                       created_at: '2023-09-26T14:38:57Z',
+                       created_by_name: 'Eric Schubert',
+                       last_modified_at: '2023-09-26T14:38:57Z',
+                       last_modified_by_name: 'Eric Schubert',
+                       location: '/Folder with spaces',
+                       mime_type: 'application/x-op-directory',
+                       permissions: %i[readable writeable]
+                     }
+                   ])
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+
+      context 'with a given parent folder', vcr: 'one_drive/files_query_parent_folder' do
+        subject do
+          described_class.call(storage:, user:, folder: '/Folder/Subfolder').result
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'returns the files content' do
+          expect(subject.files.map(&:to_h))
+            .to eq([
+                     {
+                       id: '01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA',
+                       name: 'NextcloudHub.md',
+                       size: 1095,
+                       created_at: '2023-09-26T14:45:25Z',
+                       created_by_name: 'Eric Schubert',
+                       last_modified_at: '2023-09-26T14:46:13Z',
+                       last_modified_by_name: 'Eric Schubert',
+                       location: '/Folder/Subfolder/NextcloudHub.md',
+                       mime_type: 'application/octet-stream',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '01AZJL5PLOL2KZTJNVFBCJWFXYGYVBQVMZ',
+                       name: 'test.txt',
+                       size: 28,
+                       created_at: '2023-09-26T14:45:23Z',
+                       created_by_name: 'Eric Schubert',
+                       last_modified_at: '2023-09-26T14:45:45Z',
+                       last_modified_by_name: 'Eric Schubert',
+                       location: '/Folder/Subfolder/test.txt',
+                       mime_type: 'text/plain',
+                       permissions: %i[readable writeable]
+                     }
+                   ])
+        end
+        # rubocop:enable RSpec/ExampleLength
+
+        it 'returns ancestors with a forged id' do
+          expect(subject.ancestors.map { |a| { id: a.id, name: a.name, location: a.location } })
+            .to eq([
+                     {
+                       id: 'a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d',
+                       name: 'Root',
+                       location: '/'
+                     }, {
+                       id: '74ccd43303847f2655300641a934959cdb11689ce171aa0f00faa92917fbd340',
+                       name: 'Folder',
+                       location: '/Folder'
+                     }
+                   ])
+        end
+
+        it 'returns the parent itself' do
+          expect(subject.parent.id).to eq('01AZJL5PPWP5UOATNRJJBYJG5TACDHEUAG')
+          expect(subject.parent.name).to eq('Subfolder')
+          expect(subject.parent.location).to eq('/Folder/Subfolder')
+        end
+      end
+
+      context 'with parent folder being empty', vcr: 'one_drive/files_query_empty_folder' do
+        it 'returns an empty StorageFiles object with parent and ancestors' do
+          storage_files = described_class.call(storage:, user:, folder: '/Folder with spaces/very empty folder').result
+
+          expect(storage_files).to be_a(Storages::StorageFiles)
+          expect(storage_files.files).to be_empty
+
+          # in an empty folder the parent id cannot be retrieved, hence the parent id will get forged
+          expect(storage_files.parent.id).to eq('678cb16697b9f7ef05a99a2dc83aaf1b377e5e2a9d7a09e1db4343b41d44f874')
+        end
+      end
+
+      context 'with a path full of umlauts', vcr: 'one_drive/files_query_umlauts' do
+        it 'returns the correct StorageFiles object' do
+          storage_files = described_class.call(storage:, user:, folder: '/Folder/Ümlæûts').result
+
+          expect(storage_files).to be_a(Storages::StorageFiles)
+          expect(storage_files.parent.id).to eq('01AZJL5PNQYF5NM3KWYNA3RJHJIB2XMMMB')
+          expect(storage_files.parent.name).to eq('Ümlæûts')
+          expect(storage_files.parent.location).to eq('/Folder/Ümlæûts')
+          expect(storage_files.files.map(&:to_h))
+            .to eq([
+                     {
+                       id: '01AZJL5PNDURPQGKUSGFCJQJMNNWXKTHSE',
+                       name: 'Anrüchiges deutsches Dokument.docx',
+                       size: 18007,
+                       created_at: '2023-10-09T15:26:45Z',
+                       created_by_name: 'Eric Schubert',
+                       last_modified_at: '2023-10-09T15:27:25Z',
+                       last_modified_by_name: 'Eric Schubert',
+                       location: '/Folder/Ümlæûts/Anrüchiges deutsches Dokument.docx',
+                       mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                       permissions: %i[readable writeable]
+                     }
+                   ])
+        end
+      end
     end
 
-    it 'fakes a parent' do
-      storage_files = described_class.call(storage:, user:, folder: '/TestBatchingFolder').result
+    context 'with not existent parent folder', vcr: 'one_drive/files_query_invalid_parent' do
+      it 'must return unauthorized' do
+        result = described_class.call(storage:, user:, folder: '/I/just/made/that/up')
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(described_class)
 
-      expect(storage_files.ancestors.size).to eq(1)
-      expect(storage_files.ancestors[0].location).to eq '/'
-    end
-  end
-
-  context 'when accessing a specific folder' do
-    let(:json) { read_json('specific_folder') }
-
-    it 'uses the specific drive url' do
-      uri = "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root:/Class%20Documents:/children#{described_class::FIELDS}"
-      stub_request(:get, uri)
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 200, body: json, headers: {})
-
-      storage_files = described_class.call(storage:, user:, folder: '/Class Documents').result
-
-      expect(storage_files.files.size).to eq(22)
-      expect(storage_files.parent.name).to eq('Class Documents')
-
-      expect(storage_files.ancestors.size).to eq(1)
-    end
-  end
-
-  context 'when accessing a folder two levels deep in the hierarchy' do
-    let(:payload) { read_json('two_levels_deep_folder') }
-    let(:storage) do
-      create(:one_drive_storage,
-             :with_oauth_client,
-             drive_id: 'b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd')
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:not_found) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
     end
 
-    it 'has one ancestors and one parent' do
-      stub_request(
-        :get,
-        "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root:/Contoso%20Clothing/Clothing%20Articles:/children#{described_class::FIELDS}"
-      ).with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 200, body: payload, headers: {})
+    context 'with invalid oauth token', vcr: 'one_drive/files_query_invalid_token' do
+      before do
+        token = build_stubbed(:oauth_client_token, oauth_client: storage.oauth_client)
+        allow(Storages::Peripherals::StorageInteraction::OneDrive::Util)
+          .to receive(:using_user_token)
+                .and_yield(token)
+      end
 
-      storage_files = described_class.call(storage:, user:, folder: "/Contoso Clothing/Clothing Articles").result
+      it 'must return unauthorized' do
+        result = described_class.call(storage:, user:, folder: nil)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(described_class)
 
-      expect(storage_files.ancestors.size).to eq(2)
-      expect(storage_files.ancestors.map(&:location)).to contain_exactly("/", "/Contoso Clothing")
-      expect(storage_files.parent.name).to eq('Clothing Articles')
-    end
-  end
-
-  describe 'error handling' do
-    it 'returns a notfound error if the API call returns a 404' do
-      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root/children#{described_class::FIELDS}")
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 404, body: '', headers: {})
-
-      storage_files = described_class.call(storage:, user:, folder: nil)
-
-      expect(storage_files).to be_failure
-      expect(storage_files.result).to eq(:not_found)
-      expect(storage_files.errors.to_s).to eq(Storages::StorageError.new(code: :not_found).to_s)
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
     end
 
-    it 'retries authentication when it returns a 401' do
-      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root/children#{described_class::FIELDS}")
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 401, body: '', headers: {})
+    context 'with not existent oauth token' do
+      let(:user_without_token) { create(:user) }
 
-      storage_files = described_class.call(storage:, user:, folder: nil)
+      it 'must return unauthorized' do
+        result = described_class.call(storage:, user: user_without_token, folder: nil)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(OAuthClients::ConnectionManager)
 
-      expect(storage_files).to be_failure
-      expect(storage_files.result).to eq(:unauthorized)
-      expect(storage_files.errors.to_s).to eq(Storages::StorageError.new(code: :unauthorized).to_s)
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
     end
   end
 end

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_empty_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_empty_folder.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder%20with%20spaces/very%20empty%20folder:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 68954b2c-23ca-4bcf-a9c5-2fd15e67cfe9
+      Client-Request-Id:
+      - 68954b2c-23ca-4bcf-a9c5-2fd15e67cfe9
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"006","RoleInstance":"AM1PEPF00027E51"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 09 Oct 2023 15:35:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)","value":[]}'
+  recorded_at: Mon, 09 Oct 2023 15:35:05 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_invalid_parent.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_invalid_parent.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/I/just/made/that/up:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 11be5934-563c-4a16-a8b3-441a36997cca
+      Client-Request-Id:
+      - 11be5934-563c-4a16-a8b3-441a36997cca
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"003","RoleInstance":"AM1PEPF000105CE"}}'
+      Date:
+      - Mon, 09 Oct 2023 15:56:29 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"itemNotFound","message":"The resource could not be
+        found.","innerError":{"date":"2023-10-09T15:56:30","request-id":"11be5934-563c-4a16-a8b3-441a36997cca","client-request-id":"11be5934-563c-4a16-a8b3-441a36997cca"}}}'
+  recorded_at: Mon, 09 Oct 2023 15:56:30 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_invalid_token.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_invalid_token.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 1234567890-1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 1e1e9a8d-3746-490e-b12e-9ede175e597b
+      Client-Request-Id:
+      - 1e1e9a8d-3746-490e-b12e-9ede175e597b
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"004","RoleInstance":"AM2PEPF0001D018"}}'
+      Www-Authenticate:
+      - Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize",
+        client_id="00000003-0000-0000-c000-000000000000"
+      Date:
+      - Mon, 09 Oct 2023 15:51:36 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"InvalidAuthenticationToken","message":"CompactToken
+        parsing failed with error code: 80049217","innerError":{"date":"2023-10-09T15:51:36","request-id":"1e1e9a8d-3746-490e-b12e-9ede175e597b","client-request-id":"1e1e9a8d-3746-490e-b12e-9ede175e597b"}}}'
+  recorded_at: Mon, 09 Oct 2023 15:51:36 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_parent_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_parent_folder.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder/Subfolder:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 06150b68-8909-4daf-822a-83e46b1ae0f7
+      Client-Request-Id:
+      - 06150b68-8909-4daf-822a-83e46b1ae0f7
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"AM2PEPF0000BE04"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 09 Oct 2023 15:35:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)","value":[{"@odata.etag":"\"{128880A2-6DA3-4DFA-995F-A075F7ACED60},3\"","id":"01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA","name":"NextcloudHub.md","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder/Subfolder/NextcloudHub.md","size":1095,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PPWP5UOATNRJJBYJG5TACDHEUAG","name":"Subfolder","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder/Subfolder","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"file":{"mimeType":"application/octet-stream","hashes":{"quickXorHash":"2HQJc625zkgBM9NAAjuXr1Im/0M="}},"fileSystemInfo":{"createdDateTime":"2023-09-26T14:45:25Z","lastModifiedDateTime":"2023-09-26T14:46:13Z"}},{"@odata.etag":"\"{99955E6E-B5A5-4428-9B16-F8362A185599},2\"","id":"01AZJL5PLOL2KZTJNVFBCJWFXYGYVBQVMZ","name":"test.txt","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder/Subfolder/test.txt","size":28,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PPWP5UOATNRJJBYJG5TACDHEUAG","name":"Subfolder","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder/Subfolder","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"file":{"mimeType":"text/plain","hashes":{"quickXorHash":"9UxjuqUZcnTLEZxAEa00UdsSOLA="}},"fileSystemInfo":{"createdDateTime":"2023-09-26T14:45:23Z","lastModifiedDateTime":"2023-09-26T14:45:45Z"}}]}'
+  recorded_at: Mon, 09 Oct 2023 15:35:05 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_root.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 982d11e6-1a44-4078-9c64-423d058bf00b
+      Client-Request-Id:
+      - 982d11e6-1a44-4078-9c64-423d058bf00b
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"003","RoleInstance":"AM1PEPF000105CC"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 09 Oct 2023 15:35:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)","value":[{"@odata.etag":"\"{6087B980-4C01-4020-BBF2-1E349BD0C831},1\"","id":"01AZJL5PMAXGDWAAKMEBALX4Q6GSN5BSBR","name":"Folder","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder","size":257394,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","name":"VCR","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"fileSystemInfo":{"createdDateTime":"2023-09-26T14:38:50Z","lastModifiedDateTime":"2023-09-26T14:38:50Z"},"folder":{"childCount":5}},{"@odata.etag":"\"{BAABD554-2A6E-4B51-A07F-22B54378CC94},1\"","id":"01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU","name":"Folder
+        with spaces","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder%20with%20spaces","size":35141,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","name":"VCR","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"fileSystemInfo":{"createdDateTime":"2023-09-26T14:38:57Z","lastModifiedDateTime":"2023-09-26T14:38:57Z"},"folder":{"childCount":4}}]}'
+  recorded_at: Mon, 09 Oct 2023 15:35:04 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_umlauts.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_umlauts.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder/%C3%9Cml%C3%A6%C3%BBts:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - a4658512-81eb-48db-8ab7-4a3369f1eaee
+      Client-Request-Id:
+      - a4658512-81eb-48db-8ab7-4a3369f1eaee
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"009","RoleInstance":"AM1PEPF00029CE7"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 09 Oct 2023 15:35:05 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)","value":[{"@odata.etag":"\"{035FA4A3-922A-4431-9825-8D6DAEA99E44},4\"","id":"01AZJL5PNDURPQGKUSGFCJQJMNNWXKTHSE","name":"Anr\u00fcchiges
+        deutsches Dokument.docx","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/_layouts/15/Doc.aspx?sourcedoc=%7B035FA4A3-922A-4431-9825-8D6DAEA99E44%7D&file=Anr%C3%BCchiges%20deutsches%20Dokument.docx&action=default&mobileredirect=true","size":18007,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PNQYF5NM3KWYNA3RJHJIB2XMMMB","name":"\u00dcml\u00e6\u00fbts","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder/\u00dcml\u00e6\u00fbts","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"file":{"mimeType":"application/vnd.openxmlformats-officedocument.wordprocessingml.document","hashes":{}},"fileSystemInfo":{"createdDateTime":"2023-10-09T15:26:45Z","lastModifiedDateTime":"2023-10-09T15:27:25Z"}}]}'
+  recorded_at: Mon, 09 Oct 2023 15:35:05 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
### What?

- refactored test for `one_drive/files_query` to use vcr data
- fixed found bugs
- added error data to files query

### Why?

- because live data is more accurate then stubs