### PR TITLE
Bug/50768 icalender are not updated automatically

### DIFF
--- a/modules/calendar/app/services/calendar/create_ical_service.rb
+++ b/modules/calendar/app/services/calendar/create_ical_service.rb
@@ -45,6 +45,7 @@ module Calendar
       calendar = Icalendar::Calendar.new
 
       calendar.prodid = "-//OpenProject GmbH//OpenProject Core Project//EN"
+      calendar.refresh_interval = 'PT1H'
       calendar.x_wr_calname = calendar_name
 
       work_packages.each do |work_package|

--- a/modules/calendar/spec/services/create_ical_service_spec.rb
+++ b/modules/calendar/spec/services/create_ical_service_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Calendar::CreateICalService, type: :model do
       VERSION:2.0
       PRODID:-//OpenProject GmbH//OpenProject Core Project//EN
       CALSCALE:GREGORIAN
+      REFRESH-INTERVAL;VALUE=DURATION:PT1H
       X-WR-CALNAME:#{query_name}
       BEGIN:VEVENT
       DTSTAMP:#{work_package_with_due_date.updated_at.utc.strftime('%Y%m%dT%H%M%SZ')}


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/50768

This PR follows the suggestion of Dataport and Open-Xchange to include the `REFRESH-INTERVAL` in the iCalendar output. It acts as a suggestion for the client application and can be overwritten. More information can be found here: https://datatracker.ietf.org/doc/html/rfc7986#section-5.7

As discussed with @lindenthal, the value is statically set to `1H` (1 hour). 

I'm not sure if this default value should be configurable via an OpenProject administrator. I tend to think that the effort is not worth it as an iCalendar client application typically enables the user to set/overwrite the `REFRESH-INTERVAL` in case it's necessary. 

If the value can be implemented statically (as done currently), the question is, if `1H` is a legit default value for our context.

@ulferts could you please share your quick opinions on that? Thank you!