### PR TITLE
[#51274] return correct parent id

### DIFF
--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, 
           expect(storage_files.files).to be_empty
 
           # in an empty folder the parent id cannot be retrieved, hence the parent id will get forged
-          expect(storage_files.parent.id).to eq('678cb16697b9f7ef05a99a2dc83aaf1b377e5e2a9d7a09e1db4343b41d44f874')
+          expect(storage_files.parent.id).to eq('01AZJL5PMGEIRPHZPHRRH2NM3D734VIR7H')
         end
       end
 

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_empty_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/files_query_empty_folder.yml
@@ -31,17 +31,68 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 68954b2c-23ca-4bcf-a9c5-2fd15e67cfe9
+      - 1f09d34b-0d2d-4f3d-b918-b6b294acc930
       Client-Request-Id:
-      - 68954b2c-23ca-4bcf-a9c5-2fd15e67cfe9
+      - 1f09d34b-0d2d-4f3d-b918-b6b294acc930
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"West Europe","Slice":"E","Ring":"5","ScaleUnit":"006","RoleInstance":"AM1PEPF00027E51"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF00000366"}}'
       Odata-Version:
       - '4.0'
       Date:
-      - Mon, 09 Oct 2023 15:35:04 GMT
+      - Tue, 28 Nov 2023 12:34:15 GMT
     body:
       encoding: UTF-8
       string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)","value":[]}'
-  recorded_at: Mon, 09 Oct 2023 15:35:05 GMT
+  recorded_at: Tue, 28 Nov 2023 12:34:16 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder%20with%20spaces/very%20empty%20folder?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Etag:
+      - '"{F3222286-E7E5-4F8C-A6B3-63FEF95447E7},2"'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - b438c351-7aae-44cc-90ae-9e2249d64156
+      Client-Request-Id:
+      - b438c351-7aae-44cc-90ae-9e2249d64156
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E4"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Tue, 28 Nov 2023 12:34:15 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root(id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference)/$entity","@odata.etag":"\"{F3222286-E7E5-4F8C-A6B3-63FEF95447E7},2\"","id":"01AZJL5PMGEIRPHZPHRRH2NM3D734VIR7H","name":"very
+        empty folder","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Folder%20with%20spaces/very%20empty%20folder","size":0,"createdBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"eschubert.op@outlook.com","id":"0a0d38a9-a59b-4245-93fa-0d2cf727f17a","displayName":"Eric
+        Schubert"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU","name":"Folder
+        with spaces","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:/Folder
+        with spaces","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"fileSystemInfo":{"createdDateTime":"2023-10-09T14:02:44Z","lastModifiedDateTime":"2023-10-09T14:02:44Z"},"folder":{"childCount":0}}'
+  recorded_at: Tue, 28 Nov 2023 12:34:16 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
[OP#51274](https://community.openproject.org/wp/51274)

### WAT?

- one drive files query now returns real parent id when folder is empty, not the fake id like before

### But ... WHY?

- upload needs it for the prepare upload request, fake id led to error
