### PR TITLE
Seting login_required=true by default

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -598,7 +598,7 @@ module Settings
         writable: false
       },
       login_required: {
-        default: false
+        default: true
       },
       lookbook_enabled: {
         description: 'Enable the Lookbook component documentation tool. Discouraged for production environments.',

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -291,6 +291,20 @@ When a filter is defined, synchronization happens directly during seeding for en
 
 
 
+## Allowing public access
+
+By default, any request to the OpenProject application needs to be authenticated. If you want to enable public unauthenticated access like we do for https://community.openproject.com, you can set the `login_required` to `false`. If not provided through environment variables, this setting is also accessible in the administrative UI. Please see the [authentication settings guide](../../system-admin-guide/authentication/authentication-settings/#general-authentication-settings) for more details.
+
+*default: true*
+
+To disable, set the configuration option:
+
+```yaml
+OPENPROJECT_LOGIN__REQUIRED="false"
+```
+
+
+
 ## Setting session options
 
 **Delete old sessions for the same user when logging in**

--- a/docs/system-admin-guide/authentication/authentication-settings/README.md
+++ b/docs/system-admin-guide/authentication/authentication-settings/README.md
@@ -13,7 +13,9 @@ You can adapt the following under the authentication settings:
 
 ## General authentication settings
 
-1. Select if the **authentication is required** to access OpenProject. **Watch out**: If you un-tick this box your OpenProject instance will be visible to the general public without logging in. The visibility of individual projects depends on [this setting](../../../user-guide/projects/#set-a-project-to-public). 
+1. Select if the **authentication is required** to access OpenProject. For versions 13.1 and higher of OpenProject, this setting will be checked by default
+
+   **Important note**: If you un-tick this box your OpenProject instance will be visible to the general public without logging in. The visibility of individual projects depends on [this setting](../../../user-guide/projects/#set-a-project-to-public). 
 
 2. Select an option for **self-registration**. Self-registration can either be **disabled**, or it can be allowed with the following criteria:
 

--- a/modules/bim/spec/features/bcf/api_authorization_spec.rb
+++ b/modules/bim/spec/features/bcf/api_authorization_spec.rb
@@ -132,12 +132,12 @@ RSpec.describe 'authorization for BCF api',
     # While not being logged in and without a token, the api cannot be accessed
     visit("/api/bcf/2.1/projects/#{project.id}")
     expect(page)
-      .to have_content(JSON.dump(message: "The requested resource could not be found."))
+      .to have_content(JSON.dump(message: "You need to be authenticated to access this resource."))
 
     ## Without the access token, access is denied
     api_session = ActionDispatch::Integration::Session.new(Rails.application)
     response = api_session.get("/api/bcf/2.1/projects/#{project.id}")
-    expect(response).to eq 404
+    expect(response).to eq 401
 
     # With the access token, access is allowed
     response = api_session.get("/api/bcf/2.1/projects/#{project.id}",

--- a/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
+++ b/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
@@ -72,10 +72,7 @@ RSpec.describe 'API v3 Budget resource' do
         get get_path
       end
 
-      it_behaves_like 'error response',
-                      403,
-                      'MissingPermission',
-                      I18n.t('api_v3.errors.code_403')
+      it_behaves_like 'forbidden response based on login_required'
     end
   end
 
@@ -99,7 +96,7 @@ RSpec.describe 'API v3 Budget resource' do
         get get_path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found response based on login_required'
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe 'logging requesting users' do
+  describe 'logging requesting users', with_settings: { login_required: false } do
     let(:user_message) do
       "OpenProject User: #{user.firstname} Crazy! Name with ## " +
         "Newline (#{user.login} ID: #{user.id} <#{user.mail}>)"
@@ -84,7 +84,7 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe 'unverified request' do
+  describe 'unverified request', with_settings: { login_required: false } do
     shared_examples 'handle_unverified_request resets session' do
       before do
         ActionController::Base.allow_forgery_protection = true
@@ -99,11 +99,11 @@ RSpec.describe ApplicationController do
 
         allow(controller)
           .to receive(:cookies)
-          .and_return(cookies_double)
+                .and_return(cookies_double)
 
         expect(cookies_double)
           .to receive(:delete)
-          .with(OpenProject::Configuration['autologin_cookie_name'])
+                .with(OpenProject::Configuration['autologin_cookie_name'])
 
         post :index
       end
@@ -149,7 +149,7 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe 'rack timeout duplicate error suppression' do
+  describe 'rack timeout duplicate error suppression', with_settings: { login_required: false } do
     controller do
       include OpenProjectErrorHelper
 
@@ -188,8 +188,8 @@ RSpec.describe ApplicationController do
         allow(controller.request.env).to receive(:[]).and_call_original
         allow(controller.request.env)
           .to receive(:[])
-          .with(Rack::Timeout::ENV_INFO_KEY)
-          .and_return(OpenStruct.new(state: :timed_out))
+                .with(Rack::Timeout::ENV_INFO_KEY)
+                .and_return(OpenStruct.new(state: :timed_out))
       end
 
       it "suppresses the (duplicate) error report" do

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -64,25 +64,45 @@ RSpec.describe ForumsController do
       end
     end
 
-    it 'renders 404 for not found' do
-      get :index, params: { project_id: 'not found' }
-      expect(response.status).to eq 404
+
+    context 'when login_required', with_settings: { login_required: true } do
+      it 'redirects to login' do
+        get :index, params: { project_id: 'not found' }
+        expect(response).to redirect_to signin_path(back_url: project_forums_url('not found'))
+      end
+    end
+
+    context 'when not login_required', with_settings: { login_required: false } do
+      it 'renders 404 for not found' do
+        get :index, params: { project_id: 'not found' }
+        expect(response.status).to eq 404
+      end
     end
   end
 
   describe '#show' do
     before do
-      expect(project).to receive_message_chain(:forums, :find).and_return(forum)
-      expect(@controller).to receive(:authorize)
-      expect(@controller).to receive(:find_project_by_project_id) do
+      allow(project).to receive_message_chain(:forums, :find).and_return(forum)
+      allow(@controller).to receive(:authorize)
+      allow(@controller).to receive(:find_project_by_project_id) do
         @controller.instance_variable_set(:@project, project)
       end
     end
 
-    it 'renders the show template' do
-      get :show, params: { project_id: project.id, id: 1 }
-      expect(response).to be_successful
-      expect(response).to render_template 'forums/show'
+
+    context 'when login_required', with_settings: { login_required: true } do
+      it 'redirects to login' do
+        get :show, params: { project_id: project.id, id: 1 }
+        expect(response).to redirect_to signin_path(back_url: project_forum_url(project.id, 1))
+      end
+    end
+
+    context 'when not login_required', with_settings: { login_required: false } do
+      it 'renders the show template' do
+        get :show, params: { project_id: project.id, id: 1 }
+        expect(response).to be_successful
+        expect(response).to render_template 'forums/show'
+      end
     end
   end
 
@@ -139,7 +159,7 @@ RSpec.describe ForumsController do
     end
   end
 
-  describe '#destroy' do
+  describe '#destroy',  with_settings: { login_required: false } do
     let(:forum_params) { { name: 'my forum', description: 'awesome forum' } }
 
     before do
@@ -174,7 +194,7 @@ RSpec.describe ForumsController do
       allow(@controller).to receive(:authorize).and_return(true)
     end
 
-    describe '#higher' do
+    describe '#higher',  with_settings: { login_required: false } do
       let(:move_to) { 'higher' }
 
       before do
@@ -253,7 +273,7 @@ RSpec.describe ForumsController do
     end
   end
 
-  describe '#sticky' do
+  describe '#sticky', with_settings: { login_required: false } do
     let!(:message1) { create(:message, forum:) }
     let!(:message2) { create(:message, forum:) }
     let!(:sticked_message1) do

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -49,19 +49,29 @@ RSpec.describe MessagesController, with_settings: { journal_aggregation_time_min
   before { allow(User).to receive(:current).and_return user }
 
   describe '#show' do
-    context 'public project' do
+    context 'with a public project' do
       let(:user) { User.anonymous }
       let(:project) { create(:public_project) }
       let!(:message) { create(:message, forum:) }
 
-      it 'renders the show template' do
-        get :show, params: { project_id: project.id, id: message.id }
 
-        expect(response).to be_successful
-        expect(response).to render_template 'messages/show'
-        expect(assigns(:topic)).to be_present
-        expect(assigns(:forum)).to be_present
-        expect(assigns(:project)).to be_present
+      context 'when login_required', with_settings: { login_required: true } do
+        it 'redirects to login' do
+          get :show, params: { project_id: project.id, id: message.id }
+          expect(response).to redirect_to signin_path(back_url: topic_url(message.id))
+        end
+      end
+
+      context 'when not login_required', with_settings: { login_required: false } do
+        it 'renders the show template' do
+          get :show, params: { project_id: project.id, id: message.id }
+
+          expect(response).to be_successful
+          expect(response).to render_template 'messages/show'
+          expect(assigns(:topic)).to be_present
+          expect(assigns(:forum)).to be_present
+          expect(assigns(:project)).to be_present
+        end
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -99,11 +99,19 @@ RSpec.describe ProjectsController do
     context 'as anonymous user' do
       let(:user) { User.anonymous }
 
-      it_behaves_like 'successful index'
+      context 'when login_required', with_settings: { login_required: true } do
+        it 'redirects to login' do
+          expect(response).to redirect_to signin_path(back_url: projects_url)
+        end
+      end
 
-      it "shows only (active) public projects" do
-        expect(assigns[:projects])
-          .to contain_exactly(project_c)
+      context 'when not login_required', with_settings: { login_required: false } do
+        it_behaves_like 'successful index'
+
+        it "shows only (active) public projects" do
+          expect(assigns[:projects])
+            .to contain_exactly(project_c)
+        end
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -883,9 +883,17 @@ RSpec.describe UsersController do
       context 'when not being logged in' do
         let(:current_user) { User.anonymous }
 
-        it 'responds with 404' do
-          expect(response)
-            .to have_http_status(:not_found)
+        context 'when login_required', with_settings: { login_required: true } do
+          it 'redirects to login' do
+            expect(response).to redirect_to signin_path(back_url: user_url(user.id))
+          end
+        end
+
+        context 'when not login_required', with_settings: { login_required: false } do
+          it 'responds with 404' do
+            expect(response)
+              .to have_http_status(:not_found)
+          end
         end
 
         context 'when requesting special value "me"' do

--- a/spec/features/auth/auth_stages_spec.rb
+++ b/spec/features/auth/auth_stages_spec.rb
@@ -112,11 +112,7 @@ RSpec.describe 'Authentication Stages',
     end
 
     it 'redirects to authentication stage after registration via omniauth too' do
-      visit signin_path
-
-      within("#new_user") do
-        click_on "Omniauth Developer"
-      end
+      visit '/auth/developer'
 
       fill_in "first_name", with: "Adam"
       fill_in "last_name", with: "Apfel"
@@ -201,8 +197,6 @@ RSpec.describe 'Authentication Stages',
 
   it 'redirects to the referer if there is one' do
     visit "/projects"
-
-    click_on "Sign in"
 
     expect do
       within('#login-form') do

--- a/spec/features/auth/logout_spec.rb
+++ b/spec/features/auth/logout_spec.rb
@@ -50,11 +50,14 @@ RSpec.describe 'Logout', js: true do
     end
 
     expect(page)
-      .to have_current_path home_path
+      .to have_current_path /login/
 
     # Can not access the my page but is redirected
     # to login instead.
     visit my_page_path
+    
+    expect(page)
+      .to have_current_path /login/
 
     expect(page)
       .to have_field('Username')

--- a/spec/features/homescreen/robots_spec.rb
+++ b/spec/features/homescreen/robots_spec.rb
@@ -35,16 +35,24 @@ RSpec.describe 'robots.txt' do
     visit '/robots.txt'
   end
 
-  it 'disallows global paths and paths from public project' do
-    expect(page).to have_content('Disallow: /activity')
-    expect(page).to have_content('Disallow: /activities')
-    expect(page).to have_content('Disallow: /search')
+  context 'when login_required', with_settings: { login_required: true } do
+    it 'disallows everything' do
+      expect(page).to have_content('Disallow: /')
+    end
+  end
 
-    [project.identifier, project.id].each do |identifier|
-      expect(page).to have_content("Disallow: /projects/#{identifier}/repository")
-      expect(page).to have_content("Disallow: /projects/#{identifier}/work_packages")
-      expect(page).to have_content("Disallow: /projects/#{identifier}/activity")
-      expect(page).to have_content("Disallow: /projects/#{identifier}/search")
+  context 'when not login_required', with_settings: { login_required: false } do
+    it 'disallows global paths and paths from public project' do
+      expect(page).to have_content('Disallow: /activity')
+      expect(page).to have_content('Disallow: /activities')
+      expect(page).to have_content('Disallow: /search')
+
+      [project.identifier, project.id].each do |identifier|
+        expect(page).to have_content("Disallow: /projects/#{identifier}/repository")
+        expect(page).to have_content("Disallow: /projects/#{identifier}/work_packages")
+        expect(page).to have_content("Disallow: /projects/#{identifier}/activity")
+        expect(page).to have_content("Disallow: /projects/#{identifier}/search")
+      end
     end
   end
 end

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -138,8 +138,16 @@ RSpec.describe 'Top menu items', :js, :with_cuprite do
     context 'as an anonymous user' do
       let(:user) { create(:anonymous) }
 
-      it 'displays only projects, activity and news' do
-        has_menu_items? project_item, activity_item, news_item
+      context 'when login_required', with_settings: { login_required: true } do
+        it 'redirects to login' do
+          expect(page).to have_current_path /login/
+        end
+      end
+
+      context 'when not login_required', with_settings: { login_required: false } do
+        it 'displays only projects, activity and news' do
+          has_menu_items? project_item, activity_item, news_item
+        end
       end
     end
   end

--- a/spec/features/search/recently_viewed_work_packages_spec.rb
+++ b/spec/features/search/recently_viewed_work_packages_spec.rb
@@ -30,7 +30,9 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Recently viewed work packages', js: true do
+RSpec.describe 'Recently viewed work packages',
+               :js,
+               with_settings: { login_required: false } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   let(:global_search) { Components::GlobalSearch.new }

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Setting do
       expect(described_class).to be_self_registration
     end
 
-    it 'allows anonymous users to access public information' do
-      expect(described_class).not_to be_login_required
+    it 'allows users to not access public information by default' do
+      expect(described_class).to be_login_required
     end
   end
 

--- a/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
+++ b/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
@@ -142,9 +142,18 @@ RSpec.describe 'API v3 Custom Options resource', :aggregate_failures do
         let(:user) { User.anonymous }
         let(:permissions) { [] }
 
-        it 'is 404' do
-          expect(subject.status)
-            .to be(404)
+        context 'when login_required', with_settings: { login_required: true } do
+          it_behaves_like 'error response',
+                          401,
+                          'Unauthenticated',
+                          I18n.t('api_v3.errors.code_401')
+        end
+
+        context 'when not login_required', with_settings: { login_required: false } do
+          it 'is 404' do
+            expect(subject.status)
+              .to be(404)
+          end
         end
       end
     end
@@ -187,10 +196,7 @@ RSpec.describe 'API v3 Custom Options resource', :aggregate_failures do
         let(:user) { User.anonymous }
         let(:permissions) { [] }
 
-        it 'is 404' do
-          expect(subject.status)
-            .to be(404)
-        end
+        it_behaves_like 'not found response based on login_required'
       end
     end
 

--- a/spec/requests/api/v3/days/non_working_days_show_resource_spec.rb
+++ b/spec/requests/api/v3/days/non_working_days_show_resource_spec.rb
@@ -70,15 +70,17 @@ RSpec.describe API::V3::Days::NonWorkingDaysAPI,
   context 'for a not logged in user' do
     let(:user) { build(:anonymous) }
 
-    it_behaves_like 'successful response'
-
-    it 'responds with the correct _type' do
-      expect(subject).to be_json_eql('NonWorkingDay'.to_json).at_path('_type')
+    context 'when login_required', with_settings: { login_required: true } do
+      it_behaves_like 'unauthenticated access'
     end
 
-    it 'responds with the correct day' do
-      expect(subject).to be_json_eql('NonWorkingDay'.to_json).at_path('_type')
-      expect(subject).to be_json_eql(non_working_day.date.to_json).at_path('date')
+    context 'when not login_required', with_settings: { login_required: false } do
+      it_behaves_like 'successful response'
+
+      it 'responds with the correct _type and day', :aggregate_failures do
+        expect(subject).to be_json_eql('NonWorkingDay'.to_json).at_path('_type')
+        expect(subject).to be_json_eql(non_working_day.date.to_json).at_path('date')
+      end
     end
   end
 end

--- a/spec/requests/api/v3/days/week_show_resource_spec.rb
+++ b/spec/requests/api/v3/days/week_show_resource_spec.rb
@@ -61,11 +61,17 @@ RSpec.describe API::V3::Days::WeekAPI,
   context 'for a not logged in user' do
     let(:user) { build(:anonymous) }
 
-    it_behaves_like 'successful response'
+    context 'when login_required', with_settings: { login_required: true } do
+      it_behaves_like 'unauthenticated access'
+    end
 
-    it 'responds with the correct day' do
-      expect(subject).to be_json_eql('WeekDay'.to_json).at_path('_type')
-      expect(subject).to be_json_eql(1.to_json).at_path('day')
+    context 'when not login_required', with_settings: { login_required: false } do
+      it_behaves_like 'successful response'
+
+      it 'responds with the correct day', :aggregate_failures do
+        expect(subject).to be_json_eql('WeekDay'.to_json).at_path('_type')
+        expect(subject).to be_json_eql(1.to_json).at_path('day')
+      end
     end
   end
 end

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -376,8 +376,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
   describe 'as an anonymous user' do
     let(:current_user) { User.anonymous }
 
-    it 'returns a 403 response' do
-      expect(last_response.status).to eq(403)
-    end
+    it_behaves_like 'forbidden response based on login_required'
   end
 end

--- a/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
   context 'when anonymous user' do
     let(:user) { create(:anonymous) }
 
-    it_behaves_like 'deletion is not allowed'
+    context 'when login_required', with_settings: { login_required: true } do
+      it_behaves_like 'error response',
+                      401,
+                      'Unauthenticated',
+                      I18n.t('api_v3.errors.code_401')
+    end
+
+    context 'when not login_required', with_settings: { login_required: false } do
+      it_behaves_like 'deletion is not allowed'
+    end
   end
 end

--- a/spec/requests/api/v3/priority_resource_spec.rb
+++ b/spec/requests/api/v3/priority_resource_spec.rb
@@ -61,10 +61,7 @@ RSpec.describe 'API v3 Priority resource' do
         get get_path
       end
 
-      it_behaves_like 'error response',
-                      403,
-                      'MissingPermission',
-                      I18n.t('api_v3.errors.code_403')
+      it_behaves_like 'forbidden response based on login_required'
     end
   end
 
@@ -96,15 +93,12 @@ RSpec.describe 'API v3 Priority resource' do
       end
     end
 
-    context 'not logged in user' do
+    context 'when not logged in user' do
       before do
         get get_path
       end
 
-      it_behaves_like 'error response',
-                      403,
-                      'MissingPermission',
-                      I18n.t('api_v3.errors.code_403')
+      it_behaves_like 'forbidden response based on login_required'
     end
   end
 end

--- a/spec/requests/api/v3/projects/show_resource_spec.rb
+++ b/spec/requests/api/v3/projects/show_resource_spec.rb
@@ -177,6 +177,6 @@ RSpec.describe 'API v3 Project resource show', content_type: :json do
       get get_path
     end
 
-    it_behaves_like 'not found'
+    it_behaves_like 'not found response based on login_required'
   end
 end

--- a/spec/requests/api/v3/root_resource_spec.rb
+++ b/spec/requests/api/v3/root_resource_spec.rb
@@ -50,12 +50,18 @@ RSpec.describe 'API v3 Root resource' do
         get get_path
       end
 
-      it 'responds with 200' do
-        expect(response.status).to eq(200)
+      context 'when login_required', with_settings: { login_required: true } do
+        it_behaves_like 'error response',
+                        401,
+                        'Unauthenticated',
+                        I18n.t('api_v3.errors.code_401')
       end
 
-      it 'responds with a root representer' do
-        expect(subject).to have_json_path('instanceName')
+      context 'when not login_required', with_settings: { login_required: false } do
+        it 'responds with 200', :aggregate_failures do
+          expect(response.status).to eq(200)
+          expect(subject).to have_json_path('instanceName')
+        end
       end
     end
 

--- a/spec/requests/api/v3/status_resource_spec.rb
+++ b/spec/requests/api/v3/status_resource_spec.rb
@@ -62,10 +62,7 @@ RSpec.describe 'API v3 Status resource' do
           get get_path
         end
 
-        it_behaves_like 'error response',
-                        403,
-                        'MissingPermission',
-                        I18n.t('api_v3.errors.code_403')
+        it_behaves_like 'forbidden response based on login_required'
       end
     end
   end
@@ -103,10 +100,7 @@ RSpec.describe 'API v3 Status resource' do
           get get_path
         end
 
-        it_behaves_like 'error response',
-                        403,
-                        'MissingPermission',
-                        I18n.t('api_v3.errors.code_403')
+        it_behaves_like 'forbidden response based on login_required'
       end
     end
   end

--- a/spec/requests/api/v3/string_objects_resource_spec.rb
+++ b/spec/requests/api/v3/string_objects_resource_spec.rb
@@ -42,15 +42,21 @@ RSpec.describe 'API v3 String Objects resource' do
       get path
     end
 
-    it 'return 410 GONE' do
-      expect(subject.status).to be(410)
+    context 'when login_required', with_settings: { login_required: true } do
+      it_behaves_like 'unauthenticated access'
     end
 
-    context 'nil string' do
-      let(:path) { '/api/v3/string_objects?value' }
-
+    context 'when not login_required', with_settings: { login_required: false } do
       it 'return 410 GONE' do
         expect(subject.status).to be(410)
+      end
+
+      context 'nil string' do
+        let(:path) { '/api/v3/string_objects?value' }
+
+        it 'return 410 GONE' do
+          expect(subject.status).to be(410)
+        end
       end
     end
   end

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -158,6 +158,26 @@ RSpec.shared_examples_for 'not found' do |message = I18n.t('api_v3.errors.code_4
                    message
 end
 
+RSpec.shared_examples_for 'forbidden response based on login_required' do
+  context 'when login_required', with_settings: { login_required: true } do
+    it_behaves_like 'unauthenticated access'
+  end
+
+  context 'when not login_required', with_settings: { login_required: false } do
+    it_behaves_like 'unauthorized access'
+  end
+end
+
+RSpec.shared_examples_for 'not found response based on login_required' do |message = I18n.t('api_v3.errors.code_404')|
+  context 'when login_required', with_settings: { login_required: true } do
+    it_behaves_like 'unauthenticated access'
+  end
+
+  context 'when not login_required', with_settings: { login_required: false } do
+    it_behaves_like 'not found', message
+  end
+end
+
 RSpec.shared_examples_for 'param validation error' do
   subject { JSON.parse(last_response.body) }
 

--- a/spec/requests/api/v3/types/type_resource_spec.rb
+++ b/spec/requests/api/v3/types/type_resource_spec.rb
@@ -62,10 +62,7 @@ RSpec.describe 'API v3 Type resource' do
           get get_path
         end
 
-        it_behaves_like 'error response',
-                        403,
-                        'MissingPermission',
-                        I18n.t('api_v3.errors.code_403')
+        it_behaves_like 'forbidden response based on login_required'
       end
     end
   end
@@ -103,10 +100,7 @@ RSpec.describe 'API v3 Type resource' do
           get get_path
         end
 
-        it_behaves_like 'error response',
-                        403,
-                        'MissingPermission',
-                        I18n.t('api_v3.errors.code_403')
+        it_behaves_like 'forbidden response based on login_required'
       end
     end
   end

--- a/spec/requests/api/v3/types/types_by_project_resource_spec.rb
+++ b/spec/requests/api/v3/types/types_by_project_resource_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe '/api/v3/projects/:id/types' do
         get get_path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found response based on login_required'
     end
   end
 end

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -288,12 +288,10 @@ RSpec.describe 'API v3 User resource',
     end
 
     shared_examples 'deletion is not allowed' do
-      it 'responds with 403' do
-        expect(subject.status).to eq 403
-      end
+      it_behaves_like 'unauthorized access'
 
       it 'does not delete the user' do
-        expect(User.exists?(user.id)).to be_truthy
+        expect(User).to exist(user.id)
       end
     end
 
@@ -350,14 +348,21 @@ RSpec.describe 'API v3 User resource',
     context 'as anonymous user' do
       let(:current_user) { create(:anonymous) }
 
-      it_behaves_like 'deletion is not allowed'
+      context 'when login_required', with_settings: { login_required: true } do
+        it_behaves_like 'error response',
+                        401,
+                        'Unauthenticated',
+                        I18n.t('api_v3.errors.code_401')
+      end
+
+      context 'when not login_required', with_settings: { login_required: false } do
+        it_behaves_like 'deletion is not allowed'
+      end
 
       context 'requesting current user' do
         let(:get_path) { api_v3_paths.user 'me' }
 
-        it 'responses with 403' do
-          expect(subject.status).to eq(403)
-        end
+        it_behaves_like 'forbidden response based on login_required'
       end
     end
   end

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -57,12 +57,15 @@ RSpec.describe 'API v3 UserPreferences resource', content_type: :json do
     context 'when not logged in' do
       let(:user) { User.anonymous }
 
-      it 'responds with 200' do
-        expect(subject.status).to eq(200)
+      context 'when login_required', with_settings: { login_required: true } do
+        it_behaves_like 'unauthenticated access'
       end
 
-      it 'responds with a UserPreferences representer' do
-        expect(subject.body).to be_json_eql('UserPreferences'.to_json).at_path('_type')
+      context 'when not login_required', with_settings: { login_required: false } do
+        it 'responds with a UserPreferences representer', :aggregate_failures do
+          expect(subject.status).to eq(200)
+          expect(subject.body).to be_json_eql('UserPreferences'.to_json).at_path('_type')
+        end
       end
     end
 

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe 'API v3 Work package resource',
         get get_path
       end
 
-      it_behaves_like 'not found',
+      it_behaves_like 'not found response based on login_required',
                       I18n.t('api_v3.errors.not_found.work_package')
     end
   end

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -174,10 +174,11 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
     end
 
     context 'not logged in' do
-      it 'acts as if the schema does not exist' do
+      before do
         get schema_path
-        expect(last_response.status).to be(404)
       end
+
+      it_behaves_like 'not found response based on login_required'
     end
   end
 
@@ -210,11 +211,12 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
       end
     end
 
-    context 'not logged in' do
-      it 'acts as if the schema does not exist' do
+    context 'when not logged in' do
+      before do
         get schema_path
-        expect(last_response.status).to be(404)
       end
+
+      it_behaves_like 'not found response based on login_required'
     end
   end
 end

--- a/spec/requests/oauth/client_credentials_flow_spec.rb
+++ b/spec/requests/oauth/client_credentials_flow_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe 'OAuth client credentials flow' do
     body['access_token']
   end
 
-  subject do
+  let(:make_request) do
     # Perform request with it
     headers = { 'HTTP_CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{access_token}" }
-    response = get '/api/v3', {}, headers
-    expect(response).to be_successful
-
-    JSON.parse(response.body)
+    get '/api/v3', {}, headers
   end
+
+  subject { JSON.parse(make_request.body) }
 
   describe 'when application provides client credentials impersonator' do
     let(:user) { create(:user) }
     let(:user_id) { user.id }
 
     it 'allows client credential flow as the user' do
+      expect(make_request).to be_successful
       expect(subject.dig('_links', 'user', 'href')).to eq("/api/v3/users/#{user.id}")
     end
   end
@@ -64,8 +64,19 @@ RSpec.describe 'OAuth client credentials flow' do
   describe 'when application does not provide client credential impersonator' do
     let(:user_id) { nil }
 
-    it 'allows client credential flow as the anonymous user' do
-      expect(subject.dig('_links', 'user', 'href')).to be_nil
+    before do
+      make_request
+    end
+
+    context 'when login_required', with_settings: { login_required: true } do
+      it_behaves_like 'unauthenticated access'
+    end
+
+    context 'when not login_required', with_settings: { login_required: false } do
+      it 'allows client credential flow as the anonymous user' do
+        expect(make_request).to be_successful
+        expect(subject.dig('_links', 'user', 'href')).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This ensures all access to the API and the application are authenticated by default. If users want to provide truly public access, they can change this setting.

https://community.openproject.org/work_packages/50890