### PR TITLE
Guard access behavior for shared work packages with a feature spec

### DIFF
--- a/spec/factories/work_package_role_factory.rb
+++ b/spec/factories/work_package_role_factory.rb
@@ -38,7 +38,8 @@ FactoryBot.define do
     builtin { Role::BUILTIN_WORK_PACKAGE_VIEWER }
     permissions do
       %i(view_work_packages
-         export_work_packages)
+         export_work_packages
+         show_github_content)
     end
   end
 
@@ -50,7 +51,12 @@ FactoryBot.define do
          work_package_assigned
          add_work_package_notes
          edit_own_work_package_notes
-         export_work_packages)
+         export_work_packages
+         view_own_time_entries
+         log_own_time
+         edit_own_time_entries
+         show_github_content
+         view_file_links)
     end
   end
 
@@ -65,7 +71,12 @@ FactoryBot.define do
          edit_own_work_package_notes
          manage_work_package_relations
          copy_work_packages
-         export_work_packages)
+         export_work_packages
+         view_own_time_entries
+         log_own_time
+         edit_own_time_entries
+         show_github_content
+         view_file_links)
     end
   end
 end

--- a/spec/factories/work_package_role_factory.rb
+++ b/spec/factories/work_package_role_factory.rb
@@ -49,6 +49,7 @@ FactoryBot.define do
     permissions do
       %i(view_work_packages
          work_package_assigned
+         add_work_package_attachments
          add_work_package_notes
          edit_own_work_package_notes
          export_work_packages

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -1,0 +1,123 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe 'Shared User Access',
+               :js, :with_cuprite,
+               with_ee: %i[work_package_sharing],
+               with_flag: { work_package_sharing: true } do
+  shared_let(:project) { create(:project) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:sharer) do
+    create(:user,
+           member_with_permissions: { project => %i[share_work_packages
+                                                    view_shared_work_packages
+                                                    view_work_packages] })
+  end
+  shared_let(:shared_with_user) { create(:user, firstname: 'Mean', lastname: 'Turkey') }
+
+  shared_let(:viewer_role) { create(:view_work_package_role) }
+  shared_let(:commenter_role) { create(:comment_work_package_role) }
+  shared_let(:editor_role) { create(:edit_work_package_role) }
+
+  let(:projects_page) { Pages::Projects::Index.new }
+  let(:project_page) { Pages::Projects::Show.new(project) }
+  let(:projects_top_menu) { Components::Projects::TopMenu.new }
+  let(:global_work_packages_page) { Pages::WorkPackagesTable.new }
+  let(:work_packages_page) { Pages::WorkPackagesTable.new(project) }
+  let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
+  let(:share_modal) { Components::WorkPackages::ShareModal.new(work_package) }
+
+  specify "Work Package Access" do
+    using_session "shared-with user" do
+      login_as(shared_with_user)
+
+      #
+      # Work Package's project is not visible without the work package having been shared
+      # 1. Via the Project's Index Page
+      projects_page.visit!
+      projects_page.expect_projects_not_listed(project)
+
+      # 2. Via the Projects dropdown in the top menu
+      projects_top_menu.toggle!
+      projects_top_menu.expect_blankslate
+
+      # 3. Visiting the Project's URL directly
+      project_page.visit!
+      project_page.expect_toast(type: :error, message: I18n.t(:notice_not_authorized))
+
+      #
+      # Work Package is not visible without the work package having been shared
+      # 1. Via the Work Packages Global Index Page
+      global_work_packages_page.visit!
+      global_work_packages_page.expect_toast(type: :error, message: I18n.t(:notice_not_authorized))
+
+      # 2. Via the URL to work package
+      work_package_page.visit!
+      work_package_page.expect_toast(type: :error, message: I18n.t(:notice_file_not_found))
+    end
+
+    using_session "sharer" do
+      # Sharing the Work Package with "View" access
+      login_as(sharer)
+
+      work_package_page.visit!
+      work_package_page.click_share_button
+      share_modal.expect_open
+
+      share_modal.invite_user(shared_with_user, 'View')
+      share_modal.expect_shared_with(shared_with_user)
+    end
+
+    using_session "shared-with user" do
+      # Work Package's project is now listed
+      # 1. Via the Projects Index Page
+      projects_page.visit!
+      projects_page.expect_projects_listed(project)
+
+      # 2. Via the Projects dropdown in the top menu
+      projects_top_menu.toggle!
+      projects_top_menu.expect_result(project.name)
+
+      # 3. Visiting the Project's URL directly
+      project_page.visit!
+
+      #
+      # Work Package is now visible
+      project_page.within_sidebar do
+        click_link(I18n.t('label_work_package_plural'))
+      end
+      work_packages_page.expect_work_package_listed(work_package)
+      work_package_page.visit!
+
+      expect(page)
+        .to have_text(work_package.subject)
+    end
+  end
+end

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -92,8 +92,7 @@ RSpec.describe 'Shared Work Package Access',
       work_package_page.click_share_button
       share_modal.expect_open
 
-      share_modal.invite_user(shared_with_user, 'View')
-      share_modal.expect_shared_with(shared_with_user)
+      share_modal.invite_user!(shared_with_user, 'View')
     end
 
     using_session "shared-with user" do

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe 'Shared Work Package Access',
         work_package_page.edit_field(field).expect_read_only
       end
 
+      work_package_page.ensure_page_loaded # waits for activity section to be ready
       work_package_page.within_active_tab do
         # Commenting is disabled
         expect(page)

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Shared Work Package Access',
                :js, :with_cuprite,
                with_ee: %i[work_package_sharing] do
   shared_let(:project) { create(:project_with_types) }
-  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:work_package) { create(:work_package, project:, journal_notes: 'Hello!') }
   shared_let(:sharer) do
     create(:user,
            member_with_permissions: { project => %i[share_work_packages
@@ -52,6 +52,8 @@ RSpec.describe 'Shared Work Package Access',
   let(:work_packages_page) { Pages::WorkPackagesTable.new(project) }
   let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
   let(:share_modal) { Components::WorkPackages::ShareModal.new(work_package) }
+  let(:add_comment_button_selector) { '.work-packages--activity--add-comment' }
+  let(:attach_files_button_selector) { 'op-attachments--upload-button' }
 
   specify "Shared-with user access" do
     using_session "shared-with user" do
@@ -125,7 +127,19 @@ RSpec.describe 'Shared Work Package Access',
         work_package_page.edit_field(field).expect_read_only
       end
 
-      # So is commenting and file upload...
+      work_package_page.within_active_tab do
+        # Commenting is disabled
+        expect(page)
+          .not_to have_css(add_comment_button_selector)
+      end
+
+      # And so is viewing and uploading attachments
+      work_package_page.switch_to_tab(tab: 'Files')
+      work_package_page.expect_tab('Files')
+      work_package_page.within_active_tab do
+        expect(page)
+          .not_to have_test_selector(attach_files_button_selector)
+      end
     end
   end
 end

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -30,8 +30,7 @@ require 'spec_helper'
 
 RSpec.describe 'Shared Work Package Access',
                :js, :with_cuprite,
-               with_ee: %i[work_package_sharing],
-               with_flag: { work_package_sharing: true } do
+               with_ee: %i[work_package_sharing] do
   shared_let(:project) { create(:project_with_types) }
   shared_let(:work_package) { create(:work_package, project:) }
   shared_let(:sharer) do

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -37,7 +37,13 @@ module Components
 
       def toggle
         page.find_by_id('projects-menu').click
-        wait_for_network_idle if using_cuprite?
+        wait_for_network_idle(timeout: 10) if using_cuprite?
+      end
+
+      # Ensures modal registers as #open? before proceeding
+      def toggle!
+        toggle
+        expect_open
       end
 
       def open?
@@ -94,6 +100,10 @@ module Components
         within search_results do
           expect(page).not_to have_selector(autocompleter_item_title_selector, text: name)
         end
+      end
+
+      def expect_blankslate
+        expect(page).not_to have_test_selector('op-project-list-modal--no-results', wait: 0)
       end
 
       def expect_item_with_hierarchy_level(hierarchy_level:, item_name:)

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -220,6 +220,16 @@ module Components
       alias_method :invite_users, :invite_user
       alias_method :invite_group, :invite_user
 
+      # Augments +invite_user+ by asserting that the modifications to the
+      # share have reflected in the modal's UI and we're able to continue
+      # with our spec without any waits or network related assertions.
+      #
+      # As a side benefit, it just keeps the spec file cleaner.
+      def invite_user!(user, role_name)
+        invite_user(user, role_name)
+        expect_shared_with(user, role_name)
+      end
+
       def search_user(search_string)
         search_autocomplete page.find('[data-test-selector="op-share-wp-invite-autocomplete"]'),
                             query: search_string,

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -57,7 +57,14 @@ module Pages
       def expect_projects_not_listed(*projects)
         within '#project-table' do
           projects.each do |project|
-            expect(page).not_to have_text(project)
+            case project
+            when Project
+              expect(page).not_to have_text(project.name)
+            when String
+              expect(page).not_to have_text(project)
+            else
+              raise ArgumentError, "#{project.inspect} is not a Project or a String"
+            end
           end
         end
       end

--- a/spec/support/pages/projects/show.rb
+++ b/spec/support/pages/projects/show.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'support/pages/page'
+
+module Pages
+  module Projects
+    class Show < ::Pages::Page
+      attr_reader :project
+
+      # rubocop:disable Lint/MissingSuper
+      def initialize(project)
+        @project = project
+      end
+      # rubocop:enable Lint/MissingSuper
+
+      def path
+        project_path(project)
+      end
+
+      def within_sidebar(&)
+        within('#menu-sidebar', &)
+      end
+
+      def toast_type
+        :rails
+      end
+    end
+  end
+end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -94,9 +94,9 @@ module Pages
     def ensure_page_loaded
       expect_angular_frontend_initialized
       expect(page).to have_css('.op-user-activity--user-name',
-                                    text: work_package.journals.last.user.name,
-                                    minimum: 1,
-                                    wait: 10)
+                               text: work_package.journals.last.user.name,
+                               minimum: 1,
+                               wait: 10)
     end
 
     def disable_ajax_requests
@@ -141,7 +141,7 @@ module Pages
 
     def expect_activity_message(message)
       expect(page).to have_css('.work-package-details-activities-messages .message',
-                                    text: message)
+                               text: message)
     end
 
     def expect_no_parent

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -49,6 +49,10 @@ module Pages
       expect(page).to have_css('.op-tab-row--link_selected', text: tab.to_s.upcase)
     end
 
+    def within_active_tab(&)
+      within('.work-packages-full-view--split-right .work-packages--panel-inner', &)
+    end
+
     def edit_field(attribute)
       work_package_field(attribute)
     end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -46,7 +46,7 @@ module Pages
     end
 
     def expect_tab(tab)
-      expect(page).to have_selector('.op-tab-row--link_selected', text: tab.to_s.upcase)
+      expect(page).to have_css('.op-tab-row--link_selected', text: tab.to_s.upcase)
     end
 
     def edit_field(attribute)
@@ -93,7 +93,7 @@ module Pages
 
     def ensure_page_loaded
       expect_angular_frontend_initialized
-      expect(page).to have_selector('.op-user-activity--user-name',
+      expect(page).to have_css('.op-user-activity--user-name',
                                     text: work_package.journals.last.user.name,
                                     minimum: 1,
                                     wait: 10)
@@ -106,21 +106,21 @@ module Pages
     end
 
     def expect_group(name, &)
-      expect(page).to have_selector('.attributes-group--header-text', text: name.upcase)
+      expect(page).to have_css('.attributes-group--header-text', text: name.upcase)
       if block_given?
         page.within(".attributes-group[data-group-name='#{name}']", &)
       end
     end
 
     def expect_no_group(name)
-      expect(page).not_to have_selector('.attributes-group--header-text', text: name.upcase)
+      expect(page).not_to have_css('.attributes-group--header-text', text: name.upcase)
     end
 
     def expect_attributes(attribute_expectations)
       attribute_expectations.each do |label_name, value|
         label = label_name.to_s
         if label == 'status'
-          expect(page).to have_selector("[data-test-selector='op-wp-status-button'] .button", text: value)
+          expect(page).to have_css("[data-test-selector='op-wp-status-button'] .button", text: value)
         else
           expect(page).to have_selector(".inline-edit--container.#{label.camelize(:lower)}", text: value)
         end
@@ -140,41 +140,41 @@ module Pages
     end
 
     def expect_activity_message(message)
-      expect(page).to have_selector('.work-package-details-activities-messages .message',
+      expect(page).to have_css('.work-package-details-activities-messages .message',
                                     text: message)
     end
 
     def expect_no_parent
       visit_tab!('relations')
 
-      expect(page).not_to have_selector('[data-test-selector="op-wp-breadcrumb-parent"]')
+      expect(page).not_to have_css('[data-test-selector="op-wp-breadcrumb-parent"]')
     end
 
     def expect_zen_mode
-      expect(page).to have_selector('.zen-mode')
-      expect(page).to have_selector('#main-menu', visible: false)
-      expect(page).to have_selector('.op-app-header', visible: false)
+      expect(page).to have_css('.zen-mode')
+      expect(page).to have_css('#main-menu', visible: false)
+      expect(page).to have_css('.op-app-header', visible: false)
     end
 
     def expect_no_zen_mode
-      expect(page).not_to have_selector('.zen-mode')
-      expect(page).to have_selector('#main-menu', visible: true)
-      expect(page).to have_selector('.op-app-header', visible: true)
+      expect(page).not_to have_css('.zen-mode')
+      expect(page).to have_css('#main-menu', visible: true)
+      expect(page).to have_css('.op-app-header', visible: true)
     end
 
     def expect_custom_action(name)
       expect(page)
-        .to have_selector('.custom-action', text: name)
+        .to have_css('.custom-action', text: name)
     end
 
     def expect_custom_action_disabled(name)
       expect(page)
-        .to have_selector('.custom-action [disabled]', text: name)
+        .to have_css('.custom-action [disabled]', text: name)
     end
 
     def expect_no_custom_action(name)
       expect(page)
-        .not_to have_selector('.custom-action', text: name)
+        .not_to have_css('.custom-action', text: name)
     end
 
     def expect_custom_action_order(*names)
@@ -294,7 +294,7 @@ module Pages
     end
 
     def subject_field
-      expect(page).to have_selector('.inline-edit--container.subject input', wait: 10)
+      expect(page).to have_css('.inline-edit--container.subject input', wait: 10)
       find('.inline-edit--container.subject input')
     end
 

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -152,14 +152,14 @@ module Pages
 
     def expect_zen_mode
       expect(page).to have_css('.zen-mode')
-      expect(page).to have_css('#main-menu', visible: false)
-      expect(page).to have_css('.op-app-header', visible: false)
+      expect(page).to have_css('#main-menu', visible: :hidden)
+      expect(page).to have_css('.op-app-header', visible: :hidden)
     end
 
     def expect_no_zen_mode
       expect(page).not_to have_css('.zen-mode')
-      expect(page).to have_css('#main-menu', visible: true)
-      expect(page).to have_css('.op-app-header', visible: true)
+      expect(page).to have_css('#main-menu')
+      expect(page).to have_css('.op-app-header')
     end
 
     def expect_custom_action(name)

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -125,7 +125,7 @@ module Pages
 
     def expect_no_work_package_listed
       within(table_container) do
-        expect(page).to have_selector('#empty-row-notification')
+        expect(page).to have_css('#empty-row-notification')
       end
     end
 


### PR DESCRIPTION
## Description
A comprehensive feature spec walking through the relevant sections of the application in the different stages a user is in whenever a work package is shared with them. This serves as a living specification for access control according to the different `WorkPackageRole`s

## Notes
See: https://community.openproject.org/wp/51273