### PR TITLE
fix slow project visible scope for admins

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -150,13 +150,13 @@ class Project < ApplicationRecord
   friendly_id :identifier, use: :finders
 
   include ::Scopes::Scoped
-  scopes :allowed_to
+  scopes :allowed_to,
+         :visible
 
   scope :has_module, ->(mod) {
     where(["#{Project.table_name}.id IN (SELECT em.project_id FROM #{EnabledModule.table_name} em WHERE em.name=?)", mod.to_s])
   }
   scope :public_projects, -> { where(public: true) }
-  scope :visible, ->(user = User.current) { where(id: Project.visible_by(user)) }
   scope :with_visible_work_packages, ->(user = User.current) do
     where(id: WorkPackage.visible(user).select(:project_id)).or(allowed_to(user, :view_work_packages))
   end
@@ -197,16 +197,6 @@ class Project < ApplicationRecord
 
   def self.selectable_projects
     Project.visible.select { |p| User.current.member_of? p }.sort_by(&:to_s)
-  end
-
-  # Returns all projects the user is allowed to see.
-  #
-  # Employs the :view_project permission to perform the
-  # authorization check as the permission is public, meaning it is granted
-  # to everybody having at least one role in a project regardless of the
-  # role's permissions.
-  def self.visible_by(user = User.current)
-    allowed_to(user, :view_project).or(where(id: WorkPackage.visible(user).select(:project_id)))
   end
 
   # Returns a :conditions SQL string that can be used to find the issues associated with this project.

--- a/app/models/projects/scopes/visible.rb
+++ b/app/models/projects/scopes/visible.rb
@@ -1,0 +1,50 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects::Scopes
+  module Visible
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns all projects the user is allowed to see.
+      # Those include projects where the user has the permission:
+      # * :view_project via a project role (which might also be the non member/anonymous role) or by being administrator
+      # * :view_work_packages via a work package role
+      def visible(user = User.current)
+        # Use a shortcut for admins and anonymous where
+        # we don't need to calculate for work package roles which is more expensive
+        if user.admin? || user.anonymous?
+          Project.allowed_to(user, :view_project)
+        else
+          Project.allowed_to(user, :view_project)
+                 .or(where(id: WorkPackage.allowed_to(user, :view_work_packages).select(:project_id)))
+        end
+      end
+    end
+  end
+end

--- a/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
+++ b/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
@@ -134,7 +134,7 @@ module Redmine
 
           def searchable_projects_condition
             projects = if searchable_options[:permission].nil?
-                         Project.visible_by(User.current)
+                         Project.visible(User.current)
                        else
                          Project.allowed_to(User.current, searchable_options[:permission])
                        end

--- a/spec/models/projects/scopes/visible_spec.rb
+++ b/spec/models/projects/scopes/visible_spec.rb
@@ -1,0 +1,130 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+
+RSpec.describe Projects::Scopes::Visible do
+  shared_let(:activity) { create(:time_entry_activity) }
+  shared_let(:project) { create(:project) }
+  shared_let(:public_project) { create(:public_project) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_let(:shared_in_project) { create(:project) }
+  shared_let(:shared_work_package) { create(:work_package, project: shared_in_project) }
+  shared_let(:view_work_package_role) { create(:view_work_package_role) }
+  shared_let(:non_member_role) { create(:non_member) }
+  shared_let(:anonymous_role) { create(:anonymous_role) }
+  shared_let(:shared_user) do
+    create(:user).tap do |u|
+      create(:member,
+             project:,
+             principal: u,
+             roles: [create(:project_role)])
+
+      create(:work_package_member,
+             entity: shared_work_package,
+             principal: u,
+             roles: [view_work_package_role])
+    end
+  end
+  shared_let(:admin_user) { create(:admin) }
+  shared_let(:only_project_user) do
+    create(:user).tap do |u|
+      create(:member,
+             project:,
+             principal: u,
+             roles: [create(:project_role)])
+    end
+  end
+  shared_let(:only_shared_user) do
+    create(:user).tap do |u|
+      create(:work_package_member,
+             entity: shared_work_package,
+             principal: u,
+             roles: [view_work_package_role])
+    end
+  end
+  shared_let(:no_membership_user) do
+    create(:user)
+  end
+
+  subject { Project.visible(current_user) }
+
+  context 'for an admin user' do
+    let(:current_user) { admin_user }
+
+    it 'list all projects' do
+      expect(subject)
+        .to contain_exactly(shared_in_project, project, public_project)
+    end
+  end
+
+  context 'for a user a work package is shared with and who has a memberships' do
+    let(:current_user) { shared_user }
+
+    it 'list all projects' do
+      expect(subject)
+        .to contain_exactly(shared_in_project, project, public_project)
+    end
+  end
+
+  context 'for a user having only a project membership' do
+    let(:current_user) { only_project_user }
+
+    it 'list only the project in which the user has the membership and the public project' do
+      expect(subject)
+        .to contain_exactly(project, public_project)
+    end
+  end
+
+  context 'for a user only having a share' do
+    let(:current_user) { only_shared_user }
+
+    it 'list only the project in which the shared work package is and the public project' do
+      expect(subject)
+        .to contain_exactly(shared_in_project, public_project)
+    end
+  end
+
+  context 'for a user without any permission' do
+    let(:current_user) { no_membership_user }
+
+    it 'list only the public project' do
+      expect(subject)
+        .to contain_exactly(public_project)
+    end
+  end
+
+  context 'for an anonymous user' do
+    let(:current_user) { create(:anonymous) }
+
+    it 'list only the public project' do
+      expect(subject)
+        .to contain_exactly(public_project)
+    end
+  end
+end


### PR DESCRIPTION
Short circuit the visible check for admins since having a work package shared with them is irrelevant for the visible calculation. The only condition relevant for them is for the project to be active.

It reduces the runtime of the SQL query on the dataset tested with from roughly 50s to 5ms.

This is a quick fix for https://community.openproject.org/wp/51659

The visible scope is still not as optimized as it could be. For a non admin user it will: 
* Check if the user has a project membership
* Check if the user has no project membership and the project is public
* Check if the user has the permission via a work package membership which involves
  * Checking if the user has a work package share with the :view_work_packages permission
  * Checking if the user has a project membership granting the :view_work_packages permission
  * Checking if the non member role has the :view_work_packages permission, the user has no membership and the project is public

This is done conveniently by joining two available scopes. But it has a lot of overhead (e.g. the check for the non member to have the :view_work_packages permission is redundant with checking if the project is public before).

Since both scopes work on the same data structure (e.g. `members`, `member_roles` and `roles`), it might well be possible to have them use the exact same query, without nesting, and just querying for multiple permissions at the same time (`:view_project` and `:view_work_packages`). This however is not part of the PR but will be done in a subsequent one.  