### PR TITLE
Fix copying meetings between types, allow empty copy of structured meetings

### DIFF
--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -21,12 +21,21 @@
                   item.with_leading_visual_icon(icon: :pencil)
                 end if @meeting.editable?
 
+                menu.with_item(label: t(:button_copy),
+                               href: copy_meeting_path(@meeting),
+                               content_arguments: {
+                                 data: { turbo: false }
+                               }) do |item|
+                  item.with_leading_visual_icon(icon: :copy)
+                end
+
                 menu.with_item(label: t(:label_icalendar_download),
                                href: download_ics_meeting_path(@meeting)) do |item|
                   item.with_leading_visual_icon(icon: :download)
                 end
 
-                if User.current.allowed_to?(:send_meeting_agendas_notification, @meeting.project)
+                if User.current.allowed_in_project?(:send_meeting_agendas_notification, @meeting.project
+                )
                   menu.with_item(label: t('meeting.label_mail_all_participants'),
                                  href: notify_meeting_path(@meeting),
                                  form_arguments: { method: :post, data: { turbo: 'false' } }) do |item|

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -102,7 +102,7 @@ class MeetingsController < ApplicationController
     params[:copied_from_meeting_id] = @meeting.id
     params[:copied_meeting_agenda_text] = @meeting.agenda.text if @meeting.agenda.present?
     @meeting = @meeting.copy(author: User.current)
-    render action: 'new', project_id: @project
+    render action: 'new', project_id: @project, locals: { copy: true }
   end
 
   def destroy

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -165,13 +165,15 @@ class Meeting < ApplicationRecord
   def copy(attrs)
     copy = dup
 
-    # Called simply to initialize the value
-    copy.start_date
-    copy.start_time_hour
+    # Set a default to next week
+    copy.start_time = start_time + 1.week
 
     copy.author = attrs.delete(:author)
     copy.attributes = attrs
     copy.set_initial_values
+    # Initialize virtual attributes
+    copy.start_date
+    copy.start_time_hour
 
     copy.participants.clear
     copy.participants_attributes = allowed_participants.collect(&:copy_attributes)

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -55,6 +55,10 @@ See COPYRIGHT and LICENSE files for more details.
               </span>
                 <p class="op-tile-block--description">
                   <%= t('meeting.types.structured_text') %>
+                  <% if local_assigns[:copy] %>
+                    <br/>
+                    <strong><%= t('meeting.types.structured_text_copy') %></strong>
+                  <% end %>
                 </p>
               </div>
             </div>

--- a/modules/meeting/app/views/meetings/new.html.erb
+++ b/modules/meeting/app/views/meetings/new.html.erb
@@ -30,12 +30,13 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_meeting_new) %>
 <%= toolbar title: t(:label_meeting_new) %>
 <%= labelled_tabular_form_for @meeting,
+                              as: :meeting,
                               url: {:controller => '/meetings', :action => 'create', :project_id => @project},
                               :html => {:id => 'meeting-form',
                                         :data => { :controller => 'refresh-on-form-changes',
                                                    'refresh-on-form-changes-target': 'form',
                                                    'refresh-on-form-changes-turbo-stream-url-value': new_meeting_url }} do |f| -%>
-  <%= render :partial => 'form', :locals => {:f => f} %>
+  <%= render :partial => 'form', :locals => { f:, copy: local_assigns[:copy] } %>
   <%= styled_button_tag t(:button_create), class: '-highlight' %>
   <%= link_to t(:button_cancel), { :action => 'index', :project_id => @project },
         class: 'button' %>

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
       classic_text: 'Organize your meeting in a formattable text agenda and protocol.'
       structured: 'Dynamic'
       structured_text: 'Organize your meeting as a list of agenda items, optionally linking them to a work package.'
+      structured_text_copy: 'Copying a meeting will currently not copy the associated meeting agenda items, just the details'
     copied: "Copied from Meeting #%{id}"
 
   notice_successful_notification: "Notification sent successfully"

--- a/modules/meeting/spec/features/meetings_copy_spec.rb
+++ b/modules/meeting/spec/features/meetings_copy_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Meetings copy', :js, :with_cuprite do
 
   shared_let(:twelve_hour_format) { "%I:%M %p" }
   shared_let(:copied_meeting_time_heading) do
-    date = start_time.strftime("%m/%d/%Y")
+    date = start_time.next_week.strftime("%m/%d/%Y")
     start_of_meeting = start_time.strftime(twelve_hour_format)
     end_of_meeting = (start_time + meeting.duration.hours).strftime(twelve_hour_format)
 
@@ -90,7 +90,7 @@ RSpec.describe 'Meetings copy', :js, :with_cuprite do
     expect(page)
       .to have_field 'Duration',   with: meeting.duration
     expect(page)
-      .to have_field 'Start date', with: start_time.strftime("%Y-%m-%d")
+      .to have_field 'Start date', with: start_time.next_week.strftime("%Y-%m-%d")
     expect(page)
       .to have_field 'Time',       with: start_time.strftime("%H:%M")
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe 'Structured meetings CRUD',
     click_button 'Create'
 
     expect(page).to have_text 'Your meeting is empty'
-    new_meeting = StructuredMeeting.order(id: :asc).last
+    new_meeting = StructuredMeeting.reorder(id: :asc).last
     expect(page).to have_current_path "/meetings/#{new_meeting.id}"
   end
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe 'Structured meetings CRUD',
 
   let(:current_user) { user }
   let(:new_page) { Pages::Meetings::New.new(project) }
-  let(:show_page) { Pages::StructuredMeeting::Show.new(StructuredMeeting.order(id: :asc).last) }
+  let(:meeting) { StructuredMeeting.order(id: :asc).last }
+  let(:show_page) { Pages::StructuredMeeting::Show.new(meeting) }
 
   before do
     login_as current_user
@@ -248,6 +249,30 @@ RSpec.describe 'Structured meetings CRUD',
     end
 
     expect(page).to have_css('.flash', text: I18n.t('activerecord.errors.messages.error_conflict'))
+  end
+
+  it 'can copy the meeting (empty)' do
+    show_page.expect_toast(message: 'Successful creation')
+
+    # Can add and edit a single item
+    show_page.add_agenda_item do
+      fill_in 'Title', with: 'My agenda item'
+      fill_in 'Duration (min)', with: '25'
+    end
+
+    show_page.expect_agenda_item title: 'My agenda item'
+    show_page.cancel_add_form
+
+    click_button('op-meetings-header-action-trigger')
+    click_link 'Copy'
+
+    expect(page).to have_current_path "/meetings/#{meeting.id}/copy"
+
+    click_button 'Create'
+
+    expect(page).to have_text 'Your meeting is empty'
+    new_meeting = StructuredMeeting.order(id: :asc).last
+    expect(page).to have_current_path "/meetings/#{new_meeting.id}"
   end
 
   context 'with a work package reference to another' do


### PR DESCRIPTION
https://community.openproject.org/work_packages/51214

It was already possible to select "structured meeting" when copying an existing meeting but that failed when selected. This PR fixes this behavior, but also allows meetings to be copied.