### PR TITLE
Add configurable `slowmo` option to cuprite specs

### DIFF
--- a/docs/development/running-tests/README.md
+++ b/docs/development/running-tests/README.md
@@ -455,6 +455,7 @@ Possible reasons are:
   * To help diagnose why a system test is failing:
     * Browser screenshots are created for failing system tests involving a browser. You can find them in the job log output.
     * Try running with `OPENPROJECT_TESTING_NO_HEADLESS=1` to view what the browser is doing. Use `OPENPROJECT_TESTING_AUTO_DEVTOOLS=1` to have DevTools opened so that you can use `debugger` statements in the js code.
+    * If the interactions are still too fast to understand why the test is failing, use `OPENPROJECT_TESTING_SLOWDOWN_FACTOR`, providing the number of seconds to slow down every browser command with. For example, if you'd like to slow down every interaction by 200 milliseconds, run with `OPENPROJECT_TESTING_SLOWDOWN_FACTOR=0.2`.
 * Migration executed locally
   * While developing on another branch, you may run migrations and forget to roll them back when switching branches. This can lead to different test results: a migration modifying a database column default value can impact system behavior and change test results.
   * To find if this is your case, run `rails db:migrate:status` to list migration status. Look for `up    <migration-id>  ********** NO FILE **********` patterns. If you have some, try looking up the commit associated with this migration and check if it explains behavior difference.

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -76,8 +76,8 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       options = options.merge(window_size:)
     end
 
-    if headful_mode? && ENV['SLOWMO']
-      options = options.merge(slowmo: ENV['SLOWMO'])
+    if headful_mode? && ENV['OPENPROJECT_TESTING_SLOWDOWN_FACTOR']
+      options = options.merge(slowmo: ENV['OPENPROJECT_TESTING_SLOWDOWN_FACTOR'])
     end
 
     if ENV['CHROME_URL'].present?

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -76,6 +76,10 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       options = options.merge(window_size:)
     end
 
+    if headful_mode? && ENV['SLOWMO']
+      options = options.merge(slowmo: ENV['SLOWMO'])
+    end
+
     if ENV['CHROME_URL'].present?
       options = options.merge(url: ENV['CHROME_URL'])
     end


### PR DESCRIPTION
Have you ever wanted to debug a spec in headful mode but it's running way too fast to tell what's going on? Adding a `OPENPROJECT_TESTING_SLOWDOWN_FACTOR` environment variable lets you add a delay (in seconds) to every action taken by the driver.

Setting

```
OPENPROJECT_TESTING_SLOWDOWN_FACTOR=0.2
```

is a pretty good delay in order to be able to nicely inspect what's going on and slows down the spec run enough to understand it.

Hope this helps everyone as it's helped me!