### PR TITLE
Bug 52089: fixed WP lockVersion in API for change_work_package_status

### DIFF
--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -31,7 +31,7 @@ module WorkPackages
     include UnchangedProject
 
     attribute :lock_version,
-              permission: %i[edit_work_packages assign_versions manage_subtasks move_work_packages] do
+              permission: %i[edit_work_packages change_work_package_status assign_versions manage_subtasks move_work_packages] do
       if model.lock_version.nil? || model.lock_version_changed?
         errors.add :base, :error_conflict
       end

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe API::V3::WorkPackages::WorkPackagePayloadRepresenter do
 
         it { is_expected.to be_json_eql(work_package.lock_version.to_json).at_path('lockVersion') }
 
+        context 'with only change_work_package_status permission' do
+          before do
+            mock_permissions_for(user) do |mock|
+              mock.allow_in_project :change_work_package_status, project: work_package.project
+            end
+          end
+
+          it { is_expected.to have_json_path('lockVersion') }
+        end
+
         context 'with a lock version of nil (new work package)' do
           before do
             allow(work_package)


### PR DESCRIPTION
This fixes bug https://community.openproject.org/projects/openproject/work_packages/52089/activity

I though about `add_work_package_attachments` permission as well, but if the user has only that permission, he should not be able to reach the form call (everything on WP detail is inactive) and also, attachment upload uses a different endpoint that should not rely on `lockVersion` info.