### PR TITLE
Adds user origin_user_id to the OAuthClientToken for OneDrive/Sharepoint

### DIFF
--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -122,7 +122,7 @@ module OAuthClients
           OAuthClientToken.create(
             user: @user,
             oauth_client: @oauth_client,
-            origin_user_id: rack_access_token.raw_attributes[:user_id], # ID of user at OAuth2 Authorization Server
+            origin_user_id: @config.extract_origin_user_id(rack_access_token), # ID of user at OAuth2 Authorization Server
             access_token: rack_access_token.access_token,
             token_type: rack_access_token.token_type, # :bearer
             refresh_token: rack_access_token.refresh_token,

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/nextcloud_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/nextcloud_configuration.rb
@@ -37,7 +37,6 @@ module Storages
         def initialize(storage)
           @uri = storage.uri
           @oauth_client = storage.oauth_client.freeze
-          super()
         end
 
         def authorization_state_check(token)
@@ -53,6 +52,10 @@ module Storages
               }
             ).status
           end
+        end
+
+        def extract_origin_user_id(rack_access_token)
+          rack_access_token.raw_attributes[:user_id]
         end
 
         def scope

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
@@ -56,15 +56,12 @@ module Storages
 
         def extract_origin_user_id(rack_access_token)
           Net::HTTP.start(@uri.host, @uri.port, use_ssl: true) do |http|
-            response = http.get('/v1.0/me',
-                                { Authorization: "Bearer #{rack_access_token.access_token}", Accept: 'application/json' })
+            response = http.get(
+              '/v1.0/me',
+              { Authorization: "Bearer #{rack_access_token.access_token}", Accept: 'application/json' }
+            )
 
-            # if response == Net::HTTPSuccess
-            parsed = JSON.parse(response.body)
-            parsed['userPrincipalName']
-            # else
-            #   nil
-            # end
+            JSON.parse(response.body)['id']
           end
         end
 

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
@@ -55,14 +55,12 @@ module Storages
         end
 
         def extract_origin_user_id(rack_access_token)
-          Net::HTTP.start(@uri.host, @uri.port, use_ssl: true) do |http|
-            response = http.get(
-              '/v1.0/me',
-              { Authorization: "Bearer #{rack_access_token.access_token}", Accept: 'application/json' }
-            )
+          util = ::Storages::Peripherals::StorageInteraction::OneDrive::Util
 
-            JSON.parse(response.body)['id']
-          end
+          HTTPX.get(
+            util.join_uri_path(@uri, '/v1.0/me'),
+            headers: { 'Authorization' => "Bearer #{rack_access_token.access_token}", 'Accept' => 'application/json' }
+          ).raise_for_status.json['id']
         end
 
         def scope

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/one_drive_configuration.rb
@@ -41,7 +41,6 @@ module Storages
           @uri = storage.uri
           @oauth_client = storage.oauth_client
           @oauth_uri = URI('https://login.microsoftonline.com/').normalize
-          super()
         end
 
         def authorization_state_check(access_token)
@@ -52,6 +51,20 @@ module Storages
               util.join_uri_path(@uri, '/v1.0/me'),
               headers: { 'Authorization' => "Bearer #{access_token}", 'Accept' => 'application/json' }
             ).status
+          end
+        end
+
+        def extract_origin_user_id(rack_access_token)
+          Net::HTTP.start(@uri.host, @uri.port, use_ssl: true) do |http|
+            response = http.get('/v1.0/me',
+                                { Authorization: "Bearer #{rack_access_token.access_token}", Accept: 'application/json' })
+
+            # if response == Net::HTTPSuccess
+            parsed = JSON.parse(response.body)
+            parsed['userPrincipalName']
+            # else
+            #   nil
+            # end
           end
         end
 

--- a/spec/services/oauth_clients/connection_manager_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_spec.rb
@@ -173,6 +173,13 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
         expect(subject.success).to be_truthy
         expect(subject.result).to be_a OAuthClientToken
       end
+
+      it 'fills in the origin_user_id' do
+        expect { subject }.to change(OAuthClientToken, :count).by(1)
+        last_token = OAuthClientToken.where(access_token: 'yjTDZ...RYvRH').last
+
+        expect(last_token.origin_user_id).to eq('admin')
+      end
     end
 
     context 'with known error' do

--- a/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
+++ b/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
                      .where(access_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q...")
                      .last
 
-      expect(last_token.origin_user_id).to eq('palpatine@senate.com')
+      expect(last_token.origin_user_id).to eq('87d349ed-44d7-43e1-9a83-5f2406dee5bd')
     end
   end
 

--- a/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
+++ b/spec/services/oauth_clients/one_drive_connection_manager_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
 
       expect(last_token.origin_user_id).to eq('87d349ed-44d7-43e1-9a83-5f2406dee5bd')
     end
+
+    context 'when the identification request fails' do
+      before do
+        stub_request(:get, 'https://graph.microsoft.com/v1.0/me')
+          .with(headers: { Authorization: "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q..." })
+          .to_return(status: 404)
+      end
+
+      it 'raises an error' do
+        expect { subject.code_to_token(code) }.to raise_error(HTTPX::HTTPError)
+      end
+    end
   end
 
   describe '#get_authorization_uri' do


### PR DESCRIPTION
#### Related WorkPackage: [OP#51783](https://community.openproject.org/projects/openproject/work_packages/51783)

For handling access with the Automatically Managed Project Folders, we need to have a way to link a OP User to a Sharepoint one.

This has been done by the way of the user token for nextcloud and here I mimic the behaviour.