### PR TITLE
Fix hcaptcha usage and provide as a setting

### DIFF
--- a/modules/recaptcha/app/controllers/recaptcha/admin_controller.rb
+++ b/modules/recaptcha/app/controllers/recaptcha/admin_controller.rb
@@ -32,7 +32,7 @@ module ::Recaptcha
     end
 
     def permitted_params
-      params.permit(:recaptcha_type, :website_key, :secret_key)
+      params.permit(:recaptcha_type, :website_key, :secret_key, :response_limit)
     end
 
     def default_breadcrumb

--- a/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
+++ b/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
@@ -20,10 +20,17 @@ module ::Recaptcha
     # Skip if user has confirmed already
     before_action :skip_if_user_verified
 
+    # Ensure we set the correct configuration for rendering/verifying the captcha
+    around_action :set_captcha_settings
+
     ##
     # Request verification form
     def perform
-      use_content_security_policy_named_append(:recaptcha)
+      if OpenProject::Recaptcha::Configuration.use_hcaptcha?
+        use_content_security_policy_named_append(:hcaptcha)
+      else
+        use_content_security_policy_named_append(:recaptcha)
+      end
     end
 
     def verify
@@ -37,6 +44,16 @@ module ::Recaptcha
 
     private
 
+    def set_captcha_settings(&block)
+      if OpenProject::Recaptcha::Configuration.use_hcaptcha?
+        Recaptcha.with_configuration(verify_url: OpenProject::Recaptcha.hcaptcha_verify_url,
+                                     api_server_url: OpenProject::Recaptcha.hcaptcha_api_server_url,
+                                     &block)
+      else
+        block.call
+      end
+    end
+
     ##
     # Insert that the account was verified
     def save_recaptcha_verification_success!
@@ -49,7 +66,7 @@ module ::Recaptcha
       case recaptcha_settings['recaptcha_type']
       when ::OpenProject::Recaptcha::TYPE_DISABLED
         0
-      when ::OpenProject::Recaptcha::TYPE_V2
+      when ::OpenProject::Recaptcha::TYPE_V2, ::OpenProject::Recaptcha::TYPE_HCAPTCHA
         2
       when ::OpenProject::Recaptcha::TYPE_V3
         3

--- a/modules/recaptcha/app/helpers/recaptcha_helper.rb
+++ b/modules/recaptcha/app/helpers/recaptcha_helper.rb
@@ -3,7 +3,8 @@ module RecaptchaHelper
     [
       [I18n.t('recaptcha.settings.type_disabled'), ::OpenProject::Recaptcha::TYPE_DISABLED],
       [I18n.t('recaptcha.settings.type_v2'), ::OpenProject::Recaptcha::TYPE_V2],
-      [I18n.t('recaptcha.settings.type_v3'), ::OpenProject::Recaptcha::TYPE_V3]
+      [I18n.t('recaptcha.settings.type_v3'), ::OpenProject::Recaptcha::TYPE_V3],
+      [I18n.t('recaptcha.settings.type_hcaptcha'), ::OpenProject::Recaptcha::TYPE_HCAPTCHA]
     ]
   end
 

--- a/modules/recaptcha/app/views/recaptcha/admin/show.html.erb
+++ b/modules/recaptcha/app/views/recaptcha/admin/show.html.erb
@@ -17,6 +17,7 @@
         </div>
         <div class="form--field-instructions">
           <%= I18n.t('recaptcha.settings.recaptcha_description_html',
+                     hcaptcha_link: link_to('https://docs.hcaptcha.com/switch/', 'https://docs.hcaptcha.com/switch/', target: '_blan'),
                      recaptcha_link: link_to('https://www.google.com/recaptcha', 'https://www.google.com/recaptcha', target: '_blank')).html_safe %>
         </div>
       </div>
@@ -38,6 +39,16 @@
         </div>
         <div class="form--field-instructions">
           <%= I18n.t('recaptcha.settings.secret_key_text') %>
+        </div>
+      </div>
+      <div class="form--field">
+        <label class="form--label" for='secret_key'><%= t('recaptcha.settings.response_limit') %></label>
+        <div class="form--field-container">
+          <%= styled_text_field_tag 'response_limit',
+                                    Setting.plugin_openproject_recaptcha['response_limit'] %>
+        </div>
+        <div class="form--field-instructions">
+          <%= I18n.t('recaptcha.settings.response_limit_text') %>
         </div>
       </div>
     </fieldset>

--- a/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
+++ b/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
@@ -3,13 +3,13 @@
 <div id="login-form" class="form -bordered">
   <%= styled_form_tag({ action: :verify }, { :autocomplete => "off", :id => 'submit_captcha' }) do %>
     <h2><%= t 'recaptcha.verify_account' %></h2>
-    <% if recaptcha_settings['recaptcha_type'] == ::OpenProject::Recaptcha::TYPE_V2 %>
+    <% if [OpenProject::Recaptcha::TYPE_V2, OpenProject::Recaptcha::TYPE_HCAPTCHA].include?(recaptcha_settings['recaptcha_type']) %>
       <% input_name = "g-recaptcha-response" %>
       <input type="hidden" name="<%= input_name %>" />
       <%= recaptcha_tags(
         nonce: content_security_policy_script_nonce,
         callback: 'submitRecaptchaForm',
-        site_key: recaptcha_settings['website_key']
+        site_key: recaptcha_settings['website_key'],
       ) %>
 
       <%= nonced_javascript_tag do %>

--- a/modules/recaptcha/config/initializers/recaptcha.rb
+++ b/modules/recaptcha/config/initializers/recaptcha.rb
@@ -1,10 +1,3 @@
-Recaptcha.configure do |config|
-  # site_key and secret_key are defined via ENV already (RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY)
-
-  config.verify_url = OpenProject::Recaptcha.verify_url_override || config.verify_url
-  config.api_server_url = OpenProject::Recaptcha.api_server_url_override || config.api_server_url
-end
-
 module RecaptchaLimitOverride
   def invalid_response?(resp)
     return super unless OpenProject::Recaptcha::use_hcaptcha?

--- a/modules/recaptcha/config/locales/en.yml
+++ b/modules/recaptcha/config/locales/en.yml
@@ -10,6 +10,8 @@ en:
     error_captcha: "Your account could not be verified. Please contact an administrator."
     settings:
       website_key: 'Website key'
+      response_limit: 'Response limit for HCaptcha'
+      response_limit_text: 'The maximum number of characters to treat the HCaptcha response as valid.'
       website_key_text: 'Enter the website key you created on the reCAPTCHA admin console for this domain.'
       secret_key: 'Secret key'
       secret_key_text: 'Enter the secret key you created on the reCAPTCHA admin console.'
@@ -17,9 +19,13 @@ en:
       type_disabled: 'Disable reCAPTCHA'
       type_v2: 'reCAPTCHA v2'
       type_v3: 'reCAPTCHA v3'
+      type_hcaptcha: 'HCaptcha'
       recaptcha_description_html: >
         reCAPTCHA is a free service by Google that can be enabled for your OpenProject instance.
         If enabled, a captcha form will be rendered upon login for all users that have not verified a captcha yet.
         <br/>
         Please see the following link for more details on reCAPTCHA and their versions, and how
         to create the website and secret keys: %{recaptcha_link}
+        <br/>
+        HCaptcha is a Google-free alternative that you can use if you do not want to use reCAPTCHA.
+        See this link for more information: %{hcaptcha_link}

--- a/modules/recaptcha/lib/open_project/recaptcha.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha.rb
@@ -3,6 +3,7 @@ module OpenProject
     TYPE_DISABLED ||= 'disabled'
     TYPE_V2 ||= 'v2'
     TYPE_V3 ||= 'v3'
+    TYPE_HCAPTCHA ||= 'hcaptcha'
 
     require "open_project/recaptcha/engine"
     require "open_project/recaptcha/configuration"

--- a/modules/recaptcha/lib/open_project/recaptcha/configuration.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha/configuration.rb
@@ -5,20 +5,20 @@ module OpenProject
 
       extend self
 
+      def enabled?
+        type.present? && type != ::OpenProject::Recaptcha::TYPE_DISABLED
+      end
+
       def use_hcaptcha?
-        OpenProject::Configuration[CONFIG_KEY]
+        type == ::OpenProject::Recaptcha::TYPE_HCAPTCHA
+      end
+
+      def type
+        @type ||= ::Setting.plugin_openproject_recaptcha['recaptcha_type']
       end
 
       def hcaptcha_response_limit
-        @hcaptcha_response_limit ||= (ENV["RECAPTCHA_RESPONSE_LIMIT"].presence || 5000).to_i
-      end
-
-      def api_server_url_override
-        ENV["RECAPTCHA_API_SERVER_URL"].presence || ((use_hcaptcha? || nil) && hcaptcha_api_server_url)
-      end
-
-      def verify_url_override
-        ENV["RECAPTCHA_VERIFY_URL"].presence || ((use_hcaptcha? || nil) && hcaptcha_verify_url)
+        (::Setting.plugin_openproject_recaptcha['response_limit'] || '5000').to_i
       end
 
       def hcaptcha_verify_url

--- a/modules/recaptcha/lib/open_project/recaptcha/engine.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha/engine.rb
@@ -11,7 +11,8 @@ module OpenProject::Recaptcha
              author_url: 'https://www.openproject.org',
              settings: {
                default: {
-                 recaptcha_type: ::OpenProject::Recaptcha::TYPE_DISABLED
+                 recaptcha_type: ::OpenProject::Recaptcha::TYPE_DISABLED,
+                 response_limit: 5000,
                }
              },
              bundled: true do
@@ -28,27 +29,23 @@ module OpenProject::Recaptcha
 
     config.after_initialize do
       SecureHeaders::Configuration.named_append(:recaptcha) do
-        if OpenProject::Recaptcha.use_hcaptcha?
-          value = %w(https://*.hcaptcha.com)
-          keys = %i(frame_src script_src style_src connect_src)
+        {
+          frame_src: %w[https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/]
+        }
+      end
 
-          keys.index_with value
-        else
-          {
-            frame_src: %w[https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/]
-          }
-        end
+      SecureHeaders::Configuration.named_append(:hcaptcha) do
+        value = %w(https://*.hcaptcha.com)
+        keys = %i(frame_src script_src style_src connect_src)
+
+        keys.index_with value
       end
 
       OpenProject::Authentication::Stage.register(
         :recaptcha,
         nil,
         run_after_activation: true,
-        active: -> {
-          type = Setting.plugin_openproject_recaptcha['recaptcha_type']
-
-          type.present? && type.to_s != ::OpenProject::Recaptcha::TYPE_DISABLED
-        }
+        active: -> { OpenProject::Recaptcha.enabled? }
       ) do
         recaptcha_request_path
       end


### PR DESCRIPTION
HCaptcha was only available as an env, but the configuration was not clear. We can provide it as a setting instead to ensure it gets used.