### PR TITLE
Don't raise ArgumentError when providing empty date

### DIFF
--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -285,9 +285,7 @@ class Meeting < ApplicationRecord
     date = parsed_start_date
     time = parsed_start_time_hour
 
-    if date.nil? || time.nil?
-      raise ArgumentError, 'Provided composite start_time is invalid.'
-    end
+    return if date.nil? || time.nil?
 
     Time.zone.local(
       date.year,

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Meeting do
       it 'marks invalid start dates' do
         meeting.start_date = '-'
         expect(meeting.start_date).to eq('-')
-        expect { meeting.start_time }.to raise_error(ArgumentError)
+        expect(meeting.start_time).to be_nil
         expect(meeting).not_to be_valid
         expect(meeting.errors.count).to eq(1)
       end
@@ -80,7 +80,7 @@ RSpec.describe Meeting do
       it 'marks invalid start hours' do
         meeting.start_time_hour = '-'
         expect(meeting.start_time_hour).to eq('-')
-        expect { meeting.start_time }.to raise_error(ArgumentError)
+        expect(meeting.start_time).to be_nil
         expect(meeting).not_to be_valid
         expect(meeting.errors.count).to eq(1)
       end
@@ -96,8 +96,9 @@ RSpec.describe Meeting do
 
       it 'accepts changes after invalid dates' do
         meeting.start_date = '-'
-        expect { meeting.start_time }.to raise_error(ArgumentError)
+        expect(meeting.start_time).to be_nil
         expect(meeting).not_to be_valid
+        expect(meeting.errors[:start_date]).to contain_exactly 'is not a valid date. Required format: YYYY-MM-DD.'
 
         meeting.start_date = Time.zone.today.iso8601
         expect(meeting).to be_valid


### PR DESCRIPTION
Instead, a validation on start_date or start_time_hour is presented so that the form can be validated

https://community.openproject.org/work_packages/50456