### PR TITLE
apply permission check to revisions link

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -193,7 +193,8 @@ module API
           }
         end
 
-        link :revisions do
+        link :revisions,
+             cache_if: -> { current_user.allowed_in_project?(:view_changesets, represented.project) } do
           {
             href: api_v3_paths.work_package_revisions(represented.id)
           }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -608,6 +608,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
             api_v3_paths.work_package_revisions(work_package.id)
           end
         end
+
+        context 'when user lacks the view_changesets permission' do
+          let(:permissions) { all_permissions - [:view_changesets] }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'revisions' }
+          end
+        end
       end
 
       describe 'version' do


### PR DESCRIPTION
This was [specified to already be the case](https://github.com/opf/openproject/blob/dev/docs/api/apiv3/tags/work_packages.yml#L39) according to the documentation but was not implemented.