### PR TITLE
[chore] enabled correct localisation of storage provider types

### DIFF
--- a/modules/storages/app/components/storages/admin/storage_list_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_list_component.html.erb
@@ -41,7 +41,7 @@
             end
 
             grid.with_area(:provider, tag: :div, color: :subtle, mr: 3, hide: :sm, data: { 'test-selector': 'storage-provider' }) do
-              render(Primer::Beta::Truncate.new(font_weight: :light)) { storage.short_provider_type.capitalize }
+              render(Primer::Beta::Truncate.new(font_weight: :light)) { I18n.t("storages.provider_types.#{storage.short_provider_type}.name") }
             end
 
             grid.with_area(:time, tag: :div, color: :subtle, mr: 3) do

--- a/modules/storages/app/components/storages/admin/storage_list_component.sass
+++ b/modules/storages/app/components/storages/admin/storage_list_component.sass
@@ -1,7 +1,7 @@
 .op-storage-list--header,
 .op-storage-list--row
   display: grid
-  grid-template-columns: 1fr 180px 100px 240px
+  grid-template-columns: 1fr 180px 160px 240px
   grid-template-areas: "name user provider time" "host user provider time"
 
 @media screen and (max-width: $breakpoint-md)


### PR DESCRIPTION
### What?

- fixed storage list component to render a localized provider type string
- increased column width of provider type column

### Screens

#### Before

![image](https://github.com/opf/openproject/assets/38206611/9c42e02c-3337-4cfb-a48f-f920fd4660f0)

#### After

![image](https://github.com/opf/openproject/assets/38206611/db85feb5-1261-412e-996a-6f334851246b)
