### PR TITLE
[51851] Renaming Work Package Views/ Boards : Edit Lock Issue

### DIFF
--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -1,5 +1,9 @@
 import { Component, ElementRef, Injector, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
+import {
+  EMPTY,
+  Observable,
+  Subscription,
+} from 'rxjs';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { BoardListComponent } from 'core-app/features/boards/board/board-list/board-list.component';
 import { StateService } from '@uirouter/core';
@@ -19,7 +23,12 @@ import { BoardPartitionedPageComponent } from 'core-app/features/boards/board/bo
 import { AddListModalComponent } from 'core-app/features/boards/board/add-list-modal/add-list-modal.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { BoardListCrossSelectionService } from 'core-app/features/boards/board/board-list/board-list-cross-selection.service';
-import { filter, tap } from 'rxjs/operators';
+import {
+  catchError,
+  filter,
+  finalize,
+  tap,
+} from 'rxjs/operators';
 import { BoardActionsRegistryService } from 'core-app/features/boards/board/board-actions/board-actions-registry.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
@@ -159,7 +168,21 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   }
 
   saveBoard(board:Board):void {
-    this.boardComponent.boardSaver.request(board);
+    this.Boards
+      .save(board)
+      .pipe(
+        catchError((error) => {
+          this.halNotification.handleRawError(error);
+          return EMPTY;
+        }),
+        finalize(() => {
+          this.boardComponent.toolbarDisabled = false;
+          this.boardComponent.cdRef.detectChanges();
+        }),
+      ).subscribe(() => {
+        this.toastService.addSuccess(this.text.updateSuccessful);
+      },
+    );
   }
 
   private setupQueryUpdatedMonitoring(board:Board) {

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
@@ -21,7 +21,12 @@ import { ZenModeButtonComponent } from 'core-app/features/work-packages/componen
 import { BoardsMenuButtonComponent } from 'core-app/features/boards/board/toolbar-menu/boards-menu-button.component';
 import { RequestSwitchmap } from 'core-app/shared/helpers/rxjs/request-switchmap';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
-import { finalize, take } from 'rxjs/operators';
+import {
+  catchError,
+  finalize,
+  take,
+  tap,
+} from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
@@ -30,6 +35,11 @@ import { BoardFiltersService } from 'core-app/features/boards/board/board-filter
 import { CardViewHandlerRegistry } from 'core-app/features/work-packages/components/wp-card-view/event-handler/card-view-handler-registry';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { OpTitleService } from 'core-app/core/html/op-title.service';
+import {
+  EMPTY,
+  Observable,
+  of,
+} from 'rxjs';
 
 export function boardCardViewHandlerFactory(injector:Injector) {
   return new CardViewHandlerRegistry(injector);
@@ -111,18 +121,6 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
     },
   };
 
-  // We remember when we want to update the board
-  boardSaver = new RequestSwitchmap(
-    (board:Board) => {
-      this.toolbarDisabled = true;
-      return this.Boards
-        .save(board)
-        .pipe(
-          finalize(() => (this.toolbarDisabled = false)),
-        );
-    },
-  );
-
   toolbarButtonComponents:ToolbarButtonComponentDefinition[] = [
     {
       component: WorkPackageFilterButtonComponent,
@@ -142,7 +140,8 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
     },
   ];
 
-  constructor(readonly I18n:I18nService,
+  constructor(
+    readonly I18n:I18nService,
     readonly cdRef:ChangeDetectorRef,
     readonly $transitions:TransitionService,
     readonly state:StateService,
@@ -152,22 +151,14 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
     readonly apiV3Service:ApiV3Service,
     readonly boardFilters:BoardFiltersService,
     readonly Boards:BoardService,
-    readonly titleService:OpTitleService) {
+    readonly titleService:OpTitleService,
+  ) {
     super();
   }
 
   ngOnInit():void {
     // Ensure board is being loaded
     this.Boards.loadAllBoards();
-
-    this.boardSaver
-      .observe(componentDestroyed(this))
-      .subscribe(
-        () => {
-          this.toastService.addSuccess(this.text.updateSuccessful);
-        },
-        (error:unknown) => this.halNotification.handleRawError(error),
-      );
 
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
       const toState = transition.to();
@@ -216,7 +207,22 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
         const params = { isNew: false, query_props: null };
         this.state.go('.', params, { custom: { notify: false } });
 
-        this.boardSaver.request(board);
+        this.toolbarDisabled = true;
+        this.Boards
+          .save(board)
+          .pipe(
+            catchError((error) => {
+              this.halNotification.handleRawError(error);
+              return EMPTY;
+            }),
+            finalize(() => {
+              this.toolbarDisabled = false;
+              this.cdRef.detectChanges();
+            }),
+          ).subscribe(() => {
+            this.toastService.addSuccess(this.text.updateSuccessful);
+          },
+        );
       });
   }
 

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
@@ -218,7 +218,10 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
     this.currentQuery!.name = val;
     this.wpListService
       .save(this.currentQuery)
-      .finally(() => { this.toolbarDisabled = false; });
+      .finally(() => {
+        this.toolbarDisabled = false;
+        this.cdRef.detectChanges();
+      });
   }
 
   updateTitle(query?:QueryResource):void {

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -215,6 +215,23 @@ RSpec.describe 'Board management spec', :js, with_ee: %i[board_view] do
         expect(queries.first.name).to eq 'Unnamed list'
       end
     end
+
+    it 'allows renaming the board with an error in between (regression #51851)' do
+      board_view
+      board_index.visit!
+
+      board_page = board_index.open_board board_view
+      board_page.expect_query 'List 1', editable: true
+      board_page.expect_editable_board true
+      board_page.expect_editable_list true
+
+      # Leave the toolbar name empty
+      board_page.rename_via_toolbar ''
+      board_page.expect_toast message: "Name #{I18n.t('activerecord.errors.messages.blank')}", type: :error
+
+      # I can immediately enter the correct name
+      board_page.rename_board 'My new name'
+    end
   end
 
   context 'with view boards + work package permission' do

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -302,17 +302,21 @@ module Pages
         input.set new_name
         input.send_keys :enter
       else
-        page.within('.toolbar-container') do
-          input = page.find('.editable-toolbar-title--input').click
-          input.set new_name
-          input.send_keys :enter
-        end
+        rename_via_toolbar new_name
       end
 
       expect_and_dismiss_toaster message: I18n.t('js.notice_successful_update')
 
       page.within('.toolbar-container') do
         expect(page).to have_field('editable-toolbar-title', with: new_name)
+      end
+    end
+
+    def rename_via_toolbar(new_name)
+      page.within('.toolbar-container') do
+        input = page.find('.editable-toolbar-title--input').click
+        input.set new_name
+        input.send_keys :enter
       end
     end
 


### PR DESCRIPTION
For whatever reason the RequestSwitchMap is cancelling all further events after the first error. So if the user accidentaly submitted an empty board header, it could not be changed afterwards


https://community.openproject.org/projects/openproject/work_packages/51851/activity