### PR TITLE
Fix flaky query spec in bcf_view_management_spec.rb

### DIFF
--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -110,6 +110,10 @@ module Components
         add_filter(name)
 
         set_filter(name, operator, value, selector)
+
+        # Wait for the debounce of the filter input to apply filters
+        # See frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts:69
+        sleep 0.5
       end
 
       def set_operator(name, operator, selector = nil)


### PR DESCRIPTION
`./modules/bim/spec/features/bcf_view_management_spec.rb:67` could fail with the following error:

```
     Failure/Error: expect(page).to have_selector(".op-toast.-#{type}", text: message, wait: 20)
       expected to find css ".op-toast.-success" but there were no matches
```

The save query dialog is open, it clicks on save button but nothing happens. Under the hood, there is an error message in the devtools console: `Uncaught TypeError: Cannot read properties of undefined (reading '$links')`.

The error is that it tries to link the filter to a known schema, and looks it up, but it looks up the schema for "status", and there is none. Actually, the input for the filter has still not debounced, so it is not yet applied, and the filters are the default ones with "status == open".

That's why a sleep 500ms is needed so that the filter value is debounced and the filters are applied through
`WorkPackageViewFiltersService.applyToQuery`.