### PR TITLE
have fixed non working days in spec setup

### DIFF
--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -183,9 +183,9 @@ RSpec.describe 'Working Days', js: true, with_cuprite: true do
   describe 'non-working days' do
     shared_let(:non_working_days) do
       [
-        create(:non_working_day),
-        create(:non_working_day),
-        create(:non_working_day)
+        create(:non_working_day, date: Date.new(Date.current.year, 6, 10)),
+        create(:non_working_day, date: Date.new(Date.current.year, 8, 20)),
+        create(:non_working_day, date: Date.new(Date.current.year, 9, 25))
       ]
     end
 


### PR DESCRIPTION
Switching the years runs into errors as the flatpicker does not correctly update the days displayed for the month. Even if it were, the subsequent expectations do not account for switching the year so that they will not find the newly created non working day.