### PR TITLE
Default op-autocompleter to virtualScroll=true

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -181,7 +181,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   @Input() public bufferAmount ? = 4;
 
-  @Input() public virtualScroll?:boolean;
+  @Input() public virtualScroll = true;
 
   @Input() public selectableGroup?:boolean = false;
 


### PR DESCRIPTION
This is noticable on e.g., the sharing modal user invite on community, which renders a lot of users