### PR TITLE
Bump `rspec-rails` to 6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -231,7 +231,7 @@ group :test do
   gem 'rack_session_access'
   gem 'rspec', '~> 3.12.0'
   # also add to development group, so "spec" rake task gets loaded
-  gem 'rspec-rails', '~> 6.0.0', group: :development
+  gem 'rspec-rails', '~> 6.1.0', group: :development
 
   # Retry failures within the same environment
   gem 'retriable', '~> 3.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -875,7 +875,7 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.4)
+    rspec-rails (6.1.0)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -1197,7 +1197,7 @@ DEPENDENCIES
   roar (~> 1.2.0)
   rouge (~> 4.2.0)
   rspec (~> 3.12.0)
-  rspec-rails (~> 6.0.0)
+  rspec-rails (~> 6.1.0)
   rspec-retry (~> 0.6.1)
   rubocop
   rubocop-inflector


### PR DESCRIPTION
This bumps the gem to a Rails 7.1 compatible version. See https://github.com/rspec/rspec-rails/blob/6-1-maintenance/Changelog.md#610--2023-11-21