### PR TITLE
Added possibilty to add tenant and drive ID for a OneDrive storage

### DIFF
--- a/modules/storages/app/constants/storages/admin.rb
+++ b/modules/storages/app/constants/storages/admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -28,8 +30,10 @@
 
 module Storages
   module Admin
-    LABEL_OAUTH_CLIENT_ID = 'OAuth Client ID'.freeze
-    LABEL_OAUTH_CLIENT_SECRET = 'OAuth Client Secret'.freeze
-    LABEL_OAUTH_REDIRECT_URI = 'OAuth Redirect URI'.freeze
+    LABEL_OAUTH_CLIENT_ID = 'OAuth Client ID'
+    LABEL_OAUTH_CLIENT_SECRET = 'OAuth Client Secret'
+    LABEL_OAUTH_REDIRECT_URI = 'OAuth Redirect URI'
+    LABEL_TENANT_ID = 'Tenant ID'
+    LABEL_DRIVE_ID = 'Drive ID'
   end
 end

--- a/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
@@ -32,5 +32,9 @@ module Storages::Storages
   class OneDriveContract < ::ModelContract
     attribute :host
     validates :host, absence: true
+    attribute :tenant_id
+    validates :tenant_id, format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
+    attribute :drive_id
+    validates :drive_id, format: { with: /\A[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\z/i }, allow_nil: true
   end
 end

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -111,9 +111,14 @@ class Storages::Admin::StoragesController < ApplicationController
   # See also: create above
   # Called by: Global app/config/routes.rb to serve Web page
   def update
+    storage_params = permitted_storage_params
+    parts = storage_params[:drive_id].split(',')
+
+    storage_params[:drive_id] = parts.count > 1 ? parts[1] : parts[0]
+
     service_result = ::Storages::Storages::UpdateService
                        .new(user: current_user, model: @storage)
-                       .call(permitted_storage_params)
+                       .call(storage_params)
 
     if service_result.success?
       flash[:notice] = I18n.t(:notice_successful_update)

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -42,7 +42,7 @@ class Storages::Admin::StoragesController < ApplicationController
   # and set the @<controller_name> variable to the object referenced in the URL.
   before_action :require_admin
   before_action :find_model_object, only: %i[show destroy edit update replace_oauth_application]
-  before_action :parse_drive_id, only: %i[update]
+  before_action :prepare_update_params, only: %i[update]
 
   # menu_item is defined in the Redmine::MenuManager::MenuController
   # module, included from ApplicationController.
@@ -172,7 +172,7 @@ class Storages::Admin::StoragesController < ApplicationController
 
   private
 
-  def parse_drive_id
+  def prepare_update_params
     @storage_params = permitted_storage_params
 
     if @storage.provider_type_one_drive? && @storage.drive_id.nil?

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -88,7 +88,7 @@ class Storages::Admin::StoragesController < ApplicationController
       case @storage.provider_type
       when ::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
         flash[:notice] = I18n.t(:notice_successful_create)
-        redirect_to new_admin_settings_storage_oauth_client_path(@storage)
+        render '/storages/admin/storages/one_drive/edit'
       when ::Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
         if @oauth_application.present?
           flash.now[:notice] = I18n.t(:notice_successful_create)
@@ -103,7 +103,7 @@ class Storages::Admin::StoragesController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   # Edit page is very similar to new page, except that we don't need to set
-  # default attribute values because the object already exists
+  # default attribute values because the object already exists;
   # Called by: Global app/config/routes.rb to serve Web page
   def edit; end
 
@@ -180,6 +180,6 @@ class Storages::Admin::StoragesController < ApplicationController
   def permitted_storage_params
     params
       .require(:storages_storage)
-      .permit('name', 'provider_type', 'host', 'oauth_client_id', 'oauth_client_secret')
+      .permit('name', 'provider_type', 'host', 'oauth_client_id', 'oauth_client_secret', 'tenant_id', 'drive_id')
   end
 end

--- a/modules/storages/app/views/storages/admin/storages/one_drive/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/one_drive/edit.html.erb
@@ -1,0 +1,64 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+++#%>
+
+<% html_title t(:label_administration), t("project_module_storages"), @storage.name, "#{t("storages.provider_types.#{@storage.short_provider_type}.name")} #{t("storages.label_information")}" %>
+
+<% local_assigns[:additional_breadcrumb] = [
+  link_to(@storage.name, edit_admin_settings_storage_path(@storage)),
+  t("storages.label_oauth_breadcrumb.#{@storage.short_provider_type}")
+] %>
+<%= toolbar title: "#{t("storages.provider_types.#{@storage.short_provider_type}.name")} #{t("storages.label_information")}" %>
+
+<%= labelled_tabular_form_for @storage, url: admin_settings_storage_path(@storage), as: :storages_storage do |f| -%>
+  <fieldset class="form--fieldset">
+    <div class="form--field -required">
+      <%= f.text_field :tenant_id,
+                       label: Storages::Admin::LABEL_TENANT_ID,
+                       required: true,
+                       size: 40,
+                       container_class: '-wide'
+                       %>
+      <span class="form--field-instructions">
+      <%= t("storages.instructions.#{@storage.short_provider_type}.tenant_id") %>
+    </span>
+    </div>
+
+    <div class="form--field -required">
+      <%= f.text_field :drive_id,
+                       label: Storages::Admin::LABEL_DRIVE_ID,
+                       required: true,
+                       size: 40,
+                       container_class: '-wide' %>
+      <span class="form--field-instructions">
+      <%= t("storages.instructions.#{@storage.short_provider_type}.drive_id") %>
+    </span>
+    </div>
+  </fieldset>
+
+  <%= styled_button_tag t("storages.buttons.save_and_continue_setup"), class: "-highlight -with-icon icon-checkmark" %>
+<% end %>

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
         tenant_id: >
           Please insert the tenant ID you got from your SharePoint administrator.
         drive_id: >
-          The drive ID can be obtained by you SharePoint Administrator.
+          The drive ID can be obtained by you SharePoint administrator.
     help_texts:
       project_folder: >
         The project folder is the default folder for file uploads for this project.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -126,6 +126,10 @@ en:
           Copy the client secret from the Azure portal. For a newly created application the secret first needs to be
           created manually. For authorization of web applications a secret is mandatory.
         missing_client_id_for_redirect_uri: "Client ID missing to provide redirect URI."
+        tenant_id: >
+          Please insert the tenant ID you got from your SharePoint administrator.
+        drive_id: >
+          The drive ID can be obtained by you SharePoint Administrator.
     help_texts:
       project_folder: >
         The project folder is the default folder for file uploads for this project.
@@ -167,6 +171,7 @@ en:
       one_drive: "OneDrive OAuth"
     label_oauth_application_details: "OAuth application details"
     label_oauth_client_details: "OAuth client details"
+    label_information: "Additional information"
     label_provider_type: "Provider type"
     label_project_folder: "Project folder"
     label_new_storage: "New storage"

--- a/modules/storages/spec/controller/storages_controller_spec.rb
+++ b/modules/storages/spec/controller/storages_controller_spec.rb
@@ -49,10 +49,13 @@ RSpec.describe Storages::Admin::StoragesController, type: :controller, webmock: 
     login_as admin
     mock_server_capabilities_response(host)
     mock_server_config_check_response(host)
-    post :create, params:
   end
 
   describe 'with valid storage attributes' do
+    before do
+      post :create, params:
+    end
+
     it 'is successful' do
       expect(response).to be_successful
       expect(response.body).not_to include('Host is not providing a &quot;Secure Context&quot;.')
@@ -63,9 +66,35 @@ RSpec.describe Storages::Admin::StoragesController, type: :controller, webmock: 
   describe 'with invalid storage attributes' do
     let(:schema) { 'http' }
 
+    before do
+      post :create, params:
+    end
+
     it 'shows the errors of the dependent service result, complaining about HTTP being invalid' do
       expect(response).to be_successful # you get a 200 response despite errors...
       expect(response.body).to include('Host is not providing a &quot;Secure Context&quot;.')
+    end
+  end
+
+  describe 'with drive ID triple' do
+    let(:storage) { create(:one_drive_storage) }
+    let(:drive_id) { "1b4b6576-906d-4d94-8f49-6d00a9507b50" }
+    let(:params) do
+      {
+        id: storage.id,
+        storages_storage: {
+          drive_id: "example.sharepoint.com,#{drive_id},7ef259e8-8eed-4645-920a-8b367bb0d8e0"
+        }
+      }
+    end
+
+    before do
+      put :update, params:
+    end
+
+    it 'drive ID must be parsed down to a single UUID' do
+      storage.reload
+      expect(storage.drive_id).to eq(drive_id)
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/50141

This PR is implementing the function of providing the Tenant ID and the Drive ID during the setup of a OneDrive/Sharepoint storage.

- A new page between the storage type selection and OAuth settings
- Contract for validating that TenantId and DriveId are UUIDs (solved with a regex)
- `before_action` for parsing the parameter for the update action to get the drive id