### PR TITLE
[#52109] fixed tooltips on file links

### DIFF
--- a/frontend/src/app/shared/components/storages/functions/storages.functions.ts
+++ b/frontend/src/app/shared/components/storages/functions/storages.functions.ts
@@ -33,7 +33,7 @@ import {
 } from 'core-app/shared/components/storages/icons.mapping';
 import { IHalResourceLink } from 'core-app/core/state/hal-resource';
 import { IFileLinkOriginData } from 'core-app/core/state/file-links/file-link.model';
-import { nextcloud } from 'core-app/shared/components/storages/storages-constants.const';
+import { nextcloud, oneDrive } from 'core-app/shared/components/storages/storages-constants.const';
 
 export function isDirectory(originData:IFileLinkOriginData):boolean {
   return originData.mimeType === 'application/x-op-directory';
@@ -66,6 +66,7 @@ export function makeFilesCollectionLink(storageLink:IHalResourceLink, location:s
 
 const storageTypeMap:Record<string, string> = {
   [nextcloud]: 'js.storages.types.nextcloud',
+  [oneDrive]: 'js.storages.types.one_drive',
   default: 'js.storages.types.default',
 };
 

--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -16,6 +16,7 @@ en:
 
       types:
         nextcloud: "Nextcloud"
+        one_drive: "OneDrive/SharePoint"
         default: "Storage"
 
       information:
@@ -91,7 +92,7 @@ en:
         link_uploaded_file_error: >
           An error occurred linking the recently uploaded file '%{fileName}' to the work package %{workPackageId}.
         tooltip:
-          not_logged_in: "Please log in to Nextcloud to access this file."
+          not_logged_in: "Please log in to the storage to access this file."
           view_not_allowed: "You have no permission to see this file."
           not_found: "This file cannot be found."
         already_linked_file: "This file is already linked to this work package."


### PR DESCRIPTION
[#52109](https://community.openproject.org/wp/52109)

### Wat?

- disabled file links now show generic message
- added OneDrive/SharePoint localisation to files tab display texts