### PR TITLE
[#51275] Fix Primer checkboxes lacking a background in High Contrast Mode  

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -4,7 +4,6 @@
   [data-color-mode] {
       --body-background: var(--color-canvas-default);
       --body-font-color: var(--color-fg-default);
-      --color-accent-fg: var(--content-link-color) !important;
   }
   [data-light-theme=light_high_contrast]{
     --avatar-border-color: var(--color-avatar-border);

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -5,6 +5,11 @@
       --body-background: var(--color-canvas-default);
       --body-font-color: var(--color-fg-default);
   }
+  /* Override Primer variable to ensure compatibility with currently
+     configured design outside of high contrast mode  */
+  [data-color-mode]:not([data-light-theme=light_high_contrast]) {
+    --color-accent-fg: var(--content-link-color) !important;
+  }
   [data-light-theme=light_high_contrast]{
     --avatar-border-color: var(--color-avatar-border);
     --list-item-hover--border-color: var(--color-action-list-item-default-active-border);


### PR DESCRIPTION
## Description
This was setting Primer's CSS variable to one of our variables. As a side effect, this fix is two fold:

1. Sets the right background color on checkboxes in High Contrast Mode.
2. Sets Links to the default color as indicated in the Primer Lookbook while in High Contrast Mode.

## Notes
I'm a bit torn on whether the links should be black or blue while in High Contrast Mode. According to the Primer Lookbook, links have the following schemes while in High Contrast Mode:

<img width="558" alt="Primer color schemes for links" src="https://github.com/opf/openproject/assets/61627014/6cb179ab-5005-4003-a326-2a8df1056465">

I had a talk with @bsatarnejad about this and the black color on links seems to be intentional. This would mean that the "primary" style might be the desired scheme to use by default. I see the default is intended to be blue according to the lookbook.

See: https://community.openproject.org/work_packages/51275