### PR TITLE
[#50782] "Edit meeting dateils" tooltip visible when meeting details modal is canceled

### DIFF
--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -47,3 +47,14 @@ action-menu
 
 ul.tabnav-tabs
   margin-left: 0
+
+// This fixes the following bug:
+// - https://github.com/primer/view_components/issues/2065
+// - https://community.openproject.org/wp/50782
+// If an icon button triggers a dropdown or dialog, the focus moves to the dropdown/dialog.
+// When we close the dropdown/dialog, the focus moves back to the button and it also triggers
+// displaying the label tooltip. The tooltip also gets stuck open.
+// The solution is to hide the tooltip if the focus was not triggered via a mouse click (:hover)
+// or if it wasn't triggered by the keyboard (:focus-visible).
+button:focus:not(:focus-visible):not(:hover) + tool-tip
+  visibility: hidden


### PR DESCRIPTION
https://community.openproject.org/work_packages/50782