### PR TITLE
Faster retry intervals

### DIFF
--- a/modules/meeting/spec/support/pages/structured_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/structured_meeting/show.rb
@@ -111,7 +111,7 @@ module Pages::StructuredMeeting
         page.within("#meeting-agenda-items-item-component-#{item.id}") do
           page.find_test_selector('op-meeting-agenda-actions').click
         end
-        page.find('.Overlay')
+        page.find('.Overlay', wait: 1)
       end
 
       page.within('.Overlay') do

--- a/spec/support/rspec_retry.rb
+++ b/spec/support/rspec_retry.rb
@@ -29,7 +29,7 @@ end
 ##
 # Allow specific code blocks to retry on specific errors
 Retriable.configure do |c|
-  c.intervals = [1, 1, 2]
+  c.intervals = [0.1, 0.5, 1, 2]
 end
 
 ##


### PR DESCRIPTION
The retriable intervals are unnecessarily high. Often times a click does not go through (e.g. F..during initialization) and can be retried directly. This should speed up the test suite somewhat. Ideally we would gradually increase the capybara wait time instead  