### PR TITLE
[51135] Fix selection of "group by" option in work package list view

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -76,7 +76,7 @@ export class WpTableConfigurationDisplaySettingsTabComponent implements TabCompo
       .onReady()
       .then(() => {
         this.availableGroups = _.sortBy(this.wpTableGroupBy.available, 'name');
-        this.currentGroup = this.wpTableGroupBy.current;
+        this.currentGroup = this.wpTableGroupBy.current || this.availableGroups[0];
       });
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -39,12 +39,13 @@ export class WpTableConfigurationDisplaySettingsTabComponent implements TabCompo
     },
   };
 
-  constructor(readonly injector:Injector,
+  constructor(
+    readonly injector:Injector,
     readonly I18n:I18nService,
     readonly wpTableGroupBy:WorkPackageViewGroupByService,
     readonly wpTableHierarchies:WorkPackageViewHierarchiesService,
-    readonly wpTableSums:WorkPackageViewSumService) {
-  }
+    readonly wpTableSums:WorkPackageViewSumService,
+  ) { }
 
   public onSave() {
     // Update hierarchy state
@@ -72,7 +73,7 @@ export class WpTableConfigurationDisplaySettingsTabComponent implements TabCompo
 
     this.displaySums = this.wpTableSums.current;
 
-    this.wpTableGroupBy
+    void this.wpTableGroupBy
       .onReady()
       .then(() => {
         this.availableGroups = _.sortBy(this.wpTableGroupBy.available, 'name');

--- a/spec/features/work_packages/table/group_by/group_by_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe 'Work Package group by progress', :js do
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+  let(:group_by) { Components::WorkPackages::GroupBy.new }
+
+  current_user { user }
+
+  before do
+    create_list(:work_package, 3, project:, author: user)
+  end
+
+  it 'switches to grouped view when selecting "group by" option' do
+    visit work_packages_path(project:)
+
+    # Activate group by option
+    group_by.enable
+
+    # Expect table to be grouped into 1 group
+    group_by.expect_number_of_groups 1
+    group_by.expect_grouped_by_value '-', 3
+  end
+end

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -41,30 +41,30 @@ module Components
         end
       end
 
-      def enable_via_menu(name)
-        modal = TableConfigurationModal.new
+      def enable
+        set_display_mode('grouped')
+      end
 
-        modal.open_and_set_display_mode 'grouped'
-        select name, from: 'selected_grouping'
-        modal.save
+      def enable_via_menu(name)
+        set_display_mode('grouped') do
+          select name, from: 'selected_grouping'
+        end
       end
 
       def disable_via_menu
-        modal = TableConfigurationModal.new
-        modal.open_and_set_display_mode 'default'
-        modal.save
+        set_display_mode('default')
       end
 
       def expect_number_of_groups(count)
-        expect(page).to have_selector('[data-test-selector="op-group--value"] .count', count:)
+        expect(page).to have_css('[data-test-selector="op-group--value"] .count', count:)
       end
 
       def expect_grouped_by_value(value_name, count)
-        expect(page).to have_selector('[data-test-selector="op-group--value"]', text: "#{value_name} (#{count})")
+        expect(page).to have_css('[data-test-selector="op-group--value"]', text: "#{value_name} (#{count})")
       end
 
       def expect_no_groups
-        expect(page).not_to have_selector('[data-test-selector="op-group--value"]')
+        expect(page).not_to have_css('[data-test-selector="op-group--value"]')
       end
 
       def expect_not_grouped_by(name)
@@ -76,6 +76,14 @@ module Components
       end
 
       private
+
+      def set_display_mode(mode)
+        modal = TableConfigurationModal.new
+
+        modal.open_and_set_display_mode mode
+        yield if block_given?
+        modal.save
+      end
 
       def open_table_column_context_menu(name)
         page.find(".generic-table--sort-header ##{name.downcase}").click


### PR DESCRIPTION
https://community.openproject.org/wp/51135

Selecting "Group by" view option, selecting the first attribute from the drop down, and then clicking "Apply" has no effect.
It should apply the grouping.

This bug blocks me for renaming "Progress (%)" into "% Complete" because there is a feature test where the work packages are grouped by `done_ratio`, and after renaming it, "% Complete" is the first one in the list and the grouping is not applied.