### PR TITLE
[#51174] Update the button labels for the automatically managed form to change based on checkbox active

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/storages/automatically-managed-project-folders-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/automatically-managed-project-folders-form.controller.ts
@@ -33,16 +33,22 @@ import { Controller } from '@hotwired/stimulus';
 export default class AutomaticallyManagedProjectFoldersFormController extends Controller {
   static targets = [
     'applicationPasswordInput',
+    'submitButton',
   ];
 
   static values = {
     isAutomaticallyManaged: Boolean,
+    doneCompleteLabel: String,
+    doneCompleteWithoutLabel: String,
   };
 
   declare readonly applicationPasswordInputTarget:HTMLElement;
+  declare readonly submitButtonTarget:HTMLElement;
   declare readonly hasApplicationPasswordInputTarget:boolean;
 
   declare isAutomaticallyManagedValue:boolean;
+  declare doneCompleteLabelValue:string;
+  declare doneCompleteWithoutLabelValue:string;
 
   connect():void {
     // On first load if isAutomaticallyManaged is true, show the applicationPasswordInput
@@ -60,8 +66,10 @@ export default class AutomaticallyManagedProjectFoldersFormController extends Co
 
     if (displayApplicationPasswordInput) {
       this.applicationPasswordInputTarget.style.display = 'flex';
+      this.submitButtonTarget.textContent = this.doneCompleteLabelValue;
     } else {
       this.applicationPasswordInputTarget.style.display = 'none';
+      this.submitButtonTarget.textContent = this.doneCompleteWithoutLabelValue;
     }
   }
 }

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
@@ -8,6 +8,8 @@
         controller: "storages--automatically-managed-project-folders-form",
         'application-target': "dynamic",
         'storages--automatically-managed-project-folders-form-is-automatically-managed-value': storage.automatically_managed?,
+        'storages--automatically-managed-project-folders-form-done-complete-label-value': I18n.t("storages.buttons.done_complete_setup"),
+        'storages--automatically-managed-project-folders-form-done-complete-without-label-value': I18n.t("storages.buttons.complete_without_setup"),
       }
     ) do |form|
       flex_layout do |project_folders_form|

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
@@ -42,7 +42,8 @@ module Storages::Admin::Forms
     end
 
     def submit_button_options
-      { label: I18n.t("storages.buttons.done_complete_setup") }.tap do |options_hash|
+      { label: I18n.t("storages.buttons.done_complete_setup"),
+        data: { 'storages--automatically-managed-project-folders-form-target': 'submitButton' } }.tap do |options_hash|
         # For create action, break from Turbo Frame and follow full page redirect
         options_hash[:data] = { turbo: false } if new_record?
       end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
       done_continue: "Done, continue"
       done_continue_setup: "Done. Continue setup"
       done_complete_setup: "Done, complete setup"
+      complete_without_setup: "Complete without it"
       edit_automatically_managed_project_folders: "Edit automatically managed project folders"
       replace_openproject_oauth: "Replace OpenProject OAuth"
       replace_provider_type_oauth: "Replace %{provider_type} OAuth"


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/51174

Toggle btn `Done, complete setup` and `Complete without it` based on automatic management checked status


https://github.com/opf/openproject/assets/17295175/2f7b9a9e-0257-4766-8db8-47f21f34fb4e

