### PR TITLE
Permission Rework [8/x]: Fix public permissions not being added

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -62,10 +62,7 @@ module Roles
                                 []
                               end
 
-      permissions_to_remove += OpenProject::AccessControl.public_permissions
-
-      OpenProject::AccessControl.project_permissions -
-        permissions_to_remove
+      OpenProject::AccessControl.project_permissions - permissions_to_remove
     end
 
     def check_permission_prerequisites

--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -86,13 +86,18 @@ module Users::PermissionChecks
   end
 
   def all_permissions_for(context)
-    Authorization
+    permissions = Authorization
       .roles(self, context)
       .includes(:role_permissions)
       .pluck(:permission)
       .compact
-      .uniq
       .map(&:to_sym)
+
+    if context.is_a?(Project) || context.nil?
+      permissions + OpenProject::AccessControl.public_permissions.map(&:name)
+    else
+      permissions
+    end.uniq
   end
 
   # Old allowed_to? interface. Marked as deprecated, should be removed at some point ... Guessing 14.0?

--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -86,18 +86,13 @@ module Users::PermissionChecks
   end
 
   def all_permissions_for(context)
-    permissions = Authorization
+    Authorization
       .roles(self, context)
       .includes(:role_permissions)
       .pluck(:permission)
       .compact
       .map(&:to_sym)
-
-    if context.is_a?(Project) || context.nil?
-      permissions + OpenProject::AccessControl.public_permissions.map(&:name)
-    else
-      permissions
-    end.uniq
+      .uniq
   end
 
   # Old allowed_to? interface. Marked as deprecated, should be removed at some point ... Guessing 14.0?

--- a/app/seeders/basic_data/project_role_seeder.rb
+++ b/app/seeders/basic_data/project_role_seeder.rb
@@ -29,5 +29,11 @@ module BasicData
   class ProjectRoleSeeder < BaseRoleSeeder
     self.model_class = ProjectRole
     self.seed_data_model_key = 'project_roles'
+
+    def update_permissions_with_modules_data(role_data)
+      super(role_data)
+
+      role_data['permissions'] += OpenProject::AccessControl.public_permissions.map(&:name)
+    end
   end
 end

--- a/app/services/roles/set_attributes_service.rb
+++ b/app/services/roles/set_attributes_service.rb
@@ -28,8 +28,16 @@
 
 module Roles
   class SetAttributesService < ::BaseServices::SetAttributes
+    def set_attributes(params)
+      super(params)
+
+      if model.is_a?(ProjectRole)
+        model.permissions += OpenProject::AccessControl.public_permissions.map(&:name)
+      end
+    end
+
     def set_default_attributes(*)
-      model.permissions = ProjectRole.non_member.permissions if model.permissions.blank?
+      model.permissions = ProjectRole.non_member.permissions if model.permissions.blank? && model.is_a?(ProjectRole)
     end
   end
 end

--- a/db/migrate/20231026111049_add_public_permissions_to_project_roles.rb
+++ b/db/migrate/20231026111049_add_public_permissions_to_project_roles.rb
@@ -1,0 +1,13 @@
+class AddPublicPermissionsToProjectRoles < ActiveRecord::Migration[7.0]
+  def up
+    ProjectRole.find_each do |role|
+      role.add_permission! *OpenProject::AccessControl.public_permissions.map(&:name)
+    end
+  end
+
+  def down
+    ProjectRole.find_each do |role|
+      role.remove_permission! *OpenProject::AccessControl.public_permissions.map(&:name)
+    end
+  end
+end

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -80,9 +80,9 @@ RSpec.shared_examples_for 'roles contract' do
           .to receive_messages(project_permissions: all_permissions, public_permissions:)
       end
 
-      it 'is all project permissions excluding public ones' do
+      it 'is all project permissions' do
         expect(contract.assignable_permissions)
-          .to eql(all_permissions - public_permissions)
+          .to eql(all_permissions)
       end
     end
 

--- a/spec/factories/project_role_factory.rb
+++ b/spec/factories/project_role_factory.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
     permissions { [] }
     sequence(:name) { |n| "Project role #{n}" }
 
+    after(:create) do |role|
+      role.add_permission!(*OpenProject::AccessControl.public_permissions.map(&:name))
+    end
+
     factory :non_member do
       name { 'Non member' }
       builtin { Role::BUILTIN_NON_MEMBER }

--- a/spec/factories/project_role_factory.rb
+++ b/spec/factories/project_role_factory.rb
@@ -32,9 +32,14 @@ FactoryBot.define do
   factory :project_role do
     permissions { [] }
     sequence(:name) { |n| "Project role #{n}" }
+    transient do
+      add_public_permissions { nil }
+    end
 
-    after(:create) do |role|
-      role.add_permission!(*OpenProject::AccessControl.public_permissions.map(&:name))
+    after(:create) do |role, evaluator|
+      if evaluator.add_public_permissions
+        role.add_permission!(*OpenProject::AccessControl.public_permissions.map(&:name))
+      end
     end
 
     factory :non_member do

--- a/spec/factories/project_role_factory.rb
+++ b/spec/factories/project_role_factory.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     permissions { [] }
     sequence(:name) { |n| "Project role #{n}" }
     transient do
-      add_public_permissions { nil }
+      add_public_permissions { true }
     end
 
     after(:create) do |role, evaluator|

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MigrateTeamPlannerPermissions, type: :model do
     it_behaves_like 'migration is idempotent'
   end
 
-  context 'for a role with manage_team_planner' do
+  context 'for a role that already has the manage_team_planner and view_team_planner permission' do
     let(:permissions) do
       %i[manage_team_planner view_team_planner view_work_packages add_work_packages
          edit_work_packages save_queries manage_public_queries permission1 permission2]

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -26,8 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require Rails.root.join("db/migrate/20220414085531_migrate_team_planner_permissions.rb")
 require 'spec_helper'
+require Rails.root.join("db/migrate/20220414085531_migrate_team_planner_permissions.rb")
 
 RSpec.describe MigrateTeamPlannerPermissions, type: :model do
   # Silencing migration logs, since we are not interested in that during testing
@@ -53,9 +53,10 @@ RSpec.describe MigrateTeamPlannerPermissions, type: :model do
 
   shared_examples_for 'adding permissions' do |new_permissions|
     it "adds the #{new_permissions} permissions for the role" do
+      public_permissions = OpenProject::AccessControl.public_permissions.map(&:name)
       expect { subject }.to change { role.reload.permissions }
-        .from(match_array(permissions))
-        .to match_array(permissions + new_permissions)
+        .from(match_array(permissions + public_permissions))
+        .to match_array(permissions + public_permissions + new_permissions)
     end
 
     it "adds #{new_permissions.size} new permissions" do

--- a/spec/models/queries/roles/filters/allows_becoming_assignee_filter_spec.rb
+++ b/spec/models/queries/roles/filters/allows_becoming_assignee_filter_spec.rb
@@ -47,12 +47,14 @@ RSpec.describe Queries::Roles::Filters::AllowsBecomingAssigneeFilter do
     shared_let(:assignable_role) do
       create(:project_role,
              name: 'assignable_role',
-             permissions: %i[work_package_assigned])
+             permissions: %i[work_package_assigned],
+             add_public_permissions: false)
     end
     shared_let(:unassignable_role) do
       create(:project_role,
              name: 'unassignable_role',
-             permissions: %i[wrong])
+             permissions: %i[wrong],
+             add_public_permissions: false)
     end
 
     let(:instance) do

--- a/spec/models/users/permission_checks_spec.rb
+++ b/spec/models/users/permission_checks_spec.rb
@@ -64,17 +64,20 @@ RSpec.describe User, "permission check methods" do
 
     let!(:non_member) { create(:non_member, permissions: %i[view_work_packages manage_members]) }
 
+    let(:public_permissions) { OpenProject::AccessControl.public_permissions.map(&:name) }
+
     subject do
       create(:user, global_permissions: [:create_user],
                     member_with_permissions: { project => %i[view_work_packages edit_work_packages] })
     end
 
     it 'returns all permissions given on the project' do
-      expect(subject.all_permissions_for(project)).to match_array(%i[view_work_packages edit_work_packages])
+      expect(subject.all_permissions_for(project)).to match_array(%i[view_work_packages edit_work_packages] + public_permissions)
     end
 
     it 'returns non-member permissions given on the project the user is not a member of' do
-      expect(subject.all_permissions_for(other_project)).to match_array(%i[view_work_packages manage_members])
+      expect(subject.all_permissions_for(other_project)).to match_array(%i[view_work_packages
+                                                                           manage_members] + public_permissions)
     end
 
     it 'returns all global permissions' do
@@ -87,7 +90,7 @@ RSpec.describe User, "permission check methods" do
     it 'returns all permissions the user has (with project and global permissions)' do
       expect(subject.all_permissions_for(nil)).to match_array(%i[create_user
                                                                  view_work_packages edit_work_packages
-                                                                 manage_members])
+                                                                 manage_members] + public_permissions)
     end
   end
 end

--- a/spec/seeders/basic_data/project_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_role_seeder_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe BasicData::ProjectRoleSeeder do
   subject(:seeder) { described_class.new(seed_data) }
 
   let(:seed_data) { Source::SeedData.new(data_hash) }
+  let(:public_permissions) { OpenProject::AccessControl.public_permissions.map(&:name) }
 
   before do
     seeder.seed!
@@ -61,11 +62,11 @@ RSpec.describe BasicData::ProjectRoleSeeder do
       expect(Role.count).to eq(2)
       expect(Role.find_by(name: 'Non member')).to have_attributes(
         builtin: Role::BUILTIN_NON_MEMBER,
-        permissions: %i[view_status view_presentations]
+        permissions: %i[view_status view_presentations] + public_permissions
       )
       expect(Role.find_by(name: 'Anonymous')).to have_attributes(
         builtin: Role::BUILTIN_ANONYMOUS,
-        permissions: %i[read_information]
+        permissions: %i[read_information] + public_permissions
       )
     end
 
@@ -93,7 +94,7 @@ RSpec.describe BasicData::ProjectRoleSeeder do
       expect(Role.find_by(name: 'Member')).to have_attributes(
         position: 5,
         builtin: Role::NON_BUILTIN,
-        permissions: %i[view_movies eat_popcorn]
+        permissions: %i[view_movies eat_popcorn] + public_permissions
       )
     end
 
@@ -157,7 +158,7 @@ RSpec.describe BasicData::ProjectRoleSeeder do
             rate_ebooks
             play_music
             add_song
-          ]
+          ] + public_permissions
         )
     end
   end

--- a/spec/services/roles/delete_service_spec.rb
+++ b/spec/services/roles/delete_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Roles::DeleteService, type: :model do
     expect(result).to be_success
     expect(OpenProject::Notifications).to have_received(:send).with(
       OpenProject::Events::ROLE_DESTROYED,
-      permissions: existing_permissions
+      permissions: existing_permissions + OpenProject::AccessControl.public_permissions.map(&:name)
     )
   end
 end

--- a/spec/services/roles/set_attributes_service_spec.rb
+++ b/spec/services/roles/set_attributes_service_spec.rb
@@ -1,0 +1,143 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe Roles::SetAttributesService, type: :model do
+  let(:current_user) { build_stubbed(:admin) }
+
+  let(:contract_instance) do
+    contract = instance_double(Roles::CreateContract, 'contract_instance')
+    allow(contract).to receive(:validate).and_return(contract_valid)
+    allow(contract).to receive(:errors).and_return(contract_errors)
+    contract
+  end
+
+  let(:contract_errors) { instance_double(ActiveModel::Errors, 'contract_errors') }
+  let(:contract_valid) { true }
+  let(:model_valid) { true }
+
+  let(:instance) do
+    described_class.new(user: current_user, model: model_instance, contract_class:, contract_options: {})
+  end
+  let(:model_instance) { ProjectRole.new }
+  let(:contract_class) do
+    allow(Roles::CreateContract).to receive(:new).and_return(contract_instance)
+
+    Roles::CreateContract
+  end
+
+  let(:params) { {} }
+  let(:permissions) { %i[view_work_packages view_wiki_pages] }
+
+  before do
+    allow(model_instance).to receive(:valid?).and_return(model_valid)
+  end
+
+  subject { instance.call(params) }
+
+  it 'returns the instance as the result' do
+    expect(subject.result).to eql model_instance
+  end
+
+  it 'is a success' do
+    expect(subject).to be_success
+  end
+
+  context 'with params' do
+    let(:params) do
+      {
+        permissions:
+      }
+    end
+
+    before do
+      create(:non_member, permissions: %i[view_meetings view_wiki_pages])
+      subject
+    end
+
+    context 'with a ProjectRole' do
+      it 'assigns the params with the public permissions' do
+        expect(model_instance.permissions).to match_array(OpenProject::AccessControl.public_permissions.map(&:name) + permissions)
+      end
+
+      context 'when no permissions are given' do
+        let(:permissions) { [] }
+
+        it 'assigns the permissions the non member role has' do
+          expect(model_instance.permissions).to match_array(ProjectRole.non_member.permissions + OpenProject::AccessControl.public_permissions.map(&:name))
+        end
+      end
+    end
+
+    context 'with a GlobalRole' do
+      let(:model_instance) { GlobalRole.new }
+
+      it 'assigns the params' do
+        expect(model_instance.permissions).to match_array(permissions)
+      end
+
+      context 'when no permissions are given' do
+        let(:permissions) { [] }
+
+        it 'assigns nothing' do
+          expect(model_instance.permissions).to be_empty
+        end
+      end
+    end
+
+    context 'with a WorkPackageRole' do
+      let(:model_instance) { WorkPackageRole.new }
+
+      it 'assigns the params' do
+        expect(model_instance.permissions).to match_array(permissions)
+      end
+
+      context 'when no permissions are given' do
+        let(:permissions) { [] }
+
+        it 'assigns nothing' do
+          expect(model_instance.permissions).to be_empty
+        end
+      end
+    end
+  end
+
+  context 'with an invalid contract' do
+    let(:contract_valid) { false }
+
+    it 'returns failure' do
+      expect(subject).not_to be_success
+    end
+
+    it "returns the contract's errors" do
+      expect(subject.errors)
+        .to eql(contract_errors)
+    end
+  end
+end

--- a/spec/services/roles/set_attributes_service_spec.rb
+++ b/spec/services/roles/set_attributes_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Roles::SetAttributesService, type: :model do
         let(:permissions) { [] }
 
         it 'assigns the permissions the non member role has' do
-          expect(model_instance.permissions).to match_array(ProjectRole.non_member.permissions + OpenProject::AccessControl.public_permissions.map(&:name))
+          expect(model_instance.permissions).to match_array(ProjectRole.non_member.permissions) # public permissions are included via the factory
         end
       end
     end

--- a/spec/services/roles/update_service_spec.rb
+++ b/spec/services/roles/update_service_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Roles::UpdateService, type: :model do
   it 'sends an update notification' do
     allow(OpenProject::Notifications).to receive(:send)
 
-    existing_permissions = %i[view_files view_work_packages view_calender]
+    existing_permissions = %i[view_files view_work_packages
+                              view_calender] + OpenProject::AccessControl.public_permissions.map(&:name)
     added_permissions = %i[write_files view_wiki_pages]
     role = create(:project_role, permissions: existing_permissions)
 


### PR DESCRIPTION
In the current implementation we cache all roles the user has on a project and if the permission is allowed on any of them, we allow it. This check includes checking the public permissions as well:

https://github.com/opf/openproject/blob/8bf10659b80f1843bda5b39c4bcec61696727391/app/models/role.rb#L162-L164

With the new system we skip that step of caching the roles and cache the permissions directly. This lead to the public permissions being ignored. This PR fixes this.

---

After some back and forth with @ulferts we decided to look into adding the public permissions to the roles automatically (in seeds, set attribute service and via a migration)