### PR TITLE
[50487] (Mobile) Author and duration overlap

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -29,10 +29,7 @@ $meeting-agenda-item--author-width: 300px
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr 50px
     grid-template-areas: "drag-handle content content actions" ". author author duration" ". notes notes notes"
-
-    &--duration
-      justify-self: end
-    
+ 
     &--author
       justify-self: stretch
 

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -32,3 +32,7 @@ $meeting-agenda-item--author-width: 300px
 
     &--duration
       justify-self: end
+    
+    &--author
+      justify-self: stretch
+


### PR DESCRIPTION
Move Author to the right (start) and make it stretches to fill the grid cell and shortens when there is not enough space.
https://community.openproject.org/wp/50487