### PR TITLE
Bump `factory_bot` gems to `~> 6.4.0`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ gem 'lookbook', '~> 2.1.0'
 # Require factory_bot for usage with openproject plugins testing
 gem 'factory_bot', '~> 6.4.0', require: false
 # require factory_bot_rails for convenience in core development
-gem 'factory_bot_rails', '~> 6.2.0', require: false
+gem 'factory_bot_rails', '~> 6.4.0', require: false
 
 gem 'turbo-rails', "~> 1.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -212,7 +212,7 @@ gem 'view_component'
 gem 'lookbook', '~> 2.1.0'
 
 # Require factory_bot for usage with openproject plugins testing
-gem 'factory_bot', '~> 6.2.0', require: false
+gem 'factory_bot', '~> 6.4.0', require: false
 # require factory_bot_rails for convenience in core development
 gem 'factory_bot_rails', '~> 6.2.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,10 +483,10 @@ GEM
     eventmachine (1.2.7)
     eventmachine_httpserver (0.2.1)
     excon (0.104.0)
-    factory_bot (6.2.1)
+    factory_bot (6.4.2)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.2.0)
-      factory_bot (~> 6.2.0)
+    factory_bot_rails (6.4.2)
+      factory_bot (~> 6.4)
       railties (>= 5.0.0)
     faraday (2.7.11)
       base64
@@ -1100,8 +1100,8 @@ DEPENDENCIES
   erb_lint
   erblint-github
   escape_utils (~> 1.3)
-  factory_bot (~> 6.2.0)
-  factory_bot_rails (~> 6.2.0)
+  factory_bot (~> 6.4.0)
+  factory_bot_rails (~> 6.4.0)
   ffi (~> 1.15)
   flamegraph
   fog-aws


### PR DESCRIPTION
Prepares for Rails 7.1 upgrade. See: https://github.com/thoughtbot/factory_bot_rails/releases/tag/v6.4.2

* Bumps `factory_bot` to `~> 6.4.0`
* Bumps `factory_bot_rails` to `~> 6.4.0`