### PR TITLE
Fixed storage edit page heading change on rename

### DIFF
--- a/modules/storages/app/components/storages/admin/storage_general_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_general_info_component.html.erb
@@ -1,0 +1,29 @@
+<%=
+  grid_layout('op-storage-view--row', tag: :div, align_items: :center) do |grid|
+    grid.with_area(:item, tag: :div, mr: 3) do
+      concat(render(Primer::Beta::Text.new(font_weight: :semibold, mr: 1, test_selector: 'storage-provider-label')) { I18n.t('storages.file_storage_view.storage_provider') })
+      concat(configuration_check_label_for(:host_name_configured))
+    end
+
+    grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-description') do
+      render(Primer::Beta::Truncate.new(font_weight: :light)) { storage_description }
+    end
+
+    grid.with_area(:"icon-button", tag: :div, color: :subtle) do
+      flex_layout(justify_content: :flex_end) do |icons_container|
+        icons_container.with_column do
+          render(
+            Primer::Beta::IconButton.new(
+              icon: :pencil,
+              tag: :a,
+              scheme: :invisible,
+              href: edit_host_admin_settings_storage_path(storage),
+              aria: { label: I18n.t('storages.label_edit_storage_host') } ,
+              test_selector: 'storage-edit-host-button'
+            )
+          )
+        end
+      end
+    end
+  end
+%>

--- a/modules/storages/app/components/storages/admin/storage_general_info_component.rb
+++ b/modules/storages/app/components/storages/admin/storage_general_info_component.rb
@@ -29,7 +29,7 @@
 #++
 #
 module Storages::Admin
-  class StorageViewComponent < ApplicationComponent
+  class StorageGeneralInfoComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
     alias_method :storage, :model
     include StorageViewInformation

--- a/modules/storages/app/components/storages/admin/storage_view_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_view_component.html.erb
@@ -6,33 +6,7 @@
 
     component.with_row(scheme: :default) do
       render(OpTurbo::FrameComponent.new(storage, context: :storage_view_general_info)) do
-        grid_layout('op-storage-view--row', tag: :div, align_items: :center) do |grid|
-          grid.with_area(:item, tag: :div, mr: 3) do
-            concat(render(Primer::Beta::Text.new(font_weight: :semibold, mr: 1, test_selector: 'storage-provider-label')) { I18n.t('storages.file_storage_view.storage_provider') })
-            concat(configuration_check_label_for(:host_name_configured))
-          end
-
-          grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-description') do
-            render(Primer::Beta::Truncate.new(font_weight: :light)) { storage_description }
-          end
-
-          grid.with_area(:"icon-button", tag: :div, color: :subtle) do
-            flex_layout(justify_content: :flex_end) do |icons_container|
-              icons_container.with_column do
-                render(
-                  Primer::Beta::IconButton.new(
-                    icon: :pencil,
-                    tag: :a,
-                    scheme: :invisible,
-                    href: edit_host_admin_settings_storage_path(storage),
-                    aria: { label: I18n.t('storages.label_edit_storage_host') } ,
-                    test_selector: 'storage-edit-host-button'
-                  )
-                )
-              end
-            end
-          end
-        end
+        render(Storages::Admin::StorageGeneralInfoComponent.new(storage))
       end
     end
 

--- a/modules/storages/app/components/storages/admin/storage_view_information.rb
+++ b/modules/storages/app/components/storages/admin/storage_view_information.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Storages::Admin
+  module StorageViewInformation
+    private
+
+    def storage_description
+      [storage.short_provider_type.capitalize,
+       storage.name,
+       storage.host].compact.join(' - ')
+    end
+
+    def configuration_check_label_for(config)
+      if storage.configuration_checks[config.to_sym]
+        status_label(I18n.t('storages.label_connected'), scheme: :success, test_selector: "label-#{config}-status")
+      else
+        status_label(I18n.t('storages.label_incomplete'), scheme: :attention, test_selector: "label-#{config}-status")
+      end
+    end
+
+    def status_label(label, scheme:, test_selector:)
+      render(Primer::Beta::Label.new(scheme:, test_selector:)) { label }
+    end
+
+    def automatically_managed_project_folders_status_label
+      test_selector = 'label-managed-project-folders-status'
+
+      if storage.automatically_managed?
+        status_label(I18n.t('storages.label_active'), scheme: :success, test_selector:)
+      elsif storage.automatic_management_unspecified?
+        status_label(I18n.t('storages.label_incomplete'), scheme: :attention, test_selector:)
+      else
+        status_label(I18n.t('storages.label_inactive'), scheme: :secondary, test_selector:)
+      end
+    end
+
+    def openproject_oauth_client_description
+      return unless storage.oauth_application
+
+      "#{I18n.t('storages.label_oauth_client_id')}: #{storage.oauth_application.uid}"
+    end
+
+    def provider_oauth_client_description
+      if storage.oauth_client
+        "#{I18n.t('storages.label_oauth_client_id')}: #{storage.oauth_client.client_id}"
+      else
+        I18n.t('storages.configuration_checks.oauth_client_incomplete', provider: storage.short_provider_type.capitalize)
+      end
+    end
+  end
+end

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -119,7 +119,10 @@ class Storages::Admin::StoragesController < ApplicationController
 
     if service_result.success?
       flash[:notice] = I18n.t(:notice_successful_update)
-      redirect_to edit_admin_settings_storage_path(@storage)
+      respond_to do |format|
+        format.html { redirect_to edit_admin_settings_storage_path(@storage) }
+        format.turbo_stream
+      end
     elsif OpenProject::FeatureDecisions.storage_primer_design_active?
       render :edit_host
     else

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -32,7 +32,9 @@ See COPYRIGHT and LICENSE files for more details.
 <% if OpenProject::FeatureDecisions.storage_primer_design_active? %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
     <% header.with_title(test_selector: 'storage-name-title') do %>
-      <%= @storage.name %>
+      <%= render OpTurbo::FrameComponent.new(@storage, context: :edit_storage_header) do %>
+        <%= @storage.name %>
+      <% end %>
     <% end %>
 
     <% header.with_actions do %>
@@ -77,9 +79,9 @@ See COPYRIGHT and LICENSE files for more details.
       <% component.with_header(title: "OpenProject #{t(:'storages.label_oauth_application_details')}") %>
 
       <% component.with_attributes([
-                                    { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @storage.oauth_application.uid },
-                                    { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
-                                  ]) %>
+                                     { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_ID}", value: @storage.oauth_application.uid },
+                                     { key: "OpenProject #{Storages::Admin::LABEL_OAUTH_CLIENT_SECRET}", value: "●●●●●●●●●●●●●●●●" },
+                                   ]) %>
 
       <%= link_to(t("storages.buttons.replace_openproject_oauth"),
                   replace_oauth_application_admin_settings_storage_path(@storage),
@@ -99,15 +101,15 @@ See COPYRIGHT and LICENSE files for more details.
         <%= link_to(t("storages.buttons.configure"), new_admin_settings_storage_automatically_managed_project_folders_path(@storage), class: 'button -with-icon icon-add') %>
       <% else %>
         <% component.with_attribute(
-            key: t(:"storages.label_managed_project_folders.automatically_managed_folders"),
-            value: @storage.automatically_managed? ? t(:"storages.label_active") : t(:"storages.label_inactive")
-          ) %>
+             key: t(:"storages.label_managed_project_folders.automatically_managed_folders"),
+             value: @storage.automatically_managed? ? t(:"storages.label_active") : t(:"storages.label_inactive")
+           ) %>
 
         <% if @storage.automatically_managed? %>
           <% component.with_attribute(
-              key: t(:"storages.label_managed_project_folders.application_password"),
-              value: "●●●●●●●●●●●●●●●●"
-            ) %>
+               key: t(:"storages.label_managed_project_folders.application_password"),
+               value: "●●●●●●●●●●●●●●●●"
+             ) %>
         <% end %>
 
         <%= link_to(t("storages.buttons.edit_automatically_managed_project_folders"),

--- a/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
+++ b/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update ActionView::RecordIdentifier.dom_id(@storage, :storage_view_general_info) do %>
+  <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+<% end %>
+<%= turbo_stream.update ActionView::RecordIdentifier.dom_id(@storage, :edit_storage_header) do %>
+  <%= @storage.name %>
+<% end %>

--- a/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
+++ b/modules/storages/app/views/storages/admin/storages/update.turbo_stream.erb
@@ -1,6 +1,6 @@
-<%= turbo_stream.update ActionView::RecordIdentifier.dom_id(@storage, :storage_view_general_info) do %>
-  <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+<%= turbo_stream.update dom_id(@storage, :storage_view_general_info) do %>
+  <%= render(::Storages::Admin::StorageGeneralInfoComponent.new(@storage)) %>
 <% end %>
-<%= turbo_stream.update ActionView::RecordIdentifier.dom_id(@storage, :edit_storage_header) do %>
+<%= turbo_stream.update dom_id(@storage, :edit_storage_header) do %>
   <%= @storage.name %>
 <% end %>

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe 'Admin storages',
           click_button 'Save and continue'
         end
 
+        expect(page).to have_test_selector('storage-name-title', text: 'My Nextcloud')
         expect(page).to have_test_selector('storage-description', text: [storage.short_provider_type.capitalize,
                                                                          'My Nextcloud',
                                                                          storage.host].join(' - '))


### PR DESCRIPTION
The name of the storage in the heading of the edit page needs to change when the storage is renamed.

Because we use Turbo for this now, the heading became a turbo frame and gets updated with a turbo stream with the response of the `update` action.