### PR TITLE
feat[#50499]: Add navigational elements (breadcrumb and back buttons)

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -30,13 +30,13 @@ module BreadcrumbHelper
   def full_breadcrumbs
     items = breadcrumb_paths.compact
     render(Primer::Beta::Breadcrumbs.new(data: { 'test-selector': "op-breadcrumb" })) do |breadcrumbs|
-      items.each do |item|
+      items.each_with_index do |item, index|
         item = anchor_string_to_object(item) if item.is_a?(String) && item.start_with?("\u003c")
 
         if item.is_a?(Hash)
-          breadcrumbs.with_item(href: item[:href]) { item[:text] }
+          breadcrumbs.with_item(href: item[:href], classes: index == 0 ? "first-breadcrumb-element" : nil) { item[:text] }
         else
-          breadcrumbs.with_item(href: "#") { item }
+          breadcrumbs.with_item(href: "#", classes: index == 0 ? "first-breadcrumb-element" : nil) { item }
         end
       end
     end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -43,9 +43,7 @@ module BreadcrumbHelper
   end
 
   def breadcrumb_paths(*args)
-    if args.nil?
-      nil
-    elsif args.empty?
+    if args.empty?
       @breadcrumb_paths ||= [default_breadcrumb]
     else
       @breadcrumb_paths ||= []

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -29,7 +29,7 @@
 module BreadcrumbHelper
   def full_breadcrumbs
     items = breadcrumb_paths.compact
-    render(Primer::Beta::Breadcrumbs.new(data: { 'test-selector': "op-breadcrumb" })) do |breadcrumbs|
+    render(Primer::Beta::Breadcrumbs.new(test_selector: "op-breadcrumb" )) do |breadcrumbs|
       items.each_with_index do |item, index|
         item = anchor_string_to_object(item) if item.is_a?(String) && item.start_with?("\u003c")
 

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -29,7 +29,7 @@
 module BreadcrumbHelper
   def full_breadcrumbs
     items = breadcrumb_paths.compact
-    render(Primer::Beta::Breadcrumbs.new) do |breadcrumbs|
+    render(Primer::Beta::Breadcrumbs.new(data: { 'test-selector': "op-breadcrumb" })) do |breadcrumbs|
       items.each do |item|
         item = anchor_string_to_object(item) if item.is_a?(String) && item.start_with?("\u003c")
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -118,7 +118,9 @@ See COPYRIGHT and LICENSE files for more details.
       <% if show_decoration %>
         <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>">
           <%= you_are_here_info %>
-          <%= full_breadcrumbs %>
+          <div id="full_breadcrumbs">
+            <%= full_breadcrumbs %>
+          </div>
           <%= call_hook :view_layouts_base_breadcrumb %>
         </div>
       <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -118,7 +118,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if show_decoration %>
         <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>">
           <%= you_are_here_info %>
-          <%= full_breadcrumb %>
+          <%= full_breadcrumbs %>
           <%= call_hook :view_layouts_base_breadcrumb %>
         </div>
       <% end %>

--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -63,3 +63,6 @@ button:focus:not(:focus-visible):not(:hover) + tool-tip
 #breadcrumb
   ol
     margin-left: 0
+  .breadcrumb-item.breadcrumb-item-selected
+    a
+      pointer-events: none

--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -58,3 +58,8 @@ ul.tabnav-tabs
 // or if it wasn't triggered by the keyboard (:focus-visible).
 button:focus:not(:focus-visible):not(:hover) + tool-tip
   visibility: hidden
+
+/* Remove margin-left: 2rem from Breadcrumbs */
+nav
+  > ol
+    margin-left: 0

--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -60,6 +60,6 @@ button:focus:not(:focus-visible):not(:hover) + tool-tip
   visibility: hidden
 
 /* Remove margin-left: 2rem from Breadcrumbs */
-nav
-  > ol
+#breadcrumb
+  ol
     margin-left: 0

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -214,7 +214,7 @@ class Storages::Admin::StoragesController < ApplicationController
   # See: default_breadcrum above
   # Defines whether to show breadcrumbs on the page or not.
   def show_local_breadcrumb
-    !OpenProject::FeatureDecisions.storage_primer_design_active?
+    true
   end
 
   private

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -28,6 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% html_title t(:label_administration), t("project_module_storages"), t('label_edit_x', x: @storage.name) %>
+<% local_assigns[:additional_breadcrumb] = @storage.name %>
 
 <% if OpenProject::FeatureDecisions.storage_primer_design_active? %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
@@ -37,6 +38,8 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% end %>
 
+    <% header.with_back_button(href: admin_settings_storages_path, 'aria-label':  I18n.t("button_back")) %>
+   
     <% header.with_actions do %>
       <%=
         primer_form_with(
@@ -64,7 +67,6 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
 <% else %>
-  <% local_assigns[:additional_breadcrumb] = @storage.name %>
   <%= toolbar title: t('label_edit_x', x: @storage.name) %>
 
   <%= render(::Storages::Admin::ConfigurationChecksComponent.new(storage: @storage)) %>

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -39,7 +39,11 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
 
     <% header.with_back_button(href: admin_settings_storages_path, 'aria-label':  I18n.t("button_back")) %>
-   
+
+    <% header.with_parent_link(href: admin_settings_storages_path, 'aria-label':  I18n.t("button_back")) do %>
+      <%= t(:project_module_storages) %>
+    <% end %>
+
     <% header.with_actions do %>
       <%=
         primer_form_with(

--- a/modules/storages/app/views/storages/admin/storages/new.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/new.html.erb
@@ -8,6 +8,12 @@
       <%= t("storages.label_new_file_storage") %>
     <% end %>
 
+    <% header.with_back_button(href: admin_settings_storages_path, 'aria-label':  I18n.t("button_back")) %>
+
+    <% header.with_parent_link(href: admin_settings_storages_path, 'aria-label':  I18n.t("button_back")) do %>
+      <%= t(:project_module_storages) %>
+    <% end %>
+
     <% header.with_description do %>
       <%=
         t("storages.instructions.new_storage",

--- a/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
+++ b/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
@@ -1,6 +1,16 @@
 <%= turbo_stream.update dom_id(@storage, :edit_storage_header) do %>
   <%= @storage.name %>
 <% end %>
+<%= turbo_stream.update :full_breadcrumbs do %>
+  <%
+    breadcrumb_paths(
+      link_to(t(:label_administration), admin_index_path),
+      default_breadcrumb,
+      @storage.name
+    )
+  %>
+  <%= full_breadcrumbs %>
+<% end %>
 
 <%= turbo_stream.update :storage_general_info_section do %>
   <%= render(::Storages::Admin::GeneralInfoComponent.new(@storage)) %>

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -729,7 +729,7 @@ RSpec.describe 'Admin storages',
     ######### End Edit Automatically managed project folders #########
 
     # List of storages
-    page.find("ul.op-breadcrumb li", text: "File storages").click
+    page.find("#{test_selector('op-breadcrumb')} ol li", text: "File storages").click
 
     # Delete on List page
     page.find('td.buttons .icon-delete').click
@@ -771,7 +771,7 @@ RSpec.describe 'Admin storages',
 
         expect(page).not_to have_css('.flash.flash-error')
 
-        within('.op-breadcrumb') do
+        within(test_selector('op-breadcrumb')) do
           click_link 'File storages'
         end
 


### PR DESCRIPTION
Work package: https://community.openproject.org/wp/50499

This PR adds '`OpPrimer::BackButtonComponent`' in `app/components/op_primer` 
This button inherits from Primer::Beta::IconButton and needs only the `href` as parameter.

This PR also adds this BackButton and breadcrumbs in storage edit view.
The breadcrumbs are outside of the header because `Primer::OpenProject::PageHeader` doesn't have a `slot` for breadcumbs.

There is a `left-margin` problem that I need to clarify with @HDinger (see picture below). Or maybe @akabiru you know too where the `margin-left: 2rem;` for `<ol>` tags should be overridden.  

<img width="1725" alt="Screenshot 2023-10-20 at 14 34 56" src="https://github.com/opf/openproject/assets/1113942/b921c6cf-9203-4268-b064-8dbc66e55810">

I will clarify this before merging



