### PR TITLE
Allow multiple-directory dynamic Stimulus controller namespacing

### DIFF
--- a/frontend/src/stimulus/controllers/op-application.controller.ts
+++ b/frontend/src/stimulus/controllers/op-application.controller.ts
@@ -31,6 +31,6 @@ export class OpApplicationController extends ApplicationController {
    * @private
    */
   private derivePath(controller:string):string {
-    return controller.replace('--', '/');
+    return controller.replace(/--/g, '/');
   }
 }


### PR DESCRIPTION
As per the docs:
https://devdocs.io/javascript/global_objects/string/replace

> "If pattern is a string, only the first occurrence will be replaced."

---

This should allow a stimulus controller to be namespaced upon multiple subdirectories. For example:

`dynamic/work-packages/shares/x.controller.ts`