### PR TITLE
Remove autofocus from meetings datepicker

### DIFF
--- a/modules/meeting/app/forms/meeting/start_date.rb
+++ b/modules/meeting/app/forms/meeting/start_date.rb
@@ -36,7 +36,7 @@ class Meeting::StartDate < ApplicationForm
       label: Meeting.human_attribute_name(:start_date),
       leading_visual: { icon: :calendar },
       required: true,
-      autofocus: true
+      autofocus: false
     )
   end
 


### PR DESCRIPTION
The focus is caught by the modal anyway, but autofocus=true causes the datepicker opening on mobile https://community.openproject.org/work_packages/50781