### PR TITLE
Fix ref name when triggering deployments

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,9 +19,9 @@ jobs:
           TOKEN: ${{ secrets.OPENPROJECT_CI_TOKEN }}
           REPOSITORY: opf/openproject-flavours
           WORKFLOW_ID: ci.yml
-          CORE_REF: ${{ github.ref }}
+          CORE_REF: ${{ github.ref_name }}
         run: |
           curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
             -XPOST -H"Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \
-            -d '{"ref": "dev", "inputs": { "ref" : "$CORE_REF" }}'
+            -d '{"ref": "${{ github.ref_name }}", "inputs": { "ref" : "'$CORE_REF'" }}'


### PR DESCRIPTION
There were two issues:
- the `$CORE_REF` variable was not expanded (can be seen on a [flavours workflow run](https://github.com/opf/openproject-flavours/actions/runs/7097824164/job/19318613990) that the variable value is `$CORE_REF`)
- the `ref` parameter was not set correctly ([github ref doc](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context))

As `$CORE_REF` is between single quotes, it is not expanded. The downstream workflow job is triggered with `ref = '$CORE_REF'` instead of `ref = 'dev'`.

When the ci.yml workflow is triggered, it calls commands like

```
./bin/deploy "${{ matrix.flavour }}" "${{ inputs.ref }}" "${{env.core_gitref}}"
```

which is for instance expanded to

```
./bin/deploy "saas-openproject" "$CORE_REF" "5ce35a2094a45dc0f34f992c7ed22b41e0d3ce15"
```

`"$CORE_REF"` is expanded to `""` and so the default value `dev` is used by default in the script, thanks to `local core_ref=${2:-"dev"}`.

Also use `github.ref_name` instead of `github.ref`: `github.ref` looks like `refs/heads/<branch_name>`, while `github.ref_name` is just `<branch_name>`.

We should maybe validate `ref` value in flavours repository to prevent such issues.