### PR TITLE
[51482] "New meeting" buttons in Meetings module have different translation strings

### DIFF
--- a/modules/meeting/app/views/meetings/_menu_query_select.html.erb
+++ b/modules/meeting/app/views/meetings/_menu_query_select.html.erb
@@ -72,7 +72,7 @@ See COPYRIGHT and LICENSE files for more details.
                       aria: { label: t(:label_meeting_new) },
                       title: t(:label_meeting_new) } do %>
         <%= spot_icon('add') %>
-        <span><%= Meeting.model_name.human %></span>
+        <span><%= t(:label_meeting) %></span>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
Use same string for sidebar create button as for the create button in the toolbar

https://community.openproject.org/projects/openproject/work_packages/51482/activity