### PR TITLE
Move successful_login out of the retained session yield

### DIFF
--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -48,9 +48,9 @@ module Users
         User.current = user
 
         set_autologin_cookie if autologin_requested
-
-        successful_login
       end
+
+      successful_login
     end
 
     private


### PR DESCRIPTION
Ensure that the successful_login hooks receive all retained values from the session

https://community.openproject.org/work_packages/52185