### PR TITLE
[51374] Notes on Add work package to meeting modal are overflowing

### DIFF
--- a/modules/meeting/app/components/meetings/sidebar/participants_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/participants_form_component.html.erb
@@ -1,13 +1,14 @@
 <%=
   content_tag("turbo-frame", id: "edit-participants-dialog-frame") do
-    component_wrapper do
+    component_wrapper(class: 'Overlay-form') do
       primer_form_with(
         model: @meeting,
         method: :put,
-        url: update_participants_meeting_path(@meeting)
+        url: update_participants_meeting_path(@meeting),
+        class: 'Overlay-form'
       ) do |f|
         component_collection do |collection|
-          collection.with_component(Primer::Alpha::Dialog::Body.new(style: "max-height: 460px;", my: 3)) do
+          collection.with_component(Primer::Alpha::Dialog::Body.new(my: 3)) do
             flex_layout(mt: 3) do |form_container|
               form_container.with_row do
                 flex_layout(justify_content: :flex_end) do |header|

--- a/modules/meeting/app/components/op_turbo/op_primer/async_dialog_component.html.erb
+++ b/modules/meeting/app/components/op_turbo/op_primer/async_dialog_component.html.erb
@@ -14,6 +14,7 @@
                   id: "#{@id}-frame",
                   loading: :lazy,
                   src: @src,
+                  class: 'Overlay-form',
                   data: { 'op-turbo-op-primer-async-dialog-target': "frameElement" }) do
         flex_layout(justify_content: :center) do |flex|
           flex.with_column(my: 5) do

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
@@ -1,10 +1,11 @@
 <%=
   content_tag("turbo-frame", id: "add-work-package-to-meeting-dialog-frame") do
-    component_wrapper do
+    component_wrapper(class: 'Overlay-form') do
       primer_form_with(
         model: @meeting_agenda_item,
         method: :post,
-        url: work_package_meeting_agenda_items_path(@work_package)
+        url: work_package_meeting_agenda_items_path(@work_package),
+        class: 'Overlay-form'
       ) do |f|
         component_collection do |collection|
           collection.with_component(Primer::Alpha::Dialog::Body.new(test_selector: 'op-add-work-package-to-meeting-dialog-body')) do


### PR DESCRIPTION
The Primer dialog component normally expects the body and the footer being a direct sibling of the header. If that is not the case (e.g. when a form is in between), the dialog does not handle overflows correctly. For that case, Primer offers the class `Overlay-form`. Since we have multiple hierarchy elements in between, we have to set that class onto all of them to prevent an overflow of the dialog. 


https://community.openproject.org/projects/openproject/work_packages/51374/activity