### PR TITLE
[42646] Fix untranslated "Spent time" widget name

### DIFF
--- a/db/migrate/20240115112549_fix_spent_time_widget_identifier.rb
+++ b/db/migrate/20240115112549_fix_spent_time_widget_identifier.rb
@@ -1,0 +1,9 @@
+class FixSpentTimeWidgetIdentifier < ActiveRecord::Migration[7.0]
+  def up
+    execute("UPDATE grid_widgets SET identifier = 'time_entries_list' WHERE identifier = 'time_entries_project'")
+  end
+
+  def down
+    execute("UPDATE grid_widgets SET identifier = 'time_entries_project' WHERE identifier = 'time_entries_list'")
+  end
+end

--- a/frontend/src/app/shared/components/grids/openproject-grids.module.ts
+++ b/frontend/src/app/shared/components/grids/openproject-grids.module.ts
@@ -256,7 +256,7 @@ export function registerWidgets(injector:Injector) {
         },
       },
       {
-        identifier: 'time_entries_project',
+        identifier: 'time_entries_list',
         component: WidgetTimeEntriesProjectComponent,
         title: i18n.t('js.grid.widgets.time_entries_list.title'),
         properties: {

--- a/modules/grids/lib/grids/configuration/in_project_base_registration.rb
+++ b/modules/grids/lib/grids/configuration/in_project_base_registration.rb
@@ -8,7 +8,7 @@ module Grids::Configuration
             'subprojects',
             'work_packages_calendar',
             'work_packages_overview',
-            'time_entries_project',
+            'time_entries_list',
             'members',
             'news',
             'documents',


### PR DESCRIPTION
https://community.openproject.org/wp/42646

The widget was registered with the identifier `time_entries_project` which did not match the i18n key
`js.grid.widgets.time_entries_list.title`, so the presented title was the `widget.options.name` value which is the translation at the widget creation time. For instance if French was the locale when the widget is added then the title would be in French.

Using the correct identifier `time_entries_list` fixes the issue and translates it for all users.