### PR TITLE
[51244] Create separate project module "Gantt"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,11 @@ PATH
     openproject-documents (1.0.0)
 
 PATH
+  remote: modules/gantt
+  specs:
+    openproject-gantt (1.0.0)
+
+PATH
   remote: modules/github_integration
   specs:
     openproject-github_integration (1.0.0)
@@ -1148,6 +1153,7 @@ DEPENDENCIES
   openproject-boards!
   openproject-calendar!
   openproject-documents!
+  openproject-gantt!
   openproject-github_integration!
   openproject-job_status!
   openproject-ldap_groups!

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -44,6 +44,7 @@ group :opf_plugins do
   gem 'overviews',                             path: 'modules/overviews'
   gem 'budgets',                               path: 'modules/budgets'
   gem 'openproject-team_planner',              path: 'modules/team_planner'
+  gem 'openproject-gantt',                     path: 'modules/gantt'
   gem 'openproject-calendar',                  path: 'modules/calendar'
   gem 'openproject-storages',                  path: 'modules/storages'
 

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -30,6 +30,7 @@ class WorkPackagesController < ApplicationController
   include QueriesHelper
   include PaginationHelper
   include Layout
+  include WorkPackagesControllerHelper
 
   accept_key_auth :index, :show
 
@@ -116,47 +117,10 @@ class WorkPackagesController < ApplicationController
                      journals: }
   end
 
-  def atom_list
-    render_feed(@work_packages,
-                title: "#{@project || Setting.app_title}: #{I18n.t(:label_work_package_plural)}")
-  end
-
   private
 
   def authorize_on_work_package
     deny_access(not_found: true) unless work_package
-  end
-
-  def protect_from_unauthorized_export
-    if (supported_list_formats + %w[atom]).include?(params[:format]) && !user_allowed_to_export?
-      deny_access
-      false
-    end
-  end
-
-  def user_allowed_to_export?
-    User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project)
-  end
-
-  def supported_list_formats
-    ::Exports::Register.list_formats(WorkPackage).map(&:to_s)
-  end
-
-  def supported_single_formats
-    ::Exports::Register.single_formats(WorkPackage).map(&:to_s)
-  end
-
-  def load_and_validate_query
-    @query ||= retrieve_query(@project)
-    @query.name = params[:title] if params[:title].present?
-
-    unless @query.valid?
-      # Ensure outputting an html response
-      request.format = 'html'
-      render_400(message: @query.errors.full_messages.join(". "))
-    end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def per_page_param

--- a/app/helpers/work_packages_controller_helper.rb
+++ b/app/helpers/work_packages_controller_helper.rb
@@ -1,0 +1,66 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackagesControllerHelper
+  def protect_from_unauthorized_export
+    if (supported_list_formats + %w[atom]).include?(params[:format]) && !user_allowed_to_export?
+      deny_access
+      false
+    end
+  end
+
+  def user_allowed_to_export?
+    User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project)
+  end
+
+  def supported_list_formats
+    ::Exports::Register.list_formats(WorkPackage).map(&:to_s)
+  end
+
+  def supported_single_formats
+    ::Exports::Register.single_formats(WorkPackage).map(&:to_s)
+  end
+
+  def load_and_validate_query
+    @query ||= retrieve_query(@project)
+    @query.name = params[:title] if params[:title].present?
+
+    unless @query.valid?
+      # Ensure outputting an html response
+      request.format = 'html'
+      render_400(message: @query.errors.full_messages.join(". "))
+    end
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+
+  def atom_list
+    render_feed(@work_packages,
+                title: "#{@project || Setting.app_title}: #{I18n.t(:label_work_package_plural)}")
+  end
+end

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if mod.blank? %>
         <%= show_global_role ? t(:label_global) : Project.model_name.human %>
       <% else %>
-        <%= l_or_humanize(mod, prefix: 'project_module_') %>
+        <%= I18n.t("permission_header_for_project_module_#{mod}", default: l_or_humanize(mod, prefix: 'project_module_')) %>
       <% end %>
     </legend>
     <div class="form--toolbar">

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -546,7 +546,7 @@ Redmine::MenuManager.map :project_menu do |menu|
   menu.push :work_packages,
             { controller: '/work_packages', action: 'index' },
             caption: :label_work_package_plural,
-            icon: 'view-timeline',
+            icon: 'view-list',
             html: {
               id: 'main-menu-work-packages',
               'wp-query-menu': 'wp-query-menu'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2642,6 +2642,7 @@ en:
   project_module_news: "News"
   project_module_repository: "Repository"
   project_module_wiki: "Wiki"
+  permission_header_for_project_module_work_package_tracking: "Work packages and Gantt"
 
   query:
     attribute_and_direction: "%{attribute} (%{direction})"

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
@@ -45,6 +45,9 @@ export class WorkPackagesQueryViewService {
     if (this.$state.includes('calendar')) {
       return 'work_packages_calendar';
     }
+    if (this.$state.includes('gantt')) {
+      return 'gantt';
+    }
 
     throw new Error('Not on a path defined for query views');
   }

--- a/frontend/src/app/features/work-packages/openproject-work-package-routes.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-package-routes.module.ts
@@ -30,6 +30,7 @@ import { NgModule } from '@angular/core';
 import { UIRouterModule } from '@uirouter/angular';
 import { WORK_PACKAGES_ROUTES } from 'core-app/features/work-packages/routing/work-packages-routes';
 import { OpenprojectWorkPackagesModule } from 'core-app/features/work-packages/openproject-work-packages.module';
+import { WORK_PACKAGES_GANTT_ROUTES } from 'core-app/features/work-packages/routing/work-packages-gantt-routes';
 
 /**
  * Separate module for work package routes because WP modules
@@ -44,7 +45,7 @@ import { OpenprojectWorkPackagesModule } from 'core-app/features/work-packages/o
     OpenprojectWorkPackagesModule,
 
     // Routes for /work_packages
-    UIRouterModule.forChild({ states: WORK_PACKAGES_ROUTES }),
+    UIRouterModule.forChild({ states: [...WORK_PACKAGES_ROUTES, ...WORK_PACKAGES_GANTT_ROUTES] }),
   ],
 })
 export class OpenprojectWorkPackageRoutesModule {

--- a/frontend/src/app/features/work-packages/routing/work-packages-gantt-routes.ts
+++ b/frontend/src/app/features/work-packages/routing/work-packages-gantt-routes.ts
@@ -1,0 +1,86 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2023 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { WorkPackageSplitViewComponent } from 'core-app/features/work-packages/routing/wp-split-view/wp-split-view.component';
+import { Ng2StateDeclaration } from '@uirouter/angular';
+import { WorkPackagesBaseComponent } from 'core-app/features/work-packages/routing/wp-base/wp--base.component';
+import { WorkPackageListViewComponent } from 'core-app/features/work-packages/routing/wp-list-view/wp-list-view.component';
+import { WorkPackageViewPageComponent } from 'core-app/features/work-packages/routing/wp-view-page/wp-view-page.component';
+import { makeSplitViewRoutes } from 'core-app/features/work-packages/routing/split-view-routes.template';
+
+export const menuItemClass = 'gantt-menu-item';
+
+export const WORK_PACKAGES_GANTT_ROUTES:Ng2StateDeclaration[] = [
+  {
+    name: 'gantt',
+    parent: 'optional_project',
+    url: '/gantt?query_id&query_props&start_onboarding_tour',
+    redirectTo: 'gantt.partitioned.list',
+    views: {
+      '!$default': { component: WorkPackagesBaseComponent },
+    },
+    data: {
+      bodyClasses: 'router--work-packages-base',
+      menuItem: menuItemClass,
+    },
+    params: {
+      query_id: { type: 'query', dynamic: true },
+      // Use custom encoder/decoder that ensures validity of URL string
+      query_props: { type: 'opQueryString' },
+      // Optional initial tour param
+      start_onboarding_tour: { type: 'query', squash: true, value: undefined },
+    },
+  },
+  {
+    name: 'gantt.partitioned',
+    component: WorkPackageViewPageComponent,
+    url: '',
+    data: {
+      // This has to be empty to avoid inheriting the parent bodyClasses
+      bodyClasses: '',
+    },
+  },
+  {
+    name: 'gantt.partitioned.list',
+    url: '',
+    reloadOnSearch: false,
+    views: {
+      'content-left': { component: WorkPackageListViewComponent },
+    },
+    data: {
+      bodyClasses: 'router--work-packages-partitioned-split-view',
+      menuItem: menuItemClass,
+      partition: '-left-only',
+    },
+  },
+  ...makeSplitViewRoutes(
+    'gantt.partitioned.list',
+    menuItemClass,
+    WorkPackageSplitViewComponent,
+  ),
+];

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -164,8 +164,7 @@ export class StaticQueriesService {
       },
       {
         title: this.text.gantt,
-        // TODO: GANTT
-        uiSref: 'work-packages',
+        uiSref: 'gantt',
         uiParams: {
           query_id: '',
           query_props: '{"c":["id","type","subject","status","startDate","dueDate","duration"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -127,15 +127,6 @@ export class StaticQueriesService {
         view: 'WorkPackagesTable',
       },
       {
-        title: this.text.gantt,
-        uiSref: 'work-packages',
-        uiParams: {
-          query_id: '',
-          query_props: '{"c":["id","type","subject","status","startDate","dueDate","duration"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',
-        },
-        view: 'WorkPackagesTable',
-      },
-      {
         title: this.text.overdue,
         uiSref: 'work-packages',
         uiParams: {
@@ -170,6 +161,16 @@ export class StaticQueriesService {
           query_props: '{"c":["id","subject","bcfThumbnail","type","status","assignee","createdAt"],"t":"createdAt:desc","f":[{"n":"status","o":"o","v":[]}]}',
         },
         view: 'Bim',
+      },
+      {
+        title: this.text.gantt,
+        // TODO: GANTT
+        uiSref: 'work-packages',
+        uiParams: {
+          query_id: '',
+          query_props: '{"c":["id","type","subject","status","startDate","dueDate","duration"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',
+        },
+        view: 'Gantt',
       },
     ];
 

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -53,7 +53,7 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { MAGIC_PAGE_NUMBER } from 'core-app/core/apiv3/helpers/get-paginated-results';
 
-export type ViewType = 'WorkPackagesTable'|'Bim'|'TeamPlanner'|'WorkPackagesCalendar';
+export type ViewType = 'WorkPackagesTable'|'Bim'|'TeamPlanner'|'WorkPackagesCalendar'|'Gantt';
 
 export const opViewSelectSelector = 'op-view-select';
 

--- a/modules/gantt/app/contracts/gantt/views/contract_strategy.rb
+++ b/modules/gantt/app/contracts/gantt/views/contract_strategy.rb
@@ -1,0 +1,30 @@
+module ::Gantt
+  module Views
+    class ContractStrategy < ::BaseContract
+      validate :manageable
+
+      private
+
+      def manageable
+        return if model.query.blank?
+
+        errors.add(:base, :error_unauthorized) unless query_permissions?
+      end
+
+      def query_permissions?
+        # The visibility i.e. whether a private query belongs to the user is checked via the
+        # query_visible? method.
+        (model.query.public && user_allowed_on_query?(:manage_public_queries)) ||
+          (!model.query.public && user_allowed_on_query?(:save_queries))
+      end
+
+      def user_allowed_on_query?(permission)
+        if model.query.project
+          user.allowed_in_project?(permission, model.query.project)
+        else
+          user.allowed_in_any_project?(permission)
+        end
+      end
+    end
+  end
+end

--- a/modules/gantt/app/controllers/gantt/base_controller.rb
+++ b/modules/gantt/app/controllers/gantt/base_controller.rb
@@ -1,0 +1,4 @@
+module ::Gantt
+  class BaseController < ::ApplicationController
+  end
+end

--- a/modules/gantt/app/controllers/gantt/gantt_controller.rb
+++ b/modules/gantt/app/controllers/gantt/gantt_controller.rb
@@ -1,0 +1,5 @@
+module ::Gantt
+  class GanttController < BaseController
+    menu_item :gantt
+  end
+end

--- a/modules/gantt/app/controllers/gantt/gantt_controller.rb
+++ b/modules/gantt/app/controllers/gantt/gantt_controller.rb
@@ -1,5 +1,31 @@
 module ::Gantt
-  class GanttController < BaseController
+  class GanttController < ApplicationController
+    include Layout
+    include WorkPackagesControllerHelper
+
+    accept_key_auth :index
+
+    before_action :find_optional_project, :protect_from_unauthorized_export, only: :index
+
+    before_action :load_and_validate_query, only: :index, unless: -> { request.format.html? }
+
     menu_item :gantt
+    def index
+      respond_to do |format|
+        format.html do
+          render :index,
+                 locals: { query: @query, project: @project, menu_name: project_or_global_menu },
+                 layout: 'angular/angular'
+        end
+
+        format.any(*supported_list_formats) do
+          export_list(request.format.symbol)
+        end
+
+        format.atom do
+          atom_list
+        end
+      end
+    end
   end
 end

--- a/modules/gantt/app/views/gantt/gantt/_menu.html.erb
+++ b/modules/gantt/app/views/gantt/gantt/_menu.html.erb
@@ -4,7 +4,7 @@
                           inputs: {
                             projectId: (@project ? @project.id.to_s : ''),
                             menuItems: [parent_name, name],
-                            baseRoute: 'work-packages',
+                            baseRoute: 'gantt',
                             viewType: 'Gantt',
                           },
                           class: 'op-sidebar--body'

--- a/modules/gantt/app/views/gantt/gantt/_menu.html.erb
+++ b/modules/gantt/app/views/gantt/gantt/_menu.html.erb
@@ -1,0 +1,12 @@
+<div class="op-sidebar">
+  <%=
+    angular_component_tag 'op-view-select',
+                          inputs: {
+                            projectId: (@project ? @project.id.to_s : ''),
+                            menuItems: [parent_name, name],
+                            baseRoute: 'work-packages',
+                            viewType: 'Gantt',
+                          },
+                          class: 'op-sidebar--body'
+  %>
+</div>

--- a/modules/gantt/app/views/gantt/gantt/index.html.erb
+++ b/modules/gantt/app/views/gantt/gantt/index.html.erb
@@ -1,0 +1,36 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2023 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title(t('label_gantt')) -%>
+<%= call_hook(:view_work_packages_index_bottom, { project: project, query: query }) %>
+
+<% content_for :header_tags do %>
+  <%= auto_discovery_link_tag(:atom, {query_id: query, format: 'atom', page: nil, key: User.current.rss_key}, title: t(:label_gantt)) %>
+  <%= auto_discovery_link_tag(:atom, {controller: '/journals', action: 'index', query_id: query, format: 'atom', page: nil, key: User.current.rss_key}, title: t(:label_changes_details)) %>
+<% end %>

--- a/modules/gantt/config/locales/en.yml
+++ b/modules/gantt/config/locales/en.yml
@@ -1,0 +1,3 @@
+# English strings go here
+en:
+  project_module_gantt: "Gantt"

--- a/modules/gantt/config/routes.rb
+++ b/modules/gantt/config/routes.rb
@@ -1,2 +1,21 @@
-# OpenProject::Application.routes.draw do
-# end
+OpenProject::Application.routes.draw do
+  scope 'projects/:project_id', as: 'project' do
+    resources :gantt, controller: 'gantt/gantt', only: [:index] do
+      collection do
+        # states managed by client-side routing on work_package#index
+        get '(/*state)' => 'gantt/gantt#index', as: ''
+        get '/create_new' => 'gantt/gantt#index', as: 'new_split'
+      end
+    end
+  end
+
+  resources :gantt, controller: 'gantt/gantt', only: [:index] do
+    collection do
+      # states managed by client-side routing on work_package#index
+      get 'details/*state' => 'gantt/gantt#index', as: :details
+
+      # states managed by client-side (angular) routing on work_package#show
+      get '/' => 'gantt/gantt#index', as: 'index'
+    end
+  end
+end

--- a/modules/gantt/config/routes.rb
+++ b/modules/gantt/config/routes.rb
@@ -1,0 +1,2 @@
+# OpenProject::Application.routes.draw do
+# end

--- a/modules/gantt/lib/open_project/gantt.rb
+++ b/modules/gantt/lib/open_project/gantt.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Gantt
+    require 'open_project/gantt/engine'
+  end
+end

--- a/modules/gantt/lib/open_project/gantt/engine.rb
+++ b/modules/gantt/lib/open_project/gantt/engine.rb
@@ -53,7 +53,7 @@ module OpenProject::Gantt
 
       # menu :global_menu,
       #      :gantt,
-      #      { controller: '/work_packages', action: 'index' },
+      #      { controller: '/gantt/gantt', action: 'index' },
       #      caption: :label_gantt,
       #      icon: 'view-timeline',
       #      html: {
@@ -62,7 +62,7 @@ module OpenProject::Gantt
 
       menu :project_menu,
            :gantt,
-           { controller: '/work_packages', action: 'index' },
+           { controller: '/gantt/gantt', action: 'index' },
            caption: :label_gantt,
            after: :work_packages,
            if: ->(project) { project.module_enabled?(:gantt) },
@@ -73,7 +73,7 @@ module OpenProject::Gantt
 
       menu :project_menu,
            :gantt_query_select,
-           { controller: '/work_packages', action: 'index' },
+           { controller: '/gantt/gantt', action: 'index' },
            parent: :gantt,
            partial: 'gantt/gantt/menu',
            last: true,
@@ -82,7 +82,7 @@ module OpenProject::Gantt
 
       # menu :top_menu,
       #      :gantt,
-      #      { controller: '/work_packages', action: 'index' },
+      #      { controller: '/gantt/gantt', action: 'index' },
       #      caption: :label_gantt,
       #      icon: 'view-timeline',
       #      html: {

--- a/modules/gantt/lib/open_project/gantt/engine.rb
+++ b/modules/gantt/lib/open_project/gantt/engine.rb
@@ -1,0 +1,84 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2021-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module OpenProject::Gantt
+  class Engine < ::Rails::Engine
+    engine_name :openproject_gantt
+
+    include OpenProject::Plugins::ActsAsOpEngine
+
+    register 'openproject-gantt',
+             author_url: 'https://www.openproject.org',
+             bundled: true,
+             settings: {} do
+      # should_render_global_menu_item = Proc.new do
+      #   (User.current.logged? || !Setting.login_required?) &&
+      #   User.current.allowed_in_any_project?(:view_work_packages)
+      # end
+
+      # menu :global_menu,
+      #      :gantt,
+      #      { controller: '/work_packages', action: 'index' },
+      #      caption: :label_gantt,
+      #      icon: 'view-timeline',
+      #      html: {
+      #        id: 'main-menu-gantt',
+      #      }
+
+      menu :project_menu,
+           :gantt,
+           { controller: '/work_packages', action: 'index' },
+           caption: :label_gantt,
+           after: :work_packages,
+           icon: 'view-timeline',
+           html: {
+             id: 'main-menu-gantt'
+           }
+
+      menu :project_menu,
+           :gantt_query_select,
+           { controller: '/work_packages', action: 'index' },
+           parent: :gantt,
+           partial: 'gantt/gantt/menu',
+           last: true,
+           caption: :label_gantt_chart
+
+      # menu :top_menu,
+      #      :gantt,
+      #      { controller: '/work_packages', action: 'index' },
+      #      caption: :label_gantt,
+      #      icon: 'view-timeline',
+      #      html: {
+      #        id: 'main-menu-gantt',
+      #      }
+    end
+
+    add_view :Gantt,
+             contract_strategy: 'Gantt::Views::ContractStrategy'
+  end
+end

--- a/modules/gantt/lib/open_project/gantt/engine.rb
+++ b/modules/gantt/lib/open_project/gantt/engine.rb
@@ -36,6 +36,16 @@ module OpenProject::Gantt
              author_url: 'https://www.openproject.org',
              bundled: true,
              settings: {} do
+      Rails.application.reloader.to_prepare do
+        OpenProject::AccessControl.map do |ac_map|
+          ac_map.project_module(:gantt, dependencies: :work_package_tracking, order: 95)
+        end
+
+        OpenProject::AccessControl.permission(:view_work_packages).tap do |add|
+          add.controller_actions << 'gantt/gantt/index'
+        end
+      end
+
       # should_render_global_menu_item = Proc.new do
       #   (User.current.logged? || !Setting.login_required?) &&
       #   User.current.allowed_in_any_project?(:view_work_packages)
@@ -55,6 +65,7 @@ module OpenProject::Gantt
            { controller: '/work_packages', action: 'index' },
            caption: :label_gantt,
            after: :work_packages,
+           if: ->(project) { project.module_enabled?(:gantt) },
            icon: 'view-timeline',
            html: {
              id: 'main-menu-gantt'
@@ -66,7 +77,8 @@ module OpenProject::Gantt
            parent: :gantt,
            partial: 'gantt/gantt/menu',
            last: true,
-           caption: :label_gantt_chart
+           caption: :label_gantt_chart,
+           if: ->(project) { project.module_enabled?(:gantt) }
 
       # menu :top_menu,
       #      :gantt,

--- a/modules/gantt/lib/openproject-gantt.rb
+++ b/modules/gantt/lib/openproject-gantt.rb
@@ -1,0 +1,1 @@
+require 'open_project/gantt'

--- a/modules/gantt/openproject-gantt.gemspec
+++ b/modules/gantt/openproject-gantt.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |s|
+  s.name        = 'openproject-gantt'
+  s.version     = '1.0.0'
+  s.authors     = 'OpenProject GmbH'
+  s.email       = 'info@openproject.com'
+  s.summary     = 'OpenProject Gantt'
+  s.description = 'Provides gantt views'
+  s.license     = 'GPLv3'
+
+  s.files = Dir['{app,config,db,lib}/**/*']
+  s.metadata['rubygems_mfa_required'] = 'true'
+end

--- a/modules/gantt/spec/routing/gantt_routing_spec.rb
+++ b/modules/gantt/spec/routing/gantt_routing_spec.rb
@@ -1,0 +1,71 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe 'Gantt routing' do
+  context 'with :project_id' do
+    it 'routes to gantt#index' do
+      expect(subject)
+        .to route(:get, '/projects/foobar/gantt')
+              .to(controller: 'gantt/gantt', action: :index, project_id: 'foobar')
+    end
+
+    it 'connects GET /projects/:project_id/gantt/create_new to gantt#index' do
+      expect(get('/projects/1/gantt/create_new'))
+        .to route_to(controller: 'gantt/gantt',
+                     action: 'index',
+                     project_id: '1',
+                     state: 'create_new')
+    end
+
+    it 'connects GET /projects/:project_id/gantt/details/:id/:state' +
+         ' to gantt#index' do
+      expect(get('/projects/1/gantt/details/2/overview'))
+        .to route_to(controller: 'gantt/gantt',
+                     action: 'index',
+                     project_id: '1',
+                     state: 'details/2/overview')
+    end
+  end
+
+  context 'without :project_id' do
+    it 'routes to gantt#index' do
+      expect(subject)
+        .to route(:get, '/gantt')
+              .to(controller: 'gantt/gantt', action: :index)
+    end
+
+    it 'connects GET /gantt/details/:state to gantt#index' do
+      expect(get('/gantt/details/5/overview'))
+        .to route_to(controller: 'gantt/gantt',
+                     action: 'index',
+                     state: '5/overview')
+    end
+  end
+end

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Redmine::MenuManager do
                       :work_packages,
                       :ifc_models,
                       :calendar_view,
+                      :gantt,
                       :team_planner_view,
                       :boards,
                       :dashboards,


### PR DESCRIPTION
### ToDo

**General**
- [x] Add a module "Gantt" for the left sidebar
- [x] There will be a sidebar with default, favourite and private views
  - [x] It will be possible to save and favorite views (as in WP module)
- [x] The permissions are exactly the same as for the WP module
- [x] Gantt module can be turned off in the project settings

**URL routing**
- [x] There will be new URLs `.../gantt`
- [x] When accessing a work package in full screen view, the URL will remain `/work_packages/{id}...`
- [x] The back button will take the user where they came from (Gantt or Work packages)
- [x] For deep links (shared URL, for example), the back button will direct the user to the work packages module

**Administration**
- [x] In Administrator settings: Rename permission section 'Work packages' to 'Work packages and Gantt'

**Tests**
- [x] Basic test for the routes

**Out of scope**
* Create button should open the split screen with `gantt` URL

https://community.openproject.org/projects/openproject/work_packages/51244/activity