### PR TITLE
Avoid treating underscores as ilike input

### DIFF
--- a/app/models/queries/operators/concerns/contains_all_values.rb
+++ b/app/models/queries/operators/concerns/contains_all_values.rb
@@ -35,7 +35,7 @@ module Queries::Operators::Concerns
         values
           .first
           .split(/\s+/)
-          .map { |substr| "#{db_table}.#{db_field} ILIKE '%#{connection.quote_string(substr)}%'" }
+          .map { |token| "#{db_table}.#{db_field} ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(token)}%'" }
           .join(' AND ')
       end
     end

--- a/lib/open_project/sql_sanitization.rb
+++ b/lib/open_project/sql_sanitization.rb
@@ -44,5 +44,11 @@ module OpenProject
     def self.sanitize(sql, *args)
       sanitize_sql_array [sql, *args]
     end
+
+    ##
+    # Quoted, escaped input for LIKE/ILIKE statements
+    def self.quoted_sanitized_sql_like(input)
+      connection.quote_string ActiveRecord::Base.sanitize_sql_like(input)
+    end
   end
 end

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
                   customizable_journals.journal_id = journals.id
                   AND customizable_journals.custom_field_id = #{custom_field.id}
                 SQL
-              expect(subject_sql).to include "customizable_journals.value ILIKE '%Wednesday_CV%'"
+              expect(subject_sql).to include "customizable_journals.value ILIKE '%Wednesday\\_CV%'"
             end
           end
 

--- a/spec/models/queries/work_packages/filter/search_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/search_filter_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe Queries::WorkPackages::Filter::SearchFilter do
     end
   end
 
+  describe 'escaping underscores for the filter (Regression #33574)' do
+    subject { WorkPackage.joins(instance.joins).where(instance.where) }
+
+    let!(:work_package) { create(:work_package, description: "Some text c_tree_h more text") }
+    let!(:no_match) { create(:work_package, description: "Some cotreeoh text") }
+
+    it 'finds in description' do
+      instance.values = ['c_tree_h']
+      expect(subject)
+        .to contain_exactly(work_package)
+    end
+  end
+
   describe 'partial (not fuzzy) match of string in subject (#29832)' do
     subject { WorkPackage.joins(instance.joins).where(instance.where) }
 


### PR DESCRIPTION
This doesn't actually fix this bug, as the bug is not a bug. (See my comment for details). But the underscores are treated as escape characters in ILIKE, so they will also match an underscore, but other characters as well which is not desired.

https://community.openproject.org/work_packages/33574