### PR TITLE
Include ongoing meetings in meeting tab

### DIFF
--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -43,7 +43,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
     ) do |select|
       MeetingAgendaItems::CreateContract
         .assignable_meetings(User.current)
-        .where('meetings.start_time >= ?', Time.zone.now)
+        .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.zone.now)
         .find_each do |meeting|
         select.option(
           label: "#{meeting.title} #{format_date(meeting.start_time)} #{format_time(meeting.start_time, false)}",

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -201,7 +201,7 @@ en:
 
   label_add_work_package_to_meeting_dialog_title: "Add work package to meeting"
   label_add_work_package_to_meeting_dialog_button: "Add to meeting"
-  label_meeting_selection_caption: "It's only possible to add this work package to open, upcoming meetings."
+  label_meeting_selection_caption: "It's only possible to add this work package to upcoming or ongoing open meetings."
 
   text_add_work_package_to_meeting_description: "A work package can be added to one or multiple meetings for discussion. Any notes concerning it are also visible here."
   text_agenda_item_no_notes: "No notes provided"

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -296,10 +296,13 @@ RSpec.describe 'Open the Meetings tab', :js do
       end
 
       context 'when open, upcoming meetings are visible for the user' do
-        let!(:past_meeting) { create(:structured_meeting, project:, start_time: Date.yesterday - 10.hours) }
-        let!(:first_upcoming_meeting) { create(:structured_meeting, project:) }
-        let!(:second_upcoming_meeting) { create(:structured_meeting, project:) }
-        let!(:closed_upcoming_meeting) { create(:structured_meeting, project:, state: :closed) }
+        shared_let(:past_meeting) { create(:structured_meeting, project:, start_time: Date.yesterday - 10.hours) }
+        shared_let(:first_upcoming_meeting) { create(:structured_meeting, project:) }
+        shared_let(:second_upcoming_meeting) { create(:structured_meeting, project:) }
+        shared_let(:closed_upcoming_meeting) { create(:structured_meeting, project:, state: :closed) }
+        shared_let(:ongoing_meeting) do
+          create(:structured_meeting, title: 'Ongoing', project:, start_time: 1.hour.ago, duration: 4.0)
+        end
 
         it 'enables the user to add the work package to multiple open, upcoming meetings' do
           work_package_page.visit!
@@ -332,6 +335,16 @@ RSpec.describe 'Open the Meetings tab', :js do
           page.within_test_selector("op-meeting-container-#{second_upcoming_meeting.id}") do
             expect(page).to have_content('A very important note added from the meetings tab to the second meeting!')
           end
+        end
+
+        it 'allows the user to select ongoing meetings' do
+          work_package_page.visit!
+          switch_to_meetings_tab
+
+          meetings_tab.open_add_to_meeting_dialog
+
+          fill_in('meeting_agenda_item_meeting_id', with: ongoing_meeting.title)
+          expect(page).to have_css('.ng-option-marked', text: ongoing_meeting.title)
         end
 
         it 'does not enable the user to select a past meeting' do


### PR DESCRIPTION
Casting the duration with `make_interval` is not possible, as the duration is an hourly fractional value. The recommended way is to multiply by a 1 hour interval instead.

https://community.openproject.org/work_packages/51715