### PR TITLE
[chore] Refactor nextcloud files query spec to vcr

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
@@ -65,7 +65,11 @@ module Storages::Peripherals::StorageInteraction::Nextcloud::Util
         on_success: ->(token) do
           connection_manager.request_with_token_refresh(token) { yield token }
         end,
-        on_failure: ->(_) { error(:unauthorized, 'Query could not be created! No access token found!') }
+        on_failure: ->(_) do
+          error(:unauthorized,
+                'Query could not be created! No access token found!',
+                Storages::StorageErrorData.new(source: connection_manager))
+        end
       )
     end
 

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/files_query_spec.rb
@@ -31,131 +31,199 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesQuery, :webmock do
-  let(:storage) { create(:nextcloud_storage, :with_oauth_client) }
-  let(:folder) { Storages::Peripherals::ParentFolder.new('/') }
+RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesQuery, :vcr, :webmock do
+  using Storages::Peripherals::ServiceResultRefinements
+
   let(:user) { create(:user) }
-  let(:token) do
-    create(:oauth_client_token, user:, oauth_client: storage.oauth_client, origin_user_id: 'darth@vader with spaces')
+  let(:storage) do
+    create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)
   end
+  let(:folder) { Storages::Peripherals::ParentFolder.new('/') }
 
-  let(:origin_user_id) { 'darth@vader with spaces' }
-  let(:webdav_success_response) { create(:webdav_data, parent_path: '', root_path: '', origin_user_id:) }
+  describe '#call' do
+    it 'responds with correct parameters' do
+      expect(described_class).to respond_to(:call)
 
-  subject(:files_query) { described_class }
-
-  before do
-    uri = "#{storage.host}/remote.php/dav/files/darth@vader%20with%20spaces/"
-    allow(Storages::Peripherals::StorageInteraction::Nextcloud::Util).to receive(:token).and_yield(token)
-    stub_request(:propfind, uri).to_return(status: 207, body: webdav_success_response, headers: {})
-  end
-
-  it '.call requires 3 arguments: storage, user, and folder' do
-    expect(described_class).to respond_to(:call)
-
-    method = described_class.method(:call)
-    expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq folder])
-  end
-
-  it 'returns a list of files and folders' do
-    storage_files = files_query.call(storage:, folder:, user:).result
-    expect(storage_files).to be_a(Storages::StorageFiles)
-
-    expect(storage_files.files.size).to eq(4)
-    expect(storage_files.ancestors.size).to eq(0)
-    expect(storage_files.parent.location).to eq('/')
-
-    mime_types = storage_files.files.map(&:mime_type).uniq!
-
-    expect(mime_types).to include('application/pdf') # file
-    expect(mime_types).to include('application/x-op-directory') # folder
-  end
-
-  it 'returns permissions for each' do
-    storage_files = files_query.call(storage:, folder:, user:).result
-
-    writeable_folder = storage_files.files.find { |file| file.mime_type == 'application/x-op-directory' }
-    expect(writeable_folder.permissions).to match_array(%i[readable writeable])
-
-    readonly_file = storage_files.files.find { |file| file.mime_type == 'application/pdf' }
-    expect(readonly_file.permissions).to match_array(%i[readable])
-  end
-
-  context 'when requesting a sub-folder' do
-    let(:folder) { Storages::Peripherals::ParentFolder.new('/Photos/Birds') }
-    let(:webdav_subfolder_success_response) { create(:webdav_data, parent_path: folder.path, root_path: '', origin_user_id:) }
-
-    before do
-      uri = "#{storage.host}/remote.php/dav/files/darth@vader%20with%20spaces#{folder.path}"
-      stub_request(:propfind, uri).to_return(status: 207, body: webdav_subfolder_success_response, headers: {})
+      method = described_class.method(:call)
+      expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq user], %i[keyreq folder])
     end
 
-    subject(:query_result) { files_query.call(user:, storage:, folder:).result }
+    context 'with outbound requests successful' do
+      context 'with parent folder being root', vcr: 'nextcloud/files_query_root' do
+        # rubocop:disable RSpec/ExampleLength
+        it 'returns a StorageFiles object for root' do
+          storage_files = described_class.call(storage:, user:, folder:).result
 
-    it 'returns 2 ancestors' do
-      ancestors = query_result.ancestors
+          expect(storage_files).to be_a(Storages::StorageFiles)
+          expect(storage_files.ancestors).to be_empty
+          expect(storage_files.parent.name).to eq("Root")
 
-      expect(ancestors.size).to eq(2)
-      expect(ancestors.map(&:location)).to match_array(%w[/ /Photos])
-      expect(ancestors.map(&:name)).to match_array(%w[/ Photos])
-    end
-
-    it 'returns the parent folder' do
-      expect(query_result.parent.name).to eq('Birds')
-      expect(query_result.parent.location).to eq('/Photos/Birds')
-    end
-
-    it 'lists the contents of the folder' do
-      expect(query_result.files).to all(be_a(Storages::StorageFile))
-      expect(query_result.files.size).to eq(4)
-    end
-
-    it 'the files "location" include the entire path and the file name' do
-      expect(query_result.files.last.location).to eq("/Photos/Birds/Manual.pdf")
-    end
-  end
-
-  context 'when the storage runs on a subfolder' do
-    let(:storage) { create(:nextcloud_storage, :with_oauth_client, host: 'https://example.com/death_star_blueprints') }
-
-    it 'just works' do
-      storage_files = files_query.call(storage:, user:, folder:)
-
-      expect(storage_files).to be_success
-    end
-  end
-
-  describe 'with missing OAuth token' do
-    before do
-      allow(Storages::Peripherals::StorageInteraction::Nextcloud::Util)
-        .to receive(:token)
-              .and_return(ServiceResult.failure(result: :unauthorized,
-                                                errors: Storages::StorageError.new(code: :unauthorized)))
-    end
-
-    it 'returns an ":unauthorized" ServiceResult' do
-      result = files_query.call(folder:, user:, storage:)
-      expect(result).to be_failure
-      expect(result.errors.code).to be(:unauthorized)
-    end
-  end
-
-  shared_examples_for 'outbound is failing' do |code = 500, symbol = :error|
-    describe "with outbound request returning #{code}" do
-      before do
-        uri = "#{storage.host}/remote.php/dav/files/darth@vader%20with%20spaces/"
-        stub_request(:propfind, uri).to_return(status: code)
+          expect(storage_files.files.size).to eq(10)
+          expect(storage_files.files[0].to_h)
+            .to eq({
+                     id: '45',
+                     name: 'Documents',
+                     size: 1107988,
+                     created_at: nil,
+                     created_by_name: 'admin',
+                     last_modified_at: '2023-10-16T13:26:30Z',
+                     last_modified_by_name: nil,
+                     location: '/Documents',
+                     mime_type: 'application/x-op-directory',
+                     permissions: %i[readable writeable]
+                   })
+          expect(storage_files.files[6].to_h)
+            .to eq({
+                     id: '52',
+                     name: 'Reasons to use Nextcloud.pdf',
+                     size: 976625,
+                     created_at: nil,
+                     created_by_name: 'admin',
+                     last_modified_at: '2023-07-27T13:30:24Z',
+                     last_modified_by_name: nil,
+                     location: '/Reasons%20to%20use%20Nextcloud.pdf',
+                     mime_type: 'application/pdf',
+                     permissions: %i[readable writeable]
+                   })
+          expect(storage_files.files[5].to_h)
+            .to eq({
+                     id: '713',
+                     name: 'Readme.md',
+                     size: 554,
+                     created_at: nil,
+                     created_by_name: 'admin',
+                     last_modified_at: '2023-11-28T14:29:59Z',
+                     last_modified_by_name: nil,
+                     location: '/Readme.md',
+                     mime_type: 'text/markdown',
+                     permissions: %i[readable writeable]
+                   })
+        end
+        # rubocop:enable RSpec/ExampleLength
       end
 
-      it "must return :#{symbol} ServiceResult" do
-        result = files_query.call(folder:, user:, storage:)
+      context 'with a given parent folder', vcr: 'nextcloud/files_query_parent_folder' do
+        let(:folder) { Storages::Peripherals::ParentFolder.new('/Documents/New Requests') }
+
+        subject do
+          described_class.call(storage:, user:, folder:).result
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'returns the files content' do
+          expect(subject.files.size).to eq(2)
+          expect(subject.files.map(&:to_h))
+            .to eq([
+                     {
+                       id: '738',
+                       name: 'request_001.md',
+                       size: 16,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2023-11-28T14:39:34Z',
+                       last_modified_by_name: nil,
+                       location: '/Documents/New%20Requests/request_001.md',
+                       mime_type: 'text/markdown',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '740',
+                       name: 'request_002.md',
+                       size: 19,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2023-11-28T14:39:58Z',
+                       last_modified_by_name: nil,
+                       location: '/Documents/New%20Requests/request_002.md',
+                       mime_type: 'text/markdown',
+                       permissions: %i[readable writeable]
+                     }
+                   ])
+        end
+        # rubocop:enable RSpec/ExampleLength
+
+        it 'returns ancestors with a forged id' do
+          expect(subject.ancestors.map { |a| { id: a.id, name: a.name, location: a.location } })
+            .to eq([
+                     {
+                       id: '8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1',
+                       name: 'Root',
+                       location: '/'
+                     }, {
+                       id: '4eb3246b9f5e1daf394b0ab4cfb9a640978465a028a6bf0d2ad561b7a815c8a1',
+                       name: 'Documents',
+                       location: '/Documents'
+                     }
+                   ])
+        end
+
+        it 'returns the parent itself' do
+          expect(subject.parent.id).to eq('737')
+          expect(subject.parent.name).to eq('New Requests')
+          expect(subject.parent.location).to eq('/Documents/New%20Requests')
+        end
+      end
+
+      context 'with parent folder being empty', vcr: 'nextcloud/files_query_empty_folder' do
+        let(:folder) { Storages::Peripherals::ParentFolder.new('/Photos/todo') }
+
+        it 'returns an empty StorageFiles object with parent and ancestors' do
+          storage_files = described_class.call(storage:, user:, folder:).result
+
+          expect(storage_files).to be_a(Storages::StorageFiles)
+          expect(storage_files.files).to be_empty
+          expect(storage_files.parent.id).to eq('760')
+          expect(storage_files.ancestors.map(&:name)).to eq(%w[Root Photos])
+        end
+      end
+    end
+
+    context 'with not existent parent folder', vcr: 'nextcloud/files_query_invalid_parent' do
+      let(:folder) { Storages::Peripherals::ParentFolder.new('/I/just/made/that/up') }
+
+      it 'must return not found' do
+        result = described_class.call(storage:, user:, folder:)
         expect(result).to be_failure
-        expect(result.errors.code).to be(symbol)
+        expect(result.error_source).to be_a(described_class)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:not_found) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
+    end
+
+    context 'with invalid oauth token', vcr: 'nextcloud/files_query_invalid_token' do
+      before do
+        token = build_stubbed(:oauth_client_token, oauth_client: storage.oauth_client)
+        allow(Storages::Peripherals::StorageInteraction::Nextcloud::Util)
+          .to receive(:token).and_yield(token)
+      end
+
+      it 'must return unauthorized' do
+        result = described_class.call(storage:, user:, folder:)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(described_class)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
+      end
+    end
+
+    context 'with not existent oauth token' do
+      let(:user_without_token) { create(:user) }
+
+      it 'must return unauthorized' do
+        result = described_class.call(storage:, user: user_without_token, folder:)
+        expect(result).to be_failure
+        expect(result.error_source).to be_a(OAuthClients::ConnectionManager)
+
+        result.match(
+          on_failure: ->(error) { expect(error.code).to eq(:unauthorized) },
+          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
+        )
       end
     end
   end
-
-  include_examples 'outbound is failing', 404, :not_found
-  include_examples 'outbound is failing', 401, :unauthorized
-  include_examples 'outbound is failing', 500, :error
 end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/files_query_spec.rb
@@ -58,52 +58,61 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesQuery,
           expect(storage_files.ancestors).to be_empty
           expect(storage_files.parent.name).to eq("Root")
 
-          expect(storage_files.files.size).to eq(10)
-          expect(storage_files.files[0].to_h)
-            .to eq({
-                     id: '45',
-                     name: 'Documents',
-                     size: 1107988,
-                     created_at: nil,
-                     created_by_name: 'admin',
-                     last_modified_at: '2023-10-16T13:26:30Z',
-                     last_modified_by_name: nil,
-                     location: '/Documents',
-                     mime_type: 'application/x-op-directory',
-                     permissions: %i[readable writeable]
-                   })
-          expect(storage_files.files[6].to_h)
-            .to eq({
-                     id: '52',
-                     name: 'Reasons to use Nextcloud.pdf',
-                     size: 976625,
-                     created_at: nil,
-                     created_by_name: 'admin',
-                     last_modified_at: '2023-07-27T13:30:24Z',
-                     last_modified_by_name: nil,
-                     location: '/Reasons%20to%20use%20Nextcloud.pdf',
-                     mime_type: 'application/pdf',
-                     permissions: %i[readable writeable]
-                   })
-          expect(storage_files.files[5].to_h)
-            .to eq({
-                     id: '713',
-                     name: 'Readme.md',
-                     size: 554,
-                     created_at: nil,
-                     created_by_name: 'admin',
-                     last_modified_at: '2023-11-28T14:29:59Z',
-                     last_modified_by_name: nil,
-                     location: '/Readme.md',
-                     mime_type: 'text/markdown',
-                     permissions: %i[readable writeable]
-                   })
+          expect(storage_files.files.size).to eq(4)
+          expect(storage_files.files.map(&:to_h))
+            .to eq([
+                     {
+                       id: '172',
+                       name: 'Folder',
+                       size: 982713473,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2023-11-29T15:31:30Z',
+                       last_modified_by_name: nil,
+                       location: '/Folder',
+                       mime_type: 'application/x-op-directory',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '173',
+                       name: 'Folder with spaces',
+                       size: 74,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2023-11-29T15:42:21Z',
+                       last_modified_by_name: nil,
+                       location: '/Folder%20with%20spaces',
+                       mime_type: 'application/x-op-directory',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '211',
+                       name: 'Practical_guide_to_BAGGM_Digital.pdf',
+                       size: 154592937,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2022-08-09T06:53:12Z',
+                       last_modified_by_name: nil,
+                       location: '/Practical_guide_to_BAGGM_Digital.pdf',
+                       mime_type: 'application/pdf',
+                       permissions: %i[readable writeable]
+                     }, {
+                       id: '178',
+                       name: 'Readme.md',
+                       size: 31,
+                       created_at: nil,
+                       created_by_name: 'admin',
+                       last_modified_at: '2023-11-29T15:29:16Z',
+                       last_modified_by_name: nil,
+                       location: '/Readme.md',
+                       mime_type: 'text/markdown',
+                       permissions: %i[readable writeable]
+                     }
+                   ])
         end
         # rubocop:enable RSpec/ExampleLength
       end
 
       context 'with a given parent folder', vcr: 'nextcloud/files_query_parent_folder' do
-        let(:folder) { Storages::Peripherals::ParentFolder.new('/Documents/New Requests') }
+        let(:folder) { Storages::Peripherals::ParentFolder.new('/Folder with spaces/New Requests') }
 
         subject do
           described_class.call(storage:, user:, folder:).result
@@ -115,25 +124,25 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesQuery,
           expect(subject.files.map(&:to_h))
             .to eq([
                      {
-                       id: '738',
+                       id: '181',
                        name: 'request_001.md',
-                       size: 16,
+                       size: 48,
                        created_at: nil,
                        created_by_name: 'admin',
-                       last_modified_at: '2023-11-28T14:39:34Z',
+                       last_modified_at: '2023-11-29T15:35:25Z',
                        last_modified_by_name: nil,
-                       location: '/Documents/New%20Requests/request_001.md',
+                       location: '/Folder%20with%20spaces/New%20Requests/request_001.md',
                        mime_type: 'text/markdown',
                        permissions: %i[readable writeable]
                      }, {
-                       id: '740',
+                       id: '182',
                        name: 'request_002.md',
-                       size: 19,
+                       size: 26,
                        created_at: nil,
                        created_by_name: 'admin',
-                       last_modified_at: '2023-11-28T14:39:58Z',
+                       last_modified_at: '2023-11-29T15:35:34Z',
                        last_modified_by_name: nil,
-                       location: '/Documents/New%20Requests/request_002.md',
+                       location: '/Folder%20with%20spaces/New%20Requests/request_002.md',
                        mime_type: 'text/markdown',
                        permissions: %i[readable writeable]
                      }
@@ -149,30 +158,30 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::FilesQuery,
                        name: 'Root',
                        location: '/'
                      }, {
-                       id: '4eb3246b9f5e1daf394b0ab4cfb9a640978465a028a6bf0d2ad561b7a815c8a1',
-                       name: 'Documents',
-                       location: '/Documents'
+                       id: 'c8776f1f6dd36c023c6615d39f01a71d68dd1707b232115b7a4f58bc6da94e2e',
+                       name: 'Folder with spaces',
+                       location: '/Folder%20with%20spaces'
                      }
                    ])
         end
 
         it 'returns the parent itself' do
-          expect(subject.parent.id).to eq('737')
+          expect(subject.parent.id).to eq('180')
           expect(subject.parent.name).to eq('New Requests')
-          expect(subject.parent.location).to eq('/Documents/New%20Requests')
+          expect(subject.parent.location).to eq('/Folder%20with%20spaces/New%20Requests')
         end
       end
 
       context 'with parent folder being empty', vcr: 'nextcloud/files_query_empty_folder' do
-        let(:folder) { Storages::Peripherals::ParentFolder.new('/Photos/todo') }
+        let(:folder) { Storages::Peripherals::ParentFolder.new('/Folder/empty') }
 
         it 'returns an empty StorageFiles object with parent and ancestors' do
           storage_files = described_class.call(storage:, user:, folder:).result
 
           expect(storage_files).to be_a(Storages::StorageFiles)
           expect(storage_files.files).to be_empty
-          expect(storage_files.parent.id).to eq('760')
-          expect(storage_files.ancestors.map(&:name)).to eq(%w[Root Photos])
+          expect(storage_files.parent.id).to eq('174')
+          expect(storage_files.ancestors.map(&:name)).to eq(%w[Root Folder])
         end
       end
     end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, 
     end
 
     context 'with outbound requests successful' do
-      context 'with parent folder being nil', vcr: 'one_drive/files_query_root' do
+      context 'with parent folder being root', vcr: 'one_drive/files_query_root' do
         # rubocop:disable RSpec/ExampleLength
         it 'returns a StorageFiles object for root' do
           storage_files = described_class.call(storage:, user:, folder:).result
@@ -192,7 +192,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, 
     context 'with not existent parent folder', vcr: 'one_drive/files_query_invalid_parent' do
       let(:folder) { Storages::Peripherals::ParentFolder.new('/I/just/made/that/up') }
 
-      it 'must return unauthorized' do
+      it 'must return not found' do
         result = described_class.call(storage:, user:, folder:)
         expect(result).to be_failure
         expect(result.error_source).to be_a(described_class)

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
     end
 
     name { 'Nextcloud Local' }
-    host { 'https://nextcloud.local' }
+    host { ENV.fetch('NEXTCLOUD_LOCAL_HOST', 'https://nextcloud.local') }
 
     initialize_with do
       Storages::NextcloudStorage.create_or_find_by(attributes.except(:oauth_client, :oauth_application))

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
     end
 
     name { 'Nextcloud Local' }
-    host { ENV.fetch('NEXTCLOUD_LOCAL_HOST', 'https://nextcloud.local') }
+    host { 'https://nextcloud.local' }
 
     initialize_with do
       Storages::NextcloudStorage.create_or_find_by(attributes.except(:oauth_client, :oauth_application))

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_empty_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_empty_folder.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: propfind
+    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/Photos/todo
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <oc:permissions/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Depth:
+      - '1'
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Length:
+      - '646'
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Tue, 28 Nov 2023 14:48:45 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.56 (Debian)
+      Set-Cookie:
+      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=lax
+      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=strict
+      - oc832qmuhv8d=9cdbabaa40830fe8626473e57057cce0; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc_sessionPassphrase=beSPWmx0Am%2BxbGDr5nGo5tGCEa5mhWMKTbvUNK%2FeEd%2F6FrvSfseZbFB1sdAFDZ1fau37ETJAJa7Wk%2BsDDdGLSw%2FZUJ1SvYeeJNhAkEdkU3NUlg3Gv68Wnn%2Fbr%2FIVZIqs;
+        path=/html; secure; HttpOnly; SameSite=Lax
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - Mu2VZo0F0xAb60zJ4tgI
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.8
+      X-Request-Id:
+      - Mu2VZo0F0xAb60zJ4tgI
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/Photos/todo/</d:href><d:propstat><d:prop><oc:fileid>760</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:48:01 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Tue, 28 Nov 2023 14:48:45 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_empty_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_empty_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: propfind
-    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/Photos/todo
+    uri: https://nextcloud.local/remote.php/dav/files/admin/Folder/empty
     body:
       encoding: UTF-8
       string: |
@@ -36,13 +36,13 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache, must-revalidate
       Content-Length:
-      - '646'
+      - '642'
       Content-Security-Policy:
       - default-src 'none';
       Content-Type:
       - application/xml; charset=utf-8
       Date:
-      - Tue, 28 Nov 2023 14:48:45 GMT
+      - Wed, 29 Nov 2023 15:45:31 GMT
       Dav:
       - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
         nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
@@ -53,48 +53,38 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.56 (Debian)
+      - Apache/2.4.57 (Debian)
       Set-Cookie:
-      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+      - __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100
         23:59:59 GMT; SameSite=lax
-      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
-        23:59:59 GMT; SameSite=strict
-      - oc832qmuhv8d=9cdbabaa40830fe8626473e57057cce0; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=e2b1e083784e589483fa13295c69fc1e; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc_sessionPassphrase=beSPWmx0Am%2BxbGDr5nGo5tGCEa5mhWMKTbvUNK%2FeEd%2F6FrvSfseZbFB1sdAFDZ1fau37ETJAJa7Wk%2BsDDdGLSw%2FZUJ1SvYeeJNhAkEdkU3NUlg3Gv68Wnn%2Fbr%2FIVZIqs;
-        path=/html; secure; HttpOnly; SameSite=Lax
+      - __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict
+      - oc_sessionPassphrase=22EqvC5iCSsL87itrDPml%2BkF6aOUj79GbuodxMNmF04ZQPKog6y5BvL4iU80hQZS24xkgYLO%2FhmBf98JM7q%2Brl2HSCJ9DstQH8KZwDV8BrS6XNjxnhLWBWf7Jp4kMk4Y;
+        path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=53b37579a2a843efd20055cdb5509976; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=9ef63f90ae539c41f094193243b80bdf; path=/; secure; HttpOnly; SameSite=Lax
       Vary:
       - Brief,Prefer
       X-Content-Type-Options:
       - nosniff
       X-Debug-Token:
-      - Mu2VZo0F0xAb60zJ4tgI
+      - BnfzarP0I9NC7ERZOIJE
       X-Frame-Options:
       - SAMEORIGIN
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.8
+      - PHP/8.2.13
       X-Request-Id:
-      - Mu2VZo0F0xAb60zJ4tgI
+      - BnfzarP0I9NC7ERZOIJE
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
@@ -103,6 +93,6 @@ http_interactions:
       encoding: UTF-8
       string: |
         <?xml version="1.0"?>
-        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/Photos/todo/</d:href><d:propstat><d:prop><oc:fileid>760</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:48:01 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
-  recorded_at: Tue, 28 Nov 2023 14:48:45 GMT
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/admin/Folder/empty/</d:href><d:propstat><d:prop><oc:fileid>174</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Wed, 29 Nov 2023 13:20:49 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Wed, 29 Nov 2023 15:45:31 GMT
 recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_parent.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_parent.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: propfind
+    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/I/just/made/that/up
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <oc:permissions/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Depth:
+      - '1'
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Length:
+      - '231'
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Tue, 28 Nov 2023 14:12:42 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.56 (Debian)
+      Set-Cookie:
+      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=lax
+      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=strict
+      - oc832qmuhv8d=84b188a214c8bc1fbdb76f5742b14e22; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc_sessionPassphrase=K%2BYrdVtRKepSWS2lqZw3cohZVH3XCYg6AMQVUTC7LGj085dE%2Bk5YDuEpd5CoDe4OFV3MANEe%2FL0qcYqgffEansXbupSIxmDUDbTQ4g4ZlUOEWCMvq6xZsmruRp%2F1QAhl;
+        path=/html; secure; HttpOnly; SameSite=Lax
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.8
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+          <s:exception>Sabre\DAV\Exception\NotFound</s:exception>
+          <s:message>File with name //I could not be located</s:message>
+        </d:error>
+  recorded_at: Tue, 28 Nov 2023 14:12:42 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_parent.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_parent.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: propfind
-    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/I/just/made/that/up
+    uri: https://nextcloud.local/remote.php/dav/files/admin/I/just/made/that/up
     body:
       encoding: UTF-8
       string: |
@@ -42,7 +42,7 @@ http_interactions:
       Content-Type:
       - application/xml; charset=utf-8
       Date:
-      - Tue, 28 Nov 2023 14:12:42 GMT
+      - Wed, 29 Nov 2023 15:45:31 GMT
       Dav:
       - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
         nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
@@ -53,34 +53,24 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.56 (Debian)
+      - Apache/2.4.57 (Debian)
       Set-Cookie:
-      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+      - __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100
         23:59:59 GMT; SameSite=lax
-      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
-        23:59:59 GMT; SameSite=strict
-      - oc832qmuhv8d=84b188a214c8bc1fbdb76f5742b14e22; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=9a7f5cbefe7220045783b5bc96975817; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc_sessionPassphrase=K%2BYrdVtRKepSWS2lqZw3cohZVH3XCYg6AMQVUTC7LGj085dE%2Bk5YDuEpd5CoDe4OFV3MANEe%2FL0qcYqgffEansXbupSIxmDUDbTQ4g4ZlUOEWCMvq6xZsmruRp%2F1QAhl;
-        path=/html; secure; HttpOnly; SameSite=Lax
+      - __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict
+      - oc_sessionPassphrase=AuJ23gTtnDdXny94O5aZVzdnJweQRNRURJtvHaNmNCsLKR6zrr6SFgwx09HomshABCrw6slULrxyYOfwbnCqJGzSVC9SCKp5YflugSzmPJfBfwURLU2GQnICBPsfFFCL;
+        path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=93109f99dfe19218102d5dc8b2e3cc40; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=b4faf57238eda6bee9a3397e7989534e; path=/; secure; HttpOnly; SameSite=Lax
       Vary:
       - Brief,Prefer
       X-Content-Type-Options:
@@ -90,7 +80,7 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.8
+      - PHP/8.2.13
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
@@ -103,5 +93,5 @@ http_interactions:
           <s:exception>Sabre\DAV\Exception\NotFound</s:exception>
           <s:message>File with name //I could not be located</s:message>
         </d:error>
-  recorded_at: Tue, 28 Nov 2023 14:12:42 GMT
+  recorded_at: Wed, 29 Nov 2023 15:45:31 GMT
 recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_token.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: propfind
-    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/
+    uri: https://nextcloud.local/remote.php/dav/files/admin/
     body:
       encoding: UTF-8
       string: |
@@ -42,7 +42,7 @@ http_interactions:
       Content-Type:
       - application/xml; charset=utf-8
       Date:
-      - Tue, 28 Nov 2023 14:02:54 GMT
+      - Wed, 29 Nov 2023 15:45:31 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Pragma:
@@ -50,22 +50,18 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.56 (Debian)
+      - Apache/2.4.57 (Debian)
       Set-Cookie:
-      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+      - __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100
         23:59:59 GMT; SameSite=lax
-      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
-        23:59:59 GMT; SameSite=strict
-      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=bf6c4795c04a55fb3a9ce522ff241dd9; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc_sessionPassphrase=kLV%2BQwn3MxcGgIjFhjqZ%2Ba2L0xMFmbP1WwGl59f0lUIryai3aRYjtkV1Y%2FUL3vBq8XBHzPfwSWcI3c%2FvvXMa%2B7ZiyalMEviDdsNNEW9u308irZAUgLgzB7oOybZ%2B%2FY0W;
-        path=/html; secure; HttpOnly; SameSite=Lax
+      - __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict
+      - oc_sessionPassphrase=UXh8eFuRtTRf9T7iZTT0kzicJGCTmNYEv3KVKHQGG%2BZr8KS8oJPhgRClJm2zErUam7AK8qAWgc%2FVXHitCHegMiwPALDz14awrmo1H7qHMrZaDdGjwvfN7d%2Bcul%2BFa9YB;
+        path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=633a1046540dd6fb7ce9e41e77b73076; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=633a1046540dd6fb7ce9e41e77b73076; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=633a1046540dd6fb7ce9e41e77b73076; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=f939fd60240f843f64f1a146dac38aef; path=/; secure; HttpOnly; SameSite=Lax
       Www-Authenticate:
       - Basic realm="Nextcloud", charset="UTF-8"
       X-Content-Type-Options:
@@ -75,7 +71,7 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.8
+      - PHP/8.2.13
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
@@ -88,5 +84,5 @@ http_interactions:
           <s:exception>Sabre\DAV\Exception\NotAuthenticated</s:exception>
           <s:message>No public access to this resource., No 'Authorization: Basic' header found. Either the client didn't send one, or the server is misconfigured, Bearer token was incorrect, No 'Authorization: Basic' header found. Either the client didn't send one, or the server is misconfigured</s:message>
         </d:error>
-  recorded_at: Tue, 28 Nov 2023 14:02:54 GMT
+  recorded_at: Wed, 29 Nov 2023 15:45:31 GMT
 recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_token.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_invalid_token.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: propfind
+    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <oc:permissions/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Depth:
+      - '1'
+      Authorization:
+      - Bearer 1234567890-1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Length:
+      - '476'
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Tue, 28 Nov 2023 14:02:54 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.56 (Debian)
+      Set-Cookie:
+      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=lax
+      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=strict
+      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=0ea46bd4c95a5ee5d9de30ec26c609bb; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=bf6c4795c04a55fb3a9ce522ff241dd9; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc_sessionPassphrase=kLV%2BQwn3MxcGgIjFhjqZ%2Ba2L0xMFmbP1WwGl59f0lUIryai3aRYjtkV1Y%2FUL3vBq8XBHzPfwSWcI3c%2FvvXMa%2B7ZiyalMEviDdsNNEW9u308irZAUgLgzB7oOybZ%2B%2FY0W;
+        path=/html; secure; HttpOnly; SameSite=Lax
+      Www-Authenticate:
+      - Basic realm="Nextcloud", charset="UTF-8"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.8
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+          <s:exception>Sabre\DAV\Exception\NotAuthenticated</s:exception>
+          <s:message>No public access to this resource., No 'Authorization: Basic' header found. Either the client didn't send one, or the server is misconfigured, Bearer token was incorrect, No 'Authorization: Basic' header found. Either the client didn't send one, or the server is misconfigured</s:message>
+        </d:error>
+  recorded_at: Tue, 28 Nov 2023 14:02:54 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_parent_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_parent_folder.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: propfind
+    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/Documents/New%20Requests
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <oc:permissions/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Depth:
+      - '1'
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Length:
+      - '1556'
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Tue, 28 Nov 2023 14:42:47 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.56 (Debian)
+      Set-Cookie:
+      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=lax
+      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=strict
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=2ea07ff7a2dce07f1f5cceb53d519bf7; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc_sessionPassphrase=%2BTiwB1hoNR1qBaSd3FwP3e%2B0N464jtcL5rxrmOMJTzaBr8drLsmiOQqc71VAjy8MzFtYPaP7HvvITNQnimloRoMLnSCTMo%2FSPllXUQ6oIy9%2BT0zu%2BtXQ1rv5mWg%2F6Oyl;
+        path=/html; secure; HttpOnly; SameSite=Lax
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - ABf8Ml48dBqqobMTI5Jy
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.8
+      X-Request-Id:
+      - ABf8Ml48dBqqobMTI5Jy
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/</d:href><d:propstat><d:prop><oc:fileid>737</oc:fileid><oc:size>35</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:39:58 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/request_001.md</d:href><d:propstat><d:prop><oc:fileid>738</oc:fileid><oc:size>16</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:39:34 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/request_002.md</d:href><d:propstat><d:prop><oc:fileid>740</oc:fileid><oc:size>19</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:39:58 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Tue, 28 Nov 2023 14:42:47 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_parent_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_parent_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: propfind
-    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/Documents/New%20Requests
+    uri: https://nextcloud.local/remote.php/dav/files/admin/Folder%20with%20spaces/New%20Requests
     body:
       encoding: UTF-8
       string: |
@@ -36,13 +36,13 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache, must-revalidate
       Content-Length:
-      - '1556'
+      - '1580'
       Content-Security-Policy:
       - default-src 'none';
       Content-Type:
       - application/xml; charset=utf-8
       Date:
-      - Tue, 28 Nov 2023 14:42:47 GMT
+      - Wed, 29 Nov 2023 15:45:31 GMT
       Dav:
       - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
         nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
@@ -53,48 +53,38 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.56 (Debian)
+      - Apache/2.4.57 (Debian)
       Set-Cookie:
-      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+      - __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100
         23:59:59 GMT; SameSite=lax
-      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
-        23:59:59 GMT; SameSite=strict
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=08548d6fc7a3ddf915a5734d8bbaca36; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=2ea07ff7a2dce07f1f5cceb53d519bf7; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc_sessionPassphrase=%2BTiwB1hoNR1qBaSd3FwP3e%2B0N464jtcL5rxrmOMJTzaBr8drLsmiOQqc71VAjy8MzFtYPaP7HvvITNQnimloRoMLnSCTMo%2FSPllXUQ6oIy9%2BT0zu%2BtXQ1rv5mWg%2F6Oyl;
-        path=/html; secure; HttpOnly; SameSite=Lax
+      - __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict
+      - oc_sessionPassphrase=ZUGkvN6AtRd3BMd9WNLyNUlbyLsJl7lrAbm8b3bQh9fLnDZpObjSBgEKxxuLTP%2BOSYpi5LBdL1rsvMcLCH3l2cuWWaoJzBtM6UQP6qwRIi44%2BCR4Co%2BWJ3XntkwW2thI;
+        path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=7e810689e8d2f5d3afc1b95304ecbaa5; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=8f0dd038af1514461c89134f5fbf5d50; path=/; secure; HttpOnly; SameSite=Lax
       Vary:
       - Brief,Prefer
       X-Content-Type-Options:
       - nosniff
       X-Debug-Token:
-      - ABf8Ml48dBqqobMTI5Jy
+      - bWE99kGYKlvLkfbLzVa5
       X-Frame-Options:
       - SAMEORIGIN
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.8
+      - PHP/8.2.13
       X-Request-Id:
-      - ABf8Ml48dBqqobMTI5Jy
+      - bWE99kGYKlvLkfbLzVa5
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
@@ -103,6 +93,6 @@ http_interactions:
       encoding: UTF-8
       string: |
         <?xml version="1.0"?>
-        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/</d:href><d:propstat><d:prop><oc:fileid>737</oc:fileid><oc:size>35</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:39:58 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/request_001.md</d:href><d:propstat><d:prop><oc:fileid>738</oc:fileid><oc:size>16</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:39:34 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/New%20Requests/request_002.md</d:href><d:propstat><d:prop><oc:fileid>740</oc:fileid><oc:size>19</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:39:58 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
-  recorded_at: Tue, 28 Nov 2023 14:42:47 GMT
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/admin/Folder%20with%20spaces/New%20Requests/</d:href><d:propstat><d:prop><oc:fileid>180</oc:fileid><oc:size>74</oc:size><d:getlastmodified>Wed, 29 Nov 2023 15:42:21 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Folder%20with%20spaces/New%20Requests/request_001.md</d:href><d:propstat><d:prop><oc:fileid>181</oc:fileid><oc:size>48</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Wed, 29 Nov 2023 15:35:25 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Folder%20with%20spaces/New%20Requests/request_002.md</d:href><d:propstat><d:prop><oc:fileid>182</oc:fileid><oc:size>26</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Wed, 29 Nov 2023 15:35:34 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Wed, 29 Nov 2023 15:45:31 GMT
 recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_root.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: propfind
+    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <oc:permissions/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Depth:
+      - '1'
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Length:
+      - '5136'
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Tue, 28 Nov 2023 14:30:34 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.56 (Debian)
+      Set-Cookie:
+      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=lax
+      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+        23:59:59 GMT; SameSite=strict
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc832qmuhv8d=603e568193fcac992537f468ef89f5d0; path=/html; secure; HttpOnly;
+        SameSite=Lax
+      - oc_sessionPassphrase=6sF77FqHYcr0DbdX0yYf%2BdyhYPR4uUw0mDTpX1znBTIPuynjhNLc9ALsrVthjvvEzyIOWJAsVb6tFifGTPIPxhhJH3yCEQkd%2FXEdRobmTpuKxRxa6HCtXYabSh9sfWcs;
+        path=/html; secure; HttpOnly; SameSite=Lax
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - GJwtlCYkKBZ23cIsoJsa
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.8
+      X-Request-Id:
+      - GJwtlCYkKBZ23cIsoJsa
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/</d:href><d:propstat><d:prop><oc:fileid>2</oc:fileid><oc:size>192581767</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:29:59 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/</d:href><d:propstat><d:prop><oc:fileid>45</oc:fileid><oc:size>1107988</oc:size><d:getlastmodified>Mon, 16 Oct 2023 13:26:30 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud%20intro.mp4</d:href><d:propstat><d:prop><oc:fileid>43</oc:fileid><oc:size>3963036</oc:size><d:getcontenttype>video/mp4</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud%20Manual.pdf</d:href><d:propstat><d:prop><oc:fileid>50</oc:fileid><oc:size>15181180</oc:size><d:getcontenttype>application/pdf</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud.png</d:href><d:propstat><d:prop><oc:fileid>51</oc:fileid><oc:size>50598</oc:size><d:getcontenttype>image/png</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Photos/</d:href><d:propstat><d:prop><oc:fileid>33</oc:fileid><oc:size>5656463</oc:size><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Readme.md</d:href><d:propstat><d:prop><oc:fileid>713</oc:fileid><oc:size>554</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:29:59 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Reasons%20to%20use%20Nextcloud.pdf</d:href><d:propstat><d:prop><oc:fileid>52</oc:fileid><oc:size>976625</oc:size><d:getcontenttype>application/pdf</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Templates/</d:href><d:propstat><d:prop><oc:fileid>7</oc:fileid><oc:size>10721152</oc:size><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Templates%20credits.md</d:href><d:propstat><d:prop><oc:fileid>44</oc:fileid><oc:size>2403</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/OpenProject/</d:href><d:propstat><d:prop><oc:fileid>174</oc:fileid><oc:size>154921768</oc:size><d:getlastmodified>Tue, 07 Nov 2023 13:38:22 GMT</d:getlastmodified><oc:permissions>MG</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Tue, 28 Nov 2023 14:30:34 GMT
+recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_query_root.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: propfind
-    uri: https://nextcloud-sub.local/html/remote.php/dav/files/admin/
+    uri: https://nextcloud.local/remote.php/dav/files/admin/
     body:
       encoding: UTF-8
       string: |
@@ -36,13 +36,13 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache, must-revalidate
       Content-Length:
-      - '5136'
+      - '2453'
       Content-Security-Policy:
       - default-src 'none';
       Content-Type:
       - application/xml; charset=utf-8
       Date:
-      - Tue, 28 Nov 2023 14:30:34 GMT
+      - Wed, 29 Nov 2023 15:45:31 GMT
       Dav:
       - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
         nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
@@ -53,48 +53,38 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.56 (Debian)
+      - Apache/2.4.57 (Debian)
       Set-Cookie:
-      - nc_sameSiteCookielax=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
+      - __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100
         23:59:59 GMT; SameSite=lax
-      - nc_sameSiteCookiestrict=true; path=/html; httponly;secure; expires=Fri, 31-Dec-2100
-        23:59:59 GMT; SameSite=strict
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=35ba41621a0306dce7c58ce4596df4ff; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc832qmuhv8d=603e568193fcac992537f468ef89f5d0; path=/html; secure; HttpOnly;
-        SameSite=Lax
-      - oc_sessionPassphrase=6sF77FqHYcr0DbdX0yYf%2BdyhYPR4uUw0mDTpX1znBTIPuynjhNLc9ALsrVthjvvEzyIOWJAsVb6tFifGTPIPxhhJH3yCEQkd%2FXEdRobmTpuKxRxa6HCtXYabSh9sfWcs;
-        path=/html; secure; HttpOnly; SameSite=Lax
+      - __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict
+      - oc_sessionPassphrase=GbRpWHnYMah5MsH1g4BlOE84L%2BO6UTAjmpWwjYhUXRZb%2Bj28Odo72%2Bw9sOzYxfHX8eHk3Ym5PAD9Upai2RuXrhdGPZt7nb5MQdrX4LEUZzAlpT7eaR5QWQPeYVeSQmym;
+        path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=122d05aec559552ba065da6d97dac314; path=/; secure; HttpOnly; SameSite=Lax
+      - ocirabgzify6=dbc8dc90dbf91d3af72e31d7fe2c39d6; path=/; secure; HttpOnly; SameSite=Lax
       Vary:
       - Brief,Prefer
       X-Content-Type-Options:
       - nosniff
       X-Debug-Token:
-      - GJwtlCYkKBZ23cIsoJsa
+      - xYiM1mg2MIoYdIaOxFHf
       X-Frame-Options:
       - SAMEORIGIN
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.8
+      - PHP/8.2.13
       X-Request-Id:
-      - GJwtlCYkKBZ23cIsoJsa
+      - xYiM1mg2MIoYdIaOxFHf
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
@@ -103,6 +93,6 @@ http_interactions:
       encoding: UTF-8
       string: |
         <?xml version="1.0"?>
-        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/html/remote.php/dav/files/admin/</d:href><d:propstat><d:prop><oc:fileid>2</oc:fileid><oc:size>192581767</oc:size><d:getlastmodified>Tue, 28 Nov 2023 14:29:59 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Documents/</d:href><d:propstat><d:prop><oc:fileid>45</oc:fileid><oc:size>1107988</oc:size><d:getlastmodified>Mon, 16 Oct 2023 13:26:30 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud%20intro.mp4</d:href><d:propstat><d:prop><oc:fileid>43</oc:fileid><oc:size>3963036</oc:size><d:getcontenttype>video/mp4</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud%20Manual.pdf</d:href><d:propstat><d:prop><oc:fileid>50</oc:fileid><oc:size>15181180</oc:size><d:getcontenttype>application/pdf</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Nextcloud.png</d:href><d:propstat><d:prop><oc:fileid>51</oc:fileid><oc:size>50598</oc:size><d:getcontenttype>image/png</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Photos/</d:href><d:propstat><d:prop><oc:fileid>33</oc:fileid><oc:size>5656463</oc:size><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Readme.md</d:href><d:propstat><d:prop><oc:fileid>713</oc:fileid><oc:size>554</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Tue, 28 Nov 2023 14:29:59 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Reasons%20to%20use%20Nextcloud.pdf</d:href><d:propstat><d:prop><oc:fileid>52</oc:fileid><oc:size>976625</oc:size><d:getcontenttype>application/pdf</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Templates/</d:href><d:propstat><d:prop><oc:fileid>7</oc:fileid><oc:size>10721152</oc:size><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/Templates%20credits.md</d:href><d:propstat><d:prop><oc:fileid>44</oc:fileid><oc:size>2403</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Thu, 27 Jul 2023 13:30:24 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/html/remote.php/dav/files/admin/OpenProject/</d:href><d:propstat><d:prop><oc:fileid>174</oc:fileid><oc:size>154921768</oc:size><d:getlastmodified>Tue, 07 Nov 2023 13:38:22 GMT</d:getlastmodified><oc:permissions>MG</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
-  recorded_at: Tue, 28 Nov 2023 14:30:34 GMT
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/admin/</d:href><d:propstat><d:prop><oc:fileid>2</oc:fileid><oc:size>1137306515</oc:size><d:getlastmodified>Wed, 29 Nov 2023 15:42:21 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Folder/</d:href><d:propstat><d:prop><oc:fileid>172</oc:fileid><oc:size>982713473</oc:size><d:getlastmodified>Wed, 29 Nov 2023 15:31:30 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Folder%20with%20spaces/</d:href><d:propstat><d:prop><oc:fileid>173</oc:fileid><oc:size>74</oc:size><d:getlastmodified>Wed, 29 Nov 2023 15:42:21 GMT</d:getlastmodified><oc:permissions>RGDNVCK</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Practical_guide_to_BAGGM_Digital.pdf</d:href><d:propstat><d:prop><oc:fileid>211</oc:fileid><oc:size>154592937</oc:size><d:getcontenttype>application/pdf</d:getcontenttype><d:getlastmodified>Tue, 09 Aug 2022 06:53:12 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/files/admin/Readme.md</d:href><d:propstat><d:prop><oc:fileid>178</oc:fileid><oc:size>31</oc:size><d:getcontenttype>text/markdown</d:getcontenttype><d:getlastmodified>Wed, 29 Nov 2023 15:29:16 GMT</d:getlastmodified><oc:permissions>RGDNVW</oc:permissions><oc:owner-display-name>admin</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Wed, 29 Nov 2023 15:45:31 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
### WAT?

- refactored files query spec for nextcloud query to use VCR cassettes
- some small adjustments of production code to satisfy common interface
  - root entity has now name `Root` in both queries, and no longer `/` in nextcloud
  - error data contains now source in payload for files query of nextcloud

### But ... WHY?

- because VCR is the much more awesome test setup