### PR TITLE
[44859] Total progress does not change color

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -387,7 +387,7 @@ module ApplicationHelper
   def progress_bar(pcts, options = {})
     pcts = Array(pcts).map(&:round)
     closed = pcts[0]
-    done   = (pcts[1] || closed) - closed
+    done   = pcts[1] || 0
     width = options[:width] || '100px;'
     legend = options[:legend] || ''
     total_progress = options[:hide_total_progress] ? '' : t(:total_progress)


### PR DESCRIPTION
### Problem
On the budgets overview the progress calculation had some weird bugs. Sometimes there was no red bar at all although the budget was exceeded, sometimes there was a white bar left, although it was exceeded.

<img width="311" alt="Bildschirmfoto 2023-11-24 um 13 17 29" src="https://github.com/opf/openproject/assets/7457313/2f439bdc-44ec-4c9b-9d91-9957aa970575">

### Solution
The comment above the function which shows the progress bar basically already provided the answer as the past values where already correctly calculated. Thus there was no additional calculation needed.

<img width="287" alt="Bildschirmfoto 2023-11-24 um 13 18 13" src="https://github.com/opf/openproject/assets/7457313/06663ff6-ac88-4393-ba3a-62239e6d91fa">


https://community.openproject.org/projects/14/work_packages/44859/actvitiy