### PR TITLE
[#50167] changed azure oidc provider form to ensure v2

### DIFF
--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -10,7 +10,7 @@ end
 
 gem 'omniauth-openid_connect-providers',
     git: 'https://github.com/opf/omniauth-openid_connect-providers.git',
-    ref: '7559f44e70203f94572a90e1b4d1d1f8279cd40f'
+    ref: 'c7e2498a8b093cfc5693d4960cae2e903a5e10cd'
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',

--- a/modules/openid_connect/app/views/openid_connect/providers/_azure_form.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/_azure_form.html.erb
@@ -5,13 +5,13 @@
                     'admin--openid-connect-providers-target': 'azureForm',
                   },
                   hidden: @provider.name.present? && @provider.name != 'azure' do %>
-    <div class="form--field">
+    <div class="form--field -required">
       <%= f.text_field :tenant, required: true, container_class: '-middle' %>
       <div class="form--field-instructions">
         <%= t('openid_connect.setting_instructions.azure_tenant_html') %>
       </div>
     </div>
-    <div class="form--field">
+    <div class="form--field -hidden">
       <%= f.check_box :use_graph_api, container_class: '-middle' %>
       <div class="form--field-instructions">
         <%= t('openid_connect.setting_instructions.azure_graph_api') %>

--- a/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
@@ -1,3 +1,11 @@
+<% if @provider.persisted? && @provider.name == 'azure' && @provider.tenant.empty? %>
+  <div class="op-toast -warning">
+    <div class="op-toast--content">
+      <p><%= 'The configured Azure app points to a deprecated API from Azure. Please create a new Azure app to ensure the functionality in future.' %></p>
+    </div>
+  </div>
+<% end %>
+
 <fieldset class="form--fieldset">
   <% unless @provider.persisted? -%>
     <div class="form--field -required">

--- a/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
@@ -1,7 +1,7 @@
 <% if @provider.persisted? && @provider.name == 'azure' && @provider.tenant.empty? %>
   <div class="op-toast -warning">
     <div class="op-toast--content">
-      <p><%= 'The configured Azure app points to a deprecated API from Azure. Please create a new Azure app to ensure the functionality in future.' %></p>
+      <p><%= I18n.t('openid_connect.setting_instructions.azure_deprecation_warning') %></p>
     </div>
   </div>
 <% end %>

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
       plural: OpenID providers
       singular: OpenID provider
     setting_instructions:
+      azure_deprecation_warning: >
+        The configured Azure app points to a deprecated API from Azure. Please create a new Azure app to ensure the functionality in future.
       azure_graph_api: >
         Use the graph.microsoft.com userinfo endpoint to request userdata. This should be the default unless you have an older azure application.
       azure_tenant_html: >


### PR DESCRIPTION
companion PR: https://github.com/opf/omniauth-openid_connect-providers/pull/10

- made tenant input required
- hide graph api checkbox (true by default)
- added deprecation banner, if old azure app without tenant is edited
