### PR TITLE
Add Bulk Sharing Capabilities to Share Modal

### DIFF
--- a/app/components/work_packages/share/bulk_permission_button_component.html.erb
+++ b/app/components/work_packages/share/bulk_permission_button_component.html.erb
@@ -1,0 +1,27 @@
+<%=
+  render(Primer::Alpha::ActionMenu.new(select_variant: :single,
+                                       dynamic_label: true,
+                                       anchor_align: :end,
+                                       color: :subtle,
+                                       data: { test_selector: 'op-share-wp-bulk-update-role'})) do |menu|
+    menu.with_show_button(data: { 'work-packages--share--bulk-selection-target': 'bulkUpdateRole' }) do |button|
+      button.with_trailing_action_icon(icon: "triangle-down")
+      'Placeholder'
+    end
+
+    options.each do |option|
+      menu.with_item(label: option[:label],
+                     href: update_path,
+                     method: :patch,
+                     active: false,
+                     form_arguments: {
+                       method: :patch,
+                       name: 'role_ids[]',
+                       value: option[:value],
+                       data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }
+                     }) do |item|
+        item.with_description.with_content(option[:description])
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/share/bulk_permission_button_component.html.erb
+++ b/app/components/work_packages/share/bulk_permission_button_component.html.erb
@@ -4,7 +4,7 @@
                                        anchor_align: :end,
                                        color: :subtle,
                                        data: { test_selector: 'op-share-wp-bulk-update-role'})) do |menu|
-    menu.with_show_button(data: { 'work-packages--share--bulk-selection-target': 'bulkUpdateRole' }) do |button|
+    menu.with_show_button(data: { 'work-packages--share--bulk-selection-target': 'bulkUpdateRoleLabel' }) do |button|
       button.with_trailing_action_icon(icon: "triangle-down")
       'Placeholder'
     end
@@ -18,7 +18,9 @@
                        method: :patch,
                        name: 'role_ids[]',
                        value: option[:value],
-                       data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }
+                       data: { 'work-packages--share--bulk-selection-target': 'bulkForm bulkUpdateRoleForm',
+                               'role-name': option[:label],
+                               'test-selector': "op-share-wp-bulk-update-role-permission-#{option[:label]}" }
                      }) do |item|
         item.with_description.with_content(option[:description])
       end

--- a/app/components/work_packages/share/bulk_permission_button_component.rb
+++ b/app/components/work_packages/share/bulk_permission_button_component.rb
@@ -1,6 +1,8 @@
-#-- copyright
+# frozen_string_literal: true
+
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) 2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,41 +26,20 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
 module WorkPackages
   module Share
-    class PermissionButtonComponent < ApplicationComponent
-      include ApplicationHelper
-      include OpPrimer::ComponentHelpers
-      include OpTurbo::Streamable
-
-      def initialize(share:, **system_arguments)
+    class BulkPermissionButtonComponent < ApplicationComponent
+      def initialize(work_package:)
         super
 
-        @share = share
-        @system_arguments = system_arguments
+        @work_package = work_package
       end
 
-      # Switches the component to either update the share directly (by sending a PATCH to the share path)
-      # or be passive and work like a select inside a form.
       def update_path
-        if share.persisted?
-          work_packages_share_path(share)
-        end
+        work_package_shares_bulk_path(@work_package)
       end
-
-      def option_active?(option)
-        option[:value] == active_role.builtin
-      end
-
-      def wrapper_uniq_by
-        share.id || @system_arguments.dig(:data, :'test-selector')
-      end
-
-      private
-
-      attr_reader :share
 
       def options
         [
@@ -72,20 +53,6 @@ module WorkPackages
             value: Role::BUILTIN_WORK_PACKAGE_VIEWER,
             description: I18n.t('work_package.sharing.permissions.view_description') }
         ]
-      end
-
-      def active_role
-        if share.persisted?
-          share.roles
-               .merge(MemberRole.only_non_inherited)
-               .first
-        else
-          share.roles.first
-        end
-      end
-
-      def permission_name(value)
-        options.select { |option| option[:value] == value }
       end
     end
   end

--- a/app/components/work_packages/share/bulk_selection_counter_component.html.erb
+++ b/app/components/work_packages/share/bulk_selection_counter_component.html.erb
@@ -9,13 +9,13 @@
   )
 
   concat(
-    render(Primer::Beta::Text.new(pl: 2, data: { 'work-packages--share--bulk-selection-target': 'sharedCounter' })) do
+    render(Primer::Beta::Text.new(ml: 2, data: { 'work-packages--share--bulk-selection-target': 'sharedCounter' })) do
       I18n.t('work_package.sharing.count', count:)
     end
   )
 
   # Text contents managed by Stimulus controller
   concat(
-    render(Primer::Beta::Text.new(pl: 2, data: { 'work-packages--share--bulk-selection-target': 'selectedCounter' }))
+    render(Primer::Beta::Text.new(ml: 2, data: { 'work-packages--share--bulk-selection-target': 'selectedCounter' }))
   )
 %>

--- a/app/components/work_packages/share/bulk_selection_counter_component.html.erb
+++ b/app/components/work_packages/share/bulk_selection_counter_component.html.erb
@@ -1,0 +1,21 @@
+<%
+  concat(
+    render(Primer::Alpha::CheckBox.new(name: 'toggle_all',
+                                       value: nil,
+                                       label: I18n.t('work_package.sharing.label_toggle_all'),
+                                       visually_hide_label: true,
+                                       data: { 'work-packages--share--bulk-selection-target': 'toggleAll',
+                                               action: 'work-packages--share--bulk-selection#toggle' }))
+  )
+
+  concat(
+    render(Primer::Beta::Text.new(pl: 2, data: { 'work-packages--share--bulk-selection-target': 'sharedCounter' })) do
+      I18n.t('work_package.sharing.count', count:)
+    end
+  )
+
+  # Text contents managed by Stimulus controller
+  concat(
+    render(Primer::Beta::Text.new(pl: 2, data: { 'work-packages--share--bulk-selection-target': 'selectedCounter' }))
+  )
+%>

--- a/app/components/work_packages/share/bulk_selection_counter_component.rb
+++ b/app/components/work_packages/share/bulk_selection_counter_component.rb
@@ -30,7 +30,7 @@
 
 module WorkPackages
   module Share
-    class ShareCounterComponent < ApplicationComponent
+    class BulkSelectionCounterComponent < ApplicationComponent
       def initialize(count:)
         super
 

--- a/app/components/work_packages/share/concerns/displayable_roles.rb
+++ b/app/components/work_packages/share/concerns/displayable_roles.rb
@@ -30,17 +30,21 @@
 
 module WorkPackages
   module Share
-    class BulkPermissionButtonComponent < ApplicationComponent
-      include WorkPackages::Share::Concerns::DisplayableRoles
-
-      def initialize(work_package:)
-        super
-
-        @work_package = work_package
-      end
-
-      def update_path
-        work_package_shares_bulk_path(@work_package)
+    module Concerns
+      module DisplayableRoles
+        def options
+          [
+            { label: I18n.t('work_package.sharing.permissions.edit'),
+              value: Role::BUILTIN_WORK_PACKAGE_EDITOR,
+              description: I18n.t('work_package.sharing.permissions.edit_description') },
+            { label: I18n.t('work_package.sharing.permissions.comment'),
+              value: Role::BUILTIN_WORK_PACKAGE_COMMENTER,
+              description: I18n.t('work_package.sharing.permissions.comment_description') },
+            { label: I18n.t('work_package.sharing.permissions.view'),
+              value: Role::BUILTIN_WORK_PACKAGE_VIEWER,
+              description: I18n.t('work_package.sharing.permissions.view_description') }
+          ]
+        end
       end
     end
   end

--- a/app/components/work_packages/share/counter_component.html.erb
+++ b/app/components/work_packages/share/counter_component.html.erb
@@ -1,0 +1,10 @@
+<%=
+  component_wrapper(class: 'op-share-wp-modal-body--header--counter--container',
+                    data: { test_selector: 'op-share-wp-active-count'}) do
+    if sharing_manageable?
+      render(WorkPackages::Share::BulkSelectionCounterComponent.new(count:))
+    else
+      render(WorkPackages::Share::ShareCounterComponent.new(count:))
+    end
+  end
+%>

--- a/app/components/work_packages/share/counter_component.html.erb
+++ b/app/components/work_packages/share/counter_component.html.erb
@@ -1,13 +1,14 @@
 <%=
-  component_wrapper(class: 'op-share-wp-modal-body--header--counter--container',
-                    data: { test_selector: 'op-share-wp-active-count'}) do
-    # There's no point in rendering the BulkSelectionCounterComponent even if
-    # I'm able to manage shares if the only user that the work package is
-    # currently shared is myself, since I'm not able to manage my own share.
-    if sharing_manageable? && shared_with_anyone_else_other_than_myself?
-      render(WorkPackages::Share::BulkSelectionCounterComponent.new(count:))
-    else
-      render(WorkPackages::Share::ShareCounterComponent.new(count:))
+  component_wrapper(data: { test_selector: 'op-share-wp-active-count'}) do
+    render(Primer::Box.new(display: :flex, aligns_items: :center)) do
+      # There's no point in rendering the BulkSelectionCounterComponent even if
+      # I'm able to manage shares if the only user that the work package is
+      # currently shared is myself, since I'm not able to manage my own share.
+      if sharing_manageable? && shared_with_anyone_else_other_than_myself?
+        render(WorkPackages::Share::BulkSelectionCounterComponent.new(count:))
+      else
+        render(WorkPackages::Share::ShareCounterComponent.new(count:))
+      end
     end
   end
 %>

--- a/app/components/work_packages/share/counter_component.html.erb
+++ b/app/components/work_packages/share/counter_component.html.erb
@@ -1,7 +1,10 @@
 <%=
   component_wrapper(class: 'op-share-wp-modal-body--header--counter--container',
                     data: { test_selector: 'op-share-wp-active-count'}) do
-    if sharing_manageable?
+    # There's no point in rendering the BulkSelectionCounterComponent even if
+    # I'm able to manage shares if the only user that the work package is
+    # currently shared is myself, since I'm not able to manage my own share.
+    if sharing_manageable? && shared_with_anyone_else_other_than_myself?
       render(WorkPackages::Share::BulkSelectionCounterComponent.new(count:))
     else
       render(WorkPackages::Share::ShareCounterComponent.new(count:))

--- a/app/components/work_packages/share/counter_component.rb
+++ b/app/components/work_packages/share/counter_component.rb
@@ -30,16 +30,22 @@
 
 module WorkPackages
   module Share
-    class ShareCounterComponent < ApplicationComponent
-      def initialize(count:)
+    class CounterComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpTurbo::Streamable
+      include OpPrimer::ComponentHelpers
+      include WorkPackages::Share::Concerns::Authorization
+
+      def initialize(work_package:, count:)
         super
 
+        @work_package = work_package
         @count = count
       end
 
       private
 
-      attr_reader :count
+      attr_reader :work_package, :count
     end
   end
 end

--- a/app/components/work_packages/share/counter_component.rb
+++ b/app/components/work_packages/share/counter_component.rb
@@ -46,6 +46,12 @@ module WorkPackages
       private
 
       attr_reader :work_package, :count
+
+      def shared_with_anyone_else_other_than_myself?
+        Member.of_work_package(@work_package)
+              .where.not(principal: User.current)
+              .any?
+      end
     end
   end
 end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -31,10 +31,22 @@
                   render(WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: shared_principals.size))
                 end
 
-                header_grid.with_area(:remove, tag: :div) do
-                  form_with url: work_package_shares_bulk_path, method: :delete do
-                    concat(content_tag(:div, {}, data: { 'work-packages--share--bulk-selection-target': 'hiddenShareIdsContainer' }))
-                    concat(render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') })
+                header_grid.with_area(:actions,
+                                      tag: :div,
+                                      hidden: true, # Prevent flicker on initial render
+                                      data: { 'work-packages--share--bulk-selection-target': 'actions' }) do
+                  if sharing_manageable?
+                    concat(
+                      render(WorkPackages::Share::BulkPermissionButtonComponent.new(work_package: @work_package))
+                    )
+
+                    concat(
+                      form_with(url: work_package_shares_bulk_path,
+                                method: :delete,
+                                data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }) do
+                        render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
+                      end
+                    )
                   end
                 end
               end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -20,10 +20,24 @@
           end
         end
       else
-        modal_content.with_row(mt: 3, data: { 'test-selector': 'op-share-wp-active-list'}) do
+        modal_content.with_row(mt: 3,
+                               data: { 'test-selector': 'op-share-wp-active-list',
+                                       controller: 'work-packages--share--bulk-selection',
+                                       application_target: 'dynamic' }) do
           invited_user_list do |border_box|
-            border_box.with_header(color: :subtle, data: { 'test-selector': 'op-share-wp-active-count' }) do
-              render(WorkPackages::Share::ShareCounterComponent.new(count: shared_principals.count))
+            border_box.with_header(color: :subtle, data: { 'test-selector': 'op-share-wp-header' }) do
+              grid_layout('op-share-wp-modal-body--header', tag: :div, align_items: :center) do |header_grid|
+                header_grid.with_area(:counter, tag: :div) do
+                  render(WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: shared_principals.size))
+                end
+
+                header_grid.with_area(:remove, tag: :div) do
+                  form_with url: work_package_shares_bulk_path, method: :delete do
+                    concat(content_tag(:div, {}, data: { 'work-packages--share--bulk-selection-target': 'hiddenShareIdsContainer' }))
+                    concat(render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') })
+                  end
+                end
+              end
             end
 
             shared_principals.each do |principal|
@@ -31,8 +45,7 @@
                                .where(entity: @work_package)
                                .first
 
-              render(WorkPackages::Share::ShareRowComponent.new(share:,
-                                                                container: border_box))
+              render(WorkPackages::Share::ShareRowComponent.new(share:, container: border_box))
             end
           end
         end

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -32,6 +32,7 @@ module WorkPackages
       include ApplicationHelper
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
+      include WorkPackages::Share::Concerns::Authorization
 
       def initialize(work_package:)
         super

--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -1,6 +1,13 @@
 .op-share-wp-modal-body
   &--user-row
     display: grid
-    grid-template-columns: 1fr auto auto
-    grid-template-areas: "user button remove"
+    grid-template-columns: 20px 1fr auto auto
+    grid-template-areas: "selection user button remove"
     grid-gap: 10px
+  &--header
+    display: grid
+    grid-template-columns: 1fr auto
+    grid-template-areas: "counter remove"
+    &--counter
+      &--container
+        display: flex // Vertically align checkbox and counter

--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -5,7 +5,7 @@
     grid-template-areas: "user"
     grid-column-gap: 10px
 
-    &-manageable
+    &_manageable
       display: grid
       grid-template-columns: 20px 1fr auto auto
       grid-template-areas: "selection user button remove"

--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -16,7 +16,3 @@
     grid-template-columns: 1fr auto
     grid-template-areas: "counter actions"
     grid-column-gap: 10px
-    &--counter
-      &--container
-        display: flex // Vertically align checkbox and counter
-        align-items: center

--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -1,13 +1,22 @@
 .op-share-wp-modal-body
   &--user-row
     display: grid
-    grid-template-columns: 20px 1fr auto auto
-    grid-template-areas: "selection user button remove"
-    grid-gap: 10px
+    grid-template-columns: 1fr
+    grid-template-areas: "user"
+    grid-column-gap: 10px
+
+    &-manageable
+      display: grid
+      grid-template-columns: 20px 1fr auto auto
+      grid-template-areas: "selection user button remove"
+      grid-column-gap: 10px
+
   &--header
     display: grid
     grid-template-columns: 1fr auto
-    grid-template-areas: "counter remove"
+    grid-template-areas: "counter actions"
+    grid-column-gap: 10px
     &--counter
       &--container
         display: flex // Vertically align checkbox and counter
+        align-items: center

--- a/app/components/work_packages/share/permission_button_component.html.erb
+++ b/app/components/work_packages/share/permission_button_component.html.erb
@@ -1,25 +1,28 @@
 <%=
-  render(Primer::Alpha::ActionMenu.new(**{ select_variant: :single,
-                                         dynamic_label: true,
-                                         anchor_align: :end,
-                                         color: :subtle }
-                                         .deep_merge(@system_arguments))) do |menu|
-    menu.with_show_button do |button|
-      button.with_trailing_action_icon(icon: :"triangle-down")
-      permission_name(active_role.builtin)
-    end
-    options.each do |option|
-      menu.with_item(label: option[:label],
-                     href: update_path,
-                     method: :patch,
-                     active: option_active?(option),
-                     data: { value: option[:value] },
-                     form_arguments: {
+  component_wrapper do
+    render(Primer::Alpha::ActionMenu.new(**{ select_variant: :single,
+                                             dynamic_label: true,
+                                             anchor_align: :end,
+                                             color: :subtle }.deep_merge(@system_arguments))) do |menu|
+      menu.with_show_button(data: { 'work-packages--share--bulk-selection-target': 'userRowRole',
+                                    'share-id': share.id,
+                                    'active-role-name': permission_name(active_role.builtin)}) do |button|
+        button.with_trailing_action_icon(icon: :"triangle-down")
+        permission_name(active_role.builtin)
+      end
+      options.each do |option|
+        menu.with_item(label: option[:label],
+                       href: update_path,
                        method: :patch,
-                       name: 'role_ids[]',
-                       value: option[:value]
-                     }) do |item|
-        item.with_description.with_content(option[:description])
+                       active: option_active?(option),
+                       data: { value: option[:value] },
+                       form_arguments: {
+                         method: :patch,
+                         name: 'role_ids[]',
+                         value: option[:value]
+                       }) do |item|
+          item.with_description.with_content(option[:description])
+        end
       end
     end
   end

--- a/app/components/work_packages/share/permission_button_component.rb
+++ b/app/components/work_packages/share/permission_button_component.rb
@@ -32,6 +32,7 @@ module WorkPackages
       include ApplicationHelper
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
+      include WorkPackages::Share::Concerns::DisplayableRoles
 
       def initialize(share:, **system_arguments)
         super
@@ -59,20 +60,6 @@ module WorkPackages
       private
 
       attr_reader :share
-
-      def options
-        [
-          { label: I18n.t('work_package.sharing.permissions.edit'),
-            value: Role::BUILTIN_WORK_PACKAGE_EDITOR,
-            description: I18n.t('work_package.sharing.permissions.edit_description') },
-          { label: I18n.t('work_package.sharing.permissions.comment'),
-            value: Role::BUILTIN_WORK_PACKAGE_COMMENTER,
-            description: I18n.t('work_package.sharing.permissions.comment_description') },
-          { label: I18n.t('work_package.sharing.permissions.view'),
-            value: Role::BUILTIN_WORK_PACKAGE_VIEWER,
-            description: I18n.t('work_package.sharing.permissions.view_description') }
-        ]
-      end
 
       def active_role
         if share.persisted?

--- a/app/components/work_packages/share/share_counter_component.html.erb
+++ b/app/components/work_packages/share/share_counter_component.html.erb
@@ -1,5 +1,5 @@
 <%
   concat(render(Primer::Beta::Octicon.new(icon: 'person')))
 
-  concat(render(Primer::Beta::Text.new(pl: 2)) { I18n.t('work_package.sharing.count', count:) })
+  concat(render(Primer::Beta::Text.new(ml: 2)) { I18n.t('work_package.sharing.count', count:) })
 %>

--- a/app/components/work_packages/share/share_counter_component.html.erb
+++ b/app/components/work_packages/share/share_counter_component.html.erb
@@ -1,5 +1,5 @@
-<%=
-  component_wrapper do
-    I18n.t('work_package.sharing.count', count:)
-  end
+<%
+  concat(render(Primer::Beta::Octicon.new(icon: 'person')))
+
+  concat(render(Primer::Beta::Text.new(pl: 2)) { I18n.t('work_package.sharing.count', count:) })
 %>

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -1,14 +1,14 @@
 <%=
   component_wrapper(:border_box_row, data: { 'test-selector': "op-share-wp-active-user-#{principal.id}" }) do
-    grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
+    grid_layout(grid_css_classes, tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
       user_row_grid.with_area(:selection, tag: :div) do
         if share_editable?
           render(Primer::Alpha::CheckBox.new(name: "share_ids", value: share.id, label: "#{principal.name}",
-                                             visually_hide_label: true, scheme: :array,
-                                             data: {
-                                               'work-packages--share--bulk-selection-target': 'shareCheckbox',
-                                               action: 'work-packages--share--bulk-selection#refresh'
-                                             }))
+                                                    visually_hide_label: true, scheme: :array,
+                                                    data: {
+                                                      'work-packages--share--bulk-selection-target': 'shareCheckbox',
+                                                      action: 'work-packages--share--bulk-selection#refresh'
+                                                    }))
         end
       end
 

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -1,10 +1,20 @@
 <%=
   component_wrapper(:border_box_row, data: { 'test-selector': "op-share-wp-active-user-#{principal.id}" }) do
     grid_layout('op-share-wp-modal-body--user-row', tag: :div, align_items: :center, classes: 'ellipsis') do |user_row_grid|
-      user_row_grid.with_area(:user, tag: :div, classes: '  ellipsis') do
-        render(Users::AvatarComponent.new(user: principal, size: :medium))
+      user_row_grid.with_area(:selection, tag: :div) do
+        if share_editable?
+          render(Primer::Alpha::CheckBox.new(name: "share_ids", value: share.id, label: "#{principal.name}",
+                                             visually_hide_label: true, scheme: :array,
+                                             data: {
+                                               'work-packages--share--bulk-selection-target': 'shareCheckbox',
+                                               action: 'work-packages--share--bulk-selection#refresh'
+                                             }))
+        end
       end
 
+      user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
+        render(Users::AvatarComponent.new(user: principal, size: :medium))
+      end
 
       if share_editable?
         user_row_grid.with_area(:button, tag: :div, color: :subtle) do

--- a/app/components/work_packages/share/share_row_component.rb
+++ b/app/components/work_packages/share/share_row_component.rb
@@ -72,7 +72,7 @@ module WorkPackages
 
       def grid_css_classes
         if sharing_manageable?
-          'op-share-wp-modal-body--user-row-manageable'
+          'op-share-wp-modal-body--user-row_manageable'
         else
           'op-share-wp-modal-body--user-row'
         end

--- a/app/components/work_packages/share/share_row_component.rb
+++ b/app/components/work_packages/share/share_row_component.rb
@@ -69,6 +69,16 @@ module WorkPackages
       def share_editable?
         @share_editable ||= User.current != share.principal && sharing_manageable?
       end
+
+      def select_share_checkbox_options
+        {
+          name: "share_ids",
+          value: share.id,
+          scheme: :array,
+          label: principal.name,
+          visually_hide_label: true
+        }
+      end
     end
   end
 end

--- a/app/components/work_packages/share/share_row_component.rb
+++ b/app/components/work_packages/share/share_row_component.rb
@@ -70,6 +70,14 @@ module WorkPackages
         @share_editable ||= User.current != share.principal && sharing_manageable?
       end
 
+      def grid_css_classes
+        if sharing_manageable?
+          'op-share-wp-modal-body--user-row-manageable'
+        else
+          'op-share-wp-modal-body--user-row'
+        end
+      end
+
       def select_share_checkbox_options
         {
           name: "share_ids",

--- a/app/controllers/work_packages/shares/bulk_controller.rb
+++ b/app/controllers/work_packages/shares/bulk_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class WorkPackages::Shares::BulkController < ApplicationController
+  include OpTurbo::ComponentStream
+
+  before_action :find_work_package
+  before_action :find_shares
+  before_action :find_project
+  before_action :authorize
+
+  def update; end
+
+  def destroy
+    @shares.each do |share|
+      WorkPackageMembers::DeleteService
+        .new(user: current_user, model: share)
+        .call
+    end
+
+    if current_visible_member_count.zero?
+      respond_with_replace_modal
+    else
+      respond_with_remove_shares
+    end
+  end
+
+  private
+
+  def respond_with_replace_modal
+    replace_via_turbo_stream(
+      component: WorkPackages::Share::ModalBodyComponent.new(work_package: @work_package)
+    )
+
+    respond_with_turbo_streams
+  end
+
+  def respond_with_remove_shares
+    @shares.each do |share|
+      remove_via_turbo_stream(
+        component: WorkPackages::Share::ShareRowComponent.new(share:)
+      )
+    end
+
+    update_via_turbo_stream(
+      component: WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: current_visible_member_count)
+    )
+
+    respond_with_turbo_streams
+  end
+
+  def find_work_package
+    @work_package = WorkPackage.find(params[:work_package_id])
+  end
+
+  def find_project
+    @project = @work_package.project
+  end
+
+  def find_shares
+    @shares = Member.of_work_package(@work_package).where(id: params[:share_ids])
+  end
+
+  def current_visible_member_count
+    @current_visible_member_count ||= Member
+                                        .joins(:member_roles)
+                                        .of_work_package(@work_package)
+                                        .merge(MemberRole.only_non_inherited)
+                                        .size
+  end
+end

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -89,7 +89,7 @@ class WorkPackages::SharesController < ApplicationController
     )
 
     update_via_turbo_stream(
-      component: WorkPackages::Share::ShareCounterComponent.new(count: current_visible_member_count)
+      component: WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: current_visible_member_count)
     )
 
     prepend_via_turbo_stream(
@@ -106,7 +106,7 @@ class WorkPackages::SharesController < ApplicationController
     )
 
     update_via_turbo_stream(
-      component: WorkPackages::Share::ShareCounterComponent.new(count: current_visible_member_count)
+      component: WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: current_visible_member_count)
     )
 
     respond_with_turbo_streams

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -58,7 +58,7 @@ class WorkPackages::SharesController < ApplicationController
       .new(user: current_user, model: @share)
       .call(role_ids: find_role_ids(params[:role_ids]))
 
-    head :no_content
+    respond_with_update_permission_button
   end
 
   def destroy
@@ -95,6 +95,15 @@ class WorkPackages::SharesController < ApplicationController
     prepend_via_turbo_stream(
       component: WorkPackages::Share::ShareRowComponent.new(share: @share),
       target_component: WorkPackages::Share::ModalBodyComponent.new(work_package: @work_package)
+    )
+
+    respond_with_turbo_streams
+  end
+
+  def respond_with_update_permission_button
+    replace_via_turbo_stream(
+      component: WorkPackages::Share::PermissionButtonComponent.new(share: @share,
+                                                                    data: { 'test-selector': 'op-share-wp-update-role' })
     )
 
     respond_with_turbo_streams

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -118,7 +118,8 @@ Rails.application.reloader.to_prepare do
 
       map.permission :share_work_packages,
                      {
-                       'work_packages/shares': %i[index create destroy update]
+                       'work_packages/shares': %i[index create destroy update],
+                       'work_packages/shares/bulk': %i[update destroy]
                      },
                      permissible_on: :project,
                      dependencies: %i[edit_work_packages view_shared_work_packages],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3201,6 +3201,7 @@ en:
       invite: "Invite"
       label_search: "Search for users to invite"
       label_search_placeholder: "Search by user or email address"
+      label_toggle_all: "Toggle all shares"
       permissions:
         comment: "Comment"
         comment_description: "Can view and comment this work package."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1099,6 +1099,8 @@ en:
         share: 'Share'
         title: "Share work package"
         selected_count: "%{count} selected"
+        selection:
+          mixed: "Mixed"
       table:
         configure_button: 'Configure work package table'
         summary: "Table with rows of work package and columns of work package attributes."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1098,6 +1098,7 @@ en:
       sharing:
         share: 'Share'
         title: "Share work package"
+        selected_count: "%{count} selected"
       table:
         configure_button: 'Configure work package table'
         summary: "Table with rows of work package and columns of work package attributes."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -468,7 +468,11 @@ OpenProject::Application.routes.draw do
     get 'details/*state' => 'work_packages#index', on: :collection, as: :details
 
     # Rails managed sharing route
-    resources :shares, controller: 'work_packages/shares', only: %i[index create]
+    resources :shares, controller: 'work_packages/shares', only: %i[index create] do
+      collection do
+        resource :bulk, controller: 'work_packages/shares/bulk', only: %i[update destroy], as: :shares_bulk
+      end
+    end
 
     # states managed by client-side (angular) routing on work_package#show
     get '/' => 'work_packages#index', on: :collection, as: 'index'

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
@@ -46,7 +46,8 @@ export default class BulkSelectionController extends Controller {
     'bulkForm',
     'hiddenShare',
     'userRowRole',
-    'bulkUpdateRole',
+    'bulkUpdateRoleLabel',
+    'bulkUpdateRoleForm',
   ];
 
   // Checkboxes
@@ -59,12 +60,14 @@ export default class BulkSelectionController extends Controller {
 
   // Bulk Forms
   declare readonly bulkFormTargets:HTMLFormElement[];
+  // Specific target for bulk update permission forms
+  declare readonly bulkUpdateRoleFormTargets:HTMLFormElement[];
   declare readonly hiddenShareTargets:HTMLInputElement[];
   declare readonly actionsTarget:HTMLElement;
 
   // Permission Buttons
   declare readonly userRowRoleTargets:HTMLButtonElement[];
-  declare readonly bulkUpdateRoleTarget:HTMLButtonElement;
+  declare readonly bulkUpdateRoleLabelTarget:HTMLButtonElement;
 
   // Refresh when a user is invited
   shareCheckboxTargetConnected() {
@@ -91,11 +94,15 @@ export default class BulkSelectionController extends Controller {
   // as the updated share might have been selected and the label
   // may no longer be correct
   userRowRoleTargetConnected() {
+    if (this.checked.length === 0) {
+      return;
+    }
+
     this.updateBulkUpdateRoleLabelValue();
   }
 
   bulkUpdateRoleLabelValueChanged(current:string, _old:string) {
-    const label = this.bulkUpdateRoleTarget.querySelector('.Button-label') as HTMLElement;
+    const label = this.bulkUpdateRoleLabelTarget.querySelector('.Button-label') as HTMLElement;
     label.textContent = current;
   }
 
@@ -122,9 +129,9 @@ export default class BulkSelectionController extends Controller {
       this.actionsTarget.setAttribute('hidden', 'true');
     } else {
       this.actionsTarget.removeAttribute('hidden');
+      this.updateBulkUpdateRoleLabelValue();
     }
 
-    this.updateBulkUpdateRoleLabelValue();
     this.updateCounter();
   }
 
@@ -138,8 +145,14 @@ export default class BulkSelectionController extends Controller {
   private updateBulkUpdateRoleLabelValue() {
     if (new Set(this.selectedPermissions).size > 1) {
       this.bulkUpdateRoleLabelValue = I18n.t('js.work_packages.sharing.selection.mixed');
+      this.bulkPermissionButtons.forEach((button) => button.setAttribute('aria-checked', 'false'));
     } else {
       this.bulkUpdateRoleLabelValue = this.selectedPermissions[0];
+      const bulkUpdateRoleForm = this.bulkUpdateRoleFormTargets.find((form) => {
+        return form.getAttribute('data-role-name') === this.bulkUpdateRoleLabelValue.trim();
+      }) as HTMLFormElement;
+      const button = bulkUpdateRoleForm.querySelector('button[type=submit]') as HTMLButtonElement;
+      button.setAttribute('aria-checked', 'true');
     }
   }
 
@@ -183,6 +196,12 @@ export default class BulkSelectionController extends Controller {
       hiddenInput.setAttribute('data-work-packages--share--bulk-selection-target', 'hiddenShare');
 
       return hiddenInput;
+    });
+  }
+
+  private get bulkPermissionButtons():HTMLButtonElement[] {
+    return this.bulkUpdateRoleFormTargets.map((bulkUpdateForm) => {
+      return bulkUpdateForm.querySelector('button[type=submit]') as HTMLButtonElement;
     });
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
@@ -1,0 +1,121 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class BulkSelectionController extends Controller {
+  static targets = [
+    'toggleAll',
+    'sharedCounter',
+    'selectedCounter',
+    'shareCheckbox',
+    'hiddenShareIdsContainer',
+  ];
+
+  declare readonly toggleAllTarget:HTMLInputElement;
+  declare readonly sharedCounterTarget:HTMLElement;
+  declare readonly selectedCounterTarget:HTMLElement;
+  declare readonly shareCheckboxTargets:HTMLInputElement[];
+  declare readonly hiddenShareIdsContainerTargets:HTMLElement[];
+
+  toggleAllTargetConnected() {
+    this.refresh();
+  }
+
+  shareCheckboxTargetConnected() {
+    this.refresh();
+  }
+
+  shareCheckboxTargetDisconnected() {
+    this.refresh();
+  }
+
+  toggle(e:Event) {
+    e.preventDefault();
+
+    this.shareCheckboxTargets.forEach((share) => {
+      share.checked = this.toggleAllTarget.checked;
+    });
+
+    this.shareCheckboxTargets.forEach((share) => {
+      this.triggerInputEvent((share));
+    });
+
+    this.updateCounter();
+  }
+
+  triggerInputEvent(checkbox:HTMLInputElement) {
+    const event = new Event('input', { bubbles: false, cancelable: true });
+    checkbox.dispatchEvent(event);
+  }
+
+  refresh() {
+    const checkedSharesCount = this.checked.length;
+    const sharesCount = this.shareCheckboxTargets.length;
+
+    this.toggleAllTarget.checked = checkedSharesCount === sharesCount;
+    this.updateCounter();
+  }
+
+  updateCounter() {
+    if (this.checked.length === 0) {
+      this.sharedCounterTarget.removeAttribute('hidden');
+      this.selectedCounterTarget.setAttribute('hidden', 'true');
+    } else {
+      this.sharedCounterTarget.setAttribute('hidden', 'true');
+      this.selectedCounterTarget.removeAttribute('hidden');
+      this.selectedCounterTarget.textContent = I18n.t('js.work_packages.sharing.selected_count', { count: this.checked.length });
+    }
+
+    this.hiddenShareIdsContainerTargets.forEach((checkboxIdsContainer) => {
+      checkboxIdsContainer.innerHTML = '';
+      const hiddenShareIds = this.createHiddenShareIds();
+      hiddenShareIds.forEach((hiddenShare) => checkboxIdsContainer.appendChild(hiddenShare));
+    });
+  }
+
+  createHiddenShareIds() {
+    return this.checked.map((checkbox) => {
+      const hiddenInput = document.createElement('input');
+      hiddenInput.type = 'hidden';
+      hiddenInput.name = 'share_ids[]';
+      hiddenInput.value = checkbox.value;
+      return hiddenInput;
+    });
+  }
+
+  get checked() {
+    return this.shareCheckboxTargets.filter((checkbox) => checkbox.checked);
+  }
+
+  get unchecked() {
+    return this.shareCheckboxTargets.filter((checkbox) => !checkbox.checked);
+  }
+}

--- a/spec/features/work_packages/share/bulk_sharing_spec.rb
+++ b/spec/features/work_packages/share/bulk_sharing_spec.rb
@@ -43,8 +43,17 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
                                           share_work_packages])
   end
 
-  shared_let(:sharer)       { create(:user, firstname: 'Sharer', lastname: 'User')   }
-  shared_let(:project)      { create(:project, members: { sharer => [sharer_role] }) }
+  shared_let(:viewer_role) do
+    create(:project_role, permissions: %i[view_work_packages
+                                          view_shared_work_packages])
+  end
+
+  shared_let(:sharer) { create(:user, firstname: 'Sharer', lastname: 'User') }
+  shared_let(:viewer) { create(:user, firstname: 'Viewer', lastname: 'User') }
+
+  shared_let(:project) do
+    create(:project, members: { sharer => [sharer_role], viewer => [viewer_role] })
+  end
 
   shared_let(:dinesh)   { create(:user, firstname: 'Dinesh', lastname: 'Chugtai')    }
   shared_let(:gilfoyle) { create(:user, firstname: 'Bertram', lastname: 'Gilfoyle')  }
@@ -61,9 +70,9 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
   let(:work_package_page) { Pages::FullWorkPackage.new(work_package)               }
   let(:share_modal)       { Components::WorkPackages::ShareModal.new(work_package) }
 
-  current_user { sharer }
-
   context 'when having share permission' do
+    current_user { sharer }
+
     it 'allows administrating shares in bulk' do
       work_package_page.visit!
 
@@ -72,52 +81,72 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
       share_modal.expect_shared_count_of(3)
 
       aggregate_failures "Selection behavior" do
+        # Bulk actions hidden until at least one selection
+        share_modal.expect_bulk_actions_not_available
+
         # Selecting one individually
         share_modal.select_shares(richard)
         share_modal.expect_selected(richard)
         share_modal.expect_selected_count_of(1)
         share_modal.expect_select_all_untoggled
+        # Available now
+        share_modal.expect_bulk_actions_available
+        share_modal.expect_bulk_update_label('View')
 
         # Toggling all selects all
         share_modal.toggle_select_all
         share_modal.expect_selected(richard, dinesh, gilfoyle)
         share_modal.expect_selected_count_of(3)
         share_modal.expect_select_all_toggled
+        share_modal.expect_bulk_actions_available
+        share_modal.expect_bulk_update_label('Mixed')
 
         # Deselecting one individually
         share_modal.deselect_shares(richard)
         share_modal.expect_selected(dinesh, gilfoyle)
         share_modal.expect_selected_count_of(2)
         share_modal.expect_select_all_untoggled
+        share_modal.expect_bulk_actions_available
+        share_modal.expect_bulk_update_label('Mixed')
 
         # Re-selecting the missing share
         share_modal.select_shares(richard)
         share_modal.expect_selected(richard, dinesh, gilfoyle)
         share_modal.expect_selected_count_of(3)
         share_modal.expect_select_all_toggled
+        share_modal.expect_bulk_actions_available
+        share_modal.expect_bulk_update_label('Mixed')
 
         # De-selecting all
         share_modal.toggle_select_all
         share_modal.expect_deselected(richard, dinesh, gilfoyle)
         share_modal.expect_shared_count_of(3)
         share_modal.expect_select_all_untoggled
+        # No longer available
+        share_modal.expect_bulk_actions_not_available
 
         # Re-selecting all
         share_modal.toggle_select_all
         share_modal.expect_selected(richard, dinesh, gilfoyle)
         share_modal.expect_selected_count_of(3)
         share_modal.expect_select_all_toggled
+        # Available again
+        share_modal.expect_bulk_actions_available
+        share_modal.expect_bulk_update_label('Mixed')
 
         # De-selecting all individually
         share_modal.deselect_shares(richard, dinesh, gilfoyle)
         share_modal.expect_shared_count_of(3)
         share_modal.expect_select_all_untoggled
+        # No longer available
+        share_modal.expect_bulk_actions_not_available
       end
 
-      aggregate_failures "Preserving selected states when performing individual updates" do
+      aggregate_failures "Preserving selected states when performing individual deletions" do
         share_modal.select_shares(richard, dinesh)
         share_modal.expect_selected_count_of(2)
         share_modal.expect_select_all_untoggled
+        share_modal.expect_bulk_update_label('Mixed')
 
         share_modal.remove_user(gilfoyle)
         share_modal.expect_not_shared_with(gilfoyle)
@@ -125,16 +154,47 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
         share_modal.expect_selected(richard, dinesh)
         share_modal.expect_selected_count_of(2)
         share_modal.expect_select_all_toggled
+        share_modal.expect_bulk_update_label('Mixed')
 
         share_modal.invite_user(gilfoyle, 'Comment')
         share_modal.expect_shared_with(gilfoyle)
         share_modal.expect_selected(richard, dinesh)
         share_modal.expect_selected_count_of(2)
         share_modal.expect_select_all_untoggled
+        share_modal.expect_bulk_update_label('Mixed')
       end
 
+      aggregate_failures "Preserving selected states when performing individual updates" do
+        share_modal.change_role(gilfoyle, 'View')
+        share_modal.expect_shared_with(gilfoyle, 'View')
+
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_untoggled
+        share_modal.expect_bulk_update_label('Mixed')
+
+        share_modal.toggle_select_all
+        share_modal.expect_selected_count_of(3)
+        share_modal.expect_select_all_toggled
+        share_modal.expect_bulk_update_label('Mixed')
+
+        share_modal.change_role(gilfoyle, 'Edit')
+        share_modal.expect_shared_with(gilfoyle, 'Edit')
+        share_modal.expect_selected_count_of(3)
+        share_modal.expect_select_all_toggled
+        share_modal.expect_bulk_update_label('Mixed')
+      end
+
+      # Reset
+      share_modal.toggle_select_all
+      share_modal.expect_select_all_untoggled
+
       aggregate_failures "Bulk deletion" do
-        # Richard and Dinesh already selected from above
+        share_modal.select_shares(richard, dinesh)
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_untoggled
+
         share_modal.bulk_remove
 
         share_modal.expect_not_shared_with(richard, dinesh)
@@ -142,12 +202,101 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
         share_modal.expect_shared_count_of(1)
 
         share_modal.select_shares(gilfoyle)
+        share_modal.expect_selected(gilfoyle)
         share_modal.expect_selected_count_of(1)
         share_modal.expect_select_all_toggled
         share_modal.bulk_remove
 
         share_modal.expect_blankslate
       end
+
+      # Re-populate
+      share_modal.invite_user(richard, 'View')
+      share_modal.expect_shared_with(richard)
+      share_modal.invite_user(dinesh, 'Comment')
+      share_modal.expect_shared_with(dinesh)
+
+      aggregate_failures 'Bulk updating' do
+        share_modal.select_shares(richard)
+        share_modal.expect_selected(richard)
+        share_modal.expect_selected_count_of(1)
+        share_modal.expect_bulk_update_label('View')
+
+        share_modal.bulk_update('Edit')
+
+        share_modal.expect_shared_with(richard, 'Edit')
+        share_modal.expect_shared_with(dinesh, 'Comment')
+        share_modal.expect_selected(richard)
+        share_modal.expect_selected_count_of(1)
+        share_modal.expect_bulk_update_label('Edit')
+
+        share_modal.select_shares(richard, dinesh)
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_bulk_update_label('Mixed')
+
+        share_modal.bulk_update('View')
+
+        share_modal.expect_shared_with(richard, 'View')
+        share_modal.expect_shared_with(dinesh, 'View')
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_bulk_update_label('View')
+
+        share_modal.toggle_select_all
+        share_modal.expect_deselected(richard, dinesh)
+        share_modal.expect_shared_count_of(2)
+      end
+
+      aggregate_failures "Bulk selection disabled when current user is the only shared with user" do
+        create(:work_package_member,
+               principal: current_user,
+               entity: work_package,
+               roles: [comment_work_package_role])
+
+        share_modal.close
+        share_modal.expect_closed
+        click_button 'Share'
+        share_modal.expect_open
+
+        share_modal.expect_shared_count_of(3)
+        share_modal.expect_select_all_available
+
+        share_modal.remove_user(richard)
+        share_modal.expect_not_shared_with(richard)
+        share_modal.remove_user(dinesh)
+        share_modal.expect_not_shared_with(dinesh)
+
+        share_modal.expect_shared_count_of(1)
+        share_modal.expect_select_all_not_available
+        share_modal.expect_bulk_actions_not_available
+
+        share_modal.invite_user(richard, 'View')
+        share_modal.expect_shared_with(richard, 'View')
+        share_modal.expect_shared_count_of(2)
+
+        share_modal.expect_select_all_available
+      end
+    end
+  end
+
+  context 'without share permission' do
+    current_user { viewer }
+
+    it 'does not allow bulk sharing' do
+      work_package_page.visit!
+
+      click_button 'Share'
+      share_modal.expect_open
+
+      share_modal.expect_shared_count_of(3)
+      share_modal.expect_shared_with(richard, editable: false)
+      share_modal.expect_shared_with(dinesh,  editable: false)
+      share_modal.expect_shared_with(gilfoyle, editable: false)
+
+      share_modal.expect_select_all_not_available
+      share_modal.expect_bulk_actions_not_available
+      share_modal.expect_not_selectable(richard, dinesh, gilfoyle)
     end
   end
 end

--- a/spec/features/work_packages/share/bulk_sharing_spec.rb
+++ b/spec/features/work_packages/share/bulk_sharing_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Work Packages', 'Bulk Sharing',
+               :js, :with_cuprite,
+               with_flag: { work_package_sharing: true } do
+  shared_let(:view_work_package_role)    { create(:view_work_package_role)    }
+  shared_let(:comment_work_package_role) { create(:comment_work_package_role) }
+  shared_let(:edit_work_package_role)    { create(:edit_work_package_role)    }
+
+  shared_let(:sharer_role) do
+    create(:project_role, permissions: %i[view_work_packages
+                                          view_shared_work_packages
+                                          share_work_packages])
+  end
+
+  shared_let(:sharer)       { create(:user, firstname: 'Sharer', lastname: 'User')   }
+  shared_let(:project)      { create(:project, members: { sharer => [sharer_role] }) }
+
+  shared_let(:dinesh)   { create(:user, firstname: 'Dinesh', lastname: 'Chugtai')    }
+  shared_let(:gilfoyle) { create(:user, firstname: 'Bertram', lastname: 'Gilfoyle')  }
+  shared_let(:richard)  { create(:user, firstname: 'Richard', lastname: 'Hendricks') }
+
+  shared_let(:work_package) do
+    create(:work_package, project:) do |wp|
+      create(:work_package_member, principal: richard,  entity: wp, roles: [view_work_package_role])
+      create(:work_package_member, principal: dinesh,   entity: wp, roles: [edit_work_package_role])
+      create(:work_package_member, principal: gilfoyle, entity: wp, roles: [comment_work_package_role])
+    end
+  end
+
+  let(:work_package_page) { Pages::FullWorkPackage.new(work_package)               }
+  let(:share_modal)       { Components::WorkPackages::ShareModal.new(work_package) }
+
+  current_user { sharer }
+
+  context 'when having share permission' do
+    it 'allows administrating shares in bulk' do
+      work_package_page.visit!
+
+      click_button 'Share'
+      share_modal.expect_open
+      share_modal.expect_shared_count_of(3)
+
+      aggregate_failures "Selection behavior" do
+        # Selecting one individually
+        share_modal.select_shares(richard)
+        share_modal.expect_selected(richard)
+        share_modal.expect_selected_count_of(1)
+        share_modal.expect_select_all_untoggled
+
+        # Toggling all selects all
+        share_modal.toggle_select_all
+        share_modal.expect_selected(richard, dinesh, gilfoyle)
+        share_modal.expect_selected_count_of(3)
+        share_modal.expect_select_all_toggled
+
+        # Deselecting one individually
+        share_modal.deselect_shares(richard)
+        share_modal.expect_selected(dinesh, gilfoyle)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_untoggled
+
+        # Re-selecting the missing share
+        share_modal.select_shares(richard)
+        share_modal.expect_selected(richard, dinesh, gilfoyle)
+        share_modal.expect_selected_count_of(3)
+        share_modal.expect_select_all_toggled
+
+        # De-selecting all
+        share_modal.toggle_select_all
+        share_modal.expect_deselected(richard, dinesh, gilfoyle)
+        share_modal.expect_shared_count_of(3)
+        share_modal.expect_select_all_untoggled
+
+        # Re-selecting all
+        share_modal.toggle_select_all
+        share_modal.expect_selected(richard, dinesh, gilfoyle)
+        share_modal.expect_selected_count_of(3)
+        share_modal.expect_select_all_toggled
+
+        # De-selecting all individually
+        share_modal.deselect_shares(richard, dinesh, gilfoyle)
+        share_modal.expect_shared_count_of(3)
+        share_modal.expect_select_all_untoggled
+      end
+
+      aggregate_failures "Preserving selected states when performing individual updates" do
+        share_modal.select_shares(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_untoggled
+
+        share_modal.remove_user(gilfoyle)
+        share_modal.expect_not_shared_with(gilfoyle)
+
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_toggled
+
+        share_modal.invite_user(gilfoyle, 'Comment')
+        share_modal.expect_shared_with(gilfoyle)
+        share_modal.expect_selected(richard, dinesh)
+        share_modal.expect_selected_count_of(2)
+        share_modal.expect_select_all_untoggled
+      end
+
+      aggregate_failures "Bulk deletion" do
+        # Richard and Dinesh already selected from above
+        share_modal.bulk_remove
+
+        share_modal.expect_not_shared_with(richard, dinesh)
+        share_modal.expect_shared_with(gilfoyle)
+        share_modal.expect_shared_count_of(1)
+
+        share_modal.select_shares(gilfoyle)
+        share_modal.expect_selected_count_of(1)
+        share_modal.expect_select_all_toggled
+        share_modal.bulk_remove
+
+        share_modal.expect_blankslate
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -192,6 +192,8 @@ RSpec.describe 'Work package sharing',
         # Updating a group's share role also propagates to the inherited member roles of
         # its users
         share_modal.change_role(not_shared_yet_with_group, 'Comment')
+        wait_for_network_idle
+
         share_modal.expect_shared_with(not_shared_yet_with_group, 'Comment')
         share_modal.expect_shared_count_of(8)
         expect(inherited_member_roles(group: not_shared_yet_with_group))
@@ -206,12 +208,13 @@ RSpec.describe 'Work package sharing',
         # When removing a group's share, its users also get their inherited member roles removed
         # while keeping member roles that were granted independently of the group
         share_modal.remove_user(not_shared_yet_with_group)
+        wait_for_network_idle
+
         share_modal.expect_not_shared_with(not_shared_yet_with_group)
         share_modal.expect_not_shared_with(richard)
         share_modal.expect_shared_with(dinesh, 'Edit')
         share_modal.expect_shared_with(gilfoyle, 'Comment')
         share_modal.expect_shared_count_of(7)
-
         expect(inherited_member_roles(group: not_shared_yet_with_group))
           .to be_empty
 

--- a/spec/routing/work_package/shares/bulk_spec.rb
+++ b/spec/routing/work_package/shares/bulk_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Work package bulk sharing routing' do
+  describe 'DELETE /work_packages/:work_package_id/shares' do
+    it 'routes to work_packages/shares/bulk#destroy' do
+      expect(delete('/work_packages/1/shares/bulk'))
+        .to route_to(controller: 'work_packages/shares/bulk',
+                     action: 'destroy',
+                     work_package_id: '1')
+    end
+  end
+
+  describe 'PATCH /work_packages/:work_package_id/shares' do
+    it 'routes to work_packages/shares/bulk#update' do
+      expect(patch('/work_packages/1/shares/bulk'))
+        .to route_to(controller: 'work_packages/shares/bulk',
+                     action: 'update',
+                     work_package_id: '1')
+    end
+  end
+end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -155,7 +155,32 @@ module Components
           expect(page)
             .to have_css('[data-test-selector="op-share-wp-bulk-update-role"] .Button-label',
                          text: label_text)
+          if label_text == 'Mixed'
+            %w[View Comment Edit].each do |permission_name|
+              within bulk_update_form(permission_name) do
+                expect(page)
+                  .to have_css(unchecked_permission, visible: :all)
+              end
+            end
+          else
+            within bulk_update_form(label_text) do
+              expect(page)
+                .to have_css(checked_permission, visible: :all)
+            end
+          end
         end
+      end
+
+      def bulk_update_form(permission_name)
+        find("[data-test-selector='op-share-wp-bulk-update-role-permission-#{permission_name}']", visible: :all)
+      end
+
+      def checked_permission
+        'button[type=submit][aria-checked=true]'
+      end
+
+      def unchecked_permission
+        'button[type=submit][aria-checked="false"]'
       end
 
       def expect_blankslate

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -61,6 +61,14 @@ module Components
         end
       end
 
+      def expect_not_selectable(*principals)
+        principals.each do |principal|
+          within user_row(principal) do
+            expect(page).not_to have_field(principal.name)
+          end
+        end
+      end
+
       def toggle_select_all
         within shares_header do
           if page.find_field('toggle_all').checked?
@@ -92,6 +100,16 @@ module Components
           .to have_text("#{count} selected")
       end
 
+      def expect_select_all_available
+        expect(shares_header)
+          .to have_field('toggle_all')
+      end
+
+      def expect_select_all_not_available
+        expect(shares_header)
+          .not_to have_field('toggle_all', wait: 0)
+      end
+
       def expect_select_all_toggled
         within shares_header do
           expect(page).to have_checked_field('toggle_all')
@@ -104,9 +122,39 @@ module Components
         end
       end
 
+      def expect_bulk_actions_available
+        within shares_header do
+          expect(page).to have_button 'Remove'
+          expect(page).to have_test_selector('op-share-wp-bulk-update-role')
+        end
+      end
+
+      def expect_bulk_actions_not_available
+        within shares_header do
+          expect(page).not_to have_button 'Remove'
+          expect(page).not_to have_test_selector('op-share-wp-bulk-update-role')
+        end
+      end
+
       def bulk_remove
         within shares_header do
           click_button 'Remove'
+        end
+      end
+
+      def bulk_update(role_name)
+        within shares_header do
+          find('[data-test-selector="op-share-wp-bulk-update-role"]').click
+
+          find('.ActionListContent', text: role_name).click
+        end
+      end
+
+      def expect_bulk_update_label(label_text)
+        within shares_header do
+          expect(page)
+            .to have_css('[data-test-selector="op-share-wp-bulk-update-role"] .Button-label',
+                         text: label_text)
         end
       end
 

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -45,6 +45,77 @@ module Components
         @work_package = work_package
       end
 
+      def select_shares(*principals)
+        within shares_list do
+          principals.each do |principal|
+            check principal.name
+          end
+        end
+      end
+
+      def deselect_shares(*principals)
+        within shares_list do
+          principals.each do |principal|
+            uncheck principal.name
+          end
+        end
+      end
+
+      def toggle_select_all
+        within shares_header do
+          if page.find_field('toggle_all').checked?
+            uncheck 'toggle_all'
+          else
+            check 'toggle_all'
+          end
+        end
+      end
+
+      def expect_selected(*principals)
+        within shares_list do
+          principals.each do |principal|
+            expect(page).to have_checked_field(principal.name)
+          end
+        end
+      end
+
+      def expect_deselected(*principals)
+        within shares_list do
+          principals.each do |principal|
+            expect(page).to have_unchecked_field(principal.name)
+          end
+        end
+      end
+
+      def expect_selected_count_of(count)
+        expect(shares_header)
+          .to have_text("#{count} selected")
+      end
+
+      def expect_select_all_toggled
+        within shares_header do
+          expect(page).to have_checked_field('toggle_all')
+        end
+      end
+
+      def expect_select_all_untoggled
+        within shares_header do
+          expect(page).to have_unchecked_field('toggle_all')
+        end
+      end
+
+      def bulk_remove
+        within shares_header do
+          click_button 'Remove'
+        end
+      end
+
+      def expect_blankslate
+        within_modal do
+          expect(page).to have_text(I18n.t('work_package.sharing.text_empty_state_description'))
+        end
+      end
+
       def invite_user(user, role_name)
         # Adding a user to the list of shared users
         select_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
@@ -115,16 +186,18 @@ module Components
         end
       end
 
-      def expect_not_shared_with(user)
+      def expect_not_shared_with(*principals)
         within shares_list do
-          expect(page)
-            .not_to have_text(user.name)
+          principals.each do |principal|
+            expect(page)
+              .not_to have_text(principal.name)
+          end
         end
       end
 
       def expect_shared_count_of(count)
-        expect(active_list)
-          .to have_css('[data-test-selector="op-share-wp-active-count"]', text: "#{count} users")
+        expect(shares_header)
+          .to have_text(I18n.t('work_package.sharing.count', count:))
       end
 
       def expect_no_invite_option
@@ -135,13 +208,21 @@ module Components
       end
 
       def user_row(user)
-        modal_element
+        shares_list
           .find("[data-test-selector=\"op-share-wp-active-user-#{user.id}\"]")
       end
 
       def active_list
         modal_element
           .find('[data-test-selector="op-share-wp-active-list"]')
+      end
+
+      def shares_header
+        active_list.find('[data-test-selector="op-share-wp-header"]')
+      end
+
+      def shares_counter
+        shares_header.find('[data-test-selector="op-share-wp-active-count"]')
       end
 
       def shares_list


### PR DESCRIPTION
## Description
* The `BulkSelection` Stimulus controller is where most of the bulk selection magic happens. Mechanically, this is handled by appending hidden inputs with the selected shares to the forms. The original intention was to leverage the `form` attribute on HTML input elements to bind them to the form. However, the `ActionMenu` Primer components render a form in themselves and we'd have to bind the checkboxes to multiple forms at a time which is not valid in the HTML specification.
* Hiding and showing the "Bulk Actions" section is a bit jumpy in this PR. The final behavior would be toggling between "Filters" and "Actions" which would cause the section not to be jumpy and always have a set of "Controls" to the right side of the List Heading.
* I've added quite an extensive and verbose test coverage to ensure that the selection state is solid for the bulk selection behavior.
## Demo
![Kapture 2023-10-24 at 14 37 15](https://github.com/opf/openproject/assets/61627014/985dcaad-7e27-4f47-9980-f0255047de7e)



## Notes
* See: https://community.openproject.org/wp/50257
* Acknowledged caveats: The `Primer::Alpha::Checkbox` component doesn't get re-styled when in High Contrast Mode.
