### PR TITLE
[50733] Polish spot modal to look more like Primer

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
@@ -3,8 +3,18 @@
 >
   <div
     class="spot-modal--header"
-    [textContent]="this.text.title"
   >
+    <div
+      class="spot-modal--header-title"
+      [textContent]="this.text.title">
+    </div>
+    <svg
+      x-icon
+      class="spot-modal--header-close"
+      size="small"
+      (click)="closeMe($event)"
+      [attr.title]="text.button_close"
+    ></svg>
   </div>
 
   <div class="spot-modal--body spot-container">

--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
@@ -8,13 +8,17 @@
       class="spot-modal--header-title"
       [textContent]="this.text.title">
     </div>
-    <svg
-      x-icon
-      class="spot-modal--header-close"
-      size="small"
+    <button
+      class="button button_no-margin -transparent spot-modal--header-close-button"
+      [attr.aria-label]="text.button_close"
       (click)="closeMe($event)"
-      [attr.title]="text.button_close"
-    ></svg>
+    >
+      <svg
+        x-icon
+        size="small"
+        class="spot-modal--header-close-button-icon"
+      ></svg>
+    </button>
   </div>
 
   <div class="spot-modal--body spot-container">

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -1,13 +1,17 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OpIconComponent } from './icon.component';
-import { ShareAndroidIconComponent } from '@openproject/octicons-angular';
+import {
+  ShareAndroidIconComponent,
+  XIconComponent,
+} from '@openproject/octicons-angular';
 
 @NgModule({
   imports: [
     CommonModule,
 
     ShareAndroidIconComponent,
+    XIconComponent,
   ],
   declarations: [
     OpIconComponent,
@@ -18,6 +22,7 @@ import { ShareAndroidIconComponent } from '@openproject/octicons-angular';
     OpIconComponent,
 
     ShareAndroidIconComponent,
+    XIconComponent,
   ],
 })
 export class IconModule {}

--- a/frontend/src/app/spot/styles/sass/components/action-bar.sass
+++ b/frontend/src/app/spot/styles/sass/components/action-bar.sass
@@ -1,7 +1,6 @@
 .spot-action-bar
   display: grid
   grid-template-columns: 1fr
-  background-color: $spot-color-basic-gray-6
   padding: 0 $spot-spacing-1
 
   a.button

--- a/frontend/src/app/spot/styles/sass/components/modal-close-button.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-close-button.sass
@@ -1,9 +1,0 @@
-.spot-modal-close-button
-  display: block
-  margin: 1rem
-
-  @media (min-width: 680px)
-    display: none
-
-  @media (max-height: 480px)
-    align-self: end

--- a/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
@@ -5,7 +5,7 @@
   right: 0
   bottom: 0
   @include spot-z-index("drop-modal")
-  background: rgba(0, 0, 0, 0.75)
+  background: rgba(0, 0, 0, 0.5)
   justify-content: center
   align-items: center
   display: none

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -46,9 +46,17 @@
     &-title
       flex-grow: 1
 
-    &-close
+    &-close-button
+      border-radius: 6px
+      border-color: transparent
+      margin-right: -$spot-spacing-0-5
+
       &:hover
         cursor: pointer
+
+      &-icon
+        &:focus
+          outline: none
 
     &_highlight
       background-color: var(--header-bg-color)

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -1,4 +1,3 @@
-@import './modal-close-button'
 @import './modal-overlay'
 @import './modal-overrides'
 
@@ -11,7 +10,7 @@
   background: white
   pointer-events: all
 
-  border-radius: $spot-spacing-0-25
+  border-radius: $spot-spacing-0-75
   width: 40rem
 
   max-width: calc(100vw - 2rem)
@@ -44,11 +43,12 @@
     > .spot-icon
       margin-right: $spot-spacing-0-5
 
-    &-button
-      font-weight: normal
-
     &-title
       flex-grow: 1
+
+    &-close
+      &:hover
+        cursor: pointer
 
     &_highlight
       background-color: var(--header-bg-color)


### PR DESCRIPTION
Polish the spot modal to look more like the Primer dialog. 

- [x] Round the corners
- [x] Remove the background of the action bar
- [x] Add the option for a closing cross icon in the top right corner
- [x] Lighten the overlay

https://community.openproject.org/projects/openproject/work_packages/50733/activity

### Before
<img width="400" alt="Bildschirmfoto 2023-10-25 um 13 37 42" src="https://github.com/opf/openproject/assets/7457313/184d427a-9f8b-4190-aa77-674ccca69fb4">

### After
<img width="400" alt="Bildschirmfoto 2023-10-25 um 13 36 18" src="https://github.com/opf/openproject/assets/7457313/003e04c7-d2f6-49c6-8817-ad9f9e5ea5f9">
