### PR TITLE
[#51698] added specific css for grid-area containing client ids

### DIFF
--- a/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
@@ -5,7 +5,11 @@
       concat(configuration_check_label_for(:openproject_oauth_application_configured))
     end
 
-    grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-openproject-oauth-application-description') do
+    grid.with_area(:description,
+                   classes: 'break-word',
+                   tag: :div,
+                   color: :subtle,
+                   test_selector: 'storage-openproject-oauth-application-description') do
       render(Primer::Beta::Text.new) { openproject_oauth_client_description }
     end
 

--- a/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_component.html.erb
@@ -6,7 +6,7 @@
     end
 
     grid.with_area(:description,
-                   classes: 'break-word',
+                   classes: 'wb-break-word',
                    tag: :div,
                    color: :subtle,
                    test_selector: 'storage-openproject-oauth-application-description') do

--- a/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
@@ -9,7 +9,11 @@
       concat(configuration_check_label_for(:storage_oauth_client_configured))
     end
 
-    grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-oauth-client-id-description') do
+    grid.with_area(:description,
+                   classes: 'break-word',
+                   tag: :div,
+                   color: :subtle,
+                   test_selector: 'storage-oauth-client-id-description') do
       render(Primer::Beta::Text.new) { provider_oauth_client_description }
     end
 

--- a/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_client_info_component.html.erb
@@ -10,7 +10,7 @@
     end
 
     grid.with_area(:description,
-                   classes: 'break-word',
+                   classes: 'wb-break-word',
                    tag: :div,
                    color: :subtle,
                    test_selector: 'storage-oauth-client-id-description') do

--- a/modules/storages/app/components/storages/admin/storage_view_component.sass
+++ b/modules/storages/app/components/storages/admin/storage_view_component.sass
@@ -3,6 +3,8 @@
   grid-template-columns: 3fr 1fr
   grid-template-areas: "item icon-button" "description icon-button"
 
+// A very specific handling for single grid cells in the storage grid, that contain credentials.
+// Those are long strings and must be shown not shortened, but broken down to fit in narrow screens.
 .break-word
   overflow: hidden
   word-wrap: break-word

--- a/modules/storages/app/components/storages/admin/storage_view_component.sass
+++ b/modules/storages/app/components/storages/admin/storage_view_component.sass
@@ -2,3 +2,7 @@
   display: grid
   grid-template-columns: 3fr 1fr
   grid-template-areas: "item icon-button" "description icon-button"
+
+.break-word
+  overflow: hidden
+  word-wrap: break-word

--- a/modules/storages/app/components/storages/admin/storage_view_component.sass
+++ b/modules/storages/app/components/storages/admin/storage_view_component.sass
@@ -2,9 +2,3 @@
   display: grid
   grid-template-columns: 3fr 1fr
   grid-template-areas: "item icon-button" "description icon-button"
-
-// A very specific handling for single grid cells in the storage grid, that contain credentials.
-// Those are long strings and must be shown not shortened, but broken down to fit in narrow screens.
-.break-word
-  overflow: hidden
-  word-wrap: break-word


### PR DESCRIPTION
[#51698](https://community.openproject.org/wp/51698)

### Wat?

- added specific handling for descriptions with credentials -> added `break-word` to those grid-areas