### PR TITLE
WP Descendant query also allows single WP access

### DIFF
--- a/app/models/work_packages/scopes/left_join_self_and_descendants.rb
+++ b/app/models/work_packages/scopes/left_join_self_and_descendants.rb
@@ -63,7 +63,9 @@ module WorkPackages::Scopes::LeftJoinSelfAndDescendants
     end
 
     def allowed_to_view_work_packages(user)
-      wp_descendants_table[:project_id].in(Project.allowed_to(user, :view_work_packages).select(:id).arel)
+      wp_descendants_table[:project_id].in(Project.allowed_to(user, :view_work_packages).select(:id).arel).or(
+        wp_descendants_table[:id].in(WorkPackage.visible(user).select(:id).arel)
+      )
     end
 
     def self_or_descendant_condition


### PR DESCRIPTION
The query still limited access to only those WPs where you had access throught the entire project. This change fixes the access query so that the time is correctly displayed.

Fixes https://community.openproject.org/work_packages/51403/activity