### PR TITLE
fix reversing the relation if necessary before validation

### DIFF
--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -46,7 +46,7 @@ module Relations
       Relation
     end
 
-    def validate!(*args)
+    def valid?(*args)
       # same as before_validation callback
       model.send(:reverse_if_needed)
 
@@ -65,7 +65,7 @@ module Relations
 
     def validate_nodes_relatable
       if (model.from_id_changed? || model.to_id_changed?) &&
-         WorkPackage.relatable(model.from, model.relation_type).where(id: model.to).empty?
+         WorkPackage.relatable(model.from, model.relation_type, ignore_relation: model).where(id: model.to).empty?
         errors.add :base, I18n.t(:'activerecord.errors.messages.circular_dependency')
       end
     end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -63,7 +63,7 @@ module Relations
 
     def validate_nodes_relatable
       if (model.from_id_changed? || model.to_id_changed?) &&
-         WorkPackage.relatable(model.from, model.relation_type, ignored_relation: model).where(id: model.to).empty?
+         WorkPackage.relatable(model.from, model.relation_type, ignored_relation: model).where(id: model.to_id).empty?
         errors.add :base, I18n.t(:'activerecord.errors.messages.circular_dependency')
       end
     end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'model_contract'
-
 module Relations
   class BaseContract < ::ModelContract
     attribute :relation_type
@@ -65,7 +63,7 @@ module Relations
 
     def validate_nodes_relatable
       if (model.from_id_changed? || model.to_id_changed?) &&
-         WorkPackage.relatable(model.from, model.relation_type, ignore_relation: model).where(id: model.to).empty?
+         WorkPackage.relatable(model.from, model.relation_type, ignored_relation: model).where(id: model.to).empty?
         errors.add :base, I18n.t(:'activerecord.errors.messages.circular_dependency')
       end
     end

--- a/app/contracts/relations/update_contract.rb
+++ b/app/contracts/relations/update_contract.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'relations/base_contract'
-
 module Relations
   class UpdateContract < BaseContract
     validate :from_immutable

--- a/app/models/work_packages/scopes/directly_related.rb
+++ b/app/models/work_packages/scopes/directly_related.rb
@@ -31,9 +31,11 @@ module WorkPackages::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      def directly_related(work_package)
-        where(id: Relation.where(from_id: work_package).select(:to_id))
-          .or(where(id: Relation.where(to_id: work_package).select(:from_id)))
+      def directly_related(work_package, ignore_relation: nil)
+        relations_without_ignored = ignore_relation ? Relation.where.not(id: ignore_relation.id) : Relation.all
+
+        where(id: relations_without_ignored.where(from_id: work_package).select(:to_id))
+        .or(where(id: relations_without_ignored.where(to_id: work_package).select(:from_id)))
       end
     end
   end

--- a/app/models/work_packages/scopes/directly_related.rb
+++ b/app/models/work_packages/scopes/directly_related.rb
@@ -31,8 +31,8 @@ module WorkPackages::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      def directly_related(work_package, ignore_relation: nil)
-        relations_without_ignored = ignore_relation ? Relation.where.not(id: ignore_relation.id) : Relation.all
+      def directly_related(work_package, ignored_relation: nil)
+        relations_without_ignored = ignored_relation ? Relation.where.not(id: ignored_relation.id) : Relation.all
 
         where(id: relations_without_ignored.where(from_id: work_package).select(:to_id))
         .or(where(id: relations_without_ignored.where(to_id: work_package).select(:from_id)))

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -168,7 +168,14 @@ module WorkPackages::Scopes
       # * includes_hierarchy - boolean indicating that the last relation taken was a hierarchy relation. For a queried for
       #                        PARENT relation, whenever that is the case, the work package is a valid relation target although
       #                        it appears in the CTE.
-      def relatable(work_package, relation_type)
+      #
+      # The caller can can also provide a relation that is ignored for the calculation of which
+      # work packages are relatable. This can be helpful in case an existing relation is updated
+      # especially if the the direction is switched. Only a single relation can be provided and
+      # that one has to either be from or to the work package queried for.
+      def relatable(work_package, relation_type, ignore_relation: nil)
+        relatable_ensure_single_relation(ignore_relation, work_package)
+
         return all if work_package.new_record?
 
         scope = case relation_type
@@ -177,11 +184,11 @@ module WorkPackages::Scopes
                 when Relation::TYPE_CHILD
                   not_having_potential_tree_relation_child(work_package)
                 else
-                  where.not(id: directly_related(work_package))
+                  where.not(id: directly_related(work_package, ignore_relation:))
                 end
 
         scope = scope
-                  .not_having_transitive_relation(work_package, relation_type)
+                  .not_having_transitive_relation(work_package, relation_type, ignore_relation:)
                   .where.not(id: work_package.id)
 
         if Setting.cross_project_work_package_relations
@@ -191,7 +198,7 @@ module WorkPackages::Scopes
         end
       end
 
-      def not_having_transitive_relation(work_package, relation_type)
+      def not_having_transitive_relation(work_package, relation_type, ignore_relation:)
         if relation_type == Relation::TYPE_RELATES
           # Bypassing the recursive query in this case as only children and parent needs to be excluded.
           # Using this more complicated statement since
@@ -204,7 +211,7 @@ module WorkPackages::Scopes
           sql = <<~SQL.squish
             WITH
               RECURSIVE
-              #{non_relatable_paths_sql(work_package, relation_type)}
+              #{non_relatable_paths_sql(work_package, relation_type, ignore_relation:)}
 
               SELECT id
               FROM related
@@ -243,7 +250,7 @@ module WorkPackages::Scopes
           .where.not(id: where(parent_id: work_package.id).select(:id))
       end
 
-      def non_relatable_paths_sql(work_package, relation_type)
+      def non_relatable_paths_sql(work_package, relation_type, ignore_relation: nil)
         <<~SQL.squish
           related (id,
                    from_hierarchy,
@@ -268,7 +275,7 @@ module WorkPackages::Scopes
               FROM
                 related
               JOIN LATERAL (
-                #{joined_existing_connections(relation_type)}
+                #{joined_existing_connections(relation_type, ignore_relation:)}
               ) relations ON 1 = 1
           )
         SQL
@@ -308,7 +315,7 @@ module WorkPackages::Scopes
                     id: work_package.id
       end
 
-      def joined_existing_connections(relation_type)
+      def joined_existing_connections(relation_type, ignore_relation:)
         unions = [existing_hierarchy_lateral(with_descendants: relation_type != Relation::TYPE_CHILD)]
 
         case relation_type
@@ -316,14 +323,14 @@ module WorkPackages::Scopes
           unions << existing_relation_of_type_lateral(Relation::TYPE_FOLLOWS, limit_direction: true)
           unions << existing_relation_of_type_lateral(Relation::TYPE_PRECEDES, limit_direction: true)
         else
-          unions << existing_relation_of_type_lateral(relation_type)
+          unions << existing_relation_of_type_lateral(relation_type, ignore_relation:)
         end
 
         unions.join(' UNION ')
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def existing_relation_of_type_lateral(relation_type, limit_direction: false)
+      def existing_relation_of_type_lateral(relation_type, ignore_relation: nil, limit_direction: false)
         canonical_type = Relation.canonical_type(relation_type)
 
         is_canonical = canonical_type == relation_type
@@ -356,6 +363,7 @@ module WorkPackages::Scopes
           WHERE (relations.#{direction2} = related.id AND relations.relation_type = :relation_type)
             AND NOT related.from_#{direction2}
             #{direction_limit ? "AND NOT #{direction_limit}" : ''}
+            #{ignore_relation&.id ? " AND NOT relations.id = #{ignore_relation.id}" : ''}
         SQL
 
         ::OpenProject::SqlSanitization
@@ -406,6 +414,14 @@ module WorkPackages::Scopes
         WorkPackageHierarchy
           .where(descendant_id: work_packages)
           .select(:ancestor_id)
+      end
+
+      def relatable_ensure_single_relation(ignored_relation, work_package)
+        if ignored_relation && (!ignored_relation.is_a?(Relation) ||
+          (ignored_relation.from_id != work_package.id && ignored_relation.to_id != work_package.id))
+          raise ArgumentError, 'only a single relation with from_id or to_id pointing ' \
+                               'to the work package for which relatable is queried for is supported'
+        end
       end
     end
   end

--- a/spec/contracts/relations/create_contract_spec.rb
+++ b/spec/contracts/relations/create_contract_spec.rb
@@ -27,51 +27,17 @@
 #++
 
 require 'spec_helper'
+require_relative 'shared_contract_examples'
 
 RSpec.describe Relations::CreateContract do
-  let(:from) { build_stubbed(:work_package) }
-  let(:to) { build_stubbed(:work_package) }
-  let(:user) { build_stubbed(:admin) }
-
-  let(:relation) do
-    Relation.new from:, to:, relation_type: "follows", delay: 42
-  end
-
-  subject(:contract) { described_class.new relation, user }
-
-  before do
-    allow(WorkPackage)
-      .to receive_message_chain(:visible, :exists?)
-      .and_return(true)
-  end
-
-  describe 'to' do
-    context 'not visible' do
-      before do
-        allow(WorkPackage)
-          .to receive_message_chain(:visible, :exists?)
-          .with(to.id)
-          .and_return(false)
-      end
-
-      it 'is invalid' do
-        expect(subject).not_to be_valid
-      end
+  it_behaves_like 'relation contract' do
+    let(:relation) do
+      Relation.new from: relation_from,
+                   to: relation_to,
+                   relation_type:,
+                   delay: relation_delay
     end
-  end
 
-  describe 'from' do
-    context 'not visible' do
-      before do
-        allow(WorkPackage)
-          .to receive_message_chain(:visible, :exists?)
-          .with(from.id)
-          .and_return(false)
-      end
-
-      it 'is invalid' do
-        expect(subject).not_to be_valid
-      end
-    end
+    subject(:contract) { described_class.new relation, current_user }
   end
 end

--- a/spec/contracts/relations/create_contract_spec.rb
+++ b/spec/contracts/relations/create_contract_spec.rb
@@ -37,7 +37,5 @@ RSpec.describe Relations::CreateContract do
                    relation_type:,
                    delay: relation_delay
     end
-
-    subject(:contract) { described_class.new relation, current_user }
   end
 end

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -70,7 +70,7 @@ RSpec.shared_examples_for 'relation contract' do
 
     allow(scope)
       .to receive(:where)
-            .with(id: canonical_relation_to)
+            .with(id: canonical_relation_to.id)
             .and_return(scope)
 
     allow(scope)

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -1,0 +1,144 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'contracts/shared/model_contract_shared_context'
+
+RSpec.shared_examples_for 'relation contract' do
+  include_context 'ModelContract shared context'
+
+  let(:current_user) { build_stubbed(:user) }
+  let(:relation_from) do
+    build_stubbed(:work_package, subject: 'From WP') do |wp|
+      allow(wp_visible_scope)
+        .to receive(:exists?)
+              .with(wp.id)
+              .and_return(relation_from_visible)
+    end
+  end
+  let(:relation_to) do
+    build_stubbed(:work_package, subject: 'To WP') do |wp|
+      allow(wp_visible_scope)
+        .to receive(:exists?)
+              .with(wp.id)
+              .and_return(relation_to_visible)
+    end
+  end
+  let(:relation_type) do
+    Relation::TYPE_RELATES
+  end
+  let(:relation_delay) { 42 }
+  let!(:wp_visible_scope) do
+    instance_double(ActiveRecord::Relation).tap do |relation|
+      allow(WorkPackage)
+        .to receive(:visible)
+              .with(current_user)
+              .and_return(relation)
+    end
+  end
+  let!(:relatable_scope) do
+    scope = instance_double(ActiveRecord::Relation)
+
+    allow(WorkPackage)
+      .to receive(:relatable)
+            .with(canonical_relation_from, canonical_relation_type, ignored_relation: relation)
+            .and_return(scope)
+
+    allow(scope)
+      .to receive(:where)
+            .with(id: canonical_relation_to)
+            .and_return(scope)
+
+    allow(scope)
+      .to receive(:empty?)
+            .and_return(!relatable)
+
+    scope
+  end
+
+  # The relation might get reversed by the code under test
+  let(:canonical_relation_from) { Relation::TYPES.dig(relation_type, :reverse).present? ? relation_to : relation_from }
+  let(:canonical_relation_to) { Relation::TYPES.dig(relation_type, :reverse).present? ? relation_from : relation_to }
+  let(:canonical_relation_type) do
+    Relation::TYPES.dig(relation_type, :reverse).present? ? Relation::TYPES[relation_type][:reverse] : relation_type
+  end
+
+  let(:relation_from_visible) { true }
+  let(:relation_to_visible) { true }
+  let(:relatable) { true }
+  let(:permissions) { [:manage_work_package_relations] }
+
+  before do
+    mock_permissions_for(current_user) do |mock|
+      mock.allow_in_project *permissions, project: canonical_relation_from.project
+    end
+  end
+
+  describe 'validation' do
+    it_behaves_like 'contract is valid'
+
+    context 'when lacking the necessary permission' do
+      let(:permissions) { [] }
+
+      it_behaves_like 'contract is invalid', base: :error_unauthorized
+    end
+
+    context 'when the work package for from is not visible' do
+      let(:relation_from_visible) { false }
+
+      it_behaves_like 'contract is invalid', from: :error_not_found
+    end
+
+    context 'when the work package for to is not visible' do
+      let(:relation_to_visible) { false }
+
+      it_behaves_like 'contract is invalid', to: :error_not_found
+    end
+
+    Relation::TYPES.keys.select { Relation::TYPES[_1][:reverse].nil? }.each do |available_type|
+      context "when having the type '#{available_type}'" do
+        let(:relation_type) { available_type }
+
+        it_behaves_like 'contract is valid'
+      end
+    end
+
+    Relation::TYPES.keys.select { Relation::TYPES[_1][:reverse].present? }.each do |available_type|
+      context "when having the type '#{available_type}'" do
+        let(:relation_type) { available_type }
+
+        it_behaves_like 'contract is valid'
+      end
+    end
+
+    context 'when the work package type is unknown' do
+      let(:relation_type) { 'some_bogus' }
+
+      it_behaves_like 'contract is invalid', relation_type: :inclusion
+    end
+  end
+end

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -92,6 +92,8 @@ RSpec.shared_examples_for 'relation contract' do
   let(:relatable) { true }
   let(:permissions) { [:manage_work_package_relations] }
 
+  subject(:contract) { described_class.new relation, current_user }
+
   before do
     mock_permissions_for(current_user) do |mock|
       mock.allow_in_project *permissions, project: canonical_relation_from.project
@@ -119,15 +121,7 @@ RSpec.shared_examples_for 'relation contract' do
       it_behaves_like 'contract is invalid', to: :error_not_found
     end
 
-    Relation::TYPES.keys.select { Relation::TYPES[_1][:reverse].nil? }.each do |available_type|
-      context "when having the type '#{available_type}'" do
-        let(:relation_type) { available_type }
-
-        it_behaves_like 'contract is valid'
-      end
-    end
-
-    Relation::TYPES.keys.select { Relation::TYPES[_1][:reverse].present? }.each do |available_type|
+    Relation::TYPES.each_key do |available_type|
       context "when having the type '#{available_type}'" do
         let(:relation_type) { available_type }
 

--- a/spec/contracts/relations/update_contract_spec.rb
+++ b/spec/contracts/relations/update_contract_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe Relations::UpdateContract do
                     relation_type:,
                     delay: relation_delay)
     end
-
-    let(:contract) { described_class.new(relation, current_user) }
   end
 
   describe 'valid?' do

--- a/spec/contracts/relations/update_contract_spec.rb
+++ b/spec/contracts/relations/update_contract_spec.rb
@@ -1,0 +1,98 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+require_relative 'shared_contract_examples'
+
+RSpec.describe Relations::UpdateContract do
+  it_behaves_like 'relation contract' do
+    let(:relation) do
+      build_stubbed(:relation,
+                    from: relation_from,
+                    to: relation_to,
+                    relation_type:,
+                    delay: relation_delay)
+    end
+
+    let(:contract) { described_class.new(relation, current_user) }
+  end
+
+  describe 'valid?' do
+    create_shared_association_defaults_for_work_package_factory
+    let(:current_user) { build_stubbed(:admin) }
+    let(:contract) { described_class.new(relation, current_user) }
+
+    context 'when an isolated relation is reversed' do
+      let(:relation) do
+        create(:relation, relation_type: Relation::TYPE_BLOCKS)
+      end
+
+      before do
+        relation.relation_type = Relation::TYPE_BLOCKED
+      end
+
+      it 'is valid' do
+        expect(contract).to be_valid
+      end
+    end
+
+    context 'when a relation that cannot be reversed is reversed' do
+      let(:relation_from_wp) { create(:work_package) }
+      let(:relation_to_wp) { create(:work_package) }
+      let(:intermediary_wp) { create(:work_package) }
+
+      let!(:to_intermediary_wp) do
+        create(:relation,
+               from: relation_from_wp,
+               to: intermediary_wp,
+               relation_type: Relation::TYPE_FOLLOWS)
+      end
+      let!(:from_intermediary_wp) do
+        create(:relation,
+               from: intermediary_wp,
+               to: relation_to_wp,
+               relation_type: Relation::TYPE_FOLLOWS)
+      end
+
+      let(:relation) do
+        create(:relation,
+               from: relation_from_wp,
+               to: relation_to_wp,
+               relation_type: Relation::TYPE_FOLLOWS)
+      end
+
+      before do
+        relation.relation_type = Relation::TYPE_PRECEDES
+      end
+
+      it 'is invalid' do
+        expect(contract).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/work_packages/scopes/directly_related_spec.rb
+++ b/spec/models/work_packages/scopes/directly_related_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' 
 
   let!(:existing_relations) { [relation_to, transitive_relation_to, relation_from, transitive_relation_from] }
 
-  subject(:directly_related) { WorkPackage.directly_related(origin, ignore_relation: ignored_relations) }
+  subject(:directly_related) { WorkPackage.directly_related(origin, ignored_relation: ignored_relations) }
 
   it 'is an AR scope' do
     expect(directly_related)

--- a/spec/models/work_packages/scopes/directly_related_spec.rb
+++ b/spec/models/work_packages/scopes/directly_related_spec.rb
@@ -62,10 +62,11 @@ RSpec.describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' 
            to: related_work_package_to,
            from: transitively_related_work_package_to)
   end
+  let(:ignored_relations) { nil }
 
   let!(:existing_relations) { [relation_to, transitive_relation_to, relation_from, transitive_relation_from] }
 
-  subject(:directly_related) { WorkPackage.directly_related(origin) }
+  subject(:directly_related) { WorkPackage.directly_related(origin, ignore_relation: ignored_relations) }
 
   it 'is an AR scope' do
     expect(directly_related)
@@ -78,7 +79,16 @@ RSpec.describe WorkPackages::Scopes::DirectlyRelated, '.directly_related scope' 
     context "with existing relations of type '#{current_type}'" do
       it 'contains the directly related work packages in both directions' do
         expect(directly_related)
-          .to match_array([related_work_package_to, related_work_package_from])
+          .to contain_exactly(related_work_package_to, related_work_package_from)
+      end
+    end
+
+    context "with existing relations of type '#{current_type}' and ignoring one relation" do
+      let(:ignored_relations) { relation_to }
+
+      it 'contains the directly related work packages for which the relation isn`t ignored' do
+        expect(directly_related)
+          .to contain_exactly(related_work_package_from)
       end
     end
   end

--- a/spec/models/work_packages/scopes/for_scheduling_spec.rb
+++ b/spec/models/work_packages/scopes/for_scheduling_spec.rb
@@ -29,6 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
+  create_shared_association_defaults_for_work_package_factory
+
   let(:project) { create(:project) }
   let(:origin) { create(:work_package, project:) }
   let(:predecessor) do

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   let(:existing_work_packages) { [] }
 
   let(:relation_type) { Relation::TYPE_FOLLOWS }
+  let(:ignored_relation) { nil }
 
-  subject(:relatable) { WorkPackage.relatable(origin, relation_type) }
+  subject(:relatable) { WorkPackage.relatable(origin, relation_type, ignore_relation: ignored_relation) }
 
   it 'is an AR scope' do
     expect(relatable)
@@ -87,7 +88,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
     it 'contains every other work package' do
       expect(relatable)
-        .to match_array([unrelated_work_package])
+        .to contain_exactly(unrelated_work_package)
     end
   end
 
@@ -100,7 +101,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the unrelated_work_package' do
           expect(relatable)
-            .to match_array([unrelated_work_package])
+            .to contain_exactly(unrelated_work_package)
         end
       end
 
@@ -122,7 +123,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the unrelated_work_package' do
           expect(relatable)
-            .to match_array([unrelated_work_package])
+            .to contain_exactly(unrelated_work_package)
         end
       end
     end
@@ -150,6 +151,16 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
             .to be_empty
         end
       end
+
+      context "with the existing relation and the queried being '#{current_type}' typed but explicitly ignoring the existing" do
+        let(:relation_type) { current_type }
+        let(:ignored_relation) { directly_related_work_package.relations.first }
+
+        it 'is empty' do
+          expect(relatable)
+            .to contain_exactly directly_related_work_package
+        end
+      end
     end
   end
 
@@ -162,7 +173,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
         it 'contains the sibling' do
           expect(relatable)
-            .to match_array([sibling])
+            .to contain_exactly(sibling)
         end
       end
     end
@@ -174,7 +185,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     context "for a 'follows' relation and the existing relations being in the same direction" do
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -210,7 +221,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'includes the not directly related work package' do
         expect(relatable)
-          .to match_array [origin]
+          .to contain_exactly(origin)
       end
     end
 
@@ -268,7 +279,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       # semantic in the system, the relationship is not prohibited.
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -279,7 +290,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
       end
     end
 
@@ -293,7 +304,30 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       # semantic in the system, the relationship is not prohibited.
       it 'contains the transitively related work package' do
         expect(relatable)
-          .to match_array([transitively_related_work_package])
+          .to contain_exactly(transitively_related_work_package)
+      end
+    end
+
+    context "for a 'blocks' relation and the existing relations being 'blocks' when ignoring origin`s relation" do
+      let(:relation_type) { Relation::TYPE_BLOCKS }
+      let(:directly_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:transitively_related_work_package_type) { Relation::TYPE_BLOCKS }
+      let(:ignored_relation) { origin.relations.first }
+
+      it 'contains the the related work packages' do
+        expect(relatable)
+          .to contain_exactly(directly_related_work_package, transitively_related_work_package)
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being of opposite direction but ignoring origin`s relation" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:ignored_relation) { origin.relations.first }
+
+      it 'contains the the related work packages' do
+        expect(relatable)
+          .to contain_exactly(directly_related_work_package, transitively_related_work_package)
       end
     end
   end
@@ -341,7 +375,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the work packages in the other hierarchy' do
         expect(relatable)
-          .to match_array [other_parent, other_child]
+          .to contain_exactly(other_parent, other_child)
       end
     end
 
@@ -352,7 +386,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains the work packages in the other hierarchy' do
         expect(relatable)
-          .to match_array [other_parent, other_child]
+          .to contain_exactly(other_parent, other_child)
       end
     end
 
@@ -375,7 +409,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent and aunt' do
         expect(relatable)
-          .to match_array [grandparent, aunt]
+          .to contain_exactly(grandparent, aunt)
       end
     end
 
@@ -384,7 +418,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -393,7 +427,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -402,7 +436,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -415,7 +449,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent' do
         expect(relatable)
-          .to match_array [grandparent]
+          .to contain_exactly(grandparent)
       end
     end
 
@@ -428,7 +462,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt' do
         expect(relatable)
-          .to match_array [aunt]
+          .to contain_exactly(aunt)
       end
     end
 
@@ -441,7 +475,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt, grandparent]
+          .to contain_exactly(aunt, grandparent)
       end
     end
 
@@ -450,7 +484,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains aunt and grandparent' do
         expect(relatable)
-          .to match_array [aunt, grandparent]
+          .to contain_exactly(aunt, grandparent)
       end
     end
   end
@@ -469,7 +503,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandparent and grand_grandparent' do
         expect(relatable)
-          .to match_array [grandparent, grand_grandparent]
+          .to contain_exactly(grandparent, grand_grandparent)
       end
     end
 
@@ -525,7 +559,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it 'contains grandchild and grand_grandchild' do
         expect(relatable)
-          .to match_array [grandchild, grand_grandchild]
+          .to contain_exactly(grandchild, grand_grandchild)
       end
     end
 
@@ -564,7 +598,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent]
+          .to contain_exactly(predecessor_parent)
       end
     end
 
@@ -631,7 +665,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent]
+          .to contain_exactly(predecessor_parent)
       end
     end
 
@@ -649,7 +683,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -667,7 +701,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -676,7 +710,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
 
@@ -685,7 +719,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_predecessor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_predecessor)
       end
     end
   end
@@ -711,7 +745,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and its successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -720,7 +754,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor of the predecessor's parent" do
         expect(relatable)
-          .to match_array [predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent_successor)
       end
     end
 
@@ -729,7 +763,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -738,7 +772,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent_successor)
       end
     end
 
@@ -747,7 +781,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -756,7 +790,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
 
@@ -765,7 +799,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [predecessor_parent, predecessor_parent_successor]
+          .to contain_exactly(predecessor_parent, predecessor_parent_successor)
       end
     end
   end
@@ -791,7 +825,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent" do
         expect(relatable)
-          .to match_array [successor_parent]
+          .to contain_exactly(successor_parent)
       end
     end
 
@@ -818,7 +852,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -827,7 +861,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -836,7 +870,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
 
@@ -845,7 +879,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's successor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_successor]
+          .to contain_exactly(successor_parent, successor_parent_successor)
       end
     end
   end
@@ -871,7 +905,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and its predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -880,7 +914,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor of the successor's parent" do
         expect(relatable)
-          .to match_array [successor_parent_predecessor]
+          .to contain_exactly(successor_parent_predecessor)
       end
     end
 
@@ -889,7 +923,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent_predecessor]
+          .to contain_exactly(successor_parent_predecessor)
       end
     end
 
@@ -898,7 +932,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "is contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -907,7 +941,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -916,7 +950,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
 
@@ -925,7 +959,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the successor's parent and that parent's predecessor" do
         expect(relatable)
-          .to match_array [successor_parent, successor_parent_predecessor]
+          .to contain_exactly(successor_parent, successor_parent_predecessor)
       end
     end
   end
@@ -943,7 +977,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -961,7 +995,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -979,7 +1013,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
 
@@ -988,7 +1022,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's predecessor" do
         expect(relatable)
-          .to match_array [parent_predecessor]
+          .to contain_exactly(parent_predecessor)
       end
     end
   end
@@ -1006,7 +1040,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1033,7 +1067,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1042,7 +1076,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
 
@@ -1051,7 +1085,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent's successor" do
         expect(relatable)
-          .to match_array [parent_successor]
+          .to contain_exactly(parent_successor)
       end
     end
   end
@@ -1075,7 +1109,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's successor and the grandparent" do
         expect(relatable)
-          .to match_array [child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1084,7 +1118,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and that's ancestors" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1093,7 +1127,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and the parent of that" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
 
@@ -1111,7 +1145,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's successor and the parent of that" do
         expect(relatable)
-          .to match_array [child_successor, child_successor_parent, child_successor_grandparent]
+          .to contain_exactly(child_successor, child_successor_parent, child_successor_grandparent)
       end
     end
   end
@@ -1135,7 +1169,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's predecessor" do
         expect(relatable)
-          .to match_array [child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1144,7 +1178,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and that's ancestors" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1162,7 +1196,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and the parent of that" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
 
@@ -1171,7 +1205,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's predecessor and the parent of that" do
         expect(relatable)
-          .to match_array [child_predecessor, child_predecessor_parent, child_predecessor_grandparent]
+          .to contain_exactly(child_predecessor, child_predecessor_parent, child_predecessor_grandparent)
       end
     end
   end
@@ -1195,7 +1229,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent of the child's blocked work package" do
         expect(relatable)
-          .to match_array [child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1204,7 +1238,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the work package blocked by the child and that's ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1213,7 +1247,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1222,7 +1256,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1231,7 +1265,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1240,7 +1274,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child's blocked work package and its ancestors" do
         expect(relatable)
-          .to match_array [child_blocked, child_blocked_parent, child_blocked_grandparent]
+          .to contain_exactly(child_blocked, child_blocked_parent, child_blocked_grandparent)
       end
     end
 
@@ -1279,7 +1313,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1297,7 +1331,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1306,7 +1340,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1315,7 +1349,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
 
@@ -1324,7 +1358,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the predecessor's child" do
         expect(relatable)
-          .to match_array [predecessor_child]
+          .to contain_exactly(predecessor_child)
       end
     end
   end
@@ -1348,7 +1382,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent and the child" do
         expect(relatable)
-          .to match_array [blocks_parent, blocks_child]
+          .to contain_exactly(blocks_parent, blocks_child)
       end
     end
 
@@ -1366,7 +1400,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent" do
         expect(relatable)
-          .to match_array [blocks_parent]
+          .to contain_exactly(blocks_parent)
       end
     end
 
@@ -1375,7 +1409,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child" do
         expect(relatable)
-          .to match_array [blocks_child]
+          .to contain_exactly(blocks_child)
       end
     end
   end
@@ -1408,7 +1442,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent and the child" do
         expect(relatable)
-          .to match_array [blocked_parent, blocked_child]
+          .to contain_exactly(blocked_parent, blocked_child)
       end
     end
 
@@ -1417,7 +1451,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent" do
         expect(relatable)
-          .to match_array [blocked_parent]
+          .to contain_exactly(blocked_parent)
       end
     end
 
@@ -1426,7 +1460,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child" do
         expect(relatable)
-          .to match_array [blocked_child]
+          .to contain_exactly(blocked_child)
       end
     end
   end
@@ -1466,7 +1500,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_predecessor_parent]
+          .to contain_exactly(transitive_predecessor_parent)
       end
     end
 
@@ -1475,7 +1509,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_predecessor_child]
+          .to contain_exactly(transitive_predecessor_child)
       end
     end
   end
@@ -1506,7 +1540,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the parent at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_successor_parent]
+          .to contain_exactly(transitive_successor_parent)
       end
     end
 
@@ -1515,8 +1549,65 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
 
       it "contains the child at the beginning of the chain" do
         expect(relatable)
-          .to match_array [transitive_successor_child]
+          .to contain_exactly(transitive_successor_child)
       end
+    end
+  end
+
+  context 'with a transitively related work package that is also directly related' do
+    let!(:existing_work_packages) { [directly_related_work_package, transitively_related_work_package] }
+    let!(:additional_direct_relation) do
+      create(:relation,
+             relation_type: transitively_related_work_package_type,
+             from: origin,
+             to: transitively_related_work_package)
+    end
+
+    context "for a 'follows' relation and the existing relations being in the same direction" do
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being in the opposite direction" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+
+    context "for a 'follows' relation and the existing relations being of opposite direction and ignoring the direct relation" do
+      let(:directly_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
+      let(:ignored_relation) { additional_direct_relation }
+
+      it 'is empty' do
+        expect(relatable)
+          .to be_empty
+      end
+    end
+  end
+
+  context 'when ignoring anything else then a single relation' do
+    let(:ignored_relation) { transitively_related_work_package.relations }
+
+    it 'raises an error' do
+      expect { relatable }
+        .to raise_error ArgumentError
+    end
+  end
+
+  context 'when ignoring with a relation neither starting nor ending in the work package queried for' do
+    let!(:existing_work_packages) { [directly_related_work_package, transitively_related_work_package] }
+    let(:ignored_relation) { transitively_related_work_package.relations.first }
+
+    it 'raises an error' do
+      expect { relatable }
+        .to raise_error ArgumentError
     end
   end
 end

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
   let(:relation_type) { Relation::TYPE_FOLLOWS }
   let(:ignored_relation) { nil }
 
-  subject(:relatable) { WorkPackage.relatable(origin, relation_type, ignore_relation: ignored_relation) }
+  subject(:relatable) { WorkPackage.relatable(origin, relation_type, ignored_relation:) }
 
   it 'is an AR scope' do
     expect(relatable)

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
         let(:relation_type) { current_type }
         let(:ignored_relation) { directly_related_work_package.relations.first }
 
-        it 'is empty' do
+        it 'contains the directly related work package' do
           expect(relatable)
             .to contain_exactly directly_related_work_package
         end
@@ -314,7 +314,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       let(:transitively_related_work_package_type) { Relation::TYPE_BLOCKS }
       let(:ignored_relation) { origin.relations.first }
 
-      it 'contains the the related work packages' do
+      it 'contains the related work packages' do
         expect(relatable)
           .to contain_exactly(directly_related_work_package, transitively_related_work_package)
       end
@@ -325,7 +325,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
       let(:transitively_related_work_package_type) { Relation::TYPE_PRECEDES }
       let(:ignored_relation) { origin.relations.first }
 
-      it 'contains the the related work packages' do
+      it 'contains the related work packages' do
         expect(relatable)
           .to contain_exactly(directly_related_work_package, transitively_related_work_package)
       end
@@ -1592,7 +1592,7 @@ RSpec.describe WorkPackages::Scopes::Relatable, '.relatable scope' do
     end
   end
 
-  context 'when ignoring anything else then a single relation' do
+  context 'when ignoring anything else than a single relation' do
     let(:ignored_relation) { transitively_related_work_package.relations }
 
     it 'raises an error' do


### PR DESCRIPTION
Reactivates inverting the relation if necessary before the validation takes place. This got broken by renaming the `BaseContract`'s super method. 

But this then leads to the problem that a relation can no longer be changing its direction, e.g. by turning a 'blocks' relation into a 'blocked by' relation, since the `WorkPackage.relatable` scope, when determining the work packages with which an origin work package is related, would include the relation to be reversed. To circumvent this, the modified relation needs to be excluded from the calculation as if it did not exist.  