### PR TITLE
[#51277] Use system argument to specify `ul` id in `Primer::Beta::BorderBox`es

### DIFF
--- a/app/components/op_primer/component_helpers.rb
+++ b/app/components/op_primer/component_helpers.rb
@@ -44,21 +44,6 @@ module OpPrimer
       render(OpPrimer::ComponentCollectionComponent.new(**), &)
     end
 
-    # There is currently no available system argument for setting an id on the
-    # rendered <ul> tag that houses the row slots on Primer::Beta::BorderBox components.
-    # Setting an id is required to be able to uniquely identify a target for
-    # TurboStream +insert+ actions and being able to prepend and append to it.
-    def border_box_with_id(id, **, &)
-      border_box = Primer::Beta::BorderBox.new(**)
-
-      new_list_arguments = border_box.instance_variable_get(:@list_arguments)
-                                     .merge(id:)
-
-      border_box.instance_variable_set(:@list_arguments, new_list_arguments)
-
-      render(border_box, &)
-    end
-
     def border_box_row(wrapper_arguments, &)
       if container
         container.with_row(**wrapper_arguments, &)

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -24,7 +24,7 @@
                                data: { 'test-selector': 'op-share-wp-active-list',
                                        controller: 'work-packages--share--bulk-selection',
                                        application_target: 'dynamic' }) do
-          border_box_with_id(insert_target_modifier_id) do |border_box|
+          render(Primer::Beta::BorderBox.new(list_id: insert_target_modifier_id)) do |border_box|
             border_box.with_header(color: :muted, data: { 'test-selector': 'op-share-wp-header' }) do
               grid_layout('op-share-wp-modal-body--header', tag: :div, align_items: :center) do |header_grid|
                 header_grid.with_area(:counter, tag: :div) do


### PR DESCRIPTION
## Description
Applying the new system argument added in https://github.com/opf/primer_view_components/pull/57

## Notes
See: https://community.openproject.org/work_packages/51277
