### PR TITLE
Bump frontend docker dev container to node v18 and pin npm v10

### DIFF
--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15
+FROM node:18
 MAINTAINER operations@openproject.com
 
 ARG DEV_UID=1000
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y chromium
 
 ENV CHROME_BIN=/usr/bin/chromium
 
-RUN npm i -g npm
+RUN npm i -g npm@10
 
 RUN groupadd $USER || true
 RUN groupmod -g $DEV_GID $USER || true


### PR DESCRIPTION
During the OpenProject development setup via docker an error occurred.

The command:
`docker compose run --rm frontend npm install`

Produced following error message:
```
------                                                                                                     
 > [3/9] RUN npm i -g npm:
#0 0.377 npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
#0 0.775 npm ERR! code EBADENGINE
#0 0.775 npm ERR! engine Unsupported engine
#0 0.775 npm ERR! engine Not compatible with your version of node/npm: npm@10.2.0
#0 0.776 npm ERR! notsup Not compatible with your version of node/npm: npm@10.2.0
#0 0.776 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
#0 0.776 npm ERR! notsup Actual:   {"npm":"8.11.0","node":"v16.15.1"}
#0 0.777 
#0 0.777 npm ERR! A complete log of this run can be found in:
#0 0.777 npm ERR!     /root/.npm/_logs/2023-10-10T08_07_39_227Z-debug-0.log
------
```

As `npm i -g npm` has no version specified the latest (v10) is attempted to be installed - which is not compatible with Node v16.

This PR bumps node to v18 and pins npm to v10 in the frontend docker dev container.


FYI as of today following versions got installed:
$ node --version
v18.18.0
$ npm --version
10.2.0

