### PR TITLE
[51656] Fix missing translation user wrote in wp activity

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -42,6 +42,7 @@ module MetaTagsHelper
         data: {
           locale: I18n.locale,
           defaultLocale: I18n.default_locale,
+          instanceLocale: Setting.default_language,
           firstWeekOfYear: locale_first_week_of_year,
           firstDayOfWeek: locale_first_day_of_week,
           environment: Rails.env,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -814,6 +814,7 @@ en:
 
     text_are_you_sure: "Are you sure?"
     text_data_lost: "All entered data will be lost."
+    text_user_wrote: "%{value} wrote:"
 
     types:
       attribute_groups:

--- a/frontend/src/app/core/i18n/i18n.service.ts
+++ b/frontend/src/app/core/i18n/i18n.service.ts
@@ -6,10 +6,14 @@ import { FormatNumberOptions, TranslateOptions } from 'i18n-js/src/typing';
 @Injectable({ providedIn: 'root' })
 export class I18nService {
   private i18n:I18n = window.I18n;
+  private instanceLocale:string;
 
   constructor(
     private config:NgSelectConfig,
   ) {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name=openproject_initializer]');
+    this.instanceLocale = meta?.dataset.instancelocale || 'en';
+
     this.config.addTagText = this.t('js.autocomplete_ng_select.add_tag');
     this.config.clearAllText = this.t('js.autocomplete_ng_select.clear_all');
     this.config.loadingText = this.t('js.autocomplete_ng_select.loading');
@@ -23,6 +27,16 @@ export class I18nService {
 
   public t<T = string>(input:string, options:Partial<TranslateOptions> = {}) {
     return this.i18n.t<T>(input, options);
+  }
+
+  public instance_locale_translate<T = string>(input:string, options:Partial<TranslateOptions> = {}) {
+    const locale = this.i18n.locale;
+    try {
+      this.i18n.locale = this.instanceLocale;
+      return this.t<T>(input, options);
+    } finally {
+      this.i18n.locale = locale;
+    }
   }
 
   public toTime = this.i18n.toTime.bind(this.i18n);

--- a/frontend/src/app/core/setup/init-locale.ts
+++ b/frontend/src/app/core/setup/init-locale.ts
@@ -31,16 +31,19 @@ import * as i18njs from 'i18n-js';
 
 export function initializeLocale() {
   const meta = document.querySelector<HTMLMetaElement>('meta[name=openproject_initializer]');
-  const locale = meta?.dataset.locale || 'en';
+  const userLocale = meta?.dataset.locale || 'en';
+  const defaultLocale = meta?.dataset.defaultlocale || 'en';
+  const instanceLocale = meta?.dataset.instancelocale || 'en';
   const firstDayOfWeek = parseInt(meta?.dataset.firstdayofweek || '', 10); // properties of meta.dataset are exposed in lowercase
   const firstWeekOfYear = parseInt(meta?.dataset.firstweekofyear || '', 10); // properties of meta.dataset are exposed in lowercase
 
   window.I18n = new i18njs.I18n();
-  I18n.locale = locale;
+  I18n.locale = userLocale;
+  I18n.defaultLocale = defaultLocale;
 
   if (!Number.isNaN(firstDayOfWeek) && !Number.isNaN(firstWeekOfYear)) {
     // ensure locale like "zh-CN" falls back to "zh-cn"
-    moment.locale(locale);
+    moment.locale(userLocale);
     moment.updateLocale(moment.locale(), {
       week: {
         dow: firstDayOfWeek,
@@ -66,8 +69,15 @@ export function initializeLocale() {
     },
   );
 
-  return import(/* webpackChunkName: "locale" */ `../../../locales/${I18n.locale}.json`)
-    .then((imported:{ default:object }) => {
-      I18n.store(imported.default);
-    });
+  const localeImports = _
+    .chain([userLocale, instanceLocale])
+    .uniq()
+    .map(
+      (locale) => import(/* webpackChunkName: "locale" */ `../../../locales/${locale}.json`)
+        .then((imported:{ default:object }) => {
+          I18n.store(imported.default);
+        }),
+      )
+    .value();
+  return Promise.all(localeImports);
 }

--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.ts
@@ -100,19 +100,21 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
 
   private $element:JQuery;
 
-  constructor(readonly elementRef:ElementRef,
+  constructor(
+    readonly elementRef:ElementRef,
     readonly injector:Injector,
     readonly sanitization:DomSanitizer,
     readonly PathHelper:PathHelperService,
     readonly wpLinkedActivities:WorkPackagesActivityService,
     readonly commentService:CommentService,
-    readonly ConfigurationService:ConfigurationService,
+    readonly configurationService:ConfigurationService,
     readonly apiV3Service:ApiV3Service,
     readonly cdRef:ChangeDetectorRef,
     readonly I18n:I18nService,
     readonly ngZone:NgZone,
     readonly deviceService:DeviceService,
-    protected appRef:ApplicationRef) {
+    protected appRef:ApplicationRef,
+  ) {
     super(elementRef, injector);
   }
 
@@ -232,7 +234,7 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
     return this.focused;
   }
 
-  setErrors(newErrors:string[]):void {
+  setErrors(_newErrors:string[]):void {
     // interface
   }
 
@@ -240,7 +242,8 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
     const quoted = rawComment.split('\n')
       .map((line:string) => `\n> ${line}`)
       .join('');
-    return `${this.userName} wrote:\n${quoted}`;
+    const userWrote = this.I18n.instance_locale_translate('js.text_user_wrote', { value: this.userName });
+    return `${userWrote}\n${quoted}`;
   }
 
   deactivate(focus:boolean):void {


### PR DESCRIPTION
https://community.openproject.org/wp/51656

In work package activity, when quoting a message, the text "<username> wrote:" was hard coded. This PR changes it to be translated in the instance default language.