### PR TITLE
Add optimistic locking to meetings and agenda items

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,6 +706,7 @@ en:
         error_enterprise_only: "%{action} is only available in the OpenProject Enterprise edition"
         error_unauthorized: "may not be accessed."
         error_readonly: "was attempted to be written but is not writable."
+        error_conflict: "Information has been updated by at least one other user in the meantime."
         email: "is not a valid email address."
         empty: "can't be empty."
         even: "must be even."

--- a/db/migrate/20231119192222_add_locking_to_meeting.rb
+++ b/db/migrate/20231119192222_add_locking_to_meeting.rb
@@ -1,0 +1,6 @@
+class AddLockingToMeeting < ActiveRecord::Migration[7.0]
+  def change
+    add_column :meetings, :lock_version, :integer, default: 0, null: false
+    add_column :meeting_agenda_items, :lock_version, :integer, default: 0, null: false
+  end
+end

--- a/modules/meeting/app/components/meetings/sidebar/details_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/details_form_component.html.erb
@@ -9,6 +9,10 @@
         collection.with_component(Primer::Alpha::Dialog::Body.new) do
           flex_layout(my: 3) do |modal_body|
             modal_body.with_row do
+              render(BaseErrorsComponent.new(@meeting))
+            end
+
+            modal_body.with_row do
               render(Meeting::StartDate.new(f, initial_value: start_date_initial_value))
             end
 
@@ -22,6 +26,10 @@
 
             modal_body.with_row(mt: 3) do
               render(Meeting::Location.new(f))
+            end
+
+            modal_body.with_row do
+              render(Meeting::LockVersion.new(f))
             end
           end
         end

--- a/modules/meeting/app/contracts/meetings/base_contract.rb
+++ b/modules/meeting/app/contracts/meetings/base_contract.rb
@@ -26,25 +26,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
-  class UpdateContract < BaseContract
-    validate :user_allowed_to_edit
-
-    attribute :lock_version do
-      if model.lock_version.nil? || model.lock_version_changed?
-        errors.add :base, :error_conflict
-      end
+module Meetings
+  class BaseContract < ::ModelContract
+    def self.model
+      Meeting
     end
 
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
-        errors.add :base, :error_unauthorized
-      end
-    end
+    attribute :title
+    attribute :author_id
+    attribute :project_id
+    attribute :location
+    attribute :duration
+    attribute :state
+    attribute :start_date
+    attribute :start_time_hour
   end
 end

--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
+module Meetings
   class UpdateContract < BaseContract
     validate :user_allowed_to_edit
 
@@ -36,13 +36,8 @@ module MeetingAgendaItems
       end
     end
 
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
     def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
+      unless user.allowed_in_project?(:edit_meetings, model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -195,7 +195,9 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def meeting_agenda_item_params
-    params.require(:meeting_agenda_item).permit(:title, :duration_in_minutes, :notes, :work_package_id)
+    params
+      .require(:meeting_agenda_item)
+      .permit(:title, :duration_in_minutes, :notes, :work_package_id, :lock_version)
   end
 
   def generic_call_failure_response(call)

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -167,17 +167,19 @@ class MeetingsController < ApplicationController
   end
 
   def update_details
-    @meeting.update(structured_meeting_params)
+    call = ::Meetings::UpdateService
+      .new(user: current_user, model: @meeting)
+      .call(structured_meeting_params)
 
-    if @meeting.errors.any?
-      update_sidebar_details_form_component_via_turbo_stream
-    else
+    if call.success?
       update_header_component_via_turbo_stream
       update_sidebar_details_component_via_turbo_stream
 
       # the list needs to be updated if the start time has changed
       # in order to update the agenda item time slots
       update_list_via_turbo_stream if @meeting.previous_changes[:start_time].present?
+    else
+      update_sidebar_details_form_component_via_turbo_stream
     end
 
     respond_with_turbo_streams
@@ -307,7 +309,9 @@ class MeetingsController < ApplicationController
 
   def structured_meeting_params
     if params[:structured_meeting].present?
-      params.require(:structured_meeting).permit(:title, :location, :start_time_hour, :duration, :start_date, :state)
+      params
+        .require(:structured_meeting)
+        .permit(:title, :location, :start_time_hour, :duration, :start_date, :state, :lock_version)
     end
   end
 

--- a/modules/meeting/app/forms/meeting/lock_version.rb
+++ b/modules/meeting/app/forms/meeting/lock_version.rb
@@ -26,25 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
-  class UpdateContract < BaseContract
-    validate :user_allowed_to_edit
-
-    attribute :lock_version do
-      if model.lock_version.nil? || model.lock_version_changed?
-        errors.add :base, :error_conflict
-      end
-    end
-
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
-        errors.add :base, :error_unauthorized
-      end
-    end
+class Meeting::LockVersion < ApplicationForm
+  form do |meeting_form|
+    meeting_form.hidden(name: :lock_version)
   end
 end

--- a/modules/meeting/app/forms/meeting_agenda_item/submit.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/submit.rb
@@ -29,6 +29,7 @@
 class MeetingAgendaItem::Submit < ApplicationForm
   form do |agenda_item_form|
     agenda_item_form.group(layout: :horizontal) do |button_group|
+      button_group.hidden(name: :lock_version)
       button_group.hidden(name: :type, value: @type, scope_name_to_model: false)
       button_group.submit(name: :submit_button, label: I18n.t("button_save"), scheme: :primary)
     end

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -26,24 +26,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
-  class UpdateContract < BaseContract
-    validate :user_allowed_to_edit
-
-    attribute :lock_version do
-      if model.lock_version.nil? || model.lock_version_changed?
-        errors.add :base, :error_conflict
-      end
-    end
-
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
-        errors.add :base, :error_unauthorized
+module Meetings
+  class SetAttributesService < ::BaseServices::SetAttributes
+    def set_default_attributes(_params)
+      model.change_by_system do
+        model.author = user
       end
     end
   end

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -26,25 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
-  class UpdateContract < BaseContract
-    validate :user_allowed_to_edit
-
-    attribute :lock_version do
-      if model.lock_version.nil? || model.lock_version_changed?
-        errors.add :base, :error_conflict
-      end
-    end
-
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
-        errors.add :base, :error_unauthorized
-      end
-    end
+module Meetings
+  class UpdateService < ::BaseServices::Update
   end
 end

--- a/modules/meeting/spec/services/meetings/update_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/update_service_spec.rb
@@ -26,25 +26,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module MeetingAgendaItems
-  class UpdateContract < BaseContract
-    validate :user_allowed_to_edit
+require 'spec_helper'
+require 'services/base_services/behaves_like_update_service'
 
-    attribute :lock_version do
-      if model.lock_version.nil? || model.lock_version_changed?
-        errors.add :base, :error_conflict
-      end
-    end
-
-    ##
-    # Meeting agenda items can currently be only edited
-    # through the project permission :manage_agendas
-    # When MeetingRole becomes available, agenda items will
-    # be edited through meeting permissions :manage_agendas
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:manage_agendas, model.project)
-        errors.add :base, :error_unauthorized
-      end
-    end
+RSpec.describe Meetings::UpdateService, type: :model do
+  it_behaves_like 'BaseServices update service' do
+    let(:factory) { :meeting }
   end
 end


### PR DESCRIPTION
Optimistic locking is now in place in the default update actions, as they are only used by the old meetings

https://community.openproject.org/work_packages/51154