### PR TITLE
[#50172] fixed dotnet runtime for packaged installation

### DIFF
--- a/packaging/addons/openproject-edition/bin/preinstall
+++ b/packaging/addons/openproject-edition/bin/preinstall
@@ -22,9 +22,9 @@ if [ "$edition" = "bim" ]; then
 		"debian")
 			case "$OSVERSION" in
 				"22.04")
-					wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-					wget -qO /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/22.04/prod.list
-					apt-get update -qq
+					# Ubuntu 22.04 comes with its own package sources for dotnet6 (see https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-redhat#whats-going-on)
+					# Therefore we should use those and not the ones from packages.microsoft.com, as otherwise the assumption for
+					# setting the DOTNET_ROOT later fails, leading to bugs like https://community.openproject.org/wp/50172.
 					;;
 				"20.04")
 					wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -


### PR DESCRIPTION
- https://community.openproject.org/wp/50172
- removed insertion of Microsoft package sources for packaged installation for Ubuntu 22.04