### PR TITLE
Fix `in_project` scope that is used by the members filter

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -80,11 +80,11 @@ class Principal < ApplicationRecord
          :status
 
   scope :in_project, ->(project) {
-    where(id: Member.of_project(project).select(:user_id))
+    where(id: Member.of_anything_in_project(project).select(:user_id))
   }
 
   scope :not_in_project, ->(project) {
-    where.not(id: Member.of_project(project).select(:user_id))
+    where.not(id: Member.of_anything_in_project(project).select(:user_id))
   }
 
   scope :in_group, ->(group) {

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -80,10 +80,18 @@ class Principal < ApplicationRecord
          :status
 
   scope :in_project, ->(project) {
-    where(id: Member.of_anything_in_project(project).select(:user_id))
+    where(id: Member.of_project(project).select(:user_id))
   }
 
   scope :not_in_project, ->(project) {
+    where.not(id: Member.of_project(project).select(:user_id))
+  }
+
+  scope :in_anything_in_project, ->(project) {
+    where(id: Member.of_anything_in_project(project).select(:user_id))
+  }
+
+  scope :not_in_anything_in_project, ->(project) {
     where.not(id: Member.of_anything_in_project(project).select(:user_id))
   }
 

--- a/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
+++ b/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
@@ -28,7 +28,10 @@
 
 class Queries::Principals::Filters::AccessToAnythingInProjectFilter < Queries::Principals::Filters::PrincipalFilter
   def allowed_values
-    Project.active.pluck(:name, :id)
+    Project
+    .visible(User.current)
+    .active
+    .pluck(:name, :id)
   end
 
   def type
@@ -61,6 +64,6 @@ class Queries::Principals::Filters::AccessToAnythingInProjectFilter < Queries::P
   def member_included_scope
     visible_scope
       .includes(:members)
-      .merge(Member.of_any_project)
+      .merge(Member.where.not(project: nil))
   end
 end

--- a/app/models/queries/work_packages/filter/shared_with_user_filter.rb
+++ b/app/models/queries/work_packages/filter/shared_with_user_filter.rb
@@ -70,9 +70,8 @@ class Queries::WorkPackages::Filter::SharedWithUserFilter <
   end
 
   def visible_shared_work_packages
-    WorkPackage.joins("JOIN members ON members.entity_id = work_packages.id")
-               .where(members: { entity_type: 'WorkPackage',
-                                 project: visible_projects })
+    WorkPackage.joins("JOIN members ON members.entity_type = 'WorkPackage' AND members.entity_id = work_packages.id")
+               .where(members: { project: visible_projects })
   end
 
   def visible_projects

--- a/lib/api/v3/queries/schemas/assignee_or_group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assignee_or_group_filter_dependency_representer.rb
@@ -30,8 +30,7 @@ module API
   module V3
     module Queries
       module Schemas
-        class AssigneeOrGroupFilterDependencyRepresenter <
-          AllPrincipalsFilterDependencyRepresenter
+        class AssigneeOrGroupFilterDependencyRepresenter < ProjectMembersFilterDependencyRepresenter
         end
       end
     end

--- a/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
@@ -55,7 +55,7 @@ module API
             CreatedAtFilter: 'DateTimeFilter',
             UpdatedAtFilter: 'DateTimeFilter',
             AuthorFilter: 'UserFilter',
-            ResponsibleFilter: 'AllPrincipalsFilter',
+            ResponsibleFilter: 'ProjectMembersFilter',
             AssignedToFilter: 'AccessToProjectFilter',
             SharedWithUserFilter: 'AccessToProjectFilter',
             WatcherFilter: 'UserFilter'

--- a/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
@@ -56,8 +56,8 @@ module API
             UpdatedAtFilter: 'DateTimeFilter',
             AuthorFilter: 'UserFilter',
             ResponsibleFilter: 'AllPrincipalsFilter',
-            AssignedToFilter: 'AllPrincipalsFilter',
-            SharedWithUserFilter: 'AllPrincipalsFilter',
+            AssignedToFilter: 'AccessToProjectFilter',
+            SharedWithUserFilter: 'AccessToProjectFilter',
             WatcherFilter: 'UserFilter'
           }
 

--- a/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
@@ -56,7 +56,7 @@ module API
             UpdatedAtFilter: 'DateTimeFilter',
             AuthorFilter: 'UserFilter',
             ResponsibleFilter: 'ProjectMembersFilter',
-            AssignedToFilter: 'AccessToProjectFilter',
+            AssignedToFilter: 'ProjectMembersFilter',
             SharedWithUserFilter: 'AccessToProjectFilter',
             WatcherFilter: 'UserFilter'
           }

--- a/lib/api/v3/queries/schemas/project_members_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/project_members_filter_dependency_representer.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module Queries
       module Schemas
-        class AllPrincipalsFilterDependencyRepresenter <
+        class ProjectMembersFilterDependencyRepresenter <
           PrincipalFilterDependencyRepresenter
           def json_cache_key
             if filter.project

--- a/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe API::V3::Queries::Schemas::FilterDependencyRepresenterFactory do
       let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.create! }
 
       it 'is a all principals with access to project dependency' do
-        expect(subject).to be_a(API::V3::Queries::Schemas::AccessToProjectFilterDependencyRepresenter)
+        expect(subject).to be_a(API::V3::Queries::Schemas::ProjectMembersFilterDependencyRepresenter)
       end
     end
 

--- a/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
@@ -40,16 +40,24 @@ RSpec.describe API::V3::Queries::Schemas::FilterDependencyRepresenterFactory do
     context 'assigned to filter' do
       let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.create! }
 
-      it 'is a all principals dependency' do
-        expect(subject).to be_a(API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter)
+      it 'is a all principals with access to project dependency' do
+        expect(subject).to be_a(API::V3::Queries::Schemas::AccessToProjectFilterDependencyRepresenter)
+      end
+    end
+
+    context 'shared with user filter' do
+      let(:filter) { Queries::WorkPackages::Filter::SharedWithUserFilter.create! }
+
+      it 'is a all principals with access to project dependency' do
+        expect(subject).to be_a(API::V3::Queries::Schemas::AccessToProjectFilterDependencyRepresenter)
       end
     end
 
     context 'responsible filter' do
       let(:filter) { Queries::WorkPackages::Filter::ResponsibleFilter.create! }
 
-      it 'is a all principals dependency' do
-        expect(subject).to be_a(API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter)
+      it 'is a project members dependency' do
+        expect(subject).to be_a(API::V3::Queries::Schemas::ProjectMembersFilterDependencyRepresenter)
       end
     end
 

--- a/spec/lib/api/v3/queries/schemas/project_members_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_members_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter do
+RSpec.describe API::V3::Queries::Schemas::ProjectMembersFilterDependencyRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }


### PR DESCRIPTION
The filter that was used only returned users, when they were explicit members of the project. Instead the filter now returns all users that have any access to items within the project.

Fixes https://community.openproject.org/projects/openproject/work_packages/51476/activity