### PR TITLE
[52076] Add link from work / estimated work sum to detailed query view

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -35,7 +35,7 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
     super();
   }
 
-  protected processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):boolean {
+  protected processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):void {
     debugLog('Starting editing on cell: ', evt.target);
     evt.preventDefault();
 
@@ -46,7 +46,7 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
 
     if (!fieldName) {
       debugLog('Click handled by cell not a field? ', evt.target);
-      return true;
+      return;
     }
 
     // Locate the row
@@ -70,7 +70,5 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
         handler.focus(positionOffset);
       })
       .catch(() => target.addClass(readOnlyClassName));
-
-    return false;
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/cell/relations-cell-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/cell/relations-cell-handler.ts
@@ -28,7 +28,7 @@ export class RelationsCellHandler extends ClickOrEnterHandler implements TableEv
     super();
   }
 
-  protected processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):boolean {
+  protected processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):void {
     debugLog('Handled click on relation cell %o', evt.target);
     evt.preventDefault();
 
@@ -46,7 +46,5 @@ export class RelationsCellHandler extends ClickOrEnterHandler implements TableEv
     } else {
       this.wpTableRelationColumns.setExpandFor(workPackageId, columnId);
     }
-
-    return false;
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/click-or-enter-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/click-or-enter-handler.ts
@@ -8,10 +8,7 @@ import { WorkPackageTable } from '../wp-fast-table';
 export function onClickOrEnter(evt:JQuery.TriggeredEvent, callback:() => void) {
   if (evt.type === 'click' || (evt.type === 'keydown' && evt.which === KeyCodes.ENTER)) {
     callback();
-    return false;
   }
-
-  return true;
 }
 
 export abstract class ClickOrEnterHandler {
@@ -19,5 +16,5 @@ export abstract class ClickOrEnterHandler {
     onClickOrEnter(evt, () => this.processEvent(view.workPackageTable, evt));
   }
 
-  protected abstract processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):boolean;
+  protected abstract processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):void;
 }

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/hierarchy-click-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/hierarchy-click-handler.ts
@@ -29,7 +29,7 @@ export class HierarchyClickHandler extends ClickOrEnterHandler implements TableE
     return jQuery(view.workPackageTable.tbody);
   }
 
-  public processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):boolean {
+  public processEvent(table:WorkPackageTable, evt:JQuery.TriggeredEvent):void {
     const target = jQuery(evt.target);
 
     // Locate the row from event
@@ -40,6 +40,5 @@ export class HierarchyClickHandler extends ClickOrEnterHandler implements TableE
 
     evt.stopImmediatePropagation();
     evt.preventDefault();
-    return false;
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -40,27 +40,35 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
   protected workPackage:WorkPackageResource;
 
   public handleEvent(view:TableEventComponent, evt:JQuery.TriggeredEvent) {
-    // Avoid the state capture when clicking with modifier
+    evt.stopPropagation();
+
+    // Avoid the state capture when clicking with modifier to allow browser opening in new tab
     if (evt.shiftKey || evt.ctrlKey || evt.metaKey || evt.altKey) {
       return true;
     }
 
     // Locate the details link from event
-    const target = jQuery(evt.target);
-    const element = target.closest(this.SELECTOR);
-    const state = element.data('wpState');
-    const workPackageId = element.data('workPackageId');
+    // debugger;
+    const target = evt.target as HTMLElement;
+    const element = target.closest(this.SELECTOR) as HTMLElement & { dataset:DOMStringMap };
+    const state = element.dataset.wpState;
+    const workPackageId = element.dataset.workPackageId;
+
+    // Normal link processing if there are no state and work package information
+    if (!state || !workPackageId) {
+      return true;
+    }
 
     // Blur the target to avoid focus being kept there
-    target.closest('a').blur();
+    target.closest('a')?.blur();
 
     // The current row is the last selected work package
     // not matter what other rows are (de-)selected below.
     // Thus save that row for the details view button.
     // Locate the row from event
-    const row = target.closest(`.${tableRowClassName}`);
-    const classIdentifier = row.data('classIdentifier');
-    const [index, _] = view.workPackageTable.findRenderedRow(classIdentifier);
+    const row = target.closest(`.${tableRowClassName}`) as HTMLElement & { dataset:DOMStringMap };
+    const classIdentifier = row.dataset.classIdentifier as string;
+    const [index] = view.workPackageTable.findRenderedRow(classIdentifier);
 
     // Update single selection if no modifier present
     this.wpTableSelection.setSelection(workPackageId, index);
@@ -68,7 +76,6 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
     view.stateLinkClicked.emit({ workPackageId, requestedState: state });
 
     evt.preventDefault();
-    evt.stopPropagation();
     return false;
   }
 }

--- a/frontend/src/app/shared/components/fields/display/display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.module.ts
@@ -38,6 +38,8 @@ export const cssClassCustomOption = 'custom-option';
 export class DisplayField<T extends HalResource = HalResource> extends Field {
   public static type:string;
 
+  public resource:T;
+
   public mode:string | null = null;
 
   public activeChange:ResourceChangeset<T>|null = null;

--- a/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
@@ -28,10 +28,19 @@
 
 import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import * as URI from 'urijs';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { uiStateLinkClass } from 'core-app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder';
 
 export class EstimatedTimeDisplayField extends DisplayField {
   @InjectField() timezoneService:TimezoneService;
+
+  @InjectField() PathHelper:PathHelperService;
+
+  @InjectField() apiV3Service:ApiV3Service;
 
   private derivedText = this.I18n.t('js.label_value_derived_from_children');
 
@@ -100,13 +109,15 @@ export class EstimatedTimeDisplayField extends DisplayField {
   }
 
   public renderDerived(element:HTMLElement, displayText:string):void {
-    const span = document.createElement('span');
+    const link = document.createElement('a');
 
-    span.textContent = `Σ ${displayText}`;
-    span.title = `${this.derivedValueString} ${this.derivedText}`;
-    span.classList.add('-derived-value');
+    link.textContent = `Σ ${displayText}`;
+    link.title = `${this.derivedValueString} ${this.derivedText}`;
+    link.classList.add('-derived-value', uiStateLinkClass);
 
-    element.appendChild(span);
+    this.addURLToViewWorkPackageChildren(link);
+
+    element.appendChild(link);
   }
 
   public get title():string|null {
@@ -119,5 +130,30 @@ export class EstimatedTimeDisplayField extends DisplayField {
     const derived = this.derivedValue;
 
     return !value && !derived;
+  }
+
+  private addURLToViewWorkPackageChildren(link:HTMLAnchorElement):void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (this.resource && this.resource.id && this.resource.project) {
+      const wpID = this.resource.id.toString();
+      this
+        .apiV3Service
+        .projects
+        .id(this.resource.project as ProjectResource)
+        .get()
+        .subscribe((project:ProjectResource) => {
+          const props = {
+            c: ['id', 'subject', 'type', 'status', 'estimatedTime', 'remainingTime'],
+            hi: true,
+            is: true,
+            f: [{ n: 'parent', o: '=', v: [wpID] }],
+          };
+          const href = URI(this.PathHelper.projectWorkPackagesPath(project.identifier as string))
+            .query({ query_props: JSON.stringify(props) })
+            .toString();
+
+          link.href = href;
+        });
+    }
   }
 }

--- a/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -63,16 +63,16 @@ export class WorkPackageSpentTimeDisplayField extends EstimatedTimeDisplayField 
       link.setAttribute('class', 'time-logging--value');
     }
 
-    if (this.resource.project) {
+    if (this.resource.project && this.resource.id) {
       const wpID = this.resource.id.toString();
       this
         .apiV3Service
         .projects
-        .id(this.resource.project)
+        .id(this.resource.project as ProjectResource)
         .get()
         .subscribe((project:ProjectResource) => {
           // Link to the cost report having the work package filter preselected. No grouping.
-          const href = URI(this.PathHelper.projectTimeEntriesPath(project.identifier))
+          const href = URI(this.PathHelper.projectTimeEntriesPath(project.identifier as string))
             .search(`fields[]=WorkPackageId&operators[WorkPackageId]=%3D&values[WorkPackageId]=${wpID}&set_filter=1`)
             .toString();
 

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -108,10 +108,6 @@ display-field
       padding-right: 0.25rem
       text-align: center
 
-    .-derived-value
-      color: var(--color-fg-muted)
-      font-weight: var(--base-text-weight-bold)
-
   &.spentTime .time-logging--value
     padding: 0 2px
 


### PR DESCRIPTION
https://community.openproject.org/wp/52076

Before:

![image](https://github.com/opf/openproject/assets/176055/3fa5a838-da49-4fb6-b469-4858e04d8081)

After:

![image](https://github.com/opf/openproject/assets/176055/1c94f5d9-fc8a-439b-b901-b5a12664fce5)

The "Σ 12 h" is now a link. Clicking it shows the work package and its direct children so the user can inspect it to understand the calculation result.