### PR TITLE
[51008] Long text overflows in MOBILE storage primer views

### DIFF
--- a/modules/storages/app/components/storages/admin/automatically_managed_project_folders_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/automatically_managed_project_folders_info_component.html.erb
@@ -6,7 +6,7 @@
     end
 
     grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-automatically-managed-project-folders-description') do
-      render(Primer::Beta::Truncate.new) { I18n.t('storages.page_titles.managed_project_folders.subtitle_short') }
+      render(Primer::Beta::Text.new) { I18n.t('storages.page_titles.managed_project_folders.subtitle_short') }
     end
 
     if editable_storage?

--- a/modules/storages/app/components/storages/admin/general_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/general_info_component.html.erb
@@ -6,7 +6,7 @@
     end
 
     grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-description') do
-      render(Primer::Beta::Truncate.new) { storage_description }
+      render(Primer::Beta::Text.new) { storage_description }
     end
 
     if editable_storage?

--- a/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
@@ -6,7 +6,7 @@
     end
 
     grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-openproject-oauth-application-description') do
-      render(Primer::Beta::Truncate.new) { openproject_oauth_client_description }
+      render(Primer::Beta::Text.new) { openproject_oauth_client_description }
     end
 
     if editable_storage?

--- a/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
@@ -10,7 +10,7 @@
     end
 
     grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-oauth-client-id-description') do
-      render(Primer::Beta::Truncate.new) { provider_oauth_client_description }
+      render(Primer::Beta::Text.new) { provider_oauth_client_description }
     end
 
     if editable_storage?


### PR DESCRIPTION
Truncate component has 'white-space: nowrap' style, so the text will never wrap to the next line and continue to reach a <br> tag. Due to this reason, I changed it from Truncate to Text primer component.

https://community.openproject.org/work_packages/51008/activity