### PR TITLE
Add installtion of gpg to debian package based documentation

### DIFF
--- a/docs/installation-and-operations/installation/packaged/README.md
+++ b/docs/installation-and-operations/installation/packaged/README.md
@@ -123,7 +123,7 @@ As root update the `apt` package index and install packages to allow `apt` to us
 ```shell
 su -
 apt update
-apt install apt-transport-https ca-certificates wget
+apt install apt-transport-https ca-certificates wget gpg
 ```
 
 Import the PGP key used to sign our packages:
@@ -155,7 +155,7 @@ As root update the `apt` package index and install packages to allow `apt` to us
 ```shell
 su -
 apt update
-apt install apt-transport-https ca-certificates wget
+apt install apt-transport-https ca-certificates wget gpg
 ```
 
 Import the PGP key used to sign our packages:


### PR DESCRIPTION
Add installation of gpg to package based documentation. 
Because it is needed for importing the gpg key.