### PR TITLE
Fix permissions unknown on SaaS

### DIFF
--- a/config/initializers/module_handler.rb
+++ b/config/initializers/module_handler.rb
@@ -27,8 +27,14 @@
 #++
 
 Rails.application.config.to_prepare do
-  if OpenProject::Configuration.disabled_modules.any?
-    to_disable = OpenProject::Configuration.disabled_modules
+  # Dashboards should currently always be disabled since the functionality is not desired.
+  to_disable = if Rails.env.test?
+                 OpenProject::Configuration.disabled_modules
+               else
+                 ['dashboards'] + OpenProject::Configuration.disabled_modules
+               end
+
+  if to_disable.any?
     OpenProject::Plugins::ModuleHandler.disable_modules!(to_disable)
   end
 end

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -38,10 +38,9 @@ module API
           end
 
           get do
-            self_path = api_v3_paths.work_package_revisions(work_package.id)
-
-            revisions = work_package.changesets.visible
-            RevisionCollectionRepresenter.new(revisions, self_link: self_path, current_user:)
+            RevisionCollectionRepresenter.new(work_package.changesets.visible,
+                                              self_link: api_v3_paths.work_package_revisions(work_package.id),
+                                              current_user:)
           end
         end
       end

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -107,6 +107,10 @@ module OpenProject
           @enabled
         end
       end
+
+      def disable!
+        @enabled = false
+      end
     end
   end
 end

--- a/lib/open_project/plugins/module_handler.rb
+++ b/lib/open_project/plugins/module_handler.rb
@@ -34,7 +34,7 @@ module OpenProject::Plugins
 
     def disable_modules!(module_names)
       @@disabled_modules += Array(module_names).map(&:to_sym).each do |module_name|
-        OpenProject::AccessControl.remove_modules_permissions(module_name)
+        OpenProject::AccessControl.disable_modules_permissions(module_name)
       end
     end
   end

--- a/modules/dashboards/lib/dashboards/engine.rb
+++ b/modules/dashboards/lib/dashboards/engine.rb
@@ -21,7 +21,7 @@ module Dashboards
 
     initializer 'dashboards.permissions' do
       Rails.application.reloader.to_prepare do
-        # deactivate for now
+        # Deactivate for now since the module isn't loaded in production
         next unless Rails.env.test?
 
         OpenProject::AccessControl.map do |ac_map|
@@ -44,6 +44,9 @@ module Dashboards
     end
 
     config.to_prepare do
+      # Deactivate for now since the module isn't loaded in production
+      next unless Rails.env.test?
+
       Dashboards::GridRegistration.register!
     end
   end

--- a/modules/dashboards/lib/dashboards/engine.rb
+++ b/modules/dashboards/lib/dashboards/engine.rb
@@ -21,9 +21,6 @@ module Dashboards
 
     initializer 'dashboards.permissions' do
       Rails.application.reloader.to_prepare do
-        # Deactivate for now since the module isn't loaded in production
-        next unless Rails.env.test?
-
         OpenProject::AccessControl.map do |ac_map|
           ac_map.project_module(:dashboards) do |pm_map|
             pm_map.permission(:view_dashboards,
@@ -44,9 +41,6 @@ module Dashboards
     end
 
     config.to_prepare do
-      # Deactivate for now since the module isn't loaded in production
-      next unless Rails.env.test?
-
       Dashboards::GridRegistration.register!
     end
   end

--- a/spec/services/authorization_spec.rb
+++ b/spec/services/authorization_spec.rb
@@ -174,8 +174,13 @@ RSpec.describe Authorization do
         let(:raise_on_unknown) { false }
 
         it 'warns and returns an empty array' do
-          expect(Rails.logger).to receive(:warn).with(/Used permission "#{action}" that is not defined./)
+          allow(Rails.logger).to receive(:debug)
+
           expect(subject).to be_empty
+
+          expect(Rails.logger).to have_received(:debug) do |_, &block|
+            expect(block.call).to include("Used permission \"#{action}\" that is not defined.")
+          end
         end
       end
 
@@ -183,8 +188,13 @@ RSpec.describe Authorization do
         let(:raise_on_unknown) { true }
 
         it 'warns and raises' do
-          expect(Rails.logger).to receive(:warn).with(/Used permission "#{action}" that is not defined./)
+          allow(Rails.logger).to receive(:debug)
+
           expect { subject }.to raise_error(Authorization::UnknownPermissionError)
+
+          expect(Rails.logger).to have_received(:debug) do |_, &block|
+            expect(block.call).to include("Used permission \"#{action}\" that is not defined.")
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes unknown permission errors that occur only in production or even only on SaaS because of disabled modules:

* Dashboards (which breaks the overview page)
* Repository (which breaks the work package activity)

It is caused by permissions being checked that are valid in that they exist in the codebase but are disabled e.g. because the module is disabled for the current instance. This is for example the case for the `view_changesets` permission of the `repository` module which is disabled on SaaS.

The PR thus changes the behaviour when encountering a disabled permission. Such a permission will not cause an exception.

https://community.openproject.org/wp/50455