### PR TITLE
chore[Op#50985]: Remove unused flash for automatic management update

### DIFF
--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -104,7 +104,6 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
     service_result = call_update_service
 
     if service_result.success?
-      flash[:notice] = I18n.t(:notice_successful_update)
       redirect_to edit_admin_settings_storage_path(@storage)
     else
       render '/storages/admin/storages/automatically_managed_project_folders/edit'


### PR DESCRIPTION
#### https://community.openproject.org/wp/50985

Followup to #14213, automatic management is now updated via turbo streams and the state displayed to the user via the labels that change from "incomplete", "inactive" and "active"


https://github.com/opf/openproject/assets/17295175/efd1e1ef-bed2-499e-b099-ae7475a0cc59

