### PR TITLE
[#51186] Render the "Share" button based on the user's viewing capability

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -131,7 +131,7 @@ Rails.application.reloader.to_prepare do
                      },
                      permissible_on: :project,
                      require: :member,
-                     contract_actions: { shares: %i[index] }
+                     contract_actions: { work_package_shares: %i[index] }
 
       map.permission :view_members,
                      { members: [:index] },

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -130,7 +130,8 @@ Rails.application.reloader.to_prepare do
                        'work_packages/shares': %i[index]
                      },
                      permissible_on: :project,
-                     require: :member
+                     require: :member,
+                     contract_actions: { shares: %i[index] }
 
       map.permission :view_members,
                      { members: [:index] },

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -108,7 +108,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     this.displayWatchButton = Object.prototype.hasOwnProperty.call(wp, 'unwatch') || Object.prototype.hasOwnProperty.call(wp, 'watch');
     this.displayTimerButton = Object.prototype.hasOwnProperty.call(wp, 'logTime');
     this.displayShareButton$ = this.configurationService.activeFeatureFlags.includes('workPackageSharing')
-      && this.currentUserService.hasCapabilities$('shares/index', wp.project.id);
+      && this.currentUserService.hasCapabilities$('work_package_shares/index', wp.project.id);
 
     // watchers
     if (wp.watchers) {

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -33,7 +33,7 @@ import {
   Injector,
   OnInit,
 } from '@angular/core';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import { WorkPackageSingleViewBase } from 'core-app/features/work-packages/routing/wp-view-base/work-package-single-view.base';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
@@ -42,6 +42,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
 import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
 import { RecentItemsService } from 'core-app/core/recent-items.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 
 @Component({
   templateUrl: './wp-full-view.html',
@@ -62,7 +63,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
 
   public displayTimerButton = false;
 
-  public displayShareButton = false;
+  public displayShareButton$:false|Observable<boolean> = false;
 
   public watchers:any;
 
@@ -79,6 +80,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     public wpTableSelection:WorkPackageViewSelectionService,
     public recentItemsService:RecentItemsService,
     readonly $state:StateService,
+    readonly currentUserService:CurrentUserService,
     private readonly configurationService:ConfigurationService,
   ) {
     super(injector, $state.params.workPackageId);
@@ -105,7 +107,8 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     this.isWatched = Object.prototype.hasOwnProperty.call(wp, 'unwatch');
     this.displayWatchButton = Object.prototype.hasOwnProperty.call(wp, 'unwatch') || Object.prototype.hasOwnProperty.call(wp, 'watch');
     this.displayTimerButton = Object.prototype.hasOwnProperty.call(wp, 'logTime');
-    this.displayShareButton = this.configurationService.activeFeatureFlags.includes('workPackageSharing');
+    this.displayShareButton$ = this.configurationService.activeFeatureFlags.includes('workPackageSharing')
+      && this.currentUserService.hasCapabilities$('shares/index', wp.project.id);
 
     // watchers
     if (wp.watchers) {

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -25,7 +25,8 @@
             [stateName$]="stateName$">
           </wp-create-button>
         </li>
-        <li class="toolbar-item" *ngIf="displayShareButton">
+        <li class="toolbar-item"
+            *ngIf="displayShareButton$ | async">
           <wp-share-button [workPackage]="workPackage">
           </wp-share-button>
         </li>

--- a/spec/features/work_packages/share/bulk_sharing_spec.rb
+++ b/spec/features/work_packages/share/bulk_sharing_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
     it 'allows administrating shares in bulk' do
       work_package_page.visit!
 
-      click_button 'Share'
+      work_package_page.click_share_button
+
       share_modal.expect_open
       share_modal.expect_shared_count_of(3)
 
@@ -257,7 +258,8 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
 
         share_modal.close
         share_modal.expect_closed
-        click_button 'Share'
+
+        work_package_page.click_share_button
         share_modal.expect_open
 
         share_modal.expect_shared_count_of(3)
@@ -287,7 +289,7 @@ RSpec.describe 'Work Packages', 'Bulk Sharing',
     it 'does not allow bulk sharing' do
       work_package_page.visit!
 
-      click_button 'Share'
+      work_package_page.click_share_button
       share_modal.expect_open
 
       share_modal.expect_shared_count_of(3)

--- a/spec/features/work_packages/share/enterprise_restriction_spec.rb
+++ b/spec/features/work_packages/share/enterprise_restriction_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe 'Work Package Sharing Enterprise Restriction',
 
   before do
     work_package_page.visit!
-    click_button 'Share'
+    work_package_page.click_share_button
+
     share_modal.expect_open
   end
 

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Work package sharing',
   context 'when having share permission' do
     before do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
     end
 
     it 'allows to filter for the type' do

--- a/spec/features/work_packages/share/multi_invite_spec.rb
+++ b/spec/features/work_packages/share/multi_invite_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Work package sharing',
       # Clicking on the share button opens a modal which lists all of the users a work package
       # is explicitly shared with.
       # Project members are not listed unless the work package is also shared with them explicitly.
-      click_button 'Share'
+      work_package_page.click_share_button
 
       aggregate_failures "Inviting multiple users or groups at once" do
         share_modal.expect_shared_count_of(1)
@@ -135,7 +135,7 @@ RSpec.describe 'Work package sharing',
       end
 
       share_modal.close
-      click_button 'Share'
+      work_package_page.click_share_button
 
       aggregate_failures "Re-opening the modal after changes performed" do
         # This user preserved
@@ -161,7 +161,7 @@ RSpec.describe 'Work package sharing',
 
     before do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
     end
 
     it 'allows adding multiple users and updates the modal correctly' do
@@ -193,7 +193,7 @@ RSpec.describe 'Work package sharing',
 
     it 'allows creating multiple users at once' do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
 
       share_modal.expect_open
       share_modal.expect_shared_count_of(1)
@@ -233,7 +233,7 @@ RSpec.describe 'Work package sharing',
 
     it 'allows sharing with an existing user and creating a new one at the same time' do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
 
       share_modal.expect_open
       share_modal.expect_shared_count_of(1)
@@ -267,7 +267,7 @@ RSpec.describe 'Work package sharing',
 
       it 'shows a warning as soon as you reach the user limit' do
         work_package_page.visit!
-        click_button 'Share'
+        work_package_page.click_share_button
 
         share_modal.expect_open
         share_modal.expect_shared_count_of(1)

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -269,34 +269,51 @@ RSpec.describe 'Work package sharing',
   end
 
   context 'when lacking share permission' do
-    let(:sharer_role) do
-      create(:project_role,
-             permissions: %i(view_work_packages
-                             view_shared_work_packages))
+    context 'with :view_shared_work_packages permission' do
+      let(:sharer_role) do
+        create(:project_role,
+               permissions: %i(view_work_packages
+                               view_shared_work_packages))
+      end
+
+      it 'allows seeing shares but not editing' do
+        work_package_page.visit!
+
+        # Clicking on the share button opens a modal which lists all of the users a work package
+        # is explicitly shared with.
+        # Project members are not listed unless the work package is also shared with them explicitly.
+        click_button 'Share'
+
+        share_modal.expect_open
+        share_modal.expect_shared_with(view_user, editable: false)
+        share_modal.expect_shared_with(comment_user, editable: false)
+        share_modal.expect_shared_with(dinesh, editable: false)
+        share_modal.expect_shared_with(edit_user, editable: false)
+        share_modal.expect_shared_with(shared_project_user, editable: false)
+        share_modal.expect_shared_with(current_user, editable: false)
+
+        share_modal.expect_not_shared_with(non_shared_project_user)
+        share_modal.expect_not_shared_with(not_shared_yet_with_user)
+
+        share_modal.expect_shared_count_of(6)
+
+        share_modal.expect_no_invite_option
+      end
     end
 
-    it 'allows seeing shares but not editing' do
-      work_package_page.visit!
+    context 'without the :view_shared_work_packages permission' do
+      let(:sharer_role) do
+        create(:project_role,
+               permissions: %i(view_work_packages))
+      end
 
-      # Clicking on the share button opens a modal which lists all of the users a work package
-      # is explicitly shared with.
-      # Project members are not listed unless the work package is also shared with them explicitly.
-      click_button 'Share'
+      it 'does not render the "Share" button to open the modal' do
+        work_package_page.visit!
 
-      share_modal.expect_open
-      share_modal.expect_shared_with(view_user, editable: false)
-      share_modal.expect_shared_with(comment_user, editable: false)
-      share_modal.expect_shared_with(dinesh, editable: false)
-      share_modal.expect_shared_with(edit_user, editable: false)
-      share_modal.expect_shared_with(shared_project_user, editable: false)
-      share_modal.expect_shared_with(current_user, editable: false)
-
-      share_modal.expect_not_shared_with(non_shared_project_user)
-      share_modal.expect_not_shared_with(not_shared_yet_with_user)
-
-      share_modal.expect_shared_count_of(6)
-
-      share_modal.expect_no_invite_option
+        within work_package_page.toolbar do
+          expect(page).not_to have_button('Share', wait: 0)
+        end
+      end
     end
   end
 

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Work package sharing',
       # Clicking on the share button opens a modal which lists all of the users a work package
       # is explicitly shared with.
       # Project members are not listed unless the work package is also shared with them explicitly.
-      click_button 'Share'
+      work_package_page.click_share_button
 
       aggregate_failures "Initial shares list" do
         share_modal.expect_title(I18n.t('js.work_packages.sharing.title'))
@@ -225,7 +225,7 @@ RSpec.describe 'Work package sharing',
       end
 
       share_modal.close
-      click_button 'Share'
+      work_package_page.click_share_button
 
       aggregate_failures "Re-opening the modal after changes performed" do
         # This user preserved its group independent share
@@ -255,8 +255,7 @@ RSpec.describe 'Work package sharing',
 
     it "lets the sharer know a user needs to be selected to share the work package with them" do
       work_package_page.visit!
-
-      click_button 'Share'
+      work_package_page.click_share_button
 
       share_modal.expect_open
       share_modal.click_share
@@ -342,7 +341,7 @@ RSpec.describe 'Work package sharing',
 
     before do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
     end
 
     it 'allows inviting and directly sharing with a user who is not part of the instance yet' do
@@ -390,7 +389,7 @@ RSpec.describe 'Work package sharing',
   context 'when lacking global invite permission' do
     it 'does not allow creating a user who is not part of the instance yet' do
       work_package_page.visit!
-      click_button 'Share'
+      work_package_page.click_share_button
 
       share_modal.expect_open
       share_modal.expect_shared_count_of(6)

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -34,6 +34,10 @@ module Pages
       find('.work-packages--details--subject', match: :first)
     end
 
+    def toolbar
+      find_by_id('toolbar-items')
+    end
+
     private
 
     def container

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -38,6 +38,18 @@ module Pages
       find_by_id('toolbar-items')
     end
 
+    def click_share_button
+      within toolbar do
+        # The request to the capabilities endpoint determines
+        # whether the "Share" button is rendered or not.
+        # Instead of waiting for an idle network (which may
+        # include waiting for other network requests unrelated to
+        # sharing), waiting for the button to be present makes
+        # the spec a tad faster.
+        click_button('Share', wait: 10)
+      end
+    end
+
     private
 
     def container


### PR DESCRIPTION
## Description
* Adds a contract action to `:view_shared_work_packages` so it's registered in the capabilities query
* Renders the "Share" button conditionally if the capabilities request for the current user allows viewing shares
## Notes
See: https://community.openproject.org/work_packages/51186