### PR TITLE
Fix Flaky `my_page_spec.rb`

### DIFF
--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 require_relative '../../support/pages/my/page'
 
-RSpec.describe 'My page', js: true do
+RSpec.describe 'My page', :js do
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type]) }
   let!(:open_status) { create(:default_status) }
@@ -96,7 +96,8 @@ RSpec.describe 'My page', js: true do
   end
 
   it 'renders the default view, allows altering and saving' do
-    sleep(0.5)
+    # Waits for the default view to be created
+    my_page.expect_toast(message: 'Successful update')
 
     assigned_area.expect_to_exist
     created_area.expect_to_exist


### PR DESCRIPTION
This started bugging me quite a lot in the other open PRs.

Instead of sleeping for an arbitrary amount of time, adding an expectation for the toast ensures that the default grid already exists and can be queried for.

Without this, the spec is quite flaky as we can't guarantee that the Grid exists within 0.5 seconds of the time the page loads.