### PR TITLE
[#51384] fixed storage admin pages

### DIFF
--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -265,11 +265,14 @@ module OpenProject
               one_drive_setup: {
                 href: 'https://www.openproject.org/docs/system-admin-guide/integrations/one-drive/'
               },
+              one_drive_drive_id_guide: {
+                href: 'https://www.openproject.org/docs/system-admin-guide/integrations/one-drive/drive-id-guide/'
+              },
               nextcloud_oauth_application: {
                 href: 'https://apps.nextcloud.com/apps/integration_openproject'
               },
               one_drive_oauth_application: {
-                href: 'https://docs.microsoft.com/en-us/graph/auth-register-app-v2'
+                href: 'https://portal.azure.com/'
               }
             },
             ical_docs: {

--- a/modules/storages/app/components/storages/admin/storage_view_information.rb
+++ b/modules/storages/app/components/storages/admin/storage_view_information.rb
@@ -23,6 +23,9 @@ module Storages::Admin
     end
 
     def configuration_check_label_for(*configs)
+      # do not show the status label, if storage is completely empty (initial state)
+      return nil if storage.configuration_checks.values.none?
+
       if storage.configuration_checks.slice(*configs.map(&:to_sym)).values.all?
         status_label(I18n.t('storages.label_completed'), scheme: :success, test_selector: "label-#{configs.join('-')}-status")
       else
@@ -35,6 +38,9 @@ module Storages::Admin
     end
 
     def automatically_managed_project_folders_status_label
+      # do not show the status label, if storage is completely empty (initial state)
+      return nil if storage.configuration_checks.values.none?
+
       test_selector = 'label-managed-project-folders-status'
 
       if storage.automatically_managed?

--- a/modules/storages/app/components/storages/admin/storage_view_information.rb
+++ b/modules/storages/app/components/storages/admin/storage_view_information.rb
@@ -24,7 +24,7 @@ module Storages::Admin
 
     def configuration_check_label_for(*configs)
       # do not show the status label, if storage is completely empty (initial state)
-      return nil if storage.configuration_checks.values.none?
+      return if storage.configuration_checks.values.none?
 
       if storage.configuration_checks.slice(*configs.map(&:to_sym)).values.all?
         status_label(I18n.t('storages.label_completed'), scheme: :success, test_selector: "label-#{configs.join('-')}-status")
@@ -39,7 +39,7 @@ module Storages::Admin
 
     def automatically_managed_project_folders_status_label
       # do not show the status label, if storage is completely empty (initial state)
-      return nil if storage.configuration_checks.values.none?
+      return if storage.configuration_checks.values.none?
 
       test_selector = 'label-managed-project-folders-status'
 

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -88,8 +88,7 @@ class Storages::Admin::StoragesController < ApplicationController
     service_result = ::Storages::Storages::SetAttributesService
                  .new(user: current_user,
                       model: @object,
-                      contract_class: EmptyContract,
-                      contract_options: { skip_provider_type_strategy: true })
+                      contract_class: EmptyContract)
                  .call
     @storage = service_result.result
 

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -88,7 +88,7 @@ class Storages::Admin::StoragesController < ApplicationController
     service_result = ::Storages::Storages::SetAttributesService
                  .new(user: current_user,
                       model: @object,
-                      contract_class: Storages::Storages::BaseContract,
+                      contract_class: EmptyContract,
                       contract_options: { skip_provider_type_strategy: true })
                  .call
     @storage = service_result.result

--- a/modules/storages/app/forms/storages/admin/provider_drive_id_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_drive_id_input_form.rb
@@ -34,10 +34,19 @@ module Storages::Admin
         label: Storages::Admin::LABEL_DRIVE_ID,
         visually_hide_label: false,
         required: true,
-        caption: I18n.t("storages.instructions.one_drive.drive_id"),
-        placeholder: I18n.t("storages.instructions.one_drive.drive_id_placeholder"),
+        caption: caption.html_safe, # rubocop:disable Rails/OutputSafety
         input_width: :large
       )
+    end
+
+    private
+
+    def caption
+      href = ::OpenProject::Static::Links[:storage_docs][:one_drive_drive_id_guide][:href]
+      I18n.t('storages.instructions.one_drive.drive_id',
+             drive_id_link_text: render(Primer::Beta::Link.new(href:, target: '_blank')) do
+               I18n.t('storages.instructions.one_drive.documentation_link_text')
+             end)
     end
   end
 end

--- a/modules/storages/app/forms/storages/admin/provider_tenant_id_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/provider_tenant_id_input_form.rb
@@ -34,10 +34,20 @@ module Storages::Admin
         label: I18n.t('activerecord.attributes.storages/storage.tenant'),
         visually_hide_label: false,
         required: true,
-        caption: I18n.t("storages.instructions.one_drive.tenant_id"),
-        placeholder: I18n.t("storages.instructions.one_drive.tenant_id_placeholder"),
+        caption: caption.html_safe, # rubocop:disable Rails/OutputSafety
+        placeholder: I18n.t('storages.instructions.one_drive.tenant_id_placeholder'),
         input_width: :large
       )
+    end
+
+    private
+
+    def caption
+      href = ::OpenProject::Static::Links[:storage_docs][:one_drive_oauth_application][:href]
+      I18n.t('storages.instructions.one_drive.tenant_id',
+             application_link_text: render(Primer::Beta::Link.new(href:, target: '_blank')) do
+               I18n.t('storages.instructions.one_drive.application_link_text')
+             end)
     end
   end
 end

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -30,7 +30,7 @@
 
 module Storages
   class OneDriveStorage < Storage
-    store_attribute :provider_fields, :tenant_id, :string, default: 'consumers'
+    store_attribute :provider_fields, :tenant_id, :string
     store_attribute :provider_fields, :drive_id, :string
 
     using ::Storages::Peripherals::ServiceResultRefinements

--- a/modules/storages/app/services/storages/storages/set_attributes_service.rb
+++ b/modules/storages/app/services/storages/storages/set_attributes_service.rb
@@ -33,7 +33,6 @@ module Storages::Storages
 
     def set_default_attributes(_params)
       storage.creator ||= user
-      storage.name ||= derive_default_storage_name
     end
 
     private
@@ -51,7 +50,7 @@ module Storages::Storages
       cloned_param = params.clone
 
       if cloned_param[:host] == ''
-        cloned_param.merge!(host: nil)
+        cloned_param[:host] = nil
       end
 
       cloned_param
@@ -69,15 +68,6 @@ module Storages::Storages
 
     def storage
       model
-    end
-
-    def derive_default_storage_name
-      prefix = I18n.t("storages.default_name")
-      last_id = Storages::Storage.where("name like ?", "#{prefix}%").maximum(:id)
-
-      return prefix if last_id.nil?
-
-      "#{prefix} #{last_id + 1}"
     end
 
     def nextcloud_storage?

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -142,21 +142,26 @@ en:
         application_link_text: "application “Integration OpenProject”"
         integration: "Nextcloud Administration / OpenProject"
       one_drive:
-        provider_configuration: "Please make sure you have administration privileges in the %{application_link_text} before doing the setup."
-        oauth_configuration: "Copy these values from the %{application_link_text}. After that, copy the redirect URI back to the %{application_link_text}."
-        application_link_text: "Azure application"
+        provider_configuration: >
+          Please make sure you have administration privileges in the %{application_link_text} or contact your Microsoft
+          administrator before doing the setup. In the portal, you also need to register an Azure application or use an
+          existing one for authentication.
+        oauth_configuration: "Copy these values from the desired application in the %{application_link_text}."
+        application_link_text: "Azure portal"
         integration: "OneDrive/SharePoint"
         oauth_client_id: >
           Copy the client id from the Azure portal. This is needed to generate the redirect URI.
         oauth_client_secret: >
-          The client secret has been automatically copied from an already fully connected file storage with the same Application (client) ID.
+          In case there is no application client secret under Client credentials, please create a new one.
         oauth_client_redirect_uri: >
           Please copy this value to a new Web redirect URI under Redirect URIs.
         missing_client_id_for_redirect_uri: "Please fill the OAuth values to generate a URI"
-        tenant_id: "Please copy the tenant from your Azure application."
+        tenant_id: >
+          Please copy the Directory (tenant) ID from the desired application und App registrations
+          in the %{application_link_text}.
         tenant_id_placeholder: "Name or UUID"
-        drive_id: "Please copy the drive ID from your Azure application."
-        drive_id_placeholder: "UUID or triple ID"
+        drive_id: "Please copy the ID from the desired drive by following the steps in the %{drive_id_link_text}."
+        documentation_link_text: "OneDrive/SharePoint file storages documentation"
     help_texts:
       project_folder: >
         The project folder is the default folder for file uploads for this project.

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -308,9 +308,7 @@ RSpec.describe 'Admin storages',
         aggregate_failures 'General information' do
           within_test_selector('storage-general-info-form') do
             fill_in 'storages_one_drive_storage_name', with: 'My OneDrive', fill_options: { clear: :backspace }
-            fill_in 'storages_one_drive_storage_tenant_id',
-                    with: '029d4741-a4be-44c6-a8e4-e4eff7b19f65',
-                    fill_options: { clear: :backspace }
+            fill_in 'storages_one_drive_storage_tenant_id', with: '029d4741-a4be-44c6-a8e4-e4eff7b19f65'
             click_button 'Save and continue'
 
             expect(page).to have_text("Drive can't be blank.")

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -144,18 +144,18 @@ RSpec.describe 'Admin storages',
 
           # OAuth application
           expect(page).to have_test_selector('storage-openproject-oauth-label', text: 'OpenProject OAuth')
-          expect(page).to have_test_selector('label-openproject_oauth_application_configured-status', text: 'Incomplete')
+          expect(page).not_to have_test_selector('label-openproject_oauth_application_configured-status')
 
           # OAuth client
           wait_for(page).to have_test_selector('storage-oauth-client-label', text: 'Nextcloud OAuth')
-          expect(page).to have_test_selector('label-storage_oauth_client_configured-status', text: 'Incomplete')
+          expect(page).not_to have_test_selector('label-storage_oauth_client_configured-status')
           expect(page).to have_test_selector('storage-oauth-client-id-description',
                                              text: "Allow OpenProject to access Nextcloud data using OAuth.")
 
           # Automatically managed project folders
           expect(page).to have_test_selector('storage-managed-project-folders-label',
                                              text: 'Automatically managed folders')
-          expect(page).to have_test_selector('label-managed-project-folders-status', text: 'Incomplete')
+          expect(page).not_to have_test_selector('label-managed-project-folders-status')
           expect(page).to have_test_selector('storage-automatically-managed-project-folders-description',
                                              text: 'Let OpenProject create folders per project automatically.')
         end
@@ -293,11 +293,13 @@ RSpec.describe 'Admin storages',
           # General information
           expect(page).to have_test_selector('storage-provider-configuration-instructions',
                                              text: "Please make sure you have administration privileges in the " \
-                                                   "Azure application before doing the setup.")
+                                                   "Azure portal or contact your Microsoft administrator before " \
+                                                   "doing the setup. In the portal, you also need to register an " \
+                                                   "Azure application or use an existing one for authentication.")
 
           # OAuth client
           wait_for(page).to have_test_selector('storage-oauth-client-label', text: 'Azure OAuth')
-          expect(page).to have_test_selector('label-storage_oauth_client_configured-status', text: 'Incomplete')
+          expect(page).not_to have_test_selector('label-storage_oauth_client_configured-status')
           expect(page).to have_test_selector('storage-oauth-client-id-description',
                                              text: "Allow OpenProject to access Azure data using OAuth " \
                                                    "to connect OneDrive/Sharepoint.")
@@ -306,6 +308,9 @@ RSpec.describe 'Admin storages',
         aggregate_failures 'General information' do
           within_test_selector('storage-general-info-form') do
             fill_in 'storages_one_drive_storage_name', with: 'My OneDrive', fill_options: { clear: :backspace }
+            fill_in 'storages_one_drive_storage_tenant_id',
+                    with: '029d4741-a4be-44c6-a8e4-e4eff7b19f65',
+                    fill_options: { clear: :backspace }
             click_button 'Save and continue'
 
             expect(page).to have_text("Drive can't be blank.")
@@ -322,8 +327,8 @@ RSpec.describe 'Admin storages',
         aggregate_failures 'OAuth Client' do
           within_test_selector('storage-oauth-client-form') do
             expect(page).to have_test_selector('storage-provider-credentials-instructions',
-                                               text: 'Copy these values from the Azure application. ' \
-                                                     'After that, copy the redirect URI back to the Azure application.')
+                                               text: 'Copy these values from the desired application in the ' \
+                                                     'Azure portal.')
 
             # With null values, submit button should be disabled
             expect(page).to have_css('#oauth_client_client_id', value: '')

--- a/modules/storages/spec/services/storages/storages/set_attributes_service_spec.rb
+++ b/modules/storages/spec/services/storages/storages/set_attributes_service_spec.rb
@@ -88,10 +88,6 @@ RSpec.describe Storages::Storages::SetAttributesService, type: :model do
       expect(subject.result.provider_type).to eq Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
     end
 
-    it 'sets name to "My Nextcloud" by default' do
-      expect(subject.result.name).to eq I18n.t('storages.default_name')
-    end
-
     context 'when setting host' do
       before do
         params[:host] = "https://some.host.com//"


### PR DESCRIPTION
[OP#51384](https://community.openproject.org/wp/51384)

### Wat?

- synch display texts
- updated static links
- hide "incomplete" status labels, if storage is pristine (initial state on new storage)
- remove default values "consumers" and "My storage"