### PR TITLE
[#51317] Remove requirement for a Content-Type header on DELETE requests

### DIFF
--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -91,8 +91,8 @@ module API
       end
 
       def enforce_content_type
-        # Content-Type is not present in GET
-        return if request.get?
+        # Content-Type is not present in GET or DELETE requests
+        return if request.get? || request.delete?
 
         # Raise if missing header
         content_type = request.content_type

--- a/spec/requests/api/v3/content_type_header_spec.rb
+++ b/spec/requests/api/v3/content_type_header_spec.rb
@@ -62,5 +62,13 @@ RSpec.describe 'API v3 Content-Type header' do
         expect(last_response).to be_no_content
       end
     end
+
+    context 'on any other HTTP method' do
+      it 'responds with a 406 status and a missing Content-Type header message' do
+        patch api_v3_paths.work_package(work_package.id), {}
+        expect(last_response.status).to eq(406)
+        expect(last_response.body).to include('Missing content-type header')
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/content_type_header_spec.rb
+++ b/spec/requests/api/v3/content_type_header_spec.rb
@@ -54,5 +54,13 @@ RSpec.describe 'API v3 Content-Type header' do
         expect(last_response).to be_ok
       end
     end
+
+    context 'on a DELETE request' do
+      it 'is successful' do
+        delete api_v3_paths.work_package(work_package.id)
+        expect(last_response.status).not_to eq(406)
+        expect(last_response).to be_no_content
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/content_type_header_spec.rb
+++ b/spec/requests/api/v3/content_type_header_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+require 'rack/test'
+
+RSpec.describe 'API v3 Content-Type header' do
+  include Rack::Test::Methods
+  include Capybara::RSpecMatchers
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project)      { create(:project) }
+  shared_let(:work_package) { create(:work_package, project:) }
+  shared_current_user       { create(:admin) }
+
+  before do
+    allow(current_session).to receive(:env_for).and_wrap_original do |original_method, *args, &block|
+      original_method.call(*args, &block).except("CONTENT_TYPE")
+    end
+  end
+
+  describe 'a missing Content-Type header' do
+    context 'on a GET request' do
+      it 'is successful' do
+        get api_v3_paths.work_package(work_package.id)
+        expect(last_response.status).not_to eq(406)
+        expect(last_response).to be_ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
DELETE requests should not include a body in their payload. Some request implementations even end up stripping them out. The need for the Content-Type header is hence made irrelevant and to some extent surprising that a `406` response is generated in DELETE requests.

See: https://community.openproject.org/work_packages/51317