### PR TITLE
[#50945] Ensure filters are re-applied on CRUD share actions

### DIFF
--- a/app/components/work_packages/share/permission_button_component.html.erb
+++ b/app/components/work_packages/share/permission_button_component.html.erb
@@ -18,8 +18,7 @@
                        data: { value: option[:value] },
                        form_arguments: {
                          method: :patch,
-                         name: 'role_ids[]',
-                         value: option[:value]
+                         inputs: form_inputs(option[:value])
                        }) do |item|
           item.with_description.with_content(option[:description])
         end

--- a/app/components/work_packages/share/permission_button_component.rb
+++ b/app/components/work_packages/share/permission_button_component.rb
@@ -74,6 +74,13 @@ module WorkPackages
       def permission_name(value)
         options.select { |option| option[:value] == value }
       end
+
+      def form_inputs(role_id)
+        [].tap do |inputs|
+          inputs << { name: 'role_ids[]', value: role_id }
+          inputs << { name: 'filters', value: params[:filters] } if params[:filters]
+        end
+      end
     end
   end
 end

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -87,7 +87,15 @@ class WorkPackages::SharesController < ApplicationController
       .new(user: current_user, model: @share)
       .call(role_ids: find_role_ids(params[:role_ids]))
 
-    respond_with_update_permission_button
+    find_shares
+
+    if @shares.empty?
+      respond_with_replace_modal
+    elsif @shares.include?(@share)
+      respond_with_update_permission_button
+    else
+      respond_with_remove_share
+    end
   end
 
   def destroy

--- a/app/controllers/work_packages/shares_controller.rb
+++ b/app/controllers/work_packages/shares_controller.rb
@@ -197,10 +197,7 @@ class WorkPackages::SharesController < ApplicationController
   end
 
   def find_shares
-    @shares = Member.includes(:roles)
-                    .references(:member_roles)
-                    .of_work_package(@work_package)
-                    .merge(MemberRole.only_non_inherited)
+    @shares = load_shares(load_query)
   end
 
   def find_project
@@ -208,11 +205,7 @@ class WorkPackages::SharesController < ApplicationController
   end
 
   def current_visible_member_count
-    @current_visible_member_count ||= Member
-      .joins(:member_roles)
-      .of_work_package(@work_package)
-      .merge(MemberRole.only_non_inherited)
-      .size
+    @current_visible_member_count ||= load_shares(load_query).size
   end
 
   def load_query

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -273,6 +273,35 @@ RSpec.describe 'Work package sharing',
       end
     end
 
+    it 'only displays shares that match the current set of applied filters' do
+      share_modal.expect_open
+
+      share_modal.toggle_select_all
+      share_modal.bulk_update("View")
+      share_modal.toggle_select_all
+
+      share_modal.filter('role', "View")
+
+      share_modal.expect_shared_with(project_user)
+      share_modal.expect_shared_with(project_user2)
+      share_modal.expect_shared_with(inherited_project_user)
+      share_modal.expect_shared_with(non_project_user)
+      share_modal.expect_shared_with(shared_project_group)
+      share_modal.expect_shared_with(shared_non_project_group)
+
+      share_modal.change_role(project_user, "Comment")
+      share_modal.filter('role', "Comment")
+      share_modal.expect_shared_with(project_user, "Comment")
+      share_modal.expect_not_shared_with(project_user2)
+      share_modal.expect_not_shared_with(inherited_project_user)
+      share_modal.expect_not_shared_with(non_project_user)
+      share_modal.expect_not_shared_with(shared_project_group)
+      share_modal.expect_not_shared_with(shared_non_project_group)
+
+      share_modal.filter('role', "Edit")
+      share_modal.expect_empty_search_blankslate
+    end
+
     context 'when filtering for a specific role' do
       before do
         share_modal.expect_open

--- a/spec/features/work_packages/share/filter_spec.rb
+++ b/spec/features/work_packages/share/filter_spec.rb
@@ -272,5 +272,22 @@ RSpec.describe 'Work package sharing',
         share_modal.expect_select_all_untoggled
       end
     end
+
+    context 'when filtering for a specific role' do
+      before do
+        share_modal.expect_open
+        share_modal.filter('role', "View")
+      end
+
+      context 'and a share from the filtered list is subsequently updated' do
+        before do
+          share_modal.change_role(project_user, "Comment")
+        end
+
+        it 'removes the updated share from the list' do
+          share_modal.expect_not_shared_with(project_user)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
This PR ensures that turbo stream responses are context-aware of the currently applied filter on the modal. We don't want to ship a row update if the currently applied filter does not include the updated share any longer.

## Notes
See: https://community.openproject.org/work_packages/50945
