### PR TITLE
Fix flaky account activation spec

### DIFF
--- a/spec/features/work_packages/share/share_account_activation_spec.rb
+++ b/spec/features/work_packages/share/share_account_activation_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Work package sharing invited users',
-               :js,
+               :js, :with_cuprite,
                with_ee: %i[work_package_sharing],
                with_flag: { work_package_sharing: true } do
   shared_let(:view_work_package_role) { create(:view_work_package_role) }
@@ -60,8 +60,9 @@ RSpec.describe 'Work package sharing invited users',
     expect(page).to have_current_path '/my/page'
 
     work_package_page.visit!
-    click_button 'Share'
+    work_package_page.click_share_button
 
+    share_modal.expect_open
     # Invite a user that does not exist yet
     share_modal.invite_user('foobar@example.com', 'View')
     # New user is shown in the list of shares


### PR DESCRIPTION
Uses the page object method that waits until the capabilities request
comes through and renders the "Share" button.