### PR TITLE
[51737] Hide new Gantt module behind a feature flag

### DIFF
--- a/app/models/queries/views/filters/type_filter.rb
+++ b/app/models/queries/views/filters/type_filter.rb
@@ -36,6 +36,11 @@ class Queries::Views::Filters::TypeFilter < Queries::Views::Filters::ViewFilter
   end
 
   def transformed_values
+    if !OpenProject::FeatureDecisions.show_separate_gantt_module_active? && values.include?('Views::WorkPackagesTable')
+      # If there is no separate Gantt module enabled: Show the Gantt queries in the WorkPackage module as well
+      values.push('Views::Gantt')
+    end
+
     values.map { |value| value[/Views::(?<name>.*?)$/, "name"].underscore }
   end
 

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
@@ -4,18 +4,27 @@ import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { Observable } from 'rxjs';
 import { IView } from 'core-app/core/state/views/view.model';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Injectable()
 export class WorkPackagesQueryViewService {
+  // Todo: Delete the whole attribute with feature flag `show_separate_gantt_module`
+  private query:QueryResource;
+
   constructor(
     protected $state:StateService,
     protected apiV3Service:ApiV3Service,
+    // Todo: Delete the whole attribute with feature flag `show_separate_gantt_module`
+    protected configurationService:ConfigurationService,
   ) { }
 
   create(query:QueryResource):Observable<IView> {
     if (!query.href) {
       throw new Error('Expected only queries that are created since an href is required');
     }
+
+    // Todo: Delete the whole attribute with feature flag `show_separate_gantt_module`
+    this.query = query;
 
     return this
       .apiV3Service
@@ -33,6 +42,14 @@ export class WorkPackagesQueryViewService {
   }
 
   private get viewType() {
+    // Todo: Delete the whole attribute with feature flag `show_separate_gantt_module`
+    if (!this.configurationService.activeFeatureFlags.includes('showSeparateGanttModule')) {
+      // Queries with an activated Gantt should already get the ViewType "gantt"
+      if (this.$state.includes('work-packages') && this.query.timelineVisible) {
+        return 'gantt';
+      }
+    }
+
     if (this.$state.includes('work-packages')) {
       return 'work_packages_table';
     }

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -35,6 +35,7 @@ import { StateService } from '@uirouter/core';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { IOpSidemenuItem } from 'core-app/shared/components/sidemenu/sidemenu.component';
 import { ViewType } from 'core-app/shared/components/op-view-select/op-view-select.component';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 interface IStaticQuery extends IOpSidemenuItem {
   view:ViewType;
@@ -50,6 +51,7 @@ export class StaticQueriesService {
     private readonly CurrentProject:CurrentProjectService,
     private readonly PathHelper:PathHelperService,
     private readonly CurrentUser:CurrentUserService,
+    private readonly configurationService:ConfigurationService,
   ) {
     this.staticQueries = this.buildQueries();
   }
@@ -169,7 +171,7 @@ export class StaticQueriesService {
           query_id: '',
           query_props: '{"c":["id","type","subject","status","startDate","dueDate","duration"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',
         },
-        view: 'Gantt',
+        view: this.configurationService.activeFeatureFlags.includes('showSeparateGanttModule') ? 'Gantt' : 'WorkPackagesTable',
       },
     ];
 

--- a/spec/models/queries/views/filters/type_filter_spec.rb
+++ b/spec/models/queries/views/filters/type_filter_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Queries::Views::Filters::TypeFilter do
+RSpec.describe Queries::Views::Filters::TypeFilter, with_flag: { show_separate_gantt_module: true }  do
   let(:current_user) { create(:user) }
 
   before do

--- a/spec/requests/api/v3/queries/query_resource_spec.rb
+++ b/spec/requests/api/v3/queries/query_resource_spec.rb
@@ -30,7 +30,8 @@ require 'spec_helper'
 require 'rack/test'
 
 RSpec.describe 'API v3 Query resource',
-               content_type: :json do
+               content_type: :json,
+               with_flag: { show_separate_gantt_module: true } do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 

--- a/spec/requests/api/v3/queries/update_query_spec.rb
+++ b/spec/requests/api/v3/queries/update_query_spec.rb
@@ -29,7 +29,8 @@
 require 'spec_helper'
 
 RSpec.describe "PATCH /api/v3/queries/:id",
-               with_ee: %i[baseline_comparison] do
+               with_ee: %i[baseline_comparison],
+               with_flag: { show_separate_gantt_module: true } do
   shared_let(:user) { create(:admin) }
   shared_let(:status) { create(:status) }
   shared_let(:project) { create(:project) }

--- a/spec/services/queries/update_service_spec.rb
+++ b/spec/services/queries/update_service_spec.rb
@@ -29,6 +29,6 @@
 require 'spec_helper'
 require 'services/base_services/behaves_like_update_service'
 
-RSpec.describe Queries::UpdateService do
+RSpec.describe Queries::UpdateService, with_flag: { show_separate_gantt_module: true } do
   it_behaves_like 'BaseServices update service'
 end


### PR DESCRIPTION
Add feature flag to hide the separate Gantt module. Therefore some mentionable changes were made:

* The viewType filter was changed to show both Gantt, and WorkPackagTable in the WorkPackage module.
* When saving a new query, the viewType is set depending on whether a timeline is visible
* When saving an exisiting query, the View is updated accordingly


https://community.openproject.org/projects/openproject/work_packages/51737/github?query_id=4859