### PR TITLE
[#50517] Ensure a user is selected when clicking the "Share" button

### DIFF
--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -1,35 +1,39 @@
 <%=
-  component_wrapper(data: { controller: "user-limit",
-                            'user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
-                            'application-target': "dynamic" }) do
+  component_wrapper do
     if sharing_manageable?
       primer_form_with(
         model: new_share,
-        url: work_package_shares_path(@work_package)
+        url: work_package_shares_path(@work_package),
+        data: { controller: 'user-limit ' \
+                            'work-packages--share--user-selected',
+                'application-target': 'dynamic',
+                'user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
+                action: 'submit->work-packages--share--user-selected#ensureUsersSelected' }
       ) do |form|
         grid_layout('invite-user-form',
-                    tag: :div,
-                    data: { 'user-limit-target': 'inviteUserForm' }) do |invite_form|
+                    tag: :div) do |invite_form|
           invite_form.with_area('invitee') do
             render(WorkPackages::Share::Invitee.new(form))
           end
 
           invite_form.with_area('permission') do
-            render(WorkPackages::Share::PermissionButtonComponent.new(share: new_share,
-                                                                      form_arguments: { builder: form, name: "role_id" },
-                                                                      data: { 'test-selector': 'op-share-wp-invite-role' }))
+            render(WorkPackages::Share::PermissionButtonComponent.new(
+              share: new_share,
+              form_arguments: { builder: form, name: "role_id" },
+              data: { 'test-selector': 'op-share-wp-invite-role' })
+            )
           end
 
           invite_form.with_area('submit') do
-            render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) { I18n.t('work_package.sharing.share') }
+            render(Primer::Beta::Button.new(scheme: :primary, type: :submit)) do
+              I18n.t('work_package.sharing.share')
+            end
           end
 
           if OpenProject::Enterprise.user_limit.present?
-            invite_form.with_area('userLimit',
-                                  data: {
-                                    'user-limit-target': 'limitWarning',
-                                    'test-selector': 'op-share-wp-user-limit'
-                                  },
+            invite_form.with_area('userLimitWarning',
+                                  data: { 'user-limit-target': 'limitWarning',
+                                          'test-selector': 'op-share-wp-user-limit' },
                                   display: :none) do
               flex_layout do |user_limit_row|
                 user_limit_row.with_column(mr: 2) do
@@ -37,8 +41,29 @@
                 end
 
                 user_limit_row.with_column do
-                  render(Primer::Beta::Text.new(color: :danger)) { I18n.t("work_package.sharing.warning_user_limit_reached#{'_admin' if User.current.admin?}",
-                                                                          upgrade_url: OpenProject::Enterprise.upgrade_url).html_safe }
+                  render(Primer::Beta::Text.new(color: :danger)) do
+                    I18n.t(
+                      "work_package.sharing.warning_user_limit_reached#{'_admin' if User.current.admin?}",
+                      upgrade_url: OpenProject::Enterprise.upgrade_url
+                    ).html_safe
+                  end
+                end
+              end
+            end
+          end
+
+          invite_form.with_area('userSelectedWarning',
+                                data: { 'work-packages--share--user-selected-target': 'error',
+                                        'test-selector': 'op-share-wp-no-user-selected' },
+                                display: :none) do
+            flex_layout do |no_selected_user_row|
+              no_selected_user_row.with_column(mr: 2) do
+                render(Primer::Beta::Octicon.new(icon: :'alert-fill', color: :danger))
+              end
+
+              no_selected_user_row.with_column do
+                render(Primer::Beta::Text.new(color: :danger)) do
+                  I18n.t("work_package.sharing.warning_no_selected_user")
                 end
               end
             end

--- a/app/components/work_packages/share/invite_user_form_component.sass
+++ b/app/components/work_packages/share/invite_user_form_component.sass
@@ -1,5 +1,13 @@
 .invite-user-form
   display: grid
   grid-template-columns: 1fr auto auto
-  grid-template-areas: "invitee permission submit" "userLimit userLimit userLimit"
+  grid-template-areas: "invitee permission submit" "userLimitWarning userLimitWarning userLimitWarning" "userSelectedWarning userSelectedWarning userSelectedWarning"
+  //
+  //  There's no multiline tokens support in SASS due to the indentation parsing engine.
+  // For a quick grok of the template areas structure above, here's a diagram:
+  //
+  // invitee             permission          submit
+  // userLimitWarning    userLimitWarning    userLimitWarning
+  // userSelectedWarning userSelectedWarning userSelectedWarning
+  //
   grid-column-gap: 0.5rem

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3282,6 +3282,7 @@ en:
         Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this work package.
       warning_user_limit_reached_admin: >
         Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to ensure external users are able to access this work package.
+      warning_no_selected_user: "Please select users to share this work package with"
       user_details:
         locked: "Locked user"
         invited: "Invite sent. "

--- a/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/user-limit.controller.ts
@@ -36,7 +36,6 @@ import {
 export default class UserLimitController extends Controller {
   static targets = [
     'limitWarning',
-    'inviteUserForm',
   ];
 
   static values = {
@@ -46,40 +45,45 @@ export default class UserLimitController extends Controller {
   };
 
   declare readonly limitWarningTarget:HTMLElement;
-  declare readonly hasLimitWarningTarget:HTMLElement;
-  declare readonly inviteUserFormTarget:HTMLElement;
+  declare readonly hasLimitWarningTarget:boolean;
 
   declare readonly openSeatsValue:number;
-  declare readonly hasOpenSeatsValue:number;
+  declare readonly hasOpenSeatsValue:boolean;
   declare readonly memberAutocompleterValue:boolean;
 
-  private autocompleter:HTMLElement;
   private autocompleterListener = this.triggerLimitWarningIfReached.bind(this);
+  private selectedValues:IUserAutocompleteItem[] = [];
 
   connect() {
-    if (this.memberAutocompleterValue) {
-      this.autocompleter = this.inviteUserFormTarget.querySelector('opce-members-autocompleter') as HTMLElement;
-    } else {
-      this.autocompleter = this.inviteUserFormTarget.querySelector('opce-user-autocompleter') as HTMLElement;
-    }
-
-    this.autocompleter.addEventListener('change', this.autocompleterListener);
+    this.autocompleterElement.addEventListener('change', this.autocompleterListener);
   }
 
   disconnect() {
-    this.autocompleter.removeEventListener('change', this.autocompleterListener);
+    this.autocompleterElement.removeEventListener('change', this.autocompleterListener);
   }
 
   triggerLimitWarningIfReached(evt:CustomEvent) {
-    const values = evt.detail as IUserAutocompleteItem[];
+    this.selectedValues = evt.detail as IUserAutocompleteItem[];
 
     if (this.hasLimitWarningTarget && this.hasOpenSeatsValue) {
-      const numberOfNewUsers = values.filter(({ id }) => typeof (id) === 'string' && id.includes('@')).length;
-      if (numberOfNewUsers > 0 && numberOfNewUsers > this.openSeatsValue) {
+      if (this.numberOfNewUsers > 0 && this.numberOfNewUsers > this.openSeatsValue) {
         this.limitWarningTarget.classList.remove('d-none');
       } else {
         this.limitWarningTarget.classList.add('d-none');
       }
     }
+  }
+
+  // Accessors
+  private get autocompleterElement():HTMLElement {
+    if (this.memberAutocompleterValue) {
+      return this.element.querySelector('opce-members-autocompleter') as HTMLElement;
+    }
+
+    return this.element.querySelector('opce-user-autocompleter') as HTMLElement;
+  }
+
+  private get numberOfNewUsers() {
+    return this.selectedValues.filter(({ id }) => typeof (id) === 'string' && id.includes('@')).length;
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-selected.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/user-selected.controller.ts
@@ -1,0 +1,84 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import {
+  IUserAutocompleteItem,
+} from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
+
+export default class UserSelectedController extends Controller {
+  static targets = [
+    'shareButton',
+    'error',
+  ];
+
+  declare readonly errorTarget:HTMLElement;
+
+  private selectedValues:IUserAutocompleteItem[] = [];
+
+  connect() {
+    this.autocompleterElement.addEventListener('change', this.handleValueSelected.bind(this));
+  }
+
+  disconnect() {
+    this.autocompleterElement.removeEventListener('change', this.handleValueSelected.bind(this));
+  }
+
+  ensureUsersSelected(evt:CustomEvent):void {
+    if (this.selectedValues.length === 0) {
+      evt.preventDefault(); // Don't submit
+      this.showError();
+    } else {
+      this.hideError();
+    }
+  }
+
+  // Private methods
+  handleValueSelected(evt:CustomEvent) {
+    this.selectedValues = evt.detail as IUserAutocompleteItem[];
+
+    if (this.selectedValues.length !== 0) {
+      this.hideError();
+    }
+  }
+
+  private showError() {
+    this.errorTarget.classList.remove('d-none');
+  }
+
+  private hideError() {
+    this.errorTarget.classList.add('d-none');
+  }
+
+  // Accessors
+  private get autocompleterElement():HTMLElement {
+    return this.element.querySelector('opce-user-autocompleter') as HTMLElement;
+  }
+}

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -209,8 +209,6 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_not_shared_with(non_project_user)
       share_modal.expect_not_shared_with(shared_project_group)
 
-      sleep 1
-
       # Additional filter for: project members (users only)
       # role: view
       # type: project members (users only)
@@ -223,8 +221,6 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_not_shared_with(non_project_user)
       share_modal.expect_not_shared_with(shared_project_group)
       share_modal.expect_not_shared_with(shared_non_project_group)
-
-      sleep 1
 
       # Change type filter to: project members (groups only)
       # role: view
@@ -239,8 +235,6 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_not_shared_with(non_project_user)
       share_modal.expect_not_shared_with(shared_project_group)
 
-      sleep 1
-
       # Reset role filter
       # role: none
       # type: non-project members (groups only)
@@ -253,8 +247,6 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_not_shared_with(inherited_project_user)
       share_modal.expect_not_shared_with(non_project_user)
       share_modal.expect_not_shared_with(shared_project_group)
-
-      sleep 1
 
       # Reset type filter
       # role: none

--- a/spec/features/work_packages/share/multi_invite_spec.rb
+++ b/spec/features/work_packages/share/multi_invite_spec.rb
@@ -265,8 +265,6 @@ RSpec.describe 'Work package sharing',
       end
 
       it 'shows a warning as soon as you reach the user limit' do
-	pending 'Spec fails/flickers regularly. Ticket: https://community.openproject.org/work_packages/51185'
-
         share_modal.expect_open
         share_modal.expect_shared_count_of(1)
 

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -252,6 +252,20 @@ RSpec.describe 'Work package sharing',
         share_modal.expect_shared_count_of(7)
       end
     end
+
+    it "lets the sharer know a user needs to be selected to share the work package with them" do
+      work_package_page.visit!
+
+      click_button 'Share'
+
+      share_modal.expect_open
+      share_modal.click_share
+      share_modal.expect_select_a_user_hint
+
+      share_modal.invite_user(not_shared_yet_with_user, 'View')
+      share_modal.expect_shared_with(not_shared_yet_with_user, position: 1)
+      share_modal.expect_no_select_a_user_hint
+    end
   end
 
   context 'when lacking share permission' do

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -240,10 +240,14 @@ module Components
       def filter(filter_name, value)
         within modal_element.find("[data-test-selector='op-share-wp-filter-#{filter_name}']") do
           # Open the ActionMenu
-          click_button filter_name.capitalize
+          retry_block do # Sometimes this is just too fast.
+            click_button filter_name.capitalize
 
-          find('.ActionListContent', text: value).click
+            find('.ActionListContent', text: value).click
+          end
         end
+
+        wait_for_network_idle # Ensures filtering is done
       end
 
       def close

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -34,12 +34,20 @@ module Components
     class ShareModal < Components::Common::Modal
       include Components::Autocompleter::NgSelectAutocompleteHelpers
 
-      attr_reader :work_package
+      attr_reader :work_package, :title
 
       def initialize(work_package)
         super()
 
         @work_package = work_package
+        @title = I18n.t('js.work_packages.sharing.title')
+      end
+
+      def expect_open
+        super
+
+        expect_title(title)
+        wait_for_network_idle(timeout: 10)
       end
 
       def select_shares(*principals)
@@ -352,7 +360,8 @@ module Components
 
       def expect_no_user_limit_warning
         within modal_element do
-          expect(page).not_to have_css('[data-test-selector="op-share-wp-user-limit"]')
+          expect(page)
+            .not_to have_text(I18n.t('work_package.sharing.warning_user_limit_reached'), wait: 0)
         end
       end
 

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -264,6 +264,12 @@ module Components
         end
       end
 
+      def click_share
+        within_modal do
+          click_button 'Share'
+        end
+      end
+
       def expect_shared_with(user, role_name = nil, position: nil, editable: true)
         within_modal do
           expect(page).to have_list_item(text: user.name, position:)
@@ -369,6 +375,20 @@ module Components
         within modal_element do
           expect(page)
             .to have_text(I18n.t('work_package.sharing.warning_user_limit_reached'))
+        end
+      end
+
+      def expect_select_a_user_hint
+        within modal_element do
+          expect(page)
+            .to have_text(I18n.t("work_package.sharing.warning_no_selected_user"))
+        end
+      end
+
+      def expect_no_select_a_user_hint
+        within modal_element do
+          expect(page)
+            .not_to have_text(I18n.t("work_package.sharing.warning_no_selected_user"), wait: 0)
         end
       end
     end


### PR DESCRIPTION
## Description
- Cleans up the `user-limit` Stimulus controller a bit
- Adds Stimulus controller that prevents the `submit` event from going through when no users have been selected in the autocomplete. This ensures that submitting the form via a click or the return key is handled and accessible to keyboard users.
- Provide some feedback as to why the form is not submitting.
- Stabilizes the spec marked as pending in https://community.openproject.org/work_packages/51185
- Adds a spec to ensure the behavior is safeguarded


## Notes
See: https://community.openproject.org/work_packages/50517