### PR TITLE
Revert "Bump googleauth from 1.8.1 to 1.9.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,11 +553,8 @@ GEM
       webrick
     google-apis-gmail_v1 (0.36.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-cloud-env (2.0.1)
-      faraday (>= 1.0, < 3.a)
-    googleauth (1.9.0)
-      faraday (>= 1.0, < 3.a)
-      google-cloud-env (~> 2.0, >= 2.0.1)
+    googleauth (1.8.1)
+      faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)


### PR DESCRIPTION
Reverts opf/openproject#14364

I can not run bundle install locally due to the absence of 1.9.0. on [rubygems](https://rubygems.org/gems/googleauth).
![image](https://github.com/opf/openproject/assets/11717656/072f4834-3659-4da2-908e-c81730b85ab6)
