### PR TITLE
[chore] attempt to fix exception in error handling

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -118,6 +118,10 @@ class OAuthClientsController < ApplicationController
   end
 
   def set_oauth_errors(service_result)
+    if service_result.errors.is_a?(::Storages::StorageError)
+      service_result.errors = service_result.errors.to_active_model_errors
+    end
+
     flash[:error] = ["#{t(:'oauth_client.errors.oauth_authorization_code_grant_had_errors')}:"]
     service_result.errors.each do |error|
       flash[:error] << "#{t(:'oauth_client.errors.oauth_reported')}: #{error.full_message}"


### PR DESCRIPTION
Update: this fixes [#51756](https://community.openproject.org/wp/51756)

### Wat?
- oauth controller needs to specifically react to StorageError

### Discussion needed

- The fix here is merely a hack.
- The oauth controller is actually only used by storages code right now, yet it exists outside of the storages namespace.
- This is one of the topics, where we need to be sure, what interface we have. So, right now, we return here a `ServiceResult` with the occasional `StorageError` in the property `errors` of the result (! no array, but a singular error object).

Any suggestions, how we can fix that more gracefully?