### PR TITLE
[52120] WP full view applies the wrong styles

### DIFF
--- a/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
@@ -108,7 +108,7 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
     component: WorkPackagesFullViewComponent,
     data: {
       baseRoute: 'work-packages',
-      bodyClasses: 'router--work-packages-full-view',
+      bodyClasses: ['router--work-packages-full-view', 'router--work-packages-base'],
       newRoute: 'work-packages.new',
       menuItem: menuItemClass,
     },


### PR DESCRIPTION
Add WorkPackage base routing class so that all styles are correctly applied when switching to the full view via Angular.

https://community.openproject.org/projects/openproject/work_packages/52120/activity