### PR TITLE
Enable Capybara screenshots S3 upload only with valid secrets

### DIFF
--- a/spec/support/capybara_browser_screenshots.rb
+++ b/spec/support/capybara_browser_screenshots.rb
@@ -7,7 +7,7 @@ require 'capybara-screenshot/rspec'
 Capybara::Screenshot.prune_strategy = :keep_last_run
 
 # Set up S3 uploads if desired
-if ENV['CAPYBARA_AWS_ACCESS_KEY_ID']
+if ENV['CAPYBARA_AWS_ACCESS_KEY_ID'].present?
   Capybara::Screenshot.s3_configuration = {
     s3_client_credentials: {
       access_key_id: ENV.fetch('CAPYBARA_AWS_ACCESS_KEY_ID'),


### PR DESCRIPTION
`CAPYBARA_AWS_ACCESS_KEY_ID` and `CAPYBARA_AWS_SECRET_ACCESS_KEY` are stored as GitHub secrets and are only available to people with collaborator access to the repository.

External collaborators and bots like dependabot will not be able to upload screenshots to S3 on feature tests failure.

As the `docker-compose.ci.yml` forwards `CAPYBARA_AWS_ACCESS_KEY_ID` and `CAPYBARA_AWS_SECRET_ACCESS_KEY`, they will be set to an empty string if the value is not available due to access restrictions. That's why checking for environment variable existence is not enough. It has to check for presence (non-blank).