### PR TITLE
[#50931] Ensure the Share Modal's header section is always present

### DIFF
--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -88,24 +88,12 @@
           if @shares.blank?
             border_box.with_row do
               render(Primer::Beta::Blankslate.new) do |component|
-                if params[:filters].blank?
-                  component.with_visual_icon(icon: :people, size: :medium)
-                  component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
-                  component.with_description do
-                    flex_layout do |flex|
-                      flex.with_row(mb: 2) do
-                        render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
-                      end
-                    end
-                  end
-                else
-                  component.with_visual_icon(icon: :search, size: :medium)
-                  component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_search_header') )
-                  component.with_description do
-                    flex_layout do |flex|
-                      flex.with_row(mb: 2) do
-                        render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_search_description') }
-                      end
+                component.with_visual_icon(icon: blankslate_config[:icon], size: :medium)
+                component.with_heading(tag: :h2).with_content(blankslate_config[:heading_text])
+                component.with_description do
+                  flex_layout do |flex|
+                    flex.with_row(mb: 2) do
+                      render(Primer::Beta::Text.new(color: :subtle)) { blankslate_config[:description_text] }
                     end
                   end
                 end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -5,101 +5,101 @@
         render(WorkPackages::Share::InviteUserFormComponent.new(work_package: @work_package))
       end
 
-      if @shares.blank?
-        modal_content.with_row(mt: 3) do
-          render(Primer::Beta::Blankslate.new(border: true)) do |component|
-            component.with_visual_icon(icon: :people, size: :medium)
-            component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
-            component.with_description do
-              flex_layout do |flex|
-                flex.with_row(mb: 2) do
-                  render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
+      modal_content.with_row(mt: 3,
+                             data: { 'test-selector': 'op-share-wp-active-list',
+                                     controller: 'work-packages--share--bulk-selection',
+                                     application_target: 'dynamic' }) do
+        render(Primer::Beta::BorderBox.new(list_id: insert_target_modifier_id)) do |border_box|
+          border_box.with_header(color: :muted, data: { 'test-selector': 'op-share-wp-header' }) do
+            grid_layout('op-share-wp-modal-body--header', tag: :div, align_items: :center) do |header_grid|
+              header_grid.with_area(:counter, tag: :div) do
+                render(WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: @shares.size))
+              end
+
+              header_grid.with_area(:actions,
+                                    tag: :div,
+                                    data: { 'work-packages--share--bulk-selection-target': 'defaultActions' }) do
+                flex_layout do |header_actions|
+                  header_actions.with_column(mr: 2) do
+                    render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
+                                                         select_variant: :single,
+                                                         dynamic_label: true,
+                                                         color: :muted,
+                                                         data: { 'test-selector': 'op-share-wp-filter-type' })) do |menu|
+                      menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-type-button' }) do |button|
+                        button.with_trailing_action_icon(icon: "triangle-down")
+                        I18n.t('work_package.sharing.filter.type')
+                      end
+                      type_filter_options.each do |option|
+                        menu.with_item(label: option[:label],
+                                       href: filter_url(type_option: option),
+                                       method: :get,
+                                       tag: :a,
+                                       active: type_filter_option_active?(option),
+                                       role: "menuitem")
+                      end
+                    end
+                  end
+
+                  header_actions.with_column do
+                    render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
+                                                         select_variant: :single,
+                                                         dynamic_label: true,
+                                                         color: :muted,
+                                                         data: { 'test-selector': 'op-share-wp-filter-role' })) do |menu|
+                      menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-role-button' }) do |button|
+                        button.with_trailing_action_icon(icon: "triangle-down")
+                        I18n.t('work_package.sharing.filter.role')
+                      end
+                      options.each do |option|
+                        menu.with_item(label: option[:label],
+                                       href: filter_url(role_option: option),
+                                       method: :get,
+                                       tag: :a,
+                                       active: role_filter_option_active?(option),
+                                       role: "menuitem")
+                      end
+                    end
+                  end
+                end
+              end
+
+              header_grid.with_area(:actions,
+                                    tag: :div,
+                                    hidden: true, # Prevent flicker on initial render
+                                    data: { 'work-packages--share--bulk-selection-target': 'bulkActions' }) do
+                if sharing_manageable?
+                  concat(
+                    render(WorkPackages::Share::BulkPermissionButtonComponent.new(work_package: @work_package))
+                  )
+
+                  concat(
+                    form_with(url: work_package_shares_bulk_path(@work_package),
+                              method: :delete,
+                              data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }) do
+                      render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
+                    end
+                  )
                 end
               end
             end
           end
-        end
-      else
-        modal_content.with_row(mt: 3,
-                               data: { 'test-selector': 'op-share-wp-active-list',
-                                       controller: 'work-packages--share--bulk-selection',
-                                       application_target: 'dynamic' }) do
-          render(Primer::Beta::BorderBox.new(list_id: insert_target_modifier_id)) do |border_box|
-            border_box.with_header(color: :muted, data: { 'test-selector': 'op-share-wp-header' }) do
-              grid_layout('op-share-wp-modal-body--header', tag: :div, align_items: :center) do |header_grid|
-                header_grid.with_area(:counter, tag: :div) do
-                  render(WorkPackages::Share::CounterComponent.new(work_package: @work_package, count: @shares.size))
-                end
 
-                header_grid.with_area(:actions,
-                                      tag: :div,
-                                      data: { 'work-packages--share--bulk-selection-target': 'defaultActions' }) do
-                  flex_layout do |header_actions|
-                    header_actions.with_column(mr: 2) do
-                      render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
-                                                           select_variant: :single,
-                                                           dynamic_label: true,
-                                                           color: :muted,
-                                                           data: { 'test-selector': 'op-share-wp-filter-type' })) do |menu|
-                        menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-type-button' }) do |button|
-                          button.with_trailing_action_icon(icon: "triangle-down")
-                          I18n.t('work_package.sharing.filter.type')
-                        end
-                        type_filter_options.each do |option|
-                          menu.with_item(label: option[:label],
-                                         href: filter_url(type_option: option),
-                                         method: :get,
-                                         tag: :a,
-                                         active: type_filter_option_active?(option),
-                                         role: "menuitem")
-                        end
-                      end
+          if @shares.blank?
+            border_box.with_row do
+              render(Primer::Beta::Blankslate.new) do |component|
+                component.with_visual_icon(icon: :people, size: :medium)
+                component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
+                component.with_description do
+                  flex_layout do |flex|
+                    flex.with_row(mb: 2) do
+                      render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
                     end
-
-                    header_actions.with_column do
-                      render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
-                                                           select_variant: :single,
-                                                           dynamic_label: true,
-                                                           color: :muted,
-                                                           data: { 'test-selector': 'op-share-wp-filter-role' })) do |menu|
-                        menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-role-button' }) do |button|
-                          button.with_trailing_action_icon(icon: "triangle-down")
-                          I18n.t('work_package.sharing.filter.role')
-                        end
-                        options.each do |option|
-                          menu.with_item(label: option[:label],
-                                         href: filter_url(role_option: option),
-                                         method: :get,
-                                         tag: :a,
-                                         active: role_filter_option_active?(option),
-                                         role: "menuitem")
-                        end
-                      end
-                    end
-                  end
-                end
-
-                header_grid.with_area(:actions,
-                                      tag: :div,
-                                      hidden: true, # Prevent flicker on initial render
-                                      data: { 'work-packages--share--bulk-selection-target': 'bulkActions' }) do
-                  if sharing_manageable?
-                    concat(
-                      render(WorkPackages::Share::BulkPermissionButtonComponent.new(work_package: @work_package))
-                    )
-
-                    concat(
-                      form_with(url: work_package_shares_bulk_path,
-                                method: :delete,
-                                data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }) do
-                        render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
-                      end
-                    )
                   end
                 end
               end
             end
-
+          else
             @shares.each do |share|
               render(WorkPackages::Share::ShareRowComponent.new(share: share, container: border_box))
             end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -38,9 +38,10 @@
                     header_actions.with_column(mr: 2) do
                       render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
                                                            select_variant: :single,
+                                                           dynamic_label: true,
                                                            color: :muted,
                                                            data: { 'test-selector': 'op-share-wp-filter-type' })) do |menu|
-                        menu.with_show_button(scheme: :invisible, color: :muted) do |button|
+                        menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-type-button' }) do |button|
                           button.with_trailing_action_icon(icon: "triangle-down")
                           I18n.t('work_package.sharing.filter.type')
                         end
@@ -58,9 +59,10 @@
                     header_actions.with_column do
                       render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
                                                            select_variant: :single,
+                                                           dynamic_label: true,
                                                            color: :muted,
                                                            data: { 'test-selector': 'op-share-wp-filter-role' })) do |menu|
-                        menu.with_show_button(scheme: :invisible, color: :muted) do |button|
+                        menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-role-button' }) do |button|
                           button.with_trailing_action_icon(icon: "triangle-down")
                           I18n.t('work_package.sharing.filter.role')
                         end

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -24,6 +24,7 @@
                     render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
                                                          select_variant: :single,
                                                          dynamic_label: true,
+                                                         dynamic_label_prefix: I18n.t('work_package.sharing.filter.type'),
                                                          color: :muted,
                                                          data: { 'test-selector': 'op-share-wp-filter-type' })) do |menu|
                       menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-type-button' }) do |button|
@@ -45,6 +46,7 @@
                     render(Primer::Alpha::ActionMenu.new(anchor_align: :end,
                                                          select_variant: :single,
                                                          dynamic_label: true,
+                                                         dynamic_label_prefix: I18n.t('work_package.sharing.filter.role'),
                                                          color: :muted,
                                                          data: { 'test-selector': 'op-share-wp-filter-role' })) do |menu|
                       menu.with_show_button(scheme: :invisible, color: :muted, data: { 'test-selector': 'op-share-wp-filter-role-button' }) do |button|

--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -88,12 +88,24 @@
           if @shares.blank?
             border_box.with_row do
               render(Primer::Beta::Blankslate.new) do |component|
-                component.with_visual_icon(icon: :people, size: :medium)
-                component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
-                component.with_description do
-                  flex_layout do |flex|
-                    flex.with_row(mb: 2) do
-                      render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
+                if params[:filters].blank?
+                  component.with_visual_icon(icon: :people, size: :medium)
+                  component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_state_header') )
+                  component.with_description do
+                    flex_layout do |flex|
+                      flex.with_row(mb: 2) do
+                        render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_state_description') }
+                      end
+                    end
+                  end
+                else
+                  component.with_visual_icon(icon: :search, size: :medium)
+                  component.with_heading(tag: :h2).with_content(I18n.t('work_package.sharing.text_empty_search_header') )
+                  component.with_description do
+                    flex_layout do |flex|
+                      flex.with_row(mb: 2) do
+                        render(Primer::Beta::Text.new(color: :subtle)) { I18n.t('work_package.sharing.text_empty_search_description') }
+                      end
                     end
                   end
                 end

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -93,7 +93,7 @@ module WorkPackages
       end
 
       def filter_url(type_option: nil, role_option: nil)
-        return work_package_shares_path if type_option.nil? && role_option.nil?
+        return work_package_shares_path(@work_package) if type_option.nil? && role_option.nil?
 
         args = {}
         filter = []
@@ -103,7 +103,7 @@ module WorkPackages
 
         args[:filters] = filter.to_json unless filter.empty?
 
-        work_package_shares_path(args)
+        work_package_shares_path(@work_package, **args)
       end
 
       def apply_role_filter(_option)

--- a/app/components/work_packages/share/modal_body_component.rb
+++ b/app/components/work_packages/share/modal_body_component.rb
@@ -57,6 +57,20 @@ module WorkPackages
         'op-share-wp-active-shares'
       end
 
+      def blankslate_config
+        @blankslate_config ||= {}.tap do |config|
+          if params[:filters].blank?
+            config[:icon] = :people
+            config[:heading_text] = I18n.t('work_package.sharing.text_empty_state_header')
+            config[:description_text] = I18n.t('work_package.sharing.text_empty_state_description')
+          else
+            config[:icon] = :search
+            config[:heading_text] = I18n.t('work_package.sharing.text_empty_search_header')
+            config[:description_text] = I18n.t('work_package.sharing.text_empty_search_description')
+          end
+        end
+      end
+
       def type_filter_options
         [
           { label: I18n.t('work_package.sharing.filter.project_member'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3276,8 +3276,10 @@ en:
         view_description: "Can view this work package."
       remove: "Remove"
       share: "Share"
+      text_empty_search_description: "There are no users with the current filter criteria."
+      text_empty_search_header: "We couldn't find any matching results."
       text_empty_state_description: "The work package has not been shared with anyone yet."
-      text_empty_state_header: "No shared users"
+      text_empty_state_header: "No shared members."
       text_user_limit_reached: "Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this work package."
       text_user_limit_reached_admins: 'Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to add more users.'
       warning_user_limit_reached: >

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/share/bulk-selection.controller.ts
@@ -125,7 +125,11 @@ export default class BulkSelectionController extends Controller {
   refresh() {
     const checkedSharesCount = this.checked.length;
     const sharesCount = this.shareCheckboxTargets.length;
-    this.toggleAllTarget.checked = checkedSharesCount === sharesCount;
+    if (sharesCount === 0) {
+      this.toggleAllTarget.checked = false;
+    } else {
+      this.toggleAllTarget.checked = checkedSharesCount === sharesCount;
+    }
 
     if (this.checked.length === 0) {
       this.bulkActionsTarget.setAttribute('hidden', 'true');

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(shared_non_project_group, 'View')
     end
 
-    it 'allow to filter for the role' do
+    it 'allows to filter for the role' do
       share_modal.expect_open
       share_modal.expect_shared_count_of(6)
 
@@ -192,7 +192,7 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(shared_non_project_group, 'View')
     end
 
-    it 'allow to filter for role and type at the same time' do
+    it 'allows to filter for role and type at the same time' do
       share_modal.expect_open
       share_modal.expect_shared_count_of(6)
 
@@ -260,6 +260,18 @@ RSpec.describe 'Work package sharing',
       share_modal.expect_shared_with(non_project_user, 'Edit')
       share_modal.expect_shared_with(shared_project_group, 'Edit')
       share_modal.expect_shared_with(shared_non_project_group, 'View')
+    end
+
+    context 'and there are no matching results for my filter' do
+      it 'does not check the "toggle all" checkbox' do
+        share_modal.expect_open
+        share_modal.filter('type', I18n.t('work_package.sharing.filter.not_project_member'))
+        share_modal.filter('role', I18n.t('work_package.sharing.permissions.view'))
+
+        share_modal.expect_blankslate
+        share_modal.expect_shared_count_of(0)
+        share_modal.expect_select_all_untoggled
+      end
     end
   end
 end

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe 'Work package sharing',
         share_modal.filter('type', I18n.t('work_package.sharing.filter.not_project_member'))
         share_modal.filter('role', I18n.t('work_package.sharing.permissions.view'))
 
-        share_modal.expect_blankslate
+        share_modal.expect_empty_search_blankslate
         share_modal.expect_shared_count_of(0)
         share_modal.expect_select_all_untoggled
       end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -275,15 +275,17 @@ module Components
 
       def expect_shared_with(user, role_name = nil, position: nil, editable: true)
         within_modal do
-          expect(page).to have_list_item(text: user.name, position:)
-          within(:list_item, text: user.name, position:) do
-            if role_name
-              expect(page).to have_button(role_name),
-                              "Expected share with #{user.name.inspect} to have button #{role_name}."
-            end
-            unless editable
-              expect(page).not_to have_button,
-                                  "Expected share with #{user.name.inspect} not to be editable (expected no buttons)."
+          within shares_list do
+            expect(page).to have_list_item(text: user.name, position:)
+            within(:list_item, text: user.name, position:) do
+              if role_name
+                expect(page).to have_button(role_name),
+                                "Expected share with #{user.name.inspect} to have button #{role_name}."
+              end
+              unless editable
+                expect(page).not_to have_button,
+                                    "Expected share with #{user.name.inspect} not to be editable (expected no buttons)."
+              end
             end
           end
         end
@@ -343,7 +345,7 @@ module Components
       end
 
       def shares_list
-        active_list.find_by_id('op-share-wp-active-shares')
+        find_by_id('op-share-wp-active-shares')
       end
 
       def select_existing_user(user)

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -246,11 +246,14 @@ module Components
       end
 
       def filter(filter_name, value)
-        within modal_element.find("[data-test-selector='op-share-wp-filter-#{filter_name}']") do
-          # Open the ActionMenu
-          retry_block do # Sometimes this is just too fast.
-            click_button filter_name.capitalize
+        within(shares_header) do
+          retry_block do
+            # The button's text changes dynamically based on the currently selected option
+            # Hence the spec's readability is hindered by using something like
+            # `click_button filter_name.capitalize`
+            find("[data-test-selector='op-share-wp-filter-#{filter_name}-button']").click
 
+            # Open the ActionMenu
             find('.ActionListContent', text: value).click
           end
         end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -136,8 +136,8 @@ module Components
 
       def expect_bulk_actions_not_available
         within shares_header do
-          expect(page).not_to have_button 'Remove'
-          expect(page).not_to have_test_selector('op-share-wp-bulk-update-role')
+          expect(page).not_to have_button('Remove', wait: 0)
+          expect(page).not_to have_test_selector('op-share-wp-bulk-update-role', wait: 0)
         end
       end
 

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -194,6 +194,12 @@ module Components
         end
       end
 
+      def expect_empty_search_blankslate
+        within_modal do
+          expect(page).to have_text(I18n.t('work_package.sharing.text_empty_search_description'))
+        end
+      end
+
       def invite_user(users, role_name)
         Array(users).each do |user|
           case user


### PR DESCRIPTION
## Description
Ensure the Border Box's header component remains present at all times, regardless if there are shared users being displayed or not. This prevents the scenario where if I filter for the "Comment" role, and there are no shared users with the "Comment" role, the filters are gone and I can't undo the filters unless I close and re-open the modal.

And... improved the spec's performance a bit ❤️
### Demos
<details>
<summary>No Shared Members</summary>
<img width="977" alt="No Shared Members Blankslate" src="https://github.com/opf/openproject/assets/61627014/5daf27f5-b84d-4158-92ac-449107c93a31">
</details>

<details>
<summary>No Results from Filter</summary>
<ul>
<li>Selected filter is shown</li>
<li>Selected filter is prefixed by the filter type (Role)</li>
<li>Counter remains present reflecting that there are no users in the result set</li>
</ul>
<img width="972" alt="No Results from Filter" src="https://github.com/opf/openproject/assets/61627014/b64bb944-bb33-4dd1-a8e0-dbf4b862acb1">
</details>

## Notes
See: https://community.openproject.org/work_packages/50931