### PR TITLE
Reshape the error handling of the Nextcloud's GroupSyncService

### DIFF
--- a/modules/storages/app/common/storages/peripherals/service_result_refinements.rb
+++ b/modules/storages/app/common/storages/peripherals/service_result_refinements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -67,6 +69,20 @@ module Storages::Peripherals
       def error_payload
         errors.data&.payload
       end
+
+      def result_or
+        return result if success?
+
+        yield errors
+      end
+      alias_method :error_and, :result_or
+
+      def result_and
+        return errors if failure?
+
+        yield result
+      end
+      alias_method :error_or, :result_and
     end
   end
 end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/add_user_to_group_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/add_user_to_group_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -58,26 +60,26 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
         when "100"
           ServiceResult.success(message: "User has been added successfully")
         when "101"
-          Util.error(:error, "No group specified")
+          Util.error(:error, "No group specified", response)
         when "102"
-          Util.error(:error, "Group does not exist")
+          Util.error(:error, "Group does not exist", response)
         when "103"
-          Util.error(:error, "User does not exist")
+          Util.error(:error, "User does not exist", response)
         when "104"
-          Util.error(:error, "Insufficient privileges")
+          Util.error(:error, "Insufficient privileges", response)
         when "105"
-          Util.error(:error, "Failed to add user to group")
+          Util.error(:error, "Failed to add user to group", response)
         end
       when Net::HTTPMethodNotAllowed
-        Util.error(:not_allowed)
-      when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
+        Util.error(:not_allowed, 'Outbound request method not allowed', response)
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found', response)
+      when Net::HTTPUnauthorized
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       when Net::HTTPConflict
-        Util.error(:conflict)
+        Util.error(:conflict, Util.error_text_from_response(response), response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
@@ -60,9 +60,9 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
           Util.error(:not_allowed, 'Outbound request method not allowed', response)
         end
       when Net::HTTPNotFound
-        Util.error(:not_found, 'Outbound request destination not found!', response)
+        Util.error(:not_found, 'Outbound request destination not found', response)
       when Net::HTTPUnauthorized
-        Util.error(:unauthorized, 'Outbound request not authorized!', response)
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       when Net::HTTPConflict
         Util.error(:conflict, Util.error_text_from_response(response), response)
       else

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
@@ -57,16 +57,16 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
         if Util.error_text_from_response(response) == 'The resource you tried to create already exists'
           ServiceResult.success(message: 'Folder already exists.')
         else
-          Util.error(:not_allowed)
+          Util.error(:not_allowed, 'Outbound request method not allowed', response)
         end
       when Net::HTTPNotFound
         Util.error(:not_found, 'Outbound request destination not found!', response)
       when Net::HTTPUnauthorized
         Util.error(:unauthorized, 'Outbound request not authorized!', response)
       when Net::HTTPConflict
-        Util.error(:conflict, Util.error_text_from_response(response))
+        Util.error(:conflict, Util.error_text_from_response(response), response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -57,10 +59,10 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
         else
           Util.error(:not_allowed)
         end
-      when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found!', response)
+      when Net::HTTPUnauthorized
+        Util.error(:unauthorized, 'Outbound request not authorized!', response)
       when Net::HTTPConflict
         Util.error(:conflict, Util.error_text_from_response(response))
       else

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_info_query.rb
@@ -78,7 +78,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
       when Net::HTTPUnauthorized
         Util.error(:unauthorized, 'Outbound request not authorized!', response)
       else
-        Util.error(:error, 'Outbound request failed!')
+        Util.error(:error, 'Outbound request failed!', response)
       end
     end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/group_users_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/group_users_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -53,15 +55,15 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
                         .map(&:text)
         ServiceResult.success(result: group_users)
       when Net::HTTPMethodNotAllowed
-        Util.error(:not_allowed)
-      when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
+        Util.error(:not_allowed, 'Outbound request method not allowed', response)
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found', response)
+      when Net::HTTPUnauthorized
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       when Net::HTTPConflict
-        Util.error(:conflict, error_text_from_response(response))
+        Util.error(:conflict, Util.error_text_from_response(response), response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
@@ -120,13 +120,13 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Internal
 
         ServiceResult.success(result:)
       when Net::HTTPMethodNotAllowed
-        UTIL.error(:not_allowed)
-      when Net::HTTPUnauthorized
-        UTIL.error(:unauthorized)
+        UTIL.error(:not_allowed, 'Outbound request method not allowed', response)
       when Net::HTTPNotFound
         UTIL.error(:not_found, 'Outbound request destination not found', response)
+      when Net::HTTPUnauthorized
+        UTIL.error(:unauthorized, 'Outbound request not authorized', response)
       else
-        UTIL.error(:error, '', response)
+        UTIL.error(:error, 'Outbound request failed', response)
       end
     end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
@@ -124,9 +124,9 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Internal
       when Net::HTTPUnauthorized
         UTIL.error(:unauthorized)
       when Net::HTTPNotFound
-        UTIL.error(:not_found)
+        UTIL.error(:not_found, 'Outbound request destination not found', response)
       else
-        UTIL.error(:error)
+        UTIL.error(:error, '', response)
       end
     end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/remove_user_from_group_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/remove_user_from_group_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -58,27 +60,27 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
         when "100"
           ServiceResult.success(message: "User has been removed from group")
         when "101"
-          Util.error(:error, "No group specified")
+          Util.error(:error, "No group specified", response)
         when "102"
-          Util.error(:error, "Group does not exist")
+          Util.error(:error, "Group does not exist", response)
         when "103"
-          Util.error(:error, "User does not exist")
+          Util.error(:error, "User does not exist", response)
         when "104"
-          Util.error(:error, "Insufficient privileges")
+          Util.error(:error, "Insufficient privileges", response)
         when "105"
           message = Nokogiri::XML(response.body).xpath('/ocs/meta/message').text
-          Util.error(:error, "Failed to remove user #{user} from group #{group}: #{message}")
+          Util.error(:error, "Failed to remove user #{user} from group #{group}: #{message}", response)
         end
       when Net::HTTPMethodNotAllowed
-        Util.error(:not_allowed)
-      when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
+        Util.error(:not_allowed, 'Outbound request method not allowed', response)
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found', response)
+      when Net::HTTPUnauthorized
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       when Net::HTTPConflict
-        Util.error(:conflict)
+        Util.error(:conflict, Util.error_text_from_response(response), response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/rename_file_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/rename_file_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -53,11 +55,11 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
       when Net::HTTPSuccess
         ServiceResult.success
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found', response)
       when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2023 the OpenProject GmbH
@@ -90,16 +92,16 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
       when Net::HTTPSuccess
         doc = Nokogiri::XML(response.body)
         if doc.xpath("/d:multistatus/d:response/d:propstat[d:status[text() = 'HTTP/1.1 200 OK']]/d:prop/nc:acl-list").present?
-          ServiceResult.success
+          ServiceResult.success(result: :success)
         else
           Util.error(:error, "nc:acl properly has not been set for #{path}")
         end
       when Net::HTTPNotFound
-        Util.error(:not_found)
+        Util.error(:not_found, 'Outbound request destination not found!', response)
       when Net::HTTPUnauthorized
-        Util.error(:unauthorized)
+        Util.error(:unauthorized, 'Outbound request not authorized!', response)
       else
-        Util.error(:error)
+        Util.error(:error, 'Outbound request failed!', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command.rb
@@ -97,11 +97,11 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
           Util.error(:error, "nc:acl properly has not been set for #{path}")
         end
       when Net::HTTPNotFound
-        Util.error(:not_found, 'Outbound request destination not found!', response)
+        Util.error(:not_found, 'Outbound request destination not found', response)
       when Net::HTTPUnauthorized
-        Util.error(:unauthorized, 'Outbound request not authorized!', response)
+        Util.error(:unauthorized, 'Outbound request not authorized', response)
       else
-        Util.error(:error, 'Outbound request failed!', response)
+        Util.error(:error, 'Outbound request failed', response)
       end
     end
     # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
@@ -101,7 +101,8 @@ module Storages
           OpenProject.logger.warn({ command: 'nextcloud.remove_user_from_group',
                                     group: @storage.group,
                                     user:,
-                                    message: error.log_message }.to_json)
+                                    message: error.log_message,
+                                    data: { status: error.data.code, body: error.data.body } }.to_json)
         end
       end
 
@@ -110,7 +111,8 @@ module Storages
           OpenProject.logger.warn({ command: 'nextcloud.add_users_to_group',
                                     group: @storage.group,
                                     user:,
-                                    message: error.log_message }.to_json)
+                                    message: error.log_message,
+                                    data: { status: error.data.code, body: error.data.body } }.to_json)
         end
       end
     end
@@ -149,7 +151,12 @@ module Storages
       Peripherals::Registry
         .resolve("commands.nextcloud.set_permissions")
         .call(storage: @storage, **command_params)
-        .result_or { |error| OpenProject.logger.warn "PROPPATCH #{path} #{error.log_message}. Response: #{error.data.inspect}" }
+        .result_or do |error|
+        OpenProject.logger.warn({ command: 'nextcloud.set_permissions',
+                                  folder: project_storage.project_folder_path,
+                                  message: error.log_message,
+                                  data: { status: error.data.code, body: error.data.body } }.to_json)
+      end
     end
 
     def project_tokens(project_storage)
@@ -179,12 +186,10 @@ module Storages
           .resolve("commands.nextcloud.set_permissions")
           .call(storage: @storage, **command_params)
           .result_or do |error|
-          error_msg = { command: 'nextcloud.set_permissions',
-                        folder: path,
-                        message: error.log_message,
-                        data: { status: error.data.code, body: error.data.body } }.to_json
-
-          OpenProject.logger.warn error_msg
+          OpenProject.logger.warn({ command: 'nextcloud.set_permissions',
+                                    folder: path,
+                                    message: error.log_message,
+                                    data: { status: error.data.code, body: error.data.body } }.to_json)
         end
       end
     end

--- a/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
@@ -179,7 +179,12 @@ module Storages
           .resolve("commands.nextcloud.set_permissions")
           .call(storage: @storage, **command_params)
           .result_or do |error|
-          OpenProject.logger.warn "PROPPATCH #{path} #{error.log_message}. Response: #{error.data.inspect}"
+          error_msg = { command: 'nextcloud.set_permissions',
+                        folder: path,
+                        message: error.log_message,
+                        data: { status: error.data.code, body: error.data.body } }.to_json
+
+          OpenProject.logger.warn error_msg
         end
       end
     end

--- a/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/group_folder_properties_sync_service.rb
@@ -28,266 +28,240 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Storages::GroupFolderPropertiesSyncService
-  using ::Storages::Peripherals::ServiceResultRefinements
+# TODO: Rename Class to NextcloudManagedFolderSync
+#
+module Storages
+  class GroupFolderPropertiesSyncService
+    using Peripherals::ServiceResultRefinements
 
-  PERMISSIONS_MAP = {
-    read_files: 1,
-    write_files: 2,
-    create_files: 4,
-    delete_files: 8,
-    share_files: 16
-  }.freeze
-  PERMISSIONS_KEYS = PERMISSIONS_MAP.keys.freeze
-  ALL_PERMISSIONS = PERMISSIONS_MAP.values.sum
-  NO_PERMISSIONS = 0
+    PERMISSIONS_MAP = {
+      read_files: 1,
+      write_files: 2,
+      create_files: 4,
+      delete_files: 8,
+      share_files: 16
+    }.freeze
 
-  def initialize(storage)
-    @storage = storage
-    @nextcloud_system_user = storage.username
-    @group = storage.group
-    @group_folder = storage.group_folder
-  end
+    PERMISSIONS_KEYS = PERMISSIONS_MAP.keys.freeze
+    ALL_PERMISSIONS = PERMISSIONS_MAP.values.sum
+    NO_PERMISSIONS = 0
 
-  # rubocop:disable Metrics/AbcSize
-  def call
-    # we have to flush state to be able to reuse the instace of the class
-    @project_folder_ids_used_in_openproject = Set.new
-    @file_ids = nil
-    @folders_properties = nil
-    @group_users = nil
-    @admin_tokens_query = OAuthClientToken.where(oauth_client: @storage.oauth_client,
-                                                 users: User.admin.active)
-
-    @admin_nextcloud_usernames = @admin_tokens_query.pluck(:origin_user_id)
-    @nextcloud_usernames_used_in_openproject = @admin_nextcloud_usernames.to_set
-
-    set_group_folder_root_permissions
-
-    @storage.project_storages
-            .automatic
-            .includes(project: :enabled_modules)
-            .where(projects: { active: true })
-            .find_each do |project_storage|
-      project = project_storage.project
-      project_folder_path = project_storage.project_folder_path
-      @project_folder_ids_used_in_openproject << ensure_project_folder(project_storage:, project_folder_path:)
-
-      set_project_folder_permissions(path: project_folder_path, project:)
+    def initialize(storage)
+      @storage = storage
     end
 
-    hide_inactive_project_folders
-    add_active_users_to_group
-    remove_inactive_users_from_group
-  end
+    def call
+      prepare_remote_folders and apply_permissions_to_folders
+    end
 
-  # rubocop:enable Metrics/AbcSize
+    private
 
-  private
+    # rubocop:disable Metrics/AbcSize
+    def prepare_remote_folders
+      remote_folders = remote_root_folder_properties.result_or do |error|
+        error_msg = "PROPFIND #{@storage.group_folder} #{error.log_message}. Response: #{error.data.inspect}"
+        raise error_msg if error.code == :error
 
-  def set_group_folder_root_permissions
-    command_params = {
-      path: @group_folder,
-      permissions: {
-        users: { @nextcloud_system_user.to_sym => ALL_PERMISSIONS },
-        groups: { @group.to_sym => PERMISSIONS_MAP[:read_files] }
+        OpenProject.logger.warn error_msg
+        return false
+      end
+
+      ensure_root_folder_permissions.error_and do |error|
+        error_msg = "PROPPATCH #{@storage.group_folder} #{error.log_message}. Response: #{error.data.inspect}"
+        raise error_msg if error.code == :error
+
+        OpenProject.logger.warn error_msg
+        return false
+      end
+
+      ensure_folders_exist(remote_folders) and hide_inactive_folders(remote_folders)
+    end
+
+    def apply_permissions_to_folders
+      remote_admins = admin_client_tokens_scope.pluck(:origin_user_id)
+
+      active_project_storages_scope.find_each do |project_storage|
+        set_folders_permissions(remote_admins, project_storage)
+      end
+
+      add_remove_users_to_group
+    end
+
+    def add_remove_users_to_group
+      remote_users = remote_group_users.result_or { puts :error }
+      local_users = client_tokens_scope.order(:id).pluck(:origin_user_id)
+
+      (remote_users - local_users - [@storage.username]).each do |user|
+        remove_user_from_remote_group(user).result_or do |error|
+          OpenProject.logger.warn "POST #{@storage.group} #{user} #{error.log_message}. Response: #{error.data.inspect}"
+        end
+      end
+
+      (local_users - remote_users - [@storage.username]).each do |user|
+        add_user_to_remote_group(user).result_or do |error|
+          OpenProject.logger.warn "DELETE #{@storage.group} #{user} #{error.log_message}. Response: #{error.data.inspect}"
+        end
+      end
+    end
+
+    def add_user_to_remote_group(user)
+      Peripherals::Registry
+        .resolve("commands.nextcloud.add_user_to_group")
+        .call(storage: @storage, user:)
+    end
+
+    def remove_user_from_remote_group(user)
+      Peripherals::Registry
+        .resolve("commands.nextcloud.remove_user_from_group")
+        .call(storage: @storage, user:)
+    end
+
+    def set_folders_permissions(remote_admins, project_storage)
+      admin_permissions = remote_admins.to_set.map do |username|
+        [username, ALL_PERMISSIONS]
+      end.unshift([@storage.username, ALL_PERMISSIONS])
+
+      users_permissions = project_tokens(project_storage).each_with_object({}) do |token, hash|
+        permissions = token.user.all_permissions_for(project_storage.project)
+
+        hash[token.origin_user_id] = PERMISSIONS_MAP.values_at(*(PERMISSIONS_KEYS & permissions)).sum
+      end
+
+      command_params = {
+        path: project_storage.project_folder_path,
+        permissions: {
+          users: admin_permissions.to_h.merge(users_permissions),
+          groups: { "#{@storage.group}": NO_PERMISSIONS }
+        }
       }
-    }
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.set_permissions")
-      .call(storage: @storage, **command_params)
-      .on_failure(&failure_handler('set_permissions_command', command_params))
-  end
 
-  # rubocop:disable Metrics/AbcSize
-  def ensure_project_folder(project_storage:, project_folder_path:)
-    project_folder_id = project_storage.project_folder_id
-    project_storage.project
-
-    if project_folder_id.present? && file_ids.include?(project_folder_id)
-      source = folders_properties.find { |_k, v| v['fileid'] == project_folder_id }.first
-      rename_folder(source:, target: project_folder_path) if source != project_folder_path
-    else
-      create_folder(path: project_folder_path, project_storage:) >> obtain_file_id >> save_file_id
+      Peripherals::Registry
+        .resolve("commands.nextcloud.set_permissions")
+        .call(storage: @storage, **command_params)
+        .result_or { |error| OpenProject.logger.warn "PROPPATCH #{path} #{error.log_message}. Response: #{error.data.inspect}" }
     end
-    # local variable `project_folder_id` is not used due to possible update_columns call
-    # then the value inside the local variable will not be updated
-    project_storage.project_folder_id
-  end
 
-  # rubocop:enable Metrics/AbcSize
+    def project_tokens(project_storage)
+      project_tokens = client_tokens_scope.where.not(id: admin_client_tokens_scope).order(:id)
 
-  def file_ids
-    @file_ids ||= folders_properties.map { |_path, props| props['fileid'] }
-  end
-
-  def folders_properties
-    @folders_properties ||=
-      Storages::Peripherals::Registry.resolve("queries.#{@storage.short_provider_type}.file_ids")
-        .call(storage: @storage, path: @group_folder)
-        .on_failure(&failure_handler('file_ids_query', { path: @group_folder }))
-        .result
-  end
-
-  def rename_folder(source:, target:)
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.rename_file")
-      .call(storage: @storage, source:, target:)
-      .on_failure(&failure_handler('rename_file_command', { source:, target: }))
-  end
-
-  def create_folder(path:, project_storage:)
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.create_folder")
-              .call(storage: @storage, folder_path: path)
-             .match(
-               on_success: ->(_) { ServiceResult.success(result: [project_storage, path]) },
-               on_failure: failure_handler('create_folder_command', { folder_path: path })
-             )
-  end
-
-  def save_file_id
-    ->((project_storage, file_id)) do
-      project_storage.update_columns(project_folder_id: file_id, updated_at: Time.current)
-    end
-  end
-
-  def obtain_file_id
-    ->((project_storage, path)) do
-      Storages::Peripherals::Registry.resolve("queries.#{@storage.short_provider_type}.file_ids")
-        .call(storage: @storage, path:)
-        .match(
-          on_success: ->(file_ids) { ServiceResult.success(result: [project_storage, file_ids.dig(path, 'fileid')]) },
-          on_failure: failure_handler('file_id_query', { path: })
-        )
-    end
-  end
-
-  def calculate_permissions(user:, project:)
-    {
-      read_files: user.allowed_to?(:read_files, project),
-      write_files: user.allowed_to?(:write_files, project),
-      create_files: user.allowed_to?(:create_files, project),
-      share_files: user.allowed_to?(:share_files, project),
-      delete_files: user.allowed_to?(:delete_files, project)
-    }.reduce(0) do |permissions_sum, (permission, allowed)|
-      if allowed
-        permissions_sum + PERMISSIONS_MAP[permission]
+      if project_storage.project.public? && ProjectRole.non_member.permissions.intersect?(PERMISSIONS_KEYS)
+        project_tokens
       else
-        permissions_sum
+        project_tokens.where(user: project_storage.project.users)
       end
     end
-  end
 
-  def set_project_folder_permissions(path:, project:)
-    command_params = {
-      path:,
-      permissions: project_folder_permissions(project:)
-    }
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.set_permissions")
-      .call(storage: @storage, **command_params)
-      .on_failure(&failure_handler('set_permissions_command', command_params))
-  end
+    def hide_inactive_folders(remote_folders)
+      project_folder_ids = active_project_storages_scope.pluck(:project_folder_id).compact
+      remote_folders.except("#{@storage.group_folder}/").each do |(path, attrs)|
+        next if project_folder_ids.include?(attrs['fileid'])
 
-  def group_users
-    @group_users ||= begin
-      query_params = { group: @group }
-      Storages::Peripherals::Registry.resolve("queries.#{@storage.short_provider_type}.group_users")
-       .call(storage: @storage, **query_params)
-       .on_failure(&failure_handler('group_users_query', query_params))
-       .result
-    end
-  end
+        command_params = {
+          path:,
+          permissions: {
+            users: { "#{@storage.username}": ALL_PERMISSIONS },
+            groups: { "#{@storage.group}": NO_PERMISSIONS }
+          }
+        }
 
-  def project_folder_permissions(project:)
-    {
-      users: admins_project_folder_permissions.merge!(members_project_folder_permissions(project:)),
-      groups: { "#{@group}": NO_PERMISSIONS }
-    }
-  end
-
-  def admins_project_folder_permissions
-    @admin_nextcloud_usernames.each_with_object(
-      "#{@nextcloud_system_user}": ALL_PERMISSIONS
-    ) do |admin_nextcloud_username, hash_map|
-      hash_map[admin_nextcloud_username.to_sym] = ALL_PERMISSIONS
-    end
-  end
-
-  def members_project_folder_permissions(project:)
-    tokens_query(project:).each_with_object({}) do |token, permissions|
-      nextcloud_username = token.origin_user_id
-      permissions[nextcloud_username.to_sym] = calculate_permissions(user: token.user, project:)
-      @nextcloud_usernames_used_in_openproject << nextcloud_username
-    end
-  end
-
-  def tokens_query(project:)
-    tokens_query = OAuthClientToken
-                     .where(oauth_client: @storage.oauth_client)
-                     .where.not(id: @admin_tokens_query)
-                     .includes(:user)
-                     .order(:id)
-    # The user scope is required in all cases except one:
-    #   when the project is public and non member has at least one storage permission
-    #   then all non memebers should have access to the project folder
-    if !(project.public? && ProjectRole.non_member.permissions.intersect?(PERMISSIONS_KEYS))
-      tokens_query = tokens_query.where(users: project.users)
-    end
-
-    tokens_query
-  end
-
-  def add_active_users_to_group
-    @nextcloud_usernames_used_in_openproject.each do |nextcloud_username|
-      if group_users.exclude?(nextcloud_username)
-        query_params = { user: nextcloud_username }
-        Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.add_user_to_group")
-          .call(storage: @storage, **query_params)
-          .on_failure(&failure_handler('add_user_to_group_command', query_params))
+        Peripherals::Registry
+          .resolve("commands.nextcloud.set_permissions")
+          .call(storage: @storage, **command_params)
+          .result_or do |error|
+          OpenProject.logger.warn "PROPPATCH #{path} #{error.log_message}. Response: #{error.data.inspect}"
+        end
       end
     end
-  end
 
-  def remove_inactive_users_from_group
-    (group_users - @nextcloud_usernames_used_in_openproject.to_a - [@nextcloud_system_user]).each do |user|
-      remove_user_from_group(user)
+    def ensure_folders_exist(remote_folders)
+      id_folder_map = remote_folders.to_h { |folder, properties| [properties['fileid'], folder] }
+
+      active_project_storages_scope.map do |project_storage|
+        next create_folder(project_storage) unless id_folder_map.key?(project_storage.project_folder_id)
+
+        if id_folder_map[project_storage.project_folder_id] == project_storage.project_folder_path
+          project_storage.project_folder_id
+        else
+          move_folder(project_storage, id_folder_map[project_storage.project_folder_id])
+            .result_or do |error|
+            error_msg = "MOVE #{project_storage.project_folder_path} #{error.log_message}. Response: #{error.data.inspect}"
+
+            # we need to stop as this would mess with the other processes
+            return OpenProject.logger.warn error_msg
+          end
+        end
+      end
     end
-  end
 
-  def remove_user_from_group(user)
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.remove_user_from_group")
-      .call(storage: @storage, user:)
-      .on_failure do |service_result|
-      ::OpenProject.logger.warn(
-        "Nextcloud user #{user} has not been removed from Nextcloud group #{@group}: '#{service_result.errors.log_message}'"
-      )
+    def move_folder(project_storage, current_name)
+      Peripherals::Registry
+        .resolve("commands.nextcloud.rename_file")
+        .call(storage: @storage, source: current_name, target: project_storage.project_folder_path)
     end
-  end
 
-  def hide_inactive_project_folders
-    inactive_project_folder_paths.each { |folder| hide_folder(folder) }
-  end
+    def create_folder(project_storage)
+      folder_path = project_storage.project_folder_path
+      Peripherals::Registry
+        .resolve("commands.nextcloud.create_folder")
+        .call(storage: @storage, folder_path:)
+        .result_or do |error|
+        error_msg = "MKCOL #{folder_path} #{error.log_message}. Response: #{error.data.inspect}"
 
-  def inactive_project_folder_paths
-    folders_properties.except("#{@group_folder}/").each_with_object([]) do |(path, attrs), paths|
-      paths.push(path) if @project_folder_ids_used_in_openproject.exclude?(attrs['fileid'])
+        return OpenProject.logger.warn(error_msg)
+      end
+
+      folder_ids = Peripherals::Registry
+                     .resolve('queries.nextcloud.file_ids')
+                     .call(storage: @storage, path: folder_path)
+                     .result_or { |_error| puts :error } # Log this
+
+      project_storage.update(project_folder_id: folder_ids.dig(folder_path, 'fileid'))
+      project_storage.reload.project_folder_id
     end
-  end
+    # rubocop:enable Metrics/AbcSize
 
-  def hide_folder(path)
-    command_params = {
-      path:,
-      permissions: {
-        users: { "#{@nextcloud_system_user}": ALL_PERMISSIONS },
-        groups: { "#{@group}": NO_PERMISSIONS }
+    def ensure_root_folder_permissions
+      command_params = {
+        path: @storage.group_folder,
+        permissions: {
+          users: { @storage.username.to_sym => ALL_PERMISSIONS },
+          groups: { @storage.group.to_sym => PERMISSIONS_MAP[:read_files] }
+        }
       }
-    }
-    Storages::Peripherals::Registry.resolve("commands.#{@storage.short_provider_type}.set_permissions")
-      .call(storage: @storage, **command_params)
-      .on_failure(&failure_handler('set_permissions_command', command_params))
-  end
 
-  def failure_handler(command, params)
-    ->(service_result) do
-      raise "#{command} was called with #{params} and failed with: #{service_result.inspect}"
+      Peripherals::Registry
+        .resolve("commands.nextcloud.set_permissions")
+        .call(storage: @storage, **command_params)
+    end
+
+    ### Base Queries/Commands
+    def remote_root_folder_properties
+      Peripherals::Registry
+        .resolve("queries.nextcloud.file_ids")
+        .call(storage: @storage, path: @storage.group_folder)
+    end
+
+    def remote_group_users
+      Peripherals::Registry
+        .resolve("queries.nextcloud.group_users")
+        .call(storage: @storage, group: @storage.group)
+    end
+
+    ### Model Scopes
+    def project_storage_scope
+      @storage.project_storages.automatic.joins(:project)
+    end
+
+    def active_project_storages_scope
+      project_storage_scope.where(project: { active: true })
+    end
+
+    def client_tokens_scope
+      OAuthClientToken.where(oauth_client: @storage.oauth_client)
+    end
+
+    def admin_client_tokens_scope
+      OAuthClientToken.where(oauth_client: @storage.oauth_client, user: User.admin.active)
     end
   end
 end

--- a/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/group_folder_properties_sync_service_spec.rb
@@ -759,6 +759,15 @@ RSpec.describe Storages::GroupFolderPropertiesSyncService, :webmock do
           expect { described_class.new(storage).call }.to raise_error RuntimeError
         end
       end
+
+      context 'when folder creation fails'
+      context 'when renaming a folder fail'
+      context 'when hiding a folder fail'
+
+      context 'when setting project folder permissions fail'
+
+      context 'when adding a user to the group fails'
+      context 'when removing a user to the group fails'
     end
 
     private


### PR DESCRIPTION
https://community.openproject.org/work_packages/50894
https://community.openproject.org/work_packages/50616


## [Wat?](https://www.destroyallsoftware.com/talks/wat)

This PR aims to reduce the noise on AppSignal by reducing the number of raised exceptions when running.

## Why?

We keep reporting exceptions to AppSignal that are either non actionables or irrelevant, this adds noise and makes unearthing real glaring issues harder for everyone.

Besides, who does love getting AppSignal emails every 5 mins. :P

## How?

Most of the errors aren't something we can act immediately - like misconfiguration - nor are they exceptional so I started to log this info on the RoR log so, in case of failures we have just one point to look at.

All logs were made into JSON so, if structured logging is around, this becomes simpler to deal with (aaaaand it might help later on some other ideas on next steps).

Also in this PR, I extended the `ServiceResultRefinements` with the methods `result_or` and `result_and` (and their reversed forms `error_and` and `error_or`). Those 2 methods take in blocks and unwrap the `ServiceResult` `result` or `error` as needed.

```ruby
create_folder(folder) >> obtain_id >> update_storage
```

The line above calls 3 methods/lambdas taking the `ServiceResult.result` of each of then and executes then in order. How do you stop the code flow? By returning a failure.

```ruby
create_folder(folder)
  .result_and { |result| obtain_id(result) }
  .result_and {|result| update_storage(result) }
```

The line above is the same but written with the `result_and` method. If someone isn't versed in `monadic vernacular` I'd say it is slightly more legible.

But what I'd prefer is:

```ruby
create_folder(folder).result_or { |error| return error }
folder_id = obtain_folder_id(folder).result_or { |error| return error }
update_storage(folder_id).result_or { |error| return error }
```

As it conveys that I'm interested in the results, the context will return when met with errors and there's a clear order of argument passing. It is more verbose for sure, but allows us too keep cause and effect pretty close.

That being said, I've added it as an example and it can easily be converted to any other of the options we have if you folks feel it isn't great.