### PR TITLE
(Mobile) Meeting page UI problems

### DIFF
--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -42,6 +42,7 @@
       @include grid-content(12)
       display: flex
       flex: 1
+      flex-basis: 100%
       margin-left: 0
       padding: 0
     .form--field-instructions
@@ -49,7 +50,6 @@
       flex-basis: 100%
       max-width: 100%
 
-  #tab-content-info form,
   .form--label,
   .form--field-container
     flex-basis: 100%


### PR DESCRIPTION
Let the label always span 100% and move the input field below that so that they have enough space

https://community.openproject.org/projects/openproject/work_packages/50610/activity