### PR TITLE
Use `allowed_based_on_permission_context` for menu items

### DIFF
--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -419,7 +419,11 @@ module Redmine::MenuManager::MenuHelper
     url = node.url(project)
     return true unless url
 
-    user.allowed_based_on_permission_context?(url, project:)
+    begin
+      user.allowed_based_on_permission_context?(url, project:)
+    rescue Authorization::UnknownPermissionError, Authorization::IllegalPermissionContextError
+      false
+    end
   end
 
   def visible_node?(menu, node)

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -420,20 +420,8 @@ module Redmine::MenuManager::MenuHelper
     return true unless url
 
     begin
-      user.allowed_in_project?(url, project)
+      user.allowed_based_on_permission_context?(url, project:)
     rescue Authorization::UnknownPermissionError, Authorization::IllegalPermissionContextError
-      # As we throw every possible URL in here, there might be URLs that are not backed by a permission or that are
-      # global permissions. Let's ignore those errors and just treat them as the user does not have access, as this
-      # mirrors what the system did before as well.
-      # We might catch the IllegalPermissionContextError here and check if the permission is a global one and then
-      # check if the user is globaly allowed.
-      #
-      # rescue Authorization::IllegalPermissionContextError => e
-      #   if e.allowed_contexts.include?(:global)
-      #     user.allowed_globally?(url)
-      #   else
-      #     false
-      #   end
       false
     end
   end

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -419,11 +419,7 @@ module Redmine::MenuManager::MenuHelper
     url = node.url(project)
     return true unless url
 
-    begin
-      user.allowed_based_on_permission_context?(url, project:)
-    rescue Authorization::UnknownPermissionError, Authorization::IllegalPermissionContextError
-      false
-    end
+    user.allowed_based_on_permission_context?(url, project:)
   end
 
   def visible_node?(menu, node)

--- a/spec/lib/redmine/menu_manager/menu_helper_spec.rb
+++ b/spec/lib/redmine/menu_manager/menu_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Redmine::MenuManager::MenuHelper, type: :helper do
 
     # Return a fake permission for the URLs that are allowed
     allowed_urls.each do |url|
-      allow(Authorization).to receive(:permissions_for).with(url).and_return([fake_permission])
+      allow(Authorization).to receive(:permissions_for).with(url, any_args).and_return([fake_permission])
     end
 
     # When the permission is requested itself, return it


### PR DESCRIPTION
We now have the method that checks all permissions for the correct context. This fixes the sidebar not being shown, when the WorkPackage is viewed in project context.

Fixes https://community.openproject.org/projects/openproject/work_packages/51268