### PR TITLE
Save/Load CI docker image from cache

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -34,6 +34,18 @@ jobs:
       CAPYBARA_AWS_SECRET_ACCESS_KEY: "${{ secrets.CAPYBARA_AWS_SECRET_ACCESS_KEY }}"
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache DOCKER
+      id: cache_docker
+      uses: actions/cache@v3
+      with:
+        path: cache/docker
+        key: ${{ runner.os }}-docker-ci-${{ hashFiles('docker-compose.ci.yml', 'docker/ci/*', '.ruby-version', 'bin/ci') }}
+        # Note: no restore keys since whenever the above files change, we want to rebuild the full image from scratch
+    - name: Restore CI image from cache
+      if: steps.cache_docker.outputs.cache-hit == 'true'
+      run: docker load -i cache/docker/image.tar
     - name: Cache GEM
       uses: actions/cache@v3
       with:
@@ -71,6 +83,9 @@ jobs:
       run: bin/ci run-units
     - name: Feature tests
       run: bin/ci run-features
+    - name: Save CI image to cache
+      if: steps.cache_docker.outputs.cache-hit != 'true'
+      run: mkdir -p cache/docker && docker save openproject/ci:v1 -o cache/docker/image.tar
     - name: Cleanup
       if: ${{ always() }}
       run: |

--- a/bin/ci
+++ b/bin/ci
@@ -9,10 +9,10 @@ export COMPOSE_FILE=docker-compose.ci.yml
 export RUBY_VERSION="$(cat .ruby-version)"
 export LOCAL_CACHE_PATH="./cache"
 
-mkdir -p $LOCAL_CACHE_PATH/{bundle,npm,angular,runtime-logs}
+mkdir -p $LOCAL_CACHE_PATH/{bundle,npm,angular,runtime-logs,buildx}
 
 if [ "$1" = "down" ]; then
   exec docker compose down --remove-orphans --volumes
 else
-  exec docker compose run --rm --remove-orphans --build ci "$@"
+  exec docker compose run --rm --remove-orphans app "$@"
 fi

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,19 +1,10 @@
-version: "3.7"
-
-networks:
-  testing:
 
 name: "openproject-ci"
 
 services:
-  db:
-    image: postgres:13
-    tmpfs:
-      - /var/lib/postgresql/data
-    command: "-c autovacuum=off -c fsync=off -c synchronous_commit=off -c checkpoint_timeout=30min -c full_page_writes=off -c deadlock_timeout=5s -c track_activities=off -c track_counts=off -c max_connections=200 -c shared_buffers=8GB -c work_mem=10485kB -c min_wal_size=1GB -c max_wal_size=4GB -c max_worker_processes=16 -c max_parallel_workers=16"
-    environment:
-      POSTGRES_PASSWORD: p4ssw0rd
-  ci:
+  # Note: not using a database container since it adds 1min to pull and start it on CI
+  app:
+    image: openproject/ci:v1
     build:
       context: .
       dockerfile: ./docker/ci/Dockerfile
@@ -21,16 +12,15 @@ services:
         - APP_USER_UID
         - APP_USER_GID
         - RUBY_VERSION
+      cache_from: ["type=local,src=${LOCAL_CACHE_PATH}/buildx"]
+      cache_to: ["type=local,dest=${LOCAL_CACHE_PATH}/buildx"]
     environment:
       CI_JOBS: "${CI_JOBS}"
       RSPEC_RETRY_RETRY_COUNT: "${CI_RETRY_COUNT:-3}"
       CAPYBARA_AWS_ACCESS_KEY_ID: "${CAPYBARA_AWS_ACCESS_KEY_ID}"
       CAPYBARA_AWS_SECRET_ACCESS_KEY: "${CAPYBARA_AWS_SECRET_ACCESS_KEY}"
-      PGHOST: db
     tmpfs:
       - "/tmp"
-    depends_on:
-      - db
     volumes:
       - .:/app
       - ${LOCAL_CACHE_PATH}/bundle:/usr/local/bundle

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -7,10 +7,14 @@ ENV BUNDLER_VERSION="2.4.21"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV BUNDLE_WITHOUT="development:production:docker"
 
-RUN apt-get update -qq && apt-get install -y postgresql-client time imagemagick default-jre-headless firefox-esr
+ENV PGVERSION=13
+RUN wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb"
-RUN f="/tmp/chrome.deb"; wget --no-verbose -O $f $CHROME_SOURCE_URL && apt install -y $f && rm -f $f
+RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && wget --no-verbose -O $f $CHROME_SOURCE_URL && \
+  apt-get update -qq && apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr && \
+  rm -f "$f" && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl -L https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -o - | tar xJf - -C /usr/local --strip=1 && node --version
 
@@ -21,9 +25,9 @@ ENV APP_PATH=/app
 ARG APP_USER_UID
 ARG APP_USER_GID
 
-RUN groupadd --force --gid $APP_USER_GID $APP_USER
-RUN useradd -d $APP_PATH -m $APP_USER -s /bin/bash --uid $APP_USER_UID --gid $APP_USER_GID
-RUN chown -R $APP_USER:$APP_USER /usr/local/bundle
+RUN groupadd --force --gid $APP_USER_GID $APP_USER && \
+  useradd -d $APP_PATH -m $APP_USER -s /bin/bash --uid $APP_USER_UID --gid $APP_USER_GID && \
+  chown -R $APP_USER:$APP_USER /usr/local/bundle
 
 ENV CI=true
 ENV RAILS_ENV=test

--- a/docker/ci/database.yml
+++ b/docker/ci/database.yml
@@ -1,2 +1,2 @@
 test:
-  url: <%= ENV['DATABASE_URL'].sub(/\/postgres$/, "/appdb#{ENV['TEST_ENV_NUMBER']}") %>
+  url: <%= ENV['DATABASE_URL'].sub(/\/appdb$/, "/appdb#{ENV['TEST_ENV_NUMBER']}") %>


### PR DESCRIPTION
Current image build is not cached, thus we incur about 2min build time. I first tested using buildx cache to keep docker layers, but we can actually launch directly from the resulting image, since we don't use the layers to build anything else.