### PR TITLE
[49460] Enable Primer's high-contrast mode (fix/menu background color)

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -17,12 +17,12 @@
     --toolbar-item--bg-color: var(--color-btn-bg);
     --toolbar-item--border-color: var(--color-border-default);
     --header-border-bottom-width: 1px;
-    --header-bg-color: var(--AppHeader-bg);
+    --header-bg-color: var(--color-page-header-bg);
     --header-item-font-color: var(--color-fg-default);
     --header-item-bg-hover-color: var(--color-action-list-item-default-hover-bg);
     --header-item-font-hover-color: var(--color-fg-default);
     --header-border-bottom-color: var(--color-border-muted) !important;
-    --main-menu-bg-color: var(--AppHeader-bg);
+    --main-menu-bg-color: var(--color-page-header-bg);
     --main-menu-hover-font-color: var(--color-fg-default);
     --main-menu-bg-selected-background: var(--color-action-list-item-default-hover-bg);
     --main-menu-bg-hover-background: var(--color-action-list-item-default-hover-bg);


### PR DESCRIPTION
For menu background color, we should use a variable defined in primer color node module.
--AppHeader-bg variable was used in Github, but does not exist in node module.

https://community.openproject.org/work_packages/49460/activity#activity-8