### PR TITLE
Remove catching the UnknownPermissionError in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -316,16 +316,12 @@ class ApplicationController < ActionController::Base
     # context = @project || @projects
     # old_authorized = User.current.allowed_to?(action, context, global:)
 
-    is_authorized = begin
-      if global
-        User.current.allowed_based_on_permission_context?(action)
-      else
-        User.current.allowed_based_on_permission_context?(action, project: @project || @projects,
-                                                                  entity: @work_package || @work_packages)
-      end
-    rescue Authorization::UnknownPermissionError
-      false
-    end
+    is_authorized = if global
+                      User.current.allowed_based_on_permission_context?(action)
+                    else
+                      User.current.allowed_based_on_permission_context?(action, project: @project || @projects,
+                                                                                entity: @work_package || @work_packages)
+                    end
 
     unless is_authorized
       if @project&.archived?

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -89,12 +89,14 @@ class JournalsController < ApplicationController
   end
 
   def ensure_permitted
-    permission =
-      case @journal.journable_type
-      when 'WorkPackage' then :view_work_packages
-      when 'Project' then :view_project
-      end
+    permission = case @journal.journable_type
+                 when 'WorkPackage' then :view_work_packages
+                 when 'Project' then :view_project
+                 end
+
     do_authorize(permission)
+  rescue Authorization::UnknownPermissionError
+    deny_access
   end
 
   def field_param


### PR DESCRIPTION
In #14092  I was cautious and caught the `UnknownPermissionError` on the top level. This PR removes this and instead puts it in the only place where this is needed