### PR TITLE
Improve stability of custom_actions_spec

### DIFF
--- a/docs/api/apiv3/components/examples/date_alert_notification.yml
+++ b/docs/api/apiv3/components/examples/date_alert_notification.yml
@@ -5,8 +5,8 @@ value:
   id: 1
   readIAN: false
   reason: dateAlert
-  createdAt: '2022-04-05T14:38:28Z'
-  updatedAt: '2022-04-06T09:03:24Z'
+  createdAt: '2022-04-05T14:38:28.361Z'
+  updatedAt: '2022-04-06T09:03:24.347Z'
   _embedded:
     project:
       _hint: Project resource shortened for brevity

--- a/docs/api/apiv3/components/examples/grid-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/grid-simple-collection-response.yml
@@ -31,8 +31,8 @@ value:
             endRow: 3
             startColumn: 3
             endColumn: 6
-        createdAt: '2018-12-03T16:58:30Z'
-        updatedAt: '2018-12-13T19:36:40Z'
+        createdAt: '2018-12-03T16:58:30.297Z'
+        updatedAt: '2018-12-13T19:36:40.352Z'
         _links:
           scope:
             href: "/my/page"

--- a/docs/api/apiv3/components/examples/grid-simple-response.yml
+++ b/docs/api/apiv3/components/examples/grid-simple-response.yml
@@ -24,8 +24,8 @@ value:
       endRow: 3
       startColumn: 3
       endColumn: 6
-  createdAt: '2018-12-03T16:58:30Z'
-  updatedAt: '2018-12-13T19:36:40Z'
+  createdAt: '2018-12-03T16:58:30.915Z'
+  updatedAt: '2018-12-13T19:36:40.588Z'
   _links:
     self:
       href: "/api/v3/grids/2"

--- a/docs/api/apiv3/components/examples/membership-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/membership-simple-collection-response.yml
@@ -10,8 +10,8 @@ value:
     elements:
       - _type: Membership
         id: 11
-        createdAt: '2015-03-20T12:56:56Z'
-        updatedAt: '2018-12-20T18:16:11Z'
+        createdAt: '2015-03-20T12:56:56.643Z'
+        updatedAt: '2018-12-20T18:16:11.643Z'
         _links:
           self:
             href: '/api/v3/memberships/11'
@@ -39,11 +39,11 @@ value:
   _links:
     self:
       href: '/api/v3/memberships'
-    jumpTo: 
+    jumpTo:
       href: '/api/v3/memberships?filters=%5B%5D&offset=%7Boffset%7D&pageSize=20'
       templated: true
-    changeSize: 
+    changeSize:
       href: '/api/v3/memberships?filters=%5B%5D&offset=1&pageSize=%7Bsize%7D'
       templated: true
-    nextByOffset: 
+    nextByOffset:
       href: '/api/v3/memberships?filters=%5B%5D&offset=2&pageSize=20'

--- a/docs/api/apiv3/components/examples/membership-simple-response.yml
+++ b/docs/api/apiv3/components/examples/membership-simple-response.yml
@@ -3,8 +3,8 @@ description: |-
 value:
   _type: Membership
   id: 11
-  createdAt: '2015-03-20T12:56:56Z'
-  updatedAt: '2018-12-20T18:16:11Z'
+  createdAt: '2015-03-20T12:56:56.626Z'
+  updatedAt: '2018-12-20T18:16:11.563Z'
   _embedded:
     project:
       _type: Project

--- a/docs/api/apiv3/components/examples/mentioned_notification.yml
+++ b/docs/api/apiv3/components/examples/mentioned_notification.yml
@@ -5,8 +5,8 @@ value:
   id: 1
   readIAN: false
   reason: mentioned
-  createdAt: '2022-04-05T14:38:28Z'
-  updatedAt: '2022-04-06T09:03:24Z'
+  createdAt: '2022-04-05T14:38:28.881Z'
+  updatedAt: '2022-04-06T09:03:24.591Z'
   _embedded:
     author:
       _hint: User resource shortened for brevity

--- a/docs/api/apiv3/components/examples/project.yml
+++ b/docs/api/apiv3/components/examples/project.yml
@@ -51,6 +51,6 @@ value:
     format: markdown
     raw: Lorem **ipsum** dolor sit amet
     html: "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
-  createdAt: '2014-05-21T08:51:20Z'
-  updatedAt: '2014-05-21T08:51:20Z'
+  createdAt: '2014-05-21T08:51:20.396Z'
+  updatedAt: '2014-05-21T08:51:20.396Z'
   customField123: 123

--- a/docs/api/apiv3/components/examples/queries.yml
+++ b/docs/api/apiv3/components/examples/queries.yml
@@ -12,8 +12,8 @@ value:
       - _type: Query
         id: 9
         name: fdsfdsfdsf
-        createdAt: '2015-03-20T12:56:56Z'
-        updatedAt: '2015-05-20T18:16:53Z'
+        createdAt: '2015-03-20T12:56:56.413Z'
+        updatedAt: '2015-05-20T18:16:53.392Z'
         filters:
           - _type: StatusQueryFilter
             name: Status

--- a/docs/api/apiv3/components/examples/query.yml
+++ b/docs/api/apiv3/components/examples/query.yml
@@ -4,8 +4,8 @@ value:
   _type: Query
   id: 9
   name: abcdefg
-  createdAt: '2015-03-20T12:56:56Z'
-  updatedAt: '2015-05-20T18:16:53Z'
+  createdAt: '2015-03-20T12:56:56.235Z'
+  updatedAt: '2015-05-20T18:16:53.976Z'
   filters:
     - _type: StatusQueryFilter
       name: Status

--- a/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
@@ -39,8 +39,8 @@ value:
       - id: 1338
         _type: Storage
         name: EmpireSharepoint
-        createdAt: '2022-12-21T13:37:00Z'
-        updatedAt: '2022-12-21T13:37:00Z'
+        createdAt: '2022-12-21T13:37:00.296Z'
+        updatedAt: '2022-12-21T13:37:00.296Z'
         _links:
           self:
             href: /api/v3/storages/1338

--- a/docs/api/apiv3/components/schemas/activity_model.yml
+++ b/docs/api/apiv3/components/schemas/activity_model.yml
@@ -53,6 +53,6 @@ example:
     format: markdown
     raw: Lorem ipsum dolor sit amet.
     html: "<p>Lorem ipsum dolor sit amet.</p>"
-  createdAt: '2014-05-21T08:51:20Z'
-  updatedAt: '2014-05-21T09:14:02Z'
+  createdAt: '2014-05-21T08:51:20.721Z'
+  updatedAt: '2014-05-21T09:14:02.929Z'
   version: 31

--- a/docs/api/apiv3/components/schemas/attachment_model.yml
+++ b/docs/api/apiv3/components/schemas/attachment_model.yml
@@ -106,4 +106,4 @@ example:
   digest:
     algorithm: md5
     hash: 64c26a8403cd796ea4cf913cda2ee4a9
-  createdAt: '2014-05-21T08:51:20Z'
+  createdAt: '2014-05-21T08:51:20.396Z'

--- a/docs/api/apiv3/components/schemas/available_assignees_model.yml
+++ b/docs/api/apiv3/components/schemas/available_assignees_model.yml
@@ -30,8 +30,8 @@ example:
       email: shep@mail.com
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.977Z'
+      updatedAt: '2014-05-21T08:51:20.977Z'
     - _type: User
       _links:
         self:
@@ -52,5 +52,5 @@ example:
       email: shep@mail.net
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.977Z'
+      updatedAt: '2014-05-21T08:51:20.977Z'

--- a/docs/api/apiv3/components/schemas/available_responsibles_model.yml
+++ b/docs/api/apiv3/components/schemas/available_responsibles_model.yml
@@ -30,8 +30,8 @@ example:
       email: shep@mail.com
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.270Z'
+      updatedAt: '2014-05-21T08:51:20.270Z'
     - _type: User
       _links:
         self:
@@ -52,5 +52,5 @@ example:
       email: shep@mail.net
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.270Z'
+      updatedAt: '2014-05-21T08:51:20.270Z'

--- a/docs/api/apiv3/components/schemas/available_watchers_model.yml
+++ b/docs/api/apiv3/components/schemas/available_watchers_model.yml
@@ -30,8 +30,8 @@ example:
       email: shep@mail.com
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.286Z'
+      updatedAt: '2014-05-21T08:51:20.286Z'
     - _type: User
       _links:
         self:
@@ -52,5 +52,5 @@ example:
       email: shep@mail.net
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.286Z'
+      updatedAt: '2014-05-21T08:51:20.286Z'

--- a/docs/api/apiv3/components/schemas/document_model.yml
+++ b/docs/api/apiv3/components/schemas/document_model.yml
@@ -65,7 +65,7 @@ example:
       ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter
       somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero
       vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
-  createdAt: '2018-12-10T20:53:39Z'
+  createdAt: '2018-12-10T20:53:39.539Z'
   _links:
     attachments:
       href: "/api/v3/documents/1/attachments"

--- a/docs/api/apiv3/components/schemas/documents_model.yml
+++ b/docs/api/apiv3/components/schemas/documents_model.yml
@@ -24,7 +24,7 @@ example:
       _type: Document
       id: 1
       title: Some other document
-      createdAt: '2018-12-10T20:53:39Z'
+      createdAt: '2018-12-10T20:53:39.966Z'
       _links:
         attachments:
           href: "/api/v3/documents/1/attachments"
@@ -52,7 +52,7 @@ example:
       _type: Document
       id: 2
       title: Some other document
-      createdAt: '2018-12-10T20:55:54Z'
+      createdAt: '2018-12-10T20:55:54.886Z'
       _links:
         attachments:
           href: "/api/v3/documents/2/attachments"

--- a/docs/api/apiv3/components/schemas/example_form_model.yml
+++ b/docs/api/apiv3/components/schemas/example_form_model.yml
@@ -55,8 +55,8 @@ example:
             isDefault: true
             isClosed: false
             defaultDoneRatio: 0
-            createdAt: '2014-05-21T08:51:20Z'
-            updatedAt: '2014-05-21T09:12:00Z'
+            createdAt: '2014-05-21T08:51:20.759Z'
+            updatedAt: '2014-05-21T09:12:00.237Z'
           - _links:
               self:
                 href: "/api/v3/statuses/2"
@@ -67,8 +67,8 @@ example:
             isDefault: false
             isClosed: true
             defaultDoneRatio: 100
-            createdAt: '2014-05-21T08:51:20Z'
-            updatedAt: '2014-05-21T09:12:00Z'
+            createdAt: '2014-05-21T08:51:20.759Z'
+            updatedAt: '2014-05-21T09:12:00.237Z'
     validationErrors:
       subject:
         _type: Error

--- a/docs/api/apiv3/components/schemas/example_schema_model.yml
+++ b/docs/api/apiv3/components/schemas/example_schema_model.yml
@@ -38,8 +38,8 @@ example:
         isDefault: true
         isClosed: false
         defaultDoneRatio: 0
-        createdAt: '2014-05-21T08:51:20Z'
-        updatedAt: '2014-05-21T09:12:00Z'
+        createdAt: '2014-05-21T08:51:20.991Z'
+        updatedAt: '2014-05-21T09:12:00.155Z'
       - _links:
           self:
             href: "/api/v3/statuses/2"
@@ -50,5 +50,5 @@ example:
         isDefault: false
         isClosed: true
         defaultDoneRatio: 100
-        createdAt: '2014-05-21T08:51:20Z'
-        updatedAt: '2014-05-21T09:12:00Z'
+        createdAt: '2014-05-21T08:51:20.991Z'
+        updatedAt: '2014-05-21T09:12:00.155Z'

--- a/docs/api/apiv3/components/schemas/file_link_read_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_read_model.yml
@@ -53,23 +53,23 @@ properties:
           - $ref: './link.yml'
           - description: |-
               This file link.
-              
+
               **Resource**: FileLink
       storage:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The storage resource of the linked file.
-              
+
               **Resource**: Storage
       container:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The container the origin file is linked to.
-              
-              Can be one of the following **Resources**: 
-              
+
+              Can be one of the following **Resources**:
+
               - WorkPackage
       creator:
         allOf:
@@ -100,35 +100,35 @@ properties:
           - $ref: './link.yml'
           - description: |-
               The uri to open the origin file on the origin itself.
-              
+
               **Resource**: N/A
       staticOriginOpen:
         allOf:
           - $ref: './link.yml'
           - description: |-
               A static uri to open the origin file on the storage. Responds with a redirect.
-              
+
               **Resource**: N/A
       originOpenLocation:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The uri to open the location of origin file on the origin itself.
-              
+
               **Resource**: N/A
       staticOriginOpenLocation:
         allOf:
           - $ref: './link.yml'
           - description: |-
               A static uri to open the location of the origin file on the storage. Responds with a redirect.
-              
+
               **Resource**: N/A
       staticOriginDownload:
         allOf:
           - $ref: './link.yml'
           - description: |-
               A static uri to generate a new download URL from the storage. Responds with a redirect.
-              
+
               **Resource**: N/A
 
 example:
@@ -180,8 +180,8 @@ example:
       readonly: false
       startDate:
       dueDate:
-      createdAt: '2014-08-29T12:40:53Z'
-      updatedAt: '2014-08-29T12:44:41Z'
+      createdAt: '2014-08-29T12:40:53.860Z'
+      updatedAt: '2014-08-29T12:44:41.036Z'
   _links:
     self:
       href: /api/v3/work_package/17/file_links/1337

--- a/docs/api/apiv3/components/schemas/group_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/group_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This group collection
-                  
+
                   **Resource**: GroupCollectionReadModel
       _embedded:
         type: object
@@ -41,8 +41,8 @@ example:
       - _type: Group
         id: 1337
         name: Stormtroopers
-        createdAt: '2022-09-23T11:06:36Z'
-        updatedAt: '2022-09-23T11:06:36Z'
+        createdAt: '2022-09-23T11:06:36.300Z'
+        updatedAt: '2022-09-23T11:06:36.300Z'
         _links:
           self:
             href: '/api/v3/groups/9'

--- a/docs/api/apiv3/components/schemas/group_model.yml
+++ b/docs/api/apiv3/components/schemas/group_model.yml
@@ -14,7 +14,7 @@ properties:
     type: string
     description: |-
       Group's full name, formatting depends on instance settings
-      
+
       # Conditions
       - admin
   createdAt:
@@ -22,7 +22,7 @@ properties:
     format: date-time
     description: |-
       Time of creation
-      
+
       # Conditions
       - admin
   updatedAt:
@@ -39,14 +39,14 @@ properties:
           - $ref: './link.yml'
           - description: |-
               This group resource
-              
+
               **Resource**: Group
       delete:
         allOf:
           - $ref: './link.yml'
           - description: |-
               Deletes the group.
-              
+
               # Conditions
               **Permission**: Administrator
       updateImmediately:
@@ -54,7 +54,7 @@ properties:
           - $ref: './link.yml'
           - description: |-
               Updates the group's attributes.
-              
+
               # Conditions
               **Permission**: Administrator
       memberships:
@@ -63,9 +63,9 @@ properties:
           - description: |-
               Link to collection of all the group's memberships. The list will only include the memberships in projects
               in which the requesting user has the necessary permissions.
-              
+
               **Resource**: MemberCollection
-              
+
               # Conditions
               **Permission**: `view members` or `manage members` in any project
       members:
@@ -75,9 +75,9 @@ properties:
             - $ref: './link.yml'
             - description: |-
                 One of the members of the group.
-                
+
                 **Resource**: User
-                
+
                 # Conditions
                 **Permission**: `manage members` in any project to read & admin to write
 
@@ -85,8 +85,8 @@ example:
   _type: Group
   id: 9
   name: Stormtroopers
-  createdAt: '2022-09-23T11:06:36Z'
-  updatedAt: '2022-09-23T11:06:36Z'
+  createdAt: '2022-09-23T11:06:36.024Z'
+  updatedAt: '2022-09-23T11:06:36.024Z'
   _links:
     self:
       href: '/api/v3/groups/9'

--- a/docs/api/apiv3/components/schemas/list_of_news_model.yml
+++ b/docs/api/apiv3/components/schemas/list_of_news_model.yml
@@ -26,7 +26,7 @@ example:
           patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos
           velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito
           quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
-      createdAt: '2015-03-20T12:57:01Z'
+      createdAt: '2015-03-20T12:57:01.509Z'
       _links:
         self:
           href: "/api/v3/news/1"
@@ -51,7 +51,7 @@ example:
           Officia adeptio spectaculum atavus nisi cum concido bis. Harum caecus auxilium
           sol theatrum eaque consequatur. Omnis aeger suus adipisci cicuta. Cur delicate
           alias curto cursim atqui talio fugiat.</p>"
-      createdAt: '2015-03-20T12:57:01Z'
+      createdAt: '2015-03-20T12:57:01.509Z'
       _links:
         self:
           href: "/api/v3/news/2"

--- a/docs/api/apiv3/components/schemas/list_projects_by_version_model.yml
+++ b/docs/api/apiv3/components/schemas/list_projects_by_version_model.yml
@@ -34,5 +34,5 @@ example:
         format: markdown
         raw: Everything **fine**
         html: "<p>Everything <strong>fine</strong></p>"
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.142Z'
+      updatedAt: '2014-05-21T08:51:20.142Z'

--- a/docs/api/apiv3/components/schemas/news_model.yml
+++ b/docs/api/apiv3/components/schemas/news_model.yml
@@ -72,7 +72,7 @@ example:
       ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter
       somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero
       vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
-  createdAt: '2015-03-20T12:57:01Z'
+  createdAt: '2015-03-20T12:57:01.908Z'
   _links:
     self:
       href: "/api/v3/news/1"

--- a/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
+++ b/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
@@ -60,7 +60,7 @@ properties:
           - $ref: './link.yml'
           - description: |-
               The user that created the OAuth application.
-              
+
               **Resource**: User
       integration:
         allOf:
@@ -68,14 +68,14 @@ properties:
           - description: |-
               The resource that integrates this OAuth application into itself. Currently, only `Storage` resources are
               able to create and maintain own OAuth application.
-              
+
               **Resource**: Storage
       redirectUri:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The redirect URI of the OAuth application
-              
+
               **Resource**: N/A
 
 example:
@@ -84,8 +84,8 @@ example:
   name: Vader's secure OAuth app
   clientId: O5h6WObhMg1Z8IcLHRE3_LMh4jJYmmca2V6OTFSv8DA
   confidential: true
-  createdAt: '2022-12-07T12:56:42Z'
-  updatedAt: '2022-12-07T12:56:42Z'
+  createdAt: '2022-12-07T12:56:42.626Z'
+  updatedAt: '2022-12-07T12:56:42.626Z'
   scopes:
     - api_v3
   _links:

--- a/docs/api/apiv3/components/schemas/oauth_client_credentials_read_model.yml
+++ b/docs/api/apiv3/components/schemas/oauth_client_credentials_read_model.yml
@@ -48,7 +48,7 @@ properties:
           - description: |-
               The resource that integrates this OAuth client credentials. Currently, only `Storage` resources are
               able to contain OAuth client credentials.
-              
+
               **Resource**: Storage
 
 example:
@@ -56,8 +56,8 @@ example:
   _type: OAuthClientCredentials
   clientId: O5h6WObhMg1Z8IcLHRE3_LMh4jJYmmca2V6OTFSv8DA
   confidential: true
-  createdAt: '2022-12-07T12:56:42Z'
-  updatedAt: '2022-12-07T12:56:42Z'
+  createdAt: '2022-12-07T12:56:42.836Z'
+  updatedAt: '2022-12-07T12:56:42.836Z'
   _link:
     self:
       href: '/api/v3/oauth_client_credentials/1337'

--- a/docs/api/apiv3/components/schemas/principals_model.yml
+++ b/docs/api/apiv3/components/schemas/principals_model.yml
@@ -16,10 +16,10 @@ example:
       name: Danika O'Keefe
       email: jackie@dicki.org
       avatar: https://example.org/users/4/avatar
-      createdAt: '2015-03-20T12:57:02Z'
-      updatedAt: '2015-06-16T15:28:14Z'
+      createdAt: '2015-03-20T12:57:02.646Z'
+      updatedAt: '2015-06-16T15:28:14.550Z'
       status: active
-      identityUrl: 
+      identityUrl:
       _links:
         self:
           href: "/api/v3/users/4"
@@ -46,12 +46,12 @@ example:
       firstName: Peggie
       lastName: Feeney
       name: Peggie Feeney
-      email: 
+      email:
       avatar: https://example.org/users/4/avatar
-      createdAt: '2015-03-20T12:56:55Z'
-      updatedAt: '2015-03-20T12:56:55Z'
+      createdAt: '2015-03-20T12:56:55.963Z'
+      updatedAt: '2015-03-20T12:56:55.963Z'
       status: active
-      identityUrl: 
+      identityUrl:
       _links:
         self:
           href: "/api/v3/users/2"
@@ -74,8 +74,8 @@ example:
     - _type: Group
       id: 9
       name: The group
-      createdAt: '2015-09-23T11:06:36Z'
-      updatedAt: '2015-09-23T11:06:36Z'
+      createdAt: '2015-09-23T11:06:36.687Z'
+      updatedAt: '2015-09-23T11:06:36.687Z'
       _links:
         self:
           href: "/api/v3/groups/9"
@@ -83,8 +83,8 @@ example:
     - _type: PlaceholderUser
       id: 29
       name: UX Designer
-      createdAt: '2018-09-23T11:06:36Z'
-      updatedAt: '2019-10-23T11:06:36Z'
+      createdAt: '2018-09-23T11:06:36.687Z'
+      updatedAt: '2019-10-23T11:06:36.687Z'
       _links:
         self:
           href: "/api/v3/placeholder_users/29"

--- a/docs/api/apiv3/components/schemas/project_storage_model.yml
+++ b/docs/api/apiv3/components/schemas/project_storage_model.yml
@@ -42,47 +42,47 @@ properties:
           - $ref: './link.yml'
           - description: |-
               This project storage.
-              
+
               **Resource**: ProjectStorage
       creator:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              The user who created the project storage. 
-              
+              The user who created the project storage.
+
               **Resource**: User
       storage:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The storage resource, that is linked to a project with this project storage.
-              
+
               **Resource**: Storage
       project:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The project resource, that is linked to a storage with this project storage.
-              
+
               **Resource**: Project
       projectFolder:
         allOf:
           - $ref: './link.yml'
           - description: |-
               The directory on the storage that is used as a manual project folder.
-              
+
               **Resource**: StorageFile
-              
+
               # Conditions
-              
+
               Only provided, if the `projectFolderMode` is set to `manual`.
 
 example:
   _type: 'ProjectStorage'
   id: 1337
   projectFolderMode: 'manual'
-  createdAt: '2023-01-20T14:30:00Z'
-  updatedAt: '2023-05-23T11:57:48Z'
+  createdAt: '2023-01-20T14:30:00.368Z'
+  updatedAt: '2023-05-23T11:57:48.618Z'
   _links:
     self:
       href: '/api/v3/project_storages/23'

--- a/docs/api/apiv3/components/schemas/queries_model.yml
+++ b/docs/api/apiv3/components/schemas/queries_model.yml
@@ -13,8 +13,8 @@ example:
     - _type: Query
       id: 9
       name: fdsfdsfdsf
-      createdAt: '2015-03-20T12:56:56Z'
-      updatedAt: '2015-05-20T18:16:53Z'
+      createdAt: '2015-03-20T12:56:56.858Z'
+      updatedAt: '2015-05-20T18:16:53.887Z'
       filters:
       - _type: StatusQueryFilter
         name: Status
@@ -44,11 +44,11 @@ example:
       public: false
       sums: false
       starred: true
-      projections: 
+      projections:
         - _type: Query::TableProjection
         - _type: Query::TeamPlannerProjection
-          _links: 
-            rows: 
+          _links:
+            rows:
               - href: "/api/v3/users/1"
                 title: "Bob Bobbit"
         - _type: Query::CalendarProjection
@@ -99,8 +99,8 @@ example:
         - href: "/api/v3/queries/columns/updated_at"
           title: Updated on
         groupBy:
-          href: 
-          title: 
+          href:
+          title:
         sortBy:
         - href: "/api/v3/queries/sort_bys/parent-desc"
           title: Parent (Descending)

--- a/docs/api/apiv3/components/schemas/revision_model.yml
+++ b/docs/api/apiv3/components/schemas/revision_model.yml
@@ -97,4 +97,4 @@ example:
 
       An elaborate description
     html: "<p>This revision provides new features<br/><br/>An elaborate description</p>"
-  createdAt: '2015-07-21T13:36:59Z'
+  createdAt: '2015-07-21T13:36:59.859Z'

--- a/docs/api/apiv3/components/schemas/revisions_model.yml
+++ b/docs/api/apiv3/components/schemas/revisions_model.yml
@@ -33,7 +33,7 @@ example:
 
           An elaborate description
         html: "<p>This revision provides new features<br/><br/>An elaborate description</p>"
-      createdAt: '2015-07-21T13:36:59Z'
+      createdAt: '2015-07-21T13:36:59.201Z'
     - _type: Revision
       _links:
         self:
@@ -57,4 +57,4 @@ example:
 
           More information here
         html: "<p>This revision fixes some stuff<br/><br/>More information here</p>"
-      createdAt: '2015-06-30T08:47:00Z'
+      createdAt: '2015-06-30T08:47:00.548Z'

--- a/docs/api/apiv3/components/schemas/star_query_model.yml
+++ b/docs/api/apiv3/components/schemas/star_query_model.yml
@@ -5,8 +5,8 @@ example:
   _type: Query
   id: 9
   name: fdsfdsfdsf
-  createdAt: '2015-03-20T12:56:56Z'
-  updatedAt: '2015-05-20T18:16:53Z'
+  createdAt: '2015-03-20T12:56:56.085Z'
+  updatedAt: '2015-05-20T18:16:53.619Z'
   filters:
   - _type: StatusQueryFilter
     name: Status
@@ -83,8 +83,8 @@ example:
     - href: "/api/v3/queries/columns/updated_at"
       title: Updated on
     groupBy:
-      href: 
-      title: 
+      href:
+      title:
     sortBy:
     - href: "/api/v3/queries/sort_bys/parent-desc"
       title: Parent (Descending)

--- a/docs/api/apiv3/components/schemas/time_entry_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_collection_model.yml
@@ -18,7 +18,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This time entry collection
-                  
+
                   **Resource**: TimeEntryCollectionModel
       _embedded:
         type: object
@@ -46,8 +46,8 @@ examples:
             html: "<p>Some comment</p>"
           spentOn: '2015-03-20'
           hours: PT5H
-          createdAt: '2015-03-20T12:56:56Z'
-          updatedAt: '2015-03-20T12:56:56Z'
+          createdAt: '2015-03-20T12:56:56.803Z'
+          updatedAt: '2015-03-20T12:56:56.803Z'
           _links:
             self:
               href: "/api/v3/time_entries/1"
@@ -77,8 +77,8 @@ examples:
             html: "<p>Another comment</p>"
           spentOn: '2015-03-21'
           hours: PT7H
-          createdAt: '2015-03-20T12:56:56Z'
-          updatedAt: '2015-03-20T12:56:56Z'
+          createdAt: '2015-03-20T12:56:56.569Z'
+          updatedAt: '2015-03-20T12:56:56.371Z'
           _links:
             self:
               href: "/api/v3/time_entries/2"

--- a/docs/api/apiv3/components/schemas/time_entry_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_model.yml
@@ -42,69 +42,69 @@ properties:
           - "$ref": './link.yml'
           - description: |-
               This time entry
-              
+
               **Resource**: TimeEntry
       updateImmediately:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               Directly perform edits on this time entry
-              
+
               # Conditions
-              
+
               **Permission**: 'edit time entries' or 'edit own time entries' if the time entry belongs to the user
       update:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               Form endpoint that aids in preparing and performing edits on a TimeEntry
-              
+
               # Conditions
-              
+
               **Permission**: 'edit time entries' or 'edit own time entries' if the time entry belongs to the user
       delete:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               Delete this time entry
-              
+
               # Conditions
-              
+
               **Permission**: 'edit time entries' or 'edit own time entries' if the time entry belongs to the user
       schema:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               The time entry schema
-              
+
               **Resource**: Schema
       project:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               The project the time entry is bundled in. The project might be different from the work package's project once the workPackage is moved.
-              
+
               **Resource**: Project
       workPackage:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               The work package the time entry is created on
-              
+
               **Resource**: WorkPackage
       user:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               The user the time entry tracks expenditures for
-              
+
               **Resource**: User
       activity:
         allOf:
           - "$ref": './link.yml'
           - description: |-
               The time entry activity the time entry is categorized as
-              
+
               **Resource**: TimeEntriesActivity
 
 examples:
@@ -116,32 +116,31 @@ examples:
       html: "<p>The force shall set me free.</p>"
     spentOn: '2023-01-11'
     hours: 'PT4H'
-    createdAt: '2023-01-11T13:58:24Z'
-    updatedAt: '2023-01-11T13:58:24Z'
+    createdAt: '2023-01-11T13:58:24.927Z'
+    updatedAt: '2023-01-11T13:58:24.927Z'
     _links:
-      self: 
+      self:
         href: '/api/v3/time_entries/42'
-      updateImmediately: 
+      updateImmediately:
         href: '/api/v3/time_entries/42'
         method: patch
-      update: 
+      update:
         href: '/api/v3/time_entries/42/form'
         method: post
-      delete: 
+      delete:
         href: '/api/v3/time_entries/42'
         method: delete
-      schema: 
+      schema:
         href: '/api/v3/time_entries/schema'
-      project: 
+      project:
         href: '/api/v3/projects/11'
         title: DeathStarV2
-      workPackage: 
+      workPackage:
         href: '/api/v3/work_packages/77'
         title: Build new hangar
-      user: 
+      user:
         href: '/api/v3/users/3'
         title: Darth Vader
-      activity: 
+      activity:
         href: '/api/v3/time_entries/activities/1'
         title: Management
-      

--- a/docs/api/apiv3/components/schemas/type_model.yml
+++ b/docs/api/apiv3/components/schemas/type_model.yml
@@ -60,5 +60,5 @@ example:
   position: 1
   isDefault: true
   isMilestone: false
-  createdAt: '2014-05-21T08:51:20Z'
-  updatedAt: '2014-05-21T08:51:20Z'
+  createdAt: '2014-05-21T08:51:20.624Z'
+  updatedAt: '2014-05-21T08:51:20.624Z'

--- a/docs/api/apiv3/components/schemas/types_by_project_model.yml
+++ b/docs/api/apiv3/components/schemas/types_by_project_model.yml
@@ -20,8 +20,8 @@ example:
       position: 1
       isDefault: true
       isMilestone: false
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.745Z'
+      updatedAt: '2014-05-21T08:51:20.745Z'
     - _links:
         self:
           href: "/api/v3/types/2"
@@ -32,5 +32,5 @@ example:
       position: 2
       isDefault: false
       isMilestone: false
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.745Z'
+      updatedAt: '2014-05-21T08:51:20.745Z'

--- a/docs/api/apiv3/components/schemas/types_model.yml
+++ b/docs/api/apiv3/components/schemas/types_model.yml
@@ -20,8 +20,8 @@ example:
       position: 1
       isDefault: true
       isMilestone: false
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.429Z'
+      updatedAt: '2014-05-21T08:51:20.429Z'
     - _links:
         self:
           href: "/api/v3/types/2"
@@ -32,5 +32,5 @@ example:
       position: 2
       isDefault: false
       isMilestone: false
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.429Z'
+      updatedAt: '2014-05-21T08:51:20.429Z'

--- a/docs/api/apiv3/components/schemas/unstar_query_model.yml
+++ b/docs/api/apiv3/components/schemas/unstar_query_model.yml
@@ -5,8 +5,8 @@ example:
   _type: Query
   id: 9
   name: fdsfdsfdsf
-  createdAt: '2015-03-20T12:56:56Z'
-  updatedAt: '2015-05-20T18:16:53Z'
+  createdAt: '2015-03-20T12:56:56.257Z'
+  updatedAt: '2015-05-20T18:16:53.953Z'
   filters:
   - _type: StatusQueryFilter
     name: Status
@@ -83,8 +83,8 @@ example:
     - href: "/api/v3/queries/columns/updated_at"
       title: Updated on
     groupBy:
-      href: 
-      title: 
+      href:
+      title:
     sortBy:
     - href: "/api/v3/queries/sort_bys/parent-desc"
       title: Parent (Descending)

--- a/docs/api/apiv3/components/schemas/user_model.yml
+++ b/docs/api/apiv3/components/schemas/user_model.yml
@@ -108,18 +108,18 @@ properties:
           - "$ref": "./link.yml"
           - description: |-
               This user
-              
+
               **Resource**: User
       memberships:
         allOf:
           - "$ref": "./link.yml"
           - description: |-
               Link to collection of all the user's memberships. The list will only include the memberships in projects in which the requesting user has the necessary permissions.
-              
+
               **Resource**: MemberCollection
-              
+
               # Conditions
-              
+
               **Permission**: view members or manage members in any project
       showUser:
         allOf:
@@ -130,36 +130,36 @@ properties:
           - "$ref": "./link.yml"
           - description: |-
               Updates the user's attributes.
-              
+
               # Conditions
-              
+
               **Permission**: Administrator, manage_user global permission
       lock:
         allOf:
           - "$ref": "./link.yml"
           - description: |-
               Restrict the user from logging in and performing any actions
-              
+
               # Conditions
-              
+
               not locked; **Permission**: Administrator
       unlock:
         allOf:
           - "$ref": "./link.yml"
           - description: |-
               Allow a locked user to login and act again
-              
+
               # Conditions
-              
+
               locked; **Permission**: Administrator
       delete:
         allOf:
           - "$ref": "./link.yml"
           - description: |-
               Permanently remove a user from the instance
-              
+
               # Conditions
-              
+
               **Permission**: Administrator, self-delete
 
 example:
@@ -175,8 +175,8 @@ example:
   status: active
   identityUrl: null,
   language: en
-  createdAt: '2014-05-21T08:51:20Z'
-  updatedAt: '2014-05-21T08:51:20Z'
+  createdAt: '2014-05-21T08:51:20.396Z'
+  updatedAt: '2014-05-21T08:51:20.396Z'
   _links:
     self:
       href: '/api/v3/users/1'

--- a/docs/api/apiv3/components/schemas/watchers_model.yml
+++ b/docs/api/apiv3/components/schemas/watchers_model.yml
@@ -17,7 +17,7 @@ allOf:
             - "$ref": "./link.yml"
             - description: |-
                 The watcher list
-                
+
                 **Resource**: WatchersModel
               readOnly: true
       _embedded:
@@ -62,8 +62,8 @@ example:
       mail: shep@mail.com
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.396Z'
+      updatedAt: '2014-05-21T08:51:20.396Z'
     - _type: User
       _links:
         self:
@@ -84,5 +84,5 @@ example:
       mail: shep@mail.net
       avatar: https://example.org/users/1/avatar
       status: active
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T08:51:20Z'
+      createdAt: '2014-05-21T08:51:20.396Z'
+      updatedAt: '2014-05-21T08:51:20.396Z'

--- a/docs/api/apiv3/components/schemas/work_package_activities_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_activities_model.yml
@@ -24,8 +24,8 @@ example:
         format: markdown
         raw: Lorem ipsum dolor sit amet.
         html: "<p>Lorem ipsum dolor sit amet.</p>"
-      createdAt: '2014-05-21T08:51:20Z'
-      updatedAt: '2014-05-21T09:14:02Z'
+      createdAt: '2014-05-21T08:51:20.396Z'
+      updatedAt: '2014-05-21T09:14:02.324Z'
       version: 1
     - _type: Activity
       _links:
@@ -41,6 +41,6 @@ example:
         format: markdown
         raw: Lorem ipsum dolor sit amet.
         html: "<p>Lorem ipsum dolor sit amet.</p>"
-      createdAt: '2014-05-21T09:51:22Z'
-      updatedAt: '2014-05-21T10:14:02Z'
+      createdAt: '2014-05-21T09:51:22.769Z'
+      updatedAt: '2014-05-21T10:14:02.927Z'
       version: 2

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -123,9 +123,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Attach a file to the WP
-              
+
               # Conditions
-              
+
               **Permission**: edit work package
             readOnly: true
       addComment:
@@ -133,9 +133,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Post comment to WP
-              
+
               # Conditions
-              
+
               **Permission**: add work package notes
             readOnly: true
       addRelation:
@@ -143,9 +143,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Adds a relation to this work package.
-              
+
               # Conditions
-              
+
               **Permission**: manage wp relations
             readOnly: true
       addWatcher:
@@ -153,9 +153,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Add any user to WP watchers
-              
+
               # Conditions
-              
+
               **Permission**: add watcher
             readOnly: true
       customActions:
@@ -166,7 +166,7 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               A predefined action that can be applied to the work package.
-              
+
               **Resource**: CustomAction
             readOnly: true
       previewMarkup:
@@ -180,9 +180,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Remove any user from WP watchers
-              
+
               # Conditions
-              
+
               **Permission**: delete watcher
             readOnly: true
       unwatch:
@@ -190,9 +190,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Remove current user from WP watchers
-              
+
               # Conditions
-              
+
               logged in; watching
             readOnly: true
       update:
@@ -200,9 +200,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Form endpoint that aids in preparing and performing edits on a WP
-              
+
               # Conditions
-              
+
               **Permission**: edit work package
             readOnly: true
       updateImmediately:
@@ -210,9 +210,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Directly perform edits on a work package
-              
+
               # Conditions
-              
+
               **Permission**: edit work package
             readOnly: true
       watch:
@@ -220,9 +220,9 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Add current user to WP watchers
-              
+
               # Conditions
-              
+
               logged in; not watching
             readOnly: true
       self:
@@ -230,7 +230,7 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               This work package
-              
+
               **Resource**: WorkPackage
             readOnly: true
       schema:
@@ -238,7 +238,7 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The schema of this work package
-              
+
               **Resource**: Schema
             readOnly: true
       ancestors:
@@ -249,11 +249,11 @@ properties:
             - $ref: "./link.yml"
             - description: |-
                 A visible ancestor work package of the current work package.
-                
+
                 **Resource**: WorkPackage
-                
+
                 # Conditions
-                
+
                 **Permission** view work packages
               readOnly: true
       attachments:
@@ -261,14 +261,14 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The files attached to this work package
-              
+
               **Resource**: Collection
       author:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The person that created the work package
-              
+
               **Resource**: User
             readOnly: true
       assignee:
@@ -276,18 +276,18 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The person that is intended to work on the work package
-              
+
               **Resource**: User
       availableWatchers:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               All users that can be added to the work package as watchers.
-              
+
               **Resource**: User
-              
+
               # Conditions
-              
+
               **Permission** add work package watchers
             readOnly: true
       budget:
@@ -295,18 +295,18 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The budget this work package is associated to
-              
+
               **Resource**: Budget
-              
+
               # Conditions
-              
+
               **Permission** view cost objects
       category:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The category of the work package
-              
+
               **Resource**: Category
       children:
         type: array
@@ -316,11 +316,11 @@ properties:
             - $ref: "./link.yml"
             - description: |-
                 A visible child work package of the current work package.
-                
+
                 **Resource**: WorkPackage
-                
+
                 # Conditions
-                
+
                 **Permission** view work packages
               readOnly: true
       addFileLink:
@@ -346,39 +346,39 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Parent work package
-              
+
               **Resource**: WorkPackage
       priority:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The priority of the work package
-              
+
               **Resource**: Priority
       project:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The project to which the work package belongs
-              
+
               **Resource**: Project
       responsible:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The person that is responsible for the overall outcome
-              
+
               **Resource**: User
       relations:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               Relations this work package is involved in
-              
+
               **Resource**: Relation
-              
+
               # Conditions
-              
+
               **Permission** view work packages
             readOnly: true
       revisions:
@@ -386,11 +386,11 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Revisions that are referencing the work package
-              
+
               **Resource**: Revision
-              
+
               # Conditions
-              
+
               **Permission** view changesets
             readOnly: true
       status:
@@ -398,18 +398,18 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The current status of the work package
-              
+
               **Resource**: Status
       timeEntries:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               All time entries logged on the work package. Please note that this is a link to an HTML resource for now and as such, the link is subject to change.
-              
+
               **Resource**: N/A
-              
+
               # Conditions
-              
+
               **Permission** view time entries
             readOnly: true
       type:
@@ -417,25 +417,25 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               The type of the work package
-              
+
               **Resource**: Type
       version:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               The version associated to the work package
-              
+
               **Resource**: Version
       watchers:
         allOf:
           - $ref: "./link.yml"
           - description: |-
               All users that are currently watching this work package
-              
+
               **Resource**: Collection
-              
+
               # Conditions
-              
+
               **Permission** view work package watchers
             readOnly: true
 
@@ -576,5 +576,5 @@ example:
   percentageDone: 0
   customField1: Foo
   customField2: 42
-  createdAt: '2014-08-29T12:40:53Z'
-  updatedAt: '2014-08-29T12:44:41Z'
+  createdAt: '2014-08-29T12:40:53.373Z'
+  updatedAt: '2014-08-29T12:44:41.981Z'

--- a/docs/api/apiv3/paths/activity.yml
+++ b/docs/api/apiv3/paths/activity.yml
@@ -32,8 +32,8 @@ get:
                   format: markdown
                   html: "<p>Lorem ipsum dolor sit amet.</p>"
                   raw: Lorem ipsum dolor sit amet.
-                createdAt: '2014-05-21T08:51:20Z'
-                updatedAt: '2014-05-21T09:14:02Z'
+                createdAt: '2014-05-21T08:51:20.396Z'
+                updatedAt: '2014-05-21T09:14:02.300Z'
                 details:
                 - format: markdown
                   html: "<p>Lorem ipsum dolor sit amet.</p>"
@@ -81,8 +81,8 @@ patch:
                   format: markdown
                   html: "<p>Lorem ipsum dolor sit amet.</p>"
                   raw: Lorem ipsum dolor sit amet.
-                createdAt: '2014-05-21T08:51:20Z'
-                updatedAt: '2014-05-21T09:14:02Z'
+                createdAt: '2014-05-21T08:51:20.396Z'
+                updatedAt: '2014-05-21T09:14:02.776Z'
                 details:
                 - format: markdown
                   html: "<p>Lorem ipsum dolor sit amet.</p>"

--- a/docs/api/apiv3/paths/document.yml
+++ b/docs/api/apiv3/paths/document.yml
@@ -41,7 +41,7 @@ get:
                     href: "/api/v3/documents/1"
                     title: Some document
                 _type: Document
-                createdAt: '2018-12-10T20:53:39Z'
+                createdAt: '2018-12-10T20:53:39.698Z'
                 description:
                   format: markdown
                   html: "<p>Videlicet deserunt aequitas cognatus. Concedo quia est

--- a/docs/api/apiv3/paths/documents.yml
+++ b/docs/api/apiv3/paths/documents.yml
@@ -52,7 +52,7 @@ get:
                         href: "/api/v3/documents/1"
                         title: Some document
                     _type: Document
-                    createdAt: '2018-12-10T20:53:39Z'
+                    createdAt: '2018-12-10T20:53:39.184Z'
                     description:
                       format: markdown
                       html: "<p>Videlicet deserunt aequitas cognatus. Concedo quia
@@ -82,7 +82,7 @@ get:
                         href: "/api/v3/documents/2"
                         title: Some other document
                     _type: Document
-                    createdAt: '2018-12-10T20:55:54Z'
+                    createdAt: '2018-12-10T20:55:54.049Z'
                     description:
                       format: markdown
                       html: "<p>Videlicet deserunt aequitas cognatus. Concedo quia

--- a/docs/api/apiv3/paths/example_form.yml
+++ b/docs/api/apiv3/paths/example_form.yml
@@ -31,26 +31,26 @@ post:
                             self:
                               href: "/api/v3/statuses/1"
                           _type: Status
-                          createdAt: '2014-05-21T08:51:20Z'
+                          createdAt: '2014-05-21T08:51:20.396Z'
                           defaultDoneRatio: 0
                           id: 1
                           isClosed: false
                           isDefault: true
                           name: New
                           position: 1
-                          updatedAt: '2014-05-21T09:12:00Z'
+                          updatedAt: '2014-05-21T09:12:00.647Z'
                         - _links:
                             self:
                               href: "/api/v3/statuses/2"
                           _type: Status
-                          createdAt: '2014-05-21T08:51:20Z'
+                          createdAt: '2014-05-21T08:51:20.396Z'
                           defaultDoneRatio: 100
                           id: 2
                           isClosed: true
                           isDefault: false
                           name: Closed
                           position: 2
-                          updatedAt: '2014-05-21T09:12:00Z'
+                          updatedAt: '2014-05-21T09:12:00.647Z'
                       _links:
                         allowedValues:
                         - href: "/api/v3/statuses/1"

--- a/docs/api/apiv3/paths/example_schema.yml
+++ b/docs/api/apiv3/paths/example_schema.yml
@@ -24,26 +24,26 @@ get:
                         self:
                           href: "/api/v3/statuses/1"
                       _type: Status
-                      createdAt: '2014-05-21T08:51:20Z'
+                      createdAt: '2014-05-21T08:51:20.396Z'
                       defaultDoneRatio: 0
                       id: 1
                       isClosed: false
                       isDefault: true
                       name: New
                       position: 1
-                      updatedAt: '2014-05-21T09:12:00Z'
+                      updatedAt: '2014-05-21T09:12:00.441Z'
                     - _links:
                         self:
                           href: "/api/v3/statuses/2"
                       _type: Status
-                      createdAt: '2014-05-21T08:51:20Z'
+                      createdAt: '2014-05-21T08:51:20.396Z'
                       defaultDoneRatio: 100
                       id: 2
                       isClosed: true
                       isDefault: false
                       name: Closed
                       position: 2
-                      updatedAt: '2014-05-21T09:12:00Z'
+                      updatedAt: '2014-05-21T09:12:00.441Z'
                   _links:
                     allowedValues:
                     - href: "/api/v3/statuses/1"

--- a/docs/api/apiv3/paths/news.yml
+++ b/docs/api/apiv3/paths/news.yml
@@ -61,7 +61,7 @@ get:
                         href: "/api/v3/news/1"
                         title: asperiores possimus nam doloribus ab
                     _type: News
-                    createdAt: '2015-03-20T12:57:01Z'
+                    createdAt: '2015-03-20T12:57:01.209Z'
                     description:
                       format: markdown
                       html: "<p>Videlicet deserunt aequitas cognatus. Concedo quia
@@ -91,7 +91,7 @@ get:
                         href: "/api/v3/news/2"
                         title: terminatio tutamen. Officia adeptio sp
                     _type: News
-                    createdAt: '2015-03-20T12:57:01Z'
+                    createdAt: '2015-03-20T12:57:01.262Z'
                     description:
                       format: markdown
                       html: "<p>Amicitia alius cattus voluntarius. Virgo viduo terminatio

--- a/docs/api/apiv3/paths/news_item.yml
+++ b/docs/api/apiv3/paths/news_item.yml
@@ -32,7 +32,7 @@ get:
                     href: "/api/v3/news/1"
                     title: asperiores possimus nam doloribus ab
                 _type: News
-                createdAt: '2015-03-20T12:57:01Z'
+                createdAt: '2015-03-20T12:57:01.601Z'
                 description:
                   format: markdown
                   html: "<p>Videlicet deserunt aequitas cognatus. Concedo quia est

--- a/docs/api/apiv3/paths/post_attachments.yml
+++ b/docs/api/apiv3/paths/post_attachments.yml
@@ -35,7 +35,7 @@ get:
                         title: 200.gif
                     _type: Attachment
                     contentType: image/gif
-                    createdAt: '2018-06-01T07:24:19Z'
+                    createdAt: '2018-06-01T07:24:19.706Z'
                     description:
                       format: plain
                       html: ''
@@ -117,16 +117,16 @@ post:
                     _type: User
                     admin: true
                     avatar: ''
-                    createdAt: '2015-03-20T12:56:52Z'
-                    email: 
+                    createdAt: '2015-03-20T12:56:52.850Z'
+                    email:
                     firstName: OpenProject
                     id: 1
-                    identityUrl: 
+                    identityUrl:
                     lastName: Admin
                     login: admin
                     name: OpenProject Admin
                     status: active
-                    updatedAt: '2018-05-29T13:57:44Z'
+                    updatedAt: '2018-05-29T13:57:44.604Z'
                   container:
                     _links:
                       addAttachment:
@@ -159,7 +159,7 @@ post:
                     title: 200.gif
                 _type: Attachment
                 contentType: image/gif
-                createdAt: '2018-06-01T07:53:36Z'
+                createdAt: '2018-06-01T07:53:36.831Z'
                 description:
                   format: plain
                   html: ''

--- a/docs/api/apiv3/paths/principals.yml
+++ b/docs/api/apiv3/paths/principals.yml
@@ -61,16 +61,16 @@ get:
                     _type: User
                     admin: false
                     avatar: https://example.org/users/4/avatar
-                    createdAt: '2015-03-20T12:57:02Z'
+                    createdAt: '2015-03-20T12:57:02.901Z'
                     email: jackie@dicki.org
                     firstName: Danika
                     id: 4
-                    identityUrl: 
+                    identityUrl:
                     lastName: O'Keefe
                     login: Eliza92778
                     name: Danika O'Keefe
                     status: active
-                    updatedAt: '2015-06-16T15:28:14Z'
+                    updatedAt: '2015-06-16T15:28:14.565Z'
                   - _links:
                       delete:
                         href: "/api/v3/users/2"
@@ -93,34 +93,34 @@ get:
                     _type: User
                     admin: false
                     avatar: https://example.org/users/4/avatar
-                    createdAt: '2015-03-20T12:56:55Z'
-                    email: 
+                    createdAt: '2015-03-20T12:56:55.578Z'
+                    email:
                     firstName: Peggie
                     id: 2
-                    identityUrl: 
+                    identityUrl:
                     lastName: Feeney
                     login: Sebastian9686
                     name: Peggie Feeney
                     status: active
-                    updatedAt: '2015-03-20T12:56:55Z'
+                    updatedAt: '2015-03-20T12:56:55.254Z'
                   - _links:
                       self:
                         href: "/api/v3/groups/9"
                         title: The group
                     _type: Group
-                    createdAt: '2015-09-23T11:06:36Z'
+                    createdAt: '2015-09-23T11:06:36.231Z'
                     id: 9
                     name: The group
-                    updatedAt: '2015-09-23T11:06:36Z'
+                    updatedAt: '2015-09-23T11:06:36.231Z'
                   - _links:
                       self:
                         href: "/api/v3/placeholder_users/29"
                         title: UX Designer
                     _type: PlaceholderUser
-                    createdAt: '2018-09-23T11:06:36Z'
+                    createdAt: '2018-09-23T11:06:36.231Z'
                     id: 29
                     name: UX Designer
-                    updatedAt: '2019-10-23T11:06:36Z'
+                    updatedAt: '2019-10-23T11:06:36.231Z'
                 _links:
                   self:
                     href: "/api/v3/principals"

--- a/docs/api/apiv3/paths/project_available_assignees.yml
+++ b/docs/api/apiv3/paths/project_available_assignees.yml
@@ -32,14 +32,14 @@ get:
                         title: John Sheppard - j.sheppard
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.com
                     firstName: John
                     id: 1
                     lastName: Sheppard
                     login: j.sheppard
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                   - _links:
                       delete:
                         href: "/api/v3/users/2"
@@ -54,14 +54,14 @@ get:
                         title: Jim Sheppard - j.sheppard2
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.net
                     firstName: Jim
                     id: 2
                     lastName: Sheppard
                     login: j.sheppard2
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/projects/42/available_assignees"

--- a/docs/api/apiv3/paths/project_available_responsibles.yml
+++ b/docs/api/apiv3/paths/project_available_responsibles.yml
@@ -32,14 +32,14 @@ get:
                         title: John Sheppard - j.sheppard
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.com
                     firstName: John
                     id: 1
                     lastName: Sheppard
                     login: j.sheppard
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                   - _links:
                       delete:
                         href: "/api/v3/users/2"
@@ -54,14 +54,14 @@ get:
                         title: Jim Sheppard - j.sheppard2
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.net
                     firstName: Jim
                     id: 2
                     lastName: Sheppard
                     login: j.sheppard2
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/projects/42/available_responsibles"

--- a/docs/api/apiv3/paths/project_types.yml
+++ b/docs/api/apiv3/paths/project_types.yml
@@ -23,25 +23,25 @@ get:
                         href: "/api/v3/types/1"
                     _type: Type
                     color: "#ff0000"
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     id: 1
                     isDefault: true
                     isMilestone: false
                     name: Bug
                     position: 1
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                   - _links:
                       self:
                         href: "/api/v3/types/2"
                     _type: Type
                     color: "#888"
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     id: 2
                     isDefault: false
                     isMilestone: false
                     name: Feature
                     position: 2
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/projects/11/types"

--- a/docs/api/apiv3/paths/query.yml
+++ b/docs/api/apiv3/paths/query.yml
@@ -311,7 +311,7 @@ patch:
                     href: "/api/v3/users/1"
                     title: OpenProject Admin
                 _type: Query
-                createdAt: '2015-03-20T12:56:56Z'
+                createdAt: '2015-03-20T12:56:56.343Z'
                 filters:
                 - _links:
                     filter:
@@ -343,7 +343,7 @@ patch:
                 public: false
                 starred: false
                 sums: false
-                updatedAt: '2015-05-20T18:16:53Z'
+                updatedAt: '2015-05-20T18:16:53.884Z'
           schema:
             "$ref": "../components/schemas/query_model.yml"
       description: OK

--- a/docs/api/apiv3/paths/query_star.yml
+++ b/docs/api/apiv3/paths/query_star.yml
@@ -58,8 +58,8 @@ patch:
                   - href: "/api/v3/queries/columns/updated_at"
                     title: Updated on
                   groupBy:
-                    href: 
-                    title: 
+                    href:
+                    title:
                   project:
                     href: "/api/v3/projects/3"
                     title: copy
@@ -75,7 +75,7 @@ patch:
                     href: "/api/v3/users/1"
                     title: OpenProject Admin
                 _type: Query
-                createdAt: '2015-03-20T12:56:56Z'
+                createdAt: '2015-03-20T12:56:56.856Z'
                 filters:
                 - _links:
                     filter:
@@ -107,7 +107,7 @@ patch:
                 public: false
                 starred: true
                 sums: false
-                updatedAt: '2015-05-20T18:16:53Z'
+                updatedAt: '2015-05-20T18:16:53.089Z'
           schema:
             "$ref": "../components/schemas/star_query_model.yml"
       description: OK

--- a/docs/api/apiv3/paths/query_unstar.yml
+++ b/docs/api/apiv3/paths/query_unstar.yml
@@ -58,8 +58,8 @@ patch:
                   - href: "/api/v3/queries/columns/updated_at"
                     title: Updated on
                   groupBy:
-                    href: 
-                    title: 
+                    href:
+                    title:
                   project:
                     href: "/api/v3/projects/3"
                     title: copy
@@ -75,7 +75,7 @@ patch:
                     href: "/api/v3/users/1"
                     title: OpenProject Admin
                 _type: Query
-                createdAt: '2015-03-20T12:56:56Z'
+                createdAt: '2015-03-20T12:56:56.468Z'
                 filters:
                 - _links:
                     filter:
@@ -107,7 +107,7 @@ patch:
                 public: false
                 starred: false
                 sums: false
-                updatedAt: '2015-05-20T18:16:53Z'
+                updatedAt: '2015-05-20T18:16:53.386Z'
           schema:
             "$ref": "../components/schemas/unstar_query_model.yml"
       description: OK

--- a/docs/api/apiv3/paths/revision.yml
+++ b/docs/api/apiv3/paths/revision.yml
@@ -27,7 +27,7 @@ get:
                     href: "/projects/identifier/repository/revision/11f4b07"
                 _type: Revision
                 authorName: Some Developer
-                createdAt: '2015-07-21T13:36:59Z'
+                createdAt: '2015-07-21T13:36:59.454Z'
                 formattedIdentifier: 11f4b07
                 id: 1
                 identifier: 11f4b07dff4f4ce9548a52b7d002daca7cd63ec6

--- a/docs/api/apiv3/paths/type.yml
+++ b/docs/api/apiv3/paths/type.yml
@@ -21,13 +21,13 @@ get:
                     href: "/api/v3/types/1"
                 _type: Type
                 color: "#ff0000"
-                createdAt: '2014-05-21T08:51:20Z'
+                createdAt: '2014-05-21T08:51:20.396Z'
                 id: 1
                 isDefault: true
                 isMilestone: false
                 name: Bug
                 position: 1
-                updatedAt: '2014-05-21T08:51:20Z'
+                updatedAt: '2014-05-21T08:51:20.396Z'
           schema:
             "$ref": "../components/schemas/type_model.yml"
       description: OK

--- a/docs/api/apiv3/paths/types.yml
+++ b/docs/api/apiv3/paths/types.yml
@@ -15,25 +15,25 @@ get:
                         href: "/api/v3/types/1"
                     _type: Type
                     color: "#ff0000"
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     id: 1
                     isDefault: true
                     isMilestone: false
                     name: Bug
                     position: 1
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                   - _links:
                       self:
                         href: "/api/v3/types/2"
                     _type: Type
                     color: "#888"
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     id: 2
                     isDefault: false
                     isMilestone: false
                     name: Feature
                     position: 2
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/types"

--- a/docs/api/apiv3/paths/version_projects.yml
+++ b/docs/api/apiv3/paths/version_projects.yml
@@ -31,7 +31,7 @@ get:
                         href: "/api/v3/projects/1/versions"
                     _type: Project
                     active: true
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     description:
                       format: markdown
                       html: "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
@@ -43,7 +43,7 @@ get:
                       format: markdown
                       html: "<p>Everything <strong>fine</strong></p>"
                       raw: Everything **fine**
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/versions/2/projects"

--- a/docs/api/apiv3/paths/wiki_page_attachments.yml
+++ b/docs/api/apiv3/paths/wiki_page_attachments.yml
@@ -35,7 +35,7 @@ get:
                         title: 200.gif
                     _type: Attachment
                     contentType: image/gif
-                    createdAt: '2018-06-01T07:24:19Z'
+                    createdAt: '2018-06-01T07:24:19.896Z'
                     description:
                       format: plain
                       html: ''
@@ -117,16 +117,16 @@ post:
                     _type: User
                     admin: true
                     avatar: ''
-                    createdAt: '2015-03-20T12:56:52Z'
-                    email: 
+                    createdAt: '2015-03-20T12:56:52.343Z'
+                    email:
                     firstName: OpenProject
                     id: 1
-                    identityUrl: 
+                    identityUrl:
                     lastName: Admin
                     login: admin
                     name: OpenProject Admin
                     status: active
-                    updatedAt: '2018-05-29T13:57:44Z'
+                    updatedAt: '2018-05-29T13:57:44.662Z'
                   container:
                     _links:
                       addAttachment:
@@ -159,7 +159,7 @@ post:
                     title: 200.gif
                 _type: Attachment
                 contentType: image/gif
-                createdAt: '2018-06-01T07:24:19Z'
+                createdAt: '2018-06-01T07:24:19.896Z'
                 description:
                   format: plain
                   html: ''

--- a/docs/api/apiv3/paths/work_package_activities.yml
+++ b/docs/api/apiv3/paths/work_package_activities.yml
@@ -30,8 +30,8 @@ get:
                       format: markdown
                       html: "<p>Lorem ipsum dolor sit amet.</p>"
                       raw: Lorem ipsum dolor sit amet.
-                    createdAt: '2014-05-21T08:51:20Z'
-                    updatedAt: '2014-05-21T09:14:02Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
+                    updatedAt: '2014-05-21T09:14:02.726Z'
                     details: []
                     id: 1
                     version: 1
@@ -47,8 +47,8 @@ get:
                       format: markdown
                       html: "<p>Lorem ipsum dolor sit amet.</p>"
                       raw: Lorem ipsum dolor sit amet.
-                    createdAt: '2014-05-21T09:51:22Z'
-                    updatedAt: '2014-05-21T10:14:02Z'
+                    createdAt: '2014-05-21T09:51:22.077Z'
+                    updatedAt: '2014-05-21T10:14:02.957Z'
                     details: []
                     id: 2
                     version: 2

--- a/docs/api/apiv3/paths/work_package_available_watchers.yml
+++ b/docs/api/apiv3/paths/work_package_available_watchers.yml
@@ -32,14 +32,14 @@ get:
                         title: John Sheppard - j.sheppard
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.com
                     firstName: John
                     id: 1
                     lastName: Sheppard
                     login: j.sheppard
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                   - _links:
                       delete:
                         href: "/api/v3/users/2"
@@ -54,14 +54,14 @@ get:
                         title: Jim Sheppard - j.sheppard2
                     _type: User
                     avatar: https://example.org/users/1/avatar
-                    createdAt: '2014-05-21T08:51:20Z'
+                    createdAt: '2014-05-21T08:51:20.396Z'
                     email: shep@mail.net
                     firstName: Jim
                     id: 2
                     lastName: Sheppard
                     login: j.sheppard2
                     status: active
-                    updatedAt: '2014-05-21T08:51:20Z'
+                    updatedAt: '2014-05-21T08:51:20.396Z'
                 _links:
                   self:
                     href: "/api/v3/work_packages/1/available_watchers"

--- a/docs/api/apiv3/paths/work_package_revisions.yml
+++ b/docs/api/apiv3/paths/work_package_revisions.yml
@@ -31,7 +31,7 @@ get:
                         href: "/projects/identifier/repository/revision/11f4b07"
                     _type: Revision
                     authorName: John Sheppard
-                    createdAt: '2015-07-21T13:36:59Z'
+                    createdAt: '2015-07-21T13:36:59.220Z'
                     formattedIdentifier: 11f4b07
                     id: 13
                     identifier: 11f4b07dff4f4ce9548a52b7d002daca7cd63ec6
@@ -56,7 +56,7 @@ get:
                         href: "/projects/identifier/repository/revision/029ed72a"
                     _type: Revision
                     authorName: j1msheppard
-                    createdAt: '2015-06-30T08:47:00Z'
+                    createdAt: '2015-06-30T08:47:00.818Z'
                     formattedIdentifier: '029ed72a'
                     id: 13
                     identifier: '029ed72a3b7b7c4ab332b1f6eaa6576e7c946059'

--- a/docs/api/apiv3/paths/work_package_watchers.yml
+++ b/docs/api/apiv3/paths/work_package_watchers.yml
@@ -33,14 +33,14 @@ get:
                       type: text/html
                   _type: User
                   avatar: https://example.org/users/1/avatar
-                  createdAt: '2014-05-21T08:51:20Z'
+                  createdAt: '2014-05-21T08:51:20.396Z'
                   firstName: John
                   id: 1
                   lastName: Sheppard
                   login: j.sheppard
                   mail: shep@mail.com
                   status: active
-                  updatedAt: '2014-05-21T08:51:20Z'
+                  updatedAt: '2014-05-21T08:51:20.396Z'
                 - _links:
                     delete:
                       href: "/api/v3/users/2"
@@ -55,14 +55,14 @@ get:
                       title: Jim Sheppard - j.sheppard2
                   _type: User
                   avatar: https://example.org/users/1/avatar
-                  createdAt: '2014-05-21T08:51:20Z'
+                  createdAt: '2014-05-21T08:51:20.396Z'
                   firstName: Jim
                   id: 2
                   lastName: Sheppard
                   login: j.sheppard2
                   mail: shep@mail.net
                   status: active
-                  updatedAt: '2014-05-21T08:51:20Z'
+                  updatedAt: '2014-05-21T08:51:20.396Z'
             _links:
               self:
                 href: "/api/v3/work_packages/14/watchers"

--- a/docs/api/apiv3/tags/basic_objects.yml
+++ b/docs/api/apiv3/tags/basic_objects.yml
@@ -231,14 +231,14 @@ description: |-
 
   * `Date` - refers to an ISO 8601 date, e.g. "2014-05-21"
 
-  * `DateTime` - refers to an ISO 8601 combined date and time, e.g. "2014-05-21T13:37:00Z"
+  * `DateTime` - refers to an ISO 8601 combined date and time, optionally with milliseconds, e.g. "2014-05-21T13:37:00Z" or "2014-05-21T13:37:00.396Z"
 
   * `Duration` - refers to an ISO 8601 duration, e.g. "P1DT18H"
 
   * `Timestamp` - refers to an ISO 8601 combined date and time, e.g. "2014-05-21T13:37:00Z" or to an ISO 8601 duration, e.g. "P1DT18H".
   The following shorthand values are also being parsed as duration: "1d", "1w", "1m", "1y", "1y-2m", "-2y".
   It can also refer the following relative date keywords: `"oneDayAgo@HH:MM+HH:MM", "lastWorkingDay@HH:MM+HH:MM", "oneWeekAgo@HH:MM+HH:MM", "oneMonthAgo@HH:MM+HH:MM"`.
-  The `"HH:MM"` part represents the zero paded hours and minutes, e.g. `"oneMonthAgo@21:00+00:00"`. The last "+HH:MM" part represents the timezone offset from UTC
+  The `"HH:MM"` part represents the zero padded hours and minutes, e.g. `"oneMonthAgo@21:00+00:00"`. The last "+HH:MM" part represents the timezone offset from UTC
   associated with the time, e.g. `"oneMonthAgo@21:00+02:00"` means a +2 hour timezone offset from UTC.
   The offset can be positive or negative e.g."oneDayAgo@01:00+01:00", "oneDayAgo@01:00-01:00".
   Values older than 1 day are accepted only with valid Enterprise Token available.

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -79,7 +79,7 @@ module API
         def format_datetime(datetime, allow_nil: false)
           return nil if datetime.nil? && allow_nil
 
-          datetime.to_datetime.utc.iso8601
+          datetime.to_datetime.utc.iso8601(3)
         end
 
         def format_duration_from_hours(hours, allow_nil: false)

--- a/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
+++ b/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Bim::Bcf::API::V2_1::Topics::SingleRepresenter, 'rendering' do
 
     context 'creation_date' do
       it_behaves_like 'attribute' do
-        let(:value) { work_package.created_at.iso8601 }
+        let(:value) { work_package.created_at.iso8601(3) }
         let(:path) { 'creation_date' }
       end
     end
@@ -163,7 +163,7 @@ RSpec.describe Bim::Bcf::API::V2_1::Topics::SingleRepresenter, 'rendering' do
 
     context 'modified_date' do
       it_behaves_like 'attribute' do
-        let(:value) { work_package.updated_at.iso8601 }
+        let(:value) { work_package.updated_at.iso8601(3) }
         let(:path) { 'modified_date' }
       end
     end

--- a/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
           {
             assigned_to: assignee.mail,
             creation_author: work_package.author.mail,
-            creation_date: work_package.created_at.iso8601,
+            creation_date: work_package.created_at.iso8601(3),
             description: work_package.description,
             due_date: work_package.due_date.iso8601,
             guid: bcf_issue.uuid,
@@ -125,7 +125,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
             labels: bcf_issue.labels,
             priority: work_package.priority.name,
             modified_author: current_user.mail,
-            modified_date: work_package.updated_at.iso8601,
+            modified_date: work_package.updated_at.iso8601(3),
             reference_links: [
               api_v3_paths.work_package(work_package.id)
             ],
@@ -165,7 +165,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
             {
               assigned_to: assignee.mail,
               creation_author: work_package.author.mail,
-              creation_date: work_package.created_at.iso8601,
+              creation_date: work_package.created_at.iso8601(3),
               description: work_package.description,
               due_date: work_package.due_date.iso8601,
               guid: bcf_issue.uuid,
@@ -173,7 +173,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
               labels: bcf_issue.labels,
               priority: work_package.priority.name,
               modified_author: current_user.mail,
-              modified_date: work_package.updated_at.iso8601,
+              modified_date: work_package.updated_at.iso8601(3),
               reference_links: [
                 api_v3_paths.work_package(work_package.id)
               ],
@@ -210,7 +210,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
         {
           assigned_to: assignee.mail,
           creation_author: work_package.author.mail,
-          creation_date: work_package.created_at.iso8601,
+          creation_date: work_package.created_at.iso8601(3),
           description: work_package.description,
           due_date: work_package.due_date.iso8601,
           guid: bcf_issue.uuid,
@@ -218,7 +218,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
           labels: bcf_issue.labels,
           priority: work_package.priority.name,
           modified_author: current_user.mail,
-          modified_date: work_package.updated_at.iso8601,
+          modified_date: work_package.updated_at.iso8601(3),
           reference_links: [
             api_v3_paths.work_package(work_package.id)
           ],
@@ -262,7 +262,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
           {
             assigned_to: assignee.mail,
             creation_author: work_package.author.mail,
-            creation_date: work_package.created_at.iso8601,
+            creation_date: work_package.created_at.iso8601(3),
             description: work_package.description,
             due_date: work_package.due_date.iso8601,
             guid: bcf_issue.uuid,
@@ -270,7 +270,7 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
             labels: bcf_issue.labels,
             priority: work_package.priority.name,
             modified_author: current_user.mail,
-            modified_date: work_package.updated_at.iso8601,
+            modified_date: work_package.updated_at.iso8601(3),
             reference_links: [
               api_v3_paths.work_package(work_package.id)
             ],
@@ -564,9 +564,9 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
           due_date: Date.today.iso8601,
           stage:,
           creation_author: edit_member_user.mail,
-          creation_date: work_package&.created_at&.iso8601,
+          creation_date: work_package&.created_at&.iso8601(3),
           modified_author: edit_member_user.mail,
-          modified_date: work_package&.updated_at&.iso8601,
+          modified_date: work_package&.updated_at&.iso8601(3),
           description:,
           authorization: {
             topic_status: [other_status.name, status.name],
@@ -603,9 +603,9 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
         due_date: due_date || base&.due_date,
         stage: nil,
         creation_author: creation_author_mail,
-        creation_date: work_package&.created_at&.iso8601,
+        creation_date: work_package&.created_at&.iso8601(3),
         modified_author: modified_author_mail,
-        modified_date: work_package&.updated_at&.iso8601,
+        modified_date: work_package&.updated_at&.iso8601(3),
         description: description || base&.description,
         authorization: {
           topic_status: [(base && base.status.name) || default_status.name],
@@ -815,9 +815,9 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
           due_date: Date.today.iso8601,
           stage: nil,
           creation_author: work_package.author.mail,
-          creation_date: work_package&.created_at&.iso8601,
+          creation_date: work_package&.created_at&.iso8601(3),
           modified_author: edit_member_user.mail,
-          modified_date: work_package&.updated_at&.iso8601,
+          modified_date: work_package&.updated_at&.iso8601(3),
           description:,
           authorization: {
             topic_status: [other_status.name, status.name],
@@ -854,9 +854,9 @@ RSpec.describe 'BCF 2.1 topics resource', content_type: :json do
             due_date: nil,
             stage: nil,
             creation_author: work_package.author.mail,
-            creation_date: work_package&.created_at&.iso8601,
+            creation_date: work_package&.created_at&.iso8601(3),
             modified_author: edit_member_user.mail,
-            modified_date: reloaded_work_package&.updated_at&.iso8601,
+            modified_date: reloaded_work_package&.updated_at&.iso8601(3),
             description: nil,
             authorization: {
               topic_status: [default_status.name],

--- a/modules/storages/spec/requests/api/v3/file_links/mixed_case_file_links_integration_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/mixed_case_file_links_integration_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'API v3 file links resource' do
     login_as user
   end
 
-  describe 'GET /api/v3/work_packages/:work_package_id/file_links', webmock: true do
+  describe 'GET /api/v3/work_packages/:work_package_id/file_links', :webmock do
     let(:path) { api_v3_paths.file_links(work_package.id) }
     let(:response_host_happy) do
       {
@@ -211,7 +211,7 @@ RSpec.describe 'API v3 file links resource' do
       happy_file_link = elements.detect { |e| e["originData"]["id"] == "24" }
       expect(happy_file_link["_links"]["permission"]["href"]).to eql API::V3::FileLinks::URN_PERMISSION_VIEW
       # Check that we've got an updated mtime
-      expect(happy_file_link["originData"]["lastModifiedAt"]).to eql Time.zone.at(1655301234).iso8601
+      expect(happy_file_link["originData"]["lastModifiedAt"]).to eql Time.zone.at(1655301234).iso8601(3)
 
       # A file link created by another user is not_allowed
       other_user_file_link = elements.detect { |e| e["originData"]["id"] == "25" }

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -124,11 +124,11 @@ RSpec.describe API::V3::Utilities::DateTimeFormatter do
 
   describe 'format_datetime' do
     it 'formats dates' do
-      expect(subject.format_datetime(date)).to eq(date.to_datetime.utc.iso8601)
+      expect(subject.format_datetime(date)).to eq(date.to_datetime.utc.iso8601(3))
     end
 
     it 'formats datetimes' do
-      expect(subject.format_datetime(datetime)).to eq(datetime.utc.iso8601)
+      expect(subject.format_datetime(datetime)).to eq(datetime.utc.iso8601(3))
     end
 
     it_behaves_like 'can format nil' do


### PR DESCRIPTION
It was often failing with:

```
  1) Custom actions viewing workflow buttons
     Failure/Error:
       expect(page)
         .to have_css('.op-user-activity a.user-mention',
                      text: other_member_user.name,
                      wait: 10)

       expected to find css ".op-user-activity a.user-mention" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[1]/DIV[1]/MAIN[1]/DIV[2]/OPENPROJECT-BASE[1]/DIV[1]/UI-VIEW[1]/WORK-PACKAGES-BASE[1]/DIV[1]/UI-VIEW[1]/WP-FULL-VIEW-ENTRY[1]/DIV[1]/DIV[2]/DIV[2]/DIV[1]/DIV[1]/OP-WP-TAB[1]/WP-ACTIVITY-TAB[1]/WORK-PACKAGE-COMMENT[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]"> but there were no matches
```

The activities were correctly fetched from the server, but the last one was not displayed. It's because the activities tab displays acitivites with this for loop: `*ngFor="let inf of visibleActivities; trackBy:trackByIdentifier"`, and the identifier for `ActivityEntryInfo` is composed of `href`, `version`, and `updatedAt` properties from the activity.

The problem is that the `updatedAt` property only has second resolution, and the two custom actions could be triggered within the same second. In that case, the second one would not be displayed as the identifier did not change.

The fix is to send milliseconds from the API for iso8601 date times.

This is only a partial fix as there are other flickering issues with the custom_actions_spec at custom actions creation when setting the project filter. Sometimes the selection does not work and it fails. Still, this is a quality of dev improvement.

It will probably break a few specs. I'll fix them.