### PR TITLE
Update lookbook patch Gem version

### DIFF
--- a/lib/open_project/patches/lookbook_tree_node_inflector.rb
+++ b/lib/open_project/patches/lookbook_tree_node_inflector.rb
@@ -41,7 +41,7 @@ module OpenProject
 end
 
 if Rails.env.development?
-  OpenProject::Patches.patch_gem_version 'lookbook', '2.1.1' do
+  OpenProject::Patches.patch_gem_version 'lookbook', '2.2.0' do
     Lookbook::TreeNode.prepend OpenProject::Patches::LookbookTreeNodeInflector
   end
 end


### PR DESCRIPTION
Follows https://github.com/opf/openproject/commit/1db8c0b51cbe76d9293eb55c10f57c85bbba682d

There exists a Lookbook patch [`OpenProject::Patches::LookbookTreeNodeInflector`](https://github.com/opf/openproject/blob/dev/lib/open_project/patches/lookbook_tree_node_inflector.rb) - update the version to match Gemfile.lock

I reckon the static nature is so that we can always validate whether the patch is needed, otherwise a dynamic version loader would have been in order.

![Screenshot 2023-12-11 at 8 55 08 PM](https://github.com/opf/openproject/assets/17295175/1f862ace-d0e0-4699-b97e-090a2ff6df52)
