### PR TITLE
[52100] Create member button is not reachable via keayboard

### DIFF
--- a/app/components/members/index_page_header_component.html.erb
+++ b/app/components/members/index_page_header_component.html.erb
@@ -8,7 +8,6 @@
           actions.with_column(mr: BUTTON_MARGIN_RIGHT) do
             render(
               Primer::Beta::Button.new(
-                tag: :a,
                 scheme: :primary,
                 size: :medium,
                 aria: { label: I18n.t(:button_add_member) },


### PR DESCRIPTION
Remove anchor tag as there is not redirect and such no href. Without that, an anchor is not reachable via keyboard.

https://community.openproject.org/projects/openproject/work_packages/52100/activity