### PR TITLE
[#51279] Fix breadcrumb for editing custom fields is missing

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -28,9 +28,8 @@
 
 module BreadcrumbHelper
   def full_breadcrumbs
-    items = breadcrumb_paths.compact
-    render(Primer::Beta::Breadcrumbs.new(test_selector: "op-breadcrumb" )) do |breadcrumbs|
-      items.each_with_index do |item, index|
+    render(Primer::Beta::Breadcrumbs.new(test_selector: "op-breadcrumb")) do |breadcrumbs|
+      breadcrumb_paths.each_with_index do |item, index|
         item = anchor_string_to_object(item) if item.is_a?(String) && item.start_with?("\u003c")
 
         if item.is_a?(Hash)
@@ -47,7 +46,7 @@ module BreadcrumbHelper
       @breadcrumb_paths ||= [default_breadcrumb]
     else
       @breadcrumb_paths ||= []
-      @breadcrumb_paths += args
+      @breadcrumb_paths += args.flatten.compact
     end
   end
 

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -152,6 +152,18 @@ RSpec.describe 'custom fields', js: true, with_cuprite: true do
         label_min_length, label_max_length, label_regexp,
         label_possible_values, label_default_value)
     end
+
+    it "shows the correct breadcrumbs" do
+      cf_page.visit_tab type
+
+      click_on "Create a new custom field"
+      wait_for_reload
+
+      page.within_test_selector('op-breadcrumb') do
+        expect(page).to have_selector('.breadcrumb-item', text: type)
+        expect(page).to have_selector('.breadcrumb-item.breadcrumb-item-selected', text:  "New custom field")
+      end
+    end
   end
 
   describe 'projects' do
@@ -245,6 +257,13 @@ RSpec.describe 'custom fields', js: true, with_cuprite: true do
       expect(page).to have_field("custom_field_custom_options_attributes_1_default_value", checked: true)
       expect(page).to have_field("custom_field_custom_options_attributes_2_default_value", checked: false)
       expect(page).to have_field("custom_field_custom_options_attributes_3_default_value", checked: true)
+    end
+
+    it "shows the correct breadcrumbs" do
+      page.within_test_selector('op-breadcrumb') do
+        expect(page).to have_selector('.breadcrumb-item', text: "Work packages")
+        expect(page).to have_selector('.breadcrumb-item.breadcrumb-item-selected', text:  "Platform")
+      end
     end
 
     context "with work packages using the options" do


### PR DESCRIPTION
##### Related Work Package: [OP#51279](https://community.openproject.org/projects/openproject/work_packages/51279)

### Cause
In edit custom fields `local_assigns[:additional_breadcrumb]` is an array of elements.

The new BreadcrumbHelper implementation was not taking care of that use case.

### Solution
To solve this I added a flatten in the `breadcrumb_paths` method.

### Notes
At the same time I moved the `compact` from line 31 to 49 to clean up the code

