### PR TITLE
Fix untransliterable characters breaking the value binding

### DIFF
--- a/app/models/queries/work_packages/filter/attachment_base_filter.rb
+++ b/app/models/queries/work_packages/filter/attachment_base_filter.rb
@@ -44,7 +44,7 @@ class Queries::WorkPackages::Filter::AttachmentBaseFilter < Queries::WorkPackage
       SELECT 1 FROM #{attachment_table}
       WHERE #{attachment_table}.container_id = #{WorkPackage.table_name}.id
       AND #{attachment_table}.container_type = '#{WorkPackage.name}'
-      AND #{tsv_condition}
+      #{tsv_condition}
     SQL
   end
 
@@ -53,10 +53,16 @@ class Queries::WorkPackages::Filter::AttachmentBaseFilter < Queries::WorkPackage
   end
 
   def tsv_condition
-    OpenProject::FullTextSearch.tsv_where(attachment_table,
-                                          search_column,
-                                          values.first,
-                                          normalization: normalization_type)
+    condition = OpenProject::FullTextSearch.tsv_where(attachment_table,
+                                                      search_column,
+                                                      values.first,
+                                                      normalization: normalization_type)
+
+    if condition
+      "AND #{condition}"
+    else
+      ''
+    end
   end
 
   def search_column

--- a/lib/open_project/full_text_search.rb
+++ b/lib/open_project/full_text_search.rb
@@ -35,6 +35,8 @@ module OpenProject
       if OpenProject::Database.allows_tsv?
         column = "\"#{table_name}\".\"#{column_name}_tsv\""
         query = tokenize(value, concatenation, normalization)
+        return if query.blank?
+
         language = OpenProject::Configuration.main_content_language
 
         ActiveRecord::Base.send(
@@ -68,12 +70,12 @@ module OpenProject
     end
 
     def self.normalize_text(text)
-      I18n.with_locale(:en) { I18n.transliterate(text.to_s.downcase) }
+      I18n.with_locale(:en) { I18n.transliterate(text.to_s.downcase, replacement: '') }
     end
 
     def self.normalize_filename(filename)
       name_in_words = to_words filename.to_s.downcase
-      I18n.with_locale(:en) { I18n.transliterate(name_in_words) }
+      I18n.with_locale(:en) { I18n.transliterate(name_in_words, replacement: '') }
     end
 
     def self.to_words(text)

--- a/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
+++ b/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
@@ -90,7 +90,7 @@ module Redmine
             token_clauses = searchable_column_conditions
 
             if OpenProject::Database.allows_tsv?
-              tsv_clauses = searchable_tsv_column_conditions(tokens)
+              tsv_clauses = searchable_tsv_column_conditions(tokens).compact
             end
 
             if searchable_options[:search_custom_fields]

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -138,6 +138,22 @@ RSpec.describe SearchController do
       end
     end
 
+    context 'when searching in all projects with an untransliterable character' do
+      before do
+        work_package_1.update_column(:subject, 'Something 会议 something')
+        get :index, params: { q: '会议', scope: 'all' }
+      end
+
+      it_behaves_like 'successful search'
+
+      it 'returns the result', :aggregate_failures do
+        expect(assigns(:results).count).to be(1)
+        expect(assigns(:results)).to include(work_package_1)
+        expect(assigns(:results_count)).to be_a(Hash)
+        expect(assigns(:results_count)['work_packages']).to be(1)
+      end
+    end
+
     context 'when searching in project and its subprojects' do
       before { get :index, params: { q: 'issue', project_id: project.id, scope: 'subprojects' } }
 


### PR DESCRIPTION
The `I18n.transliterate` returns `?` as a default for unknown characters, resulting in it being treated as a bind variable with the way the tsv_query is formed. Instead, return a blank string for untranslatable characters and filter out the query if it turns out empty.

https://community.openproject.org/work_packages/50972