### PR TITLE
Restore roadmap progress calculation

### DIFF
--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -54,7 +54,9 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% if version.work_packages.count > 0 %>
-  <%= progress_bar([version.closed_percent, version.completed_percent], width: '40%', legend: ('%0.0f' % version.completed_percent)) %>
+  <% closed = version.closed_percent %>
+  <% done = version.completed_percent - closed %>
+  <%= progress_bar([closed, done], width: '40%', legend: ('%0.0f' % version.completed_percent)) %>
   <p class="progress-info">
     <%= link_to_if(version.closed_issues_count > 0,
                    t(:label_x_closed_work_packages_abbr, count: version.closed_issues_count),


### PR DESCRIPTION
The done percentage for roadmap includes the closed items, which is different from budgets. A fix was made for that in 2829331e689378d37ac44cfc9abd4fb062c72f48, but not applied in roadmaps

https://community.openproject.org/work_packages/52232