### PR TITLE
[49788] Columns in task board not in sync for more than one task (column width not working) 

### DIFF
--- a/frontend/src/app/features/backlogs/backlogs-page/styles/taskboard.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/taskboard.sass
@@ -121,8 +121,7 @@
     background-color: #F8F6A5
     border: none
     display: block
-    float: left
-    min-height: 84px
+    min-height: 100px
     margin: 5px
     padding: 5px
     position: relative
@@ -142,9 +141,8 @@
     border: none
     cursor: move
     display: block
-    float: left
     font-size: 10px
-    height: 80px
+    height: 85px
     padding: 5px
     margin: 5px 0px
     position: relative
@@ -167,7 +165,7 @@
       bottom: -5px
       color: #FFFFFF
       font-size: 9px
-      height: 13px
+      height: 18px
       padding-left: 5px
       padding-right: 5px
       position: absolute


### PR DESCRIPTION
Remove `float` as it caused issues in Safari

https://community.openproject.org/projects/openproject/work_packages/49788/activtiy

### Before
<img width="300" alt="Bildschirmfoto 2024-01-22 um 08 56 08" src="https://github.com/opf/openproject/assets/7457313/fb3de0ce-203b-442a-8a4c-b86cef42e2e0">

### After
<img width="300" alt="Bildschirmfoto 2024-01-22 um 08 54 56" src="https://github.com/opf/openproject/assets/7457313/af2c7d88-f01c-4a20-9c3f-b995e56f17d6">
