### PR TITLE
Complete errors (contract + model) in model.errors

### DIFF
--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -125,16 +125,6 @@ class BaseContract < Disposable::Twin
     @options = options
   end
 
-  # TODO: This should be removable here and in the subclasses
-  # we want to add a validation error whenever someone sets a property that we don't know.
-  # However AR will cleverly try to resolve the value for erroneous properties. Thus we need
-  # to hook into this method and return nil for unknown properties to avoid NoMethod errors...
-  def read_attribute_for_validation(attribute)
-    if respond_to? attribute
-      send attribute
-    end
-  end
-
   def writable_attributes
     @writable_attributes ||= reduce_writable_attributes(collect_writable_attributes)
   end
@@ -152,13 +142,6 @@ class BaseContract < Disposable::Twin
     valid?(*)
   end
 
-  # Methods required to get ActiveModel error messages working
-  extend ActiveModel::Naming
-
-  def self.model_name
-    ActiveModel::Name.new(model, nil)
-  end
-
   def errors
     if model.respond_to?(:errors)
       model.errors
@@ -166,22 +149,6 @@ class BaseContract < Disposable::Twin
       super
     end
   end
-
-  def self.model
-    @model ||= begin
-      name.deconstantize.singularize.constantize
-    rescue NameError
-      ActiveRecord::Base
-    end
-  end
-
-  # TODO: check if this can be removed
-  # use activerecord as the base scope instead of 'activemodel' to be compatible
-  # to the messages we have already stored
-  def self.i18n_scope
-    :activerecord
-  end
-  # end Methods required to get ActiveModel error messages working
 
   protected
 

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -158,6 +158,14 @@ class BaseContract < Disposable::Twin
     ActiveModel::Name.new(model, nil)
   end
 
+  def errors
+    if model.respond_to?(:errors)
+      model.errors
+    else
+      super
+    end
+  end
+
   def self.model
     @model ||= begin
       name.deconstantize.singularize.constantize

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -175,6 +175,7 @@ class BaseContract < Disposable::Twin
     end
   end
 
+  # TODO: check if this can be removed
   # use activerecord as the base scope instead of 'activemodel' to be compatible
   # to the messages we have already stored
   def self.i18n_scope

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -125,6 +125,7 @@ class BaseContract < Disposable::Twin
     @options = options
   end
 
+  # TODO: This should be removable here and in the subclasses
   # we want to add a validation error whenever someone sets a property that we don't know.
   # However AR will cleverly try to resolve the value for erroneous properties. Thus we need
   # to hook into this method and return nil for unknown properties to avoid NoMethod errors...

--- a/app/contracts/model_contract.rb
+++ b/app/contracts/model_contract.rb
@@ -32,25 +32,45 @@ require_relative './base_contract'
 # Model contract for AR records that
 # support change tracking
 class ModelContract < BaseContract
-  def valid?(*_args)
-    super()
-    readonly_attributes_unchanged
+  # Runs all the specified validations and returns +true+ if no errors were
+  # added otherwise +false+.
+  # Validations on the model as well as on the contract are run.
+  # Since the error object of this contract is the model's error object,
+  # the errors of both contract and model are both added to it.
+  # After validation, the errors can thus be accessed via both means:
+  #
+  #   model = SomeModel.new
+  #   contract = SomeModels::SomeModelContract.new(model, some_user)
+  #   contract.valid? # => false
+  #
+  #   contract.errors == model.errors # => true
+  #
+  # This of course is only true if that contract validates the model and
+  # if the model has an errors object.
+  def valid?(context = nil)
+    model.valid? if validate_model?
 
-    # Allow subclasses to check only contract errors
-    return errors.empty? unless validate_model?
-
-    model.valid?
-
-    # We need to merge the contract errors with the model errors in
-    # order to have them available at one place.
-    # This is something we need as long as we have validations split
-    # among the model and its contract.
-    errors.merge!(model.errors)
-
-    errors.empty?
+    contract_valid?(context, clear_errors: !validate_model?)
   end
 
   protected
+
+  # This method is mostly copied from ActiveModel::Validations#valid?
+  # but:
+  # * does not clear errors before validation unless explicitly instructed to do so.
+  #   Clearing would then be done in the #valid? method by calling model.valid?
+  # * Checks for readonly attributes being changed
+  def contract_valid?(context = nil, clear_errors: false)
+    current_context, self.validation_context = validation_context, context # rubocop:disable Style/ParallelAssignment
+
+    errors.clear if clear_errors
+
+    readonly_attributes_unchanged
+
+    run_validations!
+  ensure
+    self.validation_context = current_context
+  end
 
   ##
   # Allow subclasses to disable model validation

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -122,9 +122,11 @@ module Projects
 
       contract_klass = model.being_archived? ? ArchiveContract : UnarchiveContract
       contract = contract_klass.new(model, user)
+
+      former_errors = errors.dup
       contract.validate
 
-      errors.merge!(contract.errors)
+      errors.merge!(former_errors)
     end
   end
 end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -46,7 +46,7 @@ module Relations
       Relation
     end
 
-    def validate!(*args)
+    def valid?(*args)
       # same as before_validation callback
       model.send(:reverse_if_needed)
 
@@ -65,7 +65,7 @@ module Relations
 
     def validate_nodes_relatable
       if (model.from_id_changed? || model.to_id_changed?) &&
-         WorkPackage.relatable(model.from, model.relation_type).where(id: model.to).empty?
+         WorkPackage.relatable(model.from, model.relation_type, ignore_relation: model).where(id: model.to).empty?
         errors.add :base, I18n.t(:'activerecord.errors.messages.circular_dependency')
       end
     end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -46,13 +46,6 @@ module Relations
       Relation
     end
 
-    def valid?(*args)
-      # same as before_validation callback
-      model.send(:reverse_if_needed)
-
-      super
-    end
-
     private
 
     def validate_from_exists

--- a/app/contracts/views/base_contract.rb
+++ b/app/contracts/views/base_contract.rb
@@ -41,9 +41,11 @@ module Views
       # needs to validate additionally. E.g. a contract can have additional permission checks.
       if (strategy_class = Constants::Views.contract_strategy(model.type))
         strategy = strategy_class.new(model, user)
+
+        former_errors = errors.dup
         strategy.valid?
 
-        errors.merge!(strategy.errors)
+        errors.merge!(former_errors)
       end
 
       errors.empty?

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -15,6 +15,13 @@ class ApplicationRecord < ActiveRecord::Base
     errors[attribute].empty?
   end
 
+  # We want to add a validation error whenever someone sets a property that we don't know.
+  # However AR will cleverly try to resolve the value for erroneous properties. Thus we need
+  # to hook into this method and return nil for unknown properties to avoid NoMethod errors...
+  def read_attribute_for_validation(attribute)
+    super if respond_to?(attribute)
+  end
+
   ##
   # Get the newest recently changed resource for the given record classes
   #

--- a/app/models/work_packages/scopes/directly_related.rb
+++ b/app/models/work_packages/scopes/directly_related.rb
@@ -31,9 +31,11 @@ module WorkPackages::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      def directly_related(work_package)
-        where(id: Relation.where(from_id: work_package).select(:to_id))
-          .or(where(id: Relation.where(to_id: work_package).select(:from_id)))
+      def directly_related(work_package, ignore_relation: nil)
+        relations_without_ignored = ignore_relation ? Relation.where.not(id: ignore_relation.id) : Relation.all
+
+        where(id: relations_without_ignored.where(from_id: work_package).select(:to_id))
+        .or(where(id: relations_without_ignored.where(to_id: work_package).select(:from_id)))
       end
     end
   end

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -168,7 +168,14 @@ module WorkPackages::Scopes
       # * includes_hierarchy - boolean indicating that the last relation taken was a hierarchy relation. For a queried for
       #                        PARENT relation, whenever that is the case, the work package is a valid relation target although
       #                        it appears in the CTE.
-      def relatable(work_package, relation_type)
+      #
+      # The caller can can also provide a relation that is ignored for the calculation of which
+      # work packages are relatable. This can be helpful in case an existing relation is updated
+      # especially if the the direction is switched. Only a single relation can be provided and
+      # that one has to either be from or to the work package queried for.
+      def relatable(work_package, relation_type, ignore_relation: nil)
+        relatable_ensure_single_relation(ignore_relation, work_package)
+
         return all if work_package.new_record?
 
         scope = case relation_type
@@ -177,11 +184,11 @@ module WorkPackages::Scopes
                 when Relation::TYPE_CHILD
                   not_having_potential_tree_relation_child(work_package)
                 else
-                  where.not(id: directly_related(work_package))
+                  where.not(id: directly_related(work_package, ignore_relation:))
                 end
 
         scope = scope
-                  .not_having_transitive_relation(work_package, relation_type)
+                  .not_having_transitive_relation(work_package, relation_type, ignore_relation:)
                   .where.not(id: work_package.id)
 
         if Setting.cross_project_work_package_relations
@@ -191,7 +198,7 @@ module WorkPackages::Scopes
         end
       end
 
-      def not_having_transitive_relation(work_package, relation_type)
+      def not_having_transitive_relation(work_package, relation_type, ignore_relation:)
         if relation_type == Relation::TYPE_RELATES
           # Bypassing the recursive query in this case as only children and parent needs to be excluded.
           # Using this more complicated statement since
@@ -204,7 +211,7 @@ module WorkPackages::Scopes
           sql = <<~SQL.squish
             WITH
               RECURSIVE
-              #{non_relatable_paths_sql(work_package, relation_type)}
+              #{non_relatable_paths_sql(work_package, relation_type, ignore_relation:)}
 
               SELECT id
               FROM related
@@ -243,7 +250,7 @@ module WorkPackages::Scopes
           .where.not(id: where(parent_id: work_package.id).select(:id))
       end
 
-      def non_relatable_paths_sql(work_package, relation_type)
+      def non_relatable_paths_sql(work_package, relation_type, ignore_relation: nil)
         <<~SQL.squish
           related (id,
                    from_hierarchy,
@@ -268,7 +275,7 @@ module WorkPackages::Scopes
               FROM
                 related
               JOIN LATERAL (
-                #{joined_existing_connections(relation_type)}
+                #{joined_existing_connections(relation_type, ignore_relation:)}
               ) relations ON 1 = 1
           )
         SQL
@@ -308,7 +315,7 @@ module WorkPackages::Scopes
                     id: work_package.id
       end
 
-      def joined_existing_connections(relation_type)
+      def joined_existing_connections(relation_type, ignore_relation:)
         unions = [existing_hierarchy_lateral(with_descendants: relation_type != Relation::TYPE_CHILD)]
 
         case relation_type
@@ -316,14 +323,14 @@ module WorkPackages::Scopes
           unions << existing_relation_of_type_lateral(Relation::TYPE_FOLLOWS, limit_direction: true)
           unions << existing_relation_of_type_lateral(Relation::TYPE_PRECEDES, limit_direction: true)
         else
-          unions << existing_relation_of_type_lateral(relation_type)
+          unions << existing_relation_of_type_lateral(relation_type, ignore_relation:)
         end
 
         unions.join(' UNION ')
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def existing_relation_of_type_lateral(relation_type, limit_direction: false)
+      def existing_relation_of_type_lateral(relation_type, ignore_relation: nil, limit_direction: false)
         canonical_type = Relation.canonical_type(relation_type)
 
         is_canonical = canonical_type == relation_type
@@ -356,6 +363,7 @@ module WorkPackages::Scopes
           WHERE (relations.#{direction2} = related.id AND relations.relation_type = :relation_type)
             AND NOT related.from_#{direction2}
             #{direction_limit ? "AND NOT #{direction_limit}" : ''}
+            #{ignore_relation&.id ? " AND NOT relations.id = #{ignore_relation.id}" : ''}
         SQL
 
         ::OpenProject::SqlSanitization
@@ -406,6 +414,14 @@ module WorkPackages::Scopes
         WorkPackageHierarchy
           .where(descendant_id: work_packages)
           .select(:ancestor_id)
+      end
+
+      def relatable_ensure_single_relation(ignored_relation, work_package)
+        if ignored_relation && (!ignored_relation.is_a?(Relation) ||
+          (ignored_relation.from_id != work_package.id && ignored_relation.to_id != work_package.id))
+          raise ArgumentError, 'only a single relation with from_id or to_id pointing ' \
+                               'to the work package for which relatable is queried for is supported'
+        end
       end
     end
   end

--- a/app/services/oauth/persist_application_service.rb
+++ b/app/services/oauth/persist_application_service.rb
@@ -42,6 +42,7 @@ module OAuth
     def call(attributes)
       set_defaults
       application.attributes = attributes
+      set_secret_and_id
 
       result, errors = validate_and_save(application, current_user)
       ServiceResult.new success: result, errors:, result: application
@@ -52,6 +53,14 @@ module OAuth
 
       application.owner = current_user
       application.owner_type = 'User'
+    end
+
+    def set_secret_and_id
+      application.extend(OpenProject::ChangedBySystem)
+      application.change_by_system do
+        application.renew_secret if application.secret.blank?
+        application.uid = Doorkeeper::OAuth::Helpers::UniqueToken.generate if application.uid.blank?
+      end
     end
   end
 end

--- a/app/services/relations/base_service.rb
+++ b/app/services/relations/base_service.rb
@@ -42,7 +42,6 @@ class Relations::BaseService < BaseServices::BaseCallable
     model.attributes = model.attributes.merge attributes
 
     success, errors = validate_and_save(model, user)
-    success, errors = retry_with_inverse_for_relates(model, errors) unless success
 
     result = ServiceResult.new success:, errors:, result: model
 
@@ -76,16 +75,5 @@ class Relations::BaseService < BaseServices::BaseCallable
     schedule_result.success = save_result
 
     schedule_result
-  end
-
-  def retry_with_inverse_for_relates(model, errors)
-    if errors.symbols_for(:base).include?(:'typed_dag.circular_dependency') &&
-       model.canonical_type == Relation::TYPE_RELATES
-      model.from, model.to = model.to, model.from
-
-      validate_and_save(model, user)
-    else
-      [false, errors]
-    end
   end
 end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -32,10 +32,10 @@ class ServiceResult
 
   attr_accessor :success,
                 :result,
-                :errors,
                 :dependent_results
 
-  attr_writer :state
+  attr_writer :state,
+              :errors
 
   # Creates a successful ServiceResult.
   def self.success(errors: nil,
@@ -80,7 +80,7 @@ class ServiceResult
     self.result = result
     self.state = state
 
-    initialize_errors(errors)
+    @errors = errors
     @message = message
     @message_type = message_type
 
@@ -202,6 +202,10 @@ class ServiceResult
     @state ||= ::Shared::ServiceState.build
   end
 
+  def errors
+    @errors ||= new_errors_with_result
+  end
+
   private
 
   def initialize_errors(errors)
@@ -209,8 +213,10 @@ class ServiceResult
   end
 
   def new_errors_with_result
-    ActiveModel::Errors.new(self).tap do |errors|
-      errors.merge!(result) if result.try(:errors).present?
+    if result.respond_to?(:errors)
+      result.errors
+    else
+      ActiveModel::Errors.new(self)
     end
   end
 

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -88,7 +88,7 @@ module API
           errors.attribute_names.each do |attribute|
             api_attribute_name = ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
 
-            errors.symbols_and_messages_for(attribute).each do |symbol, message|
+            symbols_and_messages_for(errors, attribute).each do |symbol, message|
               api_errors << if symbol == :error_readonly
                               ::API::Errors::UnwritableProperty.new(api_attribute_name, message)
                             else
@@ -98,6 +98,13 @@ module API
           end
 
           api_errors
+        end
+
+        def symbols_and_messages_for(errors, attribute)
+          symbols = errors.details[attribute].pluck(:error)
+          messages = errors.full_messages_for(attribute)
+
+          symbols.zip(messages)
         end
       end
 

--- a/lib/open_project/patches/active_model_errors.rb
+++ b/lib/open_project/patches/active_model_errors.rb
@@ -27,16 +27,8 @@
 #++
 
 # This patch should no longer be necessary.
-# But we have references to symbolds_and_messages_for as well as for symbols_for all over
-# the code base.
+# But we have references to symbols_for still in the code base.
 module OpenProject::ActiveModelErrorsPatch
-  def symbols_and_messages_for(attribute)
-    symbols = details[attribute].pluck(:error)
-    messages = full_messages_for(attribute)
-
-    symbols.zip(messages)
-  end
-
   def symbols_for(attribute)
     details[attribute].pluck(:error)
   end

--- a/modules/storages/app/contracts/storages/storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/base_contract.rb
@@ -59,8 +59,13 @@ module Storages::Storages
       # to the list of writable attributes.
       # Otherwise, we get :readonly validation errors.
       contract.writable_attributes.append(*writable_attributes)
+
+      # Validating the contract will clear the errors
+      # of this contract so we save them for later.
+      former_errors = errors.dup
+
       contract.validate
-      errors.merge!(contract.errors)
+      errors.merge!(former_errors)
     end
   end
 end

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -732,11 +732,11 @@ RSpec.describe MailHandler do
         context 'with unknown_user: \'accept\' and permission check present' do
           let(:expected) do
             'MailHandler: work_package could not be created by Anonymous due to ' \
-              '#["may not be accessed.", ' \
-              '"Type was attempted to be written but is not writable.", ' \
+              '#["Type was attempted to be written but is not writable.", ' \
               '"Project was attempted to be written but is not writable.", ' \
               '"Subject was attempted to be written but is not writable.", ' \
-              '"Description was attempted to be written but is not writable."]'
+              '"Description was attempted to be written but is not writable.", ' \
+              '"may not be accessed."]'
           end
           let(:permission) { nil }
 

--- a/spec/models/work_packages/scopes/directly_related_spec.rb
+++ b/spec/models/work_packages/scopes/directly_related_spec.rb
@@ -62,10 +62,11 @@ RSpec.describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' 
            to: related_work_package_to,
            from: transitively_related_work_package_to)
   end
+  let(:ignored_relations) { nil }
 
   let!(:existing_relations) { [relation_to, transitive_relation_to, relation_from, transitive_relation_from] }
 
-  subject(:directly_related) { WorkPackage.directly_related(origin) }
+  subject(:directly_related) { WorkPackage.directly_related(origin, ignore_relation: ignored_relations) }
 
   it 'is an AR scope' do
     expect(directly_related)
@@ -78,7 +79,16 @@ RSpec.describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' 
     context "with existing relations of type '#{current_type}'" do
       it 'contains the directly related work packages in both directions' do
         expect(directly_related)
-          .to match_array([related_work_package_to, related_work_package_from])
+          .to contain_exactly(related_work_package_to, related_work_package_from)
+      end
+    end
+
+    context "with existing relations of type '#{current_type}' and ignoring one relation" do
+      let(:ignored_relations) { relation_to }
+
+      it 'contains the directly related work packages for which the relation isn`t ignored' do
+        expect(directly_related)
+          .to contain_exactly(related_work_package_from)
       end
     end
   end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   let(:existing_work_packages) { [] }
 
   let(:relation_type) { Relation::TYPE_FOLLOWS }
+  let(:ignored_relation) { nil }
 
-  subject(:relatable) { WorkPackage.relatable(origin, relation_type) }
+  subject(:relatable) { WorkPackage.relatable(origin, relation_type, ignore_relation: ignored_relation) }
 
   it 'is an AR scope' do
     expect(relatable)
@@ -87,7 +88,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
     it 'contains every other work package' do
       expect(relatable)
-        .to match_array([unrelated_work_package])
+        .to contain_exactly(unrelated_work_package)
     end
   end
 
@@ -100,7 +101,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the unrelated_work_package' do
           expect(relatable)
-            .to match_array([unrelated_work_package])
+            .to contain_exactly(unrelated_work_package)
         end
       end
 
@@ -122,7 +123,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the unrelated_work_package' do
           expect(relatable)
-            .to match_array([unrelated_work_package])
+            .to contain_exactly(unrelated_work_package)
         end
       end
     end
@@ -150,6 +151,16 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
             .to be_empty
         end
       end
+
+      context "with the existing relation and the queried being '#{current_type}' typed but explicitly ignoring the existing" do
+        let(:relation_type) { current_type }
+        let(:ignored_relation) { directly_related_work_package.relations.first }
+
+        it 'is empty' do
+          expect(relatable)
+            .to contain_exactly directly_related_work_package
+        end
+      end
     end
   end
 
@@ -162,7 +173,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the sibling' do
           expect(relatable)
-            .to match_array([sibling])
+            .to contain_exactly(sibling)
         end
       end
     end
@@ -174,7 +185,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'follows' relation and the existing relations being in the same direction" do
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -210,7 +221,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'includes the not directly related work package' do
         expect(relatable)
-          .to match_array [origin]
+          .to contain_exactly(origin)
       end
     end
 
@@ -268,7 +279,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       # semantic in the system, the relationship is not prohibited.
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -279,7 +290,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -293,7 +304,30 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       # semantic in the system, the relationship is not prohibited.
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
+      end
+    end
+
+    context "for a 'blocks' relation and the existing relations being 'blocks' when ignoring origin`s relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+      let(:directly_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:transitively_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:ignored_relation) { origin.relations.first }
+
+      it 'contains the the related work packages' do
+        expect(relatable)
+          .to contain_exactly(directly_related_work_package, transitively_related_work_package)
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being of opposite direction but ignoring origin`s relation" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:ignored_relation) { origin.relations.first }
+
+      it 'contains the the related work packages' do
+        expect(relatable)
+          .to contain_exactly(directly_related_work_package, transitively_related_work_package)
       end
     end
   end
@@ -341,7 +375,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the work packages in the other hierarchy' do
         expect(relatable)
-          .to match_array [other_parent, other_child]
+          .to contain_exactly(other_parent, other_child)
       end
     end
 
@@ -352,7 +386,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the work packages in the other hierarchy' do
         expect(relatable)
-          .to match_array [other_parent, other_child]
+          .to contain_exactly(other_parent, other_child)
       end
     end
 
@@ -375,7 +409,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent and aunt' do
         expect(relatable)
-          .to match_array [grandparent, aunt]
+          .to contain_exactly(grandparent, aunt)
       end
     end
 
@@ -384,7 +418,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -393,7 +427,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -402,7 +436,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -415,7 +449,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent' do
         expect(relatable)
-          .to match_array [grandparent]
+          .to contain_exactly(grandparent)
       end
     end
 
@@ -428,7 +462,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -441,7 +475,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt, grandparent]
+          .to contain_exactly(aunt, grandparent)
       end
     end
 
@@ -450,7 +484,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt, grandparent]
+          .to contain_exactly(aunt, grandparent)
       end
     end
   end
@@ -469,7 +503,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent and grand_grandparent' do
         expect(relatable)
-          .to match_array [grandparent, grand_grandparent]
+          .to contain_exactly(grandparent, grand_grandparent)
       end
     end
 
@@ -525,7 +559,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandchild and grand_grandchild' do
         expect(relatable)
-          .to match_array [grandchild, grand_grandchild]
+          .to contain_exactly(grandchild, grand_grandchild)
       end
     end
 
@@ -564,7 +598,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent]
+          .to contain_exactly(predecessor_parent)
       end
     end
 
@@ -631,7 +665,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent]
+          .to contain_exactly(predecessor_parent)
       end
     end
 
@@ -649,7 +683,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -667,7 +701,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -676,7 +710,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -685,7 +719,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
   end
@@ -711,7 +745,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and its successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -720,7 +754,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor of the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent_successor)
       end
     end
 
@@ -729,7 +763,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -738,7 +772,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent_successor)
       end
     end
 
@@ -747,7 +781,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -756,7 +790,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -765,7 +799,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
   end
@@ -791,7 +825,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent" do
         expect(relatable)
-          .to match_array [successor_parent]
+          .to contain_exactly(successor_parent)
       end
     end
 
@@ -818,7 +852,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -827,7 +861,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -836,7 +870,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -845,7 +879,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
   end
@@ -871,7 +905,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and its predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -880,7 +914,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor of the successor's parent" do
         expect(relatable)
-          .to match_array [successor_parent_predecessor]
+          .to contain_exactly(successor_parent_predecessor)
       end
     end
 
@@ -889,7 +923,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent_predecessor]
+          .to contain_exactly(successor_parent_predecessor)
       end
     end
 
@@ -898,7 +932,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -907,7 +941,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -916,7 +950,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -925,7 +959,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
   end
@@ -943,7 +977,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -961,7 +995,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -979,7 +1013,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -988,7 +1022,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
   end
@@ -1006,7 +1040,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1033,7 +1067,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1042,7 +1076,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1051,7 +1085,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
   end
@@ -1075,7 +1109,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's successor and the grandparent" do
         expect(relatable)
-          .to match_array [child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1084,7 +1118,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and that's ancestors" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1093,7 +1127,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and the parent of that" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1111,7 +1145,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and the parent of that" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
   end
@@ -1135,7 +1169,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's predecessor" do
         expect(relatable)
-          .to match_array [child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1144,7 +1178,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and that's ancestors" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1162,7 +1196,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and the parent of that" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1171,7 +1205,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and the parent of that" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
   end
@@ -1195,7 +1229,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's blocked work package" do
         expect(relatable)
-          .to match_array [child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1204,7 +1238,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the work package blocked by the child and that's ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1213,7 +1247,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1222,7 +1256,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1231,7 +1265,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1240,7 +1274,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1279,7 +1313,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1297,7 +1331,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1306,7 +1340,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1315,7 +1349,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1324,7 +1358,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
   end
@@ -1348,7 +1382,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent and the child" do
         expect(relatable)
-          .to match_array [blocks_parent, blocks_child]
+          .to contain_exactly(blocks_parent, blocks_child)
       end
     end
 
@@ -1366,7 +1400,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent" do
         expect(relatable)
-          .to match_array [blocks_parent]
+          .to contain_exactly(blocks_parent)
       end
     end
 
@@ -1375,7 +1409,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child" do
         expect(relatable)
-          .to match_array [blocks_child]
+          .to contain_exactly(blocks_child)
       end
     end
   end
@@ -1408,7 +1442,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent and the child" do
         expect(relatable)
-          .to match_array [blocked_parent, blocked_child]
+          .to contain_exactly(blocked_parent, blocked_child)
       end
     end
 
@@ -1417,7 +1451,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent" do
         expect(relatable)
-          .to match_array [blocked_parent]
+          .to contain_exactly(blocked_parent)
       end
     end
 
@@ -1426,7 +1460,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child" do
         expect(relatable)
-          .to match_array [blocked_child]
+          .to contain_exactly(blocked_child)
       end
     end
   end
@@ -1466,7 +1500,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_predecessor_parent]
+          .to contain_exactly(transitive_predecessor_parent)
       end
     end
 
@@ -1475,7 +1509,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_predecessor_child]
+          .to contain_exactly(transitive_predecessor_child)
       end
     end
   end
@@ -1506,7 +1540,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_successor_parent]
+          .to contain_exactly(transitive_successor_parent)
       end
     end
 
@@ -1515,8 +1549,65 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_successor_child]
+          .to contain_exactly(transitive_successor_child)
       end
+    end
+  end
+
+  context 'with a transitively related work package that is also directly related' do
+    let!(:existing_work_packages) { [directly_related_work_package, transitively_related_work_package] }
+    let!(:additional_direct_relation) do
+      create(:relation,
+             relation_type: transitively_related_work_package_type,
+             from: origin,
+             to: transitively_related_work_package)
+    end
+
+    context "for a 'follows' relation and the existing relations being in the same direction" do
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being in the opposite direction" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being of opposite direction and ignoring the direct relation" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:ignored_relation) { additional_direct_relation }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+  end
+
+  context 'when ignoring anything else then a single relation' do
+    let(:ignored_relation) { transitively_related_work_package.relations }
+
+    it 'raises an error' do
+      expect { relatable }
+        .to raise_error ArgumentError
+    end
+  end
+
+  context 'when ignoring with a relation neither starting nor ending in the work package queried for' do
+    let!(:existing_work_packages) { [directly_related_work_package, transitively_related_work_package] }
+    let(:ignored_relation) { transitively_related_work_package.relations.first }
+
+    it 'raises an error' do
+      expect { relatable }
+        .to raise_error ArgumentError
     end
   end
 end

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -79,21 +79,18 @@ RSpec.describe API::V3::Activities::ActivitiesAPI, content_type: :json do
 
     it_behaves_like 'valid activity patch request'
 
-    it_behaves_like 'invalid activity request', 'Version is invalid' do
-      let(:errors) do
-        ActiveModel::Errors.new(work_package.journals.first).tap do |e|
-          e.add(:version)
-        end
-      end
+    it_behaves_like 'invalid activity request',
+                    'Cause type is not set to one of the allowed values.' do
       let(:activity) do
-        allow_any_instance_of(Journal).to receive(:save).and_return(false)
-        allow_any_instance_of(Journal).to receive(:errors).and_return(errors)
-
-        work_package.journals.first
+        # Invalidating the journal
+        work_package.journals.first.tap do |journal|
+          journal.cause_type = :invalid
+          journal.save(validate: false)
+        end
       end
 
       it_behaves_like 'constraint violation' do
-        let(:message) { 'Version is invalid' }
+        let(:message) { 'Cause type is not set to one of the allowed values.' }
       end
     end
 

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -143,12 +143,17 @@ RSpec.describe ServiceResult, type: :model do
       expect(instance.errors).to be_a ActiveModel::Errors
     end
 
-    context 'when providing errors from user' do
-      let(:result) { build(:work_package) }
+    context 'when providing an object with errors of its own' do
+      let(:result) do
+        build_stubbed(:work_package) do |wp|
+          wp.errors.add(:base, 'some error')
+        end
+      end
 
-      it 'creates a new errors instance' do
+      it 'uses that error instance' do
         instance = described_class.new(result:)
-        expect(instance.errors).not_to eq result.errors
+
+        expect(instance.errors).to eq result.errors
       end
     end
   end


### PR DESCRIPTION
Changes the contracts so that their error object is the error object of the model they validate. That way, all the error are in a single place, the model's error object.

This has the advantage of then being propagated up, through the service and controller layer to the view where errors are then displayed to the user. In particular, this helps with view form objects that rely on the model's errors to display errors next to the input.

This is currently work in progress. 

### TODO

* [ ] Check for errors.
* [ ] Check if the change to the service layer is actually needed.
* [ ] Extract repeating pattern of dup-ing errors in case a contract calls another contract