### PR TITLE
[#51716] Toggle Automatically managed label on initial view render

### DIFF
--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
@@ -43,7 +43,7 @@ module Storages::Admin::Forms
 
     def submit_button_options
       {
-        label: I18n.t("storages.buttons.done_complete_setup"),
+        label: submit_button_label,
         data: { 'storages--automatically-managed-project-folders-form-target': 'submitButton' }.tap do |data_hash|
           # For create action, break from Turbo Frame and follow full page redirect
           data_hash[:turbo] = false if new_record?
@@ -56,6 +56,14 @@ module Storages::Admin::Forms
     end
 
     private
+
+    def submit_button_label
+      if storage.automatically_managed?
+        I18n.t("storages.buttons.done_complete_setup")
+      else
+        I18n.t("storages.buttons.complete_without_setup")
+      end
+    end
 
     def application_password_display_options
       {}.tap do |options_hash|


### PR DESCRIPTION
https://community.openproject.org/work_packages/51716

Do not rely on dynamic stimulus controller to toggle the application label input display as it's loaded after the fact: "akin to `DOMContentLoaded`" - See Aaron 's [explanation](https://matrix.to/#/!xcCvdAzoRtrTNmmFlD:openproject.org/$muzW49Ex6Hyn15E264DeVJkCabMa7BBVoFK69bkhj0A?via=openproject.org)

Follows: https://github.com/opf/openproject/pull/14327


https://github.com/opf/openproject/assets/17295175/ce6d3873-d8d6-4f44-9276-2c5a6f516632

