### PR TITLE
[OP#50985] use primer flash (banner) for file storage administration settings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,19 +115,19 @@ module ApplicationHelper
     end
   end
 
-  def render_primer_flash_message?
-    flash[:primer_flash].present?
+  def render_primer_banner_message?
+    flash[:primer_banner].present?
   end
 
-  def render_primer_flash_message
-    return unless render_primer_flash_message?
+  def render_primer_banner_message
+    return unless render_primer_banner_message?
 
-    render(FlashMessageComponent.new(**flash[:primer_flash].to_hash))
+    render(BannerMessageComponent.new(**flash[:primer_banner].to_hash))
   end
 
   # Renders flash messages
-  def render_legacy_flash_messages
-    return if render_primer_flash_message?
+  def render_flash_messages
+    return if render_primer_banner_message?
 
     messages = flash
       .reject { |k, _| k.start_with? '_' }
@@ -151,24 +151,20 @@ module ApplicationHelper
     end
   end
 
-  def render_legacy_flash_message(type, message, html_options = {}) # rubocop:disable Metrics/AbcSize
+  def render_flash_message(type, message, html_options = {})
     if type.to_s == 'notice'
       type = 'success'
     end
-
     toast_css_classes = ["op-toast -#{type}", html_options.delete(:class)]
-
     # Add autohide class to notice flashes if configured
     if type.to_s == 'success' && User.current.pref.auto_hide_popups?
       toast_css_classes << 'autohide-toaster'
     end
-
     html_options = { class: toast_css_classes.join(' '), role: 'alert' }.merge(html_options)
     close_button = content_tag :a, '', class: 'op-toast--close icon-context icon-close',
                                        title: I18n.t('js.close_popup_title'),
                                        tabindex: '0'
     toast = content_tag(:div, join_flash_messages(message), class: 'op-toast--content')
-
     content_tag :div, '', class: 'op-toast--wrapper' do
       content_tag :div, '', class: 'op-toast--casing' do
         content_tag :div, html_options do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,66 +115,6 @@ module ApplicationHelper
     end
   end
 
-  def render_primer_banner_message?
-    flash[:primer_banner].present?
-  end
-
-  def render_primer_banner_message
-    return unless render_primer_banner_message?
-
-    render(BannerMessageComponent.new(**flash[:primer_banner].to_hash))
-  end
-
-  # Renders flash messages
-  def render_flash_messages
-    return if render_primer_banner_message?
-
-    messages = flash
-      .reject { |k, _| k.start_with? '_' }
-      .map do |k, v|
-      if k.to_sym == :modal
-        component = v[:type].constantize
-        component.new(**v[:parameters]).render_in(self)
-      else
-        render_flash_message(k, v)
-      end
-    end
-
-    safe_join messages, "\n"
-  end
-
-  def join_flash_messages(messages)
-    if messages.respond_to?(:join)
-      safe_join(messages, '<br />'.html_safe)
-    else
-      messages
-    end
-  end
-
-  def render_flash_message(type, message, html_options = {})
-    if type.to_s == 'notice'
-      type = 'success'
-    end
-    toast_css_classes = ["op-toast -#{type}", html_options.delete(:class)]
-    # Add autohide class to notice flashes if configured
-    if type.to_s == 'success' && User.current.pref.auto_hide_popups?
-      toast_css_classes << 'autohide-toaster'
-    end
-    html_options = { class: toast_css_classes.join(' '), role: 'alert' }.merge(html_options)
-    close_button = content_tag :a, '', class: 'op-toast--close icon-context icon-close',
-                                       title: I18n.t('js.close_popup_title'),
-                                       tabindex: '0'
-    toast = content_tag(:div, join_flash_messages(message), class: 'op-toast--content')
-    content_tag :div, '', class: 'op-toast--wrapper' do
-      content_tag :div, '', class: 'op-toast--casing' do
-        content_tag :div, html_options do
-          concat(close_button)
-          concat(toast)
-        end
-      end
-    end
-  end
-
   # Yields the given block for each project with its level in the tree
   #
   # Wrapper for Project#project_tree

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,8 +115,20 @@ module ApplicationHelper
     end
   end
 
+  def render_primer_flash_message?
+    flash[:primer_flash].present?
+  end
+
+  def render_primer_flash_message
+    return unless render_primer_flash_message?
+
+    render(FlashMessageComponent.new(**flash[:primer_flash].to_hash))
+  end
+
   # Renders flash messages
-  def render_flash_messages
+  def render_legacy_flash_messages
+    return if render_primer_flash_message?
+
     messages = flash
       .reject { |k, _| k.start_with? '_' }
       .map do |k, v|
@@ -139,20 +151,24 @@ module ApplicationHelper
     end
   end
 
-  def render_flash_message(type, message, html_options = {})
+  def render_legacy_flash_message(type, message, html_options = {}) # rubocop:disable Metrics/AbcSize
     if type.to_s == 'notice'
       type = 'success'
     end
+
     toast_css_classes = ["op-toast -#{type}", html_options.delete(:class)]
+
     # Add autohide class to notice flashes if configured
     if type.to_s == 'success' && User.current.pref.auto_hide_popups?
       toast_css_classes << 'autohide-toaster'
     end
+
     html_options = { class: toast_css_classes.join(' '), role: 'alert' }.merge(html_options)
     close_button = content_tag :a, '', class: 'op-toast--close icon-context icon-close',
                                        title: I18n.t('js.close_popup_title'),
                                        tabindex: '0'
     toast = content_tag(:div, join_flash_messages(message), class: 'op-toast--content')
+
     content_tag :div, '', class: 'op-toast--wrapper' do
       content_tag :div, '', class: 'op-toast--casing' do
         content_tag :div, html_options do

--- a/app/helpers/flash_messages_helper.rb
+++ b/app/helpers/flash_messages_helper.rb
@@ -1,0 +1,100 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+
+module FlashMessagesHelper
+  extend ActiveSupport::Concern
+
+  included do
+    # For .safe_join in join_flash_messages
+    include ActionView::Helpers::OutputSafetyHelper
+  end
+
+  def render_primer_banner_message?
+    flash[:primer_banner].present?
+  end
+
+  def render_primer_banner_message
+    return unless render_primer_banner_message?
+
+    render(BannerMessageComponent.new(**flash[:primer_banner].to_hash))
+  end
+
+  # Renders flash messages
+  def render_flash_messages
+    return if render_primer_banner_message?
+
+    messages = flash
+      .reject { |k, _| k.start_with? '_' }
+      .map do |k, v|
+      if k.to_sym == :modal
+        component = v[:type].constantize
+        component.new(**v[:parameters]).render_in(self)
+      else
+        render_flash_message(k, v)
+      end
+    end
+
+    safe_join messages, "\n"
+  end
+
+  def join_flash_messages(messages)
+    if messages.respond_to?(:join)
+      safe_join(messages, '<br />'.html_safe)
+    else
+      messages
+    end
+  end
+
+  def render_flash_message(type, message, html_options = {}) # rubocop:disable Metrics/AbcSize
+    if type.to_s == 'notice'
+      type = 'success'
+    end
+
+    toast_css_classes = ["op-toast -#{type}", html_options.delete(:class)]
+
+    # Add autohide class to notice flashes if configured
+    if type.to_s == 'success' && User.current.pref.auto_hide_popups?
+      toast_css_classes << 'autohide-toaster'
+    end
+
+    html_options = { class: toast_css_classes.join(' '), role: 'alert' }.merge(html_options)
+    close_button = content_tag :a, '', class: 'op-toast--close icon-context icon-close',
+                                       title: I18n.t('js.close_popup_title'),
+                                       tabindex: '0'
+    toast = content_tag(:div, join_flash_messages(message), class: 'op-toast--content')
+    content_tag :div, '', class: 'op-toast--wrapper' do
+      content_tag :div, '', class: 'op-toast--casing' do
+        content_tag :div, html_options do
+          concat(close_button)
+          concat(toast)
+        end
+      end
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -115,6 +115,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <div class="content-overlay"></div>
     <main id="content-wrapper" class="<%= initial_classes %>">
+      <%= render_primer_flash_message %>
       <% if show_decoration %>
         <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>">
           <%= you_are_here_info %>
@@ -124,7 +125,7 @@ See COPYRIGHT and LICENSE files for more details.
           <%= call_hook :view_layouts_base_breadcrumb %>
         </div>
       <% end %>
-      <%= render_flash_messages %>
+      <%= render_legacy_flash_messages %>
       <% if show_onboarding_modal? %>
         <section data-augmented-model-wrapper
                  data-modal-initialize-now="true"

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -115,7 +115,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <div class="content-overlay"></div>
     <main id="content-wrapper" class="<%= initial_classes %>">
-      <%= render_primer_flash_message %>
+      <%= render_primer_banner_message %>
       <% if show_decoration %>
         <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>">
           <%= you_are_here_info %>
@@ -125,7 +125,7 @@ See COPYRIGHT and LICENSE files for more details.
           <%= call_hook :view_layouts_base_breadcrumb %>
         </div>
       <% end %>
-      <%= render_legacy_flash_messages %>
+      <%= render_flash_messages %>
       <% if show_onboarding_modal? %>
         <section data-augmented-model-wrapper
                  data-modal-initialize-now="true"

--- a/modules/meeting/app/components/banner_message_component.html.erb
+++ b/modules/meeting/app/components/banner_message_component.html.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(Primer::Alpha::Banner.new(full:, full_when_narrow:, dismiss_scheme:, icon:, scheme:,test_selector:)) { message }
+%>

--- a/modules/meeting/app/components/banner_message_component.rb
+++ b/modules/meeting/app/components/banner_message_component.rb
@@ -26,37 +26,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class FlashMessageComponent < ApplicationComponent
-  include ApplicationHelper
-  include OpTurbo::Streamable
-  include OpPrimer::ComponentHelpers
-
-  def initialize(message: nil, full: false, spacious: false, dismissible: false, icon: nil, scheme: :default)
+class BannerMessageComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+  def initialize(message: nil, full: false, full_when_narrow: false, dismiss_scheme: :none, icon: false, scheme: :default,
+                 test_selector: "primer-banner-message-component")
     super
 
     @message = message
     @full = full
-    @spacious = spacious
-    @dismissible = dismissible # TODO: not working yet -> JS dependency not provided?
+    @full_when_narrow = full_when_narrow
+    @dismiss_scheme = dismiss_scheme
     @icon = icon
     @scheme = scheme
+    @test_selector = test_selector
   end
 
-  def call
-    component_wrapper do
-      # even without provided message, the wrapper should be  rendered as this allows
-      # for triggering a flash message via turbo stream
-      if @message.present?
-        flash_partial
-      end
-    end
-  end
-
-  private
-
-  def flash_partial
-    render(Primer::Beta::Flash.new(
-             full: @full, spacious: @spacious, dismissible: @dismissible, icon: @icon, scheme: @scheme
-           )) { @message }
-  end
+  attr_reader :message, :full, :full_when_narrow, :dismiss_scheme, :icon, :scheme, :test_selector
 end

--- a/modules/meeting/app/components/banner_message_component.rb
+++ b/modules/meeting/app/components/banner_message_component.rb
@@ -27,7 +27,7 @@
 #++
 
 class BannerMessageComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
-  def initialize(message: nil, full: false, full_when_narrow: false, dismiss_scheme: :none, icon: false, scheme: :default,
+  def initialize(message: nil, full: true, full_when_narrow: false, dismiss_scheme: :hide, icon: false, scheme: :default,
                  test_selector: "primer-banner-message-component")
     super
 

--- a/modules/meeting/app/components/flash_message_component.rb
+++ b/modules/meeting/app/components/flash_message_component.rb
@@ -31,14 +31,14 @@ class FlashMessageComponent < ApplicationComponent
   include OpTurbo::Streamable
   include OpPrimer::ComponentHelpers
 
-  def initialize(message: nil, full: false, spacious: false, dismissible: false, icon: nil, scheme: :default,
+  def initialize(message: nil, full: false, full_when_narrow: false, dismissible: false, icon: false, scheme: :default,
                  test_selector: "primer-flash-message-component")
     super
 
     @message = message
     @full = full
-    @spacious = spacious
-    @dismissible = dismissible # TODO: not working yet -> JS dependency not provided?
+    @full_when_narrow = full_when_narrow
+    @dismissible = dismissible
     @icon = icon
     @scheme = scheme
     @test_selector = test_selector
@@ -48,7 +48,7 @@ class FlashMessageComponent < ApplicationComponent
     component_wrapper do
       # even without provided message, the wrapper should be  rendered as this allows
       # for triggering a flash message via turbo stream
-      if @message.present?
+      if message.present?
         flash_partial
       end
     end
@@ -56,10 +56,24 @@ class FlashMessageComponent < ApplicationComponent
 
   private
 
+  attr_reader :message, :full, :full_when_narrow, :dismissible, :icon, :scheme, :test_selector
+
   def flash_partial
-    render(Primer::Beta::Flash.new(
-             full: @full, spacious: @spacious, dismissible: @dismissible, icon: @icon, scheme: @scheme,
-             test_selector: @test_selector
-           )) { @message }
+    # The banner component is similar to the flash message component, but is more feature rich.
+    #  - It ALWAYS renders with an icon
+    #  - It can be dismissed
+    #  - It allows for custom actions while flash messages only allow for a dismiss action (which doesn't work yet :/)
+    # See https://primer.style/components/banner/rails/alpha
+    render(
+      Primer::Alpha::Banner.new(
+        full:, full_when_narrow:,
+        dismiss_scheme:, icon:, scheme:,
+        test_selector:
+      )
+    ) { message }
+  end
+
+  def dismiss_scheme
+    dismissible ? :remove : :none
   end
 end

--- a/modules/meeting/app/components/flash_message_component.rb
+++ b/modules/meeting/app/components/flash_message_component.rb
@@ -31,7 +31,8 @@ class FlashMessageComponent < ApplicationComponent
   include OpTurbo::Streamable
   include OpPrimer::ComponentHelpers
 
-  def initialize(message: nil, full: false, spacious: false, dismissible: false, icon: nil, scheme: :default)
+  def initialize(message: nil, full: false, spacious: false, dismissible: false, icon: nil, scheme: :default,
+                 test_selector: "primer-flash-message-component")
     super
 
     @message = message
@@ -40,6 +41,7 @@ class FlashMessageComponent < ApplicationComponent
     @dismissible = dismissible # TODO: not working yet -> JS dependency not provided?
     @icon = icon
     @scheme = scheme
+    @test_selector = test_selector
   end
 
   def call
@@ -56,7 +58,8 @@ class FlashMessageComponent < ApplicationComponent
 
   def flash_partial
     render(Primer::Beta::Flash.new(
-             full: @full, spacious: @spacious, dismissible: @dismissible, icon: @icon, scheme: @scheme
+             full: @full, spacious: @spacious, dismissible: @dismissible, icon: @icon, scheme: @scheme,
+             test_selector: @test_selector
            )) { @message }
   end
 end

--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -74,7 +74,12 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
     service_result = call_update_service
 
     if service_result.success?
-      flash[:notice] = I18n.t(:'storages.notice_successful_storage_connection')
+      flash[:primer_flash] = {
+        message: I18n.t(:'storages.notice_successful_storage_connection'),
+        scheme: :success,
+        dismissible: true,
+        full: true
+      }
       redirect_to admin_settings_storages_path
     else
       respond_to do |format|

--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -74,10 +74,10 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
     service_result = call_update_service
 
     if service_result.success?
-      flash[:primer_flash] = {
+      flash[:primer_banner] = {
         message: I18n.t(:'storages.notice_successful_storage_connection'),
         scheme: :success,
-        dismissible: true,
+        dismiss_scheme: :hide,
         full: true
       }
       redirect_to admin_settings_storages_path

--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -76,9 +76,7 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
     if service_result.success?
       flash[:primer_banner] = {
         message: I18n.t(:'storages.notice_successful_storage_connection'),
-        scheme: :success,
-        dismiss_scheme: :hide,
-        full: true
+        scheme: :success
       }
       redirect_to admin_settings_storages_path
     else

--- a/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
@@ -62,7 +62,7 @@ class Storages::Admin::OAuthClientsController < ApplicationController
   # Actually create a OAuthClient object.
   # Use service pattern to create a new OAuthClient
   # Called by: Global app/config/routes.rb to serve Web page
-  def create # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+  def create # rubocop:disable Metrics/AbcSize
     call_oauth_clients_create_service
 
     service_result.on_failure do
@@ -77,7 +77,12 @@ class Storages::Admin::OAuthClientsController < ApplicationController
           format.turbo_stream { render :create }
         end
       elsif @storage.provider_type_one_drive?
-        flash[:notice] = I18n.t(:'storages.notice_successful_storage_connection')
+        flash[:primer_flash] = {
+          message: I18n.t(:'storages.notice_successful_storage_connection'),
+          scheme: :success,
+          dismissible: true,
+          full: true
+        }
         redirect_to admin_settings_storages_path
       else
         raise "Unsupported provider type: #{@storage.short_provider_type}"

--- a/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
@@ -77,12 +77,7 @@ class Storages::Admin::OAuthClientsController < ApplicationController
           format.turbo_stream { render :create }
         end
       elsif @storage.provider_type_one_drive?
-        flash[:primer_banner] = {
-          message: I18n.t(:'storages.notice_successful_storage_connection'),
-          scheme: :success,
-          dismiss_scheme: :hide,
-          full: true
-        }
+        flash[:primer_banner] = { message: I18n.t(:'storages.notice_successful_storage_connection'), scheme: :success }
         redirect_to admin_settings_storages_path
       else
         raise "Unsupported provider type: #{@storage.short_provider_type}"

--- a/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/oauth_clients_controller.rb
@@ -77,10 +77,10 @@ class Storages::Admin::OAuthClientsController < ApplicationController
           format.turbo_stream { render :create }
         end
       elsif @storage.provider_type_one_drive?
-        flash[:primer_flash] = {
+        flash[:primer_banner] = {
           message: I18n.t(:'storages.notice_successful_storage_connection'),
           scheme: :success,
-          dismissible: true,
+          dismiss_scheme: :hide,
           full: true
         }
         redirect_to admin_settings_storages_path

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -31,6 +31,7 @@
 # Purpose: CRUD the global admin page of Storages (=Nextcloud servers)
 class Storages::Admin::StoragesController < ApplicationController
   using Storages::Peripherals::ServiceResultRefinements
+  include FlashMessagesHelper
 
   # See https://guides.rubyonrails.org/layouts_and_rendering.html for reference on layout
   layout 'admin'
@@ -133,19 +134,14 @@ class Storages::Admin::StoragesController < ApplicationController
   # Update is similar to create above
   # See also: create above
   # Called by: Global app/config/routes.rb to serve Web page
-  def update # rubocop:disable Metrics/AbcSize
+  def update
     service_result = ::Storages::Storages::UpdateService
                        .new(user: current_user, model: @storage)
                        .call(permitted_storage_params)
     @storage = service_result.result
 
     if service_result.success?
-      flash[:notice] = I18n.t(:notice_successful_update)
-
-      respond_to do |format|
-        format.html { redirect_to edit_admin_settings_storage_path(@storage) }
-        format.turbo_stream
-      end
+      respond_to { |format| format.turbo_stream }
     else
       respond_to do |format|
         format.html { render :edit }
@@ -159,15 +155,19 @@ class Storages::Admin::StoragesController < ApplicationController
   end
 
   def destroy
-    Storages::Storages::DeleteService
+    service_result = Storages::Storages::DeleteService
       .new(user: User.current, model: @storage)
       .call
-      .match(
-        # rubocop:disable Rails/ActionControllerFlashBeforeRender
-        on_success: ->(*) { flash[:notice] = I18n.t(:notice_successful_delete) },
-        on_failure: ->(error) { flash[:error] = error.full_messages }
-        # rubocop:enable Rails/ActionControllerFlashBeforeRender
-      )
+
+    # rubocop:disable Rails/ActionControllerFlashBeforeRender
+    service_result.on_failure do
+      flash[:primer_banner] = { message: join_flash_messages(service_result.errors.full_messages), scheme: :danger }
+    end
+
+    service_result.on_success do
+      flash[:primer_banner] = { message: I18n.t(:notice_successful_delete), scheme: :success }
+    end
+    # rubocop:enable Rails/ActionControllerFlashBeforeRender
 
     redirect_to admin_settings_storages_path
   end

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -373,6 +373,7 @@ RSpec.describe 'Admin storages',
       storage_delete_button.click
 
       expect(page).not_to have_text("Foo Nextcloud")
+      expect(page).to have_text('Successful deletion.')
       expect(page).to have_current_path(admin_settings_storages_path)
     end
 

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -250,8 +250,11 @@ RSpec.describe 'Admin storages',
           end
 
           expect(page).to have_current_path(admin_settings_storages_path)
-          expect(page).to have_text("Storage connected successfully! Remember to activate the module and the specific " \
-                                    "storage in the project settings of each desired project to use it.")
+          expect(page).to have_test_selector(
+            "primer-flash-message-component",
+            text: "Storage connected successfully! Remember to activate the module and the specific " \
+                  "storage in the project settings of each desired project to use it."
+          )
         end
       end
     end
@@ -320,8 +323,11 @@ RSpec.describe 'Admin storages',
           end
 
           expect(page).to have_current_path(admin_settings_storages_path)
-          wait_for(page).to have_text("Storage connected successfully! Remember to activate the module and the specific " \
-                                      "storage in the project settings of each desired project to use it.")
+          wait_for(page).to have_test_selector(
+            "primer-flash-message-component",
+            text: "Storage connected successfully! Remember to activate the module and the specific " \
+                  "storage in the project settings of each desired project to use it."
+          )
         end
       end
     end

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe 'Admin storages',
 
           expect(page).to have_current_path(admin_settings_storages_path)
           expect(page).to have_test_selector(
-            "primer-flash-message-component",
+            "primer-banner-message-component",
             text: "Storage connected successfully! Remember to activate the module and the specific " \
                   "storage in the project settings of each desired project to use it."
           )
@@ -324,7 +324,7 @@ RSpec.describe 'Admin storages',
 
           expect(page).to have_current_path(admin_settings_storages_path)
           wait_for(page).to have_test_selector(
-            "primer-flash-message-component",
+            "primer-banner-message-component",
             text: "Storage connected successfully! Remember to activate the module and the specific " \
                   "storage in the project settings of each desired project to use it."
           )


### PR DESCRIPTION
#### https://community.openproject.org/wp/50985

To test, create a storage

- [x] Support dismiss action _(Switches from [`Flash`](https://primer.style/components/flash) to [`Banner`](https://primer.style/components/banner/rails/alpha) as flash does not yet have a working dismiss action)_

See: https://github.com/primer/view_components/issues/2394

![Screenshot 2023-11-23 at 1 34 14 PM](https://github.com/opf/openproject/assets/17295175/45278057-4e99-4956-999f-14f8cd9f72e8)

