### PR TITLE
Add request_id tag to logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,7 @@ OpenProject::Application.configure do
   config.assets.quiet = true unless config.log_level == :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [:request_id]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
https://community.openproject.org/wp/50635

It's also possible to add it as metadata to lograge and grape-logging. Using logger tags is the simplest. It can be revisited later if needed.