### PR TITLE
[51225] i18n translation missing for rescheduled email header

### DIFF
--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -52,7 +52,7 @@ class MeetingMailer < UserMailer
 
     with_attached_ics(meeting, user) do
       subject = "[#{@meeting.project.name}] "
-      subject << I18n.t('meeting.email.rescheduled.header', title: @meeting.title, actor: @actor)
+      subject << I18n.t('meeting.email.rescheduled.header', title: @meeting.title)
       mail(to: user.mail, subject:)
     end
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
       invited:
         summary: "%{actor} has sent you an invitation for the meeting %{title}"
       rescheduled:
+        header: "Meeting %{title} has been rescheduled"
         summary: "Meeting %{title} has been rescheduled by %{actor}"
         body: "The meeting %{title} has been rescheduled by %{actor}."
         old_date_time: "Old date/time"


### PR DESCRIPTION
Add translation for rescheduled meeting header

https://community.openproject.org/projects/openproject/work_packages/51225/activity