### PR TITLE
Do not display project infos on the index page

### DIFF
--- a/app/components/projects/row_component.html.erb
+++ b/app/components/projects/row_component.html.erb
@@ -70,7 +70,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
   </td>
 </tr>
-<% if project.description.present? %>
+<% if User.current.allowed_in_project?(:view_project, project) && project.description.present? %>
   <tr class="project-description <%= project_css_classes %> <%= row_css_level_classes %> <%= params[:expand] == 'all' ? '-expanded' : '' %>"
       data-project-target="descriptionRow"
       data-project-id="<%= project.id %>">

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -52,6 +52,8 @@ module Projects
     end
 
     def custom_field_column(column)
+      return nil unless user_can_view_project?
+
       cf = custom_field(column)
       custom_value = project.formatted_custom_value_for(cf)
 
@@ -92,6 +94,8 @@ module Projects
     end
 
     def project_status
+      return nil unless user_can_view_project?
+
       content = ''.html_safe
 
       status_code = project.status_code
@@ -106,6 +110,8 @@ module Projects
     end
 
     def status_explanation
+      return nil unless user_can_view_project?
+
       if project.status_explanation
         content_tag :div, helpers.format_text(project.status_explanation), class: 'wiki'
       end
@@ -164,6 +170,10 @@ module Projects
         formattable = cf.field_format == 'text' ? ' -no-ellipsis' : ''
         "format-#{cf.field_format}#{formattable}"
       end
+    end
+
+    def user_can_view_project?
+      User.current.allowed_in_project?(:view_project, project)
     end
   end
 end


### PR DESCRIPTION
The index page currently still displays information about the project that a user with only shared work packages should not see