### PR TITLE
Fix historic attributes

### DIFF
--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -532,7 +532,7 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
 
     return statement if additional_conditions.blank?
 
-    "#{statement} AND #{additional_conditions.join(' AND ')}"
+    "#{statement} AND (#{additional_conditions.join(' OR ')})"
   end
 
   class NotImplementedError < StandardError; end

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -87,7 +87,7 @@ module Projects::Scopes
       def allowed_to_no_member_exists_condition(user)
         Member
           .select(1)
-          .where(principal: user, entity_id: nil, entity_type: nil)
+          .where(member_conditions(user))
           .where(Member.arel_table[:project_id].eq(arel_table[:id]))
           .arel
           .exists
@@ -116,7 +116,7 @@ module Projects::Scopes
 
       def allowed_to_member_relation(user, permissions)
         Member
-          .where(principal: user, entity_id: nil, entity_type: nil)
+          .where(member_conditions(user))
           .joins(allowed_to_member_in_active_project_join)
           .joins(allowed_to_enabled_module_join(permissions))
           .joins(:roles)
@@ -167,6 +167,12 @@ module Projects::Scopes
                .on(Project.arel_table[:active].eq(true)
                           .and(Member.arel_table[:project_id].eq(arel_table[:id])))
                .join_sources
+      end
+
+      def member_conditions(user)
+        Member.arel_table[:user_id].eq(user.id)
+        .and(Member.arel_table[:entity_id].eq(nil))
+        .and(Member.arel_table[:entity_type].eq(nil))
       end
 
       def allowed_to_permissions(permission)

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -65,11 +65,12 @@ module WorkPackages::Scopes
 
       def allowed_to_member_relation(user, permissions)
         Member
-          .joins(allowed_to_member_in_work_package_join(user))
+          .joins(allowed_to_member_in_work_package_join)
           .joins(active_project_join)
           .joins(allowed_to_enabled_module_join(permissions))
           .joins(member_roles: :role)
           .joins(allowed_to_role_permission_join(permissions))
+          .where(principal: user, entity_type: model_name.name)
           .select(arel_table[:id])
       end
 
@@ -120,14 +121,10 @@ module WorkPackages::Scopes
                   .join_sources
       end
 
-      def allowed_to_member_in_work_package_join(user)
+      def allowed_to_member_in_work_package_join
         members_table = Member.arel_table
         arel_table.join(arel_table)
-        .on(
-          members_table[:entity_id].eq(arel_table[:id])
-          .and(members_table[:entity_type].eq(model_name.name))
-          .and(members_table[:user_id].eq(user.id))
-        )
+        .on(members_table[:entity_id].eq(arel_table[:id]))
         .join_sources
       end
     end

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -70,7 +70,7 @@ module WorkPackages::Scopes
           .joins(allowed_to_enabled_module_join(permissions))
           .joins(member_roles: :role)
           .joins(allowed_to_role_permission_join(permissions))
-          .where(principal: user, entity_type: model_name.name)
+          .where(member_conditions(user))
           .select(arel_table[:id])
       end
 
@@ -126,6 +126,11 @@ module WorkPackages::Scopes
         arel_table.join(arel_table)
         .on(members_table[:entity_id].eq(arel_table[:id]))
         .join_sources
+      end
+
+      def member_conditions(user)
+        Member.arel_table[:user_id].eq(user.id)
+        .and(Member.arel_table[:entity_type].eq(model_name.name))
       end
     end
   end

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -168,11 +168,11 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
     end
 
     describe "id in subquery (Arel::Nodes::In)" do
-      let(:relation) { WorkPackage.where(id: WorkPackage.where(id: [work_package.id, 999, 9999])) }
+      let(:relation) { WorkPackage.where(id: [work_package.id, 99, 999, 9999]) }
 
       describe "#to_sql" do
         it "transforms the expression to query the correct table" do
-          expect(subject.to_sql).to include "\"journals\".\"journable_id\" IN (SELECT \"work_packages\".\"id\""
+          expect(subject.to_sql).to include "\"journals\".\"journable_id\" IN (#{work_package.id}, 99, 999, 9999)"
         end
       end
 


### PR DESCRIPTION
The historic attributes query needs to modify the `WHERE` conditions as well now. Previously everything was fixed because we simply `JOIN`ed the permission related stuff. Now we have the `UNION` query that selects allowed_to for projects and work packages. So we need to build a new AST Walker, that also modifies all the other conditions where `work_packages` table is joined and move it to `journalized_work_packages`.