### PR TITLE
[Op#50946] Use correct input field widths in managed project folders application passwor input

### DIFF
--- a/modules/storages/app/forms/storages/admin/managed_project_folders/application_password_input.rb
+++ b/modules/storages/app/forms/storages/admin/managed_project_folders/application_password_input.rb
@@ -35,7 +35,8 @@ module Storages::Admin::ManagedProjectFolders
         required: true,
         caption: application_password_caption,
         value: nil, # IMPORTANT: We don't want to show the password in the form
-        placeholder: @storage.password.present? ? "••••••••••••••••" : nil
+        placeholder: @storage.password.present? ? "••••••••••••••••" : nil,
+        input_width: :large
       )
     end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/50946

![Screenshot 2023-11-21 at 3 33 30 PM](https://github.com/opf/openproject/assets/17295175/b4f5fa40-8516-41f3-ba91-a11f36ff9234)
