### PR TITLE
Fix/fix attachments unit test

### DIFF
--- a/spec/requests/api/v3/attachments_spec.rb
+++ b/spec/requests/api/v3/attachments_spec.rb
@@ -40,21 +40,16 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
   let(:role) { create(:role, permissions:) }
   let(:permissions) { [:add_work_packages] }
 
-  context(
-    'with missing permissions',
-    with_config: {
-      attachments_storage: :fog,
-      fog: { credentials: { provider: 'AWS' } }
-    }
-  ) do
+  context 'with missing permissions', :with_direct_uploads do
     let(:permissions) { [] }
 
     let(:request_path) { api_v3_paths.prepare_new_attachment_upload }
     let(:request_parts) { { metadata: metadata.to_json, file: } }
-    let(:metadata) { { fileName: 'cat.png' } }
+    let(:metadata) { { fileName: 'cat.png', fileSize: file.size, contentType: 'image/png' } }
     let(:file) { mock_uploaded_file(name: 'original-filename.txt') }
 
     before do
+      allow(User).to receive(:current).and_return current_user
       post request_path, request_parts
     end
 

--- a/spec/requests/api/v3/attachments_spec.rb
+++ b/spec/requests/api/v3/attachments_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
   let(:role) { create(:role, permissions:) }
   let(:permissions) { [:add_work_packages] }
 
-  context 'with missing permissions', :with_direct_uploads do
-    let(:permissions) { [] }
-
+  describe 'permissions', :with_direct_uploads do
     let(:request_path) { api_v3_paths.prepare_new_attachment_upload }
     let(:request_parts) { { metadata: metadata.to_json, file: } }
     let(:metadata) { { fileName: 'cat.png', fileSize: file.size, contentType: 'image/png' } }
@@ -53,8 +51,28 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
       post request_path, request_parts
     end
 
-    it 'forbids to prepare attachments' do
-      expect(last_response.status).to eq 403
+    context 'with missing permissions' do
+      let(:permissions) { [] }
+
+      it 'forbids to prepare attachments' do
+        expect(last_response.status).to eq 403
+      end
+    end
+
+    context 'with :edit_work_packages permission' do
+      let(:permissions) { [:edit_work_packages] }
+
+      it 'can prepare attachments' do
+        expect(last_response.status).to eq 201
+      end
+    end
+
+    context 'with :add_work_package_attachments permission' do
+      let(:permissions) { [:add_work_package_attachments] }
+
+      it 'can prepare attachments' do
+        expect(last_response.status).to eq 201
+      end
     end
   end
 


### PR DESCRIPTION
While reviewing #13861, I spoted a unit test which did not behave correctly: it was expecting a 403 unauthorized because of missing permissions, but when using the correct permissions, it was still failing with 403 because it was using the anonymous user. Then it was a 422 for missing file size, and then a 422 again because the fog provider was not properly configured.

This was all fixed in the first commit.

Then the second commit adds a positive test case to ensure there will not be any regression on this anymore, and also test the `:add_work_package_attachments` permission introduced in #13861.