### PR TITLE
Bug/49947 project storage can be set to automatically managed while storage is not configured for it

### DIFF
--- a/modules/storages/app/contracts/storages/project_storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/base_contract.rb
@@ -52,7 +52,7 @@ module Storages::ProjectStorages
       end
     end
 
-    validate :project_folder_mode_can_be_automatic, unless: -> { errors.include?(:project_folder_mode) }
+    validate :project_folder_automatic_mode, unless: -> { errors.include?(:project_folder_mode) }
 
     private
 
@@ -60,10 +60,10 @@ module Storages::ProjectStorages
       @model.project_folder_manual?
     end
 
-    def project_folder_mode_can_be_automatic
-      return unless @model.storage.provider_type_nextcloud?
+    def project_folder_automatic_mode
+      return unless @model.project_folder_automatic?
 
-      if @model.project_folder_automatic? && !@model.storage.automatically_managed?
+      unless @model.automatic_management_possible?
         errors.add :project_folder_mode, :mode_unavailable
       end
     end

--- a/modules/storages/app/contracts/storages/project_storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/base_contract.rb
@@ -52,10 +52,20 @@ module Storages::ProjectStorages
       end
     end
 
+    validate :project_folder_mode_can_be_automatic, unless: -> { errors.include?(:project_folder_mode) }
+
     private
 
     def project_folder_mode_manual?
       @model.project_folder_manual?
+    end
+
+    def project_folder_mode_can_be_automatic
+      return unless @model.storage.provider_type_nextcloud?
+
+      if @model.project_folder_automatic? && !@model.storage.automatically_managed?
+        errors.add :project_folder_mode, :automatic_mode_unavailable
+      end
     end
   end
 end

--- a/modules/storages/app/contracts/storages/project_storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/base_contract.rb
@@ -64,7 +64,7 @@ module Storages::ProjectStorages
       return unless @model.storage.provider_type_nextcloud?
 
       if @model.project_folder_automatic? && !@model.storage.automatically_managed?
-        errors.add :project_folder_mode, :automatic_mode_unavailable
+        errors.add :project_folder_mode, :mode_unavailable
       end
     end
   end

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -52,7 +52,7 @@ class Storages::ProjectStorage < ApplicationRecord
   scope :automatic, -> { where(project_folder_mode: 'automatic') }
 
   def automatic_management_possible?
-    storage.provider_type_nextcloud? && storage.automatically_managed?
+    storage.present? && storage.provider_type_nextcloud? && storage.automatically_managed?
   end
 
   def project_folder_path

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -51,6 +51,10 @@ class Storages::ProjectStorage < ApplicationRecord
 
   scope :automatic, -> { where(project_folder_mode: 'automatic') }
 
+  def automatic_management_possible?
+    storage.provider_type_nextcloud? && storage.automatically_managed?
+  end
+
   def project_folder_path
     "#{storage.group_folder}/#{project.name.gsub('/', '|')} (#{project.id})/"
   end

--- a/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
@@ -88,18 +88,20 @@ See COPYRIGHT and LICENSE files for more details.
     <%= t(:"storages.instructions.no_specific_folder") %>
   </span>
 
-  <div class="form--field-container">
-    <%= f.label :project_folder_mode, class: "form--label-with-radio-button" do %>
-      <%= f.radio_button :project_folder_mode,
-                         'automatic',
-                         no_label: true,
-                         data: { action: 'project-storage-form#updateForm' } %>
-      <%= t(:"storages.label_automatic_folder") %>
-    <% end %>
-  </div>
-  <span class="form--field-instructions -xwide -with-bottom-spacing">
-    <%= t(:"storages.instructions.automatic_folder") %>
-  </span>
+  <% if @project_storage.automatic_management_possible? %>
+    <div class="form--field-container">
+      <%= f.label :project_folder_mode, class: "form--label-with-radio-button" do %>
+        <%= f.radio_button :project_folder_mode,
+                          'automatic',
+                          no_label: true,
+                          data: { action: 'project-storage-form#updateForm' } %>
+        <%= t(:"storages.label_automatic_folder") %>
+      <% end %>
+    </div>
+    <span class="form--field-instructions -xwide -with-bottom-spacing">
+      <%= t(:"storages.instructions.automatic_folder") %>
+    </span>
+  <% end %>
 
   <div class="form--field-container">
     <%= f.label :project_folder_mode, class: "form--label-with-radio-button" do %>

--- a/modules/storages/app/views/storages/project_settings/edit.html.erb
+++ b/modules/storages/app/views/storages/project_settings/edit.html.erb
@@ -31,6 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
 <% local_assigns[:additional_breadcrumb] = t('storages.label_edit_storage') %>
 <%= toolbar title: t("storages.page_titles.project_settings.edit") %>
 
+<%= error_messages_for_contract @project_storage, @errors %>
+
 <%= labelled_tabular_form_for @project_storage, url: project_settings_project_storage_path(project_id: @project_storage.project, id: @project_storage) do |f| -%>
   <section class="form--section">
     <%= render partial: '/storages/project_settings/project_folder_form',

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
         storages/project_storage:
           attributes:
             project_folder_mode:
-              automatic_mode_unavailable: "is not available for this storage."
+              mode_unavailable: "is not available for this storage."
         storages/storage:
           attributes:
             host:

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -36,6 +36,10 @@ en:
       messages:
         not_linked_to_project: "is not linked to project."
       models:
+        storages/project_storage:
+          attributes:
+            project_folder_mode:
+              automatic_mode_unavailable: "is not available for this storage."
         storages/storage:
           attributes:
             host:

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
   context 'if the project folder mode is `automatic`' do
     before do
       project_storage.project_folder_mode = 'automatic'
+      project_storage.storage.automatically_managed = true
     end
 
     it_behaves_like 'contract is valid'

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
       project_storage.storage.automatically_managed = false
     end
 
-    it_behaves_like 'contract is invalid', project_folder_mode: :automatic_mode_unavailable
+    it_behaves_like 'contract is invalid', project_folder_mode: :mode_unavailable
   end
 
   context 'if the project folder mode is `manual`' do

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
   include_context 'ModelContract shared context'
 
   let(:contract) { described_class.new(project_storage, build_stubbed(:admin)) }
-  # Creator is not writable in BaseContract; just test base contract writable attributes
-  let(:project_storage) { build(:project_storage) }
+  let(:storage) { build_stubbed(:nextcloud_storage) }
+  let(:project_storage) { build(:project_storage, storage:) }
 
   context 'if the project folder mode is `inactive`' do
     before do

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
     it_behaves_like 'contract is valid'
   end
 
+  context 'when the project folder mode is `automatic` but the storage is not automatically managed' do
+    before do
+      project_storage.project_folder_mode = 'automatic'
+      project_storage.storage.automatically_managed = false
+    end
+
+    it_behaves_like 'contract is invalid', project_folder_mode: :automatic_mode_unavailable
+  end
+
   context 'if the project folder mode is `manual`' do
     before do
       project_storage.project_folder_mode = 'manual'

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
     sequence(:host) { |n| "https://host#{n}.example.com" }
     creator factory: :user
 
+    trait :as_generic do
+      provider_type { 'Storages::Storage' }
+    end
+
     factory :nextcloud_storage, class: '::Storages::NextcloudStorage' do
       provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
 

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -32,9 +32,7 @@ require_relative '../spec_helper'
 # This tests assumes that a Storage has already been setup
 # in the Admin section, tested by admin_storage_spec.rb.
 RSpec.describe(
-  'Activation of storages in projects',
-  js: true,
-  webmock: true
+  'Activation of storages in projects', :js, :webmock
 ) do
   let(:user) { create(:user) }
   # The first page is the Project -> Settings -> General page, so we need
@@ -154,7 +152,7 @@ RSpec.describe(
     # Press Edit icon to change the project folder mode to inactive
     page.find('.icon.icon-edit').click
     expect(page).to have_current_path edit_project_settings_project_storage_path(project_id: project,
-                                                                                  id: Storages::ProjectStorage.last)
+                                                                                 id: Storages::ProjectStorage.last)
     expect(page).to have_text('Edit the file storage to this project')
     expect(page).not_to have_select('storages_project_storage_storage_id')
     expect(page).to have_text(storage.name)
@@ -173,7 +171,7 @@ RSpec.describe(
     # Click Edit icon again but cancel the edit
     page.find('.icon.icon-edit').click
     expect(page).to have_current_path edit_project_settings_project_storage_path(project_id: project,
-                                                                                  id: Storages::ProjectStorage.last)
+                                                                                 id: Storages::ProjectStorage.last)
     expect(page).to have_text('Edit the file storage to this project')
     page.click_link('Cancel')
     expect(page).to have_current_path project_settings_project_storages_path(project)
@@ -203,7 +201,8 @@ RSpec.describe(
 
   describe 'automatic project folder mode' do
     context 'when the storage is not automatically managed' do
-      let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed) }
+      let(:oauth_application) { create(:oauth_application) }
+      let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed, oauth_application:) }
       let(:project_storage) { create(:project_storage, storage:, project:) }
 
       it 'automatic option is not available' do
@@ -214,7 +213,8 @@ RSpec.describe(
     end
 
     context 'when the storage is automatically managed' do
-      let(:storage) { create(:nextcloud_storage, :as_automatically_managed) }
+      let(:oauth_application) { create(:oauth_application) }
+      let(:storage) { create(:nextcloud_storage, :as_automatically_managed, oauth_application:) }
       let(:project_storage) { create(:project_storage, storage:, project:) }
 
       it 'automatic option is available' do

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe(
     page.find('.icon.icon-delete').click
 
     # Danger zone confirmation flow
-    expect(page).to have_selector('.form--section-title', text: "DELETE FILE STORAGE")
-    expect(page).to have_selector('.danger-zone--warning', text: "Deleting a file storage is an irreversible action.")
+    expect(page).to have_css('.form--section-title', text: "DELETE FILE STORAGE")
+    expect(page).to have_css('.danger-zone--warning', text: "Deleting a file storage is an irreversible action.")
     expect(page).to have_button('Delete', disabled: true)
 
     # Cancel Confirmation
@@ -199,6 +199,30 @@ RSpec.describe(
     # List of ProjectStorages empty again
     expect(page).to have_current_path project_settings_project_storages_path(project)
     expect(page).to have_text(I18n.t('storages.no_results'))
+  end
+
+  describe 'automatic project folder mode' do
+    context 'when the storage is not automatically managed' do
+      let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed) }
+      let(:project_storage) { create(:project_storage, storage:, project:) }
+
+      it 'automatic option is not available' do
+        visit edit_project_settings_project_storage_path(project_id: project, id: project_storage)
+
+        expect(page).not_to have_content('New folder with automatically managed permissions')
+      end
+    end
+
+    context 'when the storage is automatically managed' do
+      let(:storage) { create(:nextcloud_storage, :as_automatically_managed) }
+      let(:project_storage) { create(:project_storage, storage:, project:) }
+
+      it 'automatic option is available' do
+        visit edit_project_settings_project_storage_path(project_id: project, id: project_storage)
+
+        expect(page).to have_content('New folder with automatically managed permissions')
+      end
+    end
   end
 
   describe 'configuration checks' do

--- a/modules/storages/spec/models/project_storage_spec.rb
+++ b/modules/storages/spec/models/project_storage_spec.rb
@@ -78,6 +78,38 @@ RSpec.describe Storages::ProjectStorage do
     end
   end
 
+  describe '#automatic_management_possible?' do
+    let(:project_storage) { build_stubbed(:project_storage, storage:) }
+
+    context 'when the storage is not a NextcloudStorage' do
+      let(:storage) { build_stubbed(:storage) }
+
+      it "returns false" do
+        expect(project_storage.automatic_management_possible?).to be false
+      end
+    end
+
+    context 'when the storage is a NextcloudStorage' do
+      let(:storage) { build_stubbed(:nextcloud_storage) }
+
+      context 'when the storage is not automatically managed' do
+        it "returns false" do
+          expect(project_storage.automatic_management_possible?).to be false
+        end
+      end
+
+      context 'when the storage is automatically managed' do
+        before do
+          storage.automatically_managed = true
+        end
+
+        it "returns true" do
+          expect(project_storage.automatic_management_possible?).to be true
+        end
+      end
+    end
+  end
+
   describe '#project_folder_mode' do
     let(:project_storage) { build(:project_storage) }
 

--- a/modules/storages/spec/models/project_storage_spec.rb
+++ b/modules/storages/spec/models/project_storage_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Storages::ProjectStorage do
     let(:project_storage) { build_stubbed(:project_storage, storage:) }
 
     context 'when the storage is not a NextcloudStorage' do
-      let(:storage) { build_stubbed(:storage) }
+      let(:storage) { build_stubbed(:storage, :as_generic) }
 
       it "returns false" do
         expect(project_storage.automatic_management_possible?).to be false


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/49947

When storage does not support automatic folder management, do not allow the automatic option when adding the storage into a project

![Screenshot 2023-10-17 at 3 47 27 PM](https://github.com/opf/openproject/assets/17295175/7c6d2dc4-1bf5-4e6a-8b54-5191b11de3e5)
![Screenshot 2023-10-17 at 3 45 30 PM](https://github.com/opf/openproject/assets/17295175/4ab6ced3-2b14-4055-a75a-32854ed07d95)
