### PR TITLE
[50730] Show warning if you cannot add new users due to user limit

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -1,1 +1,2 @@
 @import "work_packages/share/modal_body_component"
+@import "work_packages/share/invite_user_form_component"

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -1,23 +1,40 @@
 <%=
-  component_wrapper do
+  component_wrapper(data: { controller: "work-packages--share--user-limit",
+                            'application-target': "dynamic" }) do
     if sharing_manageable?
       primer_form_with(
         model: new_share,
         url: work_package_shares_path(@work_package)
       ) do |form|
-        flex_layout do |new_user_row|
-          new_user_row.with_column(flex: :auto, mr: 2) do
+        grid_layout('invite-user-form',
+                    tag: :div,
+                    data: { 'work-packages--share--user-limit-target': 'inviteUserForm' }) do |invite_form|
+          invite_form.with_area('invitee') do
             render(WorkPackages::Share::Invitee.new(form))
           end
 
-          new_user_row.with_column(mr: 2) do
+          invite_form.with_area('permission') do
             render(WorkPackages::Share::PermissionButtonComponent.new(share: new_share,
                                                                       form_arguments: { builder: form, name: "role_id" },
                                                                       data: { 'test-selector': 'op-share-wp-invite-role' }))
           end
 
-          new_user_row.with_column do
+          invite_form.with_area('submit') do
             render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { I18n.t('work_package.sharing.share') }
+          end
+
+          unless OpenProject::Enterprise.user_limit.nil?
+            invite_form.with_area('userLimit', data: { 'work-packages--share--user-limit-target': 'limitWarning' }, display: :none) do
+              flex_layout do |user_limit_row|
+                user_limit_row.with_column(mr: 2) do
+                  render(Primer::Beta::Octicon.new(icon: :'alert-fill', color: :danger))
+                end
+
+                user_limit_row.with_column do
+                  render(Primer::Beta::Text.new(color: :danger)) { I18n.t('work_package.sharing.text_user_limit_reached', count: OpenProject::Enterprise.open_seats_count) }
+                end
+              end
+            end
           end
         end
       end

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -1,5 +1,6 @@
 <%=
   component_wrapper(data: { controller: "work-packages--share--user-limit",
+                            'work-packages--share--user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
                             'application-target': "dynamic" }) do
     if sharing_manageable?
       primer_form_with(
@@ -23,8 +24,10 @@
             render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { I18n.t('work_package.sharing.share') }
           end
 
-          unless OpenProject::Enterprise.user_limit.nil?
-            invite_form.with_area('userLimit', data: { 'work-packages--share--user-limit-target': 'limitWarning' }, display: :none) do
+          if OpenProject::Enterprise.user_limit.present?
+            invite_form.with_area('userLimit',
+                                  data: { 'work-packages--share--user-limit-target': 'limitWarning' },
+                                  display: OpenProject::Enterprise.user_limit_reached? ? :block : :none) do
               flex_layout do |user_limit_row|
                 user_limit_row.with_column(mr: 2) do
                   render(Primer::Beta::Octicon.new(icon: :'alert-fill', color: :danger))

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -26,8 +26,11 @@
 
           if OpenProject::Enterprise.user_limit.present?
             invite_form.with_area('userLimit',
-                                  data: { 'user-limit-target': 'limitWarning' },
-                                  display: OpenProject::Enterprise.user_limit_reached? ? :block : :none) do
+                                  data: {
+                                    'user-limit-target': 'limitWarning',
+                                    'test-selector': 'op-share-wp-user-limit'
+                                  },
+                                  display: :none) do
               flex_layout do |user_limit_row|
                 user_limit_row.with_column(mr: 2) do
                   render(Primer::Beta::Octicon.new(icon: :'alert-fill', color: :danger))

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -1,6 +1,6 @@
 <%=
-  component_wrapper(data: { controller: "work-packages--share--user-limit",
-                            'work-packages--share--user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
+  component_wrapper(data: { controller: "user-limit",
+                            'user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
                             'application-target': "dynamic" }) do
     if sharing_manageable?
       primer_form_with(
@@ -9,7 +9,7 @@
       ) do |form|
         grid_layout('invite-user-form',
                     tag: :div,
-                    data: { 'work-packages--share--user-limit-target': 'inviteUserForm' }) do |invite_form|
+                    data: { 'user-limit-target': 'inviteUserForm' }) do |invite_form|
           invite_form.with_area('invitee') do
             render(WorkPackages::Share::Invitee.new(form))
           end
@@ -26,7 +26,7 @@
 
           if OpenProject::Enterprise.user_limit.present?
             invite_form.with_area('userLimit',
-                                  data: { 'work-packages--share--user-limit-target': 'limitWarning' },
+                                  data: { 'user-limit-target': 'limitWarning' },
                                   display: OpenProject::Enterprise.user_limit_reached? ? :block : :none) do
               flex_layout do |user_limit_row|
                 user_limit_row.with_column(mr: 2) do

--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -37,7 +37,8 @@
                 end
 
                 user_limit_row.with_column do
-                  render(Primer::Beta::Text.new(color: :danger)) { I18n.t('work_package.sharing.text_user_limit_reached', count: OpenProject::Enterprise.open_seats_count) }
+                  render(Primer::Beta::Text.new(color: :danger)) { I18n.t("work_package.sharing.warning_user_limit_reached#{'_admin' if User.current.admin?}",
+                                                                          upgrade_url: OpenProject::Enterprise.upgrade_url).html_safe }
                 end
               end
             end

--- a/app/components/work_packages/share/invite_user_form_component.sass
+++ b/app/components/work_packages/share/invite_user_form_component.sass
@@ -1,0 +1,5 @@
+.invite-user-form
+  display: grid
+  grid-template-columns: 1fr auto auto
+  grid-template-areas: "invitee permission submit" "userLimit userLimit userLimit"
+  grid-column-gap: 0.5rem

--- a/app/controllers/concerns/accounts/user_limits.rb
+++ b/app/controllers/concerns/accounts/user_limits.rb
@@ -89,10 +89,16 @@ module Accounts::UserLimits
   end
 
   def user_limit_warning
-    warning = I18n.t(
-      :warning_user_limit_reached,
-      upgrade_url: OpenProject::Enterprise.upgrade_url
-    )
+    warning = if current_user.admin?
+                I18n.t(
+                  :warning_user_limit_reached_admin,
+                  upgrade_url: OpenProject::Enterprise.upgrade_url
+                )
+              else
+                I18n.t(
+                  :warning_user_limit_reached
+                )
+              end
 
     warning.html_safe
   end

--- a/app/forms/work_packages/share/invitee.rb
+++ b/app/forms/work_packages/share/invitee.rb
@@ -32,6 +32,7 @@ module WorkPackages::Share
         name: :user_id,
         label: I18n.t('work_package.sharing.label_search'),
         visually_hide_label: true,
+        data: { 'work-packages--share--user-limit-target': 'autocompleter' },
         autocomplete_options: {
           id: "op-share-wp-invite-autocomplete",
           placeholder: I18n.t('work_package.sharing.label_search_placeholder'),

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -31,14 +31,23 @@ See COPYRIGHT and LICENSE files for more details.
                               method: :post,
                               html: { id: "members_add_form",
                                       class: "form -vertical -bordered -medium-compressed"},
-                              data: { 'members-form-target': 'addMemberForm' }) do |f| %>
+                              data: {
+                                'members-form-target': 'addMemberForm',
+                                controller: "user-limit",
+                                'user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
+                                'user-limit-member-autocompleter-value': true,
+                                'application-target': "dynamic",
+                              }) do |f| %>
     <a title="<%= t('js.close_form_title') %>"
        class="hide-member-form-button form--close icon-context icon-close"
        data-action="members-form#hideAddMemberForm"></a>
     <div id="new-member-message"></div>
     <div class="grid-block">
       <div class="grid-content medium-5 small-12 collapse -flex">
-        <div class="form--field">
+        <div
+          class="form--field"
+          data-user-limit-target="inviteUserForm"
+        >
           <%
             user_id_title = I18n.t(:label_principal_search)
 
@@ -90,13 +99,14 @@ See COPYRIGHT and LICENSE files for more details.
         </div>
       </div>
     </div>
-  <% if OpenProject::Enterprise.user_limit_reached? %>
-        <div class="op-toast -warning icon-warning"
-             data-members-form-target="limitWarning"
-             style="display: none;">
+
+  <% if OpenProject::Enterprise.user_limit.present? %>
+        <div class="op-toast -warning icon-warning d-none"
+             data-user-limit-target="limitWarning">
           <div class="op-toast--content">
             <p><%= I18n.t(:warning_user_limit_reached, upgrade_url: OpenProject::Enterprise.upgrade_path).html_safe %></p>
           </div>
         </div>
     <% end %>
+
 <% end %>

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -104,7 +104,7 @@ See COPYRIGHT and LICENSE files for more details.
         <div class="op-toast -warning icon-warning d-none"
              data-user-limit-target="limitWarning">
           <div class="op-toast--content">
-            <p><%= I18n.t(:warning_user_limit_reached, upgrade_url: OpenProject::Enterprise.upgrade_path).html_safe %></p>
+            <p><%= I18n.t("warning_user_limit_reached#{'_admin' if current_user.admin?}", upgrade_url: OpenProject::Enterprise.upgrade_url).html_safe %></p>
           </div>
         </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3265,6 +3265,10 @@ en:
       share: "Share"
       text_empty_state_description: "The work package has not been shared with anyone yet."
       text_empty_state_header: "No shared users"
+      text_user_limit_reached:
+        zero: "This instance has reached its user limit, you can’t share with new users. Please contact your administrator to add more members."
+        one: "Only 1 member left to reach the user limit of the instance. Please contact your administrator."
+        other: "Only %{count} members left to reach the user limit of the instance. Please contact your administrator."
 
   working_days:
     info: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3200,8 +3200,9 @@ en:
     The activation email has expired. We sent you a new one to %{email}.
     Please click the link inside of it to activate your account.
   warning_user_limit_reached: >
-    User limit reached. You cannot activate any more users.
-    Please <a href="%{upgrade_url}">upgrade your plan</a> or block members to allow for additional users.
+    Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this instance.
+  warning_user_limit_reached_admin: >
+    Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to ensure external users are able to access this instance.
   warning_user_limit_reached_instructions: >
     You reached your user limit (%{current}/%{max} active users).
     Please contact sales@openproject.com to upgrade your Enterprise edition plan and add additional users.
@@ -3265,10 +3266,12 @@ en:
       share: "Share"
       text_empty_state_description: "The work package has not been shared with anyone yet."
       text_empty_state_header: "No shared users"
-      text_user_limit_reached:
-        zero: "This instance has reached its user limit, you can’t share with new users. Please contact your administrator to add more members."
-        one: "Only 1 member left to reach the user limit of the instance. Please contact your administrator."
-        other: "Only %{count} members left to reach the user limit of the instance. Please contact your administrator."
+      text_user_limit_reached: "Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this work package."
+      text_user_limit_reached_admins: 'Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to add more users.'
+      warning_user_limit_reached: >
+        Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this work package.
+      warning_user_limit_reached_admin: >
+        Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to ensure external users are able to access this work package.
 
   working_days:
     info: >

--- a/frontend/src/stimulus/controllers/dynamic/members-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/members-form.controller.ts
@@ -29,9 +29,6 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import {
-  IUserAutocompleteItem,
-} from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
 
 export default class MembersFormController extends Controller {
   static targets = [
@@ -43,7 +40,6 @@ export default class MembersFormController extends Controller {
     'addMemberButton',
     'membershipEditForm',
     'errorExplanation',
-    'limitWarning',
   ];
 
   declare readonly filterContainerTarget:HTMLElement;
@@ -62,12 +58,7 @@ export default class MembersFormController extends Controller {
 
   declare readonly hasErrorExplanationTarget:HTMLElement;
 
-  declare readonly limitWarningTarget:HTMLElement;
-
-  declare readonly hasLimitWarningTarget:HTMLElement;
-
   private autocompleter:HTMLElement;
-  private autocompleterListener = this.triggerLimitWarningIfReached.bind(this);
 
   connect() {
     // Show/Hide content when page is loaded
@@ -80,7 +71,6 @@ export default class MembersFormController extends Controller {
     }
 
     this.autocompleter = this.addMemberFormTarget.querySelector('opce-members-autocompleter') as HTMLElement;
-    this.autocompleter.addEventListener('change', this.autocompleterListener);
 
     if (this.hasErrorExplanationTarget && this.errorExplanationTarget.textContent !== '') {
       this.showAddMemberForm();
@@ -89,10 +79,6 @@ export default class MembersFormController extends Controller {
     if (this.addMemberButtonTarget.getAttribute('data-trigger-initially')) {
       this.showAddMemberForm();
     }
-  }
-
-  disconnect() {
-    this.autocompleter.removeEventListener('change', this.autocompleterListener);
   }
 
   hideFilter() {
@@ -117,18 +103,6 @@ export default class MembersFormController extends Controller {
     this.addMemberButtonTarget.setAttribute('disabled', 'true');
 
     this.focusAutocompleter();
-  }
-
-  triggerLimitWarningIfReached(evt:CustomEvent) {
-    const values = evt.detail as IUserAutocompleteItem[];
-
-    if (this.hasLimitWarningTarget) {
-      if (values.find(({ id }) => typeof (id) === 'string' && id.includes('@'))) {
-        this.limitWarningTarget.style.display = 'block';
-      } else {
-        this.limitWarningTarget.style.display = 'none';
-      }
-    }
   }
 
   toggleMemberFilter() {

--- a/frontend/src/stimulus/controllers/dynamic/members-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/members-form.controller.ts
@@ -80,7 +80,7 @@ export default class MembersFormController extends Controller {
     }
 
     this.autocompleter = this.addMemberFormTarget.querySelector('opce-members-autocompleter') as HTMLElement;
-    this.autocompleter.addEventListener('valueChange', this.autocompleterListener);
+    this.autocompleter.addEventListener('change', this.autocompleterListener);
 
     if (this.hasErrorExplanationTarget && this.errorExplanationTarget.textContent !== '') {
       this.showAddMemberForm();
@@ -92,7 +92,7 @@ export default class MembersFormController extends Controller {
   }
 
   disconnect() {
-    this.autocompleter.removeEventListener('valueChange', this.autocompleterListener);
+    this.autocompleter.removeEventListener('change', this.autocompleterListener);
   }
 
   hideFilter() {

--- a/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
@@ -41,6 +41,7 @@ export default class UserLimitController extends Controller {
 
   static values = {
     openSeats: Number,
+    // Special case, that the autocompleter is a members-autocompleter, instead of the normal user-autocompleter
     memberAutocompleter: Boolean,
   };
 

--- a/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
@@ -41,6 +41,7 @@ export default class UserLimitController extends Controller {
 
   static values = {
     openSeats: Number,
+    memberAutocompleter: Boolean,
   };
 
   declare readonly limitWarningTarget:HTMLElement;
@@ -49,12 +50,18 @@ export default class UserLimitController extends Controller {
 
   declare readonly openSeatsValue:number;
   declare readonly hasOpenSeatsValue:number;
+  declare readonly memberAutocompleterValue:boolean;
 
   private autocompleter:HTMLElement;
   private autocompleterListener = this.triggerLimitWarningIfReached.bind(this);
 
   connect() {
-    this.autocompleter = this.inviteUserFormTarget.querySelector('opce-user-autocompleter') as HTMLElement;
+    if (this.memberAutocompleterValue) {
+      this.autocompleter = this.inviteUserFormTarget.querySelector('opce-members-autocompleter') as HTMLElement;
+    } else {
+      this.autocompleter = this.inviteUserFormTarget.querySelector('opce-user-autocompleter') as HTMLElement;
+    }
+
     this.autocompleter.addEventListener('change', this.autocompleterListener);
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-limit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-limit.controller.ts
@@ -39,9 +39,16 @@ export default class UserLimitController extends Controller {
     'inviteUserForm',
   ];
 
+  static values = {
+    openSeats: Number,
+  };
+
   declare readonly limitWarningTarget:HTMLElement;
   declare readonly hasLimitWarningTarget:HTMLElement;
   declare readonly inviteUserFormTarget:HTMLElement;
+
+  declare readonly openSeatsValue:number;
+  declare readonly hasOpenSeatsValue:number;
 
   private autocompleter:HTMLElement;
   private autocompleterListener = this.triggerLimitWarningIfReached.bind(this);
@@ -58,8 +65,9 @@ export default class UserLimitController extends Controller {
   triggerLimitWarningIfReached(evt:CustomEvent) {
     const values = evt.detail as IUserAutocompleteItem[];
 
-    if (this.hasLimitWarningTarget) {
-      if (values.find(({ id }) => typeof (id) === 'string' && id.includes('@'))) {
+    if (this.hasLimitWarningTarget && this.hasOpenSeatsValue) {
+      const numberOfNewUsers = values.filter(({ id }) => typeof (id) === 'string' && id.includes('@')).length;
+      if (numberOfNewUsers > 0 && numberOfNewUsers > this.openSeatsValue) {
         this.limitWarningTarget.classList.remove('d-none');
       } else {
         this.limitWarningTarget.classList.add('d-none');

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-limit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-limit.controller.ts
@@ -1,0 +1,69 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import {
+  IUserAutocompleteItem,
+} from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
+
+export default class UserLimitController extends Controller {
+  static targets = [
+    'limitWarning',
+    'inviteUserForm',
+  ];
+
+  declare readonly limitWarningTarget:HTMLElement;
+  declare readonly hasLimitWarningTarget:HTMLElement;
+  declare readonly inviteUserFormTarget:HTMLElement;
+
+  private autocompleter:HTMLElement;
+  private autocompleterListener = this.triggerLimitWarningIfReached.bind(this);
+
+  connect() {
+    this.autocompleter = this.inviteUserFormTarget.querySelector('opce-user-autocompleter') as HTMLElement;
+    this.autocompleter.addEventListener('change', this.autocompleterListener);
+  }
+
+  disconnect() {
+    this.autocompleter.removeEventListener('change', this.autocompleterListener);
+  }
+
+  triggerLimitWarningIfReached(evt:CustomEvent) {
+    const values = evt.detail as IUserAutocompleteItem[];
+
+    if (this.hasLimitWarningTarget) {
+      if (values.find(({ id }) => typeof (id) === 'string' && id.includes('@'))) {
+        this.limitWarningTarget.classList.remove('d-none');
+      } else {
+        this.limitWarningTarget.classList.add('d-none');
+      }
+    }
+  }
+}

--- a/lib/open_project/enterprise.rb
+++ b/lib/open_project/enterprise.rb
@@ -49,6 +49,10 @@ module OpenProject
         User.human.active.count
       end
 
+      def open_seats_count
+        user_limit - active_user_count if user_limit
+      end
+
       ##
       # Indicates if there are more active users than the support token allows for.
       #

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe UsersController do
         end
 
         it "shows a user limit error" do
-          expect(flash[:error]).to match /user limit reached/i
+          expect(flash[:error]).to match /Adding additional users will exceed the current limit/i
         end
 
         it "redirects back to the user index" do
@@ -96,7 +96,7 @@ RSpec.describe UsersController do
         end
 
         it "shows a user limit warning" do
-          expect(flash[:warning]).to match /user limit reached/i
+          expect(flash[:warning]).to match /Adding additional users will exceed the current limit/i
         end
 
         it "shows the new user page" do
@@ -451,7 +451,7 @@ RSpec.describe UsersController do
         let(:user_limit_reached) { true }
 
         it "shows the user limit reached error and recommends to upgrade" do
-          expect(flash[:error]).to match /user limit reached.*upgrade/i
+          expect(flash[:error]).to match /Adding additional users will exceed the current limit.*upgrade/i
         end
 
         it "does not activate the user" do

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe 'invite user via email', js: true do
       before do
         allow(OpenProject::Enterprise).to receive_messages(
           user_limit: 10,
-          user_limit_reached?: false,
           open_seats_count: 1
         )
       end
@@ -87,15 +86,13 @@ RSpec.describe 'invite user via email', js: true do
         members_page.search_and_select_principal! 'finkelstein@openproject.com',
                                                   'Send invite to finkelstein@openproject.com'
 
-        expect(members_page).not_to have_text sanitize_string(I18n.t(:warning_user_limit_reached,
-                                                                     upgrade_url: OpenProject::Enterprise.upgrade_path)),
+        expect(members_page).not_to have_text sanitize_string(I18n.t(:warning_user_limit_reached)),
                                               normalize_ws: true
 
         members_page.search_and_select_principal! 'frankenstein@openproject.com',
                                                   'Send invite to frankenstein@openproject.com'
 
-        expect(members_page).to have_text sanitize_string(I18n.t(:warning_user_limit_reached,
-                                                                 upgrade_url: OpenProject::Enterprise.upgrade_path)),
+        expect(members_page).to have_text sanitize_string(I18n.t(:warning_user_limit_reached)),
                                           normalize_ws: true
       end
     end

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -70,6 +70,35 @@ RSpec.describe 'invite user via email', js: true do
       members_page.visit!
       expect(members_page).to have_user 'finkelstein @openproject.com'
     end
+
+    context 'with an instance with a user limit (regression)' do
+      before do
+        allow(OpenProject::Enterprise).to receive_messages(
+          user_limit: 10,
+          user_limit_reached?: false,
+          open_seats_count: 1
+        )
+      end
+
+      it 'shows a warning when the limit is reached' do
+        members_page.visit!
+        click_button 'Add member'
+
+        members_page.search_and_select_principal! 'finkelstein@openproject.com',
+                                                  'Send invite to finkelstein@openproject.com'
+
+        expect(members_page).not_to have_text sanitize_string(I18n.t(:warning_user_limit_reached,
+                                                                     upgrade_url: OpenProject::Enterprise.upgrade_path)),
+                                              normalize_ws: true
+
+        members_page.search_and_select_principal! 'frankenstein@openproject.com',
+                                                  'Send invite to frankenstein@openproject.com'
+
+        expect(members_page).to have_text sanitize_string(I18n.t(:warning_user_limit_reached,
+                                                                 upgrade_url: OpenProject::Enterprise.upgrade_path)),
+                                          normalize_ws: true
+      end
+    end
   end
 
   context 'with a registered user' do

--- a/spec/features/work_packages/share/multi_invite_spec.rb
+++ b/spec/features/work_packages/share/multi_invite_spec.rb
@@ -260,7 +260,6 @@ RSpec.describe 'Work package sharing',
       before do
         allow(OpenProject::Enterprise).to receive_messages(
           user_limit: 10,
-          user_limit_reached?: false,
           open_seats_count: 1
         )
       end
@@ -275,7 +274,7 @@ RSpec.describe 'Work package sharing',
 
         # Add another non-existing user that would exceed the user limit
         share_modal.select_not_existing_user_option "hola@world.de"
-        share_modal.expect_user_limit_warning(open_seats: 1)
+        share_modal.expect_user_limit_warning
       end
     end
   end

--- a/spec/features/work_packages/share/multi_invite_spec.rb
+++ b/spec/features/work_packages/share/multi_invite_spec.rb
@@ -255,5 +255,28 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(not_shared_yet_with_user, 'View', position: 1)
       share_modal.expect_shared_with(new_user, 'View', position: 2)
     end
+
+    context 'and an instance user limit' do
+      before do
+        allow(OpenProject::Enterprise).to receive_messages(
+          user_limit: 10,
+          user_limit_reached?: false,
+          open_seats_count: 1
+        )
+      end
+
+      it 'shows a warning as soon as you reach the user limit' do
+        share_modal.expect_open
+        share_modal.expect_shared_count_of(1)
+
+        # Add a non-existing user to the autocompleter
+        share_modal.select_not_existing_user_option "hello@world.de"
+        share_modal.expect_no_user_limit_warning
+
+        # Add another non-existing user that would exceed the user limit
+        share_modal.select_not_existing_user_option "hola@world.de"
+        share_modal.expect_user_limit_warning(open_seats: 1)
+      end
+    end
   end
 end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -347,6 +347,19 @@ module Components
             .to have_text(I18n.t(:label_enterprise_addon))
         end
       end
+
+      def expect_no_user_limit_warning
+        within modal_element do
+          expect(page).not_to have_css('[data-test-selector="op-share-wp-user-limit"]')
+        end
+      end
+
+      def expect_user_limit_warning(open_seats:)
+        within modal_element do
+          expect(page)
+            .to have_text(I18n.t('work_package.sharing.text_user_limit_reached', count: open_seats))
+        end
+      end
     end
   end
 end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -354,10 +354,10 @@ module Components
         end
       end
 
-      def expect_user_limit_warning(open_seats:)
+      def expect_user_limit_warning
         within modal_element do
           expect(page)
-            .to have_text(I18n.t('work_package.sharing.text_user_limit_reached', count: open_seats))
+            .to have_text(I18n.t('work_package.sharing.warning_user_limit_reached'))
         end
       end
     end


### PR DESCRIPTION
Currently we can invite new users inline via the users autocompleter in the share modal and on the members page. However, the instance might have a user limit that will be exceed by this.
This PR adds an information for users if they try to invite a new user and the limit will be exceeded. For the members page that already existed (but it was broken and fixed in this PR as well).

**Note:** There is only a warning. The users can still be invited, but they cannot login until the instance is upgraded.

### Todo
- [x] Show a warning if inviting new users would exceed the user limit (share modal)
- [x] Fix the mechanism for the warning on the members page
- [x] Add a test

https://community.openproject.org/projects/openproject/work_packages/50730/github