### PR TITLE
Retry until ng-select is ready to accept events in `custom_actions_spec.rb`

### DIFF
--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -316,15 +316,24 @@ RSpec.describe 'Custom actions', :js, :with_cuprite,
 
     wp_page.click_custom_action('Unassign')
     wp_page.expect_attributes assignee: '-'
+    within '.work-package-details-activities-list' do
+      expect(page)
+        .to have_css('.op-user-activity .op-user-activity--user-name',
+                     text: user.name,
+                     wait: 10)
+    end
 
     wp_page.click_custom_action('Escalate')
     wp_page.expect_attributes priority: immediate_priority.name,
                               status: default_status.name,
                               assignee: '-',
                               "customField#{list_custom_field.id}" => selected_list_custom_field_options.map(&:name).join("\n")
-
-    expect(page)
-      .to have_css('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name, wait: 10)
+    within '.work-package-details-activities-list' do
+      expect(page)
+        .to have_css('.op-user-activity a.user-mention',
+                     text: other_member_user.name,
+                     wait: 10)
+    end
 
     wp_page.click_custom_action('Close')
     wp_page.expect_attributes status: closed_status.name,

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -86,10 +86,12 @@ module Pages
 
         def set_condition(name, value)
           Array(value).each do |val|
-            set_condition_value(name, val)
+            retry_block do
+              set_condition_value(name, val)
 
-            within '#custom-actions-form--conditions' do
-              expect_selected_option val
+              within '#custom-actions-form--conditions' do
+                expect_selected_option val
+              end
             end
           end
         end


### PR DESCRIPTION
It seems that  ng-select is not ready to receive events for some reason. I'm unaware of a way to expect it to be ready to receive events other attempting to set the value on the conditions multiple times.

Because the problem doesn't seem to be in finding the dropdown item to click on in the autocompleter but in the expectation for the the value to ACTUALLY be set, retrying on this sequence seems the way to go.

I did a bulk run while under 96% CPU usage with all passing.

This seems to be it! 🍾


```shell
-> % RSPEC_RETRY_COUNT=2 script/bulk_run_rspec ./spec/features/work_packages/custom_actions/custom_actions_spec.rb:137
1 tests to run
================================================================================
Running ./spec/features/work_packages/custom_actions/custom_actions_spec.rb:137 5 times
================================================================================
------------------------------------ Run 0 -------------------------------------
ok
------------------------------------ Run 1 -------------------------------------
ok
------------------------------------ Run 2 -------------------------------------
ok
------------------------------------ Run 3 -------------------------------------
ok
------------------------------------ Run 4 -------------------------------------
ok
PASSED
```