### PR TITLE
improve the notification performance

### DIFF
--- a/app/models/queries/principals/principal_query.rb
+++ b/app/models/queries/principals/principal_query.rb
@@ -32,6 +32,6 @@ class Queries::Principals::PrincipalQuery < Queries::BaseQuery
   end
 
   def default_scope
-    Principal.not_builtin
+    Principal.visible(User.current).not_builtin
   end
 end

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -60,8 +60,10 @@ module API
             end
           end
 
+          # No need to reapply the visibility scope here as this will be done by the used
+          # NotificationQuery.
           get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex
-            .new(model: Notification, scope: -> { notification_scope })
+            .new(model: Notification, scope: -> { Notification.where.not(read_ian: nil) })
             .mount
 
           post :read_ian do

--- a/lib/api/v3/principals/principals_api.rb
+++ b/lib/api/v3/principals/principals_api.rb
@@ -33,7 +33,7 @@ module API
         resource :principals do
           get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex
                  .new(model: Principal,
-                      scope: -> { Principal.visible(current_user).includes(:preference) })
+                      scope: -> { Principal.includes(:preference) })
                  .mount
         end
       end

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -164,7 +164,7 @@ module API
             else
               result_scope
                 .includes(constraint.includes_values)
-                .where id: constraint.select(:id)
+                .merge constraint
             end
           end
         end


### PR DESCRIPTION
This improvements has two parts:
* Avoid reapplying the visibility check for notifications.
* Merging the constraints rather than having them in a subselect.

It requires moving the visibility scope of principals as that would otherwise not be applied correctly. But since the Principal's visibility scope does already apply the constraints conditionally, moving does not change the behaviour.

https://community.openproject.org/wp/51622