### PR TITLE
Fix/make custom actions spec faster and more reliable

### DIFF
--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -48,11 +48,11 @@ module Components
     end
 
     def expect_button(label)
-      expect(container).to have_selector('.ck-button', visible: :all, text: label)
+      expect(container).to have_css('.ck-button', visible: :all, text: label)
     end
 
     def expect_no_button(label)
-      expect(container).not_to have_selector('.ck-button', visible: :all, text: label)
+      expect(container).not_to have_css('.ck-button', visible: :all, text: label)
     end
 
     def expect_value(value)
@@ -61,7 +61,7 @@ module Components
 
     def expect_supports_no_macros
       expect(container)
-          .not_to have_selector('.ck-button', visible: :all, text: 'Macros')
+          .not_to have_css('.ck-button', visible: :all, text: 'Macros')
     end
 
     def within_enabled_preview
@@ -93,7 +93,7 @@ module Components
         attachments.drag_and_drop_file(editable, image_fixture, :bottom)
 
         expect(page)
-            .to have_selector('img[src^="/api/v3/attachments/"]', count: images.length + 1, wait: 10)
+            .to have_css('img[src^="/api/v3/attachments/"]', count: images.length + 1, wait: 10)
 
         wait_until_upload_progress_toaster_cleared
 
@@ -148,16 +148,17 @@ module Components
       container.find('.ck-button', visible: :all, text: label).click
     end
 
-    def type_slowly(*text)
-      editor_element.send_keys *text
-      sleep 0.5
+    def type_slowly(*)
+      editor_element.send_keys(*)
+      sleep 0.2
     end
 
-    def click_and_type_slowly(*text)
-      sleep 0.5
+    def click_and_type_slowly(*)
+      sleep 0.2
       editor_element.click
 
-      type_slowly *text
+      sleep 0.2
+      type_slowly(*)
     end
 
     def click_hover_toolbar_button(label)

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -111,10 +111,10 @@ module Pages
 
           Array(value).each do |val|
             within field do
-              if has_selector?('.form--selected-value--container', wait: 1)
+              if has_selector?('.form--selected-value--container', wait: 0)
                 find('.form--selected-value--container').click
                 autocomplete = true
-              elsif has_selector?('.autocomplete-select-decoration--wrapper', wait: 1)
+              elsif has_selector?('.autocomplete-select-decoration--wrapper', wait: 0)
                 autocomplete = true
               end
 

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -49,7 +49,7 @@ module Pages
           end
           set_action_value(name, value)
           within '#custom-actions-form--active-actions' do
-            expect(page).to have_selector('.form--label', text: name)
+            expect(page).to have_css('.form--label', text: name)
           end
         end
 
@@ -62,7 +62,7 @@ module Pages
         end
 
         def expect_selected_option(value)
-          expect(page).to have_selector('.ng-value-label', text: value)
+          expect(page).to have_css('.ng-value-label', text: value)
         end
 
         def expect_action(name, value)
@@ -94,10 +94,12 @@ module Pages
               fill_in name, with: val
             end
 
-            find('.ng-option', wait: 5, text: val).click
+            retry_block do
+              find('.ng-option', wait: 5, text: val).click
 
-            within '#custom-actions-form--conditions' do
-              expect_selected_option val
+              within '#custom-actions-form--conditions' do
+                expect_selected_option val
+              end
             end
           end
         end

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -35,8 +35,8 @@
 # This is especially helpful as it doesn't depend on DOM elements
 # being present or gone. Instead the execution is halted until
 # requested data is done being fetched.
-def wait_for_network_idle
-  page.driver.wait_for_network_idle
+def wait_for_network_idle(...)
+  page.driver.wait_for_network_idle(...)
 end
 
 # Takes the above `wait_for_network_idle` a step further by waiting


### PR DESCRIPTION
It may not fix the `Capybara::ElementNotFound: Unable to find visible css ".ng-option" with text "Progress (%)" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/NG-DROPDOWN-PANEL[1]/DIV[1]">` error yet, but it fixes other issues that occured on my machine preventing me from investigating the real issue.
