### PR TITLE
[#50255] Add User Details to the Share Modal List

### DIFF
--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -1,14 +1,14 @@
 .op-share-wp-modal-body
   &--user-row
     display: grid
-    grid-template-columns: 1fr
-    grid-template-areas: "user"
+    grid-template-columns: auto 1fr
+    grid-template-areas: "avatar user_details"
     grid-column-gap: 10px
 
     &_manageable
       display: grid
-      grid-template-columns: 20px 1fr auto auto
-      grid-template-areas: "selection user button remove"
+      grid-template-columns: 20px auto 1fr auto auto
+      grid-template-areas: "selection avatar user_details button remove"
       grid-column-gap: 10px
 
   &--header

--- a/app/components/work_packages/share/modal_body_component.sass
+++ b/app/components/work_packages/share/modal_body_component.sass
@@ -1,13 +1,13 @@
 .op-share-wp-modal-body
   &--user-row
     display: grid
-    grid-template-columns: auto 1fr
+    grid-template-columns: minmax(31px, auto) 1fr // 31px is the width needed to display a group avatar
     grid-template-areas: "avatar user_details"
     grid-column-gap: 10px
 
     &_manageable
       display: grid
-      grid-template-columns: 20px auto 1fr auto auto
+      grid-template-columns: 20px minmax(31px, auto) 1fr auto auto
       grid-template-areas: "selection avatar user_details button remove"
       grid-column-gap: 10px
 

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -17,7 +17,7 @@
       end
 
       user_row_grid.with_area(:user_details, tag: :div) do
-        render(WorkPackages::Share::UserDetailsComponent.new(user: principal, share:, manager_mode: share_editable?))
+        render(WorkPackages::Share::UserDetailsComponent.new(share:, manager_mode: share_editable?))
       end
 
       if share_editable?

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -12,11 +12,11 @@
         end
       end
 
-      user_row_grid.with_area(:avatar, tag: :div, classes: 'ellipsis') do
+      user_row_grid.with_area(:avatar, tag: :div) do
         render(Users::AvatarComponent.new(user: principal, show_name: false, size: :medium))
       end
 
-      user_row_grid.with_area(:user_details, tag: :div) do
+      user_row_grid.with_area(:user_details, tag: :div, classes: 'ellipsis') do
         render(WorkPackages::Share::UserDetailsComponent.new(share:, manager_mode: share_editable?))
       end
 

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -12,8 +12,12 @@
         end
       end
 
-      user_row_grid.with_area(:user, tag: :div, classes: 'ellipsis') do
-        render(Users::AvatarComponent.new(user: principal, size: :medium))
+      user_row_grid.with_area(:avatar, tag: :div, classes: 'ellipsis') do
+        render(Users::AvatarComponent.new(user: principal, show_name: false, size: :medium))
+      end
+
+      user_row_grid.with_area(:user_details, tag: :div) do
+        render(WorkPackages::Share::UserDetailsComponent.new(user: principal, share:, manager_mode: share_editable?))
       end
 
       if share_editable?

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -19,7 +19,11 @@
               concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.locked") })
             elsif user.invited?
               concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
-              concat(render(Primer::Beta::Link.new(href: '#')) { I18n.t('work_package.sharing.user_details.resend_invite') })
+              concat(
+                form_with(url: resend_invite_path, method: :post) do
+                  render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :invisible)) { I18n.t('work_package.sharing.user_details.resend_invite') }
+                end
+              )
             end
           else
             if part_of_a_shared_group?

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -25,7 +25,7 @@
                 else
                   concat(
                     form_with(url: resend_invite_path, method: :post) do
-                      render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :invisible)) { I18n.t('work_package.sharing.user_details.resend_invite') }
+                      render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :link)) { I18n.t('work_package.sharing.user_details.resend_invite') }
                     end
                   )
                 end

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -5,7 +5,7 @@
         render(Primer::Beta::Link.new(font_weight: :semibold, href: principal_show_path)) { user.name }
       end
 
-      flex.with_row do
+      flex.with_row(classes: 'ellipsis') do
         if manager_mode?
           if user_is_a_group?
             if project_group?

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -1,0 +1,47 @@
+<%=
+  flex_layout do |flex|
+    flex.with_row do
+      render(Primer::Beta::Link.new(font_weight: :semibold, href: principal_show_path)) { user.name }
+    end
+
+    flex.with_row do
+      if manager_mode?
+        if user_is_a_group?
+          if project_group?
+            render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_group")}
+          else
+            render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_group")}
+          end
+        else
+          if user_in_non_active_status?
+            if user.locked?
+              concat(render(Primer::Beta::Octicon.new(icon: :lock, color: :muted, mr: 1)))
+              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.locked") })
+            elsif user.invited?
+              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
+              concat(render(Primer::Beta::Link.new(href: '#')) { I18n.t('work_package.sharing.user_details.resend_invite') })
+            end
+          else
+            if part_of_a_shared_group?
+              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.part_of_a_shared_group") })
+            end
+
+            if project_member?
+              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_member")})
+              concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { project_role_name })
+            else
+              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member")})
+            end
+          end
+        end
+      else
+        if user.invited?
+          concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invited")})
+        end
+
+        concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.role") })
+        concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { authoritative_work_package_role_name })
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -1,50 +1,56 @@
 <%=
-  flex_layout do |flex|
-    flex.with_row do
-      render(Primer::Beta::Link.new(font_weight: :semibold, href: principal_show_path)) { user.name }
-    end
+  component_wrapper do
+    flex_layout do |flex|
+      flex.with_row do
+        render(Primer::Beta::Link.new(font_weight: :semibold, href: principal_show_path)) { user.name }
+      end
 
-    flex.with_row do
-      if manager_mode?
-        if user_is_a_group?
-          if project_group?
-            render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_group")}
+      flex.with_row do
+        if manager_mode?
+          if user_is_a_group?
+            if project_group?
+              render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_group")}
+            else
+              render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_group")}
+            end
           else
-            render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_group")}
+            if user_in_non_active_status?
+              if user.locked?
+                concat(render(Primer::Beta::Octicon.new(icon: :lock, color: :muted, mr: 1)))
+                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.locked") })
+              elsif user.invited?
+                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
+                if invite_resent?
+                  concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invite_resent") })
+                else
+                  concat(
+                    form_with(url: resend_invite_path, method: :post) do
+                      render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :invisible)) { I18n.t('work_package.sharing.user_details.resend_invite') }
+                    end
+                  )
+                end
+              end
+            else
+              if part_of_a_shared_group?
+                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.part_of_a_shared_group") })
+              end
+
+              if project_member?
+                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_member")})
+                concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { project_role_name })
+              else
+                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member")})
+              end
+            end
           end
         else
-          if user_in_non_active_status?
-            if user.locked?
-              concat(render(Primer::Beta::Octicon.new(icon: :lock, color: :muted, mr: 1)))
-              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.locked") })
-            elsif user.invited?
-              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
-              concat(
-                form_with(url: resend_invite_path, method: :post) do
-                  render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :invisible)) { I18n.t('work_package.sharing.user_details.resend_invite') }
-                end
-              )
-            end
-          else
-            if part_of_a_shared_group?
-              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.part_of_a_shared_group") })
-            end
-
-            if project_member?
-              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_member")})
-              concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { project_role_name })
-            else
-              concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member")})
-            end
+          if user.invited?
+            concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invited")})
           end
-        end
-      else
-        if user.invited?
-          concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invited")})
-        end
 
-        concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.role") })
-        concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { authoritative_work_package_role_name })
+          concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.role") })
+          concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { authoritative_work_package_role_name })
+        end
       end
     end
   end

--- a/app/components/work_packages/share/user_details_component.html.erb
+++ b/app/components/work_packages/share/user_details_component.html.erb
@@ -19,10 +19,10 @@
                 concat(render(Primer::Beta::Octicon.new(icon: :lock, color: :muted, mr: 1)))
                 concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.locked") })
               elsif user.invited?
-                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
                 if invite_resent?
                   concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invite_resent") })
                 else
+                  concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.user_details.invited') })
                   concat(
                     form_with(url: resend_invite_path, method: :post) do
                       render(Primer::Beta::Button.new(type: :submit, px: 0, scheme: :link)) { I18n.t('work_package.sharing.user_details.resend_invite') }
@@ -31,15 +31,28 @@
                 end
               end
             else
-              if part_of_a_shared_group?
-                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.part_of_a_shared_group") })
-              end
-
-              if project_member?
-                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.project_member")})
-                concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { project_role_name })
+              if part_of_a_group?
+                if part_of_a_shared_group?
+                  if project_member?
+                    concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.additional_privileges_project_or_group") })
+                  else
+                    concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.additional_privileges_group") })
+                  end
+                else
+                  if inherited_project_member?
+                    concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.additional_privileges_project_or_group") })
+                  elsif project_member?
+                    concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.additional_privileges_project") })
+                  else
+                    concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member") })
+                  end
+                end
               else
-                concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member")})
+                if project_member?
+                  concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.additional_privileges_project") })
+                else
+                  concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.not_project_member") })
+                end
               end
             end
           end
@@ -47,9 +60,6 @@
           if user.invited?
             concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.invited")})
           end
-
-          concat(render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("work_package.sharing.user_details.role") })
-          concat(render(Primer::Beta::Text.new(color: :subtle, font_weight: :semibold)) { authoritative_work_package_role_name })
         end
       end
     end

--- a/app/components/work_packages/share/user_details_component.rb
+++ b/app/components/work_packages/share/user_details_component.rb
@@ -67,6 +67,10 @@ module WorkPackages
         end
       end
 
+      def resend_invite_path
+        resend_invite_work_package_share_path(share.entity, share)
+      end
+
       def user_is_a_group?
         @user_is_a_group ||= user.is_a?(Group)
       end

--- a/app/components/work_packages/share/user_details_component.rb
+++ b/app/components/work_packages/share/user_details_component.rb
@@ -98,9 +98,11 @@ module WorkPackages
 
       # Explicitly check whether the project membership was inherited by a group
       def inherited_project_member?
-        project_member? &&
-          Member.where(user_id: GroupUser.where(user_id: user.id).map(&:group_id)).any? &&
-          Member.where(user_id: user.id).any?
+        Member.includes(:roles)
+              .references(:member_roles)
+              .where(project: share.project, principal: user, entity: nil) # membership in the project
+              .merge(MemberRole.only_inherited) # that was inherited
+              .any?
       end
 
       def project_group?

--- a/app/components/work_packages/share/user_details_component.rb
+++ b/app/components/work_packages/share/user_details_component.rb
@@ -33,15 +33,19 @@ module WorkPackages
     # rubocop:disable OpenProject/AddPreviewForViewComponent
     class UserDetailsComponent < ApplicationComponent
       # rubocop:enable OpenProject/AddPreviewForViewComponent
+      include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
       include WorkPackages::Share::Concerns::DisplayableRoles
 
-      def initialize(user:, share:, manager_mode: false)
+      def initialize(share:,
+                     manager_mode: User.current.allowed_in_project?(:share_work_packages, share.project),
+                     invite_resent: false)
         super
 
-        @user = user
         @share = share
+        @user = share.principal
         @manager_mode = manager_mode
+        @invite_resent = invite_resent
       end
 
       private
@@ -49,6 +53,12 @@ module WorkPackages
       attr_reader :user, :share
 
       def manager_mode? = @manager_mode
+
+      def invite_resent? = @invite_resent
+
+      def wrapper_uniq_by
+        share.id
+      end
 
       def authoritative_work_package_role_name
         @authoritative_work_package_role_name = options.find do |option|

--- a/app/components/work_packages/share/user_details_component.rb
+++ b/app/components/work_packages/share/user_details_component.rb
@@ -89,10 +89,18 @@ module WorkPackages
         user.locked? || user.invited?
       end
 
+      # Is a user member of a project no matter whether inherited or directly assigned
       def project_member?
         Member.exists?(project: share.project,
                        principal: user,
                        entity: nil)
+      end
+
+      # Explicitly check whether the project membership was inherited by a group
+      def inherited_project_member?
+        project_member? &&
+          Member.where(user_id: GroupUser.where(user_id: user.id).map(&:group_id)).any? &&
+          Member.where(user_id: user.id).any?
       end
 
       def project_group?
@@ -101,6 +109,10 @@ module WorkPackages
 
       def part_of_a_shared_group?
         share.member_roles.where.not(inherited_from: nil).any?
+      end
+
+      def part_of_a_group?
+        GroupUser.where(user_id: user.id).any?
       end
 
       def project_role_name

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -99,7 +99,7 @@ class WorkPackages::SharesController < ApplicationController
                                     work_package_member: @share,
                                     send_notifications: true)
 
-    head :ok
+    respond_with_update_user_details
   end
 
   private
@@ -153,6 +153,15 @@ class WorkPackages::SharesController < ApplicationController
 
     update_via_turbo_stream(
       component: WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: current_visible_member_count)
+    )
+
+    respond_with_turbo_streams
+  end
+
+  def respond_with_update_user_details
+    update_via_turbo_stream(
+      component: WorkPackages::Share::UserDetailsComponent.new(share: @share,
+                                                               invite_resent: true)
     )
 
     respond_with_turbo_streams

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -30,8 +30,8 @@ class WorkPackages::SharesController < ApplicationController
   include OpTurbo::ComponentStream
   include MemberHelper
 
-  before_action :find_work_package, only: %i[index create]
-  before_action :find_share, only: %i[destroy update]
+  before_action :find_work_package, only: %i[index create resend_invite]
+  before_action :find_share, only: %i[destroy update resend_invite]
   before_action :find_project
   before_action :authorize
   before_action :enterprise_check, only: %i[index]
@@ -92,6 +92,14 @@ class WorkPackages::SharesController < ApplicationController
     else
       respond_with_remove_share
     end
+  end
+
+  def resend_invite
+    OpenProject::Notifications.send(OpenProject::Events::WORK_PACKAGE_SHARED,
+                                    work_package_member: @share,
+                                    send_notifications: true)
+
+    head :ok
   end
 
   private

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -118,7 +118,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :share_work_packages,
                      {
-                       'work_packages/shares': %i[index create destroy update],
+                       'work_packages/shares': %i[index create destroy update resend_invite],
                        'work_packages/shares/bulk': %i[update destroy]
                      },
                      permissible_on: :project,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3275,15 +3275,15 @@ en:
         Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to ensure external users are able to access this work package.
       user_details:
         locked: "Locked user"
-        invited: "Pending invitation. "
-        resend_invite: "Resend invite"
+        invited: "Invite sent. "
+        resend_invite: "Resend."
         invite_resent: "Invite has been resent"
-        project_member: "Project member: "
-        not_project_member: "Not project member"
-        project_group: "Project group"
-        not_project_group: "Not project group"
-        part_of_a_shared_group: "Part of a shared group. "
-        role: "Role: "
+        not_project_member: "Not a project member"
+        project_group: "Group members might have additional privileges (as project members)"
+        not_project_group: "Group (shared with all members)"
+        additional_privileges_project: "Might have additional privileges (as project member)"
+        additional_privileges_group: "Might have additional privileges (as group member)"
+        additional_privileges_project_or_group: "Might have additional privileges (as project or group member)"
 
   working_days:
     info: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3277,6 +3277,7 @@ en:
         locked: "Locked user"
         invited: "Pending invitation. "
         resend_invite: "Resend invite"
+        invite_resent: "Invite has been resent"
         project_member: "Project member: "
         not_project_member: "Not project member"
         project_group: "Project group"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3273,6 +3273,16 @@ en:
         Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this work package.
       warning_user_limit_reached_admin: >
         Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to ensure external users are able to access this work package.
+      user_details:
+        locked: "Locked user"
+        invited: "Pending invitation. "
+        resend_invite: "Resend invite"
+        project_member: "Project member: "
+        not_project_member: "Not project member"
+        project_group: "Project group"
+        not_project_group: "Not project group"
+        part_of_a_shared_group: "Part of a shared group. "
+        role: "Role: "
 
   working_days:
     info: >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -469,6 +469,9 @@ OpenProject::Application.routes.draw do
 
     # Rails managed sharing route
     resources :shares, controller: 'work_packages/shares', only: %i[index create] do
+      member do
+        post 'resend_invite' => 'work_packages/shares#resend_invite'
+      end
       collection do
         resource :bulk, controller: 'work_packages/shares/bulk', only: %i[update destroy], as: :shares_bulk
       end

--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
@@ -1,5 +1,5 @@
 <div
-  class="spot-modal op-share-wp-modal"
+  class="spot-modal spot-modal_wide op-share-wp-modal"
 >
   <div
     class="spot-modal--header"

--- a/spec/components/work_packages/share/user_details_component_spec.rb
+++ b/spec/components/work_packages/share/user_details_component_spec.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+require 'spec_helper'
+
+RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
+  subject { render_inline(described_class.new(user: principal, share:, manager_mode:)) }
+
+  shared_let(:project)      { create(:project) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:work_package_role) { create(:view_work_package_role) }
+  shared_let(:project_role) { create(:project_role, name: 'Cool role') }
+
+  shared_let(:user_firstname) { 'Richard' }
+  shared_let(:user_lastname)  { 'Hendricks' }
+  shared_let(:group_name)     { 'Cool group' }
+
+  def build_inherited_share(group_share:, user_share:)
+    create(:member_role,
+           member: user_share,
+           role: work_package_role,
+           inherited_from: group_share.member_roles.first.id)
+  end
+
+  describe 'when not in manager mode' do
+    let(:manager_mode) { false }
+
+    describe 'rendering for a user in a non-active state' do
+      context 'when the user is locked' do
+        let!(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname, status: :locked) }
+        let!(:share) do
+          create(:work_package_member,
+                 principal:,
+                 entity: work_package,
+                 roles: [work_package_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Richard Hendricks Role: View", normalize_ws: true)
+        end
+      end
+
+      context 'when the user is invited' do
+        let!(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname, status: :invited) }
+        let!(:share) do
+          create(:work_package_member,
+                 principal:,
+                 entity: work_package,
+                 roles: [work_package_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Richard Hendricks Pending invitation. Role: View", normalize_ws: true)
+        end
+      end
+    end
+
+    describe 'rendering for a group' do
+      shared_let(:principal) { create(:group, name: group_name) }
+      shared_let(:share) do
+        create(:work_package_member,
+               principal:,
+               entity: work_package,
+               roles: [work_package_role])
+      end
+
+      context 'when it is a member in the project' do
+        before do
+          create(:member, project:, principal:, roles: [project_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Cool group Role: View", normalize_ws: true)
+        end
+      end
+
+      context 'when it is not a member in the project' do
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Cool group Role: View", normalize_ws: true)
+        end
+      end
+    end
+
+    describe 'rendering for a user' do
+      shared_let(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname) }
+      shared_let(:share) do
+        create(:work_package_member,
+               principal:,
+               entity: work_package,
+               roles: [work_package_role])
+      end
+
+      context 'when the user is not part of a shared with group' do
+        context 'and the user is not a project member' do
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Role: View", normalize_ws: true)
+          end
+        end
+
+        context 'and the user is a project member' do
+          before do
+            create(:member, project:, principal:, roles: [project_role])
+          end
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Role: View", normalize_ws: true)
+          end
+        end
+      end
+
+      context 'when the user is part of a shared with group' do
+        shared_let(:group) { create(:group, name: group_name, members: [principal]) }
+
+        before do
+          group_share = create(:work_package_member,
+                               principal: group,
+                               entity: work_package,
+                               roles: [work_package_role])
+
+          build_inherited_share(group_share:, user_share: share)
+        end
+
+        context 'and the user is not a project member' do
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Role: View", normalize_ws: true)
+          end
+        end
+
+        context 'and the user is a project member' do
+          before do
+            create(:member, project:, principal:, roles: [project_role])
+          end
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Role: View", normalize_ws: true)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'when in manager mode' do
+    let(:manager_mode) { true }
+
+    describe 'rendering for a user in a non-active state' do
+      context 'when the user is locked' do
+        let!(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname, status: :locked) }
+        let!(:share) do
+          create(:work_package_member,
+                 principal:,
+                 entity: work_package,
+                 roles: [work_package_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_css(".octicon-lock")
+          expect(page)
+            .to have_text("Richard Hendricks Locked user", normalize_ws: true)
+        end
+      end
+
+      context 'when the user is invited' do
+        let!(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname, status: :invited) }
+        let!(:share) do
+          create(:work_package_member,
+                 principal:,
+                 entity: work_package,
+                 roles: [work_package_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Richard Hendricks Pending invitation. Resend invite", normalize_ws: true)
+        end
+      end
+    end
+
+    describe 'rendering for a group' do
+      shared_let(:principal) { create(:group, name: group_name) }
+      shared_let(:share) do
+        create(:work_package_member,
+               principal:,
+               entity: work_package,
+               roles: [work_package_role])
+      end
+
+      context 'when it is a member in the project' do
+        before do
+          create(:member, project:, principal:, roles: [project_role])
+        end
+
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Cool group Project group", normalize_ws: true)
+        end
+      end
+
+      context 'when it is not a member in the project' do
+        it "", :aggregate_failures do
+          subject
+
+          expect(page)
+            .to have_text("Cool group Not project group", normalize_ws: true)
+        end
+      end
+    end
+
+    describe 'rendering for a user' do
+      shared_let(:principal) { create(:user, firstname: user_firstname, lastname: user_lastname) }
+      shared_let(:share) do
+        create(:work_package_member,
+               principal:,
+               entity: work_package,
+               roles: [work_package_role])
+      end
+
+      context 'when the user is not part of a shared with group' do
+        context 'and the user is not a project member' do
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Not project member", normalize_ws: true)
+          end
+        end
+
+        context 'and the user is a project member' do
+          before do
+            create(:member, project:, principal:, roles: [project_role])
+          end
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Project member: Cool role", normalize_ws: true)
+          end
+        end
+      end
+
+      context 'when the user is part of a shared with group' do
+        shared_let(:group) { create(:group, name: group_name, members: [principal]) }
+
+        before do
+          group_share = create(:work_package_member,
+                               principal: group,
+                               entity: work_package,
+                               roles: [work_package_role])
+
+          build_inherited_share(group_share:, user_share: share)
+        end
+
+        context 'and the user is not a project member' do
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Part of a shared group", normalize_ws: true)
+          end
+        end
+
+        context 'and the user is a project member' do
+          before do
+            create(:member, project:, principal:, roles: [project_role])
+          end
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Part of a shared group. Project member: Cool role", normalize_ws: true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/work_packages/share/user_details_component_spec.rb
+++ b/spec/components/work_packages/share/user_details_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                  roles: [work_package_role])
         end
 
-        it "", :aggregate_failures do
+        it do
           subject
 
           expect(page)
@@ -81,7 +81,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         end
 
         context 'and the invite has not been resent' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -92,7 +92,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         context 'and the invite has been resent' do
           let(:invite_resent) { true }
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -116,7 +116,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
           create(:member, project:, principal:, roles: [project_role])
         end
 
-        it "", :aggregate_failures do
+        it do
           subject
 
           expect(page)
@@ -125,7 +125,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
       end
 
       context 'when it is not a member in the project' do
-        it "", :aggregate_failures do
+        it do
           subject
 
           expect(page)
@@ -145,7 +145,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
 
       context 'when the user is not part of a shared with group' do
         context 'and the user is not a project member' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -158,7 +158,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
             create(:member, project:, principal:, roles: [project_role])
           end
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -180,7 +180,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         end
 
         context 'and the user is not a project member' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -193,7 +193,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
             create(:member, project:, principal:, roles: [project_role])
           end
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -237,7 +237,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         end
 
         context 'and the invite has not been resent' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -248,7 +248,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         context 'and the invite has been resent' do
           let(:invite_resent) { true }
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -272,7 +272,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
           create(:member, project:, principal:, roles: [project_role])
         end
 
-        it "", :aggregate_failures do
+        it do
           subject
 
           expect(page)
@@ -281,7 +281,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
       end
 
       context 'when it is not a member in the project' do
-        it "", :aggregate_failures do
+        it do
           subject
 
           expect(page)
@@ -301,7 +301,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
 
       context 'when the user is not part of a shared with group' do
         context 'and the user is not a project member' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -314,7 +314,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
             create(:member, project:, principal:, roles: [project_role])
           end
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -336,7 +336,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
         end
 
         context 'and the user is not a project member' do
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)
@@ -349,7 +349,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
             create(:member, project:, principal:, roles: [project_role])
           end
 
-          it "", :aggregate_failures do
+          it do
             subject
 
             expect(page)

--- a/spec/components/work_packages/share/user_details_component_spec.rb
+++ b/spec/components/work_packages/share/user_details_component_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
 
   let(:invite_resent) { false }
 
-  def build_inherited_share(group_share:, user_share:)
+  def build_inherited_membership(group_membership:, user_membership:, role: work_package_role)
     create(:member_role,
-           member: user_share,
-           role: work_package_role,
-           inherited_from: group_share.member_roles.first.id)
+           member: user_membership,
+           role:,
+           inherited_from: group_membership.member_roles.first.id)
   end
 
   describe 'when not in manager mode' do
@@ -176,7 +176,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                                entity: work_package,
                                roles: [work_package_role])
 
-          build_inherited_share(group_share:, user_share: share)
+          build_inherited_membership(group_membership: group_share, user_membership: share)
         end
 
         context 'and the user is not a project member' do
@@ -300,9 +300,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
       end
 
       context 'when the user is a project member' do
-        before do
-          create(:member, project:, principal:, roles: [project_role])
-        end
+        shared_let(:user_membership) { create(:member, project:, principal:, roles: [project_role]) }
 
         context 'and the user is not part of any group' do
           it do
@@ -318,7 +316,12 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
 
           context 'and the group is a project member itself' do
             before do
-              create(:member, project:, principal: group, roles: [project_role])
+              group_membership = create(:member,
+                                        project:,
+                                        principal: group,
+                                        roles: [project_role])
+
+              build_inherited_membership(group_membership:, user_membership:, role: project_role)
             end
 
             context 'and the group is shared with' do
@@ -328,7 +331,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                                      entity: work_package,
                                      roles: [work_package_role])
 
-                build_inherited_share(group_share:, user_share: share)
+                build_inherited_membership(group_membership: group_share, user_membership: share)
               end
 
               it do
@@ -359,7 +362,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                                      entity: work_package,
                                      roles: [work_package_role])
 
-                build_inherited_share(group_share:, user_share: share)
+                build_inherited_membership(group_membership: group_share, user_membership: share)
               end
 
               it do
@@ -399,8 +402,10 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
 
           context 'and the group is a project member itself' do
             before do
-              create(:member, project:, principal: group, roles: [project_role])
-              create(:member, project:, principal:, roles: [project_role])
+              group_membership = create(:member, project:, principal: group, roles: [project_role])
+              user_membership = create(:member, project:, principal:, roles: [project_role])
+
+              build_inherited_membership(group_membership:, user_membership:, role: project_role)
             end
 
             context 'and the group is shared with' do
@@ -410,7 +415,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                                      entity: work_package,
                                      roles: [work_package_role])
 
-                build_inherited_share(group_share:, user_share: share)
+                build_inherited_membership(group_membership: group_share, user_membership: share)
               end
 
               it do
@@ -441,7 +446,7 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                                      entity: work_package,
                                      roles: [work_package_role])
 
-                build_inherited_share(group_share:, user_share: share)
+                build_inherited_membership(group_membership: group_share, user_membership: share)
               end
 
               it do

--- a/spec/components/work_packages/share/user_details_component_spec.rb
+++ b/spec/components/work_packages/share/user_details_component_spec.rb
@@ -30,7 +30,7 @@
 require 'spec_helper'
 
 RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
-  subject { render_inline(described_class.new(user: principal, share:, manager_mode:)) }
+  subject { render_inline(described_class.new(share:, manager_mode:, invite_resent:)) }
 
   shared_let(:project)      { create(:project) }
   shared_let(:work_package) { create(:work_package, project:) }
@@ -40,6 +40,8 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
   shared_let(:user_firstname) { 'Richard' }
   shared_let(:user_lastname)  { 'Hendricks' }
   shared_let(:group_name)     { 'Cool group' }
+
+  let(:invite_resent) { false }
 
   def build_inherited_share(group_share:, user_share:)
     create(:member_role,
@@ -78,11 +80,24 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                  roles: [work_package_role])
         end
 
-        it "", :aggregate_failures do
-          subject
+        context 'and the invite has not been resent' do
+          it "", :aggregate_failures do
+            subject
 
-          expect(page)
-            .to have_text("Richard Hendricks Pending invitation. Role: View", normalize_ws: true)
+            expect(page)
+              .to have_text("Richard Hendricks Pending invitation. Role: View", normalize_ws: true)
+          end
+        end
+
+        context 'and the invite has been resent' do
+          let(:invite_resent) { true }
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Pending invitation. Role: View", normalize_ws: true)
+          end
         end
       end
     end
@@ -221,11 +236,24 @@ RSpec.describe WorkPackages::Share::UserDetailsComponent, type: :component do
                  roles: [work_package_role])
         end
 
-        it "", :aggregate_failures do
-          subject
+        context 'and the invite has not been resent' do
+          it "", :aggregate_failures do
+            subject
 
-          expect(page)
-            .to have_text("Richard Hendricks Pending invitation. Resend invite", normalize_ws: true)
+            expect(page)
+              .to have_text("Richard Hendricks Pending invitation. Resend invite", normalize_ws: true)
+          end
+        end
+
+        context 'and the invite has been resent' do
+          let(:invite_resent) { true }
+
+          it "", :aggregate_failures do
+            subject
+
+            expect(page)
+              .to have_text("Richard Hendricks Pending invitation. Invite has been resent", normalize_ws: true)
+          end
         end
       end
     end

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -323,6 +323,13 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(new_user, 'Edit', position: 1)
       share_modal.expect_shared_count_of(7)
 
+      # The invite can be resent
+      share_modal.resend_invite(new_user)
+      share_modal.expect_invite_resent(new_user)
+      perform_enqueued_jobs
+      # Another invitation email sent out to the user
+      expect(ActionMailer::Base.deliveries.size).to eq(2)
+
       # The new user can be deleted
       share_modal.remove_user(new_user)
       share_modal.expect_not_shared_with(new_user)

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -305,6 +305,19 @@ module Components
         end
       end
 
+      def resend_invite(user)
+        within user_row(user) do
+          click_button I18n.t("work_package.sharing.user_details.resend_invite")
+        end
+      end
+
+      def expect_invite_resent(user)
+        within user_row(user) do
+          expect(page)
+            .to have_text(I18n.t("work_package.sharing.user_details.invite_resent"))
+        end
+      end
+
       def user_row(user)
         shares_list
           .find("[data-test-selector=\"op-share-wp-active-user-#{user.id}\"]")


### PR DESCRIPTION
This PR adds "user details" indicating the current membership state of each user within their row in the share modal. This can comprise their status ("locked", "invited"), their belonging to a group, project memberships, invitation status, and work package role.

I've written some thorough component specs for it to serve as documentation for the expected rendering based on each scenario. I hope this makes the reviewer's experience a bit smoother and can help us discuss any specific scenarios that might need textual changes.

## Notes
See: https://community.openproject.org/work_packages/50255
and https://community.openproject.org/work_packages/51165 for the detailed list of expected texts