### PR TITLE
Permission Rework [13/x]: Replace `allowed_to?` calls in controllers

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -100,7 +100,7 @@ class MembersController < ApplicationController
   private
 
   def authorize_for(controller, action)
-    current_user.allowed_to?({ controller:, action: }, @project)
+    current_user.allowed_in_project?({ controller:, action: }, @project)
   end
 
   def build_members

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -151,7 +151,7 @@ class SearchController < ApplicationController
       # don't search projects
       types.delete('projects')
       # only show what the user is allowed to view
-      types = types.select { |o| User.current.allowed_to?("view_#{o}".to_sym, projects_to_search) }
+      types = types.select { |o| User.current.allowed_in_project?("view_#{o}".to_sym, projects_to_search) }
     end
 
     types

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -88,11 +88,11 @@ class WikiController < ApplicationController
     # Set the related page ID to make it the parent of new links
     flash[:_related_wiki_page_id] = @page.id
 
-    version = params[:version] if User.current.allowed_to?(:view_wiki_edits, @project)
+    version = params[:version] if User.current.allowed_in_project?(:view_wiki_edits, @project)
 
     @page = ::WikiPages::AtVersion.new(@page, version)
 
-    if params[:format] == 'markdown' && User.current.allowed_to?(:export_wiki_pages, @project)
+    if params[:format] == 'markdown' && User.current.allowed_in_project?(:export_wiki_pages, @project)
       send_data(@page.text, type: 'text/plain', filename: "#{@page.title}.md")
       return
     end
@@ -128,7 +128,7 @@ class WikiController < ApplicationController
       page.parent_id = flash[:_related_wiki_page_id]
     end
 
-    version = params[:version] if User.current.allowed_to?(:view_wiki_edits, @project)
+    version = params[:version] if User.current.allowed_in_project?(:view_wiki_edits, @project)
 
     @page = ::WikiPages::AtVersion.new(page, version)
   end
@@ -317,7 +317,7 @@ class WikiController < ApplicationController
 
   # Export wiki to a single html file
   def export
-    if User.current.allowed_to?(:export_wiki_pages, @project)
+    if User.current.allowed_in_project?(:export_wiki_pages, @project)
       @pages = @wiki.pages.order(Arel.sql('title'))
       export = render_to_string action: 'export_multiple', layout: false
       send_data(export, type: 'text/html', filename: 'wiki.html')
@@ -381,7 +381,7 @@ class WikiController < ApplicationController
   def handle_new_wiki_page
     return unless @page.new_record?
 
-    if User.current.allowed_to?(:edit_wiki_pages, @project) && editable?
+    if User.current.allowed_in_project?(:edit_wiki_pages, @project) && editable?
       edit
       render action: :new
     elsif params[:id] == 'wiki'

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -128,11 +128,17 @@ class WorkPackagesController < ApplicationController
   end
 
   def protect_from_unauthorized_export
-    if (supported_list_formats + %w[atom]).include?(params[:format]) &&
-       !User.current.allowed_to?(:export_work_packages, @project, global: @project.nil?)
-
+    if (supported_list_formats + %w[atom]).include?(params[:format]) && !user_allowed_to_export?
       deny_access
       false
+    end
+  end
+
+  def user_allowed_to_export?
+    if @project
+      User.current.allowed_in_project?(:export_work_packages, @project)
+    else
+      User.current.allowed_in_any_project?(:export_work_packages)
     end
   end
 

--- a/lib/redmine/menu_manager/menu_controller.rb
+++ b/lib/redmine/menu_manager/menu_controller.rb
@@ -53,7 +53,7 @@ module Redmine::MenuManager::MenuController
     end
 
     def current_menu_item(actions = :default, &block)
-      raise ArgumentError '#current_menu_item requires a block' unless block_given?
+      raise ArgumentError '#current_menu_item requires a block' unless block
 
       if actions == :default
         menu_items[controller_path.to_sym][:default] = block
@@ -110,6 +110,6 @@ module Redmine::MenuManager::MenuController
   end
 
   def user_allowed_to_access_item?(project, item)
-    item && User.current.allowed_to?(item.url(project), project) && (item.condition.nil? || item.condition.call(project))
+    item && User.current.allowed_in_project?(item.url(project), project) && (item.condition.nil? || item.condition.call(project))
   end
 end

--- a/modules/backlogs/app/controllers/rb_impediments_controller.rb
+++ b/modules/backlogs/app/controllers/rb_impediments_controller.rb
@@ -71,10 +71,10 @@ class RbImpedimentsController < RbApplicationController
 
     # We block block_ids only when user is not allowed to create or update the
     # instance passed.
-    unless instance && ((instance.new_record? && User.current.allowed_to?(:add_work_packages,
-                                                                          @project)) || User.current.allowed_to?(
-                                                                            :edit_work_packages, @project
-                                                                          ))
+    unless instance && ((instance.new_record? && User.current.allowed_in_project?(:add_work_packages,
+                                                                                  @project)) || User.current.allowed_in_project?(
+                                                                                    :edit_work_packages, @project
+                                                                                  ))
       hash.delete(:block_ids)
     end
 

--- a/modules/backlogs/app/controllers/work_package_boxes_controller.rb
+++ b/modules/backlogs/app/controllers/work_package_boxes_controller.rb
@@ -39,7 +39,7 @@ class WorkPackageBoxesController < WorkPackagesController
       r.other_work_package(@work_package) && r.other_work_package(@work_package).visible?
     end
     @allowed_statuses = WorkPackages::UpdateContract.new(work_package, User.current).assignable_statuses
-    @edit_allowed = User.current.allowed_to?(:edit_work_packages, @project)
+    @edit_allowed = User.current.allowed_in_project?(:edit_work_packages, @project)
     @priorities = IssuePriority.all
     @time_entry = TimeEntry.new
 

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -72,8 +72,16 @@ module ::Boards
     end
 
     def authorize_work_package_permission
-      unless current_user.allowed_to?(:view_work_packages, @project, global: @project.nil?)
+      unless user_allowed_to_view_work_packages?
         deny_access
+      end
+    end
+
+    def user_allowed_to_view_work_packages?
+      if @project
+        current_user.allowed_in_project?(:view_work_packages, @project)
+      else
+        current_user.allowed_in_any_project?(:view_work_packages)
       end
     end
 

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -71,7 +71,7 @@ class BudgetsController < ApplicationController
   end
 
   def show
-    @edit_allowed = User.current.allowed_to?(:edit_budgets, @project)
+    @edit_allowed = User.current.allowed_in_project?(:edit_budgets, @project)
     respond_to do |format|
       format.html { render action: 'show', layout: !request.xhr? }
     end
@@ -236,7 +236,7 @@ class BudgetsController < ApplicationController
       "#{element_id}_currency" => Setting.plugin_costs['costs_currency']
     }
 
-    if current_user.allowed_to?(permission, project)
+    if current_user.allowed_in_project?(permission, project)
       response["#{element_id}_costs"] = number_to_currency(costs)
       response["#{element_id}_cost_value"] = response["#{element_id}_amount"] = unitless_currency_number(costs)
     end

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -44,7 +44,7 @@ class HourlyRatesController < ApplicationController
   # TODO: this should be an index
   def show
     if @project
-      return deny_access unless User.current.allowed_to?(:view_hourly_rates, @project)
+      return deny_access unless User.current.allowed_in_project?(:view_hourly_rates, @project)
 
       @rates = HourlyRate.where(user_id: @user, project_id: @project)
                .order("#{HourlyRate.table_name}.valid_from desc")
@@ -59,7 +59,7 @@ class HourlyRatesController < ApplicationController
     # remove code where appropriate
     if @project
       # Hourly Rate
-      return deny_access unless User.current.allowed_to?(:edit_hourly_rates, @project)
+      return deny_access unless User.current.allowed_in_project?(:edit_hourly_rates, @project)
     else
       # Default Hourly Rate
       return deny_access unless User.current.admin?
@@ -87,7 +87,7 @@ class HourlyRatesController < ApplicationController
     # remove code where appropriate
     if @project
       # Hourly Rate
-      return deny_access unless User.current.allowed_to?(:edit_hourly_rates, @project)
+      return deny_access unless User.current.allowed_in_project?(:edit_hourly_rates, @project)
     else
       # Default Hourly Rate
       return deny_access unless User.current.admin?

--- a/modules/costs/lib/costs/patches/projects_controller_patch.rb
+++ b/modules/costs/lib/costs/patches/projects_controller_patch.rb
@@ -37,7 +37,7 @@ module Costs::Patches::ProjectsControllerPatch
 
   module InstanceMethods
     def own_total_hours
-      if User.current.allowed_to?(:view_own_time_entries, @project)
+      if User.current.allowed_in_project?(:view_own_time_entries, @project)
         cond = @project.project_condition(Setting.display_subprojects_work_packages?)
         @total_hours = TimeEntry.not_ongoing.visible.includes(:project).where(cond).sum(:hours).to_f
       end

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -257,7 +257,7 @@ class MeetingsController < ApplicationController
   end
 
   def global_upcoming_meetings
-    projects = Project.allowed_to(User.current, :view_meetings)
+    projects = Project.allowed_in_project(User.current, :view_meetings)
 
     Meeting.where(project: projects).from_today
   end


### PR DESCRIPTION
All controllers except the `ApplicationController` with the main authorization method