### PR TITLE
[50615] Project Calender - Navigates to Previous Month w/ Every Filter Swap

### DIFF
--- a/frontend/src/app/features/calendar/calendar.routes.ts
+++ b/frontend/src/app/features/calendar/calendar.routes.ts
@@ -44,8 +44,8 @@ export const CALENDAR_ROUTES:Ng2StateDeclaration[] = [
     },
     params: {
       query_id: { type: 'opQueryId', dynamic: true },
-      cdate: { type: 'string', dynamic: true },
-      cview: { type: 'string', dynamic: true },
+      cdate: { type: 'string', inherit: false, dynamic: true },
+      cview: { type: 'string', inherit: false, dynamic: true },
       // Use custom encoder/decoder that ensures validity of URL string
       query_props: { type: 'opQueryString' },
     },


### PR DESCRIPTION
Do not inherit the calendar params for currently selected date and view as it should not be shared between different calendars


https://community.openproject.org/projects/openproject/work_packages/50615/activity