### PR TITLE
Use default browserlist

### DIFF
--- a/frontend/browserslist
+++ b/frontend/browserslist
@@ -1,8 +1,3 @@
 # OpenProject supported browsers
 # https://www.openproject.org/systemrequirements/
-#
-last 2 Chrome versions
-last 2 Safari major versions
-last 2 Edge versions
-last 2 Firefox versions
-Firefox esr
+defaults


### PR DESCRIPTION
This includes more versions  that are actually supported by the browser_helper https://github.com/opf/openproject/blob/stable/13/app/helpers/browser_helper.rb#L17-L18 , so we should allow them in browserlist as well.