### PR TITLE
[52087] Type selector for work packages misaligned

### DIFF
--- a/frontend/src/global_styles/content/work_packages/new/_type_status_row.sass
+++ b/frontend/src/global_styles/content/work_packages/new/_type_status_row.sass
@@ -21,10 +21,11 @@
     .inline-edit--field
       min-width: 125px
 
-  .work-packages--type-selector,
-  .work-packages--status-selector
-    .-active
-      margin: 6px 6px 6px 0px
-
-.work-packages--type-selector .-active
-    margin: 6px 6px 0px 0px
+.work-packages--type-selector,
+.work-packages--status-selector
+  .-active
+    .ng-select-container
+      height: 36px !important
+      line-height: 36px !important
+    .ng-select input
+      height: initial !important

--- a/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
+++ b/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
@@ -64,7 +64,6 @@
       font-size: 16px
       line-height: 1
 
-
 .work-packages--details--subject
   @include grid-content
   @include grid-size(expand)

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -141,14 +141,6 @@
       font-size: 20px
       font-weight: var(--base-text-weight-bold)
 
-      // Style edit field to look like the display field.
-      // Thus we avoid a visual jump when editing the subject.
-      &.-active input
-        height: 36px
-        line-height: 36px
-        padding: 5px 0 5px 5px
-        font-size: 20px
-
 .work-packages--subject-type-row
   display: flex
   position: relative


### PR DESCRIPTION
Parts of the height defintions for ngselect in the WP header where overwritten by other rules resulting in the label being offset.

https://community.openproject.org/projects/openproject/work_packages/52087/github?query_id=4859