### PR TITLE
fix packager being tripped by ruby version specified via file reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@
 
 source 'https://rubygems.org'
 
-ruby file: '.ruby-version'
+ruby '3.2.2'
 
 gem 'actionpack-xml_parser', '~> 2.0.0'
 gem 'activemodel-serializers-xml', '~> 1.0.1'


### PR DESCRIPTION
Since the ruby bump was merged, packager does not build any more. I suspect it is caused by having the ruby version specified via the file notation.

The error message is a bit cryptic so the fix is a guess:

```
-----> Installing dependencies using bundler 2.3.25

       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4

       Your Ruby version is 3.2.2, but your Gemfile specified

       Bundler Output: Your Ruby version is 3.2.2, but your Gemfile specified

       [1m[31m

       !

       !     Failed to install gems via Bundler.

       !     Detected a mismatch between your Ruby version installed and

       !     Ruby version specified in Gemfile or Gemfile.lock. You can

       !     correct this by running:

       !

       !     $ bundle update --ruby

       !     $ git add Gemfile.lock

       !     $ git commit -m "update ruby version"

       !

       !     If this does not solve the issue please see this documentation:

       !

       !     https://devcenter.heroku.com/articles/ruby-versions#your-ruby-version-is-x-but-your-gemfile-specified-y

       ![0m

       ! ERROR: compile failed

```

Please notice the `but your Gemfile specified <blank>` part where normally a version is written.
