### PR TITLE
Enable lograge at all times, improve output for grape

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,9 @@ module OpenProject
     if ENV["RAILS_LOG_TO_STDOUT"].present?
       logger           = ActiveSupport::Logger.new($stdout)
       logger.formatter = config.log_formatter
-      config.logger    = ActiveSupport::TaggedLogging.new(logger)
+      # Prepend all log lines with the following tags.
+      config.log_tags = [:request_id]
+      config.logger = ActiveSupport::TaggedLogging.new(logger)
     end
 
     # Use Rack::Deflater to gzip/deflate all the responses if the

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -590,10 +590,15 @@ module Settings
       log_requesting_user: {
         default: false
       },
-      # Use lograge to format logs, off by default
-      lograge_formatter: {
+      lograge_enabled: {
         description: 'Use lograge formatter for outputting logs',
-        default: nil,
+        default: true,
+        format: :boolean,
+        writable: false
+      },
+      lograge_formatter: {
+        description: 'Lograge formatter to use for outputting logs',
+        default: 'key_value',
         format: :string,
         writable: false
       },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,9 +105,6 @@ OpenProject::Application.configure do
 
   config.assets.quiet = true unless config.log_level == :debug
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,6 +2,7 @@ Rails.application.configure do
   next unless OpenProject::Logging.lograge_enabled?
 
   config.lograge.enabled = true
+  config.lograge.keep_original_rails_log = Rails.env.development?
   config.lograge.formatter = OpenProject::Logging.formatter
   config.lograge.base_controller_class = %w[ActionController::Base]
 

--- a/docs/installation-and-operations/operation/monitoring/README.md
+++ b/docs/installation-and-operations/operation/monitoring/README.md
@@ -8,6 +8,37 @@ sidebar_navigation:
 
 OpenProject provides different means of monitoring and auditing your application.
 
+
+
+## Logging information
+
+In production, OpenProject uses [Lograge formatter](https://github.com/roidrage/lograge) `key_value` logger by default. Every request will result in the following `info` log level:
+
+```
+I, [2023-11-14T09:21:15.136914 #56791]  INFO -- : [87a5dceb-0560-4e17-8577-2822106dfc00] method=GET path=/ format=html controller=HomescreenController action=index status=200 allocations=133182 duration=237.82 view=107.45 db=116.50 user=85742
+```
+
+This formatter makes it easy to parse and analyze logs. Let's take a look at the values:
+
+| Log entry                                      | Description                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------ |
+| `I`                                            | First letter of the level (Debug, Info, Warn, Error, ...)    |
+| `[2023-11-14T09:21:15.136914 #56791]`          | ISO8601 timestamp and #Puma worker PID                       |
+| `INFO`                                         | Log level                                                    |
+| `[87a5dceb-0560-4e17-8577-2822106dfc00]`       | Request ID [Unique ID in the request](https://api.rubyonrails.org/classes/ActionDispatch/RequestId.html) added by Rails used to connect other log entries to that request. |
+| `method=GET`                                   | HTTP method                                                  |
+| `path=/`                                       | Requested path                                               |
+| `format=html`                                  | Mime type                                                    |
+| `controller=HomescreenController action=index` | Rails controller and used action method responding to the request, information for debugging |
+| `status=200`                                   | HTTP response code                                           |
+| `allocations=1333182`                          | Rails allocated memory objects instrumentation               |
+| `duration=237.82`                              | Complete response duration (in ms)                           |
+| `view=107.45`                                  | Time spent in view (in ms)                                   |
+| `db=116.50`                                    | Time spent in database (in ms)                               |
+| `user=85742`                                   | User ID of the instance                                      |
+
+
+
 ## Displaying and filtering log files
 
 ### Packaged installation

--- a/lib/open_project/logging.rb
+++ b/lib/open_project/logging.rb
@@ -6,7 +6,7 @@ module OpenProject
       ##
       # Do we use lograge in the end to perform the payload output
       def lograge_enabled?
-        OpenProject::Configuration.lograge_formatter.present?
+        OpenProject::Configuration.lograge_enabled?
       end
 
       ##


### PR DESCRIPTION
Instead of opting into lograge, enable at all times for all environments and instead show Rails view logs in development additionally.

This makes debugging the logs easier. Also, adds request_id to all logs even for grape

API log line
```
I, [2023-11-14T09:20:35.750984 #56789]  INFO -- : [b9cbd3c2-c300-4b0b-9e7d-b58630354270] duration=71.67 db=52.79 view=18.88 status=200 method=GET path=/api/v3/time_entries params={"filters"=>"[{\"ongoing\":{\"operator\":\"=\",\"values\":[\"t\"]}}]"} host=localhost user=85742
```

Controller log line
```
I, [2023-11-14T09:21:15.136914 #56791]  INFO -- : [87a5dceb-0560-4e17-8577-2822106dfc00] method=GET path=/ format=html controller=HomescreenController action=index status=200 allocations=133182 duration=237.82 view=107.45 db=116.50 user=85742
```