### PR TITLE
[#47169] PDF doesn't contain cell color

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem 'structured_warnings', '~> 0.4.0'
 # don't require by default, instead load on-demand when actually configured
 gem 'airbrake', '~> 13.0.0', require: false
 
-gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: 'bbda8ad0054d465eec01c23fcab5c6d62c7baa44'
+gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '4952148f930a3292051efbadd9ac115d9c721157'
 gem 'prawn', '~> 2.4'
 # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
 gem 'matrix', '~> 0.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,11 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: bbda8ad0054d465eec01c23fcab5c6d62c7baa44
-  ref: bbda8ad0054d465eec01c23fcab5c6d62c7baa44
+  revision: 4952148f930a3292051efbadd9ac115d9c721157
+  ref: 4952148f930a3292051efbadd9ac115d9c721157
   specs:
-    md_to_pdf (0.0.22)
+    md_to_pdf (0.0.23)
+      color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.1)
       markly (~> 0.7)
@@ -416,6 +417,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    color_conversion (0.1.1)
     colored2 (4.0.0)
     commonmarker (1.0.4)
       rb_sys (~> 0.9)


### PR DESCRIPTION
[x] update to md_to_pdf v0.0.23 (4952148f930a3292051efbadd9ac115d9c721157) which adds support for table cell background colors

<img width="750" alt="Bildschirmfoto 2024-01-17 um 14 41 59" src="https://github.com/opf/openproject/assets/77627197/d4f834fd-fd80-44fe-b577-ddb020d7918b">

https://community.openproject.org/work_packages/47169