### PR TITLE
Move and rename WP share permissions

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -119,23 +119,6 @@ Rails.application.reloader.to_prepare do
                      dependencies: :view_members,
                      contract_actions: { members: %i[create update destroy] }
 
-      map.permission :share_work_packages,
-                     {
-                       'work_packages/shares': %i[index create destroy update resend_invite],
-                       'work_packages/shares/bulk': %i[update destroy]
-                     },
-                     permissible_on: :project,
-                     dependencies: %i[edit_work_packages view_shared_work_packages],
-                     require: :member
-
-      map.permission :view_shared_work_packages,
-                     {
-                       'work_packages/shares': %i[index]
-                     },
-                     permissible_on: :project,
-                     require: :member,
-                     contract_actions: { work_package_shares: %i[index] }
-
       map.permission :view_members,
                      {
                        members: %i[index menu],
@@ -317,6 +300,23 @@ Rails.application.reloader.to_prepare do
                      {},
                      permissible_on: :project,
                      dependencies: :view_work_packages
+
+      map.permission :share_work_packages,
+                     {
+                       'work_packages/shares': %i[index create destroy update resend_invite],
+                       'work_packages/shares/bulk': %i[update destroy]
+                     },
+                     permissible_on: :project,
+                     dependencies: %i[edit_work_packages view_shared_work_packages],
+                     require: :member
+
+      map.permission :view_shared_work_packages,
+                     {
+                       'work_packages/shares': %i[index]
+                     },
+                     permissible_on: :project,
+                     require: :member,
+                     contract_actions: { work_package_shares: %i[index] }
 
       wpt.permission :assign_versions,
                      {},

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2632,7 +2632,7 @@ en:
   permission_view_news: "View news"
   permission_view_members: "View members"
   permission_view_reportings: "View reportings"
-  permission_view_shared_work_packages: "View shared work packages"
+  permission_view_shared_work_packages: "View work package shares"
   permission_view_time_entries: "View spent time"
   permission_view_timelines: "View timelines"
   permission_view_wiki_edits: "View wiki history"


### PR DESCRIPTION
* The permissions for sharing work packages are moved to the work packages section on the role administration
* The view_shared_work_packages is renamed in the UI

----

https://community.openproject.org/wp/52086