### PR TITLE
add work package editor role to workflow administration

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -124,15 +124,15 @@ class WorkflowsController < ApplicationController
   end
 
   def find_roles
-    @roles = ProjectRole.order(Arel.sql('builtin, position'))
+    @roles = eligible_roles.order(:builtin, :position)
   end
 
   def find_types
-    @types = ::Type.order(Arel.sql('position'))
+    @types = ::Type.order(:position)
   end
 
   def find_role
-    @role = ProjectRole.find(params[:role_id])
+    @role = eligible_roles.find(params[:role_id])
   end
 
   def find_type
@@ -140,10 +140,15 @@ class WorkflowsController < ApplicationController
   end
 
   def find_optional_role
-    @role = ProjectRole.find_by(id: params[:role_id])
+    @role = eligible_roles.find_by(id: params[:role_id])
   end
 
   def find_optional_type
     @type = ::Type.find_by(id: params[:type_id])
+  end
+
+  def eligible_roles
+    Role.where(type: ProjectRole.name)
+        .or(Role.where(builtin: Role::BUILTIN_WORK_PACKAGE_EDITOR))
   end
 end

--- a/app/helpers/warning_bar_helper.rb
+++ b/app/helpers/warning_bar_helper.rb
@@ -39,12 +39,28 @@ module WarningBarHelper
       (setting_protocol_mismatched? || setting_hostname_mismatched?)
   end
 
+  def render_workflow_missing_warning?
+    current_user.admin? &&
+      no_workflow_for_wp_edit_role?
+  end
+
   def setting_protocol_mismatched?
     request.ssl? != OpenProject::Configuration.https?
   end
 
   def setting_hostname_mismatched?
     Setting.host_name.gsub(/:\d+$/, '') != request.host
+  end
+
+  def no_workflow_for_wp_edit_role?
+    workflow_exists = OpenProject::Cache.read('no_wp_share_editor_workflow')
+
+    if workflow_exists.nil?
+      workflow_exists = Workflow.exists?(role_id: Role.where(builtin: Role::BUILTIN_WORK_PACKAGE_EDITOR).select(:id))
+      OpenProject::Cache.write('no_wp_share_editor_workflow', workflow_exists) if workflow_exists
+    end
+
+    !workflow_exists
   end
 
   ##

--- a/app/helpers/warning_bar_helper.rb
+++ b/app/helpers/warning_bar_helper.rb
@@ -41,6 +41,7 @@ module WarningBarHelper
 
   def render_workflow_missing_warning?
     current_user.admin? &&
+      EnterpriseToken.allows_to?(:work_package_sharing) &&
       no_workflow_for_wp_edit_role?
   end
 

--- a/app/seeders/basic_data/workflow_seeder.rb
+++ b/app/seeders/basic_data/workflow_seeder.rb
@@ -63,12 +63,13 @@ module BasicData
     def seed_workflows
       member = seed_data.find_reference(:default_role_member)
       project_admin = seed_data.find_reference(:default_role_project_admin)
+      work_package_editor = seed_data.find_reference(:default_role_work_package_editor)
 
       # Workflow - Each type has its own workflow
       workflows.each do |type, statuses|
         statuses.each do |old_status|
           statuses.each do |new_status|
-            [member, project_admin].each do |role|
+            [member, project_admin, work_package_editor].each do |role|
               Workflow.create type:,
                               role:,
                               old_status:,

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -241,7 +241,7 @@ open_color_palette:
 
 work_package_roles:
   - reference: :default_role_work_package_editor
-    t_name: Work Package Editor
+    t_name: Work package editor
     position: 7
     builtin: :work_package_editor
     permissions:
@@ -254,7 +254,7 @@ work_package_roles:
       - :copy_work_packages
       - :export_work_packages
   - reference: :default_role_work_package_commenter
-    t_name: Work Package Commenter
+    t_name: Work package commenter
     builtin: :work_package_commenter
     position: 8
     permissions:
@@ -264,7 +264,7 @@ work_package_roles:
       - :edit_own_work_package_notes
       - :export_work_packages
   - reference: :default_role_work_package_viewer
-    t_name: Work Package Viewer
+    t_name: Work package viewer
     builtin: :work_package_viewer
     position: 9
     permissions:

--- a/app/views/warning_bar/_missing_wp_edit_role_workflows.html.erb
+++ b/app/views/warning_bar/_missing_wp_edit_role_workflows.html.erb
@@ -1,0 +1,9 @@
+<div class="warning-bar--item">
+  <p>
+    <strong><%= t('work_packages.sharing.missing_workflow_waring.title') %></strong><br>
+
+    <%= t('work_packages.sharing.missing_workflow_waring.message') %>
+    <%= link_to t('work_packages.sharing.missing_workflow_waring.link_message'),
+                copy_workflows_path %>
+  </p>
+</div>

--- a/app/views/warning_bar/_warning_bar.html.erb
+++ b/app/views/warning_bar/_warning_bar.html.erb
@@ -3,5 +3,6 @@
   <%= render partial: 'warning_bar/host_and_protocol_mismatch' if render_host_and_protocol_mismatch? %>
   <%= render partial: 'warning_bar/pending_migrations' if render_pending_migrations_warning? %>
   <%= render partial: 'warning_bar/unsupported_browser' if unsupported_browser? %>
+  <%= render partial: 'warning_bar/missing_wp_edit_role_workflows' if render_workflow_missing_warning? %>
 </div>
 <% end  %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -912,7 +912,8 @@ module Settings
       },
       show_warning_bars: {
         description: 'Render warning bars (pending migrations, deprecation, unsupported browsers)',
-        default: true,
+        # Hide warning bars by default in tests as they might overlay other elements
+        default: -> { !Rails.env.test? },
         writable: false
       },
       smtp_authentication: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,6 +446,12 @@ en:
       no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
       unsupported_for_multiple_projects: "Bulk move/copy is not supported for work packages from multiple projects"
 
+    sharing:
+      missing_workflow_waring:
+        title: "Workflow missing for work package sharing"
+        message: "No workflow configured for the 'Work package editor' role. Without a workflow, the status of a shared work package cannot be changed."
+        link_message: "Configure a workflow in the administration."
+
     summary:
       reports:
         category:

--- a/lib/open_project/cache.rb
+++ b/lib/open_project/cache.rb
@@ -30,8 +30,16 @@ require_relative 'cache/cache_key'
 
 module OpenProject
   module Cache
-    def self.fetch(*parts, **options, &)
-      Rails.cache.fetch(CacheKey.key(*parts), **options, &)
+    def self.fetch(*, **, &)
+      Rails.cache.fetch(CacheKey.key(*), **, &)
+    end
+
+    def self.read(name, **, &)
+      Rails.cache.read(CacheKey.key(name), **, &)
+    end
+
+    def self.write(name, value, **, &)
+      Rails.cache.write(CacheKey.key(name), value, **, &)
     end
 
     def self.clear

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RootSeeder,
     include_examples 'it creates records', model: IssuePriority, expected_count: 4
     include_examples 'it creates records', model: Status, expected_count: 4
     include_examples 'it creates records', model: TimeEntryActivity, expected_count: 3
-    include_examples 'it creates records', model: Workflow, expected_count: 182
+    include_examples 'it creates records', model: Workflow, expected_count: 273
   end
 
   describe 'demo data' do

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -90,9 +90,11 @@ RSpec.describe 'My page', :js do
   end
 
   def find_area(name)
-    index = grid.widgets.sort_by(&:id).each_with_index.detect { |w, _index| w.options["name"] == name }.last
+    retry_block do
+      index = grid.widgets.sort_by(&:id).each_with_index.detect { |w, _index| w.options["name"] == name }.last
 
-    Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(#{index + 1})")
+      Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(#{index + 1})")
+    end
   end
 
   it 'renders the default view, allows altering and saving' do

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -29,22 +29,32 @@
 require 'spec_helper'
 
 RSpec.describe WorkflowsController do
+  let!(:role_scope) do
+    role_scope = instance_double(ActiveRecord::Relation)
+
+    allow(Role)
+      .to receive(:where)
+            .with(type: ProjectRole.name)
+            .and_return(role_scope)
+
+    allow(role_scope)
+      .to receive_messages(order: role_scope, find_by: nil)
+
+    allow(role_scope)
+      .to receive(:find)
+            .with(role.id.to_s)
+            .and_return(role)
+
+    allow(role_scope)
+      .to receive(:find_by)
+            .with(id: role.id.to_s)
+            .and_return(role)
+
+    role_scope
+  end
+
   let!(:role) do
-    build_stubbed(:project_role) do |r|
-      allow(Role)
-        .to receive(:find)
-              .with(r.id.to_s)
-              .and_return(r)
-
-      allow(Role)
-        .to receive(:find_by)
-              .and_return(nil)
-
-      allow(Role)
-        .to receive(:find_by)
-              .with(id: r.id.to_s)
-              .and_return(r)
-    end
+    build_stubbed(:project_role)
   end
   let!(:type) do
     build_stubbed(:type) do |t|
@@ -105,7 +115,7 @@ RSpec.describe WorkflowsController do
         .to receive(:order)
               .and_return([type])
 
-      allow(Role)
+      allow(role_scope)
         .to receive(:order)
               .and_return([role])
     end
@@ -283,7 +293,7 @@ RSpec.describe WorkflowsController do
     end
 
     before do
-      allow(Role)
+      allow(role_scope)
         .to receive(:where)
               .with(id: [target_role1.id.to_s, target_role2.id.to_s])
               .and_return([target_role1, target_role2])

--- a/spec/factories/work_package_role_factory.rb
+++ b/spec/factories/work_package_role_factory.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
   end
 
   factory :view_work_package_role, parent: :work_package_role do
-    name { 'Work Package Viewer' }
+    name { 'Work package viewer' }
     builtin { Role::BUILTIN_WORK_PACKAGE_VIEWER }
     permissions do
       %i(view_work_packages
@@ -43,7 +43,7 @@ FactoryBot.define do
   end
 
   factory :comment_work_package_role, parent: :work_package_role do
-    name { 'Work Package Commenter' }
+    name { 'Work package commenter' }
     builtin { Role::BUILTIN_WORK_PACKAGE_COMMENTER }
     permissions do
       %i(view_work_packages
@@ -55,7 +55,7 @@ FactoryBot.define do
   end
 
   factory :edit_work_package_role, parent: :work_package_role do
-    name { |_n| 'Work Package Editor' }
+    name { |_n| 'Work package editor' }
     builtin { Role::BUILTIN_WORK_PACKAGE_EDITOR }
     permissions do
       %i(view_work_packages

--- a/spec/features/workflows/copy_spec.rb
+++ b/spec/features/workflows/copy_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Workflow copy' do
   let(:type) { create(:type) }
   let(:admin)  { create(:admin) }
   let(:statuses) { (1..2).map { |_i| create(:status) } }
-  let(:workflow) do
+  let!(:workflow) do
     create(:workflow, role_id: role.id,
                       type_id: type.id,
                       old_status_id: statuses[0].id,
@@ -42,26 +42,21 @@ RSpec.describe 'Workflow copy' do
                       assignee: false)
   end
 
+  current_user { admin }
+
   before do
-    allow(User).to receive(:current).and_return(admin)
+    visit url_for(controller: '/workflows', action: :copy)
   end
 
-  context 'lala' do
-    before do
-      workflow.save
-      visit url_for(controller: '/workflows', action: :copy)
+  it 'shows existing types and roles' do
+    select(role.name, from: :source_role_id)
+    within('#source_role_id') do
+      expect(page).to have_content(role.name)
+      expect(page).to have_content("--- #{I18n.t(:actionview_instancetag_blank_option)} ---")
     end
-
-    it 'shows existing types and roles' do
-      select(role.name, from: :source_role_id)
-      within('#source_role_id') do
-        expect(page).to have_content(role.name)
-        expect(page).to have_content("--- #{I18n.t(:actionview_instancetag_blank_option)} ---")
-      end
-      within('#source_type_id') do
-        expect(page).to have_content(type.name)
-        expect(page).to have_content("--- #{I18n.t(:actionview_instancetag_blank_option)} ---")
-      end
+    within('#source_type_id') do
+      expect(page).to have_content(type.name)
+      expect(page).to have_content("--- #{I18n.t(:actionview_instancetag_blank_option)} ---")
     end
   end
 end

--- a/spec/features/workflows/missing_for_sharing_wp_spec.rb
+++ b/spec/features/workflows/missing_for_sharing_wp_spec.rb
@@ -29,7 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Configuring the workflow for work package sharing',
-               with_config: { show_warning_bars: true } do
+               with_config: { show_warning_bars: true },
+               with_ee: %i[work_package_sharing] do
   let!(:role) { create(:project_role) }
   let!(:work_package_role) { create(:edit_work_package_role) }
   let!(:type) { create(:type) }

--- a/spec/features/workflows/missing_for_sharing_wp_spec.rb
+++ b/spec/features/workflows/missing_for_sharing_wp_spec.rb
@@ -1,0 +1,86 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Configuring the workflow for work package sharing',
+               with_config: { show_warning_bars: true } do
+  let!(:role) { create(:project_role) }
+  let!(:work_package_role) { create(:edit_work_package_role) }
+  let!(:type) { create(:type) }
+  let!(:start_status) { create(:status) }
+  let!(:end_status) { create(:status) }
+  let!(:workflow) do
+    create(:workflow,
+           role_id: role.id,
+           type_id: type.id,
+           old_status_id: start_status.id,
+           new_status_id: end_status.id,
+           author: false,
+           assignee: false)
+  end
+
+  current_user { create(:admin) }
+
+  before do
+    visit home_url
+  end
+
+  it 'shows a warning until a workflow is configured for the work package edit role' do
+    # There is a warning bar at the bottom informing of the missing workflow
+    within '.warning-bar--item' do
+      expect(page)
+        .to have_content("No workflow configured for the '#{work_package_role.name}' role. " \
+                         "Without a workflow, the status of a shared work package cannot be changed.")
+
+      click_link "Configure a workflow"
+    end
+
+    # On the copy workflow form, select the already existing workflow for copying
+    select type.name, from: 'source_type_id'
+    select role.name, from: 'source_role_id'
+    select type.name, from: 'target_type_ids'
+    select work_package_role.name, from: 'target_role_ids'
+
+    click_button 'Copy'
+
+    # Copying succeeds which results in the edit role having a workflow and the warning disappearing.
+    expect(page)
+      .to have_content 'Successful update'
+
+    expect(Workflow.where(role_id: work_package_role.id,
+                          type_id: type.id,
+                          old_status_id: start_status.id,
+                          new_status_id: end_status.id,
+                          author: false,
+                          assignee: false).count).to eq(1)
+
+    expect(page)
+      .not_to have_css('.warning-bar--item')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,7 +103,4 @@ RSpec.configure do |config|
   config.include ActiveJob::TestHelper
 
   OpenProject::Configuration['attachments_storage_path'] = 'tmp/files'
-
-  # Hide warning bars by default
-  OpenProject::Configuration['show_warning_bars'] = false
 end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe RootSeeder,
     include_examples 'it creates records', model: IssuePriority, expected_count: 4
     include_examples 'it creates records', model: Status, expected_count: 14
     include_examples 'it creates records', model: TimeEntryActivity, expected_count: 6
-    include_examples 'it creates records', model: Workflow, expected_count: 1172
+    include_examples 'it creates records', model: Workflow, expected_count: 1758
     include_examples 'it creates records', model: Meeting, expected_count: 1
   end
 

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe Authorization::EnterpriseService do
          readonly_work_packages
          team_planner_view
          two_factor_authentication
-         work_package_query_relation_columns).each do |guarded_action|
+         work_package_query_relation_columns
+         work_package_sharing).each do |guarded_action|
         context "guarded action #{guarded_action}" do
           let(:action) { guarded_action }
 


### PR DESCRIPTION
Adds the 'Work Package Editor' role to the roles selectable when administrating the workflows:

<img width="960" alt="image" src="https://github.com/opf/openproject/assets/617519/2335fe2e-3596-4f7d-85da-63c4b325ea4f">

Doing so, enables users having the role when having a work package shared with them to alter the status according to the workflows.

Administrators are notified of the need to configure a workflow via a warning:

<img width="1107" alt="image" src="https://github.com/opf/openproject/assets/617519/77b874b2-42f8-4cec-b9cd-0ef4fd96ad83">


### TODOs

* [x] Add editor role to workflow administration page
  * [x] limit this to only happen if an enterprise token grants the ability to have shared work packages
* [x] Display a warning to administrators in case no workflow is configured for that role  
  * [x] limit this to only happen if an enterprise token grants the ability to have shared work packages
  * [x] Cache the state of this to avoid querying the database on every request
* [x] introduce `work_package_sharing` EE action. Currently this is only limited to the workflow administration but will have to be extended to at least the share modal. 
* [x] Seed of a default workflow for new instances (same as the Project admin/member)

### Work package

https://community.openproject.org/wp/49482