### PR TITLE
Bump `view_component` to 3.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1042,7 +1042,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.2.0)
-    view_component (3.8.0)
+    view_component (3.9.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)


### PR DESCRIPTION
* Run `bundle update view_component`

In preparation for the Ruby 3.3 update, view_component 3.9.0 adds support for it.