### PR TITLE
Improve performance on `work_packages/update_ancestors_service_spec`

### DIFF
--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
         it 'updated one work package - the parent' do
           expect(subject.dependent_results.map(&:result))
-          .to match_array [parent]
+          .to contain_exactly(parent)
         end
 
         it 'has the expected aggregate done ratio' do
@@ -254,7 +254,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
       it 'returns the former ancestors in the dependent results' do
         expect(subject.dependent_results.map(&:result))
-          .to match_array [parent, grandparent]
+          .to contain_exactly(parent, grandparent)
       end
 
       it 'updates the done_ratio of the former parent' do
@@ -309,7 +309,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
         it 'returns the new ancestors in the dependent results' do
           expect(subject.dependent_results.map(&:result))
-            .to match_array [parent, grandparent]
+            .to contain_exactly(parent, grandparent)
         end
 
         it 'updates the done_ratio of the new parent' do
@@ -424,7 +424,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
       it 'returns both the former and new ancestors in the dependent results without duplicates' do
         expect(subject.dependent_results.map(&:result))
-          .to match_array [new_parent, grandparent, old_parent]
+          .to contain_exactly(new_parent, grandparent, old_parent)
       end
 
       it 'updates the done_ratio of the former parent' do
@@ -498,7 +498,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
       it 'returns the former ancestors in the dependent results' do
         expect(subject.dependent_results.map(&:result))
-          .to match_array [parent, grandparent, grandgrandparent]
+          .to contain_exactly(parent, grandparent, grandgrandparent)
       end
 
       it 'sets the ignore_non_working_days property of the former ancestor chain to the value of the
@@ -541,7 +541,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
       it 'returns the former ancestors in the dependent results' do
         expect(subject.dependent_results.map(&:result))
-          .to match_array [parent]
+          .to contain_exactly(parent)
       end
 
       it 'sets the ignore_non_working_days property of the new ancestors' do

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -29,12 +29,16 @@
 require 'spec_helper'
 
 RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
-  let(:user) { create(:user) }
+  shared_association_default(:author, factory_name: :user) { create(:user) }
+  shared_association_default(:project_with_types) { create(:project_with_types) }
+  shared_association_default(:priority) { create(:priority) }
+  shared_association_default(:open_status, factory_name: :status) { create(:status) }
+  shared_let(:closed_status) { create(:closed_status) }
+  shared_let(:user) { create(:user) }
+
   let(:estimated_hours) { [nil, nil, nil] }
   let(:done_ratios) { [0, 0, 0] }
   let(:statuses) { %i(open open open) }
-  let(:open_status) { create(:status) }
-  let(:closed_status) { create(:closed_status) }
   let(:aggregate_done_ratio) { 0.0 }
   let(:ignore_non_working_days) { [false, false, false] }
 


### PR DESCRIPTION
By using some of the [profilers provided by test-prof](https://test-prof.evilmartians.io/#/profilers/factory_prof), I found we're spending a
massive **81% of the total time in factories** for this spec file.

By leveraging the `shared_let` strategy and preventing
factory cascades, we can chop this down significantly to
something more reasonable.

As demonstrated below, the average execution time of the spec file was reduced
from **~23 seconds** down to **~6.9 seconds** .

Average time spent in factories went down from 81.2% to 48.01%.
Most of this time is still spent in work package creation but
this is just because the spec requires a lot of work packages being
created. Despite this, I still believe the changes performed are quite
a significant bump to the spec's performance! 🏎️

### Before
```
Finished in 23.04 seconds (files took 8.61 seconds to load)
65 examples, 0 failures

Randomized with seed 48285

[TEST PROF INFO] Time spent in factories: 00:20.385 (81.2% of total time)
[TEST PROF INFO] Factories usage

 Total: 1370
 Total top-level: 362
 Total time: 00:20.385 (out of 00:29.258)
 Total uniq factories: 7

   total   top-level     total time      time per call      top-level time               name

     286          65        2.9315s            0.0102s             0.6740s               user
     286           0        0.4635s            0.0016s             0.0000s notification_setting
     221         221       19.4693s            0.0881s            19.4693s       work_package
     221           0        0.6336s            0.0029s             0.0000s           priority
     221           0       12.0981s            0.0547s             0.0000s project_with_types
     115          56        0.3583s            0.0031s             0.1911s             status
      20          20        0.0507s            0.0025s             0.0507s      closed_status
```

### After
```
Finished in 6.86 seconds (files took 9 seconds to load)
65 examples, 0 failures

Randomized with seed 43677

[TEST PROF INFO] Time spent in factories: 00:04.260 (48.01% of total time)
[TEST PROF INFO] Factories usage

 Total: 254
 Total top-level: 227
 Total time: 00:04.260 (out of 00:13.042)
 Total uniq factories: 7

   total   top-level     total time      time per call      top-level time               name

     221         221        3.9714s            0.0180s             3.9714s       work_package
       7           2        0.1462s            0.0209s             0.1058s               user
       7           0        0.0201s            0.0029s             0.0000s notification_setting
       6           1        0.3817s            0.0636s             0.1561s project_with_types
       6           1        0.0230s            0.0038s             0.0114s           priority
       6           1        0.0243s            0.0040s             0.0132s             status
       1           1        0.0027s            0.0027s             0.0027s      closed_status
```
