### PR TITLE
fix[Op-52158]: Drive id message should include `ID` - "Drive ID can't be blank"

### DIFF
--- a/app/contracts/oauth_clients/create_contract.rb
+++ b/app/contracts/oauth_clients/create_contract.rb
@@ -31,7 +31,7 @@ module OAuthClients
     include ActiveModel::Validations
 
     attribute :client_id, writable: true
-    validates :client_id, presence: { message: I18n.t('oauth_client.errors.client_id_blank') }, length: { maximum: 255 }
+    validates :client_id, presence: true, length: { maximum: 255 }
 
     attribute :client_secret, writable: true
     validates :client_secret, presence: true, length: { maximum: 255 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,7 +231,7 @@ en:
       editable: "Allow the field to be editable by users themselves."
       visible: "Make field visible for all users (non-admins) in the project overview and displayed in the project details widget on the Project Overview."
       is_filter: >
-        Allow the custom field to be used in a filter in work package views. 
+        Allow the custom field to be used in a filter in work package views.
         Note that only with 'For all projects' selected, the custom field will show up in global views.
 
     tab:
@@ -591,6 +591,8 @@ en:
         row_count: "Number of rows"
         column_count: "Number of columns"
         widgets: "Widgets"
+      oauth_client:
+        client: "Client ID"
       relation:
         delay: "Delay"
         from: "Work package"
@@ -3535,7 +3537,6 @@ en:
       oauth_returned_json_error: "OAuth2 returned a JSON error"
       oauth_returned_http_error: "OAuth2 returned a network error"
       oauth_returned_standard_error: "OAuth2 returned an internal error"
-      client_id_blank: "ID can't be blank."
       wrong_token_type_returned: "OAuth2 returned a wrong type of token, expecting AccessToken::Bearer"
       oauth_issue_contact_admin: "OAuth2 reported an error. Please contact your system administrator."
       oauth_client_not_found: "OAuth2 client not found in 'callback' endpoint (redirect_uri)."

--- a/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
@@ -33,7 +33,7 @@ module Storages::Storages
     attribute :host
     validates :host, absence: true
     attribute :tenant_id
-    validates :tenant_id, presence: true
+    validates :tenant_id, format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
     attribute :drive_id
     validates :drive_id, presence: true, allow_nil: true
   end

--- a/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/one_drive_contract.rb
@@ -33,7 +33,7 @@ module Storages::Storages
     attribute :host
     validates :host, absence: true
     attribute :tenant_id
-    validates :tenant_id, format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
+    validates :tenant_id, presence: true
     attribute :drive_id
     validates :drive_id, presence: true, allow_nil: true
   end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
         origin_id: Origin Id
       storages/storage:
         creator: Creator
+        drive: Drive ID
         host: Host
         name: Name
         provider_type: Provider type

--- a/modules/storages/spec/contracts/storages/storages/one_drive_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/one_drive_contract_spec.rb
@@ -31,13 +31,13 @@
 require 'spec_helper'
 require_module_spec_helper
 
-RSpec.describe Storages::Storages::NextcloudContract, :storage_server_helpers, :webmock do
+RSpec.describe Storages::Storages::OneDriveContract, :storage_server_helpers, :webmock do
   let(:current_user) { create(:admin) }
   let(:storage) { build(:one_drive_storage) }
 
   # As the OneDriveContract is selected by the BaseContract to make writable attributes available,
   # the BaseContract needs to be instantiated here.
-  subject { Storages::Storages::BaseContract.new(storage, current_user) }
+  subject(:contract) { Storages::Storages::BaseContract.new(storage, current_user) }
 
   describe 'when a host is set' do
     before do
@@ -45,7 +45,17 @@ RSpec.describe Storages::Storages::NextcloudContract, :storage_server_helpers, :
     end
 
     it 'must be invalid' do
-      expect(subject).not_to be_valid
+      expect(contract).not_to be_valid
+    end
+  end
+
+  context 'with blank Drive ID' do
+    let(:storage) { build(:one_drive_storage, drive_id: '') }
+
+    it 'is invalid' do
+      expect(contract).not_to be_valid
+
+      expect(contract.errors[:drive_id]).to eq(["can't be blank."])
     end
   end
 end

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe 'Admin storages',
             fill_in 'storages_one_drive_storage_tenant_id', with: '029d4741-a4be-44c6-a8e4-e4eff7b19f65'
             click_button 'Save and continue'
 
-            expect(page).to have_text("Drive can't be blank.")
+            expect(page).to have_text("Drive ID can't be blank.")
 
             fill_in 'storages_one_drive_storage_drive_id', with: '1234567890'
             click_button 'Save and continue'
@@ -606,7 +606,7 @@ RSpec.describe 'Admin storages',
             click_button 'Save and continue'
 
             expect(page).to have_text("Name can't be blank.")
-            expect(page).to have_text("Drive can't be blank.")
+            expect(page).to have_text("Drive ID can't be blank.")
 
             click_link 'Cancel'
           end

--- a/spec/contracts/oauth_clients/create_contract_spec.rb
+++ b/spec/contracts/oauth_clients/create_contract_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe OAuthClients::CreateContract do
       it 'is invalid, includes `ID` in error message' do
         expect(contract).not_to be_valid
 
-        expect(contract.errors[:client_id]).to eq(["ID can't be blank."])
+        expect(contract.errors[:client_id]).to eq(["can't be blank."])
       end
     end
 

--- a/spec/contracts/oauth_clients/create_contract_spec.rb
+++ b/spec/contracts/oauth_clients/create_contract_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe OAuthClients::CreateContract do
     context 'with blank client ID' do
       let(:client_id) { '' }
 
-      it 'is invalid, includes `ID` in error message' do
+      it 'is invalid' do
         expect(contract).not_to be_valid
 
         expect(contract.errors[:client_id]).to eq(["can't be blank."])


### PR DESCRIPTION
#### https://community.openproject.org/wp/52158

Similar to https://github.com/opf/openproject/pull/14354/commits/ca0fc06d369ab3dc3c6d8a83290df1f612ba339b - active model errors strips out the "ID" from the message when the attribute name has an "_id" suffix. This overrides the default message by specifying the relation `drive` label

🐛  _Before_

![Screenshot 2024-01-17 at 3 30 00 PM](https://github.com/opf/openproject/assets/17295175/4ae0ab29-2985-4491-8349-75f7e6bb9120)

🔧  _After_

![Screenshot 2024-01-17 at 3 43 27 PM](https://github.com/opf/openproject/assets/17295175/4bbe00ee-5590-49a7-93ee-b279e36329c3)
