### PR TITLE
Disable avatars in tests by default

### DIFF
--- a/modules/avatars/lib/open_project/avatars/engine.rb
+++ b/modules/avatars/lib/open_project/avatars/engine.rb
@@ -26,8 +26,8 @@ module OpenProject::Avatars
              author_url: 'https://www.openproject.org',
              settings: {
                default: {
-                 enable_gravatars: true,
-                 enable_local_avatars: true
+                 enable_gravatars: !Rails.env.test?,
+                 enable_local_avatars: !Rails.env.test?
                },
                partial: 'settings/openproject_avatars',
                menu_item: :user_avatars


### PR DESCRIPTION
Leaving it at true results in requests to gravatar, which breaks tests in unstable internet connections