### PR TITLE
[51480] Inconsistent hrefs in WP shared mail

### DIFF
--- a/app/views/sharing_mailer/shared_work_package.html.erb
+++ b/app/views/sharing_mailer/shared_work_package.html.erb
@@ -29,7 +29,7 @@
                    work_package: @work_package,
                    unique_reasons: [:shared],
                    show_count: false,
-                   notification_url: @notification_url,
+                   notification_url: @url,
                    open_in_browser_path: @url
                  } do %>
         <table <%= placeholder_table_styles(width:'100%',style: 'width:100%;') %>>


### PR DESCRIPTION
Redirect to WP full view when a WP has been shared, because there is no notification entry to show

https://community.openproject.org/projects/openproject/work_packages/51480/activity



