### PR TITLE
Fix flaky modules/costs/spec/features/timer_spec

### DIFF
--- a/modules/costs/spec/features/timer_spec.rb
+++ b/modules/costs/spec/features/timer_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe 'Work Package timer', js: true do
       time_logging_modal.has_field_with_value 'spentOn', Date.current.strftime
       time_logging_modal.has_field_with_value 'hours', /(\d\.)?\d+/
       time_logging_modal.work_package_is_missing false
+      # wait for available_work_packages query to finish before saving
+      time_logging_modal.expect_work_package(work_package_a.subject)
 
       time_logging_modal.perform_action 'Save'
       time_logging_modal.is_visible false
@@ -104,6 +106,8 @@ RSpec.describe 'Work Package timer', js: true do
       time_logging_modal.has_field_with_value 'spentOn', Date.current.strftime
       time_logging_modal.has_field_with_value 'hours', /(\d\.)?\d+/
       time_logging_modal.work_package_is_missing false
+      # wait for available_work_packages query to finish before saving
+      time_logging_modal.expect_work_package(work_package_a.subject)
 
       time_logging_modal.perform_action 'Save'
 
@@ -167,6 +171,8 @@ RSpec.describe 'Work Package timer', js: true do
       time_logging_modal.has_field_with_value 'spentOn', Date.current.strftime
       time_logging_modal.has_field_with_value 'hours', /(\d\.)?\d+/
       time_logging_modal.work_package_is_missing false
+      # wait for available_work_packages query to finish before saving
+      time_logging_modal.expect_work_package(work_package_a.subject)
 
       time_logging_modal.perform_action 'Save'
       wp_view_b.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
@@ -178,6 +184,8 @@ RSpec.describe 'Work Package timer', js: true do
       time_logging_modal.has_field_with_value 'spentOn', Date.current.strftime
       time_logging_modal.has_field_with_value 'hours', /(\d\.)?\d+/
       time_logging_modal.work_package_is_missing false
+      # wait for available_work_packages query to finish before saving
+      time_logging_modal.expect_work_package(work_package_a.subject)
 
       time_logging_modal.perform_action 'Save'
       wp_view_b.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -28,8 +28,8 @@
 
 require 'spec_helper'
 
-RSpec.describe 'filter work packages', js: true do
-  shared_let(:user) { create(:admin) }
+RSpec.describe 'filter work packages', :js do
+  shared_let(:user) { create(:admin, preferences: { time_zone: 'Etc/UTC' }) }
   shared_let(:watcher) { create(:user) }
   shared_let(:role) { create(:existing_project_role, permissions: [:view_work_packages]) }
   shared_let(:project) { create(:project, members: { watcher => role }) }

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -123,10 +123,12 @@ module Pages
               end
 
               target = page.find_field(name)
+              has_no_css?('.ng-spinner-loader') # wait for possible async loading of options for ng-select
               target.send_keys val
             end
 
             if autocomplete
+              has_no_css?('.ng-spinner-loader') # wait for possible async loading of options for ng-select
               dropdown_el = find('.ng-option', text: val, wait: 5)
               scroll_to_and_click(dropdown_el)
             end


### PR DESCRIPTION
This spec could fail with the following error:
```
Failure/Error: expect(page).to have_selector(".op-toast.-#{type}", text: message, wait: 5)
  expected to find css ".op-toast.-success" but there were no matches
```

Indeed when stopping the timer, the log time modal is displayed and the test would click rather quickly on the save button, before the query to gather available work packages actually triggers (because of the debounce). This query is done to display available choices for the work package input field dropdown.

When this happens, the PATCH `/api/v3/time_entries/:id` query completes and sets the `ongoing` field to false. The query
`/api/v3/time_entries/:id/available_work_packages` is then triggered, but will return a 404 because the time entry is not ongoing anymore and thus is not visible to the user (in this test user only has `:log_own_time` permission).

Because of this 404, an error message will be displayed in the toaster. This will replace the toaster success message that is expected by the test. That's why the test fails.

Waiting explicitly for the input field to display the work package subject fixes the flakiness.

Still I think this covers a bug: the timer modal should prevent clicking the save button until the available work packages for the dropdown are loaded, or it should cancel the request, or there should be no debounce timer for the initial request to available work packages. Whatever the implementation, this issue could maybe be solved at its root instead of being worked around. I chose to fix it quickly, but it may come up again later in another test in another way...

FWIW this test was failing in this other PR: https://github.com/opf/openproject/pull/14378