### PR TITLE
[#50543] Failing GRAPH API call leads to rails exception

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -2,11 +2,14 @@ tmp/oas-generated.yml:
   info-license:
     - '#/info'
   operation-2xx-response:
-    - '#/paths/~1api~1v3~1work_packages~1{id}~1relations/get/responses'
     - '#/paths/~1api~1v3~1file_links~1{file_link_id}~1open/get/responses'
+    - '#/paths/~1api~1v3~1project_storages~1{id}~1open/get/responses'
+    - '#/paths/~1api~1v3~1storages~1{id}~1open/get/responses'
+    - '#/paths/~1api~1v3~1work_packages~1{id}~1relations/get/responses'
   operation-4xx-response:
     - '#/paths/~1api~1v3/get/responses'
     - '#/paths/~1api~1v3~1help_texts/get/responses'
+    - '#/paths/~1api~1v3~1work_packages~1form/post/responses'
   no-ambiguous-paths:
     - '#/paths/~1api~1v3~1queries~1{id}~1form'
     - '#/paths/~1api~1v3~1queries~1{id}~1star'

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -92,9 +92,9 @@ class MyController < ApplicationController
       .where(user: @user, oauth_client: { integration_type: 'Storages::Storage' }).find_by(id: params[:id])
 
     if token&.destroy
-      flash[:info] = I18n.t('my.access_tokens.storages.removed')
+      flash[:info] = I18n.t('my_account.access_tokens.storages.removed')
     else
-      flash[:error] = I18n.t('my.access_tokens.storages.failed')
+      flash[:error] = I18n.t('my_account.access_tokens.storages.failed')
     end
     redirect_to action: :access_token
   end

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -270,6 +270,8 @@ paths:
     "$ref": "./paths/project_storages.yml"
   "/api/v3/project_storages/{id}":
     "$ref": "./paths/project_storage.yml"
+  "/api/v3/project_storages/{id}/open":
+    "$ref": "./paths/project_storage_open.yml"
   "/api/v3/projects":
     "$ref": "./paths/projects.yml"
   "/api/v3/projects/form":
@@ -374,6 +376,8 @@ paths:
     "$ref": "./paths/storage_files_prepare_upload.yml"
   "/api/v3/storages/{id}/oauth_client_credentials":
     "$ref": "./paths/storage_oauth_client_credentials.yml"
+  "/api/v3/storages/{id}/open":
+    "$ref": "./paths/storage_open.yml"
   "/api/v3/time_entries":
     "$ref": "./paths/time_entries.yml"
   "/api/v3/time_entries/{id}/form":

--- a/docs/api/apiv3/paths/project_storage_open.yml
+++ b/docs/api/apiv3/paths/project_storage_open.yml
@@ -1,0 +1,50 @@
+# /api/v3/project_storage/{id}/open
+---
+get:
+  summary: Open the project storage
+  operationId: open_project_storage
+  tags:
+    - File Links
+  description: |-
+    Gets a redirect to the location of the project storage's remote origin. If the project storage has a project
+    folder, it is opened at this location. If not, the storage root is opened.
+  parameters:
+    - name: id
+      description: Project storage id
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: 1337
+  responses:
+    '303':
+      description: Redirect
+      headers:
+        Location:
+          schema:
+            type: string
+            format: uri
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:Unauthenticated
+            message: You are not authorized to access this resource.
+      description: |-
+        Returned if the authorization token of the current user grants no permission to access the remote storage.
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+            message: The requested resource could not be found.
+      description: |-
+        Returned if the project storage does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view file links

--- a/docs/api/apiv3/paths/storage_open.yml
+++ b/docs/api/apiv3/paths/storage_open.yml
@@ -1,0 +1,39 @@
+# /api/v3/storage/{id}/open
+---
+get:
+  summary: Open the storage
+  operationId: open_storage
+  tags:
+    - File Links
+  description: |-
+    Gets a redirect to the location of the storage's remote origin. The storage's files root should be the target
+    location.
+  parameters:
+    - name: id
+      description: Storage id
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: 1337
+  responses:
+    '303':
+      description: Redirect
+      headers:
+        Location:
+          schema:
+            type: string
+            format: uri
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          example:
+            _type: Error
+            errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+            message: The requested resource could not be found.
+      description: |-
+        Returned if the storage does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view file links

--- a/modules/storages/app/common/storages/peripherals/storage_error_helper.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_error_helper.rb
@@ -39,7 +39,7 @@ module Storages::Peripherals
       when :forbidden
         raise API::Errors::OutboundRequestForbidden.new
       else
-        raise API::Errors::InternalError.new
+        raise API::Errors::InternalError.new(error.log_message)
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud.rb
@@ -43,7 +43,8 @@ module Storages
             register(:propfind, Internal::PropfindQuery)
             register(:group_users, GroupUsersQuery)
             register(:upload_link, UploadLinkQuery)
-            register(:open_link, OpenLinkQuery)
+            register(:open_file_link, OpenFileLinkQuery)
+            register(:open_storage, OpenStorageQuery)
           end
         end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_file_link_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_file_link_query.rb
@@ -44,7 +44,7 @@ module Storages
           # rubocop:disable Lint/UnusedMethodArgument
           def call(user:, file_id:, open_location: false)
             location_flag = open_location ? 0 : 1
-            ServiceResult.success(result: File.join(@uri.to_s, "index.php/f/#{file_id}?openfile=#{location_flag}"))
+            ServiceResult.success(result: Util.join_uri_path(@uri, "index.php/f/#{file_id}?openfile=#{location_flag}"))
           end
 
           # rubocop:enable Lint/UnusedMethodArgument

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query.rb
@@ -43,7 +43,7 @@ module Storages
 
           # rubocop:disable Lint/UnusedMethodArgument
           def call(user:)
-            ServiceResult.success(result: File.join(@uri.to_s, 'index.php/apps/files'))
+            ServiceResult.success(result: Util.join_uri_path(@uri, 'index.php/apps/files'))
           end
 
           # rubocop:enable Lint/UnusedMethodArgument

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query.rb
@@ -28,28 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class API::V3::Storages::StoragesAPI < API::OpenProjectAPI
-  helpers Storages::Peripherals::Scopes
+module Storages
+  module Peripherals
+    module StorageInteraction
+      module Nextcloud
+        class OpenStorageQuery
+          def initialize(storage)
+            @uri = storage.uri
+          end
 
-  resources :storages do
-    post &API::V3::Utilities::Endpoints::Create.new(model: Storages::Storage).mount
+          def self.call(storage:, user:)
+            new(storage).call(user:)
+          end
 
-    get &API::V3::Utilities::Endpoints::Index.new(model: Storages::Storage, scope: -> { visible_storages }).mount
+          # rubocop:disable Lint/UnusedMethodArgument
+          def call(user:)
+            ServiceResult.success(result: File.join(@uri.to_s, 'index.php/apps/files'))
+          end
 
-    route_param :storage_id, type: Integer, desc: 'Storage id' do
-      after_validation do
-        @storage = visible_storages.find(params[:storage_id])
+          # rubocop:enable Lint/UnusedMethodArgument
+        end
       end
-
-      get &API::V3::Utilities::Endpoints::Show.new(model: Storages::Storage).mount
-
-      patch &API::V3::Utilities::Endpoints::Update.new(model: Storages::Storage).mount
-
-      delete &API::V3::Utilities::Endpoints::Delete.new(model: Storages::Storage).mount
-
-      mount API::V3::StorageFiles::StorageFilesAPI
-      mount API::V3::OAuthClient::OAuthClientCredentialsAPI
-      mount API::V3::Storages::StorageOpenAPI
     end
   end
 end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive.rb
@@ -38,8 +38,8 @@ module Storages
             register(:files, FilesQuery)
             register(:file_info, FileInfoQuery)
             register(:files_info, FilesInfoQuery)
-            register(:open_link, OpenLinkQuery)
-            register(:open_drive_link, OpenDriveLinkQuery)
+            register(:open_file_link, OpenFileLinkQuery)
+            register(:open_storage, OpenStorageQuery)
             register(:upload_link, UploadLinkQuery)
           end
         end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_info_query.rb
@@ -33,8 +33,6 @@ module Storages
     module StorageInteraction
       module OneDrive
         class FilesInfoQuery
-          include StorageErrorHelper
-
           using ServiceResultRefinements
 
           def self.call(storage:, user:, file_ids: [])

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query.rb
@@ -31,23 +31,53 @@
 module Storages
   module Peripherals
     module StorageInteraction
-      module Nextcloud
-        class OpenLinkQuery
-          def initialize(storage)
-            @uri = storage.uri
-          end
+      module OneDrive
+        class OpenFileLinkQuery
+          using ::Storages::Peripherals::ServiceResultRefinements
 
           def self.call(storage:, user:, file_id:, open_location: false)
             new(storage).call(user:, file_id:, open_location:)
           end
 
-          # rubocop:disable Lint/UnusedMethodArgument
-          def call(user:, file_id:, open_location: false)
-            location_flag = open_location ? 0 : 1
-            ServiceResult.success(result: File.join(@uri.to_s, "index.php/f/#{file_id}?openfile=#{location_flag}"))
+          def initialize(storage)
+            @delegate = Internal::DriveItemQuery.new(storage)
           end
 
-          # rubocop:enable Lint/UnusedMethodArgument
+          def call(user:, file_id:, open_location: false)
+            @user = user
+
+            if open_location
+              request_parent_id.call(file_id) >> request_web_url
+            else
+              request_web_url.call(file_id)
+            end
+          end
+
+          private
+
+          def request_web_url
+            ->(file_id) do
+              @delegate.call(user: @user, drive_item_id: file_id, fields: %w[webUrl]).map(&web_url)
+            end
+          end
+
+          def request_parent_id
+            ->(file_id) do
+              @delegate.call(user: @user, drive_item_id: file_id, fields: %w[parentReference]).map(&parent_id)
+            end
+          end
+
+          def web_url
+            ->(json) do
+              json[:webUrl]
+            end
+          end
+
+          def parent_id
+            ->(json) do
+              json.dig(:parentReference, :id)
+            end
+          end
         end
       end
     end

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -60,10 +60,6 @@ module Storages
       Peripherals::OAuthConfigurations::NextcloudConfiguration.new(self)
     end
 
-    def open_link
-      File.join(uri.to_s, 'index.php/apps/files')
-    end
-
     def automatic_management_unspecified?
       automatically_managed.nil?
     end

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -50,14 +50,5 @@ module Storages
     def connect_src
       %w[https://*.sharepoint.com https://*.up.1drv.com]
     end
-
-    def open_link
-      ::Storages::Peripherals::Registry.resolve("queries.one_drive.open_drive_link")
-                                       .call(storage: self, user: User.current)
-                                       .match(
-                                         on_success: ->(web_url) { web_url },
-                                         on_failure: ->(*) { '' }
-                                       )
-    end
   end
 end

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -64,19 +64,6 @@ class Storages::ProjectStorage < ApplicationRecord
     escaped_file_path.match?(%r|^/#{project_folder_path_escaped}|)
   end
 
-  def open_link
-    if project_folder_inactive?
-      storage.open_link
-    else
-      call = ::Storages::Peripherals::Registry.resolve("queries.#{storage.short_provider_type}.open_link")
-                                              .call(storage:, user: User.current, file_id: project_folder_id)
-      call.match(
-        on_success: ->(url) { url },
-        on_failure: ->(*) { storage.open_link }
-      )
-    end
-  end
-
   private
 
   def escape_path(path)

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -116,10 +116,6 @@ module Storages
       ["#{uri.scheme}://#{uri.host}"]
     end
 
-    def open_link
-      raise Errors::SubclassResponsibility
-    end
-
     def oauth_configuration
       raise Errors::SubclassResponsibility
     end

--- a/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
@@ -46,6 +46,10 @@ module API::V3::ProjectStorages
       { href: api_v3_paths.storage_file(represented.storage.id, represented.project_folder_id) }
     end
 
+    link :open do
+      { href: api_v3_paths.project_storage_open(represented.id) }
+    end
+
     associated_resource :storage, skip_render: ->(*) { true }, skip_link: ->(*) { false }
     associated_resource :project, skip_render: ->(*) { true }, skip_link: ->(*) { false }
     associated_resource :creator,

--- a/modules/storages/lib/api/v3/project_storages/project_storages_api.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storages_api.rb
@@ -63,6 +63,8 @@ module API::V3::ProjectStorages
         end
 
         get &API::V3::Utilities::Endpoints::Show.new(model: Storages::ProjectStorage).mount
+
+        mount API::V3::ProjectStorages::ProjectStorageOpenAPI
       end
     end
   end

--- a/modules/storages/lib/api/v3/storages/storage_open_api.rb
+++ b/modules/storages/lib/api/v3/storages/storage_open_api.rb
@@ -35,7 +35,7 @@ class API::V3::Storages::StorageOpenAPI < API::OpenProjectAPI
     get do
       Storages::Peripherals::Registry
         .resolve("queries.#{@storage.short_provider_type}.open_storage")
-        .call(storage: @storage, user: current_user, file_id: nil)
+        .call(storage: @storage, user: current_user)
         .match(
           on_success: ->(url) do
             redirect url, body: "The requested resource can be viewed at #{url}"

--- a/modules/storages/lib/api/v3/storages/storage_open_api.rb
+++ b/modules/storages/lib/api/v3/storages/storage_open_api.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -28,28 +26,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class API::V3::Storages::StoragesAPI < API::OpenProjectAPI
-  helpers Storages::Peripherals::Scopes
+class API::V3::Storages::StorageOpenAPI < API::OpenProjectAPI
+  helpers Storages::Peripherals::StorageErrorHelper
 
-  resources :storages do
-    post &API::V3::Utilities::Endpoints::Create.new(model: Storages::Storage).mount
+  using Storages::Peripherals::ServiceResultRefinements
 
-    get &API::V3::Utilities::Endpoints::Index.new(model: Storages::Storage, scope: -> { visible_storages }).mount
-
-    route_param :storage_id, type: Integer, desc: 'Storage id' do
-      after_validation do
-        @storage = visible_storages.find(params[:storage_id])
-      end
-
-      get &API::V3::Utilities::Endpoints::Show.new(model: Storages::Storage).mount
-
-      patch &API::V3::Utilities::Endpoints::Update.new(model: Storages::Storage).mount
-
-      delete &API::V3::Utilities::Endpoints::Delete.new(model: Storages::Storage).mount
-
-      mount API::V3::StorageFiles::StorageFilesAPI
-      mount API::V3::OAuthClient::OAuthClientCredentialsAPI
-      mount API::V3::Storages::StorageOpenAPI
+  resources :open do
+    get do
+      Storages::Peripherals::Registry
+        .resolve("queries.#{@storage.short_provider_type}.open_storage")
+        .call(storage: @storage, user: current_user, file_id: nil)
+        .match(
+          on_success: ->(url) do
+            redirect url, body: "The requested resource can be viewed at #{url}"
+            status 303
+          end,
+          on_failure: ->(error) { raise_error(error) }
+        )
     end
   end
 end

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -151,7 +151,7 @@ module API::V3::Storages
     end
 
     link :open do
-      { href: represented.open_link }
+      { href: api_v3_paths.storage_open(represented.id) }
     end
 
     link :authorizationState do

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -159,7 +159,7 @@ module OpenProject::Storages
           User.current.allowed_to?(:view_file_links, project)
           project.project_storages.each do |project_storage|
             storage = project_storage.storage
-            href = project_storage.open_link
+            href = "/api/v3/project_storages/#{project_storage.id}/open"
             icon = if storage.provider_type_nextcloud?
                      'nextcloud-circle'
                    else
@@ -228,11 +228,19 @@ module OpenProject::Storages
     end
 
     add_api_path :project_storage do |id|
-      "#{root}/project_storages/#{id}"
+      "#{project_storages}/#{id}"
+    end
+
+    add_api_path :project_storage_open do |id|
+      "#{project_storage(id)}/open"
     end
 
     add_api_path :storage do |storage_id|
       "#{storages}/#{storage_id}"
+    end
+
+    add_api_path :storage_open do |storage_id|
+      "#{storage(storage_id)}/open"
     end
 
     add_api_path :storage_files do |storage_id|

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/open_file_link_query_spec.rb
@@ -31,9 +31,7 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::OpenLinkQuery do
-  include JsonResponseHelper
-
+RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::OpenFileLinkQuery do
   let(:storage) { create(:nextcloud_storage, host: 'https://example.com') }
   let(:user) { create(:user) }
   let(:file_id) { '1337' }
@@ -43,6 +41,11 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::OpenLinkQue
 
     method = described_class.method(:call)
     expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq file_id], %i[key open_location])
+  end
+
+  it 'returns the url for opening the storage if no file id is provided' do
+    url = described_class.call(storage:, user:, file_id: nil).result
+    expect(url).to eq("#{storage.host}/index.php/apps/files")
   end
 
   it 'returns the url for opening the file on storage' do

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/open_storage_query_spec.rb
@@ -31,34 +31,28 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::OpenFileLinkQuery do
+RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::OpenStorageQuery do
   let(:storage) { create(:nextcloud_storage, host: 'https://example.com') }
   let(:user) { create(:user) }
-  let(:file_id) { '1337' }
 
   it 'responds to .call' do
     expect(described_class).to respond_to(:call)
 
     method = described_class.method(:call)
-    expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq file_id], %i[key open_location])
+    expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user])
   end
 
   it 'returns the url for opening the file on storage' do
-    url = described_class.call(storage:, user:, file_id:).result
-    expect(url).to eq("#{storage.host}/index.php/f/#{file_id}?openfile=1")
-  end
-
-  it 'returns the url for opening the file\'s location on storage' do
-    url = described_class.call(storage:, user:, file_id:, open_location: true).result
-    expect(url).to eq("#{storage.host}/index.php/f/#{file_id}?openfile=0")
+    url = described_class.call(storage:, user:).result
+    expect(url).to eq("#{storage.host}/index.php/apps/files")
   end
 
   context 'with a storage with host url with a sub path' do
     let(:storage) { create(:nextcloud_storage, host: 'https://example.com/html') }
 
     it 'returns the url for opening the file on storage' do
-      url = described_class.call(storage:, user:, file_id:).result
-      expect(url).to eq("#{storage.host}/index.php/f/#{file_id}?openfile=1")
+      url = described_class.call(storage:, user:).result
+      expect(url).to eq("#{storage.host}/index.php/apps/files")
     end
   end
 end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/download_link_query_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::DownloadLink
   it 'return an error if any other response is received' do
     stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{file_link.origin_id}/content")
       .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .and_return(status: 200, body: "")
+      .and_return(status: 200, body: '')
 
     download_link = download_link_query.call(user:, file_link:)
 

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
@@ -31,72 +31,89 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenFileLinkQuery, :webmock do
-  include JsonResponseHelper
+RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenFileLinkQuery, :vcr, :webmock do
+  using Storages::Peripherals::ServiceResultRefinements
 
-  let(:storage) do
-    create(:one_drive_storage,
-           :with_oauth_client,
-           drive_id: 'b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd')
-  end
   let(:user) { create(:user) }
-  let(:token) { create(:oauth_client_token, user:, oauth_client: storage.oauth_client) }
-  let(:folder_id) { '01BYE5RZ5MYLM2SMX75ZBIPQZIHT6OAYPB' }
-  let(:file_id) { '01BYE5RZ7T3DFLFS6TCRH2QAPWXL5APDLE' }
-  let(:not_found_json) { not_found_response }
-  let(:forbidden_json) { forbidden_response }
+  let(:storage) { create(:sharepoint_dev_drive_storage, oauth_client_token_user: user) }
+  let(:file_id) { '01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU' }
 
-  it 'responds to .call' do
-    expect(described_class).to respond_to(:call)
+  subject { described_class.new(storage) }
 
-    method = described_class.method(:call)
-    expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq file_id], %i[key open_location])
-  end
+  describe '#call' do
+    it 'responds with correct parameters' do
+      expect(described_class).to respond_to(:call)
 
-  it 'returns the url for opening the file on storage' do
-    stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{file_id}?$select=webUrl")
-      .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .to_return(status: 200, body: read_json('file_drive_item_1'), headers: {})
-
-    url = described_class.call(storage:, user:, file_id:).result
-    expect(url).to eq('https://m365x214355-my.sharepoint.com/personal/meganb_m365x214355_onmicrosoft_com/_layouts/15/Doc.aspx?sourcedoc=%7BB2CAD8F3-D3CB-4F14-A801-F6BAFA078D64%7D&file=Popular%20Mixed%20Drinks.xlsx&action=default&mobileredirect=true')
-  end
-
-  it 'returns the url for opening the file\'s location on storage' do
-    stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{file_id}?$select=parentReference")
-      .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .to_return(status: 200, body: read_json('file_drive_item_1'), headers: {})
-    stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{folder_id}?$select=webUrl")
-      .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-      .to_return(status: 200, body: read_json('folder_drive_item'), headers: {})
-
-    url = described_class.call(storage:, user:, file_id:, open_location: true).result
-    expect(url).to eq('https://m365x214355-my.sharepoint.com/personal/meganb_m365x214355_onmicrosoft_com/Documents/Business%20Data')
-  end
-
-  describe 'error handling' do
-    it 'returns a notfound error if the API call returns a 404' do
-      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{file_id}?$select=webUrl")
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 404, body: not_found_json, headers: {})
-
-      open_link_result = described_class.call(storage:, user:, file_id:)
-
-      expect(open_link_result).to be_failure
-      expect(open_link_result.result).to eq(:not_found)
-      expect(open_link_result.errors.data.payload.to_json).to eq(not_found_json)
+      method = described_class.method(:call)
+      expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq file_id], %i[key open_location])
     end
 
-    it 'returns a forbidden error if the API call returns a 403' do
-      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/items/#{file_id}?$select=webUrl")
-        .with(headers: { 'Authorization' => "Bearer #{token.access_token}" })
-        .to_return(status: 403, body: forbidden_json, headers: {})
+    context 'with outbound requests successful' do
+      context 'with open location flag not set', vcr: 'one_drive/open_file_link_query_success' do
+        it 'returns the url for opening the file on storage' do
+          call = subject.call(user:, file_id:)
+          expect(call).to be_success
+          expect(call.result).to eq('https://finn.sharepoint.com/sites/openprojectfilestoragetests/_layouts/15/Doc.aspx?sourcedoc=%7B3D884033-B88B-4195-8F36-D30B41AB9234%7D&file=Document.docx&action=default&mobileredirect=true')
+        end
+      end
 
-      open_link_result = described_class.call(storage:, user:, file_id:)
+      context 'with open location flag set', vcr: 'one_drive/open_file_link_location_query_success' do
+        it 'returns the url for opening the file on storage' do
+          call = subject.call(user:, file_id:, open_location: true)
+          expect(call).to be_success
+          expect(call.result).to eq('https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder')
+        end
+      end
+    end
 
-      expect(open_link_result).to be_failure
-      expect(open_link_result.result).to eq(:forbidden)
-      expect(open_link_result.errors.data.payload.to_json).to eq(forbidden_json)
+    context 'with not existent oauth token' do
+      let(:user_without_token) { create(:user) }
+
+      it 'must return unauthorized when called' do
+        result = subject.call(user: user_without_token, file_id:)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(OAuthClients::ConnectionManager)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
+    end
+
+    context 'with not existent file id', vcr: 'one_drive/open_file_link_query_missing_file_id' do
+      let(:file_id) { 'iamnotexistent' }
+
+      it 'must return not found' do
+        result = subject.call(user:, file_id:)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(Storages::Peripherals::StorageInteraction::OneDrive::Internal::DriveItemQuery)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:not_found) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
+    end
+
+    context 'with invalid oauth token', vcr: 'one_drive/open_file_link_query_invalid_token' do
+      before do
+        token = build_stubbed(:oauth_client_token, oauth_client: storage.oauth_client)
+        allow(Storages::Peripherals::StorageInteraction::OneDrive::Util)
+          .to receive(:using_user_token)
+                .and_yield(token)
+      end
+
+      it 'must return unauthorized' do
+        result = subject.call(user:, file_id:)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(Storages::Peripherals::StorageInteraction::OneDrive::Internal::DriveItemQuery)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
     end
   end
 end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenLinkQuery, :webmock do
+RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenFileLinkQuery, :webmock do
   include JsonResponseHelper
 
   let(:storage) do

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_storage_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_storage_query_spec.rb
@@ -31,8 +31,10 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenDriveLinkQuery, :webmock do
+RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenStorageQuery, :webmock do
   include JsonResponseHelper
+
+  using Storages::Peripherals::ServiceResultRefinements
 
   let(:storage) do
     create(:one_drive_storage,
@@ -70,7 +72,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenDriveLin
 
       expect(open_drive_link_result).to be_failure
       expect(open_drive_link_result.result).to eq(:not_found)
-      expect(open_drive_link_result.errors.data.to_json).to eq(not_found_json)
+      expect(open_drive_link_result.error_payload.to_json).to eq(not_found_json)
     end
 
     it 'returns a forbidden error if the API call returns a 403' do
@@ -82,7 +84,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenDriveLin
 
       expect(open_drive_link_result).to be_failure
       expect(open_drive_link_result.result).to eq(:forbidden)
-      expect(open_drive_link_result.errors.data.to_json).to eq(forbidden_json)
+      expect(open_drive_link_result.error_payload.to_json).to eq(forbidden_json)
     end
   end
 end

--- a/modules/storages/spec/features/storages_menu_links_spec.rb
+++ b/modules/storages/spec/features/storages_menu_links_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe 'Project menu', :js, :with_cuprite do
     it 'has links to enabled storages' do
       visit(project_path(id: project.id))
 
-      expect(page).to have_link(storage.name, href: storage.open_link)
-      project_folder_id = project_storage_with_manual_folder.project_folder_id
-      folder_href = "#{another_storage.host}/index.php/f/#{project_folder_id}?openfile=1"
-      expect(page).to have_link(another_storage.name, href: folder_href)
+      expect(page).to have_link(storage.name,
+                                href: api_v3_paths.project_storage_open(project_storage_without_folder.id))
+      expect(page).to have_link(another_storage.name,
+                                href: api_v3_paths.project_storage_open(project_storage_with_manual_folder.id))
       expect(page).not_to have_link(unlinked_storage.name)
     end
 
@@ -69,11 +69,10 @@ RSpec.describe 'Project menu', :js, :with_cuprite do
       it 'has no links to enabled storage' do
         visit(project_path(id: project.id))
 
-        expect(page).not_to have_link(storage.name, href: storage.open_link)
-        project_folder_id = project_storage_with_manual_folder.project_folder_id
-        folder_href = "#{another_storage.host}/index.php/f/#{project_folder_id}?openfile=1"
-        expect(page).not_to have_link(another_storage.name, href: folder_href)
-        expect(page).not_to have_link(another_storage.name, href: another_storage.open_link)
+        expect(page).not_to have_link(storage.name,
+                                      href: api_v3_paths.project_storage_open(project_storage_without_folder.id))
+        expect(page).not_to have_link(another_storage.name,
+                                      href: api_v3_paths.project_storage_open(project_storage_with_manual_folder.id))
         expect(page).not_to have_link(unlinked_storage.name)
       end
     end

--- a/modules/storages/spec/features/storages_menu_links_spec.rb
+++ b/modules/storages/spec/features/storages_menu_links_spec.rb
@@ -32,6 +32,8 @@ require 'spec_helper'
 require_module_spec_helper
 
 RSpec.describe 'Project menu', :js, :with_cuprite do
+  include API::V3::Utilities::PathHelper
+
   let(:storage) { create(:nextcloud_storage, name: "Storage 1") }
   let(:another_storage) { create(:nextcloud_storage, name: "Storage 2") }
   let(:unlinked_storage) { create(:nextcloud_storage, name: "Storage 3") }

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, 'rendering' do
         end
 
         before do
-          Storages::Peripherals::Registry.stub('queries.one_drive.open_drive_link', ->(_) do
+          Storages::Peripherals::Registry.stub('queries.one_drive.open_storage', ->(_) do
             ServiceResult.success(result: 'https://my.sharepoint.com/sites/DeathStar/Documents')
           end)
         end

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_location_query_success.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_location_query_success.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU?$select=parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Etag:
+      - '"{3D884033-B88B-4195-8F36-D30B41AB9234},5"'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e5f991d2-3358-4694-93dd-0c4e2bf0eb33
+      Client-Request-Id:
+      - e5f991d2-3358-4694-93dd-0c4e2bf0eb33
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF000002DC"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 18 Oct 2023 11:19:43 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/items(parentReference)/$entity","@odata.etag":"\"{3D884033-B88B-4195-8F36-D30B41AB9234},5\"","parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PMAXGDWAAKMEBALX4Q6GSN5BSBR","name":"Folder","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"}}'
+  recorded_at: Wed, 18 Oct 2023 11:19:43 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PMAXGDWAAKMEBALX4Q6GSN5BSBR?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Etag:
+      - '"{6087B980-4C01-4020-BBF2-1E349BD0C831},1"'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 9e4c6634-4ae1-44cb-bc53-4904ff8eed29
+      Client-Request-Id:
+      - 9e4c6634-4ae1-44cb-bc53-4904ff8eed29
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF000002E0"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 18 Oct 2023 11:19:43 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/items(webUrl)/$entity","@odata.etag":"\"{6087B980-4C01-4020-BBF2-1E349BD0C831},1\"","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder"}'
+  recorded_at: Wed, 18 Oct 2023 11:19:43 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_invalid_token.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_invalid_token.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 1234567890-1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - c1899d3c-0828-4441-80c5-26ed3eb657d4
+      Client-Request-Id:
+      - c1899d3c-0828-4441-80c5-26ed3eb657d4
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"004","RoleInstance":"FR2PEPF0000039E"}}'
+      Www-Authenticate:
+      - Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize",
+        client_id="00000003-0000-0000-c000-000000000000"
+      Date:
+      - Wed, 18 Oct 2023 11:24:58 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"InvalidAuthenticationToken","message":"CompactToken
+        parsing failed with error code: 80049217","innerError":{"date":"2023-10-18T11:24:58","request-id":"c1899d3c-0828-4441-80c5-26ed3eb657d4","client-request-id":"c1899d3c-0828-4441-80c5-26ed3eb657d4"}}}'
+  recorded_at: Wed, 18 Oct 2023 11:24:58 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_missing_file_id.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_missing_file_id.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/iamnotexistent?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 0e00ab2f-367b-4aca-bcc1-bd6c6d70a14a
+      Client-Request-Id:
+      - 0e00ab2f-367b-4aca-bcc1-bd6c6d70a14a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF00000362"}}'
+      Date:
+      - Wed, 18 Oct 2023 11:28:17 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"itemNotFound","message":"Item not found","innerError":{"date":"2023-10-18T11:28:17","request-id":"0e00ab2f-367b-4aca-bcc1-bd6c6d70a14a","client-request-id":"0e00ab2f-367b-4aca-bcc1-bd6c6d70a14a"}}}'
+  recorded_at: Wed, 18 Oct 2023 11:28:17 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_success.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_file_link_query_success.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Etag:
+      - '"{3D884033-B88B-4195-8F36-D30B41AB9234},5"'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 7d445471-cdbf-438f-874a-332096adeae9
+      Client-Request-Id:
+      - 7d445471-cdbf-438f-874a-332096adeae9
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E0"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 18 Oct 2023 09:29:31 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/items(webUrl)/$entity","@odata.etag":"\"{3D884033-B88B-4195-8F36-D30B41AB9234},5\"","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/_layouts/15/Doc.aspx?sourcedoc=%7B3D884033-B88B-4195-8F36-D30B41AB9234%7D&file=Document.docx&action=default&mobileredirect=true"}'
+  recorded_at: Wed, 18 Oct 2023 09:29:32 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_storage_query_invalid_token.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_storage_query_invalid_token.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 1234567890-1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - dc3446a9-9239-4e75-a70e-4db0f73167dd
+      Client-Request-Id:
+      - dc3446a9-9239-4e75-a70e-4db0f73167dd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"FR3PEPF00000165"}}'
+      Www-Authenticate:
+      - Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize",
+        client_id="00000003-0000-0000-c000-000000000000"
+      Date:
+      - Wed, 18 Oct 2023 11:33:26 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"InvalidAuthenticationToken","message":"CompactToken
+        parsing failed with error code: 80049217","innerError":{"date":"2023-10-18T11:33:27","request-id":"dc3446a9-9239-4e75-a70e-4db0f73167dd","client-request-id":"dc3446a9-9239-4e75-a70e-4db0f73167dd"}}}'
+  recorded_at: Wed, 18 Oct 2023 11:33:27 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_storage_query_success.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/open_storage_query_success.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs?$select=webUrl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 94c777a5-8135-4696-89d6-1031a4e41132
+      Client-Request-Id:
+      - 94c777a5-8135-4696-89d6-1031a4e41132
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E0"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 18 Oct 2023 11:33:27 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(webUrl)/$entity","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR"}'
+  recorded_at: Wed, 18 Oct 2023 11:33:27 GMT
+recorded_with: VCR 6.2.0

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -46,6 +46,18 @@ RSpec.shared_examples_for 'successful no content response' do |code = 204|
   end
 end
 
+RSpec.shared_examples_for 'redirect response' do |code = 303|
+  let(:location) { '' }
+
+  it "has the status code #{code}" do
+    expect(last_response.status).to eq(code)
+  end
+
+  it 'redirects to expected location' do
+    expect(last_response.headers['Location']).to eq(location)
+  end
+end
+
 RSpec.shared_examples_for 'error response' do |code, id, provided_message = nil|
   let(:expected_message) do
     provided_message || message
@@ -113,7 +125,7 @@ RSpec.shared_examples_for 'parse error' do |details|
   it 'shows the given details' do
     if details
       expect(last_response.body).to be_json_eql(details.to_json)
-        .at_path('_embedded/details/parseError')
+                                      .at_path('_embedded/details/parseError')
     end
   end
 end


### PR DESCRIPTION
[OP#50543](https://community.openproject.org/work_packages/50543)

### What???

- added new endpoints for opening storages
  - `/api/v3/storages/:id/open`
  - `/api/v3/project_storages/:id/open`
- amended queries
  - `open_file_link_query` used for generating open links of items with an id
  - `open_storage_query` used for generating open links of a storage file root
- removed `open_link` method from storage records
- added vcr based unit tests for new queries
- added api requests tests for new endpoints

### But... Why??

- providing and using static links for opening external resources has some benefits
  - links can be used in UI without making external request whil bootstrapping the app