### PR TITLE
include the roles on work package members in workflow calculation

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -449,7 +449,7 @@ module WorkPackages
       workflows = Workflow
                   .from_status(status.id,
                                model.type_id,
-                               users_roles_in_project.map(&:id),
+                               user_roles.map(&:id),
                                user_is_author?,
                                user_was_or_is_assignee?)
 
@@ -464,8 +464,8 @@ module WorkPackages
       model.author == user
     end
 
-    def users_roles_in_project
-      user.roles_for_project(model.project)
+    def user_roles
+      user.roles_for_work_package(model)
     end
 
     # We're in a readonly status and did not move into that status right now.

--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -89,6 +89,15 @@ module Users::PermissionChecks
   end
   alias :roles :roles_for_project
 
+  # Return user's role for the work package.
+  # Which consists of both the roles granted to the user directly on the work package
+  # as well as those granted to the user on the project the work package belongs to.
+  def roles_for_work_package(work_package)
+    roles_for_project(work_package.project) +
+      Role.includes(:member_roles)
+          .where(member_roles: { member_id: Member.of_work_package(work_package).select(:id) })
+  end
+
   # Return true if the user is a member of project
   def member_of?(project)
     roles_for_project(project).any?(&:member?)

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1043,8 +1043,8 @@ RSpec.describe WorkPackages::BaseContract do
 
     before do
       allow(current_user)
-        .to receive(:roles_for_project)
-         .with(work_package.project)
+        .to receive(:roles_for_work_package)
+         .with(work_package)
          .and_return(roles)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -586,6 +586,35 @@ RSpec.describe User do
     end
   end
 
+  describe '#roles_for_work_package' do
+    let(:work_package) { create(:work_package) }
+    let!(:user) do
+      create(:user,
+             member_with_roles: {
+               work_package.project => project_roles,
+               work_package => work_package_roles
+             })
+    end
+    let(:project_roles) { create_list(:project_role, 2) }
+    let(:work_package_roles) { create_list(:work_package_role, 1) }
+
+    context 'for a work_package the user has roles in' do
+      it 'returns the roles' do
+        expect(user.roles_for_work_package(work_package))
+          .to match_array project_roles + work_package_roles
+      end
+    end
+
+    context 'for a work_package the user does not have roles in' do
+      let(:other_work_package) { create(:work_package) }
+
+      it 'returns an empty set' do
+        expect(user.roles_for_work_package(other_work_package))
+          .to be_empty
+      end
+    end
+  end
+
   describe '.system' do
     context 'no SystemUser exists' do
       before do


### PR DESCRIPTION
The calculation for the new statuses available to a user on editing a work package is based on the roles the user has. With the change, the work package role is also included into the set of roles passed into the function so that workflows defined for the role are picked up on.

https://community.openproject.org/wp/51269