### PR TITLE
Use capybara accessible selectors for share wp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -256,6 +256,7 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0.17'
   gem 'cuprite', '~> 0.15.0'
   gem 'selenium-webdriver', '~> 4.15.0'
+  gem 'capybara_accessible_selectors', git: 'https://github.com/citizensadvice/capybara_accessible_selectors', branch: 'main'
 
   gem 'fuubar', '~> 2.5.0'
   gem 'timecop', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/citizensadvice/capybara_accessible_selectors
+  revision: da34e96c4787bd7705c477fe2e70f993bfad8f5c
+  branch: main
+  specs:
+    capybara_accessible_selectors (0.10.0)
+      capybara (>= 3.36.0)
+
+GIT
   remote: https://github.com/crohr/turbo_tests.git
   revision: b700cdb344e1ed8e100fd1f56525ec12fa792b45
   ref: fix/runtime-info
@@ -1065,6 +1073,7 @@ DEPENDENCIES
   budgets!
   capybara (~> 3.39.0)
   capybara-screenshot (~> 1.0.17)
+  capybara_accessible_selectors!
   carrierwave (~> 1.3.1)
   carrierwave_direct (~> 2.1.0)
   climate_control

--- a/app/views/account/_register.html.erb
+++ b/app/views/account/_register.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
     <%= back_url_hidden_field_tag %>
     <%= error_messages_for :user %>
 
-    <div class="spot-modal--header">
+    <div id="spotModalTitle" class="spot-modal--header">
       <%= I18n.t('onboarding.welcome', app_title: Setting.app_title) %>
     </div>
     <div class="spot-divider"></div>

--- a/app/views/onboarding/_configuration_modal.html.erb
+++ b/app/views/onboarding/_configuration_modal.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div class="modal-delivery-element">
   <%= labelled_tabular_form_for current_user, url: { action: 'user_settings', controller: 'onboarding' }, html: { id: 'user-form' } do |f| %>
-    <div class="spot-modal--header">
+    <div id="spotModalTitle" class="spot-modal--header">
       <%= I18n.t('onboarding.welcome', app_title: Setting.app_title) %>, <%= current_user.name %>
     </div>
 

--- a/app/views/onboarding/_onboarding_video_modal.html.erb
+++ b/app/views/onboarding/_onboarding_video_modal.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="modal-delivery-element">
   <div class="spot-modal--header">
     <span class="spot-icon spot-icon_user"></span>
-    <span><%= I18n.t('onboarding.welcome', app_title: Setting.app_title) %></span>
+    <span id="spotModalTitle"><%= I18n.t('onboarding.welcome', app_title: Setting.app_title) %></span>
   </div>
   <div class="spot-divider"></div>
   <div class="onboarding--main spot-modal--body spot-container">

--- a/app/views/projects/_project_export_modal.html.erb
+++ b/app/views/projects/_project_export_modal.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div class="modal-delivery-element">
-  <div class="spot-modal--header">
+  <div id="spotModalTitle" class="spot-modal--header">
     <%= I18n.t('js.label_export') %>
   </div>
   <div class="spot-divider"></div>

--- a/app/views/wiki/_wiki_export_modal.html.erb
+++ b/app/views/wiki/_wiki_export_modal.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div class="modal-delivery-element">
-  <div class="spot-modal--header">
+  <div id="spotModalTitle" class="spot-modal--header">
     <%= I18n.t('js.label_export') %>
   </div>
   <div class="spot-divider"></div>

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
@@ -2,7 +2,7 @@
   class="spot-modal spot-modal_autoheight confirm-form-submit--modal loading-indicator--location"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
+++ b/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal loading-indicator--location"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
@@ -1,5 +1,5 @@
 <div class="spot-modal op-enterprise-modal">
-  <div class="spot-modal--header" [textContent]="headerText$ | async"></div>
+  <div id="spotModalTitle" class="spot-modal--header" [textContent]="headerText$ | async"></div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/features/invite-user-modal/principal/principal.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal.component.html
@@ -3,7 +3,7 @@
   [formGroup]="principalForm"
   (ngSubmit)="onSubmit($event)"
 >
-  <div class="spot-modal--header">{{text.principal.title()}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.principal.title()}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
@@ -3,7 +3,7 @@
   [formGroup]="projectAndTypeForm"
   (ngSubmit)="onSubmit($event)"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/features/invite-user-modal/success/success.component.html
+++ b/frontend/src/app/features/invite-user-modal/success/success.component.html
@@ -1,4 +1,5 @@
 <div
+  id="spotModalTitle"
   class="spot-modal--header"
   [textContent]="text.title()"
 ></div>

--- a/frontend/src/app/features/invite-user-modal/summary/summary.component.html
+++ b/frontend/src/app/features/invite-user-modal/summary/summary.component.html
@@ -3,7 +3,7 @@
   (submit)="onSubmit($event)"
   class="op-ium-summary spot-modal"
 >
-  <div class="spot-modal--header">{{text.title()}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title()}}</div>
 
   <div class="spot-divider"></div>
 
@@ -16,7 +16,7 @@
     <spot-form-field [label]="text.principalLabel[type]">
       <p slot="input" class="spot-body-small op-ium-summary--details">{{ principal?.name }}</p>
     </spot-form-field>
-  
+
     <spot-form-field [label]="text.roleLabel()">
       <p slot="input" class="spot-body-small op-ium-summary--details">{{ role.name }}</p>
     </spot-form-field>

--- a/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
+++ b/frontend/src/app/features/job-status/job-status-modal/job-status.modal.html
@@ -2,6 +2,7 @@
   class="spot-modal job-status--modal"
 >
   <div
+    id="spotModalTitle"
     class="spot-modal--header"
     data-test-selector="job-status--header"
   >{{ title }}</div>

--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
@@ -5,6 +5,7 @@
     class="spot-modal--header"
   >
     <div
+      id="spotModalTitle"
       class="spot-modal--header-title"
       [textContent]="this.text.title">
     </div>

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal spot-modal_wide wp-table--configuration-modal loading-indicator--location"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/attribute-help-texts/help-text.modal.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/help-text.modal.html
@@ -7,7 +7,7 @@
     data-test-selector="attribute-help-text--header"
   >
     <span class="spot-icon spot-icon_help1"></span>
-    <span class="attribute-help-text--header-text" 
+    <span class="attribute-help-text--header-text"
           [textContent]="helpText.attributeCaption"></span>
   </div>
 

--- a/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.html
@@ -4,6 +4,7 @@
   data-test-selector="static-attribute-help-text--modal"
 >
   <div
+    id="spotModalTitle"
     class="spot-modal--header"
   >
   {{ title }}

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal loading-indicator--location"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 
@@ -25,7 +25,7 @@
         <button
           type="button"
           class="spot-list--item-action"
-          (click)="select($event, widget)" 
+          (click)="select($event, widget)"
           [id]="widget.identifier"
           [textContent]="widget.title"
         ></button>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.html
@@ -2,7 +2,7 @@
      data-indicator-name="modal"
      tabindex="0">
 
-  <div class="spot-modal--header">{{text.displayedDays}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.displayedDays}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modal/modal-overlay.component.html
+++ b/frontend/src/app/shared/components/modal/modal-overlay.component.html
@@ -8,6 +8,9 @@
   cdkTrapFocus
   [cdkTrapFocusAutoCapture]="true"
   (mousedown)="close($event, false)"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="spotModalTitle"
 >
   <button
     type="button"

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.html
@@ -6,7 +6,7 @@
   cdkTrapFocus
   [cdkTrapFocusAutoCapture]="true"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div *ngIf="divideContent" class="spot-divider"></div>
 
@@ -14,7 +14,7 @@
     <span class="op-confirm-dialog--text spot-body-small"
           [textContent]="text.text"
     ></span>
-    
+
     <ng-container *ngIf="showListData; else showData">
       <span class="op-confirm-dialog--text spot-body-small"
       [textContent]="listTitle"
@@ -25,7 +25,7 @@
         </li>
       </ul>
     </ng-container>
-    
+
     <ng-template #showData>
       <span
         *ngFor="let data of passedData"
@@ -39,7 +39,7 @@
     <span class="op-confirm-dialog--text spot-body-small"
           [innerHtml]="warningText"
     ></span>
-    
+
   </div>
 
   <div class="spot-action-bar">

--- a/frontend/src/app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal.html
+++ b/frontend/src/app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal "
   (submit)="applyAndClose($event)"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal.html
+++ b/frontend/src/app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal "
   (submit)="applyAndClose($event)"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal.html
+++ b/frontend/src/app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal"
   (submit)="applyAndClose($event)"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.html
+++ b/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.html
@@ -3,7 +3,7 @@
   (submit)="applyAndClose($event)"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
+++ b/frontend/src/app/shared/components/modals/export-modal/wp-table-export.modal.html
@@ -4,7 +4,7 @@
     cdkTrapFocus
     [cdkTrapFocusAutoCapture]="true">
 
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.html
+++ b/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.html
@@ -1,9 +1,9 @@
-<form 
+<form
   class="spot-modal loading-indicator--location op-query-get-ical-url"
   [formGroup]="tokenNameForm"
   (submit)="generateAndCopyUrl()"
 >
-  <div class="spot-modal--header">{{text.label_ical_sharing}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.label_ical_sharing}}</div>
 
   <div class="spot-divider"></div>
 
@@ -19,12 +19,12 @@
     <p>
       {{text.description_ical_sharing}}
     </p>
-    
+
     <spot-form-field [label]="text.token_name" [required]="true" showValidationErrorOn="change">
 
-      <spot-text-field 
-        formControlName="name" 
-        slot="input" 
+      <spot-text-field
+        formControlName="name"
+        slot="input"
         [placeholder]="text.token_name_placeholder"
         opAutofocus
       ></spot-text-field>
@@ -37,11 +37,11 @@
         {{nameControl?.errors?.rails}}
       </div>
 
-      <span 
-        slot="description" 
+      <span
+        slot="description"
         [innerHtml]="text.token_name_description_text"
       ></span>
-     
+
     </spot-form-field>
   </div>
 

--- a/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
+++ b/frontend/src/app/shared/components/modals/request-for-confirmation/password-confirmation.modal.html
@@ -3,7 +3,7 @@
   data-indicator-name="modal"
   (submit)="confirmAndClose($event)"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
+++ b/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
@@ -4,8 +4,8 @@
   name="modalSaveForm"
   (submit)="saveQueryAs($event)"
 >
-  <h1 class="spot-modal--header">{{text.save_as}}</h1>
-  
+  <h1 id="spotModalTitle" class="spot-modal--header">{{text.save_as}}</h1>
+
   <div class="spot-divider"></div>
 
   <div
@@ -29,9 +29,9 @@
       </div>
     </div>
     <div class="spot-divider"></div>
-    
+
     <h2 class="spot-subheader-extra-small">{{ text.label_visibility_settings }}</h2>
-      
+
       <query-sharing-form
         [isSave]="true"
         (onChange)="setValues($event)"

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
@@ -2,7 +2,7 @@
   class="spot-modal loading-indicator--location"
   data-indicator-name="modal"
 >
-  <div class="spot-modal--header">{{text.label_visibility_settings}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.label_visibility_settings}}</div>
 
   <div class="spot-divider"></div>
 

--- a/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
+++ b/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
@@ -3,7 +3,7 @@
   data-indicator-name="modal"
   id="wp_destroy_modal"
 >
-  <div class="spot-modal--header">{{text.title}}</div>
+  <div id="spotModalTitle" class="spot-modal--header">{{text.title}}</div>
 
   <div class="spot-modal--body spot-container">
     <ng-container *ngIf="singleWorkPackage">

--- a/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.html
+++ b/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.html
@@ -3,7 +3,7 @@
   data-test-selector="op-files-picker-modal"
 >
   <div class="spot-modal--header">
-    <span class="spot-modal--header-title">{{text.header}}</span>
+    <span id="spotModalTitle" class="spot-modal--header-title">{{text.header}}</span>
   </div>
 
   <div class="spot-divider"></div>

--- a/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.html
+++ b/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.html
@@ -3,7 +3,7 @@
   data-test-selector="op-files-picker-modal"
 >
   <div class="spot-modal--header">
-    <span class="spot-modal--header-title">{{text.header}}</span>
+    <span id="spotModalTitle" class="spot-modal--header-title">{{text.header}}</span>
   </div>
 
   <div class="spot-divider"></div>

--- a/frontend/src/app/shared/components/storages/upload-conflict-modal/upload-conflict-modal.component.html
+++ b/frontend/src/app/shared/components/storages/upload-conflict-modal/upload-conflict-modal.component.html
@@ -5,6 +5,7 @@
     class="spot-modal--header"
   >
     <span
+      id="spotModalTitle"
       class="spot-modal--header-title"
       [textContent]="text.header"
     ></span>

--- a/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
+++ b/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
@@ -4,7 +4,7 @@
 >
   <div class="spot-modal--header">
     <span class="spot-icon spot-icon_time"></span>
-    <span [textContent]="text.title"></span>
+    <span id="spotModalTitle" [textContent]="text.title"></span>
   </div>
 
   <div class="spot-divider"></div>

--- a/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.html
@@ -3,7 +3,7 @@
   data-test-selector="op-stop-existing-timer-modal"
 >
   <div class="spot-modal--header">
-    <span class="spot-modal--header-title">{{text.title}}</span>
+    <span id="spotModalTitle" class="spot-modal--header-title">{{text.title}}</span>
   </div>
 
   <p

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Work package sharing',
       click_button 'Share'
 
       aggregate_failures "Initial shares list" do
-        share_modal.expect_open
+        share_modal.expect_title(I18n.t('js.work_packages.sharing.title'))
         share_modal.expect_shared_with(comment_user, 'Comment', position: 1)
         share_modal.expect_shared_with(dinesh, 'Edit', position: 2)
         share_modal.expect_shared_with(edit_user, 'Edit', position: 3)


### PR DESCRIPTION
Introduce [capybara_accessible_selectors](https://github.com/citizensadvice/capybara_accessible_selectors) for better accessibility.

- Use accessible selectors `within_modal` / `find_modal` in share_spec.rb and define the modal as an accessible one: role=dialog, `aria-modal=true, aria-labelledby=spotModalTitle
- Set `spotModalTitle` id on all modals.
- Introduce new custom accessible capybara selectors for `list` and `list_item` with custom description as well as rspec matchers (`have_list` / `have_list_item`).
