### PR TITLE
Correctly restore permission cache

### DIFF
--- a/spec/lib/open_project/plugins/module_handler_spec.rb
+++ b/spec/lib/open_project/plugins/module_handler_spec.rb
@@ -28,16 +28,13 @@
 
 require 'spec_helper'
 RSpec.describe OpenProject::Plugins::ModuleHandler do
-  let!(:all_former_permissions) { OpenProject::AccessControl.permissions }
-
-  before do
+  around do |example|
+    old_mapped_permissions = OpenProject::AccessControl.instance_variable_get(:@mapped_permissions).deep_dup
     described_class.disable_modules!('repository')
-  end
 
-  after do
-    raise 'Test outdated' unless OpenProject::AccessControl.instance_variable_defined?(:@mapped_permissions)
-
-    OpenProject::AccessControl.instance_variable_set(:@mapped_permissions, all_former_permissions)
+    example.run
+  ensure
+    OpenProject::AccessControl.instance_variable_set(:@mapped_permissions, old_mapped_permissions)
     OpenProject::AccessControl.clear_caches
   end
 


### PR DESCRIPTION
Previously, running the `module_handler_spec` left the permissions given by the repository module disabled. This PR fixes the issue by completely duplicating the permissions (including the disabled state) and afterwards restoring the entire `mapped_permissions` cache to the old state