### PR TITLE
Stabilize the Custom Actions Feature Spec

### DIFF
--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -85,21 +85,11 @@ module Pages
         end
 
         def set_condition(name, value)
-          page.within('#custom-actions-form--conditions') do
-            page.find_field(name)
-          end
-
           Array(value).each do |val|
+            set_condition_value(name, val)
+
             within '#custom-actions-form--conditions' do
-              fill_in name, with: val
-            end
-
-            retry_block do
-              find('.ng-option', wait: 5, text: val).click
-
-              within '#custom-actions-form--conditions' do
-                expect_selected_option val
-              end
+              expect_selected_option val
             end
           end
         end
@@ -109,6 +99,16 @@ module Pages
         def set_action_value(name, value)
           field = find('#custom-actions-form--active-actions .form--field', text: name, wait: 5)
 
+          set_field_value(field, name, value)
+        end
+
+        def set_condition_value(name, value)
+          field = find('#custom-actions-form--conditions .form--field', text: name, wait: 5)
+
+          set_field_value(field, name, value)
+        end
+
+        def set_field_value(field, name, value)
           autocomplete = false
 
           Array(value).each do |val|


### PR DESCRIPTION
Adding the action doesn't seem to be flaky as it's treated like an ng-select autocomplete. When inspecting the failing screenshots on the CI, it seems that the value on the project condition is not even set:

![CI failure screenshot](https://github.com/opf/openproject/assets/61627014/cc8360a4-b3b5-4b06-9619-3e0fa4493b66)


This tells me that there's probably a timing issue with ng-select that a simple `fill_in :x, with: x` doesn't handle too well. However, I haven't seen a single failure on the prior step which uses the autocomplete logic for filling up the form field.

I'm giving this a try to see if just treating it like another ng-select autocomplete stabilizes the spec.