### PR TITLE
[#52088] enable file link removal for all faulty file links

### DIFF
--- a/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.component.ts
+++ b/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.component.ts
@@ -201,12 +201,8 @@ export class FileLinkListItemComponent implements OnInit, AfterViewInit {
       return [];
     }
 
-    if (this.statusIs(fileLinkStatusNotFound) && this.allowEditing) {
+    if (this.hasFaultyStatus && this.allowEditing) {
       return [this.removeAction()];
-    }
-
-    if (this.hasFaultyStatus) {
-      return [];
     }
 
     // healthy file link


### PR DESCRIPTION
[#52088](https://community.openproject.org/wp/52088)

### Wat?
- simplify floating actions construction
- now, remove file link action is available for all user with `manage_file_links` on all file links, if not `disabled` due to storage authorization state.