### PR TITLE
[52090] Allow changing status in backlogs with only change_work_package_status permission

### DIFF
--- a/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
@@ -199,8 +199,9 @@
 
         .error.icon.icon-bug
           text-align: left
-    .stories .story
+    .stories:not(.prevent_drag) .story
       cursor: move
+    .stories .story
       display: block
       font-size: 0.9rem
       margin: 0

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/backlog.js
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/backlog.js
@@ -58,6 +58,7 @@ RB.Backlog = (function ($) {
         receive: this.dragChanged,
         remove:  this.dragChanged,
         containment: $('#backlogs_container'),
+        cancel: 'input, textarea, button, select, option, .prevent_drag',
         scroll: true,
         helper: function(event, ui){
           var $clone =  $(ui).clone();

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
@@ -158,6 +158,7 @@ RB.Model = (function ($) {
           const fieldName = field.attr('fieldname');
           const fieldLabel = field.attr('fieldlabel');
           const fieldOrder = parseInt(field.attr('fieldorder'), 10);
+          const fieldEditable = field.attr('fieldeditable') || 'true';
           const fieldType = field.attr('fieldtype') || 'input';
           let typeId;
           let statusId;
@@ -190,7 +191,7 @@ RB.Model = (function ($) {
             input = $(document.createElement(fieldType));
           }
 
-          input = self.prepareInputFromFactory(input, fieldId, fieldName, fieldOrder, maxTabIndex);
+          input = self.prepareInputFromFactory(input, fieldId, fieldName, fieldOrder, maxTabIndex, fieldEditable);
 
           // Copy the value in the field to the input element
           input.val(fieldType === 'select' ? field.children('.v').first().text() : field.text());
@@ -230,10 +231,13 @@ RB.Model = (function ($) {
       return newInput;
     },
 
-    prepareInputFromFactory: function (input,fieldId,fieldName,fieldOrder, maxTabIndex) {
+    prepareInputFromFactory: function (input, fieldId, fieldName, fieldOrder, maxTabIndex, fieldEditable) {
       input.attr('id', fieldName + '_' + fieldId);
       input.attr('name', fieldName);
       input.attr('tabindex', fieldOrder + maxTabIndex);
+      if (fieldEditable !== 'true') {
+        input.attr('disabled', true);
+      }
       input.addClass(fieldName);
       input.addClass('editor');
       input.removeClass('template');

--- a/modules/backlogs/app/helpers/rb_master_backlogs_helper.rb
+++ b/modules/backlogs/app/helpers/rb_master_backlogs_helper.rb
@@ -61,10 +61,12 @@ module RbMasterBacklogsHelper
   def common_backlog_menu_items_for(backlog)
     items = {}
 
-    items[:new_story] = content_tag(:a,
-                                    I18n.t('backlogs.add_new_story'),
-                                    href: '#',
-                                    class: 'add_new_story')
+    if current_user.allowed_in_project?(:add_work_packages, @project)
+      items[:new_story] = content_tag(:a,
+                                      I18n.t('backlogs.add_new_story'),
+                                      href: '#',
+                                      class: 'add_new_story')
+    end
 
     items[:stories_tasks] = link_to(I18n.t(:label_stories_tasks),
                                     controller: '/rb_queries',

--- a/modules/backlogs/app/views/backlogs_settings/show.html.erb
+++ b/modules/backlogs/app/views/backlogs_settings/show.html.erb
@@ -34,34 +34,34 @@ See COPYRIGHT and LICENSE files for more details.
     <%= styled_label_tag("settings[story_types]", t(:backlogs_story_type)) %>
     <div class="form--field-container">
       <%= styled_select_tag("settings[story_types]",
-                   options_from_collection_for_select(Type.all, :id, :name, Story.types),
-                   :multiple => true,
-                   container_class: '-slim') %>
+                            options_from_collection_for_select(Type.all, :id, :name, Story.types),
+                            multiple: true,
+                            container_class: '-slim') %>
     </div>
   </div>
   <div class="form--field">
     <%= styled_label_tag("settings[task_type]", t(:backlogs_task_type)) %>
     <div class="form--field-container">
       <%= styled_select_tag("settings[task_type]",
-                   options_from_collection_for_select(Type.all, :id, :name, Task.type),
-                   container_class: '-slim') %>
+                            options_from_collection_for_select(Type.all, :id, :name, Task.type),
+                            container_class: '-slim') %>
     </div>
   </div>
   <div class="form--field">
     <%= styled_label_tag("settings[points_burn_direction]", t(:backlogs_points_burn_direction)) %>
     <div class="form--field-container">
       <%= styled_select_tag("settings[points_burn_direction]",
-                   options_for_select([[t(:label_points_burn_up), 'up'], [t(:label_points_burn_down), 'down']],
-                                      Setting.plugin_openproject_backlogs["points_burn_direction"]),
-                   container_class: '-slim') %>
+                            options_for_select([[t(:label_points_burn_up), 'up'], [t(:label_points_burn_down), 'down']],
+                                               Setting.plugin_openproject_backlogs["points_burn_direction"]),
+                            container_class: '-slim') %>
     </div>
   </div>
   <div class="form--field">
     <%= styled_label_tag("settings[wiki_template]", t(:backlogs_wiki_template)) %>
     <div class="form--field-container">
       <%= styled_text_field_tag("settings[wiki_template]",
-                       Setting.plugin_openproject_backlogs["wiki_template"],
-                       container_class: '-slim') %>
+                                Setting.plugin_openproject_backlogs["wiki_template"],
+                                container_class: '-slim') %>
     </div>
   </div>
 

--- a/modules/backlogs/app/views/layouts/backlogs.html.erb
+++ b/modules/backlogs/app/views/layouts/backlogs.html.erb
@@ -27,7 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-
 <% content_for :header_tags do %>
   <%= nonced_javascript_tag do %>
     <%= render(partial: 'shared/server_variables', formats: [:js]) %>

--- a/modules/backlogs/app/views/projects/settings/backlogs/show.html.erb
+++ b/modules/backlogs/app/views/projects/settings/backlogs/show.html.erb
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
             <div class="generic-table--sort-header-outer">
               <div class="generic-table--sort-header">
                 <span>
-                  <%=t('backlogs.work_package_is_closed')%>
+                  <%= t('backlogs.work_package_is_closed') %>
                 </span>
               </div>
             </div>
@@ -87,7 +87,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% end %>
 
-<h3><%=t('backlogs.rebuild_positions')%></h3>
+<h3><%= t('backlogs.rebuild_positions') %></h3>
 
 <%= styled_form_tag(controller: '/projects/settings/backlogs', action: "rebuild_positions", id: @project) do %>
   <p><%= styled_button_tag t('backlogs.rebuild'), class: '-highlight' %></p>

--- a/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
@@ -32,14 +32,14 @@ See COPYRIGHT and LICENSE files for more details.
 </h2>
 
 <% if @burndown %>
-  <%= render :partial => 'burndown', :locals => {:div => 'burndown_', :burndown => @burndown } %>
+  <%= render partial: 'burndown', locals: { div: 'burndown_', burndown: @burndown } %>
 
-  <div class="burndown_chart autoscroll" id="burndown_<%= @burndown.sprint_id %>" style="width:900px;height:450px;"><div class="loading"><%=t('backlogs.generating_chart')%></div></div>
+  <div class="burndown_chart autoscroll" id="burndown_<%= @burndown.sprint_id %>" style="width:900px;height:450px;"><div class="loading"><%= t('backlogs.generating_chart') %></div></div>
 
   <fieldset class="burndown_control form--fieldset">
       <legend class="form--fieldset-legend"><%= t('backlogs.chart_options') %></legend>
       <%= burndown_series_checkboxes(@burndown) %>
   </fieldset>
 <% else %>
-  <%= t('backlogs.no_burndown_data')%>
+  <%= t('backlogs.no_burndown_data') %>
 <% end %>

--- a/modules/backlogs/app/views/rb_impediments/_impediment.html.erb
+++ b/modules/backlogs/app/views/rb_impediments/_impediment.html.erb
@@ -27,7 +27,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% prevent_edit = User.current.allowed_in_project?(:edit_work_packages, defined?(project) ? project : impediment.project) ? '' : 'prevent_edit'%>
+<%
+  project ||= impediment.project
+  prevent_edit = if User.current.allowed_in_project?(:edit_work_packages, project)
+                   ''
+                 else
+                   'prevent_edit'
+                 end
+%>
 <div class="model work_package impediment <%= color_contrast_class(impediment) %> <%= prevent_edit %> <%= mark_if_closed(impediment) %><%= color_contrast_class(impediment) %>"
      id="work_package_<%= impediment.id %>"
      <%= build_inline_style(impediment) %>>
@@ -60,6 +67,6 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="meta">
     <div class="story_id"><%= impediment.parent_id %></div>
     <div class="status_id"><%= impediment.status_id %></div>
-    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
+    <%= render(partial: "shared/model_errors", object: errors) if defined?(errors) && !errors.empty? %>
   </div>
 </div>

--- a/modules/backlogs/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_backlog.html.erb
@@ -27,7 +27,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% folded = current_user.backlogs_preference(:versions_default_fold_state) == "closed" %>
+<%
+  folded = current_user.backlogs_preference(:versions_default_fold_state) == "closed"
+  editable = User.current.allowed_in_project?(:edit_work_packages, @project)
+%>
 <div class="backlog" id="backlog_<%= backlog.sprint.id %>">
   <div class="header">
     <% icon = folded ? 'icon-arrow-down1' : 'icon-arrow-up1' %>
@@ -36,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="velocity"> </div>
     <%= render_backlog_menu backlog %>
   </div>
-  <ul class="stories<%= ' closed' if folded %>">
+  <ul class="stories<%= ' closed' if folded %><%= ' prevent_drag' unless editable %>">
     <% reset_cycle 'stories' %>
     <% backlog.stories.each_with_index do |story, index| %>
       <% higher_item = index == 0 ? nil : backlog.stories[index - 1] %>

--- a/modules/backlogs/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_backlog.html.erb
@@ -32,19 +32,17 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="header">
     <% icon = folded ? 'icon-arrow-down1' : 'icon-arrow-up1' %>
     <div class="toggler <%= icon %> icon-small<%= ' closed' if folded %>"> </div>
-    <%= render :partial => "rb_sprints/sprint", :object => backlog.sprint %>
+    <%= render partial: "rb_sprints/sprint", object: backlog.sprint %>
     <div class="velocity"> </div>
     <%= render_backlog_menu backlog %>
   </div>
   <ul class="stories<%= ' closed' if folded %>">
     <% reset_cycle 'stories' %>
     <% backlog.stories.each_with_index do |story, index| %>
-      <% higher_item = index == 0 ? nil :
-                                    backlog.stories[index - 1] %>
+      <% higher_item = index == 0 ? nil : backlog.stories[index - 1] %>
 
-      <%= render :partial => "rb_stories/story",
-                 :locals => { :story => story,
-                              :higher_item => higher_item } %>
+      <%= render partial: "rb_stories/story",
+                 locals: { story:, higher_item: } %>
     <% end %>
   </ul>
 </div>

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -46,23 +46,21 @@ See COPYRIGHT and LICENSE files for more details.
   <%= no_results_box action_url: new_project_version_path(@project),
                      display_action: authorize_for('versions', 'new'),
                      custom_title: t(:backlogs_empty_title),
-                     custom_action_text: t(:backlogs_empty_action_text)
-
-  %>
+                     custom_action_text: t(:backlogs_empty_action_text) %>
 <% end %>
 
 <div id="rb">
   <div id="backlogs_container" class="clearfix">
     <div id="owner_backlogs_container">
-      <%= render :partial => 'backlog', :collection => @owner_backlogs %>
+      <%= render partial: 'backlog', collection: @owner_backlogs %>
     </div>
     <div id="sprint_backlogs_container">
-      <%= render :partial => 'backlog', :collection => @sprint_backlogs %>
+      <%= render partial: 'backlog', collection: @sprint_backlogs %>
     </div>
   </div>
 
   <div id="helpers">
-    <%= render :partial => "rb_stories/helpers" %>
+    <%= render partial: "rb_stories/helpers" %>
     <div id="last_updated"><%= date_string_with_milliseconds(@last_update, 0.001) %></div>
   </div>
 </div>

--- a/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
+++ b/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="v"><%= id_or_empty(sprint) %></div>
   </div>
 
-  <% User.current.allowed_in_project?(:update_sprints, @project) ? editable = "editable" :  editable = "" %>
+  <% editable = User.current.allowed_in_project?(:update_sprints, @project) ? "editable" : "" %>
 
   <div class="show">
     <div class="effective_date date <%= editable %>"
@@ -53,19 +53,19 @@ See COPYRIGHT and LICENSE files for more details.
   <% if User.current.allowed_in_project?(:update_sprints, @project) %>
     <div class="editors permanent">
       <%= angular_component_tag "op-basic-single-date-picker",
-                            inputs: {
-                              value: sprint.effective_date,
-                              inputClassNames: 'effective_date editor',
-                              id: "effective_date_#{sprint.id}",
-                              name: :effective_date
-                            } %>
+                                inputs: {
+                                  value: sprint.effective_date,
+                                  inputClassNames: 'effective_date editor',
+                                  id: "effective_date_#{sprint.id}",
+                                  name: :effective_date
+                                } %>
       <%= angular_component_tag "op-basic-single-date-picker",
-                            inputs: {
-                              value: sprint.start_date,
-                              inputClassNames: 'start_date editor',
-                              id: "start_date_#{sprint.id}",
-                              name: :start_date
-                            } %>
+                                inputs: {
+                                  value: sprint.start_date,
+                                  inputClassNames: 'start_date editor',
+                                  id: "start_date_#{sprint.id}",
+                                  name: :start_date
+                                } %>
       <%= text_field_tag :name,
                          sprint.name,
                          class: 'name editor' %>
@@ -73,6 +73,6 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 
   <div class="meta">
-    <%= render :partial => "shared/model_errors", :object => sprint.errors %>
+    <%= render partial: "shared/model_errors", object: sprint.errors %>
   </div>
 </div>

--- a/modules/backlogs/app/views/rb_stories/_helpers.html.erb
+++ b/modules/backlogs/app/views/rb_stories/_helpers.html.erb
@@ -71,5 +71,5 @@ See COPYRIGHT and LICENSE files for more details.
 </select>
 
 <div id="story_template">
-  <%= render partial: 'rb_stories/story', object: template_story %>
+  <%= render partial: 'rb_stories/story', object: template_story, locals: { project: @project, permission: :add_work_packages } %>
 </div>

--- a/modules/backlogs/app/views/rb_stories/_helpers.html.erb
+++ b/modules/backlogs/app/views/rb_stories/_helpers.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% statuses.each do |old_status, allowed_statuses| %>
     <select class="status_id helper" id="status_id_options_<%= type.id %>_<%= old_status.id %>">
       <% allowed_statuses.sort_by(&:position).each do |status| %>
-        <option value="<%= status.id %>" class="<%= (status.is_closed? ?  t(:label_closed_work_packages) + ' ' : "") %>">
+        <option value="<%= status.id %>" class="<%= (status.is_closed? ? "#{t(:label_closed_work_packages)} " : "") %>">
           <%= status.name %>
         </option>
       <% end %>
@@ -43,11 +43,11 @@ See COPYRIGHT and LICENSE files for more details.
 <% all_work_package_status.each do |old_status| %>
   <select class="status_id helper" id="status_id_options_default_<%= old_status.id %>">
     <% if old_status != default_work_package_status %>
-      <option value="<%= old_status.id %>" class="<%= (old_status.is_closed? ?  t(:label_closed_work_packages) + ' ' : "") %>">
+      <option value="<%= old_status.id %>" class="<%= (old_status.is_closed? ? "#{t(:label_closed_work_packages)} " : "") %>">
         <%= old_status.name %>
       </option>
     <% else %>
-      <option value="<%= default_work_package_status.id %>" class="<%= (default_work_package_status.is_closed? ?  t(:label_closed_work_packages) + ' ' : "") %>">
+      <option value="<%= default_work_package_status.id %>" class="<%= (default_work_package_status.is_closed? ? "#{t(:label_closed_work_packages)} " : "") %>">
         <%= default_work_package_status.name %>
       </option>
     <% end %>
@@ -56,7 +56,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <select class="status_id helper" id="status_id_options">
   <% all_work_package_status.each do |status| %>
-    <option value="<%= status.id %>" class="<%= (status.is_closed? ?  t(:label_closed_work_packages) + ' ' : "") %>">
+    <option value="<%= status.id %>" class="<%= (status.is_closed? ? "#{t(:label_closed_work_packages)} " : "") %>">
       <%= status.name %>
     </option>
   <% end %>
@@ -71,5 +71,5 @@ See COPYRIGHT and LICENSE files for more details.
 </select>
 
 <div id="story_template">
-  <%= render :partial => 'rb_stories/story', :object => template_story %>
+  <%= render partial: 'rb_stories/story', object: template_story %>
 </div>

--- a/modules/backlogs/app/views/rb_stories/_story.html.erb
+++ b/modules/backlogs/app/views/rb_stories/_story.html.erb
@@ -27,6 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<%
+  project ||= story.project
+  permission ||= :edit_work_packages
+  other_fields_editable = User.current.allowed_in_project?(permission, project)
+  status_field_editable = other_fields_editable || User.current.allowed_in_project?(:change_work_package_status, project)
+%>
 <li class="model story <%= mark_if_closed(story) %> <%= cycle('odd', 'even', name: "stories") %>" id="<%= story_html_id_or_empty(story) %>">
   <div class="id">
     <div class="t"><%= work_package_link_or_empty(story) %></div>
@@ -35,12 +41,14 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="story_points editable"
        fieldname="story_points"
        fieldlabel="<%= WorkPackage.human_attribute_name(:story_points) %>"
+       fieldeditable="<%= other_fields_editable %>"
        fieldorder="4"
        field_id="<%= story.id %>"><%= story_points_or_empty(story) %></div>
   <div class="status_id editable"
        fieldtype="select"
        fieldname="status_id"
        fieldlabel="<%= WorkPackage.human_attribute_name(:status) %>"
+       fieldeditable="<%= status_field_editable %>"
        fieldorder="3"
        field_id="<%= story.id %>">
     <div class="t ellipsis" title="<%= status_label_or_default(story) %>"><%= status_label_or_default(story) %></div>
@@ -50,6 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
        fieldtype="select"
        fieldname="type_id"
        fieldlabel="<%= WorkPackage.human_attribute_name(:type) %>"
+       fieldeditable="<%= other_fields_editable %>"
        fieldorder="1"
        field_id="<%= story.id %>">
     <div class="t"><%= type_name_or_empty(story) %>: </div>
@@ -58,6 +67,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="subject editable ellipsis"
        fieldname="subject"
        fieldlabel="<%= WorkPackage.human_attribute_name(:subject) %>"
+       fieldeditable="<%= other_fields_editable %>"
        fieldorder="2"
        title="<%= story.subject %>"
        field_id="<%= story.id %>"><%= story.subject %></div>

--- a/modules/backlogs/app/views/rb_stories/_story.html.erb
+++ b/modules/backlogs/app/views/rb_stories/_story.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<li class="model story <%= mark_if_closed(story) %> <%= cycle('odd', 'even', :name => "stories") %>" id="<%= story_html_id_or_empty(story) %>">
+<li class="model story <%= mark_if_closed(story) %> <%= cycle('odd', 'even', name: "stories") %>" id="<%= story_html_id_or_empty(story) %>">
   <div class="id">
     <div class="t"><%= work_package_link_or_empty(story) %></div>
     <div class="v"><%= id_or_empty(story) %></div>
@@ -64,6 +64,6 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="version_id"><%= story.version_id %></div>
   <div class="higher_item_id"><%= !defined?(higher_item) || higher_item.nil? ? '' : higher_item.id %></div>
   <div class="meta">
-    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
+    <%= render(partial: "shared/model_errors", object: errors) if defined?(errors) && !errors.empty? %>
   </div>
 </li>

--- a/modules/backlogs/app/views/rb_taskboards/show.html.erb
+++ b/modules/backlogs/app/views/rb_taskboards/show.html.erb
@@ -59,14 +59,14 @@ See COPYRIGHT and LICENSE files for more details.
       <tr>
         <td><div class="label_sprint_impediments"><%= t(:label_sprint_impediments) %></div></td>
         <% if User.current.allowed_in_project?(:add_work_packages, @project) %>
-          <td class ="add_new clickable">+</td>
+          <td class="add_new clickable">+</td>
         <% else %>
-          <td class ="add_new"></td>
+          <td class="add_new"></td>
           <% end %>
         <% @statuses.each do |status| %>
           <td class="swimlane list <%= status.is_closed? ? 'closed' : '' %>" id="impcell_<%= status.id %>">
-            <%= render :partial => "rb_impediments/impediment",
-                       :collection => impediments_by_position_for_status(@sprint, @project, status) %>
+            <%= render partial: "rb_impediments/impediment",
+                       collection: impediments_by_position_for_status(@sprint, @project, status) %>
           </td>
         <% end %>
       </tr>
@@ -103,14 +103,14 @@ See COPYRIGHT and LICENSE files for more details.
             </div>
           </td>
           <% if User.current.allowed_in_project?(:add_work_packages, @project) %>
-            <td class ="add_new clickable">+</td>
+            <td class="add_new clickable">+</td>
           <% else %>
-            <td class ="add_new"></td>
+            <td class="add_new"></td>
           <% end %>
           <% @statuses.each do |status| %>
             <td class="swimlane list <%= status.is_closed? ? 'closed' : '' %>" id="<%= story.id %>_<%= status.id %>">
-              <%= render :partial => "rb_tasks/task",
-                         :collection => tasks_by_status_id[status.id] %>
+              <%= render partial: "rb_tasks/task",
+                         collection: tasks_by_status_id[status.id] %>
             </td>
           <% end %>
         </tr>
@@ -128,14 +128,14 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     </select>
     <div id="task_template">
-      <%= render :partial => "rb_tasks/task", :object => Task.new, :locals => {:project => @project} %>
+      <%= render partial: "rb_tasks/task", object: Task.new, locals: { project: @project } %>
     </div>
     <div id="impediment_template">
-      <%= render :partial => "rb_impediments/impediment", :object => Impediment.new, :locals => {:project => @project} %>
+      <%= render partial: "rb_impediments/impediment", object: Impediment.new, locals: { project: @project } %>
     </div>
 
     <div id="work_package_editor"> </div>
-    <div class="meta" id="last_updated"><%= date_string_with_milliseconds( (@last_updated.blank? ? Time.now : @last_updated.updated_at) )  %></div>
+    <div class="meta" id="last_updated"><%= date_string_with_milliseconds((@last_updated.blank? ? Time.zone.now : @last_updated.updated_at)) %></div>
     <div id="charts"> </div>
     <div id="preloader">
       <div id="spinner"> </div>

--- a/modules/backlogs/app/views/rb_tasks/_task.html.erb
+++ b/modules/backlogs/app/views/rb_tasks/_task.html.erb
@@ -27,7 +27,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% prevent_edit = User.current.allowed_in_project?(:edit_work_packages, defined?(project) ? project : task.project) ? '' : 'prevent_edit'%>
+<%
+  project ||= task.project
+  prevent_edit = if User.current.allowed_in_project?(:edit_work_packages, project)
+                   ''
+                 else
+                   'prevent_edit'
+                 end
+%>
 <div class="model work_package task <%= color_contrast_class(task) %> <%= prevent_edit %> <%= mark_if_closed(task) %>" id="work_package_<%= task.id %>" <%= build_inline_style(task) %>>
   <div class="id">
     <div class="t"><%= work_package_link_or_empty(task) %></div>
@@ -53,6 +60,6 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="meta">
     <div class="story_id"><%= task.parent_id %></div>
     <div class="status_id"><%= task.status_id %></div>
-    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
+    <%= render(partial: "shared/model_errors", object: errors) if defined?(errors) && !errors.empty? %>
   </div>
 </div>

--- a/modules/backlogs/app/views/rb_tasks/index.html.erb
+++ b/modules/backlogs/app/views/rb_tasks/index.html.erb
@@ -28,9 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div>
-  <div class="meta" id="last_updated"><%= date_string_with_milliseconds( (@last_updated.blank? ? Time.parse(params[:after]) : @last_updated.updated_at), 0.001 )  %></div>
-  <%= render :partial => "task", :collection => @tasks, :locals => { :include_meta => @include_meta } %>
+  <div class="meta" id="last_updated"><%= date_string_with_milliseconds((@last_updated.blank? ? Time.zone.parse(params[:after]) : @last_updated.updated_at), 0.001) %></div>
+  <%= render partial: "task", collection: @tasks, locals: { include_meta: @include_meta } %>
   <%- if @impediments %>
-    <%= render :partial => "impediment", :collection => @impediments, :locals => { :include_meta => @include_meta }%>
+    <%= render partial: "impediment", collection: @impediments, locals: { include_meta: @include_meta } %>
   <%- end %>
 </div>

--- a/modules/backlogs/app/views/shared/_server_variables.js.erb
+++ b/modules/backlogs/app/views/shared/_server_variables.js.erb
@@ -31,7 +31,6 @@ if (window.RB === null || window.RB === undefined) {
   window.RB = {};
 }
 
-
 RB.constants = {
   project_id: <%= @project.id %>,
   sprint_id: <%= @sprint ? @sprint.id : "null" %>
@@ -44,18 +43,18 @@ RB.i18n = {
 
 RB.urlFor = (function () {
   var routes = {
-    update_sprint: '<%= backlogs_project_sprint_path(:project_id => @project.identifier, :id => ":id") %>',
+    update_sprint: '<%= backlogs_project_sprint_path(project_id: @project.identifier, id: ":id") %>',
 
-    create_story: '<%= backlogs_project_sprint_stories_path(:project_id => @project.identifier, :sprint_id => ":sprint_id") %>',
-    update_story: '<%= backlogs_project_sprint_story_path(:project_id => @project.identifier, :sprint_id => ":sprint_id", :id => ":id") %>',
+    create_story: '<%= backlogs_project_sprint_stories_path(project_id: @project.identifier, sprint_id: ":sprint_id") %>',
+    update_story: '<%= backlogs_project_sprint_story_path(project_id: @project.identifier, sprint_id: ":sprint_id", id: ":id") %>',
 
-    create_task: '<%= backlogs_project_sprint_tasks_path(:project_id => @project.identifier, :sprint_id => ":sprint_id") %>',
-    update_task: '<%= backlogs_project_sprint_task_path(:project_id => @project.identifier, :sprint_id => ":sprint_id", :id => ":id") %>',
+    create_task: '<%= backlogs_project_sprint_tasks_path(project_id: @project.identifier, sprint_id: ":sprint_id") %>',
+    update_task: '<%= backlogs_project_sprint_task_path(project_id: @project.identifier, sprint_id: ":sprint_id", id: ":id") %>',
 
-    create_impediment: '<%= backlogs_project_sprint_impediments_path(:project_id => @project.identifier, :sprint_id => ":sprint_id") %>',
-    update_impediment: '<%= backlogs_project_sprint_impediment_path(:project_id => @project.identifier, :sprint_id => ":sprint_id", :id => ":id") %>',
+    create_impediment: '<%= backlogs_project_sprint_impediments_path(project_id: @project.identifier, sprint_id: ":sprint_id") %>',
+    update_impediment: '<%= backlogs_project_sprint_impediment_path(project_id: @project.identifier, sprint_id: ":sprint_id", id: ":id") %>',
 
-    show_burndown_chart: '<%= backlogs_project_sprint_burndown_chart_path(:project_id => @project.identifier, :sprint_id => ":sprint_id") %>'
+    show_burndown_chart: '<%= backlogs_project_sprint_burndown_chart_path(project_id: @project.identifier, sprint_id: ":sprint_id") %>'
   };
 
   return function (routeName, options) {

--- a/modules/backlogs/app/views/shared/_validation_errors.html.erb
+++ b/modules/backlogs/app/views/shared/_validation_errors.html.erb
@@ -33,4 +33,4 @@ See COPYRIGHT and LICENSE files for more details.
   <li><%= msg %></li>
   <%- end %>
 </ul>
-<%= t(:error_outro ) %>
+<%= t(:error_outro) %>

--- a/modules/backlogs/app/views/shared/_view_my_settings.html.erb
+++ b/modules/backlogs/app/views/shared/_view_my_settings.html.erb
@@ -28,13 +28,13 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <fieldset class="form--fieldset">
-  <legend class="form--fieldset-legend"><%=t(:label_backlogs)%></legend>
+  <legend class="form--fieldset-legend"><%= t(:label_backlogs) %></legend>
   <div class="form--field">
     <%= styled_label_tag :backlogs_task_color, t(:'backlogs.task_color') %>
     <%= styled_text_field_tag :'backlogs[task_color]', color, container_class: '-middle' %>
   </div>
   <div class="form--field">
     <%= styled_label_tag :backlogs_versions_default_fold_state, I18n.t('backlogs.label_versions_default_fold_state') %>
-    <%= styled_check_box_tag :"backlogs[versions_default_fold_state]", "closed", versions_default_fold_state == "closed" %>
+    <%= styled_check_box_tag :'backlogs[versions_default_fold_state]', "closed", versions_default_fold_state == "closed" %>
   </div>
 </fieldset>

--- a/modules/backlogs/app/views/shared/not_configured.html.erb
+++ b/modules/backlogs/app/views/shared/not_configured.html.erb
@@ -29,8 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div id="not_configured">
   <%= t(:label_backlogs_unconfigured,
-          administration: t(:label_administration),
-          plugins: t(:label_plugins),
-          configure: t(:button_configure))
-  %>
+        administration: t(:label_administration),
+        plugins: t(:label_plugins),
+        configure: t(:button_configure)) %>
 </div>

--- a/modules/backlogs/app/views/version_settings/edit.html.erb
+++ b/modules/backlogs/app/views/version_settings/edit.html.erb
@@ -26,9 +26,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_version)  %>
+
+<%= toolbar title: t(:label_version) %>
 <% html_title t(:label_version) %>
-<% labelled_tabular_form_for :version, @version, :url => project_version_path(@project, @version), :html => {:method => :put} do |f| %>
-<%= render :partial => 'form', :locals => { :f => f } %>
+<% labelled_tabular_form_for :version, @version, url: project_version_path(@project, @version), html: { method: :put } do |f| %>
+<%= render partial: 'form', locals: { f: } %>
 <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -64,6 +64,10 @@ module OpenProject::Backlogs
           edit.controller_actions << 'rb_tasks/update'
           edit.controller_actions << 'rb_impediments/update'
         end
+
+        OpenProject::AccessControl.permission(:change_work_package_status).tap do |edit|
+          edit.controller_actions << 'rb_stories/update'
+        end
       end
 
       project_module :backlogs, dependencies: :work_package_tracking do


### PR DESCRIPTION
https://community.openproject.org/wp/52090

- Allow changing status in backlogs with only `change_work_package_status` permission and disable the other fields
- Disable drag and drop if the user does not have `edit_work_packages` permission
- Hide the "Add new story" menu entry if the user does not have `add_work_packages` permission