### PR TITLE
[#50656] no connection manager init on parsing storages

### DIFF
--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -75,8 +75,11 @@ module API::V3::Storages
     extend ClassMethods
 
     def initialize(model, current_user:, embed_links: nil)
-      @connection_manager =
-        ::OAuthClients::ConnectionManager.new(user: current_user, configuration: model.oauth_configuration)
+      unless model.empty?
+        # Do not instantiate a connection manager, if representer is used for parsing
+        @connection_manager =
+          ::OAuthClients::ConnectionManager.new(user: current_user, configuration: model.oauth_configuration)
+      end
 
       super
     end

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -75,7 +75,7 @@ module API::V3::Storages
     extend ClassMethods
 
     def initialize(model, current_user:, embed_links: nil)
-      unless model.empty?
+      if model.oauth_configuration.present?
         # Do not instantiate a connection manager, if representer is used for parsing
         @connection_manager =
           ::OAuthClients::ConnectionManager.new(user: current_user, configuration: model.oauth_configuration)


### PR DESCRIPTION
[OP#50656](https://community.openproject.org/wp/50656)

- skip instantiating connection manager, if storage representer is used for parsing