### PR TITLE
[#51749] The access token expiry date not updated on refresh for file storage tokens

### DIFF
--- a/app/views/my/access_token_partials/_storage_tokens_section.html.erb
+++ b/app/views/my/access_token_partials/_storage_tokens_section.html.erb
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
                   <span><%= format_time(token.created_at) %></span>
                 </td>
                 <td>
-                  <span><%= format_time(token.created_at + token.expires_in.seconds) %></span>
+                  <span><%= format_time(token.updated_at + token.expires_in.seconds) %></span>
                 </td>
                 <td class="buttons">
                   <%= link_to "",


### PR DESCRIPTION
[OP#51749](https://community.openproject.org/work_packages/51749) 

Use `updated_at` instead of `created_at` to calculate the displayed **EXPIRES** date.

Before:
<img width="1375" alt="Screenshot 2023-12-20 at 18 16 10" src="https://github.com/opf/openproject/assets/1113942/f744bae9-4ef5-4c6d-a954-9efc361cd38e">
