### PR TITLE
[OP-50740] Set width of primer form inputs to :large in storage forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -370,4 +370,4 @@ end
 
 gem "openproject-octicons", '~>19.7.0'
 gem "openproject-octicons_helper", '~>19.7.0'
-gem "openproject-primer_view_components", '~>0.13.0'
+gem "openproject-primer_view_components", '~>0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -698,7 +698,7 @@ GEM
       actionview
       openproject-octicons (= 19.7.0)
       railties
-    openproject-primer_view_components (0.13.1)
+    openproject-primer_view_components (0.16.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.7.0)
@@ -1145,7 +1145,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.7.0)
   openproject-octicons_helper (~> 19.7.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.13.0)
+  openproject-primer_view_components (~> 0.16.0)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!
@@ -1235,4 +1235,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.6
+   2.4.7

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.7.0",
-        "@openproject/primer-view-components": "^0.13.1",
+        "@openproject/primer-view-components": "^0.16.0",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.0.2",
         "@uirouter/angular": "^12.0.0",
@@ -4512,9 +4512,9 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.13.1.tgz",
-      "integrity": "sha512-ECndHy/XwK0ZxG+4nOd3EwDDezDnH0YWOuKrujD15o0cyUhnK6pMWh9cSA1Uimo/Soe9acYkSI6eKku6VAaC4A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.16.0.tgz",
+      "integrity": "sha512-lurqBuzK/WBc98IzKX4yEWWKHMgcFBdfxcslac+HlzDVWBnbkhtnNpEXvuFwN7KgQIIlJuW2YLMmfWoC+Asjvg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.3.4",
@@ -4525,9 +4525,14 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.2.3",
+        "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
       }
+    },
+    "node_modules/@openproject/primer-view-components/node_modules/@oddbird/popover-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
+      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
     },
     "node_modules/@openproject/reactivestates": {
       "version": "3.0.1",
@@ -23686,9 +23691,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.13.1.tgz",
-      "integrity": "sha512-ECndHy/XwK0ZxG+4nOd3EwDDezDnH0YWOuKrujD15o0cyUhnK6pMWh9cSA1Uimo/Soe9acYkSI6eKku6VAaC4A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.16.0.tgz",
+      "integrity": "sha512-lurqBuzK/WBc98IzKX4yEWWKHMgcFBdfxcslac+HlzDVWBnbkhtnNpEXvuFwN7KgQIIlJuW2YLMmfWoC+Asjvg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.3.4",
@@ -23699,8 +23704,15 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.2.3",
+        "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
+      },
+      "dependencies": {
+        "@oddbird/popover-polyfill": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
+          "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
+        }
       }
     },
     "@openproject/reactivestates": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4493,9 +4493,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.2.3.tgz",
-      "integrity": "sha512-XDK+V/gUeE4NEsWp79eVzhlK3wuVcRDJuaas63qo0IJLJpyOLHqycJLFYvuq8kebgT1nl87P3sbSb5ZN6Vyf5g=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
+      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
     },
     "node_modules/@openproject/octicons-angular": {
       "version": "19.7.0",
@@ -4528,11 +4528,6 @@
         "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
       }
-    },
-    "node_modules/@openproject/primer-view-components/node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
-      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
     },
     "node_modules/@openproject/reactivestates": {
       "version": "3.0.1",
@@ -4602,9 +4597,9 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.13.1.tgz",
-      "integrity": "sha512-ECndHy/XwK0ZxG+4nOd3EwDDezDnH0YWOuKrujD15o0cyUhnK6pMWh9cSA1Uimo/Soe9acYkSI6eKku6VAaC4A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.16.0.tgz",
+      "integrity": "sha512-lurqBuzK/WBc98IzKX4yEWWKHMgcFBdfxcslac+HlzDVWBnbkhtnNpEXvuFwN7KgQIIlJuW2YLMmfWoC+Asjvg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.3.4",
@@ -4615,7 +4610,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.2.3",
+        "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
       }
     },
@@ -23678,9 +23673,9 @@
       "optional": true
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.2.3.tgz",
-      "integrity": "sha512-XDK+V/gUeE4NEsWp79eVzhlK3wuVcRDJuaas63qo0IJLJpyOLHqycJLFYvuq8kebgT1nl87P3sbSb5ZN6Vyf5g=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
+      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
     },
     "@openproject/octicons-angular": {
       "version": "19.7.0",
@@ -23706,13 +23701,6 @@
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
-      },
-      "dependencies": {
-        "@oddbird/popover-polyfill": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
-          "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
-        }
       }
     },
     "@openproject/reactivestates": {
@@ -23756,7 +23744,7 @@
       "integrity": "sha512-kk0TfLqtGwGYJ/qXGLMXDIL4d3qWPjlEB12Hvk08krulbsQRWEsnXjejBIvJG69GyOOuYxXNoHvP2NGenxQ8Jw==",
       "requires": {
         "@primer/primitives": "^7.12.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.13.1"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.16.0"
       }
     },
     "@primer/primitives": {
@@ -23765,9 +23753,9 @@
       "integrity": "sha512-QKNxfWm7Ik1Ulswyp3KeUL2xnQj8i0E7DdB6lOrh29o7LgyuutwcOHi4CGapBIOR1fYURu+yROSTHQ2C2aDK7A=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.13.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.13.1.tgz",
-      "integrity": "sha512-ECndHy/XwK0ZxG+4nOd3EwDDezDnH0YWOuKrujD15o0cyUhnK6pMWh9cSA1Uimo/Soe9acYkSI6eKku6VAaC4A==",
+      "version": "npm:@openproject/primer-view-components@0.16.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.16.0.tgz",
+      "integrity": "sha512-lurqBuzK/WBc98IzKX4yEWWKHMgcFBdfxcslac+HlzDVWBnbkhtnNpEXvuFwN7KgQIIlJuW2YLMmfWoC+Asjvg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.3.4",
@@ -23778,7 +23766,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.2.3",
+        "@oddbird/popover-polyfill": "^0.3.0",
         "@primer/behaviors": "^1.3.4"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -175,6 +175,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.13.1"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.16.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.7.0",
-    "@openproject/primer-view-components": "^0.13.1",
+    "@openproject/primer-view-components": "^0.16.0",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.0.2",
     "@uirouter/angular": "^12.0.0",

--- a/modules/storages/app/forms/storages/admin/oauth_client_form.rb
+++ b/modules/storages/app/forms/storages/admin/oauth_client_form.rb
@@ -46,7 +46,8 @@ module Storages::Admin
       {
         name: :client_id,
         label: label_client_id,
-        required: true
+        required: true,
+        input_width: :large
       }
     end
 
@@ -54,7 +55,8 @@ module Storages::Admin
       {
         name: :client_secret,
         label: label_client_secret,
-        required: true
+        required: true,
+        input_width: :large
       }
     end
 

--- a/modules/storages/app/forms/storages/admin/provider_drive_id_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_drive_id_input_form.rb
@@ -35,7 +35,8 @@ module Storages::Admin
         visually_hide_label: false,
         required: true,
         caption: I18n.t("storages.instructions.one_drive.drive_id"),
-        placeholder: I18n.t("storages.instructions.one_drive.drive_id_placeholder")
+        placeholder: I18n.t("storages.instructions.one_drive.drive_id_placeholder"),
+        input_width: :large
       )
     end
   end

--- a/modules/storages/app/forms/storages/admin/provider_host_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_host_input_form.rb
@@ -37,7 +37,8 @@ module Storages::Admin
         type: :url,
         pattern: ".{1,255}",
         placeholder: "https://my-file-storage.com",
-        caption: I18n.t('storages.instructions.host')
+        caption: I18n.t('storages.instructions.host'),
+        input_width: :large
       )
     end
   end

--- a/modules/storages/app/forms/storages/admin/provider_name_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_name_input_form.rb
@@ -34,7 +34,8 @@ module Storages::Admin
         label: I18n.t('activerecord.attributes.storages/storage.name'),
         required: true,
         caption: I18n.t('storages.instructions.name'),
-        placeholder: I18n.t("storages.label_file_storage")
+        placeholder: I18n.t("storages.label_file_storage"),
+        input_width: :large
       )
     end
   end

--- a/modules/storages/app/forms/storages/admin/provider_tenant_id_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_tenant_id_input_form.rb
@@ -35,7 +35,8 @@ module Storages::Admin
         visually_hide_label: false,
         required: true,
         caption: I18n.t("storages.instructions.one_drive.tenant_id"),
-        placeholder: I18n.t("storages.instructions.one_drive.tenant_id_placeholder")
+        placeholder: I18n.t("storages.instructions.one_drive.tenant_id_placeholder"),
+        input_width: :large
       )
     end
   end

--- a/modules/storages/app/forms/storages/admin/provider_type_select_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_type_select_form.rb
@@ -62,7 +62,7 @@ module Storages::Admin
         include_blank: false,
         required: true,
         disabled: storage.persisted?,
-        input_width: :large
+        input_width: :small
       }
     end
   end

--- a/modules/storages/app/forms/storages/admin/provider_type_select_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_type_select_form.rb
@@ -61,7 +61,8 @@ module Storages::Admin
         caption: nil,
         include_blank: false,
         required: true,
-        disabled: storage.persisted?
+        disabled: storage.persisted?,
+        input_width: :large
       }
     end
   end


### PR DESCRIPTION
This PR introduces the new `input_width` attribute for `select` and `text_field` primer inputs and change the visual appearance of the inputs for the storage administration form for editing and creating storage base information. They are set to `:large`.

![Screenshot 2023-11-21 at 11 54 46 AM](https://github.com/opf/openproject/assets/17295175/45679944-feb3-4a08-98e2-72c54b6a0462)
