### PR TITLE
Docs: restore deleted project

### DIFF
--- a/docs/installation-and-operations/operation/restoring/README.md
+++ b/docs/installation-and-operations/operation/restoring/README.md
@@ -6,6 +6,10 @@ sidebar_navigation:
 
 # Restoring an OpenProject backup
 
+This document describes how to restore a complete backup of OpenProject.
+
+Please look [here](./restoring-a-deleted-project/README.md) if you want to restore a deleted project from a backup.
+
 ## Package-based installation (DEB/RPM)
 
 Assuming you have a backup of all the OpenProject files at hand (see the [Backing up](../backing-up) guide), here is how you would restore your OpenProject installation from that backup.
@@ -73,7 +77,7 @@ sudo openproject config:get DATABASE_URL
 #=> e.g.: postgres://<dbusername>:<dbpassword>@<dbhost>:<dbport>/<dbname>
 ```
 
-Then, to restore the PostgreSQL dump please use the `pg_restore` command utility. **WARNING:** The command `--clean --if-exists` is used and it will drop objects in the database and you will lose all changes in this database! Double-check that the database URL above is the database you want to restore to. 
+Then, to restore the PostgreSQL dump please use the `pg_restore` command utility. **WARNING:** The command `--clean --if-exists` is used and it will drop objects in the database and you will lose all changes in this database! Double-check that the database URL above is the database you want to restore to.
 
 This is necessary since the backups of OpenProject does not clean statements to remove existing options and will lead to duplicate index errors when trying to restore to an existing database. The alternative is to drop/recreate the database manually (see below), if you have the permissions to do so.
 
@@ -129,7 +133,7 @@ If you are using docker-compose this is what you do after you started everything
 
 1. Stop the OpenProject container using `docker-compose stop web worker`.
 2. Drop the existing, seeded database using `docker exec -it compose_db_1 psql -U postgres -c 'drop database openproject;'`
-3. If your database doesn't have an openproject user yet, create it with this command: `docker exec -it compose_db_1 psql -U postgres -c 'create user openproject;'` 
+3. If your database doesn't have an openproject user yet, create it with this command: `docker exec -it compose_db_1 psql -U postgres -c 'create user openproject;'`
 4. Recreate the database using `docker exec -it compose_db_1 psql -U postgres -c 'create database openproject owner openproject;'`
 5. Copy the dump onto the container: `docker cp openproject.sql compose_db_1:/`
 6. Source the dump with psql on the container: `docker exec -it compose_db_1 psql -U postgres` followed first by `\c openproject` and then by `\i openproject.sql`. You can leave this console by entering `\q` once it's done.
@@ -207,7 +211,7 @@ but then you use `pg_restore` instead to restore it.
 # 1. copy .pgdump file into container
 docker cp postgresql-dump-20211119210038.pgdump postgres:/
 
-# 2. delete existing database created in step 2) above 
+# 2. delete existing database created in step 2) above
 docker exec -it postgres dropdb -U postgres openproject
 
 # 3. import the dump

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/README.md
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/README.md
@@ -1,0 +1,67 @@
+# Restoring a deleted project
+
+Sometimes it may happen that you delete a project on accident.
+Perhaps it would be too much trouble or more recent data lost to restore a complete backup.
+
+For these kinds of cases we describe here how to restore a single project from a backup.
+The following files will be used in the examples.
+
+* [dump.sql](./dump.sql)
+* [restore.sql](./restore.sql)
+
+There is also a script ([restore.sh](./restore.sh)) that shows how to use everything together.
+
+## 1. Dump project data from backup
+
+First we copy the data from the backup, that was deleted later.
+For each relevant table, a `missing_<table-name>` table is created
+that only contains the missing data.
+
+This is then saved to `missing_data.sql` which will be used to import
+the missing data into the current database.
+
+```
+cat dump.sql | psql -d openproject_backup
+
+pg_dump -d openproject_backup -t 'missing_*' -f missing_data.sql
+```
+
+## 2. Restore missing data
+
+Now that we have the missing data, we can restore it in the current database.
+
+```
+cat missing_data.sql | psql -d openproject
+cat restore.sql | psql -d openproject
+```
+
+First we create the tables with the missing data in the current database.
+This has no effect on the actual data of OpenProject yet.
+Only with executing `restore.sql` will the data be copied from the `missing_<table-name>` tables
+into the corresponding actual `<table-name>` tables.
+
+After this is done, the `missing_*` tables are dropped.
+This all happens within a transaction.
+
+**Project hierarchy**
+
+Now it can happen that the project hierarchy does not look correct in the projects dropdown after
+you restored a deleted project. To fix this, delete the restored project's `lft` and `rgt` columns
+and rebuild the hierarchy.
+
+To do this, start an OpenProject console (e.g. `sudo openproject run console`) and execute the following.
+
+```
+p = Project.find_by(name: "Restored project")
+
+p.update_column :lft, nil
+p.update_column :rgt, nil
+
+Project.rebuild!
+```
+
+This may take a moment depending on the number of projects you have.
+After this is finished, the project hierarchy will look correct again.
+
+This operation is perfectly safe and will not affect any actual data.
+It just affects the display of projects in the projects dropdown and projects list.

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/README.md
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/README.md
@@ -20,6 +20,9 @@ that only contains the missing data.
 This is then saved to `missing_data.sql` which will be used to import
 the missing data into the current database.
 
+Before performing the next step, edit the `dump.sql` file and change the missing project ID
+to the correct value in the head of the file where it says 'DEFINE MISSING PROJECT ID HERE'.
+
 ```
 cat dump.sql | psql -d openproject_backup
 

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/dump.sql
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/dump.sql
@@ -1,0 +1,242 @@
+set search_path="public";
+
+BEGIN;
+
+-- remove all the missing_* tables we created during the last try if there are any
+DO
+$$
+DECLARE table_to_remove TEXT;
+BEGIN
+FOR table_to_remove IN (
+  select table_name
+  from information_schema.tables
+  where table_schema = 'public' and table_name like 'missing_%'
+)
+LOOP
+  EXECUTE 'DROP TABLE IF EXISTS ' || table_to_remove || ' CASCADE';
+END LOOP;
+END;
+$$;
+
+CREATE TABLE missing_projects AS (
+  select * from projects where id = 773
+);
+
+UPDATE missing_projects SET lft = null, rgt = null;
+
+CREATE TABLE missing_work_packages AS (
+  select * from work_packages where project_id = 773
+);
+CREATE TABLE missing_attachments AS (
+  select * from attachments where container_type = 'WorkPackage' and container_id in (
+    select id from missing_work_packages
+  )
+);
+CREATE TABLE missing_meetings AS (
+  select * from meetings where project_id = 773
+);
+CREATE TABLE missing_meeting_contents AS (
+  select * from meeting_contents where meeting_id in (select id from missing_meetings)
+);
+CREATE TABLE missing_documents AS (
+  select * from documents where project_id = 773
+);
+CREATE TABLE missing_forums AS (
+  select * from forums where project_id = 773
+);
+CREATE TABLE missing_messages AS (
+  select * from messages where forum_id in (select id from missing_forums)
+);
+CREATE TABLE missing_wikis AS (
+  select * from wikis where project_id = 773
+);
+CREATE TABLE missing_wiki_pages AS (
+  select * from wiki_pages where wiki_id in (select id from missing_wikis)
+);
+CREATE TABLE missing_budgets AS (
+  select * from budgets where project_id = 773
+);
+CREATE TABLE missing_repositories AS (
+  select * from repositories where project_id = 773
+);
+CREATE TABLE missing_changesets AS (
+  select * from changesets where repository_id in (select id from missing_repositories)
+);
+CREATE TABLE missing_news AS (
+  select * from news where project_id = 773
+);
+CREATE TABLE missing_time_entries AS (
+  select * from time_entries where project_id = 773
+);
+-- along projects, work packages and attachments, plus the respective journals,
+-- we would technically also have to restore the following:
+--   budgets, changesets, news, time entries
+CREATE TABLE missing_journals AS (
+  select * from journals where
+    (journable_id = 773 and journable_type = 'Project') or
+    (journable_id in (select id from missing_work_packages) and journable_type = 'WorkPackage') or
+    (journable_id in (select id from missing_attachments) and journable_type = 'Attachment') or
+    (journable_id in (select id from missing_meetings) and journable_type = 'Meeting') or
+    (journable_id in (select id from missing_meeting_contents) and journable_type = 'MeetingContent') or
+    (journable_id in (select id from missing_documents) and journable_type = 'Document') or
+    (journable_id in (select id from missing_messages) and journable_type = 'Message') or
+    (journable_id in (select id from missing_wiki_pages) and journable_type = 'WikiPage') or
+    (journable_id in (select id from missing_budgets) and journable_type = 'Budget') or
+    (journable_id in (select id from missing_changesets) and journable_type = 'Changeset') or
+    (journable_id in (select id from missing_news) and journable_type = 'News') or
+    (journable_id in (select id from missing_time_entries) and journable_type = 'TimeEntry')
+);
+CREATE TABLE missing_project_journals AS (
+  select * from project_journals where id in (
+    select data_id from missing_journals where journable_type = 'Project'
+  )
+);
+CREATE TABLE missing_work_package_journals AS (
+  select * from work_package_journals where id in (
+    select data_id from missing_journals where journable_type = 'WorkPackage'
+  )
+);
+CREATE TABLE missing_attachment_journals AS (
+  select * from attachment_journals where id in (
+    select data_id from missing_journals where journable_type = 'Attachment'
+  )
+);
+CREATE TABLE missing_meeting_journals AS (
+  select * from meeting_journals where id in (
+    select data_id from missing_journals where journable_type = 'Meeting'
+  )
+);
+CREATE TABLE missing_meeting_content_journals AS (
+  select * from meeting_content_journals where id in (
+    select data_id from missing_journals where journable_type = 'MeetingContent'
+  )
+);
+CREATE TABLE missing_document_journals AS (
+  select * from document_journals where id in (
+    select data_id from missing_journals where journable_type = 'Document'
+  )
+);
+CREATE TABLE missing_message_journals AS (
+  select * from message_journals where id in (
+    select data_id from missing_journals where journable_type = 'Message'
+  )
+);
+CREATE TABLE missing_wiki_page_journals AS (
+  select * from wiki_page_journals where id in (
+    select data_id from missing_journals where journable_type = 'WikiPage'
+  )
+);
+CREATE TABLE missing_budget_journals AS (
+  select * from budget_journals where id in (
+    select data_id from missing_journals where journable_type = 'Budget'
+  )
+);
+CREATE TABLE missing_changeset_journals AS (
+  select * from changeset_journals where id in (
+    select data_id from missing_journals where journable_type = 'Changeset'
+  )
+);
+CREATE TABLE missing_news_journals AS (
+  select * from news_journals where id in (
+    select data_id from missing_journals where journable_type = 'News'
+  )
+);
+CREATE TABLE missing_time_entry_journals AS (
+  select * from time_entry_journals where id in (
+    select data_id from missing_journals where journable_type = 'TimeEntry'
+  )
+);
+
+CREATE TABLE missing_custom_values AS (
+  select * from custom_values where
+    (customized_type = 'Project' and customized_id = 773) or
+    (customized_type = 'WorkPackage' and customized_id in (select id from missing_work_packages))
+    -- only these are present in the dump, but could also include versions, groups, users, spent time, ...
+    -- in the final version we should just loop over `distinct(customized_type)`
+);
+
+CREATE TABLE missing_enabled_modules AS (
+  select * from enabled_modules where project_id = 773
+);
+
+CREATE TABLE missing_versions AS (
+  select * from versions where project_id = 773
+);
+
+CREATE TABLE missing_categories AS (
+  select * from categories where project_id = 773
+);
+
+CREATE TABLE missing_cost_entries AS (
+  select * from cost_entries where project_id = 773
+);
+
+CREATE TABLE missing_cost_queries AS (
+  select * from cost_queries where project_id = 773
+);
+
+CREATE TABLE missing_custom_actions_projects AS (
+  select * from custom_actions_projects where project_id = 773
+);
+
+CREATE TABLE missing_custom_fields_projects AS (
+  select * from custom_fields_projects where project_id = 773
+);
+
+CREATE TABLE missing_done_statuses_for_project AS (
+  select * from done_statuses_for_project where project_id = 773
+);
+
+CREATE TABLE missing_grids AS (
+  select * from grids where project_id = 773
+);
+
+CREATE TABLE missing_members AS (
+  select * from members where project_id = 773
+);
+
+CREATE TABLE missing_notification_settings as (
+  select * from notification_settings where project_id = 773
+);
+
+CREATE TABLE missing_rates as (
+  select * from rates where project_id = 773
+);
+
+CREATE TABLE missing_projects_types as (
+  select * from projects_types where project_id = 773
+);
+
+CREATE TABLE missing_queries AS (
+  select * from queries where project_id = 773
+);
+
+CREATE TABLE missing_time_entry_activities_projects AS (
+  select * from time_entry_activities_projects where project_id = 773
+);
+
+CREATE TABLE missing_webhooks_projects AS (
+  select * from webhooks_projects where project_id = 773
+);
+
+CREATE TABLE missing_project_storages AS (
+  select * from project_storages where project_id = 773
+);
+
+CREATE TABLE missing_notifications AS (
+  select * from notifications where project_id = 773
+);
+
+CREATE TABLE missing_version_settings AS (
+  select * from version_settings where project_id = 773
+);
+
+CREATE TABLE missing_enumerations AS (
+  select * from enumerations where project_id = 773
+);
+
+CREATE TABLE missing_ifc_models AS (
+  select * from ifc_models where project_id = 773
+);
+
+COMMIT;

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/dump.sql
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/dump.sql
@@ -37,7 +37,7 @@ BEGIN
 FOR table_to_remove IN (
   select table_name
   from information_schema.tables
-  where table_schema = 'instance_community' and table_name like 'missing_%'
+  where table_schema = 'public' and table_name like 'missing_%'
 )
 LOOP
   EXECUTE 'DROP TABLE IF EXISTS ' || table_to_remove || ' CASCADE';
@@ -57,7 +57,7 @@ EXECUTE 'CREATE TABLE missing_projects AS (select * from projects where id = ' |
 FOR source_table, source_column IN (
   select table_name, column_name
   from information_schema.columns
-  where table_schema = 'instance_community' and column_name = 'project_id'
+  where table_schema = 'public' and column_name = 'project_id'
     and table_name not like '%_journals'
     and table_name != 'grids'
     -- apparently grids do not get deleted when a project is which is why we skip them here

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sh
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sh
@@ -2,6 +2,7 @@
 
 # Dump missing data from backup.
 # This assumes you restored the correct backup into a database called `openproject_backup`.
+# Edit `dump.sql` to define the missing project ID first!
 cat dump.sql | psql -d openproject_backup
 pg_dump -d openproject_backup -t 'missing_*' -f missing_data.sql
 

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sh
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Dump missing data from backup.
+# This assumes you restored the correct backup into a database called `openproject_backup`.
+cat dump.sql | psql -d openproject_backup
+pg_dump -d openproject_backup -t 'missing_*' -f missing_data.sql
+
+# Restore missing data in current database.
+# This assumes your current OpenProject database is called `openproject`.
+cat missing_data.sql | psql -d openproject
+cat restore.sql | psql -d openproject

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sql
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sql
@@ -1,0 +1,39 @@
+set search_path="public";
+
+BEGIN;
+
+DO
+$$
+DECLARE table_to_copy TEXT;
+BEGIN
+FOR table_to_copy IN (
+  select table_name
+  from information_schema.tables
+  where table_schema = 'public' and table_name like 'missing_%'
+)
+LOOP
+  raise notice 'Restoring % to %', table_to_copy, REPLACE(table_to_copy, 'missing_', '');
+
+  EXECUTE 'INSERT INTO ' || REPLACE(table_to_copy, 'missing_', '') ||
+    ' (SELECT * FROM ' || table_to_copy || ');';
+END LOOP;
+END;
+$$;
+
+-- remove all the missing_* tables we created after we're done
+DO
+$$
+DECLARE table_to_remove TEXT;
+BEGIN
+FOR table_to_remove IN (
+  select table_name
+  from information_schema.tables
+  where table_schema = 'public' and table_name like 'missing_%'
+)
+LOOP
+  EXECUTE 'DROP TABLE IF EXISTS ' || table_to_remove || ' CASCADE';
+END LOOP;
+END;
+$$;
+
+COMMIT;

--- a/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sql
+++ b/docs/installation-and-operations/operation/restoring/restoring-a-deleted-project/restore.sql
@@ -1,4 +1,4 @@
-set search_path="public";
+SET search_path="public";
 
 BEGIN;
 
@@ -10,6 +10,8 @@ FOR table_to_copy IN (
   select table_name
   from information_schema.tables
   where table_schema = 'public' and table_name like 'missing_%'
+  order by table_name = 'missing_projects' desc
+  -- order such that project is re-created first to satisfy foreign key constraints
 )
 LOOP
   raise notice 'Restoring % to %', table_to_copy, REPLACE(table_to_copy, 'missing_', '');


### PR DESCRIPTION
The default OpenProject backup and restore procedure only allows for an all or nothing approach.

This PR adds some helpful scripts and documentation on how to actually restore just a single project from a backup.
This is particularly useful as it occasionally happens that people delete projects or even whole trees of projects by accident.