### PR TITLE
[49460] Enable Primer's high-contrast mode (fix jumpy back arrow in side bar menu while hovering)

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -187,6 +187,7 @@ $arrow-left-width: 40px
   border-radius: 3px
   padding-left: 14px
   padding-right: 14px
+  border: 1px solid transparent
   &:hover, &:focus, &:active
     @include main-menu-hover
 


### PR DESCRIPTION
Add a transparent border around the back arrow so while hovering and adding a border around it, it won't jump again.

https://community.openproject.org/work_packages/49460/activity#activity-13