### PR TITLE
[chore] added project storages and ancestors

### DIFF
--- a/docs/api/apiv3/components/schemas/project_model.yml
+++ b/docs/api/apiv3/components/schemas/project_model.yml
@@ -178,3 +178,23 @@ properties:
                 # Conditions
                 
                 **Permission**: view_file_links
+      projectStorages:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The project storage collection of this project.
+              
+              **Resource**: Collection
+              
+              # Conditions
+              
+              **Permission**: view_file_links
+      ancestors:
+        type: array
+        items:
+          allOf:
+            - $ref: './link.yml'
+            - description: |-
+                The link to an ancestor project.
+                
+                **Resource**: Project


### PR DESCRIPTION
- project model in API spec now contains `projectStorages` and `ancestors`