### PR TITLE
[#51173] Regression: most of the custom fields no longer appear in PDF

### DIFF
--- a/app/models/work_package/pdf_export/work_package_detail.rb
+++ b/app/models/work_package/pdf_export/work_package_detail.rb
@@ -141,7 +141,7 @@ module WorkPackage::PDFExport::WorkPackageDetail
       cf = CustomField.find_by(id:)
       return [] if cf.nil? || cf.formattable?
 
-      return [] if work_package.project.work_package_custom_field_ids.exclude?(cf.id)
+      return [] unless cf.is_for_all? || work_package.project.work_package_custom_field_ids.include?(cf.id)
 
       return [{ label: cf.name || form_key, name: form_key }]
     end


### PR DESCRIPTION
single work package export:

[x] show globally enabled custom fields again
[x] add globally enabled custom field to test

https://community.openproject.org/work_packages/51173