### PR TITLE
Bump `test-prof` to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -225,7 +225,7 @@ group :test do
 
   # Test prof provides factories from code
   # and other niceties
-  gem 'test-prof', '~> 1.2.0'
+  gem 'test-prof', '~> 1.3.0'
   gem 'turbo_tests', github: "crohr/turbo_tests", ref: "fix/runtime-info"
 
   gem 'rack_session_access'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -984,7 +984,7 @@ GEM
     sys-filesystem (1.4.4)
       ffi (~> 1.1)
     table_print (1.5.7)
-    test-prof (1.2.3)
+    test-prof (1.3.0)
     text-hyphen (1.5.0)
     thor (1.3.0)
     thread_safe (0.3.6)
@@ -1226,7 +1226,7 @@ DEPENDENCIES
   svg-graph (~> 2.2.0)
   sys-filesystem (~> 1.4.0)
   table_print (~> 1.5.6)
-  test-prof (~> 1.2.0)
+  test-prof (~> 1.3.0)
   timecop (~> 0.9.0)
   turbo-rails (~> 1.1)
   turbo_tests!


### PR DESCRIPTION
Test-prof's changelog: https://github.com/test-prof/test-prof/blob/master/CHANGELOG.md#130-2023-11-21

* Updates Gemfile version specifier to `~> 1.3.0`
* Runs `bundle update test-prof`