### PR TITLE
Promote batch of specs to Cuprite

### DIFF
--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Backlogs', :js do
+RSpec.describe 'Backlogs', :js, :with_cuprite do
   let(:story_type) do
     create(:type_feature)
   end

--- a/modules/backlogs/spec/features/empty_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/empty_backlogs_spec.rb
@@ -29,16 +29,13 @@
 require 'spec_helper'
 
 RSpec.describe 'Empty backlogs project',
-               js: true do
-  let(:project) { create(:project, types: [story, task], enabled_module_names: %w(backlogs)) }
-  let(:story) { create(:type_feature) }
-  let(:task) { create(:type_task) }
-  let(:status) { create(:status, is_default: true) }
+               :js, :with_cuprite do
+  shared_let(:story) { create(:type_feature) }
+  shared_let(:task) { create(:type_task) }
+  shared_let(:project) { create(:project, types: [story, task], enabled_module_names: %w(backlogs)) }
+  shared_let(:status) { create(:status, is_default: true) }
 
   before do
-    project
-    status
-
     login_as current_user
     allow(Setting)
         .to receive(:plugin_openproject_backlogs)
@@ -52,8 +49,8 @@ RSpec.describe 'Empty backlogs project',
     let(:current_user) { create(:admin) }
 
     it 'shows a no results box with action' do
-      expect(page).to have_selector '.generic-table--no-results-container', text: I18n.t(:backlogs_empty_title)
-      expect(page).to have_selector '.generic-table--no-results-description', text: I18n.t(:backlogs_empty_action_text)
+      expect(page).to have_css('.generic-table--no-results-container', text: I18n.t(:backlogs_empty_title))
+      expect(page).to have_css('.generic-table--no-results-description', text: I18n.t(:backlogs_empty_action_text))
 
       link = page.find '.generic-table--no-results-description a'
       expect(link[:href]).to include(new_project_version_path(project))
@@ -65,8 +62,8 @@ RSpec.describe 'Empty backlogs project',
     let(:current_user) { create(:user, member_with_roles: { project => role }) }
 
     it 'only shows a no results box' do
-      expect(page).to have_selector '.generic-table--no-results-container', text: I18n.t(:backlogs_empty_title)
-      expect(page).not_to have_selector '.generic-table--no-results-description'
+      expect(page).to have_css('.generic-table--no-results-container', text: I18n.t(:backlogs_empty_title))
+      expect(page).not_to have_css('.generic-table--no-results-description')
     end
   end
 end

--- a/modules/backlogs/spec/features/work_packages/remaining_time_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/remaining_time_spec.rb
@@ -28,25 +28,24 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Work packages remaining time', js: true do
+RSpec.describe 'Work packages remaining time', :js, :with_cuprite do
   before do
-    allow(User).to receive(:current).and_return current_user
     allow(Setting).to receive(:plugin_openproject_backlogs).and_return('points_burn_direction' => 'down',
                                                                        'wiki_template' => '',
                                                                        'story_types' => [story_type.id.to_s],
                                                                        'task_type' => task_type.id.to_s)
   end
 
-  let(:current_user) { create(:admin) }
-  let(:project) do
+  shared_current_user { create(:admin) }
+  shared_let(:project) do
     create(:project,
            enabled_module_names: %w(work_package_tracking backlogs))
   end
-  let(:status) { create(:default_status) }
-  let(:story_type) { create(:type_feature) }
-  let(:task_type) { create(:type_feature) }
+  shared_let(:status) { create(:default_status) }
+  shared_let(:story_type) { create(:type_feature) }
+  shared_let(:task_type) { create(:type_feature) }
 
-  let(:work_package) do
+  shared_let(:work_package) do
     create(:story,
            type: task_type,
            author: current_user,

--- a/modules/backlogs/spec/features/work_packages/story_points_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/story_points_spec.rb
@@ -28,9 +28,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Work packages having story points', js: true do
+RSpec.describe 'Work packages having story points', :js, :with_cuprite do
   before do
-    allow(User).to receive(:current).and_return current_user
+    login_as current_user
     allow(Setting).to receive(:plugin_openproject_backlogs).and_return('points_burn_direction' => 'down',
                                                                        'wiki_template' => '',
                                                                        'story_types' => [story_type.id.to_s],

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -32,33 +32,24 @@ RSpec.describe 'Custom actions', :js, :with_cuprite,
                with_ee: %i[custom_actions] do
   shared_let(:admin) { create(:admin) }
 
-  let(:permissions) { %i(view_work_packages edit_work_packages move_work_packages work_package_assigned) }
-  let(:role) { create(:project_role, permissions:) }
-  let!(:other_role) { create(:project_role, permissions:) }
-  let(:user) do
-    user = create(:user,
-                  firstname: 'A',
-                  lastname: 'User')
-
-    create(:member,
-           project:,
-           roles: [role],
-           user:)
-
-    create(:member,
-           project: other_project,
-           roles: [role],
-           user:)
-    user
+  shared_let(:permissions) { %i(view_work_packages edit_work_packages move_work_packages work_package_assigned) }
+  shared_let(:role) { create(:project_role, permissions:) }
+  shared_let(:other_role) { create(:project_role, permissions:) }
+  shared_let(:project) { create(:project, name: 'This project') }
+  shared_let(:other_project) { create(:project, name: 'Other project') }
+  shared_let(:user) do
+    create(:user,
+           firstname: 'A',
+           lastname: 'User',
+           member_with_roles: { project => [role], other_project => [role] })
   end
-  let!(:other_member_user) do
+  shared_let(:other_member_user) do
     create(:user,
            firstname: 'Other member',
            lastname: 'User',
            member_with_roles: { project => role })
   end
-  let(:project) { create(:project, name: 'This project') }
-  let(:other_project) { create(:project, name: 'Other project') }
+
   let!(:work_package) do
     create(:work_package,
            project:,
@@ -333,7 +324,7 @@ RSpec.describe 'Custom actions', :js, :with_cuprite,
                               "customField#{list_custom_field.id}" => selected_list_custom_field_options.map(&:name).join("\n")
 
     expect(page)
-      .to have_selector('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name)
+      .to have_css('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name)
 
     wp_page.click_custom_action('Close')
     wp_page.expect_attributes status: closed_status.name,
@@ -494,7 +485,7 @@ RSpec.describe 'Custom actions', :js, :with_cuprite,
     wp_page.click_custom_action('Unassign', expect_success: false)
     wp_page.expect_custom_action_disabled('Unassign')
     find('[data-field-name="estimatedTime"]').click
-    expect(page).to have_selector("#wp-#{work_package.id}-inline-edit--field-estimatedTime[disabled]")
+    expect(page).to have_css("#wp-#{work_package.id}-inline-edit--field-estimatedTime[disabled]")
   end
 
   context 'with baseline enabled' do

--- a/spec/features/work_packages/details/details_refreshing_spec.rb
+++ b/spec/features/work_packages/details/details_refreshing_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 
-RSpec.describe 'Work package table refreshing due to split view', js: true do
+RSpec.describe 'Work package table refreshing due to split view', :js, :with_cuprite do
   let(:project) { create(:project_with_types) }
   let!(:work_package) { create(:work_package, project:) }
   let(:wp_split) { Pages::SplitWorkPackage.new work_package }
@@ -47,7 +47,7 @@ RSpec.describe 'Work package table refreshing due to split view', js: true do
 
     wp_table.expect_work_package_listed work_package
     page.within wp_table.row(work_package) do
-      expect(page).to have_selector('.wp-table--drag-and-drop-handle.icon-drag-handle', visible: :all)
+      expect(page).to have_css('.wp-table--drag-and-drop-handle.icon-drag-handle', visible: :all)
     end
   end
 end

--- a/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
@@ -34,7 +34,7 @@ require 'support/edit_fields/edit_field'
 require 'features/work_packages/work_packages_page'
 
 RSpec.describe 'New work package datepicker',
-               js: true, selenium: true, with_settings: { date_format: '%Y-%m-%d' } do
+               :js, :with_cuprite, with_settings: { date_format: '%Y-%m-%d' } do
   let(:project) { create(:project_with_types, public: true) }
   let(:user) { create(:admin) }
 
@@ -45,6 +45,7 @@ RSpec.describe 'New work package datepicker',
     login_as(user)
 
     wp_page_create.visit!
+    wait_for_reload
   end
 
   it 'can open and select the datepicker' do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
@@ -1,44 +1,41 @@
 require 'spec_helper'
 
-RSpec.describe 'Work Package table hierarchy and sorting', js: true do
-  let(:user) { create(:admin) }
-  let(:project) { create(:project) }
+RSpec.describe 'Work Package table hierarchy and sorting', :js, :with_cuprite do
+  shared_let(:project) { create(:project) }
 
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   let(:hierarchy) { Components::WorkPackages::Hierarchies.new }
   let(:representation) { Components::WorkPackages::DisplayRepresentation.new }
   let(:sort_by) { Components::WorkPackages::SortBy.new }
 
-  let!(:wp_root) do
+  shared_let(:wp_root) do
     create(:work_package,
            project:,
            subject: 'Parent')
   end
 
-  let!(:wp_child1) do
+  shared_let(:wp_child1) do
     create(:work_package,
            project:,
            parent: wp_root,
            subject: 'WP child 1')
   end
 
-  let!(:wp_child2) do
+  shared_let(:wp_child2) do
     create(:work_package,
            project:,
            parent: wp_root,
            subject: 'WP child 2')
   end
 
-  let!(:wp_child3) do
+  shared_let(:wp_child3) do
     create(:work_package,
            project:,
            parent: wp_root,
            subject: 'WP child 3')
   end
 
-  before do
-    login_as(user)
-  end
+  shared_current_user { create(:admin) }
 
   it 'can indent hierarchies' do
     wp_table.visit!
@@ -62,10 +59,9 @@ RSpec.describe 'Work Package table hierarchy and sorting', js: true do
 
     # Remove first child
     hierarchy.outdent! wp_child1
+    wait_for_network_idle
     hierarchy.expect_hierarchy_at(wp_root, wp_child2)
     hierarchy.expect_leaf_at(wp_child1, wp_child3)
-
-    sleep 1
 
     wp_child1.reload
     expect(wp_child1.parent).to be_nil
@@ -96,27 +92,23 @@ RSpec.describe 'Work Package table hierarchy and sorting', js: true do
 
     subject = wp_table.edit_field(wp_child3, :subject)
     subject.update 'First edit'
+    wait_for_network_idle
     wp_table.expect_and_dismiss_toaster message: 'Successful update.'
-
-    # Wait a bit before moving
-    sleep 2
 
     # Indent last child
     hierarchy.indent! wp_child3
+    wait_for_network_idle
     wp_table.expect_and_dismiss_toaster message: 'Successful update.'
 
     # Expect changed
     hierarchy.expect_hierarchy_at(wp_root, wp_child2)
     hierarchy.expect_leaf_at(wp_child1, wp_child3)
 
-    # Wait a bit again
-    sleep 2
-
     subject = wp_table.edit_field(wp_child3, :subject)
     subject.update 'Second edit'
+    wait_for_network_idle
     wp_table.expect_and_dismiss_toaster message: 'Successful update.'
 
-    sleep 2
     wp_child3.reload
     expect(wp_child3.subject).to eq 'Second edit'
     expect(wp_child3.parent).to eq wp_child2

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -65,7 +65,7 @@ Capybara::Cuprite::Driver.prepend(SetCupriteDownloadPath)
 def register_better_cuprite(language, name: :"better_cuprite_#{language}")
   Capybara.register_driver(name) do |app|
     options = {
-      process_timeout: 10,
+      process_timeout: 20,
       inspector: true,
       headless: headless_mode?,
       window_size: [1920, 1080]

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -253,7 +253,7 @@ module Pages
 
       if expect_success
         expect_and_dismiss_toaster message: 'Successful update'
-        sleep 1
+        wait_for_network_idle
       end
     end
 


### PR DESCRIPTION
A small bump in performance :)

* Bumps process timeout to 20 seconds for cuprite specs.
* Promote `new_work_package_datepicker_spec.rb` to cuprite.
* Promote `work_packages/table/hierarchy/hierarchy_indent_spec.rb` to cuprite.
* Promote `empty_backlogs_spec.rb` to cuprite.
* Promote `remaining_time_spec.rb` to cuprite.