### PR TITLE
Allow multiple dynamic Stimulus controllers on a single element

### DIFF
--- a/frontend/src/stimulus/controllers/op-application.controller.ts
+++ b/frontend/src/stimulus/controllers/op-application.controller.ts
@@ -7,17 +7,20 @@ export class OpApplicationController extends ApplicationController {
   private loaded = new Set<string>();
 
   dynamicTargetConnected(target:HTMLElement) {
-    const controller = target.dataset.controller as string;
-    const path = this.derivePath(controller);
+    const controllers = (target.dataset.controller as string).split(' ');
 
-    if (!this.loaded.has(controller)) {
-      this.loaded.add(controller);
-      void import(/* webpackChunkName: "[request]" */`./dynamic/${path}.controller`)
-        .then((imported:{ default:ControllerConstructor }) => this.application.register(controller, imported.default))
-        .catch((err:unknown) => {
-          console.error('Failed to load dyanmic controller chunk %O: %O', controller, err);
-        });
-    }
+    controllers.forEach((controller) => {
+      const path = this.derivePath(controller);
+
+      if (!this.loaded.has(controller)) {
+        this.loaded.add(controller);
+        void import(/* webpackChunkName: "[request]" */`./dynamic/${path}.controller`)
+          .then((imported:{ default:ControllerConstructor }) => this.application.register(controller, imported.default))
+          .catch((err:unknown) => {
+            console.error('Failed to load dyanmic controller chunk %O: %O', controller, err);
+          });
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Given the following setup:

```html
<div data-controller="a-controller b-controller"
     data-application-target="dynamic">
  <!-- More HTML -->
</div>
```

We'd run into the following console error:

```
op-application.controller.ts:18 Failed to load dyanmic controller chunk user-limit work-packages--share--user-selected: Error: Cannot find module './user-limit work-packages/share/user-selected.controller'
```

This is because the way the handling for dynamic controllers currently only supports a single controller at a time, causing "a-controller b-controller" to be interpreted as a single Stimulus controller.

My intent with this commit is to be able to have multiple dynamic Stimulus controllers driving an element and therefore "a-controller" AND "b-controller" being loaded as the individual controllers they are.