### PR TITLE
[#50622] Alias `Storages::NextcloudStorage#automatically_managed?` as `Storages::NextcloudStorage#automatic_management_enabled?` for clarity

### DIFF
--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
@@ -7,7 +7,7 @@
       data: {
         controller: "storages--automatically-managed-project-folders-form",
         'application-target': "dynamic",
-        'storages--automatically-managed-project-folders-form-is-automatically-managed-value': storage.automatically_managed?,
+        'storages--automatically-managed-project-folders-form-is-automatically-managed-value': storage.automatic_management_enabled?,
         'storages--automatically-managed-project-folders-form-done-complete-label-value': I18n.t("storages.buttons.done_complete_setup"),
         'storages--automatically-managed-project-folders-form-done-complete-without-label-value': I18n.t("storages.buttons.complete_without_setup"),
       }

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
@@ -22,7 +22,7 @@
         end
 
         project_folders_form.with_row(mb: 3) do
-          render(Storages::Admin::ManagedProjectFolders::AutomaticallyManagedCheckbox.new(form, storage:))
+          render(Storages::Admin::ManagedProjectFolders::AutomaticManagementCheckbox.new(form, storage:))
         end
 
         project_folders_form.with_row(mb: 3,

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.rb
@@ -58,7 +58,7 @@ module Storages::Admin::Forms
     private
 
     def submit_button_label
-      if storage.automatically_managed?
+      if storage.automatic_management_enabled?
         I18n.t("storages.buttons.done_complete_setup")
       else
         I18n.t("storages.buttons.complete_without_setup")
@@ -67,7 +67,7 @@ module Storages::Admin::Forms
 
     def application_password_display_options
       {}.tap do |options_hash|
-        options_hash[:display] = :none unless storage.automatically_managed?
+        options_hash[:display] = :none unless storage.automatic_management_enabled?
       end
     end
 

--- a/modules/storages/app/components/storages/admin/storage_view_information.rb
+++ b/modules/storages/app/components/storages/admin/storage_view_information.rb
@@ -43,7 +43,7 @@ module Storages::Admin
 
       test_selector = 'label-managed-project-folders-status'
 
-      if storage.automatically_managed?
+      if storage.automatic_management_enabled?
         status_label(I18n.t('storages.label_active'), scheme: :success, test_selector:)
       elsif storage.automatic_management_unspecified?
         status_label(I18n.t('storages.label_incomplete'), scheme: :attention, test_selector:)

--- a/modules/storages/app/contracts/storages/storages/nextcloud_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/nextcloud_contract.rb
@@ -39,27 +39,27 @@ module Storages::Storages
     attribute :automatically_managed
 
     attribute :username
-    validates :username, presence: true, if: :nextcloud_storage_automatically_managed?
+    validates :username, presence: true, if: :nextcloud_storage_automatic_management_enabled?
     validates :username,
               absence: true,
-              unless: -> { nextcloud_storage_automatically_managed? || nextcloud_default_storage_username? }
+              unless: -> { nextcloud_storage_automatic_management_enabled? || nextcloud_default_storage_username? }
 
     attribute :password
-    validates :password, presence: true, if: :nextcloud_storage_automatically_managed?
-    validates :password, absence: true, unless: :nextcloud_storage_automatically_managed?
+    validates :password, presence: true, if: :nextcloud_storage_automatic_management_enabled?
+    validates :password, absence: true, unless: :nextcloud_storage_automatic_management_enabled?
 
     validate do
-      if nextcloud_storage_automatically_managed? && errors.exclude?(:host) && errors.exclude?(:password)
+      if nextcloud_storage_automatic_management_enabled? && errors.exclude?(:host) && errors.exclude?(:password)
         NextcloudApplicationCredentialsValidator.new(self).call
       end
     end
 
     private
 
-    def nextcloud_storage_automatically_managed?
+    def nextcloud_storage_automatic_management_enabled?
       return false unless nextcloud_storage?
 
-      @model.automatically_managed?
+      @model.automatic_management_enabled?
     end
 
     def nextcloud_default_storage_username?

--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -144,7 +144,7 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
     permitted_storage_params.tap do |permitted_params|
       # If a checkbox is unchecked when its form is submitted, neither the name nor the value is submitted to the server.
       # See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
-      permitted_params.merge!(automatically_managed: false) unless permitted_params.key?('automatically_managed')
+      permitted_params.merge!(automatic_management_enabled: false) unless permitted_params.key?('automatic_management_enabled')
     end
   end
 
@@ -153,6 +153,6 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
   def permitted_storage_params
     params
       .require(:storages_nextcloud_storage)
-      .permit('automatically_managed', 'password')
+      .permit('automatic_management_enabled', 'password')
   end
 end

--- a/modules/storages/app/forms/storages/admin/managed_project_folders/automatic_management_checkbox.rb
+++ b/modules/storages/app/forms/storages/admin/managed_project_folders/automatic_management_checkbox.rb
@@ -27,10 +27,10 @@
 #++
 
 module Storages::Admin::ManagedProjectFolders
-  class AutomaticallyManagedCheckbox < ApplicationForm
-    form do |automatically_managed_form|
-      automatically_managed_form.check_box(
-        name: :automatically_managed,
+  class AutomaticManagementCheckbox < ApplicationForm
+    form do |automatic_management_form|
+      automatic_management_form.check_box(
+        name: :automatic_management_enabled,
         label: I18n.t(:'storages.label_managed_project_folders.automatically_managed_folders'),
         checked: @storage.automatic_management_enabled?,
         required: true,

--- a/modules/storages/app/forms/storages/admin/managed_project_folders/automatically_managed_checkbox.rb
+++ b/modules/storages/app/forms/storages/admin/managed_project_folders/automatically_managed_checkbox.rb
@@ -32,7 +32,7 @@ module Storages::Admin::ManagedProjectFolders
       automatically_managed_form.check_box(
         name: :automatically_managed,
         label: I18n.t(:'storages.label_managed_project_folders.automatically_managed_folders'),
-        checked: @storage.automatically_managed?,
+        checked: @storage.automatic_management_enabled?,
         required: true,
         data: {
           action: 'change->storages--automatically-managed-project-folders-form#updateDisplay'

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -41,10 +41,24 @@ module Storages
     store_attribute :provider_fields, :group, :string
     store_attribute :provider_fields, :group_folder, :string
 
-    scope :automatically_managed, -> { where("provider_fields->>'automatically_managed' = 'true'") }
+    scope :automatic_management_enabled, -> { where("provider_fields->>'automatically_managed' = 'true'") }
 
     def oauth_configuration
       Peripherals::OAuthConfigurations::NextcloudConfiguration.new(self)
+    end
+
+    def automatically_managed?
+      ActiveSupport::Deprecation.warn(
+        '`#automatically_managed?` is deprecated. Use `#automatic_management_enabled?` instead. ' \
+        'NOTE: The new method name better reflects the actual behavior of the storage. ' \
+        "It's not the storage that is automatically managed, rather the Project (Storage) Folder is. " \
+        "A storage only has this feature enabled or disabled."
+      )
+      super
+    end
+
+    def automatic_management_enabled?
+      !!automatically_managed
     end
 
     def automatic_management_new_record?

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -31,7 +31,7 @@
 module Storages
   class NextcloudStorage < Storage
     PROVIDER_FIELDS_DEFAULTS = {
-      automatically_managed: true,
+      automatic_management_enabled: true,
       username: 'OpenProject'
     }.freeze
 
@@ -56,6 +56,12 @@ module Storages
       )
       super
     end
+
+    def automatic_management_enabled=(value)
+      self.automatically_managed = value
+    end
+
+    alias automatic_management_enabled automatically_managed
 
     def automatic_management_enabled?
       !!automatically_managed

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -51,11 +51,11 @@ class Storages::ProjectStorage < ApplicationRecord
   scope :active_nextcloud_automatically_managed, -> do
     automatic
       .active
-      .where(storages: Storages::NextcloudStorage.automatically_managed)
+      .where(storages: Storages::NextcloudStorage.automatic_management_enabled)
   end
 
   def automatic_management_possible?
-    storage.present? && storage.provider_type_nextcloud? && storage.automatically_managed?
+    storage.present? && storage.provider_type_nextcloud? && storage.automatic_management_enabled?
   end
 
   def project_folder_path

--- a/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
+++ b/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
@@ -36,7 +36,7 @@ module Storages::ProjectStorages
       project_storage.creator ||= user
 
       project_storage.project_folder_mode ||=
-        if storage.present? && storage.provider_type_nextcloud? && storage.automatically_managed?
+        if storage.present? && storage.provider_type_nextcloud? && storage.automatic_management_enabled?
           "automatic"
         else
           "inactive"

--- a/modules/storages/app/services/storages/storages/set_attributes_service.rb
+++ b/modules/storages/app/services/storages/storages/set_attributes_service.rb
@@ -61,7 +61,7 @@ module Storages::Storages
       # E.g. when setting up a new storage for the first time, passthrough, credentials are set in a later stage.
       return if storage.automatic_management_unspecified?
 
-      unless storage.automatically_managed?
+      unless storage.automatic_management_enabled?
         %w[username password].each { |field| storage.provider_fields.delete(field) }
       end
     end

--- a/modules/storages/app/services/storages/storages/set_nextcloud_provider_fields_attributes_service.rb
+++ b/modules/storages/app/services/storages/storages/set_nextcloud_provider_fields_attributes_service.rb
@@ -33,7 +33,7 @@ module Storages::Storages
   class SetNextcloudProviderFieldsAttributesService < ::BaseServices::SetAttributes
     def set_default_provider_fields(_params)
       if storage.automatic_management_unspecified?
-        storage.automatically_managed = storage.provider_fields_defaults[:automatically_managed]
+        storage.automatic_management_enabled = storage.provider_fields_defaults[:automatic_management_enabled]
       end
     end
 

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -74,7 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 <% end %>
 
-<% if @storage.provider_type_nextcloud? && @storage.automatically_managed? %>
+<% if @storage.provider_type_nextcloud? && @storage.automatic_management_enabled? %>
   <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
     <% component.with_main() do %>
       <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>

--- a/modules/storages/app/workers/storages/manage_nextcloud_integration_job_mixin.rb
+++ b/modules/storages/app/workers/storages/manage_nextcloud_integration_job_mixin.rb
@@ -39,7 +39,7 @@ module Storages
         timeout_seconds: 0,
         transaction: false
       ) do
-        ::Storages::NextcloudStorage.automatically_managed.includes(:oauth_client).find_each do |storage|
+        ::Storages::NextcloudStorage.automatic_management_enabled.includes(:oauth_client).find_each do |storage|
           result = GroupFolderPropertiesSyncService.call(storage)
           result.match(
             on_success: ->(_) do

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -106,7 +106,7 @@ module API::V3::Storages
              getter: ->(represented:, **) {
                break unless represented.provider_type_nextcloud?
 
-               represented.automatically_managed?
+               represented.automatic_management_enabled?
              },
              setter: ->(*) {}
 

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -93,10 +93,10 @@ module API::V3::Storages
              getter: ->(*) {},
              setter: ->(fragment:, represented:, **) {
                if fragment.present?
-                 represented.automatically_managed = true
+                 represented.automatic_management_enabled = true
                  represented.password = fragment
                else
-                 represented.automatically_managed = false
+                 represented.automatic_management_enabled = false
                end
              }
 

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
   context 'if the project folder mode is `automatic`' do
     before do
       project_storage.project_folder_mode = 'automatic'
-      project_storage.storage.automatically_managed = true
+      project_storage.storage.automatic_management_enabled = true
     end
 
     it_behaves_like 'contract is valid'
@@ -60,7 +60,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
   context 'when the project folder mode is `automatic` but the storage is not automatically managed' do
     before do
       project_storage.project_folder_mode = 'automatic'
-      project_storage.storage.automatically_managed = false
+      project_storage.storage.automatic_management_enabled = false
     end
 
     it_behaves_like 'contract is invalid', project_folder_mode: :mode_unavailable

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -252,14 +252,14 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
     end
 
     context 'when automatically managed, no username or password' do
-      before { storage.automatically_managed = true }
+      before { storage.automatic_management_enabled = true }
 
       it_behaves_like 'contract is invalid', password: :blank
     end
 
     context 'when automatically managed, with username and password' do
       before do
-        storage.assign_attributes(automatically_managed: true, username: 'OpenProject', password: 'Password')
+        storage.assign_attributes(automatic_management_enabled: true, username: 'OpenProject', password: 'Password')
       end
 
       it_behaves_like 'contract is valid'
@@ -268,7 +268,7 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
     context 'when not automatically managed, no username or password' do
       before do
         storage.provider_fields = {}
-        storage.assign_attributes(automatically_managed: false)
+        storage.assign_attributes(automatic_management_enabled: false)
       end
 
       it_behaves_like 'contract is valid'
@@ -276,7 +276,7 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
 
     context 'when not automatically managed, with username default and password' do
       before do
-        storage.assign_attributes(automatically_managed: false, username: 'OpenProject', password: 'Password')
+        storage.assign_attributes(automatic_management_enabled: false, username: 'OpenProject', password: 'Password')
       end
 
       it_behaves_like 'contract is invalid', password: :present
@@ -284,7 +284,7 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
 
     context 'when not automatically managed, with user defined username and password' do
       before do
-        storage.assign_attributes(automatically_managed: false, username: 'Username', password: 'Password')
+        storage.assign_attributes(automatic_management_enabled: false, username: 'Username', password: 'Password')
       end
 
       it_behaves_like 'contract is invalid', username: :present, password: :present

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe 'Admin storages',
 
         aggregate_failures 'Automatically managed project folders' do
           within_test_selector('storage-automatically-managed-project-folders-form') do
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             application_password_input = page.find_by_id('storages_nextcloud_storage_password')
             expect(automatically_managed_switch).to be_checked
             expect(application_password_input.value).to be_empty
@@ -234,7 +234,7 @@ RSpec.describe 'Admin storages',
             # Mock a valid response (=401) for example.com, so the password validation should fail
             mock_nextcloud_application_credentials_validation('https://example.com', password: "1234567890",
                                                                                      response_code: 401)
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             expect(automatically_managed_switch).to be_checked
             fill_in 'storages_nextcloud_storage_password', with: "1234567890"
             # Clicking submit with application password empty should show an error
@@ -245,7 +245,7 @@ RSpec.describe 'Admin storages',
             # Mock a valid response (=200) for example.com, so the password validation should succeed
             # Fill in application password and submit
             mock_nextcloud_application_credentials_validation('https://example.com', password: "1234567890")
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             expect(automatically_managed_switch).to be_checked
             fill_in 'storages_nextcloud_storage_password', with: "1234567890"
             click_button('Done, complete setup')
@@ -527,7 +527,7 @@ RSpec.describe 'Admin storages',
           find_test_selector('storage-edit-automatically-managed-project-folders-button').click
 
           within_test_selector('storage-automatically-managed-project-folders-form') do
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             application_password_input = page.find_by_id('storages_nextcloud_storage_password')
             expect(automatically_managed_switch).to be_checked
             expect(application_password_input.value).to be_empty
@@ -540,7 +540,7 @@ RSpec.describe 'Admin storages',
             # Mock a valid response (=401) for example.com, so the password validation should fail
             mock_nextcloud_application_credentials_validation(storage.host, password: "1234567890",
                                                                             response_code: 401)
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             expect(automatically_managed_switch).to be_checked
             fill_in 'storages_nextcloud_storage_password', with: "1234567890"
             # Clicking submit with application password empty should show an error
@@ -551,7 +551,7 @@ RSpec.describe 'Admin storages',
             # Mock a valid response (=200) for example.com, so the password validation should succeed
             # Fill in application password and submit
             mock_nextcloud_application_credentials_validation(storage.host, password: "1234567890")
-            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatically_managed]"]')
+            automatically_managed_switch = page.find('[name="storages_nextcloud_storage[automatic_management_enabled]"]')
             expect(automatically_managed_switch).to be_checked
             fill_in 'storages_nextcloud_storage_password', with: "1234567890"
             click_button('Done, complete setup')

--- a/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
+++ b/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
@@ -220,20 +220,20 @@ RSpec.describe Storages::NextcloudStorage do
   end
 
   describe '#automatic_management_enabled?' do
-    context 'when automatically_managed is true' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: true) }
+    context 'when automatic management enabled is true' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: true) }
 
       it { expect(storage).to be_automatic_management_enabled }
     end
 
-    context 'when automatically_managed is false' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: false) }
+    context 'when automatic management enabled is false' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: false) }
 
       it { expect(storage).not_to be_automatic_management_enabled }
     end
 
-    context 'when automatically_managed is nil' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: nil) }
+    context 'when automatic management enabled is nil' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: nil) }
 
       it { expect(storage.automatic_management_enabled?).to be(false) }
     end
@@ -243,7 +243,7 @@ RSpec.describe Storages::NextcloudStorage do
     context 'when automatic management has just been specified but not yet persisted' do
       let(:storage) { build_stubbed(:nextcloud_storage, provider_fields: {}) }
 
-      before { storage.automatically_managed = false }
+      before { storage.automatic_management_enabled = false }
 
       it { expect(storage).to be_provider_fields_changed }
       it { expect(storage).to be_automatic_management_new_record }
@@ -265,20 +265,20 @@ RSpec.describe Storages::NextcloudStorage do
   end
 
   describe '#automatic_management_unspecified?' do
-    context 'when automatically_managed is nil' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: nil) }
+    context 'when automatic management enabled is nil' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: nil) }
 
       it { expect(storage).to be_automatic_management_unspecified }
     end
 
-    context 'when automatically_managed is true' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: true) }
+    context 'when automatic management enabled is true' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: true) }
 
       it { expect(storage).not_to be_automatic_management_unspecified }
     end
 
-    context 'when automatically_managed is false' do
-      let(:storage) { build(:nextcloud_storage, automatically_managed: false) }
+    context 'when automatic management enabled is false' do
+      let(:storage) { build(:nextcloud_storage, automatic_management_enabled: false) }
 
       it { expect(storage).not_to be_automatic_management_unspecified }
     end
@@ -288,7 +288,7 @@ RSpec.describe Storages::NextcloudStorage do
     let(:storage) { build(:nextcloud_storage) }
 
     it 'returns the default values for nextcloud' do
-      expect(storage.provider_fields_defaults).to eq({ automatically_managed: true, username: 'OpenProject' })
+      expect(storage.provider_fields_defaults).to eq({ automatic_management_enabled: true, username: 'OpenProject' })
     end
   end
 end

--- a/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
+++ b/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Storages::NextcloudStorage do
 
   it_behaves_like 'base storage'
 
+  describe '.automatic_management_enabled' do
+    let!(:automatically_managed_storage) { create(:nextcloud_storage, :as_automatically_managed) }
+    let!(:not_automatically_managed_storage) { create(:nextcloud_storage, :as_not_automatically_managed) }
+
+    it 'returns only storages with automatic management enabled' do
+      expect(described_class.automatic_management_enabled).to contain_exactly(automatically_managed_storage)
+    end
+  end
+
   describe '#provider_type?' do
     it { expect(storage).to be_a_provider_type_nextcloud }
     it { expect(storage).not_to be_a_provider_type_one_drive }
@@ -106,7 +115,6 @@ RSpec.describe Storages::NextcloudStorage do
       end
     end
   end
-
 
   describe '#configured?' do
     context 'with a complete configuration' do
@@ -207,8 +215,28 @@ RSpec.describe Storages::NextcloudStorage do
     it_behaves_like 'a stored attribute with default value', :group_folder, 'OpenProject'
   end
 
-  describe '#automatically_managed?' do
+  describe '#automatically_managed' do
     it_behaves_like 'a stored boolean attribute', :automatically_managed
+  end
+
+  describe '#automatic_management_enabled?' do
+    context 'when automatically_managed is true' do
+      let(:storage) { build(:nextcloud_storage, automatically_managed: true) }
+
+      it { expect(storage).to be_automatic_management_enabled }
+    end
+
+    context 'when automatically_managed is false' do
+      let(:storage) { build(:nextcloud_storage, automatically_managed: false) }
+
+      it { expect(storage).not_to be_automatic_management_enabled }
+    end
+
+    context 'when automatically_managed is nil' do
+      let(:storage) { build(:nextcloud_storage, automatically_managed: nil) }
+
+      it { expect(storage.automatic_management_enabled?).to be(false) }
+    end
   end
 
   describe '#automatic_management_new_record?' do


### PR DESCRIPTION
### https://community.openproject.org/work_packages/50622

See https://github.com/opf/openproject/pull/13940/files#r1363723710

The predicate `Storages::NextcloudStorage#automatically_managed?` was misleading as a storage itself is not automatically managed, rather the a Project Folder Storage is.

Deprecate `Storages::NextcloudStorage#automatically_managed?` in favour of `Storages::NextcloudStorage#automatic_management_enabled?`

```ruby
[4] pry> storage.automatically_managed?
DEPRECATION WARNING: `#automatically_managed?` is deprecated. Use `#automatic_management_enabled?` instead. NOTE: The new method name better reflects the actual behavior of the storage. It's not the storage that is automatically managed, rather the Project (Storage) Folder is. A storage only has this feature enabled or disabled.
```