### PR TITLE
Make 20% faster work_packages/update_ancestors_service_spec

### DIFF
--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -80,7 +80,8 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                  ignore_non_working_days:)
         end
       end
-      let(:parent) { create(:work_package, status: open_status) }
+
+      shared_let(:parent) { create(:work_package, status: open_status) }
 
       subject do
         # In the call we only use estimated_hours (instead of also adding
@@ -213,18 +214,18 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
 
     context 'for the previous ancestors' do
-      let(:sibling_status) { open_status }
-      let(:sibling_done_ratio) { 50 }
-      let(:sibling_estimated_hours) { 7.0 }
+      shared_let(:sibling_status) { open_status }
+      shared_let(:sibling_done_ratio) { 50 }
+      shared_let(:sibling_estimated_hours) { 7.0 }
 
-      let!(:grandparent) do
+      shared_let(:grandparent) do
         create(:work_package)
       end
-      let!(:parent) do
+      shared_let(:parent) do
         create(:work_package,
                parent: grandparent)
       end
-      let!(:sibling) do
+      shared_let(:sibling) do
         create(:work_package,
                parent:,
                status: sibling_status,
@@ -232,7 +233,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                done_ratio: sibling_done_ratio)
       end
 
-      let!(:work_package) do
+      shared_let(:work_package) do
         create(:work_package,
                parent:)
       end
@@ -283,18 +284,18 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
 
     context 'for new ancestors' do
-      let(:status) { open_status }
-      let(:done_ratio) { 50 }
-      let(:estimated_hours) { 7.0 }
+      shared_let(:status) { open_status }
+      shared_let(:done_ratio) { 50 }
+      shared_let(:estimated_hours) { 7.0 }
 
-      let!(:grandparent) do
+      shared_let(:grandparent) do
         create(:work_package)
       end
-      let!(:parent) do
+      shared_let(:parent) do
         create(:work_package,
                parent: grandparent)
       end
-      let!(:work_package) do
+      shared_let(:work_package) do
         create(:work_package,
                status:,
                estimated_hours:,
@@ -369,26 +370,26 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
 
     context 'with old and new parent having a common ancestor' do
-      let(:status) { open_status }
-      let(:done_ratio) { 50 }
-      let(:estimated_hours) { 7.0 }
+      shared_let(:status) { open_status }
+      shared_let(:done_ratio) { 50 }
+      shared_let(:estimated_hours) { 7.0 }
 
-      let!(:grandparent) do
+      shared_let(:grandparent) do
         create(:work_package,
                derived_estimated_hours: estimated_hours,
                done_ratio:)
       end
-      let!(:old_parent) do
+      shared_let(:old_parent) do
         create(:work_package,
                parent: grandparent,
                derived_estimated_hours: estimated_hours,
                done_ratio:)
       end
-      let!(:new_parent) do
+      shared_let(:new_parent) do
         create(:work_package,
                parent: grandparent)
       end
-      let!(:work_package) do
+      shared_let(:work_package) do
         create(:work_package,
                parent: old_parent,
                status:,
@@ -587,7 +588,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
       it 'returns the former ancestors in the dependent results' do
         expect(subject.dependent_results.map(&:result))
-          .to match_array []
+          .to be_empty
       end
 
       it 'sets the ignore_non_working_days property of the new ancestors' do

--- a/spec/support/shared_let.rb
+++ b/spec/support/shared_let.rb
@@ -59,7 +59,7 @@ def shared_association_default(key, factory_name: key, &block)
   # unique let identifier to prevent clashes
   let_it_be(key, reload: true, &block)
 
-  before do
+  before_all do
     set_factory_default(factory_name, send(key))
   end
 end


### PR DESCRIPTION
PR #13897 did a great job at improving the performance of running `work_packages/update_ancestors_service_spec` spec by making it 70% faster.

With some additional `shared_let`, it's possible to have less work packages created and gain a little 20% more.

Run with `FPROF=1` to have below statistics.

Before:

```
Finished in 4.55 seconds (files took 8.14 seconds to load)
65 examples, 0 failures

[TEST PROF INFO] Time spent in factories: 00:02.833 (39.19% of total time)
[TEST PROF INFO] Factories usage

 Total: 254
 Total top-level: 227
 Total time: 00:02.833 (out of 00:10.861)
 Total uniq factories: 7

   total   top-level     total time      time per call      top-level time               name

     221         221        2.6216s            0.0119s             2.6216s       work_package
       7           2        0.1100s            0.0157s             0.0777s               user
       7           0        0.0167s            0.0024s             0.0000s notification_setting
       6           1        0.2549s            0.0425s             0.1045s project_with_types
       6           1        0.0245s            0.0041s             0.0130s           priority
       6           1        0.0244s            0.0041s             0.0142s             status
       1           1        0.0024s            0.0024s             0.0024s      closed_status
```

After:

```
Finished in 3.59 seconds (files took 8.25 seconds to load)
65 examples, 0 failures

[TEST PROF INFO] Time spent in factories: 00:01.857 (29.59% of total time)
[TEST PROF INFO] Factories usage

 Total: 131
 Total top-level: 129
 Total time: 00:01.857 (out of 00:09.947)
 Total uniq factories: 7

   total   top-level     total time      time per call      top-level time               name

     123         123        1.6649s            0.0135s             1.6649s       work_package
       2           2        0.0780s            0.0390s             0.0780s               user
       2           0        0.0112s            0.0056s             0.0000s notification_setting
       1           1        0.0946s            0.0946s             0.0946s project_with_types
       1           1        0.0084s            0.0084s             0.0084s           priority
       1           1        0.0096s            0.0096s             0.0096s             status
       1           1        0.0017s            0.0017s             0.0017s      closed_status
```