### PR TITLE
[Op#51415] Toggle Automatic management password input on initial view render (#14327)

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/storages/automatically-managed-project-folders-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/automatically-managed-project-folders-form.controller.ts
@@ -65,10 +65,10 @@ export default class AutomaticallyManagedProjectFoldersFormController extends Co
     }
 
     if (displayApplicationPasswordInput) {
-      this.applicationPasswordInputTarget.style.display = 'flex';
+      this.applicationPasswordInputTarget.classList.remove('d-none');
       this.submitButtonTarget.textContent = this.doneCompleteLabelValue;
     } else {
-      this.applicationPasswordInputTarget.style.display = 'none';
+      this.applicationPasswordInputTarget.classList.add('d-none');
       this.submitButtonTarget.textContent = this.doneCompleteWithoutLabelValue;
     }
   }

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
@@ -25,7 +25,9 @@
           render(Storages::Admin::ManagedProjectFolders::AutomaticallyManagedCheckbox.new(form, storage:))
         end
 
-        project_folders_form.with_row(mb: 3, data: { 'storages--automatically-managed-project-folders-form-target': "applicationPasswordInput" }) do
+        project_folders_form.with_row(mb: 3,
+                                      data: { 'storages--automatically-managed-project-folders-form-target': "applicationPasswordInput" },
+                                      **application_password_display_options) do
           render(Storages::Admin::ManagedProjectFolders::ApplicationPasswordInput.new(form, storage:))
         end
 

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
@@ -55,6 +55,12 @@ module Storages::Admin::Forms
 
     private
 
+    def application_password_display_options
+      {}.tap do |options_hash|
+        options_hash[:display] = :none unless storage.automatically_managed?
+      end
+    end
+
     def default_form_method
       new_record? ? :post : :patch
     end


### PR DESCRIPTION
https://community.openproject.org/work_packages/51415

Port over https://github.com/opf/openproject/pull/14327 to https://github.com/opf/openproject/tree/release/13.1