### PR TITLE
Honor exisiting builtin roles when seeding

### DIFF
--- a/app/seeders/basic_data/base_role_seeder.rb
+++ b/app/seeders/basic_data/base_role_seeder.rb
@@ -28,6 +28,7 @@
 module BasicData
   class BaseRoleSeeder < ModelSeeder
     self.needs = []
+    self.attribute_names_for_lookups = %i[builtin name]
 
     def model_attributes(role_data)
       {

--- a/app/seeders/basic_data/base_role_seeder.rb
+++ b/app/seeders/basic_data/base_role_seeder.rb
@@ -28,7 +28,6 @@
 module BasicData
   class BaseRoleSeeder < ModelSeeder
     self.needs = []
-    self.attribute_names_for_lookups = %i[builtin name]
 
     def model_attributes(role_data)
       {

--- a/app/seeders/basic_data/work_package_role_seeder.rb
+++ b/app/seeders/basic_data/work_package_role_seeder.rb
@@ -29,5 +29,6 @@ module BasicData
   class WorkPackageRoleSeeder < BaseRoleSeeder
     self.model_class = WorkPackageRole
     self.seed_data_model_key = 'work_package_roles'
+    self.attribute_names_for_lookups = %i[builtin]
   end
 end

--- a/db/migrate/20231128080650_add_work_package_roles.rb
+++ b/db/migrate/20231128080650_add_work_package_roles.rb
@@ -7,7 +7,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
 
     editor_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_EDITOR,
-      name: I18n.t('seeds.common.work_package_roles.item_0', default: 'Work package editor'),
+      name: I18n.t('seeds.common.work_package_roles.item_0.name', default: 'Work package editor'),
       permissions: %i[
         view_work_packages
         edit_work_packages
@@ -26,7 +26,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
     commenter_role ||= WorkPackageRole.find_or_initialize_by(builtin: Role::BUILTIN_WORK_PACKAGE_COMMENTER)
     commenter_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_COMMENTER,
-      name: I18n.t('seeds.common.work_package_roles.item_1', default: 'Work package commenter'),
+      name: I18n.t('seeds.common.work_package_roles.item_1.name', default: 'Work package commenter'),
       permissions: %i[
         view_work_packages
         work_package_assigned
@@ -43,7 +43,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
     # Set up attributes
     viewer_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_VIEWER,
-      name: I18n.t('seeds.common.work_package_roles.item_2', default: 'Work package viewer'),
+      name: I18n.t('seeds.common.work_package_roles.item_2.name', default: 'Work package viewer'),
       permissions: %i[
         view_work_packages
         export_work_packages

--- a/db/migrate/20231128080650_add_work_package_roles.rb
+++ b/db/migrate/20231128080650_add_work_package_roles.rb
@@ -7,7 +7,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
 
     editor_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_EDITOR,
-      name: 'Work package editor',
+      name: I18n.t('seeds.common.work_package_roles.item_0', default: 'Work package editor'),
       permissions: %i[
         view_work_packages
         edit_work_packages
@@ -26,7 +26,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
     commenter_role ||= WorkPackageRole.find_or_initialize_by(builtin: Role::BUILTIN_WORK_PACKAGE_COMMENTER)
     commenter_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_COMMENTER,
-      name: 'Work package commenter',
+      name: I18n.t('seeds.common.work_package_roles.item_1', default: 'Work package commenter'),
       permissions: %i[
         view_work_packages
         work_package_assigned
@@ -43,7 +43,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
     # Set up attributes
     viewer_role.update!(
       builtin: Role::BUILTIN_WORK_PACKAGE_VIEWER,
-      name: 'Work package viewer',
+      name: I18n.t('seeds.common.work_package_roles.item_2', default: 'Work package viewer'),
       permissions: %i[
         view_work_packages
         export_work_packages

--- a/db/migrate/20231128080650_add_work_package_roles.rb
+++ b/db/migrate/20231128080650_add_work_package_roles.rb
@@ -17,6 +17,11 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
         manage_work_package_relations
         copy_work_packages
         export_work_packages
+        view_own_time_entries
+        log_own_time
+        edit_own_time_entries
+        show_github_content
+        view_file_links
       ]
     )
 
@@ -33,6 +38,11 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
         add_work_package_notes
         edit_own_work_package_notes
         export_work_packages
+        view_own_time_entries
+        log_own_time
+        edit_own_time_entries
+        show_github_content
+        view_file_links
       ]
     )
 
@@ -47,6 +57,7 @@ class AddWorkPackageRoles < ActiveRecord::Migration[7.0]
       permissions: %i[
         view_work_packages
         export_work_packages
+        show_github_content
       ]
     )
   end

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe 'Custom actions', :js, :with_cuprite,
                               "customField#{list_custom_field.id}" => selected_list_custom_field_options.map(&:name).join("\n")
 
     expect(page)
-      .to have_css('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name)
+      .to have_css('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name, wait: 10)
 
     wp_page.click_custom_action('Close')
     wp_page.expect_attributes status: closed_status.name,

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -160,6 +160,24 @@ RSpec.describe RootSeeder,
     end
   end
 
+  describe 'demo data with work package role migration having been run' do
+    shared_let(:root_seeder) { described_class.new }
+
+    before_all do
+      # call the migration which will add data for work package roles. This
+      # needs to be done manually as running tests automatically calls the
+      # `db:test:purge` rake task.
+      require(Rails.root.join('db/migrate/20231128080650_add_work_package_roles'))
+      AddWorkPackageRoles.new.up
+
+      with_edition('standard') do
+        root_seeder.seed_data!
+      end
+    end
+
+    include_examples 'creates standard demo data'
+  end
+
   describe 'demo data mock-translated in another language' do
     shared_let(:root_seeder) { described_class.new }
 


### PR DESCRIPTION
#14254 introduced the WP roles beeing seeded via a migration. This causes the seeds to run after the migrations to fail. This PR sets the RoleSeeders up to look for existing `builtin` roles before seeding. This way the seeder works correctly even with the existing WP roles already beeing seeded by the migration