### PR TITLE
chore[Op#51033]: Remove unnecessary conditional

### DIFF
--- a/app/services/oauth_clients/create_service.rb
+++ b/app/services/oauth_clients/create_service.rb
@@ -37,7 +37,7 @@ module OAuthClients
     protected
 
     def after_validate(params, contract_call)
-      OAuthClient.where(integration: params[:integration]).delete_all if contract_call.success?
+      OAuthClient.where(integration: params[:integration]).delete_all
       super(params, contract_call)
     end
   end


### PR DESCRIPTION
See: https://github.com/opf/openproject/pull/14354/files#r1431502857

`after_validate` is (already) only invoked on contract success

Ref: [base_contracted.rb#L63](https://github.com/opf/openproject/blob/a06e519ed789984cdfb2ef80a1d760ffe23e3cb4/app/services/base_services/base_contracted.rb#L63)