### PR TITLE
[#50831] Error on the work package meetings tab add button permission

### DIFF
--- a/modules/meeting/app/components/work_package_meetings_tab/heading_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/heading_component.rb
@@ -41,7 +41,7 @@ module WorkPackageMeetingsTab
     private
 
     def allowed_to_add_to_meeting?
-      User.current.allowed_in_project?(:edit_meetings, @work_package.project)
+      User.current.allowed_in_project?(:manage_agendas, @work_package.project)
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/50831

Hide the "+Add to meeting" button on the work package meetings tab, when the user has not permission to manage agenda items.