### PR TITLE
Fix tests that rely on notifications being pulled all 10 seconds

### DIFF
--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -27,10 +27,9 @@
 #++
 
 require 'spec_helper'
-require_relative './../support/onboarding_steps'
+require_relative '../support/onboarding_steps'
 
-RSpec.describe 'boards onboarding tour',
-               js: true do
+RSpec.describe 'boards onboarding tour', :js, with_settings: { notifications_polling_interval: 10_000 } do
   let(:next_button) { find('.enjoyhint_next_btn') }
   let(:user) do
     create(:admin,

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -29,7 +29,9 @@
 require 'spec_helper'
 require_relative '../support/onboarding_steps'
 
-RSpec.describe 'boards onboarding tour', :js, with_settings: { notifications_polling_interval: 10_000 } do
+# We decrease the notification polling interval because some portions of the JS code rely on something triggering
+# the Angular change detection. This is usually done by the notification polling, but we don't want to wait
+RSpec.describe 'boards onboarding tour', :js, with_settings: { notifications_polling_interval: 1_000 } do
   let(:next_button) { find('.enjoyhint_next_btn') }
   let(:user) do
     create(:admin,

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -34,9 +34,10 @@ require_module_spec_helper
 # Setup storages in Project -> Settings -> File Storages
 # This tests assumes that a Storage has already been setup
 # in the Admin section, tested by admin_storage_spec.rb.
-RSpec.describe(
-  'Activation of storages in projects', :js, :webmock
-) do
+
+# We decrease the notification polling interval because some portions of the JS code rely on something triggering
+# the Angular change detection. This is usually done by the notification polling, but we don't want to wait
+RSpec.describe 'Activation of storages in projects', :js, :webmock, with_settings: { notifications_polling_interval: 1_000 } do
   let(:user) { create(:user) }
   # The first page is the Project -> Settings -> General page, so we need
   # to provide the user with the edit_project permission in the role.

--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -29,9 +29,8 @@
 require 'spec_helper'
 require_relative '../../support/onboarding/onboarding_steps'
 
-RSpec.describe 'team planner onboarding tour', :js,
-               with_cuprite: false,
-               with_ee: %i[team_planner_view] do
+RSpec.describe 'team planner onboarding tour', :js, with_cuprite: false, with_ee: %i[team_planner_view],
+                                                    with_settings: { notifications_polling_interval: 10_000 } do
   let(:next_button) { find('.enjoyhint_next_btn') }
 
   let(:demo_project) do

--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -30,7 +30,10 @@ require 'spec_helper'
 require_relative '../../support/onboarding/onboarding_steps'
 
 RSpec.describe 'team planner onboarding tour', :js, with_cuprite: false, with_ee: %i[team_planner_view],
-                                                    with_settings: { notifications_polling_interval: 10_000 } do
+                                                    # We decrease the notification polling interval because some portions
+                                                    # of the JS code rely on something triggering the Angular change detection.
+                                                    # This is usually done by the notification polling, but we don't want to wait
+                                                    with_settings: { notifications_polling_interval: 1_000 } do
   let(:next_button) { find('.enjoyhint_next_btn') }
 
   let(:demo_project) do

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe "Notification center", :js, :with_cuprite,
                with_ee: %i[date_alerts],
-               with_settings: { journal_aggregation_time_minutes: 0 } do
+               with_settings: { journal_aggregation_time_minutes: 0, notifications_polling_interval: 10_000 } do
   # Notice that the setup in this file here is not following the normal rules as
   # it also tests notification creation.
   let!(:project1) { create(:project) }

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 RSpec.describe "Notification center", :js, :with_cuprite,
                with_ee: %i[date_alerts],
-               with_settings: { journal_aggregation_time_minutes: 0, notifications_polling_interval: 10_000 } do
+               # We decrease the notification polling interval because some portions of the JS code rely on something triggering
+               # the Angular change detection. This is usually done by the notification polling, but we don't want to wait
+               with_settings: { journal_aggregation_time_minutes: 0, notifications_polling_interval: 1_000 } do
   # Notice that the setup in this file here is not following the normal rules as
   # it also tests notification creation.
   let!(:project1) { create(:project) }


### PR DESCRIPTION
In #14413 we added a configurable amount for notification polling and the new default is 60 seconds instead of the old hard coded 10 seconds. This causes some tests to fail because they rely on some behavior that is triggered by the notification polling. Those tests now get a setting to set the notification timeout to the 10 seconds it was before.