### PR TITLE
Add instructions to install OpenJDK for running ApacheDS tests

### DIFF
--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -263,7 +263,7 @@ development mode, but only for running the entire test suite.
 ### Java 7 or later
 
 To test the integration with LDAP servers, we rely on [ladle](https://github.com/NUBIC/ladle) to spin up an LDAP server
-when runnin tests. As this runs [ApacheDS](https://directory.apache.org/apacheds/) internally, it requires Java 7 or
+when running tests. As this runs [ApacheDS](https://directory.apache.org/apacheds/) internally, it requires Java 7 or
 later to be installed.
 
 If java is not installed, some tests will stall for 60 seconds before timing out. To run the tests, install java with
@@ -286,8 +286,7 @@ brew install subversion
 
 ### Git
 
-To test the integration with Git repositories, we rely on the `git` command to be available. Git is either installed by
-with the Xcode Command Line Tools, with [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) or via homebrew.
+To test the integration with Git repositories, we rely on the `git` command to be available. Git is either installed via the Xcode Command Line Tools, with [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) or via homebrew.
 
 ```shell
 xcode-select --install

--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -255,6 +255,24 @@ RAILS_ENV=development bin/rails jobs:work
 
 This will start a Delayed::Job worker to perform asynchronous jobs like sending emails.
 
+## Additional test dependencies
+
+The test suite requires a few additional dependencies to be installed. These are not required for running OpenProject in
+development mode, but only for running the entire test suite.
+
+### Java 7 or later
+
+To test the integration with LDAP servers, we rely on [ladle](https://github.com/NUBIC/ladle) to spin up an LDAP server
+when runnin tests. As this runs [ApacheDS](https://directory.apache.org/apacheds/) internally, it requires Java 7 or
+later to be installed.
+
+```shell
+brew install openjdk
+
+# The installation instructions will tell you to add a symlink to the JDK for the `java` command to pick it up
+sudo ln -sfn $(brew --prefix)/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+```
+
 ## Known issues
 
 ### Memory management

--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -266,11 +266,35 @@ To test the integration with LDAP servers, we rely on [ladle](https://github.com
 when runnin tests. As this runs [ApacheDS](https://directory.apache.org/apacheds/) internally, it requires Java 7 or
 later to be installed.
 
+If java is not installed, some tests will stall for 60 seconds before timing out. To run the tests, install java with
+
 ```shell
 brew install openjdk
 
 # The installation instructions will tell you to add a symlink to the JDK for the `java` command to pick it up
 sudo ln -sfn $(brew --prefix)/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+```
+
+### Subversion
+
+To test the integration with Subversion repositories, we rely on the `svnadmin` command to be available. If subversion
+is not installed, the tests *will be skipped*. To run the tests, install subversion with
+
+```shell
+brew install subversion
+```
+
+### Git
+
+To test the integration with Git repositories, we rely on the `git` command to be available. Git is either installed by
+with the Xcode Command Line Tools, with [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) or via homebrew.
+
+```shell
+xcode-select --install
+
+# or
+
+brew install git
 ```
 
 ## Known issues


### PR DESCRIPTION
I did not find instructions anywhere to install Java to make the LDAP tests work. This adds the instructions at least for the macOS folks :)