### PR TITLE
Evaluate changes on journal creation only for supported associations

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -229,6 +229,14 @@ module Journals
     def relation_modifications_sql(predecessor)
       relations = []
 
+      for_supported_associations do |association|
+        relations << association_modifications_sql(association, predecessor)
+      end
+
+      relations
+    end
+
+    def for_supported_associations
       associations = {
         attachable?: :attachable,
         customizable?: :customizable,
@@ -238,11 +246,9 @@ module Journals
 
       associations.each do |is_associated, association|
         if journable.respond_to?(is_associated)
-          relations << association_modifications_sql(association, predecessor)
+          yield association
         end
       end
-
-      relations
     end
 
     def association_modifications_sql(association, predecessor)
@@ -612,28 +618,23 @@ module Journals
     end
 
     def select_changed_sql
-      <<~SQL
+      sql = <<~SQL
         SELECT
            *
         FROM
           (#{data_changes_sql}) data_changes
-        FULL JOIN
-          (#{customizable_changes_sql}) customizable_changes
-        ON
-          customizable_changes.journable_id = data_changes.journable_id
-        FULL JOIN
-          (#{attachable_changes_sql}) attachable_changes
-        ON
-          attachable_changes.journable_id = data_changes.journable_id
-        FULL JOIN
-          (#{storable_changes_sql}) storable_changes
-        ON
-          storable_changes.journable_id = data_changes.journable_id
-        FULL JOIN
-          (#{agenda_itemable_changes_sql}) agenda_itemable_changes
-        ON
-          agenda_itemable_changes.journable_id = data_changes.journable_id
       SQL
+
+      for_supported_associations do |association|
+        sql += <<~SQL
+          FULL JOIN
+            (#{send(:"#{association}_changes_sql")}) #{association}_changes
+          ON
+            #{association}_changes.journable_id = data_changes.journable_id
+        SQL
+      end
+
+      sql
     end
 
     def attachable_changes_sql


### PR DESCRIPTION
Similar to how it is already done for writing the journal changes later on, evaluating for any changes on associations (e.g. customizable_values)  is only done for associations that are actually owned by the journaled object. For a work package, this excludes e.g. agenda_items, for meetings it will exclude e.g. customizable.

This fixes https://community.openproject.org/wp/51801 since the table not existing is the `meeting_agenda_item_journals` table and this will no longer be called as work packages don't have the association. Work packages are the only type of containers that should exist at this point.