### PR TITLE
Allow omniauth integrations to map admin flag, update on login

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,8 +34,8 @@ GIT
 
 GIT
   remote: https://github.com/opf/omniauth-openid-connect.git
-  revision: efddc061a72791db019259768a4656c0435709e8
-  ref: efddc061a72791db019259768a4656c0435709e8
+  revision: d63f5967514d10db9ddece798dadfa2ac532cbe0
+  ref: d63f5967514d10db9ddece798dadfa2ac532cbe0
   specs:
     omniauth-openid-connect (0.4.0)
       addressable (~> 2.5)

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -14,7 +14,7 @@ gem 'omniauth-openid_connect-providers',
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',
-    ref: 'efddc061a72791db019259768a4656c0435709e8'
+    ref: 'd63f5967514d10db9ddece798dadfa2ac532cbe0'
 
 group :opf_plugins do
     # included so that engines can reference OpenProject::Version

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -66,10 +66,13 @@ module Authentication
       update_user_from_omniauth!(assignable_params)
 
       # If we have a new or invited user, we still need to register them
-      activation_call = activate_user!
+      call = activate_user!
+
+      # Update the admin flag when present successful
+      call = update_admin_flag(call) if call.success?
 
       # The user should be logged in now
-      tap_service_result activation_call
+      tap_service_result call
     end
 
     private
@@ -181,12 +184,40 @@ module Authentication
         ::Users::SetAttributesService
           .new(user: User.system, model: user, contract_class: ::Users::UpdateContract)
           .call(user_attributes)
-          .result
       else
-        # Update the user, but never change the admin flag
+        # Update the user, but do not change the admin flag
+        # as this call is not validated.
+        # we do this separately in +update_admin_flag+
         ::Users::UpdateService
           .new(user: User.system, model: user)
           .call(user_attributes.except(:admin))
+      end
+    end
+
+    def update_admin_flag(call)
+      return call unless user_attributes.key?(:admin)
+
+      new_admin = ActiveRecord::Type::Boolean.new.cast(user_attributes[:admin])
+      return call if user.admin == new_admin
+
+      ::Users::UpdateService
+        .new(user: User.system, model: user)
+        .call(admin: new_admin)
+        .on_failure { |res| update_admin_flag_failure(res) }
+        .on_success { update_admin_flag_success(new_admin) }
+    end
+
+    def update_admin_flag_success(new_admin)
+      if new_admin
+        OpenProject.logger.info { "[OmniAuth strategy #{strategy.name}] Granted user##{update.result.id} admin permissions" }
+      else
+        OpenProject.logger.info { "[OmniAuth strategy #{strategy.name}] Revoked user##{update.result.id} admin permissions" }
+      end
+    end
+
+    def update_admin_flag_failure(call)
+      OpenProject.logger.error do
+        "[OmniAuth strategy #{strategy.name}] Failed to update admin user permissions: #{call.message}"
       end
     end
 
@@ -217,12 +248,15 @@ module Authentication
       info = auth_hash[:info]
 
       attribute_map = {
-        login: info[:email],
+        login: info[:login] || info[:email],
         mail: info[:email],
         firstname: info[:first_name] || info[:name],
         lastname: info[:last_name],
-        identity_url: identity_url_from_omniauth
+        identity_url: identity_url_from_omniauth,
       }
+
+      # Map the admin attribute if provided in an attribute mapping
+      attribute_map[:admin] = ActiveRecord::Type::Boolean.new.cast(info[:admin]) if info.key?(:admin)
 
       # Allow strategies to override mapping
       if strategy.respond_to?(:omniauth_hash_to_user_attributes)
@@ -231,7 +265,7 @@ module Authentication
 
       # Remove any nil values to avoid
       # overriding existing attributes
-      attribute_map.compact_blank!
+      attribute_map.reject! { |_, value| value.nil? || value == '' }
 
       Rails.logger.debug { "Mapped auth_hash user attributes #{attribute_map.inspect}" }
       attribute_map

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -73,12 +73,6 @@ module OpenProject
               redirect_to omniauth_start_path(h[:name]) + "/spslo"
             end
 
-            h[:openproject_attribute_map] = Proc.new do |auth|
-              {}.tap do |additional|
-                additional[:login] = auth.info[:login] if auth.info.key? :login
-                additional[:admin] = auth.info[:admin] if auth.info.key? :admin
-              end
-            end
             h.symbolize_keys
           end
         end

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -49,14 +49,6 @@ module OpenProject::OpenIDConnect
             ::OpenProject::OpenIDConnect::SessionMapper.handle_logout(logout_token)
           end
 
-          # Allow username mapping from custom 'login' claim
-          h[:openproject_attribute_map] = Proc.new do |auth|
-            {}.tap do |additional|
-              mapped_login = auth.dig(:info, :login)
-              additional[:login] = mapped_login if mapped_login.present?
-            end
-          end
-
           h
         end
       end


### PR DESCRIPTION
Provides a separate call to Users::UpdateService when an admin attribute has been mapped to the omniauth info hash.

When updating the admin flag fails for some reason (e.g., trying to remove the last admin) it will prevent the user from logging in.

https://community.openproject.org/work_packages/50859

⚠️ Requires https://github.com/opf/omniauth-openid-connect/pull/13