### PR TITLE
[52099] Primer tooltips are cut off in OpenProject

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4589,9 +4589,9 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.12.0.tgz",
-      "integrity": "sha512-QKNxfWm7Ik1Ulswyp3KeUL2xnQj8i0E7DdB6lOrh29o7LgyuutwcOHi4CGapBIOR1fYURu+yROSTHQ2C2aDK7A=="
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.15.5.tgz",
+      "integrity": "sha512-tiJEMxy5hDi9a3YxgrBeJScLPUQSLuWsKDNuoXXiX7zLzejnYdxXXG3qOaNHzNyyn8TkSQkzmKx0ioaSLR2zNw=="
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
@@ -23756,9 +23756,9 @@
       }
     },
     "@primer/primitives": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.12.0.tgz",
-      "integrity": "sha512-QKNxfWm7Ik1Ulswyp3KeUL2xnQj8i0E7DdB6lOrh29o7LgyuutwcOHi4CGapBIOR1fYURu+yROSTHQ2C2aDK7A=="
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.15.5.tgz",
+      "integrity": "sha512-tiJEMxy5hDi9a3YxgrBeJScLPUQSLuWsKDNuoXXiX7zLzejnYdxXXG3qOaNHzNyyn8TkSQkzmKx0ioaSLR2zNw=="
     },
     "@primer/view-components": {
       "version": "npm:@openproject/primer-view-components@0.20.0",

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -56,7 +56,6 @@
   --light-gray: #CCCCCC;
   --body-background: #FFFFFF;
   --body-font-color: #333333;
-  --body-font-size: 0.875rem;
   --base-line-height: 1.5;
   --base-text-weight-bold: 600;
   --secondary-color: #bfbfbf;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,6 +1,7 @@
 // You can add global styles to this file, and also import other style files
 @import "~@ng-select/ng-select/themes/default.theme.css";
 @import "@primer/css/index.scss";
+@import "@primer/css/primitives/index.scss";
 @import "@openproject/primer-view-components/app/assets/styles/primer_view_components.css";
 
 // Variables


### PR DESCRIPTION
The tooltips were cut off because of a combination of two things:

1. The version of primer primitives that we used, did not include all variables needed
2. We didn't include the index file so that the needed file was not loaded at all.


https://community.openproject.org/projects/openproject/work_packages/52099/activity