### PR TITLE
[50666] Help icon not shown when having a custom help link setting

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -68,7 +68,7 @@ Redmine::MenuManager.map :top_menu do |menu|
             OpenProject::Static::Links.help_link,
             last: true,
             caption: '',
-            icon: 'icon-help op-app-help--icon',
+            icon: 'help op-app-help--icon',
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
                     title: I18n.t('label_help'),
                     target: '_blank' }

--- a/frontend/src/global_styles/common/header/app-help.sass
+++ b/frontend/src/global_styles/common/header/app-help.sass
@@ -1,5 +1,6 @@
 .op-app-help
-  &--icon
+  // For the higher specificity we switch to this nested class notation
+  .op-app-help--icon
     &::before
       display: flex
       justify-content: center

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -49,7 +49,7 @@ module Redmine::MenuManager::TopMenu::HelpMenu
                                   title: I18n.t(:label_help),
                                   class: 'op-app-menu--item-action',
                                   aria: { haspopup: 'true' } do
-      op_icon('icon-help op-app-help--icon')
+      spot_icon('help', size: '1_25', classnames: 'op-app-help--icon')
     end
 
     render_menu_dropdown(


### PR DESCRIPTION
When using a custom help link with `OPENPROJECT_FORCE__HELP__LINK="http://link.example.com"` the help icon was not shown.
This happened due to the menu being changed in the past to use spot icons. The `menu_helper` is expecting a spot-based class name (`help`) instead of `icon-help`. 

This became visible only with the custom link, as the normal help menu is [rendered differently (still with old icons)](https://github.com/opf/openproject/blob/release/13.0/lib/redmine/menu_manager/top_menu/help_menu.rb). I changed that implementation to use a spot-icon as well for a higher consistency.

https://community.openproject.org/projects/openproject/work_packages/50666/activity