### PR TITLE
[51693] Add second level navigation for the members page

### DIFF
--- a/app/components/individual_principal_base_filter_component.html.erb
+++ b/app/components/individual_principal_base_filter_component.html.erb
@@ -90,7 +90,7 @@ See COPYRIGHT and LICENSE files for more details.
               :shared_role_id,
               options_for_select(
                 shares,
-                params[:shared_role_id].to_i
+                params[:shared_role_id]
               ),
               {
                 include_blank: true,

--- a/app/components/individual_principal_base_filter_component.html.erb
+++ b/app/components/individual_principal_base_filter_component.html.erb
@@ -82,6 +82,24 @@ See COPYRIGHT and LICENSE files for more details.
             %>
         </li>
       <% end %>
+      <% if has_shares? %>
+        <li class="simple-filters--filter">
+          <label class='simple-filters--filter-name' for='shared_role_id'><%= t('members.menu.wp_shares') %>:</label>
+          <%=
+            select_tag(
+              :shared_role_id,
+              options_for_select(
+                shares,
+                params[:shared_role_id].to_i
+              ),
+              {
+                include_blank: true,
+                name: "shared_role_id",
+                class: 'simple-filters--filter-value'
+              })
+          %>
+        </li>
+      <% end %>
       <li class="simple-filters--filter">
         <label class='simple-filters--filter-name' for='name'><%= User.human_attribute_name :name %>:</label>
         <%= text_field_tag 'name', params[:name], class: 'simple-filters--filter-value' %>

--- a/app/components/individual_principal_base_filter_component.rb
+++ b/app/components/individual_principal_base_filter_component.rb
@@ -112,6 +112,10 @@ class IndividualPrincipalBaseFilterComponent < ApplicationComponent
     defined?(groups) && groups.present?
   end
 
+  def has_shares?
+    false
+  end
+
   def params
     model
   end

--- a/app/components/individual_principal_base_filter_component.rb
+++ b/app/components/individual_principal_base_filter_component.rb
@@ -42,8 +42,12 @@ class IndividualPrincipalBaseFilterComponent < ApplicationComponent
       query(params).results
     end
 
+    def filter_param_keys
+      %i(name status group_id role_id)
+    end
+
     def filtered?(params)
-      %i(name status group_id role_id).any? { |name| params[name].present? }
+      filter_param_keys.any? { |name| params[name].present? }
     end
 
     def filter_name(query, name)

--- a/app/components/members/user_filter_component.rb
+++ b/app/components/members/user_filter_component.rb
@@ -62,7 +62,7 @@ module Members
     def status_members_query(status)
       params = {
         project_id: project.id,
-        status:
+        status:,
       }
 
       self.class.filter(params)
@@ -111,9 +111,15 @@ module Members
 
       protected
 
+      def filter_shares(query, role_id)
+        return unless role_id > 0
+
+        query.where(:role_id, '=', role_id)
+      end
+
       def apply_filters(params, query)
         super(params, query)
-        query.where(:only_project_member, '=', 't')
+        filter_shares(query, params[:shared_role_id].to_i) if params.key?(:shared_role_id)
 
         query
       end

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -8,7 +8,7 @@
             <li class="op-sidemenu--item">
               <% selected = menu_item[:selected] ? 'selected' : '' %>
               <a class="op-sidemenu--item-action <%= selected %>" href="<%= menu_item[:href] %>">
-                <%= menu_item[:title] %>
+                <span class="op-sidemenu--item-title"><%= menu_item[:title] %></span>
               </a>
             </li>
           <% end %>
@@ -40,7 +40,7 @@
               <li class="op-sidemenu--item">
                 <% selected = child_item[:selected] ? 'selected' : '' %>
                 <a class="op-sidemenu--item-action <%= selected %>" href="<%= child_item[:href] %>">
-                  <%= child_item[:title] %>
+                  <span class="op-sidemenu--item-title"><%= child_item[:title] %></span>
                 </a>
               </li>
             <% end %>

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -1,0 +1,50 @@
+<div class="op-sidebar">
+  <div class="op-sidebar--body">
+    <% top_level_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item[:header].nil? } %>
+    <% if top_level_sidebar_menu_items.any? %>
+      <div class="op-sidemenu">
+        <ul class="op-sidemenu--items">
+          <% top_level_sidebar_menu_items.first[:children].each do |menu_item| %>
+            <li class="op-sidemenu--item">
+              <a class="op-sidemenu--item-action" href="<%= menu_item[:href] %>">
+                <%= menu_item[:title] %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+
+    <% nested_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item[:header].present? } %>
+    <% if nested_sidebar_menu_items.any? %>
+      <% nested_sidebar_menu_items.each do |menu_item| %>
+        <div class="op-sidemenu"
+             data-controller="menus--expandable-sidemenu"
+             data-application-target="dynamic">
+
+          <button class="op-sidemenu--title"
+                  type="button"
+                  data-action="click->menus--expandable-sidemenu#toggleContainer">
+            <%= menu_item[:header] %>
+            <span class="icon-small icon-arrow-up1"
+                  aria-hidden="true"
+                  data-menus--expandable-sidemenu-target="indicator">
+            </span>
+          </button>
+
+          <ul class="op-sidemenu--items"
+              data-menus--expandable-sidemenu-target="container">
+            <% menu_item[:children].each do |child_item| %>
+              <li class="op-sidemenu--item">
+                <a class="op-sidemenu--item-action" href="<%= child_item[:href] %>">
+                  <%= child_item[:title] %>
+                </a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -6,7 +6,8 @@
         <ul class="op-sidemenu--items">
           <% top_level_sidebar_menu_items.first[:children].each do |menu_item| %>
             <li class="op-sidemenu--item">
-              <a class="op-sidemenu--item-action" href="<%= menu_item[:href] %>">
+              <% selected = menu_item[:selected] ? 'selected' : '' %>
+              <a class="op-sidemenu--item-action <%= selected %>" href="<%= menu_item[:href] %>">
                 <%= menu_item[:title] %>
               </a>
             </li>
@@ -37,7 +38,8 @@
               data-menus--expandable-sidemenu-target="container">
             <% menu_item[:children].each do |child_item| %>
               <li class="op-sidemenu--item">
-                <a class="op-sidemenu--item-action" href="<%= child_item[:href] %>">
+                <% selected = child_item[:selected] ? 'selected' : '' %>
+                <a class="op-sidemenu--item-action <%= selected %>" href="<%= child_item[:href] %>">
                   <%= child_item[:title] %>
                 </a>
               </li>

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -1,14 +1,14 @@
 <div class="op-sidebar">
   <div class="op-sidebar--body">
-    <% top_level_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item[:header].nil? } %>
+    <% top_level_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item.header.nil? } %>
     <% if top_level_sidebar_menu_items.any? %>
       <div class="op-sidemenu">
         <ul class="op-sidemenu--items">
-          <% top_level_sidebar_menu_items.first[:children].each do |menu_item| %>
+          <% top_level_sidebar_menu_items.first.children.each do |menu_item| %>
             <li class="op-sidemenu--item">
-              <% selected = menu_item[:selected] ? 'selected' : '' %>
-              <a class="op-sidemenu--item-action <%= selected %>" href="<%= menu_item[:href] %>">
-                <span class="op-sidemenu--item-title"><%= menu_item[:title] %></span>
+              <% selected = menu_item.selected ? 'selected' : '' %>
+              <a class="op-sidemenu--item-action <%= selected %>" href="<%= menu_item.href %>">
+                <span class="op-sidemenu--item-title"><%= menu_item.title %></span>
               </a>
             </li>
           <% end %>
@@ -17,7 +17,7 @@
     <% end %>
 
 
-    <% nested_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item[:header].present? } %>
+    <% nested_sidebar_menu_items = @sidebar_menu_items.filter { |menu_item| menu_item.header.present? } %>
     <% if nested_sidebar_menu_items.any? %>
       <% nested_sidebar_menu_items.each do |menu_item| %>
         <div class="op-sidemenu"
@@ -27,7 +27,7 @@
           <button class="op-sidemenu--title"
                   type="button"
                   data-action="click->menus--expandable-sidemenu#toggleContainer">
-            <%= menu_item[:header] %>
+            <%= menu_item.header %>
             <span class="icon-small icon-arrow-up1"
                   aria-hidden="true"
                   data-menus--expandable-sidemenu-target="indicator">
@@ -36,11 +36,11 @@
 
           <ul class="op-sidemenu--items"
               data-menus--expandable-sidemenu-target="container">
-            <% menu_item[:children].each do |child_item| %>
+            <% menu_item.children.each do |child_item| %>
               <li class="op-sidemenu--item">
-                <% selected = child_item[:selected] ? 'selected' : '' %>
-                <a class="op-sidemenu--item-action <%= selected %>" href="<%= child_item[:href] %>">
-                  <span class="op-sidemenu--item-title"><%= child_item[:title] %></span>
+                <% selected = child_item.selected ? 'selected' : '' %>
+                <a class="op-sidemenu--item-action <%= selected %>" href="<%= child_item.href %>">
+                  <span class="op-sidemenu--item-title"><%= child_item.title %></span>
                 </a>
               </li>
             <% end %>

--- a/app/components/open_project/common/submenu_component.rb
+++ b/app/components/open_project/common/submenu_component.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+module OpenProject
+  module Common
+    class SubmenuComponent < ApplicationComponent
+      def initialize(sidebar_menu_items: nil)
+        super()
+        @sidebar_menu_items = sidebar_menu_items
+      end
+
+      def render?
+        @sidebar_menu_items.present?
+      end
+    end
+  end
+end

--- a/app/constants/menu.rb
+++ b/app/constants/menu.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Menu
+  MenuGroup = Data.define(:header, :children)
+  MenuItem = Data.define(:title, :href, :selected)
+end

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -36,13 +36,29 @@ module Members
 
     def first_level_menu_items
       [{
-        header: nil,
-        children: [
-          { title: I18n.t('members.menu.all'), href: '' }, # TODO
-          { title: I18n.t('members.menu.locked'), href: '' }, # TODO
-          { title: I18n.t('members.menu.invited'), href: '' } # TODO
-        ]
-      }]
+         header: nil,
+         children: user_status_options
+       }]
+    end
+
+    def user_status_options
+      [
+        {
+          title: I18n.t('members.menu.all'),
+          href: project_members_path,
+          selected: active_filter_count == 0
+        },
+        {
+          title: I18n.t('members.menu.locked'),
+          href: project_members_path(status: :locked),
+          selected: selected?(:status, :locked)
+        },
+        {
+          title: I18n.t('members.menu.invited'),
+          href: project_members_path(status: :invited),
+          selected: selected?(:status, :invited)
+        }
+      ]
     end
 
     def nested_menu_items
@@ -72,7 +88,25 @@ module Members
         .groups
         .order(lastname: :asc)
         .pluck(:id, :lastname)
-        .map { |id, name| { title: name, href: project_members_path(group_id: id) } }
+        .map { |id, name| group_entry(id, name) }
+    end
+
+    def group_entry(id, name)
+      {
+        title: name,
+        href: project_members_path(group_id: id),
+        selected: selected?(:group_id, id)
+      }
+    end
+
+    def selected?(filter_key, value)
+      return false if active_filter_count > 1
+
+      params[filter_key] == value.to_s
+    end
+
+    def active_filter_count
+      @active_filter_count ||= (params.keys & Members::UserFilterComponent.filter_param_keys.map(&:to_s)).count
     end
   end
 end

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -78,12 +78,9 @@ module Members
     end
 
     def permission_menu_entries
-      # todo
-      [
-        { title: I18n.t('work_package.sharing.permissions.view'), href: '' },
-        { title: I18n.t('work_package.sharing.permissions.comment'), href: '' },
-        { title: I18n.t('work_package.sharing.permissions.edit'), href: '' }
-      ]
+      Members::UserFilterComponent
+        .share_options
+        .map { |name, id| menu_item(:shared_role_id, id, name) }
     end
 
     def project_group_entries

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -36,37 +36,31 @@ module Members
 
     def first_level_menu_items
       [
-        {
-          header: nil,
-          children: user_status_options
-        }
+        Menu::MenuGroup.new(header: nil,
+                            children: user_status_options)
       ]
     end
 
     def user_status_options
       [
-        {
-          title: I18n.t('members.menu.all'),
-          href: project_members_path,
-          selected: active_filter_count == 0
-        },
-        {
-          title: I18n.t('members.menu.locked'),
-          href: project_members_path(status: :locked),
-          selected: selected?(:status, :locked)
-        },
-        {
-          title: I18n.t('members.menu.invited'),
-          href: project_members_path(status: :invited),
-          selected: selected?(:status, :invited)
-        }
+        Menu::MenuItem.new(title: I18n.t('members.menu.all'),
+                           href: project_members_path,
+                           selected: active_filter_count == 0),
+        Menu::MenuItem.new(title: I18n.t('members.menu.locked'),
+                           href: project_members_path(status: :locked),
+                           selected: selected?(:status, :locked)),
+        Menu::MenuItem.new(title: I18n.t('members.menu.invited'),
+                           href: project_members_path(status: :invited),
+                           selected: selected?(:status, :invited))
       ]
     end
 
     def nested_menu_items
-      [{ header: I18n.t('members.menu.project_roles'), children: project_roles_entries },
-       { header: I18n.t('members.menu.wp_shares'), children: permission_menu_entries },
-       { header: I18n.t('members.menu.groups'), children: project_group_entries }]
+      [
+        Menu::MenuGroup.new(header: I18n.t('members.menu.project_roles'), children: project_roles_entries),
+        Menu::MenuGroup.new(header: I18n.t('members.menu.wp_shares'), children: permission_menu_entries),
+        Menu::MenuGroup.new(header: I18n.t('members.menu.groups'), children: project_group_entries)
+      ]
     end
 
     private
@@ -95,11 +89,9 @@ module Members
     end
 
     def menu_item(filter_key, id, name)
-      {
-        title: name,
-        href: project_members_path(filter_key => id),
-        selected: selected?(filter_key, id)
-      }
+      Menu::MenuItem.new(title: name,
+                         href: project_members_path(filter_key => id),
+                         selected: selected?(filter_key, id))
     end
 
     def selected?(filter_key, value)

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -27,6 +27,8 @@
 #++
 module Members
   class MenusController < ApplicationController
+    before_action :find_project_by_project_id
+
     def show
       @sidebar_menu_items = first_level_menu_items + nested_menu_items
       render layout: nil
@@ -66,8 +68,11 @@ module Members
     end
 
     def project_group_entries
-      # todo
-      [{ title: 'GROUP X', href: '' }]
+      @project
+        .groups
+        .order(lastname: :asc)
+        .pluck(:id, :lastname)
+        .map { |id, name| { title: name, href: project_members_path(group_id: id) } }
     end
   end
 end

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module Members
+  class MenusController < ApplicationController
+    def show
+      @sidebar_menu_items = first_level_menu_items + nested_menu_items
+      render layout: nil
+    end
+
+    def first_level_menu_items
+      [{
+        header: nil,
+        children: [
+          { title: I18n.t('members.menu.all'), href: '' }, # TODO
+          { title: I18n.t('members.menu.locked'), href: '' }, # TODO
+          { title: I18n.t('members.menu.invited'), href: '' } # TODO
+        ]
+      }]
+    end
+
+    def nested_menu_items
+      [{ header: I18n.t('members.menu.project_roles'), children: project_roles_entries },
+       { header: I18n.t('members.menu.wp_shares'), children: permission_menu_entries },
+       { header: I18n.t('members.menu.groups'), children: project_group_entries }]
+    end
+
+    private
+
+    def project_roles_entries
+      # todo
+      [{ title: 'ROLE X', href: '' }]
+    end
+
+    def permission_menu_entries
+      # todo
+      [
+        { title: I18n.t('work_package.sharing.permissions.view'), href: '' },
+        { title: I18n.t('work_package.sharing.permissions.comment'), href: '' },
+        { title: I18n.t('work_package.sharing.permissions.edit'), href: '' }
+      ]
+    end
+
+    def project_group_entries
+      # todo
+      [{ title: 'GROUP X', href: '' }]
+    end
+  end
+end

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -89,6 +89,7 @@ module Members
       @project
         .groups
         .order(lastname: :asc)
+        .distinct
         .pluck(:id, :lastname)
         .map { |id, name| menu_item(:group_id, id, name) }
     end

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -35,10 +35,12 @@ module Members
     end
 
     def first_level_menu_items
-      [{
-         header: nil,
-         children: user_status_options
-       }]
+      [
+        {
+          header: nil,
+          children: user_status_options
+        }
+      ]
     end
 
     def user_status_options

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -36,30 +36,29 @@ module Members
 
     def first_level_menu_items
       [
-        Menu::MenuGroup.new(header: nil,
-                            children: user_status_options)
+        OpenProject::Menu::MenuGroup.new(header: nil, children: user_status_options)
       ]
     end
 
     def user_status_options
       [
-        Menu::MenuItem.new(title: I18n.t('members.menu.all'),
-                           href: project_members_path,
-                           selected: active_filter_count == 0),
-        Menu::MenuItem.new(title: I18n.t('members.menu.locked'),
-                           href: project_members_path(status: :locked),
-                           selected: selected?(:status, :locked)),
-        Menu::MenuItem.new(title: I18n.t('members.menu.invited'),
-                           href: project_members_path(status: :invited),
-                           selected: selected?(:status, :invited))
+        OpenProject::Menu::MenuItem.new(title: I18n.t('members.menu.all'),
+                                        href: project_members_path,
+                                        selected: active_filter_count == 0),
+        OpenProject::Menu::MenuItem.new(title: I18n.t('members.menu.locked'),
+                                        href: project_members_path(status: :locked),
+                                        selected: selected?(:status, :locked)),
+        OpenProject::Menu::MenuItem.new(title: I18n.t('members.menu.invited'),
+                                        href: project_members_path(status: :invited),
+                                        selected: selected?(:status, :invited))
       ]
     end
 
     def nested_menu_items
       [
-        Menu::MenuGroup.new(header: I18n.t('members.menu.project_roles'), children: project_roles_entries),
-        Menu::MenuGroup.new(header: I18n.t('members.menu.wp_shares'), children: permission_menu_entries),
-        Menu::MenuGroup.new(header: I18n.t('members.menu.groups'), children: project_group_entries)
+        OpenProject::Menu::MenuGroup.new(header: I18n.t('members.menu.project_roles'), children: project_roles_entries),
+        OpenProject::Menu::MenuGroup.new(header: I18n.t('members.menu.wp_shares'), children: permission_menu_entries),
+        OpenProject::Menu::MenuGroup.new(header: I18n.t('members.menu.groups'), children: project_group_entries)
       ]
     end
 
@@ -89,9 +88,9 @@ module Members
     end
 
     def menu_item(filter_key, id, name)
-      Menu::MenuItem.new(title: name,
-                         href: project_members_path(filter_key => id),
-                         selected: selected?(filter_key, id))
+      OpenProject::Menu::MenuItem.new(title: name,
+                                      href: project_members_path(filter_key => id),
+                                      selected: selected?(filter_key, id))
     end
 
     def selected?(filter_key, value)

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -70,8 +70,11 @@ module Members
     private
 
     def project_roles_entries
-      # todo
-      [{ title: 'ROLE X', href: '' }]
+      ProjectRole
+        .where(id: MemberRole.where(member_id: @project.members.select(:id)).select(:role_id))
+        .distinct
+        .pluck(:id, :name)
+        .map { |id, name| menu_item(:role_id, id, name) }
     end
 
     def permission_menu_entries
@@ -88,14 +91,14 @@ module Members
         .groups
         .order(lastname: :asc)
         .pluck(:id, :lastname)
-        .map { |id, name| group_entry(id, name) }
+        .map { |id, name| menu_item(:group_id, id, name) }
     end
 
-    def group_entry(id, name)
+    def menu_item(filter_key, id, name)
       {
         title: name,
-        href: project_members_path(group_id: id),
-        selected: selected?(:group_id, id)
+        href: project_members_path(filter_key => id),
+        selected: selected?(filter_key, id)
       }
     end
 

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -27,12 +27,15 @@
 #++
 module Members
   class MenusController < ApplicationController
-    before_action :find_project_by_project_id
+    before_action :find_project_by_project_id,
+                  :authorize
 
     def show
       @sidebar_menu_items = first_level_menu_items + nested_menu_items
       render layout: nil
     end
+
+    private
 
     def first_level_menu_items
       [

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -188,7 +188,7 @@ class MembersController < ApplicationController
   end
 
   def index_members
-    filters = params.slice(:name, :group_id, :role_id, :status)
+    filters = params.slice(*Members::UserFilterComponent.filter_param_keys)
     filters[:project_id] = @project.id.to_s
 
     @members_query = Members::UserFilterComponent.query(filters)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -142,12 +142,14 @@ class MembersController < ApplicationController
 
   def members_filter_options(roles)
     groups = Group.all.sort
+    shares = WorkPackageRole.all
     status = Members::UserFilterComponent.status_param(params)
 
     {
       groups:,
       roles:,
       status:,
+      shares:,
       clear_url: project_members_path(@project),
       project: @project
     }

--- a/app/views/members/menus/_menu.html.erb
+++ b/app/views/members/menus/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "members_menu",
-                    src: project_members_menu_path(@project),
+                    src: project_members_menu_path(@project, params.permit(*Members::UserFilterComponent.filter_param_keys)),
                     target: '_top',
                     data: { turbo: false },
                     loading: :lazy do %>

--- a/app/views/members/menus/_menu.html.erb
+++ b/app/views/members/menus/_menu.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag "members_menu",
+                    src: project_members_menu_path(@project),
+                    target: '_top',
+                    data: { turbo: false },
+                    loading: :lazy do %>
+<% end %>

--- a/app/views/members/menus/show.html.erb
+++ b/app/views/members/menus/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "members_menu" do %>
+  <%= render OpenProject::Common::SubmenuComponent.new(sidebar_menu_items: @sidebar_menu_items) %>
+<% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -582,6 +582,12 @@ Redmine::MenuManager.map :project_menu do |menu|
             before: :settings,
             icon: 'group'
 
+  menu.push :members_menu,
+            { controller: '/members', action: 'index' },
+            parent: :members,
+            partial: 'members/menus/menu',
+            caption: :label_member_plural
+
   menu.push :settings,
             { controller: '/projects/settings/general', action: :show },
             caption: :label_project_settings,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -110,7 +110,10 @@ Rails.application.reloader.to_prepare do
                      require: :member
 
       map.permission :manage_members,
-                     { members: %i[index new create update destroy autocomplete_for_member] },
+                     {
+                       members: %i[index new create update destroy autocomplete_for_member menu],
+                       'members/menus': %i[show]
+                     },
                      permissible_on: :project,
                      require: :member,
                      dependencies: :view_members,
@@ -134,7 +137,10 @@ Rails.application.reloader.to_prepare do
                      contract_actions: { work_package_shares: %i[index] }
 
       map.permission :view_members,
-                     { members: [:index] },
+                     {
+                       members: %i[index menu],
+                       'members/menus': %i[show]
+                     },
                      permissible_on: :project,
                      contract_actions: { members: %i[read] }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,13 @@ en:
       no_results_content_text: Add a member to the project
     invite_by_mail: "Send invite to %{mail}"
     send_invite_to: "Send invite to"
+    menu:
+      all: 'All'
+      invited: 'Invited'
+      locked: 'Locked'
+      project_roles: 'Project roles'
+      wp_shares: 'Work package shares'
+      groups: 'Groups'
 
   my:
     access_token:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,8 @@ en:
       no_results_content_text: Add a member to the project
     invite_by_mail: "Send invite to %{mail}"
     send_invite_to: "Send invite to"
+    filters:
+      all_shares: 'All shares'
     menu:
       all: 'All'
       invited: 'Invited'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,10 @@ OpenProject::Application.routes.draw do
       end
     end
 
+    namespace :members do
+      resource :menu
+    end
+
     resource :repository, controller: 'repositories', except: [:new] do
       # Destroy uses a get request to prompt the user before the actual DELETE request
       get :destroy_info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,7 +295,7 @@ OpenProject::Application.routes.draw do
     end
 
     namespace :members do
-      resource :menu
+      resource :menu, only: %[show]
     end
 
     resource :repository, controller: 'repositories', except: [:new] do

--- a/lib/open_project/menu.rb
+++ b/lib/open_project/menu.rb
@@ -28,7 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Menu
-  MenuGroup = Data.define(:header, :children)
-  MenuItem = Data.define(:title, :href, :selected)
+module OpenProject
+  module Menu
+    MenuGroup = Data.define(:header, :children)
+    MenuItem = Data.define(:title, :href, :selected)
+    class << self
+    end
+  end
 end

--- a/lib/open_project/menu.rb
+++ b/lib/open_project/menu.rb
@@ -32,7 +32,5 @@ module OpenProject
   module Menu
     MenuGroup = Data.define(:header, :children)
     MenuItem = Data.define(:title, :href, :selected)
-    class << self
-    end
   end
 end

--- a/lookbook/previews/open_project/common/submenu_component_preview.rb
+++ b/lookbook/previews/open_project/common/submenu_component_preview.rb
@@ -1,0 +1,30 @@
+module OpenProject
+  module Common
+    # @logical_path OpenProject/Common
+    class SubmenuComponentPreview < Lookbook::Preview
+      def default
+        # Meant to be rendered inside the left-handed sidebar
+        render OpenProject::Common::SubmenuComponent.new(
+          sidebar_menu_items: [
+            {
+              header: nil,
+              children: [
+                { title: I18n.t('members.menu.all'), href: '' },
+                { title: I18n.t('members.menu.locked'), href: '' },
+                { title: I18n.t('members.menu.invited'), href: '' }
+              ]
+            },
+            {
+              header: I18n.t('members.menu.project_roles'),
+              children: [{ title: 'ROLE X', href: '' }]
+            },
+            {
+              header: I18n.t('members.menu.groups'),
+              children: [{ title: 'GROUP X', href: '' }]
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -103,6 +103,40 @@ RSpec.describe 'Administrating memberships via the project settings', :js, :with
       expect(page).not_to have_selector('.generic-table--sort-header a', text: 'ROLES')
       expect(page).not_to have_selector('.generic-table--sort-header a', text: 'GROUP')
     end
+
+    it 'navigating the menu' do
+      members_page.expect_menu_item 'All', selected: true
+      members_page.expect_menu_item 'Invited'
+      members_page.expect_menu_item 'Locked'
+
+      members_page.expect_menu_item group.name
+      members_page.expect_menu_item 'Manager'
+      members_page.expect_menu_item 'Developer'
+
+      # Viewing invited
+      members_page.click_menu_item 'Invited'
+      expect(members_page).to have_user 'Hannibal Smith'
+      expect(members_page).not_to have_user 'Peter Pan'
+      expect(members_page).not_to have_group group.name
+
+      # Viewing locked
+      members_page.click_menu_item 'Locked'
+      expect(members_page).not_to have_user 'Hannibal Smith'
+      expect(members_page).not_to have_user 'Peter Pan'
+      expect(members_page).not_to have_group group.name
+
+      # Viewing manager role
+      members_page.click_menu_item 'Manager'
+      expect(members_page).to have_user 'Peter Pan'
+      expect(members_page).to have_group group.name
+      expect(members_page).not_to have_user 'Hannibal Smith'
+
+      # Viewing developer role
+      members_page.click_menu_item 'Developer'
+      expect(members_page).to have_user 'Hannibal Smith'
+      expect(members_page).not_to have_user 'Peter Pan'
+      expect(members_page).not_to have_group group.name
+    end
   end
 
   it 'Adding and Removing a Group as Member' do

--- a/spec/features/work_packages/share_spec.rb
+++ b/spec/features/work_packages/share_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Work package sharing',
     create(:project_role,
            permissions: %i(view_work_packages
                            view_shared_work_packages
+                           manage_members
                            share_work_packages))
   end
   let(:work_package) do
@@ -75,6 +76,7 @@ RSpec.describe 'Work package sharing',
   end
   let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
   let(:share_modal) { Components::WorkPackages::ShareModal.new(work_package) }
+  let(:members_page) { Pages::Members.new project.identifier }
 
   current_user { create(:user, firstname: 'Signed in', lastname: 'User') }
 
@@ -249,6 +251,32 @@ RSpec.describe 'Work package sharing',
         share_modal.expect_not_shared_with(non_shared_project_user)
 
         share_modal.expect_shared_count_of(7)
+      end
+
+      visit project_members_path(project)
+
+      aggregate_failures 'Observing the shared members with view permission' do
+        members_page.click_menu_item 'View'
+        expect(members_page).to have_user view_user.name
+        expect(members_page).not_to have_user gilfoyle.name
+        expect(members_page).not_to have_user comment_user.name
+        expect(members_page).not_to have_user dinesh.name
+      end
+
+      aggregate_failures 'Observing the shared members with comment permission' do
+        members_page.click_menu_item 'Comment'
+        expect(members_page).to have_user gilfoyle.name
+        expect(members_page).to have_user comment_user.name
+        expect(members_page).not_to have_user view_user.name
+        expect(members_page).not_to have_user dinesh.name
+      end
+
+      aggregate_failures 'Observing the shared members with edit permission' do
+        members_page.click_menu_item 'Edit'
+        expect(members_page).to have_user dinesh.name
+        expect(members_page).not_to have_user gilfoyle.name
+        expect(members_page).not_to have_user comment_user.name
+        expect(members_page).not_to have_user view_user.name
       end
     end
 

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -103,7 +103,7 @@ module Pages
 
     def has_added_user?(name, visible: true, css: "tr")
       has_text?("Added #{name} to the project") and ((not visible) or
-        has_css?(css, text: user_name_to_text(name)))
+        has_css?(css, text: name))
     end
 
     def has_added_group?(name, visible: true)
@@ -120,7 +120,7 @@ module Pages
     #                                   is why there must be only an edit and no delete button.
     def has_user?(name, roles: nil, group_membership: nil, group: false)
       css = group ? "tr.group" : "tr"
-      has_selector?(css, text: user_name_to_text(name)) &&
+      has_selector?(css, text: name) &&
         (roles.nil? || has_roles?(name, roles, group:)) &&
         (group_membership.nil? || group_membership == has_group_membership?(name))
     end
@@ -152,12 +152,6 @@ module Pages
         end
 
       nodes.map(&:text)
-    end
-
-    def user_name_to_text(name)
-      # the members table shows last name and first name separately
-      # let's just look for the last name
-      name.split(" ").last
     end
 
     def edit_user!(name, add_roles: [], remove_roles: [])

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -63,6 +63,20 @@ module Pages
       find('.simple-filters--controls input[type=submit]').click
     end
 
+    def expect_menu_item(text, selected: false)
+      if selected
+        expect(page).to have_css('.op-sidemenu--item-action.selected', text:)
+      else
+        expect(page).to have_css('.op-sidemenu--item-action', text:)
+      end
+    end
+
+    def click_menu_item(text)
+      page.within('#menu-sidebar') do
+        click_link text
+      end
+    end
+
     ##
     # Adds the given user to this project.
     #


### PR DESCRIPTION
### Acceptance criteria

- [x] Add second level of navigation in the sidebar of Members
- [x] That sidebar inlcude grouping of filters:
  - [x] All / Locked / Invited
  - [x] Project roles
  - [x] Work packages shares
  - [x] Groups
- [x] In the sidebar only show roles, groups that are used in the project.
- [x] Add navigation spec for members submenu
- [x] Add filtering spec for sharing options


https://community.openproject.org/projects/openproject/work_packages/51693/activity