### PR TITLE
Disable Smooth Scrolling Behavior in Feature Specs

### DIFF
--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -23,6 +23,7 @@ def register_chrome(language, name: :"chrome_#{language}", override_time_zone: n
     # This is REQUIRED for running in a docker container
     # https://github.com/grosser/parallel_tests/issues/658
     options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--disable-smooth-scrolling')
 
     options.add_preference(:download,
                            directory_upgrade: true,

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -22,6 +22,8 @@ def register_firefox(language, name: :"firefox_#{language}")
     # only one FF process
     profile['dom.ipc.processCount'] = 1
 
+    profile['general.smoothScroll'] = false
+
     options = Selenium::WebDriver::Firefox::Options.new(profile:)
 
     yield(profile, options) if block_given?

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -89,7 +89,8 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       'disable-gpu': nil,
       'disable-popup-blocking': nil,
       lang: language,
-      'no-sandbox': nil
+      'no-sandbox': nil,
+      'disable-smooth-scrolling': true
     }
 
     if ENV['OPENPROJECT_TESTING_AUTO_DEVTOOLS'].present?


### PR DESCRIPTION
This great article explains the reasons in detail better than I ever could: https://codemeister.hashnode.dev/capybara-cuprite-and-a-slow-scrolling-chrome-ar

TLDR:
1. Bigger Cuprite performance boost
2. Performance boost in our other Selenium Drivers for Chrome and Firefox
3. Gets rid of these kinds of errors when running on ARM machines:
    ```
      Capybara::Cuprite::MouseEventFailed: 
          Firing a click at coordinates [600.0,4548.3984375] failed. 
          Cuprite detected another element with CSS selector "none" 
          at this position. It may be overlapping the element you 
          are trying to interact with.
    ```