### PR TITLE
Fixed meetings copy spec that used Time's next_week in a wrong way

### DIFF
--- a/modules/meeting/spec/features/meetings_copy_spec.rb
+++ b/modules/meeting/spec/features/meetings_copy_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Meetings copy', :js, :with_cuprite do
            member_with_permissions: { project => permissions })
   end
 
-  shared_let(:start_time) { Time.current.tomorrow.at_noon }
+  shared_let(:start_time) { Time.current.beginning_of_week.at_noon }
   shared_let(:duration) { 1.5 }
   shared_let(:agenda_text) { "We will talk" }
   shared_let(:meeting) do


### PR DESCRIPTION
`next_week` of `Time` was used in a wrong way, resulting in a spec failing on certain days of the week.