### PR TITLE
[#51531] Incomplete Automatically managed form does not toggle the submit button label

### DIFF
--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
@@ -42,11 +42,13 @@ module Storages::Admin::Forms
     end
 
     def submit_button_options
-      { label: I18n.t("storages.buttons.done_complete_setup"),
-        data: { 'storages--automatically-managed-project-folders-form-target': 'submitButton' } }.tap do |options_hash|
-        # For create action, break from Turbo Frame and follow full page redirect
-        options_hash[:data] = { turbo: false } if new_record?
-      end
+      {
+        label: I18n.t("storages.buttons.done_complete_setup"),
+        data: { 'storages--automatically-managed-project-folders-form-target': 'submitButton' }.tap do |data_hash|
+          # For create action, break from Turbo Frame and follow full page redirect
+          data_hash[:turbo] = false if new_record?
+        end
+      }
     end
 
     def cancel_button_options


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/51531

The stimulus target was overwritten for `new_record?`s which resulted in the error

##### Before

https://github.com/opf/openproject/assets/17295175/d37e5582-1c39-4514-b7e3-cdeccee030dd

##### After


https://github.com/opf/openproject/assets/17295175/c4c9e79e-becf-49b7-a609-08b72f27e671



