### PR TITLE
[#49334] Meeting module: Modes and permission levels

### DIFF
--- a/db/migrate/20231025144701_migrate_agenda_item_permissions.rb
+++ b/db/migrate/20231025144701_migrate_agenda_item_permissions.rb
@@ -1,0 +1,5 @@
+class MigrateAgendaItemPermissions < ActiveRecord::Migration[7.0]
+  def change
+    RolePermission.where(permission: 'create_meeting_agendas').update_all(permission: 'manage_agendas')
+  end
+end

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -44,7 +44,7 @@ module MeetingAgendaItems
     end
 
     def render?
-      User.current.allowed_to?(:edit_meetings, @meeting.project)
+      User.current.allowed_to?(:manage_agendas, @meeting.project)
     end
 
     private

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -42,11 +42,11 @@ module MeetingAgendaItems
     private
 
     def drag_and_drop_enabled?
-      @meeting.open? && User.current.allowed_to?(:edit_meetings, @meeting.project)
+      @meeting.open? && User.current.allowed_to?(:manage_agendas, @meeting.project)
     end
 
     def edit_enabled?
-      @meeting.open? && User.current.allowed_to?(:edit_meetings, @meeting.project)
+      @meeting.open? && User.current.allowed_to?(:manage_agendas, @meeting.project)
     end
 
     def edit_action_item(menu)

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
@@ -41,7 +41,7 @@ module MeetingAgendaItems
     end
 
     def render?
-      User.current.allowed_to?(:edit_meetings, @meeting.project)
+      User.current.allowed_to?(:manage_agendas, @meeting.project)
     end
   end
 end

--- a/modules/meeting/app/contracts/meeting_agenda_items/create_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/create_contract.rb
@@ -40,7 +40,9 @@ module MeetingAgendaItems
 
     ##
     # Meeting agenda items can currently be only created
-    # through the project permission :edit_meetings
+    # through the project permission :manage_agendas
+    # When MeetingRole becomes available, agenda items will
+    # be created through meeting permissions :manage_agendas
     def user_allowed_to_add
       # when creating a meeting agenda item from the work package tab and not selecting a meeting
       # the meeting and therefore the project is not set
@@ -48,7 +50,7 @@ module MeetingAgendaItems
       # the error is added by the models presence validation
       return unless visible?
 
-      unless user.allowed_to?(:edit_meetings, model.project)
+      unless user.allowed_to?(:manage_agendas, model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/contracts/meeting_agenda_items/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/delete_contract.rb
@@ -30,6 +30,6 @@ module MeetingAgendaItems
   class DeleteContract < ::DeleteContract
     include EditableItem
 
-    delete_permission :edit_meetings
+    delete_permission :manage_agendas
   end
 end

--- a/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
@@ -32,9 +32,11 @@ module MeetingAgendaItems
 
     ##
     # Meeting agenda items can currently be only edited
-    # through the project permission :edit_meetings
+    # through the project permission :manage_agendas
+    # When MeetingRole becomes available, agenda items will
+    # be edited through meeting permissions :manage_agendas
     def user_allowed_to_edit
-      unless user.allowed_to?(:edit_meetings, model.project)
+      unless user.allowed_to?(:manage_agendas, model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -34,7 +34,7 @@ modules_permissions:
     - :edit_meetings
     - :delete_meetings
     - :view_meetings
-    - :create_meeting_agendas
+    - :manage_agendas
     - :close_meeting_agendas
     - :send_meeting_agendas_notification
     - :send_meeting_agendas_icalendar

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
   permission_edit_meetings: "Edit meetings"
   permission_delete_meetings: "Delete meetings"
   permission_view_meetings: "View meetings"
-  permission_create_meeting_agendas: "Manage agendas"
+  permission_manage_agendas: "Manage agendas"
   permission_close_meeting_agendas: "Close agendas"
   permission_send_meeting_agendas_notification: "Send review notification for agendas"
   permission_create_meeting_minutes: "Manage minutes"

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -53,7 +53,6 @@ module OpenProject::Meeting
         permission :edit_meetings,
                    {
                      meetings: %i[edit cancel_edit update update_title update_details update_participants],
-                     meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move],
                      work_package_meetings_tab: %i[add_work_package_to_meeting_dialog add_work_package_to_meeting]
                    },
                    permissible_on: :project,
@@ -66,11 +65,12 @@ module OpenProject::Meeting
                    { meetings: [:icalendar] },
                    permissible_on: :project,
                    require: :member
-        permission :create_meeting_agendas,
+        permission :manage_agendas,
                    {
-                     meeting_agendas: %i[update preview]
+                     meeting_agendas: %i[update preview],
+                     meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move]
                    },
-                   permissible_on: :project,
+                   permissible_on: :project, # TODO: Change this to :meeting when MeetingRoles are available
                    require: :member
         permission :close_meeting_agendas,
                    {

--- a/modules/meeting/spec/contracts/meeting_agenda_items/create_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_agenda_items/create_contract_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MeetingAgendaItems::CreateContract do
 
   context 'with permission' do
     let(:user) do
-      create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings] })
+      create(:user, member_with_permissions: { project => %i[view_meetings manage_agendas] })
     end
 
     it_behaves_like 'contract is valid'

--- a/modules/meeting/spec/contracts/meeting_agenda_items/delete_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_agenda_items/delete_contract_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MeetingAgendaItems::DeleteContract do
 
   context 'with permission' do
     let(:user) do
-      create(:user, member_with_permissions: { project => [:edit_meetings] })
+      create(:user, member_with_permissions: { project => [:manage_agendas] })
     end
 
     it_behaves_like 'contract is valid'

--- a/modules/meeting/spec/contracts/meeting_agenda_items/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_agenda_items/update_contract_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MeetingAgendaItems::UpdateContract do
 
   context 'with permission' do
     let(:user) do
-      create(:user, member_with_permissions: { project => [:edit_meetings] })
+      create(:user, member_with_permissions: { project => [:manage_agendas] })
     end
 
     it_behaves_like 'contract is valid'

--- a/modules/meeting/spec/features/meetings_attachments_spec.rb
+++ b/modules/meeting/spec/features/meetings_attachments_spec.rb
@@ -3,7 +3,7 @@ require 'features/page_objects/notification'
 
 RSpec.describe 'Add an attachment to a meeting (agenda)', js: true, with_cuprite: false do
   let(:role) do
-    create(:project_role, permissions: %i[view_meetings edit_meetings create_meeting_agendas])
+    create(:project_role, permissions: %i[view_meetings edit_meetings manage_agendas])
   end
 
   let(:dev) do

--- a/modules/meeting/spec/features/meetings_show_spec.rb
+++ b/modules/meeting/spec/features/meetings_show_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Meetings', js: true do
       end
 
       context 'and edit permissions' do
-        let(:permissions) { %i[view_meetings create_meeting_agendas] }
+        let(:permissions) { %i[view_meetings manage_agendas] }
         let(:field) do
           TextEditorField.new(page,
                               '',

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe 'Structured meetings CRUD',
   shared_let(:user) do
     create(:user,
            lastname: 'First',
-           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings view_work_packages] }).tap do |u|
+           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
+                                                    view_work_packages] }).tap do |u|
       u.pref[:time_zone] = 'utc'
 
       u.save!
@@ -151,14 +152,14 @@ RSpec.describe 'Structured meetings CRUD',
     expect(wp_item).to be_present
 
     # user can see actions
-    expect(page).to have_selector('#meeting-agenda-items-new-button-component')
+    expect(page).to have_css('#meeting-agenda-items-new-button-component')
     expect(page).to have_test_selector('op-meeting-agenda-actions', count: 3)
 
     # other_use can view, but not edit
     login_as other_user
     show_page.visit!
 
-    expect(page).not_to have_selector('#meeting-agenda-items-new-button-component')
+    expect(page).not_to have_css('#meeting-agenda-items-new-button-component')
     expect(page).not_to have_test_selector('op-meeting-agenda-actions')
   end
 

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe 'Open the Meetings tab', :js do
     create(:project_role,
            permissions: %i(view_work_packages
                            view_meetings
-                           edit_meetings))
+                           edit_meetings
+                           manage_agendas))
   end
   let(:meetings_tab) { Pages::MeetingsTab.new(work_package.id) }
 
@@ -278,7 +279,7 @@ RSpec.describe 'Open the Meetings tab', :js do
           meetings_tab.open_add_to_meeting_dialog
 
           fill_in('meeting_agenda_item_meeting_id', with: past_meeting.title)
-          expect(page).not_to have_selector('.ng-option-marked', text: past_meeting.title)
+          expect(page).not_to have_css('.ng-option-marked', text: past_meeting.title)
         end
 
         it 'does not enable the user to select a closed, upcoming meeting' do
@@ -288,7 +289,7 @@ RSpec.describe 'Open the Meetings tab', :js do
           meetings_tab.open_add_to_meeting_dialog
 
           fill_in('meeting_agenda_item_meeting_id', with: closed_upcoming_meeting.title)
-          expect(page).not_to have_selector('.ng-option-marked', text: closed_upcoming_meeting.title)
+          expect(page).not_to have_css('.ng-option-marked', text: closed_upcoming_meeting.title)
         end
 
         it 'requires a meeting to be selected' do


### PR DESCRIPTION
https://community.openproject.org/work_packages/49334

### Description

The purpose of this PR is to differentiate between Meeting and MeetingAgenda permissions. This is a preliminary modification for a future implementation of various Meeting roles such as Moderator, Participant, Viewer. The granularity of the permissions will support adding different meeting related permissions to the Meeting roles. ie. A moderator will be able to modify the MeetingAgenda, but a participant will not.