### PR TITLE
[50019] Fix untranslated 2fa strategies

### DIFF
--- a/app/views/oauth/applications/show.html.erb
+++ b/app/views/oauth/applications/show.html.erb
@@ -91,7 +91,7 @@ See COPYRIGHT and LICENSE files for more details.
 
   <% component.with_attribute(
     key: @application.class.human_attribute_name(:redirect_uri),
-    value: safe_join(@application.redirect_uri.split("\n"), '<br/>'.html_safe)
+    value: safe_join(@application.redirect_uri.split("\n"), tag(:br))
   ) %>
 
   <% if !@application.client_credentials_user_id %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
@@ -20,11 +20,12 @@
                                  value: if configuration['active_strategies'].empty?
                                           t(:label_none)
                                         else
-                                          configuration['active_strategies'].join(content_tag(:br)) do |key|
+                                          strategies = configuration['active_strategies'].map do |key|
                                             content_tag(:span) do
                                               t("two_factor_authentication.strategies.#{key}")
                                             end
                                           end
+                                          safe_join(strategies, tag(:br))
                                         end)
 
         component.with_attribute(key: t('two_factor_authentication.settings.label_enforced'),

--- a/spec/components/attribute_groups/attribute_key_value_component_spec.rb
+++ b/spec/components/attribute_groups/attribute_key_value_component_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe AttributeGroups::AttributeKeyValueComponent, type: :component do
       have_css('.attributes-key-value--value.-text', text: 'Attribute Value')
   end
 
+  it "preserve html in the value if it's a safe string" do
+    render_inline(described_class.new(key: 'Attribute Key', value: '<div>Some value</div>'.html_safe))
+
+    expect(page).not_to have_css('.attributes-key-value--value.-text', text: "<div>Some value</div>")
+    expect(page).to have_css('.attributes-key-value--value.-text', text: "Some value")
+  end
+
   context 'with value and content' do
     it 'renders the content' do
       render_inline(described_class.new(key: 'Attribute Key', value: 'Attribute Value')) do


### PR DESCRIPTION
https://community.openproject.org/wp/50019

> The `sns<br></br>totp` was not linked to Crowdin Openproject so we cannot translate it.
> Path: Administration -> Authentication -> 2FA settings -> Active 2FA strategies -> `sns<br></br>totp`. What does the `<br></br>` mean here, is it correct?