### PR TITLE
[50259] User multi select on share modal

### DIFF
--- a/app/controllers/concerns/member_creation.rb
+++ b/app/controllers/concerns/member_creation.rb
@@ -39,9 +39,9 @@ module MemberCreation
                        .call(member_params)
 
       if overall_result
-        overall_result.merge!(service_call)
+        overall_result.push(service_call)
       else
-        overall_result = service_call
+        overall_result = [service_call]
       end
     end
 
@@ -88,11 +88,7 @@ module MemberCreation
 
   def each_comma_separated(array, &block)
     array.map do |e|
-      if e.to_s.match? /\d(,\d)*/
-        block.call(e)
-      else
-        e
-      end
+      block.call(e)
     end.flatten
   end
 
@@ -107,8 +103,8 @@ module MemberCreation
   def possibly_separated_ids_for_entity(array, entity = :user)
     if !array[:"#{entity}_ids"].nil?
       transform_array_of_comma_separated_ids(array[:"#{entity}_ids"])
-    elsif !array[:"#{entity}_id"].nil? && (id = array[:"#{entity}_id"]).present?
-      [id]
+    elsif !array[:"#{entity}_id"].nil?
+      transform_array_of_comma_separated_ids(array[:"#{entity}_id"])
     else
       []
     end

--- a/app/controllers/concerns/member_helper.rb
+++ b/app/controllers/concerns/member_helper.rb
@@ -32,21 +32,19 @@ module MemberHelper
   def find_or_create_users(send_notification: true)
     @send_notification = send_notification
 
-    each_new_member_param do |member_params|
-      yield member_params
+    user_ids.each do |id|
+      yield permitted_params.member.merge(user_id: id, project: @project)
     end
   end
 
-  def each_new_member_param
+  def user_ids
     user_ids = user_ids_for_new_members(params[:member])
 
     group_ids = Group.where(id: user_ids).pluck(:id)
 
     user_ids.sort_by! { |id| group_ids.include?(id) ? 1 : -1 }
 
-    user_ids.each do |id|
-      yield permitted_params.member.merge(user_id: id, project: @project)
-    end
+    user_ids
   end
 
   def user_ids_for_new_members(member_params)

--- a/app/controllers/concerns/member_helper.rb
+++ b/app/controllers/concerns/member_helper.rb
@@ -82,6 +82,7 @@ module MemberHelper
   end
 
   def transform_array_of_comma_separated_ids(array)
+    return Array(array) unless array.is_a?(Array)
     return array if array.blank?
 
     each_comma_separated(array) do |elem|

--- a/app/controllers/concerns/member_helper.rb
+++ b/app/controllers/concerns/member_helper.rb
@@ -26,26 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MemberCreation
+module MemberHelper
   module_function
 
-  def create_members(send_notification: true)
+  def find_or_create_users(send_notification: true)
     @send_notification = send_notification
-    overall_result = nil
 
     each_new_member_param do |member_params|
-      service_call = Members::CreateService
-                       .new(user: current_user)
-                       .call(member_params)
-
-      if overall_result
-        overall_result.push(service_call)
-      else
-        overall_result = [service_call]
-      end
+      yield member_params
     end
-
-    overall_result
   end
 
   def each_new_member_param

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -27,7 +27,7 @@
 #++
 
 class MembersController < ApplicationController
-  include MemberCreation
+  include MemberHelper
   model_object Member
   before_action :find_model_object_and_project, except: [:autocomplete_for_member]
   before_action :find_project_by_project_id, only: [:autocomplete_for_member]
@@ -38,15 +38,28 @@ class MembersController < ApplicationController
   end
 
   def create
-    # Todo: Handle correctly
-    service_call = create_members.first
+    overall_result = []
 
-    if service_call.success?
-      display_success(members_added_notice(service_call.all_results))
+    find_or_create_users(send_notification: false) do |member_params|
+      service_call = Members::CreateService
+                       .new(user: current_user)
+                       .call(member_params)
+
+      if overall_result
+        overall_result.push(service_call)
+      else
+        overall_result = [service_call]
+      end
+    end
+
+    if overall_result.empty?
+      redirect_to project_members_path(project_id: @project, status: 'all')
+    elsif overall_result.all?(&:success?)
+      display_success(members_added_notice(overall_result.count))
 
       redirect_to project_members_path(project_id: @project, status: 'all')
     else
-      display_error(service_call)
+      display_error(overall_result.first)
 
       set_index_data!
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -38,7 +38,8 @@ class MembersController < ApplicationController
   end
 
   def create
-    service_call = create_members
+    # Todo: Handle correctly
+    service_call = create_members.first
 
     if service_call.success?
       display_success(members_added_notice(service_call.all_results))

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -53,6 +53,7 @@ class MembersController < ApplicationController
     end
 
     if overall_result.empty?
+      flash[:error] = I18n.t('activerecord.errors.models.member.principal_blank')
       redirect_to project_members_path(project_id: @project, status: 'all')
     elsif overall_result.all?(&:success?)
       display_success(members_added_notice(overall_result.map(&:result)))

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -55,7 +55,7 @@ class MembersController < ApplicationController
     if overall_result.empty?
       redirect_to project_members_path(project_id: @project, status: 'all')
     elsif overall_result.all?(&:success?)
-      display_success(members_added_notice(overall_result.count))
+      display_success(members_added_notice(overall_result.map(&:result)))
 
       redirect_to project_members_path(project_id: @project, status: 'all')
     else

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -45,11 +45,7 @@ class MembersController < ApplicationController
                        .new(user: current_user)
                        .call(member_params)
 
-      if overall_result
-        overall_result.push(service_call)
-      else
-        overall_result = [service_call]
-      end
+      overall_result.push(service_call)
     end
 
     if overall_result.empty?

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -58,11 +58,11 @@ class WorkPackages::SharesController < ApplicationController
       end
     end
 
-    @shares = overall_result.map(&:result)
+    @shares = overall_result.map(&:result).reverse
 
     unless overall_result.nil?
       if current_visible_member_count > 1
-        respond_with_prepend_share
+        respond_with_prepend_shares
       else
         respond_with_replace_modal
       end
@@ -99,7 +99,7 @@ class WorkPackages::SharesController < ApplicationController
     respond_with_turbo_streams
   end
 
-  def respond_with_prepend_share
+  def respond_with_prepend_shares
     replace_via_turbo_stream(
       component: WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package)
     )

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -61,7 +61,9 @@ class WorkPackages::SharesController < ApplicationController
     @shares = overall_result.map(&:result).reverse
 
     unless overall_result.nil?
-      if current_visible_member_count > 1
+      # In case the number of newly added shares is equal to the whole number of shares,
+      # we have to render the whole modal again to get rid of the blankslate
+      if current_visible_member_count > 1 && @shares.size < current_visible_member_count
         respond_with_prepend_shares
       else
         respond_with_replace_modal

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -40,7 +40,7 @@ class WorkPackages::SharesController < ApplicationController
   end
 
   def create
-    overall_result = nil
+    overall_result = []
 
     find_or_create_users(send_notification: false) do |member_params|
       service_call = WorkPackageMembers::CreateOrUpdateService
@@ -51,16 +51,12 @@ class WorkPackages::SharesController < ApplicationController
 
       @share = service_call.result
 
-      if overall_result
-        overall_result.push(service_call)
-      else
-        overall_result = [service_call]
-      end
+      overall_result.push(service_call)
     end
 
     @shares = overall_result.map(&:result).reverse
 
-    unless overall_result.nil?
+    if overall_result.present?
       # In case the number of newly added shares is equal to the whole number of shares,
       # we have to render the whole modal again to get rid of the blankslate
       if current_visible_member_count > 1 && @shares.size < current_visible_member_count

--- a/app/forms/work_packages/share/invitee.rb
+++ b/app/forms/work_packages/share/invitee.rb
@@ -44,6 +44,7 @@ module WorkPackages::Share
           searchKey: 'any_name_attribute',
           addTag: User.current.allowed_globally?(:create_user),
           addTagText: I18n.t('members.send_invite_to'),
+          multiple: true,
           focusDirectly: true,
           appendTo: 'body',
           disabled: @disabled

--- a/lib/primer/open_project/forms/user_autocompleter.html.erb
+++ b/lib/primer/open_project/forms/user_autocompleter.html.erb
@@ -3,7 +3,7 @@
                               data: @data_attributes,
                               inputs: @autocomplete_options.merge(
                                 classes: "ng-select--primerized #{@input.invalid? ? '-error' : ''}",
-                                inputName: builder.field_name(@input.name),
+                                inputName: builder.field_name(@input.name, multiple: @autocomplete_options[:multiple]),
                                 inputValue: builder.object.send(@input.name),
                               )
     %>

--- a/spec/features/work_packages/share/multi_invite_spec.rb
+++ b/spec/features/work_packages/share/multi_invite_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Work package sharing',
+               :js,
+               :with_cuprite,
+               with_flag: { work_package_sharing: true } do
+  shared_let(:view_work_package_role) { create(:view_work_package_role) }
+  shared_let(:comment_work_package_role) { create(:comment_work_package_role) }
+  shared_let(:edit_work_package_role) { create(:edit_work_package_role) }
+
+  shared_let(:not_shared_yet_with_user) { create(:user, firstname: 'Not shared Yet', lastname: 'User') }
+  shared_let(:another_not_shared_yet_with_user) { create(:user, firstname: 'Another not yet shared', lastname: 'User') }
+  shared_let(:richard) { create(:user, firstname: 'Richard', lastname: 'Hendricks') }
+
+  shared_let(:not_shared_yet_with_group) { create(:group, members: [richard]) }
+  shared_let(:empty_group) { create(:group, members: []) }
+
+  let(:project) do
+    create(:project,
+           members: { current_user => [sharer_role] })
+  end
+
+  let(:sharer_role) do
+    create(:project_role,
+           permissions: %i(view_work_packages
+                           view_shared_work_packages
+                           share_work_packages))
+  end
+  let(:work_package) do
+    create(:work_package, project:) do |wp|
+      create(:work_package_member, entity: wp, user: richard, roles: [edit_work_package_role])
+    end
+  end
+
+  let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
+  let(:share_modal) { Components::WorkPackages::ShareModal.new(work_package) }
+
+  current_user { create(:user, firstname: 'Signed in', lastname: 'User') }
+
+  def shared_principals
+    Principal.where(id: Member.of_work_package(work_package).select(:user_id))
+  end
+
+  def inherited_member_roles(group:)
+    MemberRole.where(inherited_from: MemberRole.where(member_id: group.memberships))
+  end
+
+  context 'when having share permission' do
+    it 'allows seeing and administrating sharing' do
+      work_package_page.visit!
+
+      # Clicking on the share button opens a modal which lists all of the users a work package
+      # is explicitly shared with.
+      # Project members are not listed unless the work package is also shared with them explicitly.
+      click_button 'Share'
+
+      aggregate_failures "Inviting multiple users or groups at once" do
+        share_modal.expect_shared_count_of(1)
+
+        # Inviting multiple users at once
+        share_modal.invite_users([not_shared_yet_with_user, another_not_shared_yet_with_user], 'Edit')
+
+        share_modal.expect_shared_count_of(3)
+
+        share_modal.expect_shared_with(not_shared_yet_with_user, 'Edit', position: 1)
+        share_modal.expect_shared_with(another_not_shared_yet_with_user, 'Edit', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(not_shared_yet_with_user)
+        # The additional check is needed because the second removal would otherwise be too fast for the test execution
+        share_modal.expect_shared_count_of(2)
+
+        share_modal.remove_user(another_not_shared_yet_with_user)
+        share_modal.expect_shared_count_of(1)
+
+        # Groups can be added simultaneously as well
+        share_modal.invite_users([not_shared_yet_with_group, empty_group], 'Comment')
+
+        share_modal.expect_shared_count_of(3)
+
+        share_modal.expect_shared_with(not_shared_yet_with_group, 'Comment', position: 1)
+        share_modal.expect_shared_with(empty_group, 'Comment', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(not_shared_yet_with_group)
+        share_modal.expect_shared_count_of(2)
+
+        share_modal.remove_user(empty_group)
+        share_modal.expect_shared_count_of(1)
+
+        # We can also mix
+        share_modal.invite_users([not_shared_yet_with_user, empty_group], 'View')
+
+        share_modal.expect_shared_count_of(3)
+
+        share_modal.expect_shared_with(not_shared_yet_with_user, 'View', position: 1)
+        share_modal.expect_shared_with(empty_group, 'View', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(not_shared_yet_with_user)
+        share_modal.expect_shared_count_of(2)
+
+        share_modal.remove_user(empty_group)
+        share_modal.expect_shared_count_of(1)
+      end
+
+      share_modal.close
+      click_button 'Share'
+
+      aggregate_failures "Re-opening the modal after changes performed" do
+        # This user preserved
+        share_modal.expect_shared_with(richard, 'Edit', position: 1)
+
+        # The users have been removed
+        share_modal.expect_not_shared_with(not_shared_yet_with_user)
+        share_modal.expect_not_shared_with(another_not_shared_yet_with_user)
+
+        # This groups have been removed
+        share_modal.expect_not_shared_with(not_shared_yet_with_group)
+        share_modal.expect_not_shared_with(empty_group)
+
+        share_modal.expect_shared_count_of(1)
+      end
+    end
+  end
+
+  context 'when having global invite permission' do
+    let(:global_manager_user) { create(:user, global_permissions: %i[manage_user create_user]) }
+    let(:current_user) { global_manager_user }
+
+    before do
+      work_package_page.visit!
+      click_button 'Share'
+    end
+
+    it 'allows creating multiple users at once' do
+      share_modal.expect_open
+      share_modal.expect_shared_count_of(1)
+
+      # Invite two users that does not exist yet
+      share_modal.invite_users(['hello@world.de', 'aloha@world.de'], 'Comment')
+
+      # New user is shown in the list of shares
+      share_modal.expect_shared_count_of(3)
+
+      # New user is created
+      new_users = User.last(2)
+
+      share_modal.expect_shared_with(new_users[0], 'Comment', position: 1)
+      share_modal.expect_shared_with(new_users[1], 'Comment', position: 2)
+
+      # The new users can be interacted with
+      share_modal.change_role(new_users[0], 'View')
+      share_modal.expect_shared_with(new_users[0], 'View', position: 1)
+      share_modal.change_role(new_users[1], 'View')
+      share_modal.expect_shared_with(new_users[1], 'View', position: 2)
+      share_modal.expect_shared_count_of(3)
+
+      # The new users can be updated simultaneously
+      share_modal.invite_user(new_users, 'Edit')
+      share_modal.expect_shared_with(new_users[0], 'Edit', position: 1)
+      share_modal.expect_shared_with(new_users[1], 'Edit', position: 2)
+      share_modal.expect_shared_count_of(3)
+
+      # The new users can be deleted
+      share_modal.remove_user(new_users[0])
+      share_modal.expect_not_shared_with(new_users[0])
+      share_modal.remove_user(new_users[1])
+      share_modal.expect_not_shared_with(new_users[1])
+      share_modal.expect_shared_count_of(1)
+    end
+
+    it 'allows sharing with an existing user and creating a new one at the same time' do
+      share_modal.expect_open
+      share_modal.expect_shared_count_of(1)
+
+      # Add an existing and a non-existing user to the autocompleter
+      share_modal.select_existing_user not_shared_yet_with_user
+      share_modal.select_not_existing_user_option "hello@world.de"
+
+      share_modal.select_invite_role('View')
+      within share_modal.modal_element do
+        click_button 'Share'
+      end
+
+      # Two users are added
+      share_modal.expect_shared_count_of(3)
+
+      # New user is created
+      new_user = User.last
+
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'View', position: 1)
+      share_modal.expect_shared_with(new_user, 'View', position: 2)
+    end
+  end
+end

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -389,27 +389,27 @@ RSpec.describe 'Work package sharing',
       # New user is created
       new_users = User.last(2)
 
-      share_modal.expect_shared_with(new_users[0], 'Comment', position: 1)
-      share_modal.expect_shared_with(new_users[1], 'Comment', position: 2)
+      share_modal.expect_shared_with(new_users[0], 'Comment', position: 2)
+      share_modal.expect_shared_with(new_users[1], 'Comment', position: 1)
 
       # The new users can be interacted with
       share_modal.change_role(new_users[0], 'View')
-      share_modal.expect_shared_with(new_user, 'View', position: 1)
+      share_modal.expect_shared_with(new_users[0], 'View', position: 2)
       share_modal.change_role(new_users[1], 'View')
-      share_modal.expect_shared_with(new_user, 'View', position: 2)
+      share_modal.expect_shared_with(new_users[1], 'View', position: 1)
       share_modal.expect_shared_count_of(8)
 
       # The new users can be updated simultaneously
       share_modal.invite_user(new_users, 'Edit')
-      share_modal.expect_shared_with(new_users[0], 'Edit', position: 1)
-      share_modal.expect_shared_with(new_users[1], 'Edit', position: 2)
+      share_modal.expect_shared_with(new_users[0], 'Edit', position: 2)
+      share_modal.expect_shared_with(new_users[1], 'Edit', position: 1)
       share_modal.expect_shared_count_of(8)
 
       # The new users can be deleted
-      share_modal.remove_user(new_user[0])
-      share_modal.expect_not_shared_with(new_user[0])
-      share_modal.remove_user(new_user[1])
-      share_modal.expect_not_shared_with(new_user[1])
+      share_modal.remove_user(new_users[0])
+      share_modal.expect_not_shared_with(new_users[0])
+      share_modal.remove_user(new_users[1])
+      share_modal.expect_not_shared_with(new_users[1])
       share_modal.expect_shared_count_of(6)
     end
 
@@ -417,7 +417,7 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_open
       share_modal.expect_shared_count_of(6)
 
-      # Add an existing and a non-existing user to the automcompleter
+      # Add an existing and a non-existing user to the autocompleter
       share_modal.select_existing_user not_shared_yet_with_user
       share_modal.select_not_existing_user_option "hello@world.de"
 

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -44,11 +44,13 @@ RSpec.describe 'Work package sharing',
   shared_let(:non_shared_project_user) { create(:user, firstname: 'Non Shared Project', lastname: 'User') }
   shared_let(:shared_project_user) { create(:user, firstname: 'Shared Project', lastname: 'User') }
   shared_let(:not_shared_yet_with_user) { create(:user, firstname: 'Not shared Yet', lastname: 'User') }
+  shared_let(:another_not_shared_yet_with_user) { create(:user, firstname: 'Not shared Yet', lastname: 'User') }
 
   shared_let(:richard) { create(:user, firstname: 'Richard', lastname: 'Hendricks') }
   shared_let(:dinesh) { create(:user, firstname: 'Dinesh', lastname: 'Chugtai') }
   shared_let(:gilfoyle) { create(:user, firstname: 'Bertram', lastname: 'Gilfoyle') }
   shared_let(:not_shared_yet_with_group) { create(:group, members: [richard, dinesh, gilfoyle]) }
+  shared_let(:empty_group) { create(:group, members: []) }
 
   let(:project) do
     create(:project,
@@ -108,6 +110,7 @@ RSpec.describe 'Work package sharing',
 
         share_modal.expect_not_shared_with(non_shared_project_user)
         share_modal.expect_not_shared_with(not_shared_yet_with_user)
+        share_modal.expect_not_shared_with(another_not_shared_yet_with_user)
 
         share_modal.expect_shared_count_of(6)
       end
@@ -224,6 +227,50 @@ RSpec.describe 'Work package sharing',
           .not_to include(not_shared_yet_with_group, richard)
       end
 
+      aggregate_failures "Inviting multiple users or groups at once" do
+        # Inviting multiple users at once
+        share_modal.invite_user([richard, another_not_shared_yet_with_user], 'Edit')
+
+        share_modal.expect_shared_count_of(9)
+
+        share_modal.expect_shared_with(another_not_shared_yet_with_user, 'Edit', position: 1)
+        share_modal.expect_shared_with(richard, 'Edit', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(richard)
+        share_modal.remove_user(another_not_shared_yet_with_user)
+
+        share_modal.expect_shared_count_of(7)
+
+        # Groups can be added simultaneously as well
+        share_modal.invite_user([not_shared_yet_with_group, empty_group], 'Comment')
+
+        share_modal.expect_shared_count_of(9)
+
+        share_modal.expect_shared_with(not_shared_yet_with_group, 'Comment', position: 1)
+        share_modal.expect_shared_with(empty_group, 'Comment', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(not_shared_yet_with_group)
+        share_modal.remove_user(empty_group)
+
+        share_modal.expect_shared_count_of(7)
+
+        # We can also mix
+        share_modal.invite_user([richard, empty_group], 'View')
+
+        share_modal.expect_shared_count_of(9)
+
+        share_modal.expect_shared_with(empty_group, 'View', position: 1)
+        share_modal.expect_shared_with(richard, 'View', position: 2)
+
+        # They can be removed again
+        share_modal.remove_user(richard)
+        share_modal.remove_user(empty_group)
+
+        share_modal.expect_shared_count_of(7)
+      end
+
       share_modal.close
       click_button 'Share'
 
@@ -290,10 +337,12 @@ RSpec.describe 'Work package sharing',
     let(:global_manager_user) { create(:user, global_permissions: %i[manage_user create_user]) }
     let(:current_user) { global_manager_user }
 
-    it 'allows inviting and directly sharing with a user who is not part of the instance yet' do
+    before do
       work_package_page.visit!
       click_button 'Share'
+    end
 
+    it 'allows inviting and directly sharing with a user who is not part of the instance yet' do
       share_modal.expect_open
       share_modal.expect_shared_count_of(6)
 
@@ -325,6 +374,66 @@ RSpec.describe 'Work package sharing',
       share_modal.remove_user(new_user)
       share_modal.expect_not_shared_with(new_user)
       share_modal.expect_shared_count_of(6)
+    end
+
+    it 'allows creating multiple users at once' do
+      share_modal.expect_open
+      share_modal.expect_shared_count_of(6)
+
+      # Invite two users that does not exist yet
+      share_modal.create_and_invite_user(['hello@world.de', 'aloha@world.de'], 'Comment')
+
+      # New user is shown in the list of shares
+      share_modal.expect_shared_count_of(8)
+
+      # New user is created
+      new_users = User.last(2)
+
+      share_modal.expect_shared_with(new_users[0], 'Comment', position: 1)
+      share_modal.expect_shared_with(new_users[1], 'Comment', position: 2)
+
+      # The new users can be interacted with
+      share_modal.change_role(new_users[0], 'View')
+      share_modal.expect_shared_with(new_user, 'View', position: 1)
+      share_modal.change_role(new_users[1], 'View')
+      share_modal.expect_shared_with(new_user, 'View', position: 2)
+      share_modal.expect_shared_count_of(8)
+
+      # The new users can be updated simultaneously
+      share_modal.invite_user(new_users, 'Edit')
+      share_modal.expect_shared_with(new_users[0], 'Edit', position: 1)
+      share_modal.expect_shared_with(new_users[1], 'Edit', position: 2)
+      share_modal.expect_shared_count_of(8)
+
+      # The new users can be deleted
+      share_modal.remove_user(new_user[0])
+      share_modal.expect_not_shared_with(new_user[0])
+      share_modal.remove_user(new_user[1])
+      share_modal.expect_not_shared_with(new_user[1])
+      share_modal.expect_shared_count_of(6)
+    end
+
+    it 'allows sharing with an existing user and creating a new one at the same time' do
+      share_modal.expect_open
+      share_modal.expect_shared_count_of(6)
+
+      # Add an existing and a non-existing user to the automcompleter
+      share_modal.select_existing_user not_shared_yet_with_user
+      share_modal.select_not_existing_user_option "hello@world.de"
+
+      share_modal.select_invite_role('View')
+      within share_modal.modal_element do
+        click_button 'Share'
+      end
+
+      # Two users are added
+      share_modal.expect_shared_count_of(8)
+
+      # New user is created
+      new_user = User.last
+
+      share_modal.expect_shared_with(new_user, 'View', position: 1)
+      share_modal.expect_shared_with(not_shared_yet_with_user, 'View', position: 2)
     end
   end
 

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -190,9 +190,13 @@ module Components
       end
 
       def invite_user(users, role_name)
-        # Adding a user to the list of shared users
         Array(users).each do |user|
-          select_existing_user user
+          case user
+          when String
+            select_not_existing_user_option(user)
+          when Principal
+            select_existing_user(user)
+          end
         end
 
         select_invite_role(role_name)
@@ -202,20 +206,8 @@ module Components
         end
       end
 
+      alias_method :invite_users, :invite_user
       alias_method :invite_group, :invite_user
-
-      def create_and_invite_user(emails, role_name)
-        # Adding a user to the list of shared users
-        Array(emails).each do |email|
-          select_not_existing_user_option email
-        end
-
-        select_invite_role(role_name)
-
-        within modal_element do
-          click_button 'Share'
-        end
-      end
 
       def search_user(search_string)
         search_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -189,12 +189,11 @@ module Components
         end
       end
 
-      def invite_user(user, role_name)
+      def invite_user(users, role_name)
         # Adding a user to the list of shared users
-        select_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
-                            query: user.firstname,
-                            select_text: user.name,
-                            results_selector: 'body'
+        Array(users).each do |user|
+          select_existing_user user
+        end
 
         select_invite_role(role_name)
 
@@ -205,12 +204,11 @@ module Components
 
       alias_method :invite_group, :invite_user
 
-      def create_and_invite_user(email, role_name)
+      def create_and_invite_user(emails, role_name)
         # Adding a user to the list of shared users
-        select_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
-                            query: email,
-                            select_text: "Send invite to\"#{email}\"",
-                            results_selector: 'body'
+        Array(emails).each do |email|
+          select_not_existing_user_option email
+        end
 
         select_invite_role(role_name)
 
@@ -324,6 +322,20 @@ module Components
 
       def shares_list
         active_list.find_by_id('op-share-wp-active-shares')
+      end
+
+      def select_existing_user(user)
+        select_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
+                            query: user.firstname,
+                            select_text: user.name,
+                            results_selector: 'body'
+      end
+
+      def select_not_existing_user_option(email)
+        select_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
+                            query: email,
+                            select_text: "Send invite to\"#{email}\"",
+                            results_selector: 'body'
       end
     end
   end


### PR DESCRIPTION
### Todo

- [x] Allow multiple options in the user_autocompleter of the share WP modal
- [x] Add test cases
- [x] Handle the following cases in the share WP modal
  - [x] One existing user is shared
  - [x] Multiple existing users are shared 
  - [x] One new user created and shared
  - [x] Multiple new users are created and shared
  - [x] Mix of existing and new users are shared
  - [x] Mix of existing, already shared with user, and a new user are shared
- [x] Same cases should work in the members page (as they share the same code base)

known issues
- [x] Update modal when initally there is no share, and then multiple are added at once
- [x] Success message on the members page shows the wrong number

https://community.openproject.org/projects/openproject/work_packages/50259/activity