### PR TITLE
29203 Fix missing permission on attachment prepare

### DIFF
--- a/lib/api/v3/attachments/attachments_by_work_package_api.rb
+++ b/lib/api/v3/attachments/attachments_by_work_package_api.rb
@@ -56,7 +56,7 @@ module API
           post &API::V3::Attachments::AttachmentsByContainerAPI.create(%i[edit_work_packages add_work_package_attachments])
 
           namespace :prepare do
-            post &API::V3::Attachments::AttachmentsByContainerAPI.prepare([:edit_work_packages])
+            post &API::V3::Attachments::AttachmentsByContainerAPI.prepare(%i[edit_work_packages add_work_package_attachments])
           end
         end
       end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -191,6 +191,7 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
   include API::V3::Utilities::PathHelper
   include FileHelpers
 
+  shared_let(:project) { create(:project, public: false) }
   let(:current_user) { user_with_permissions }
 
   let(:user_with_permissions) do
@@ -201,7 +202,6 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
     current_user
   end
 
-  let(:project) { create(:project, public: false) }
   let(:role) { create(:project_role, permissions:) }
 
   let(:attachment) { create(:attachment, container:, author:) }

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -210,11 +210,12 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
   let(:attachment_type) { raise "attachment type goes here, e.g. work_package" }
   let(:permissions) { all_permissions }
 
-  let(:all_permissions) { [create_permission, read_permission, update_permission].flatten.compact }
+  let(:all_permissions) { [create_permission, read_permission, update_permission, delete_permission].flatten.uniq.compact }
 
   let(:create_permission) { raise "permissions go here, e.g. add_work_packages" }
   let(:read_permission) { raise "permissions go here, e.g. view_work_packages" }
   let(:update_permission) { raise "permissions go here, e.g. edit_work_packages" }
+  let(:delete_permission) { update_permission }
 
   let(:missing_permissions_user) { user_with_permissions }
 
@@ -386,6 +387,8 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
     end
 
     context 'with required permissions' do
+      let(:permissions) { [read_permission, delete_permission].flatten.uniq.compact }
+
       it_behaves_like 'deletes the attachment'
 
       context 'for a non-existent attachment' do
@@ -396,7 +399,7 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
     end
 
     context 'without required permissions' do
-      let(:permissions) { all_permissions - Array(update_permission) }
+      let(:permissions) { all_permissions.without(delete_permission) }
 
       it_behaves_like 'does not delete the attachment'
     end
@@ -617,7 +620,7 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
       end
 
       context 'only allowed to add, but not to edit' do
-        let(:permissions) { all_permissions - Array(update_permission) }
+        let(:permissions) { [create_permission, read_permission].flatten.uniq.compact.without(update_permission) }
 
         it_behaves_like 'unauthorized access'
       end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -67,7 +67,7 @@ RSpec.shared_examples 'it supports direct uploads' do
       end
     end
 
-    context 'with remote AWS storage', with_direct_uploads: true do
+    context 'with remote AWS storage', :with_direct_uploads do
       before do
         request!
       end
@@ -186,7 +186,7 @@ RSpec.shared_examples 'it supports direct uploads' do
   end
 end
 
-RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type: :request do |include_by_container = true|
+RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type: :request do |include_by_container: true|
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
   include FileHelpers
@@ -210,7 +210,7 @@ RSpec.shared_examples 'an APIv3 attachment resource', content_type: :json, type:
   let(:attachment_type) { raise "attachment type goes here, e.g. work_package" }
   let(:permissions) { all_permissions }
 
-  let(:all_permissions) { Array([create_permission, read_permission, update_permission]).flatten.compact }
+  let(:all_permissions) { [create_permission, read_permission, update_permission].flatten.compact }
 
   let(:create_permission) { raise "permissions go here, e.g. add_work_packages" }
   let(:read_permission) { raise "permissions go here, e.g. view_work_packages" }

--- a/spec/requests/api/v3/attachments/forum_message_spec.rb
+++ b/spec/requests/api/v3/attachments/forum_message_spec.rb
@@ -27,10 +27,10 @@
 #++
 
 require 'spec_helper'
-require_relative './attachment_resource_shared_examples'
+require_relative 'attachment_resource_shared_examples'
 
 RSpec.describe "forum message attachments" do
-  it_behaves_like "an APIv3 attachment resource", include_by_container = false do
+  it_behaves_like "an APIv3 attachment resource", include_by_container: false do
     let(:attachment_type) { :forum_message }
 
     let(:create_permission) { nil }

--- a/spec/requests/api/v3/attachments/work_package_spec.rb
+++ b/spec/requests/api/v3/attachments/work_package_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require 'spec_helper'
-require_relative './attachment_resource_shared_examples'
+require_relative 'attachment_resource_shared_examples'
 
 RSpec.describe "work package attachments" do
   it_behaves_like "an APIv3 attachment resource" do
@@ -39,6 +39,21 @@ RSpec.describe "work package attachments" do
 
     let(:work_package) do
       create(:work_package, author: current_user, project:)
+    end
+  end
+
+  context 'with :add_work_package_attachments as update permission' do
+    it_behaves_like "an APIv3 attachment resource" do
+      let(:attachment_type) { :work_package }
+
+      let(:create_permission) { :add_work_packages }
+      let(:read_permission) { :view_work_packages }
+      let(:update_permission) { :add_work_package_attachments }
+      let(:delete_permission) { :edit_work_packages }
+
+      let(:work_package) do
+        create(:work_package, author: current_user, project:)
+      end
     end
   end
 end

--- a/spec/requests/api/v3/attachments/work_packages_export_spec.rb
+++ b/spec/requests/api/v3/attachments/work_packages_export_spec.rb
@@ -27,10 +27,10 @@
 #++
 
 require 'spec_helper'
-require_relative './attachment_resource_shared_examples'
+require_relative 'attachment_resource_shared_examples'
 
 RSpec.describe "WorkPackages::Export attachments" do
-  it_behaves_like "an APIv3 attachment resource", include_by_container = false do
+  it_behaves_like "an APIv3 attachment resource", include_by_container: false do
     let(:attachment_type) { :export }
 
     let(:create_permission) { :export_work_packages }

--- a/spec/requests/api/v3/attachments/work_packages_export_spec.rb
+++ b/spec/requests/api/v3/attachments/work_packages_export_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require_relative 'attachment_resource_shared_examples'
 
-RSpec.describe "WorkPackages::Export attachments" do
+RSpec.describe "#{WorkPackages::Export} attachments" do
   it_behaves_like "an APIv3 attachment resource", include_by_container: false do
     let(:attachment_type) { :export }
 


### PR DESCRIPTION
https://community.openproject.org/wp/29203

This fixes the error when having only the `:add_work_package_attachments` permission and trying to upload an attachment to a work package while doing a direct upload (like with s3).

This was actually a proposed implementation originally in https://github.com/opf/openproject/pull/13861/commits/19e5d9890710d9bfa7289b6d1ee2bf094493b17d#diff-b9569a0f85cab0526410ea11ced6758c01f535d5f152b2789456157cc477ce95L59