### PR TITLE
[52090] Improve backlogs permissions handling

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
@@ -304,14 +304,16 @@ RB.Model = (function ($) {
     },
 
     handleClick: function (e) {
-      var field, model, j, editor;
+      const field = $(this);
+      const model = field.parents('.model').first().data('this');
+      const j = model.$;
 
-      field = $(this);
-      model = field.parents('.model').first().data('this');
-      j = model.$;
-
-      if (!j.hasClass('editing') && !j.hasClass('dragging') && !j.hasClass('prevent_edit') && !$(e.target).hasClass('prevent_edit')) {
-        editor = model.edit();
+      if (!j.hasClass('editing')
+          && !j.hasClass('dragging')
+          && !j.hasClass('prevent_edit')
+          && !$(e.target).hasClass('prevent_edit')
+          && e.target.closest('.editable').getAttribute('fieldeditable') !== 'false' ) {
+        const editor = model.edit();
         var input = editor.find('.' + $(e.currentTarget).attr('fieldname') + '.editor');
 
         input.focus();

--- a/modules/backlogs/app/helpers/rb_master_backlogs_helper.rb
+++ b/modules/backlogs/app/helpers/rb_master_backlogs_helper.rb
@@ -92,12 +92,14 @@ module RbMasterBacklogsHelper
   def sprint_backlog_menu_items_for(backlog)
     items = {}
 
-    items[:task_board] = link_to(I18n.t(:label_task_board),
-                                 { controller: '/rb_taskboards',
-                                   action: 'show',
-                                   project_id: @project,
-                                   sprint_id: backlog.sprint },
-                                 class: 'show_task_board')
+    if current_user.allowed_in_project?(:view_taskboards, @project)
+      items[:task_board] = link_to(I18n.t(:label_task_board),
+                                   { controller: '/rb_taskboards',
+                                     action: 'show',
+                                     project_id: @project,
+                                     sprint_id: backlog.sprint },
+                                   class: 'show_task_board')
+    end
 
     if backlog.sprint.has_burndown?
       items[:burndown] = content_tag(:a,

--- a/modules/backlogs/spec/features/backlogs/change_status_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/change_status_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative '../../support/pages/backlogs'
+
+RSpec.describe 'Backlogs context menu', :js, :with_cuprite do
+  shared_let(:story_type) { create(:type_feature) }
+  shared_let(:task_type) { create(:type_task) }
+  shared_let(:project) { create(:project, types: [story_type, task_type]) }
+  shared_let(:role) do
+    create(:project_role,
+           permissions: %i[edit_work_packages
+                           change_work_package_status
+                           view_master_backlog
+                           view_work_packages])
+  end
+
+  shared_let(:user) do
+    create(:user,
+           member_with_roles: { project => role })
+  end
+  shared_let(:sprint) do
+    create(:version,
+           project:,
+           name: 'Sprint')
+  end
+  shared_let(:new_status) { create(:default_status, name: 'New') }
+  shared_let(:in_progress_status) { create(:status, name: 'In progress') }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:story) do
+    create(:work_package,
+           type: story_type,
+           project:,
+           status: new_status,
+           priority: default_priority,
+           story_points: 3,
+           version: sprint)
+  end
+  shared_let(:workflow) do
+    create(:workflow,
+           old_status: new_status,
+           new_status: in_progress_status,
+           role:,
+           type: story_type)
+  end
+
+  let(:backlogs_page) { Pages::Backlogs.new(project) }
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+            .and_return('story_types' => [story_type.id.to_s],
+                        'task_type' => task_type.id.to_s)
+    login_as(user)
+  end
+
+  def expect_fields(enabled: [], disabled: [], none: [])
+    enabled.each do |field|
+      expect(page).to have_field(WorkPackage.human_attribute_name(field))
+    end
+
+    disabled.each do |field|
+      expect(page).to have_field(WorkPackage.human_attribute_name(field), disabled: true)
+    end
+
+    none.each do |field|
+      expect(page).to have_no_field(WorkPackage.human_attribute_name(field), visible: :all)
+    end
+  end
+
+  # this test acts as a control for the other tests in this file as it's easy to
+  # expect a field to not be present, and have the test still pass when the
+  # field is renamed.
+  context 'when the user has edit_work_packages permission' do
+    it 'is possible to edit any story field' do
+      backlogs_page.visit!
+      backlogs_page.enter_edit_story_mode(story)
+
+      expect_fields(enabled: %i[type subject status story_points])
+
+      backlogs_page.alter_attributes_in_edit_story_mode(story, subject: 'Hello subject')
+      backlogs_page.save_story_from_edit_mode(story)
+
+      expect(story.reload.subject).to eq('Hello subject')
+    end
+  end
+
+  context 'when the user has only change_work_package_status permission' do
+    before do
+      RolePermission.where(permission: 'edit_work_packages').delete_all
+    end
+
+    it 'is only possible to edit status field of stories' do
+      backlogs_page.visit!
+      backlogs_page.enter_edit_story_mode(story, text: story.status.name)
+
+      expect_fields(enabled: %i[status], disabled: %i[type subject story_points])
+
+      backlogs_page.alter_attributes_in_edit_story_mode(story, status: in_progress_status.name)
+      backlogs_page.save_story_from_edit_mode(story)
+
+      expect(story.reload.status).to eq(in_progress_status)
+    end
+  end
+
+  context 'when the user has neither change_work_package_status nor edit_work_packages permission' do
+    before do
+      RolePermission.where(permission: ['change_work_package_status', 'edit_work_packages']).delete_all
+    end
+
+    it 'is not possible to edit any story field' do
+      backlogs_page.visit!
+      backlogs_page.enter_edit_story_mode(story)
+
+      expect_fields(none: %i[type subject status story_points])
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative '../../support/pages/backlogs'
+
+RSpec.describe 'Backlogs context menu', :js, :with_cuprite do
+  shared_let(:story_type) { create(:type_feature) }
+  shared_let(:task_type) { create(:type_task) }
+  shared_let(:project) { create(:project, types: [story_type, task_type]) }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: { project => %i[add_work_packages
+                                                    view_master_backlog
+                                                    view_taskboards
+                                                    view_work_packages] })
+  end
+  shared_let(:sprint) do
+    create(:version,
+           project:,
+           name: 'Sprint',
+           start_date: Date.yesterday,
+           effective_date: Date.tomorrow)
+  end
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:story) do
+    create(:work_package,
+           type: story_type,
+           project:,
+           status: default_status,
+           priority: default_priority,
+           position: 1,
+           story_points: 3,
+           version: sprint)
+  end
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+            .and_return('story_types' => [story_type.id.to_s],
+                        'task_type' => task_type.id.to_s)
+    login_as(user)
+  end
+
+  let(:backlogs_page) { Pages::Backlogs.new(project) }
+
+  def within_backlog_context_menu(&)
+    backlogs_page.visit!
+    backlogs_page.within_backlog_menu(sprint, &)
+  end
+
+  context 'when the backlog is a sprint backlog (displayed on the left, the default)' do
+    it 'displays all menu entries' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_link I18n.t('backlogs.add_new_story')
+        expect(menu).to have_link I18n.t('label_stories_tasks')
+        expect(menu).to have_link I18n.t('label_task_board')
+        expect(menu).to have_link I18n.t('backlogs.show_burndown_chart')
+        expect(menu).to have_link I18n.t('label_wiki')
+      end
+    end
+  end
+
+  context 'when the backlog is an owner backlog (displayed on the right)' do
+    let!(:version_setting) do
+      create(:version_setting,
+             project:,
+             version: sprint,
+             display: VersionSetting::DISPLAY_RIGHT)
+    end
+
+    it 'only displays the "New story" and "Stories/Tasks" menu entries' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_link I18n.t('backlogs.add_new_story')
+        expect(menu).to have_link I18n.t('label_stories_tasks')
+        expect(menu).to have_no_link I18n.t('label_task_board')
+        expect(menu).to have_no_link I18n.t('backlogs.show_burndown_chart')
+        expect(menu).to have_no_link I18n.t('label_wiki')
+      end
+    end
+  end
+
+  context 'when the sprint does not have a start date' do
+    before do
+      sprint.update(start_date: nil)
+    end
+
+    it 'does not display the "Burndown chart" menu entry' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_no_link I18n.t('backlogs.show_burndown_chart')
+      end
+    end
+  end
+
+  context 'when the sprint does not have an effective date' do
+    before do
+      sprint.update(effective_date: nil)
+    end
+
+    it 'does not display the "Burndown chart" menu entry' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_no_link I18n.t('backlogs.show_burndown_chart')
+      end
+    end
+  end
+
+  context 'when the user does not have add_work_packages permission' do
+    before do
+      RolePermission.where(permission: 'add_work_packages').delete_all
+    end
+
+    it 'does not display the "New story" menu entry' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_no_link I18n.t('backlogs.add_new_story')
+      end
+    end
+  end
+
+  context 'when the user does not have view_taskboards permission' do
+    before do
+      RolePermission.where(permission: 'view_taskboards').delete_all
+    end
+
+    it 'does not display the "Task board" menu entry' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_no_link I18n.t('label_task_board')
+      end
+    end
+  end
+
+  context 'when the wiki module is not enabled' do
+    before do
+      project.enabled_module_names -= ['wiki']
+    end
+
+    it 'does not display the "Wiki" menu entry' do
+      within_backlog_context_menu do |menu|
+        expect(menu).to have_no_link I18n.t('label_wiki')
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -224,9 +224,6 @@ RSpec.describe 'Stories in backlog', :js,
     backlogs_page
       .drag_in_sprint(sprint_story1, new_story)
 
-    # wait for backend to process the reordering
-    sleep(0.5)
-
     backlogs_page
       .expect_stories_in_order(sprint, sprint_story1, new_story, sprint_story2)
 
@@ -236,9 +233,6 @@ RSpec.describe 'Stories in backlog', :js,
     # Moving a story to bottom
     backlogs_page
       .drag_in_sprint(sprint_story1, sprint_story2, before: false)
-
-    # wait for backend to process the reordering
-    sleep(0.5)
 
     backlogs_page
       .expect_stories_in_order(sprint, new_story, sprint_story2, sprint_story1)
@@ -251,9 +245,6 @@ RSpec.describe 'Stories in backlog', :js,
     SeleniumHubWaiter.wait
     backlogs_page
       .drag_in_sprint(backlog_story1, sprint_story2, before: false)
-
-    # wait for backend to process the reordering
-    sleep(0.5)
 
     backlogs_page
       .expect_stories_in_order(sprint, new_story, sprint_story2, backlog_story1, sprint_story1)

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -140,9 +140,8 @@ module Pages
     end
 
     def click_in_backlog_menu(backlog, item_name)
-      within_backlog(backlog) do
-        find('.header .menu-trigger').click
-        find('.header .backlog-menu .item', text: item_name).click
+      within_backlog_menu(backlog) do |menu|
+        menu.find('.item', text: item_name).click
       end
     end
 
@@ -257,6 +256,15 @@ module Pages
 
     def path
       backlogs_project_backlogs_path(project)
+    end
+
+    def within_backlog_menu(backlog, &)
+      within_backlog(backlog) do
+        menu = find('.backlog-menu')
+        menu.click
+
+        yield menu
+      end
     end
 
     private

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -91,8 +91,10 @@ module Pages
 
     def save_story_from_edit_mode(story)
       save_proc = ->(*) do
-        # for some reason, have to send 2 return keys for the select field
-        find_field(disabled: false, match: :first).send_keys(:return, :return)
+        field = find_field(disabled: false, match: :first)
+        keys = [:return]
+        keys << :return if field.tag_name == 'select' # select field needs a second return key sent for some reason
+        field.send_keys(*keys)
 
         expect(page).to have_no_field(WorkPackage.human_attribute_name(:subject))
       end

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -155,6 +155,7 @@ module Pages
       target_element = find(story_selector(target))
 
       drag_n_drop_element from: moved_element, to: target_element, offset_x: 0, offset_y: before ? -5 : +10
+      wait_for_save_completion
     end
 
     def fold_backlog(backlog)


### PR DESCRIPTION
Related to code review on pull request #14574

- Add unit tests for https://community.openproject.org/wp/52090 and more
- Hide Task board menu entry if user has no `:view_taskboards` permission
- Forbid edition of a story if user has no `:edit_work_packages` nor `:change_work_package_status` permissions
  - in previous versions, it was possible to enter edition mode when having only "View master backlog", "View taskboards", and "View work packages". If trying to update a field, this would create the same issue as the one reported in #14574 code review.