### PR TITLE
[51375] Fix spacing in relations dropdown

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -60,6 +60,7 @@ export interface IWorkPackageAutocompleteItem extends WorkPackageResource {
 @Component({
   selector: 'wp-relations-autocomplete',
   templateUrl: '../../../../../../shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html',
+  styleUrls: ['../../../../../../shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageRelationsAutocompleteComponent extends OpAutocompleterComponent<IWorkPackageAutocompleteItem> {


### PR DESCRIPTION
https://community.openproject.org/wp/51375

Stylesheet was forgotten when unifying `wp-relations-autocompleter` with `OpAutocompleter` in #14246.