### PR TITLE
[#51679] Can not add invited users to existing groups

### DIFF
--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -42,12 +42,10 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 
   <div class="grid-content medium-6 -visible-overflow">
-    <% users = User
-      .user
-      .active
-      .not_in_group(@group)
-      .limit(1) %>
-    <% if users.any? %>
+    <% if User.user
+              .not_in_group(@group)
+              .where(status: [User.statuses[:active], User.statuses[:invited]])
+              .exists? %>
       <%= styled_form_tag(members_of_group_path(@group), method: :post) do %>
 
         <fieldset class="form--fieldset">

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -66,6 +66,24 @@ RSpec.describe 'group memberships through groups page', :js, :with_cuprite do
     expect(members_page).to have_user 'Hannibal Smith', roles: ['Manager']
   end
 
+  context 'when there are only invited users not in the group' do
+    let!(:peter)    { create(:invited_user, firstname: 'Peter', lastname: 'Pan') }
+    let!(:hannibal) { create(:invited_user, firstname: 'Hannibal', lastname: 'Smith') }
+    let(:group_members) { [admin] }
+
+    it 'is possible to add an invited user' do
+      visit "/admin/groups/#{group.id}/edit?tab=users"
+
+      # autocomplete section has been rendered
+      expect(page).to have_text('NEW USER')
+      expect(page).to have_text('Add')
+
+      group_page.add_user! 'Hannibal'
+      expect(page).to have_text 'Successful update'
+      expect(page).to have_text('Hannibal Smith')
+    end
+  end
+
   context 'given a group with members in a project' do
     let(:group_members) { [peter, hannibal] }
     let(:project_members) { { group => [manager] } }


### PR DESCRIPTION
https://community.openproject.org/work_packages/51679
`NEW USER` section with autocomplete is absent if there are only invited users not present in the group. So, I extended the condition when the section is rendered (invited users are taken into account).
Note: the autocomplete itself includes invited users.