### PR TITLE
#50921 Add storage health information in admin page

### DIFF
--- a/modules/storages/app/components/storages/admin/health_status_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health_status_component.html.erb
@@ -1,0 +1,24 @@
+<%= render(Primer::Box.new) do %>
+  <%= render(Primer::Beta::Heading.new(tag: :h4, mb: 2)) { I18n.t('storages.health.title') } %>
+
+  <%= render(Primer::Box.new(py: 1)) do %>
+    <%= render(Primer::Beta::Text.new) { I18n.t('storages.health.checked', datetime: helpers.format_time(storage.health_changed_at)) } %>
+    <% if storage.health_healthy? %>
+      <%= render(Primer::Beta::Label.new(scheme: :success, test_selector: "label-healthy")) {
+        I18n.t('storages.health.label_healthy')
+      } %>
+    <% elsif storage.health_unhealthy? %>
+      <%= render(Primer::Beta::Label.new(scheme: :danger, test_selector: "label-error")) {
+        I18n.t('storages.health.label_error')
+      } %>
+    <% else %>
+      <%= render(Primer::Beta::Label.new(scheme: :attention, test_selector: "label-pending")) {
+        I18n.t('storages.health.label_pending')
+      } %>
+    <% end %>
+  <% end %>
+
+  <% if storage.health_unhealthy? %>
+    <%= render(Primer::Beta::Text.new(tag: :div, color: :muted, py: 1)) { storage.formatted_health_reason } %>
+  <% end %>
+<% end %>

--- a/modules/storages/app/components/storages/admin/health_status_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health_status_component.html.erb
@@ -2,23 +2,23 @@
   <%= render(Primer::Beta::Heading.new(tag: :h4, mb: 2)) { I18n.t('storages.health.title') } %>
 
   <%= render(Primer::Box.new(py: 1)) do %>
-    <%= render(Primer::Beta::Text.new) { I18n.t('storages.health.checked', datetime: helpers.format_time(storage.health_changed_at)) } %>
+    <%= render(Primer::Beta::Text.new(test_selector: "storage-health-changed-at")) { I18n.t('storages.health.checked', datetime: helpers.format_time(storage.health_changed_at)) } %>
     <% if storage.health_healthy? %>
-      <%= render(Primer::Beta::Label.new(scheme: :success, test_selector: "label-healthy")) {
+      <%= render(Primer::Beta::Label.new(scheme: :success, test_selector: "storage-health-label-healthy")) {
         I18n.t('storages.health.label_healthy')
       } %>
     <% elsif storage.health_unhealthy? %>
-      <%= render(Primer::Beta::Label.new(scheme: :danger, test_selector: "label-error")) {
+      <%= render(Primer::Beta::Label.new(scheme: :danger, test_selector: "storage-health-label-error")) {
         I18n.t('storages.health.label_error')
       } %>
     <% else %>
-      <%= render(Primer::Beta::Label.new(scheme: :attention, test_selector: "label-pending")) {
+      <%= render(Primer::Beta::Label.new(scheme: :attention, test_selector: "storage-health-label-pending")) {
         I18n.t('storages.health.label_pending')
       } %>
     <% end %>
   <% end %>
 
   <% if storage.health_unhealthy? %>
-    <%= render(Primer::Beta::Text.new(tag: :div, color: :muted, py: 1)) { storage.formatted_health_reason } %>
+    <%= render(Primer::Beta::Text.new(tag: :div, color: :muted, py: 1, test_selector: "storage-health-reason")) { storage.formatted_health_reason } %>
   <% end %>
 <% end %>

--- a/modules/storages/app/components/storages/admin/health_status_component.rb
+++ b/modules/storages/app/components/storages/admin/health_status_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+module Storages::Admin
+  class HealthStatusComponent < ApplicationComponent
+    alias_method :storage, :model
+  end
+end

--- a/modules/storages/app/components/storages/admin/storage_list_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_list_component.html.erb
@@ -28,7 +28,11 @@
               concat(render(Primer::Beta::Link.new(href: edit_admin_settings_storage_path(storage), scheme: :primary, mr: 1, data: { 'test-selector': 'storage-name' })) { storage.name })
 
               unless storage.configured?
-                concat(render(Primer::Beta::Label.new(scheme: :attention, data: { 'test-selector': 'label-incomplete' })) { I18n.t('storages.label_incomplete') })
+                concat(render(Primer::Beta::Label.new(scheme: :attention, test_selector: "label-incomplete", mr: 1)) { I18n.t('storages.label_incomplete') })
+              end
+
+              if storage.health_unhealthy?
+                concat(render(Primer::Beta::Label.new(scheme: :danger, test_selector: "label-error")) { I18n.t('storages.health.label_error') })
               end
             end
 

--- a/modules/storages/app/components/storages/admin/storage_list_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_list_component.html.erb
@@ -28,11 +28,11 @@
               concat(render(Primer::Beta::Link.new(href: edit_admin_settings_storage_path(storage), scheme: :primary, mr: 1, data: { 'test-selector': 'storage-name' })) { storage.name })
 
               unless storage.configured?
-                concat(render(Primer::Beta::Label.new(scheme: :attention, test_selector: "label-incomplete", mr: 1)) { I18n.t('storages.label_incomplete') })
+                concat(render(Primer::Beta::Label.new(scheme: :attention, test_selector: "label-incomplete")) { I18n.t('storages.label_incomplete') })
               end
 
               if storage.health_unhealthy?
-                concat(render(Primer::Beta::Label.new(scheme: :danger, test_selector: "label-error")) { I18n.t('storages.health.label_error') })
+                concat(render(Primer::Beta::Label.new(scheme: :danger, test_selector: "storage-health-label-error")) { I18n.t('storages.health.label_error') })
               end
             end
 

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -131,5 +131,14 @@ module Storages
     def provider_type_one_drive?
       provider_type == ::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
     end
+
+    def formatted_health_reason
+      split_reason = health_reason.split('|')
+      if split_reason.length === 3
+        "#{split_reason[0].strip.capitalize}: #{split_reason[1]}"
+      else
+        health_reason
+      end
+    end
   end
 end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -132,6 +132,9 @@ module Storages
       provider_type == ::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
     end
 
+    # Currently the error messages saved look like:
+    # "unauthorized | Outbound request not authorized | #<Storages::StorageErrorData:0x0000ffff646ac570>"
+    # This method returns the first two parts of the error message.
     def formatted_health_reason
       split_reason = health_reason.split('|')
       if split_reason.length === 3

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -67,4 +67,19 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 <% end %>
 
-<%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+<% if @storage.provider_type_nextcloud? && @storage.automatically_managed? %>
+  <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
+    <% component.with_main() do %>
+      <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+    <% end %>
+    <% component.with_sidebar(col_placement: :end, row_placement: :end) do %>
+      <%= render(Primer::OpenProject::BorderGrid.new(spacious: true)) do |grid| %>
+        <% grid.with_row do %>
+          <%= render(::Storages::Admin::HealthStatusComponent.new(@storage)) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+<% end %>

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -249,3 +249,9 @@ en:
     automatically_managed_project_folder_missing: "To complete the setup, please configure automatically managed project folders for your storage."
     notice_oauth_application_replaced: "The OpenProject OAuth application was successfully replaced."
     notice_successful_storage_connection: "Storage connected successfully! Remember to activate the module and the specific storage in the project settings of each desired project to use it."
+    health:
+      title: "Managed folders status"
+      label_pending: "Pending"
+      label_error: "Error"
+      label_healthy: "Healthy"
+      checked: "Checked  %{datetime}"

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
           class: '::Storages::NextcloudStorage' do
     provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
     sequence(:host) { |n| "https://host#{n}.example.com" }
+    sequence(:name) { |n| "Storage #{n}" }
 
     trait :as_automatically_managed do
       automatically_managed { true }
@@ -63,6 +64,30 @@ FactoryBot.define do
 
     trait :as_not_automatically_managed do
       automatically_managed { false }
+    end
+
+    trait :as_healthy do
+      health_status { 'healthy' }
+      health_reason { nil }
+      health_changed_at { Time.now.utc }
+    end
+
+    trait :as_unhealthy do
+      health_status { 'unhealthy' }
+      health_reason { 'error reason' }
+      health_changed_at { Time.now.utc }
+    end
+
+    trait :as_unhealthy_long_reason do
+      health_status { 'unhealthy' }
+      health_reason { 'unauthorized | Outbound request not authorized | #<Storages::StorageErrorData:0x0000ffff646ac570>' }
+      health_changed_at { Time.now.utc }
+    end
+
+    trait :as_pending do
+      health_status { 'pending' }
+      health_reason { nil }
+      health_changed_at { Time.now.utc }
     end
   end
 
@@ -103,6 +128,18 @@ FactoryBot.define do
                                       'MISSING_NEXTCLOUD_LOCAL_OAUTH_CLIENT_REFRESH_TOKEN'),
              token_type: 'bearer',
              origin_user_id: 'admin')
+    end
+  end
+
+  factory :nextcloud_storage_with_complete_configuration,
+          parent: :nextcloud_storage,
+          traits: [:as_automatically_managed] do
+    sequence(:host) { |n| "https://host-complete#{n}.example.com" }
+    sequence(:name) { |n| "Storage complete #{n}" }
+
+    after(:create) do |storage|
+      create(:oauth_client, integration: storage)
+      create(:oauth_application, integration: storage)
     end
   end
 

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -34,7 +34,6 @@ require_module_spec_helper
 RSpec.describe 'Admin storages',
                :js,
                :storage_server_helpers do
-  include Redmine::I18n
 
   let(:admin) { create(:admin) }
 
@@ -60,24 +59,24 @@ RSpec.describe 'Admin storages',
       it 'renders a list of storages' do
         visit admin_settings_storages_path
 
-        expect(page).to have_css('[data-test-selector="storage-name"]', text: complete_storage.name)
-        expect(page).to have_css('[data-test-selector="storage-name"]', text: incomplete_storage.name)
+        expect(page).to have_test_selector('storage-name', text: complete_storage.name)
+        expect(page).to have_test_selector('storage-name', text: incomplete_storage.name)
         expect(page).to have_css("a[role='button'][aria-label='Add new storage'][href='#{new_admin_settings_storage_path}']",
                                  text: 'Storage')
 
         within "li#storages_nextcloud_storage_#{complete_storage.id}" do
-          expect(page).not_to have_css('[data-test-selector="label-incomplete"]')
+          expect(page).not_to have_test_selector('label-incomplete')
           expect(page).to have_link(complete_storage.name, href: edit_admin_settings_storage_path(complete_storage))
-          expect(page).to have_css('[data-test-selector="storage-creator"]', text: complete_storage.creator.name)
-          expect(page).to have_css('[data-test-selector="storage-provider"]', text: 'Nextcloud')
-          expect(page).to have_css('[data-test-selector="storage-host"]', text: complete_storage.host)
+          expect(page).to have_test_selector('storage-creator', text: complete_storage.creator.name)
+          expect(page).to have_test_selector('storage-provider', text: 'Nextcloud')
+          expect(page).to have_test_selector('storage-host', text: complete_storage.host)
         end
 
         within "li#storages_nextcloud_storage_#{incomplete_storage.id}" do
-          expect(page).to have_css('[data-test-selector="label-incomplete"]')
-          expect(page).to have_css('[data-test-selector="storage-name"]', text: incomplete_storage.name)
-          expect(page).to have_css('[data-test-selector="storage-provider"]', text: 'Nextcloud')
-          expect(page).to have_css('[data-test-selector="storage-host"]', text: incomplete_storage.host)
+          expect(page).to have_test_selector('label-incomplete')
+          expect(page).to have_test_selector('storage-name', text: incomplete_storage.name)
+          expect(page).to have_test_selector('storage-provider', text: 'Nextcloud')
+          expect(page).to have_test_selector('storage-host', text: incomplete_storage.host)
           expect(page).to have_css('.op-principal--name', text: incomplete_storage.creator.name)
         end
 
@@ -571,48 +570,49 @@ RSpec.describe 'Admin storages',
     end
   end
 
-  describe 'health status information in edit page' do
-    frozen_date_time = Time.current
+  describe 'Health status information in edit page' do
+    frozen_date_time = Time.zone.local(2023, 11, 28, 1, 2, 3)
 
-    Timecop.freeze(frozen_date_time) do
-      let(:complete_nextcloud_storage_health_pending) { create(:nextcloud_storage_with_complete_configuration) }
-      let(:complete_nextcloud_storage_health_healthy) { create(:nextcloud_storage_with_complete_configuration, :as_healthy) }
-      let(:complete_nextcloud_storage_health_unhealthy) { create(:nextcloud_storage_with_complete_configuration, :as_unhealthy) }
-      let(:complete_nextcloud_storage_health_unhealthy_long_reason) do
-        create(:nextcloud_storage_with_complete_configuration, :as_unhealthy_long_reason)
-      end
+    let(:complete_nextcloud_storage_health_pending) { create(:nextcloud_storage_with_complete_configuration) }
+    let(:complete_nextcloud_storage_health_healthy) { create(:nextcloud_storage_with_complete_configuration, :as_healthy) }
+    let(:complete_nextcloud_storage_health_unhealthy) { create(:nextcloud_storage_with_complete_configuration, :as_unhealthy) }
+    let(:complete_nextcloud_storage_health_unhealthy_long_reason) do
+      create(:nextcloud_storage_with_complete_configuration, :as_unhealthy_long_reason)
+    end
 
-      before do
-        complete_nextcloud_storage_health_pending
-        complete_nextcloud_storage_health_healthy
-        complete_nextcloud_storage_health_unhealthy
-        complete_nextcloud_storage_health_unhealthy_long_reason
-      end
+    before do
+      Timecop.freeze(frozen_date_time)
+      complete_nextcloud_storage_health_pending
+      complete_nextcloud_storage_health_healthy
+      complete_nextcloud_storage_health_unhealthy
+      complete_nextcloud_storage_health_unhealthy_long_reason
+    end
 
-      it 'shows healthy status for storages that are healthy' do
-        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_healthy)
-        expect(page).to have_css('[data-test-selector="storage-health-label-healthy"]', text: 'Healthy')
-        expect(page).to have_css('[data-test-selector="storage-health-changed-at"]',
-                                 text: "Checked #{format_time(frozen_date_time)}")
-      end
+    after do
+      Timecop.return
+    end
 
-      it 'shows pending label for a storage that is pending' do
-        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_pending)
-        expect(page).to have_css('[data-test-selector="storage-health-label-pending"]', text: 'Pending')
-      end
+    it 'shows healthy status for storages that are healthy' do
+      visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_healthy)
+      expect(page).to have_test_selector('storage-health-label-healthy', text: 'Healthy')
+      expect(page).to have_test_selector('storage-health-changed-at', text: "Checked 11/28/2023 01:02 AM")
+    end
 
-      it 'shows error status for storages that are unhealthy' do
-        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy)
-        expect(page).to have_css('[data-test-selector="storage-health-label-error"]', text: 'Error')
-        expect(page).to have_css('[data-test-selector="storage-health-reason"]', text: 'error reason')
-      end
+    it 'shows pending label for a storage that is pending' do
+      visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_pending)
+      expect(page).to have_test_selector('storage-health-label-pending', text: 'Pending')
+    end
 
-      it 'shows formatted error reason for storages that are unhealthy' do
-        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy_long_reason)
-        expect(page).to have_css('[data-test-selector="storage-health-label-error"]', text: 'Error')
-        expect(page).to have_css('[data-test-selector="storage-health-reason"]',
-                                 text: 'Unauthorized: Outbound request not authorized')
-      end
+    it 'shows error status for storages that are unhealthy' do
+      visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy)
+      expect(page).to have_test_selector('storage-health-label-error', text: 'Error')
+      expect(page).to have_test_selector('storage-health-reason', text: 'error reason')
+    end
+
+    it 'shows formatted error reason for storages that are unhealthy' do
+      visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy_long_reason)
+      expect(page).to have_test_selector('storage-health-label-error', text: 'Error')
+      expect(page).to have_test_selector('storage-health-reason', text: 'Unauthorized: Outbound request not authorized')
     end
   end
 end

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -34,6 +34,8 @@ require_module_spec_helper
 RSpec.describe 'Admin storages',
                :js,
                :storage_server_helpers do
+  include Redmine::I18n
+
   let(:admin) { create(:admin) }
 
   before { login_as admin }
@@ -43,9 +45,16 @@ RSpec.describe 'Admin storages',
       let(:complete_storage) { create(:nextcloud_storage_with_local_connection) }
       let(:incomplete_storage) { create(:nextcloud_storage) }
 
+      let(:complete_nextcloud_storage_health_pending) { create(:nextcloud_storage_with_complete_configuration) }
+      let(:complete_nextcloud_storage_health_healthy) { create(:nextcloud_storage_with_complete_configuration, :as_healthy) }
+      let(:complete_nextcloud_storage_health_unhealthy) { create(:nextcloud_storage_with_complete_configuration, :as_unhealthy) }
+
       before do
         complete_storage
         incomplete_storage
+        complete_nextcloud_storage_health_pending
+        complete_nextcloud_storage_health_healthy
+        complete_nextcloud_storage_health_unhealthy
       end
 
       it 'renders a list of storages' do
@@ -70,6 +79,24 @@ RSpec.describe 'Admin storages',
           expect(page).to have_css('[data-test-selector="storage-provider"]', text: 'Nextcloud')
           expect(page).to have_css('[data-test-selector="storage-host"]', text: incomplete_storage.host)
           expect(page).to have_css('.op-principal--name', text: incomplete_storage.creator.name)
+        end
+
+        within "li#storages_nextcloud_storage_#{complete_nextcloud_storage_health_pending.id}" do
+          expect(page).not_to have_test_selector('storage-health-label-error')
+          expect(page).not_to have_test_selector('storage-health-label-healthy')
+          expect(page).not_to have_test_selector('storage-health-label-pending')
+        end
+
+        within "li#storages_nextcloud_storage_#{complete_nextcloud_storage_health_healthy.id}" do
+          expect(page).not_to have_test_selector('storage-health-label-healthy')
+          expect(page).not_to have_test_selector('storage-health-label-error')
+          expect(page).not_to have_test_selector('storage-health-label-pending')
+        end
+
+        within "li#storages_nextcloud_storage_#{complete_nextcloud_storage_health_unhealthy.id}" do
+          expect(page).to have_test_selector('storage-health-label-error')
+          expect(page).not_to have_test_selector('storage-health-label-healthy')
+          expect(page).not_to have_test_selector('storage-health-label-pending')
         end
       end
     end
@@ -540,6 +567,51 @@ RSpec.describe 'Admin storages',
           expect(page).to have_test_selector('label-storage_oauth_client_configured-status', text: 'Completed')
           expect(page).to have_test_selector('storage-oauth-client-id-description', text: "OAuth Client ID: 1234567890")
         end
+      end
+    end
+  end
+
+  describe 'health status information in edit page' do
+    frozen_date_time = Time.current
+
+    Timecop.freeze(frozen_date_time) do
+      let(:complete_nextcloud_storage_health_pending) { create(:nextcloud_storage_with_complete_configuration) }
+      let(:complete_nextcloud_storage_health_healthy) { create(:nextcloud_storage_with_complete_configuration, :as_healthy) }
+      let(:complete_nextcloud_storage_health_unhealthy) { create(:nextcloud_storage_with_complete_configuration, :as_unhealthy) }
+      let(:complete_nextcloud_storage_health_unhealthy_long_reason) do
+        create(:nextcloud_storage_with_complete_configuration, :as_unhealthy_long_reason)
+      end
+
+      before do
+        complete_nextcloud_storage_health_pending
+        complete_nextcloud_storage_health_healthy
+        complete_nextcloud_storage_health_unhealthy
+        complete_nextcloud_storage_health_unhealthy_long_reason
+      end
+
+      it 'shows healthy status for storages that are healthy' do
+        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_healthy)
+        expect(page).to have_css('[data-test-selector="storage-health-label-healthy"]', text: 'Healthy')
+        expect(page).to have_css('[data-test-selector="storage-health-changed-at"]',
+                                 text: "Checked #{format_time(frozen_date_time)}")
+      end
+
+      it 'shows pending label for a storage that is pending' do
+        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_pending)
+        expect(page).to have_css('[data-test-selector="storage-health-label-pending"]', text: 'Pending')
+      end
+
+      it 'shows error status for storages that are unhealthy' do
+        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy)
+        expect(page).to have_css('[data-test-selector="storage-health-label-error"]', text: 'Error')
+        expect(page).to have_css('[data-test-selector="storage-health-reason"]', text: 'error reason')
+      end
+
+      it 'shows formatted error reason for storages that are unhealthy' do
+        visit edit_admin_settings_storage_path(complete_nextcloud_storage_health_unhealthy_long_reason)
+        expect(page).to have_css('[data-test-selector="storage-health-label-error"]', text: 'Error')
+        expect(page).to have_css('[data-test-selector="storage-health-reason"]',
+                                 text: 'Unauthorized: Outbound request not authorized')
       end
     end
   end

--- a/spec/factories/oauth_application_factory.rb
+++ b/spec/factories/oauth_application_factory.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
     confidential { true }
     owner factory: :admin
     owner_type { 'User' }
-    uid { '12345' }
+    sequence(:uid) { |n| "2345678901-#{n}" }
     redirect_uri { 'urn:ietf:wg:oauth:2.0:oob' }
     scopes { 'api_v3' }
   end


### PR DESCRIPTION
##### Related Work Package: [OP#50921](https://community.openproject.org/projects/openproject/work_packages/50921)

## What?

##### Related PR: #14130 

This PR adds labels to unhealthy storages in the index page.
And adds additional health information on the edit page.
