### PR TITLE
[#51319] hide edit action for one drive storages

### DIFF
--- a/modules/storages/app/components/storages/project_storages/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/row_component.rb
@@ -50,11 +50,11 @@ module Storages::ProjectStorages
     end
 
     def button_links
-      [edit_link, delete_link].tap do |links|
-        if project_storage.project_folder_automatic?
-          links.unshift members_connection_status_link
-        end
-      end
+      links = [delete_link]
+      links.prepend(edit_link) if project_storage.storage.provider_type_nextcloud?
+      links.prepend(members_connection_status_link) if project_storage.project_folder_automatic?
+
+      links
     end
 
     def members_connection_status_link


### PR DESCRIPTION
[OP#51319](https://community.openproject.org/wp/51319)

### Wat???

- edit action (pencil) is only shown for nextcloud