### PR TITLE
[51402] Date field on work package too narrow

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -1,5 +1,5 @@
 .spot-drop-modal
-  display: inline-flex
+  display: flex
 
   &--body
     $border-radius: 5px


### PR DESCRIPTION
Use flex to ensure that the field is wide enough (e.g. on WP create form). 


https://community.openproject.org/projects/openproject/work_packages/51402/activity