### PR TITLE
Specfiy permission for `acts_as_watchable` in Meetings

### DIFF
--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -54,7 +54,7 @@ class Meeting < ApplicationRecord
       .merge(Project.allowed_to(args.first || User.current, :view_meetings))
   }
 
-  acts_as_watchable
+  acts_as_watchable permission: :view_meetings
 
   acts_as_searchable columns: [
                        "#{table_name}.title",

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Meeting do
       meeting.save!
     end
 
-    it { expect(meeting.watchers.collect(&:user)).to match_array([user1, user2]) }
+    it { expect(meeting.watchers.collect(&:user)).to contain_exactly(user1, user2) }
   end
 
   describe '#close_agenda_and_copy_to_minutes' do
@@ -233,6 +233,20 @@ RSpec.describe Meeting do
         copy = meeting.copy({})
         expect(copy.participants.map(&:user_id)).to eq [user1.id]
       end
+    end
+  end
+
+  describe 'acts_as_watchable' do
+    it 'is watchable' do
+      expect(described_class).to include(Redmine::Acts::Watchable::InstanceMethods)
+    end
+
+    it 'uses the :view_meetings permission' do
+      expect(described_class.acts_as_watchable_permission).to eq(:view_meetings)
+    end
+
+    it 'uses the :view_meetings permission in STI classes' do
+      expect(StructuredMeeting.acts_as_watchable_permission).to eq(:view_meetings)
     end
   end
 end


### PR DESCRIPTION
Currently the permission is not explicitly defined, and thus the class name is used to generate the permission name:

```ruby
StructuredMeeting.acts_as_watchable_permission
# => :view_structured_meetings
```

This PR specifies the permission and thus the derived classes use the correct permission:

```ruby
StructuredMeeting.acts_as_watchable_permission
# => :view_meetings
```