### PR TITLE
fix nested checkboxes style

### DIFF
--- a/frontend/src/global_styles/content/user-content/_list.sass
+++ b/frontend/src/global_styles/content/user-content/_list.sass
@@ -26,19 +26,31 @@ ol.op-uc-list
     list-style: none
   list-style-type: decimal
   ol
+    &.op-uc-list_task-list
+      list-style: none
     list-style-type: lower-latin
     ol
+      &.op-uc-list_task-list
+        list-style: none
       list-style-type: lower-roman
       ol
+        &.op-uc-list_task-list
+          list-style: none
         list-style-type: upper-latin
         ol
+          &.op-uc-list_task-list
+            list-style: none
           list-style-type: upper-roman
 ul.op-uc-list
   &_task-list
     list-style: none
   list-style-type: disc
   ul
+    &.op-uc-list_task-list
+      list-style: none
     list-style-type: circle
     ul,
     ul ul
+      &.op-uc-list_task-list
+        list-style: none
       list-style-type: square


### PR DESCRIPTION
Nested lists have a rule for a marker for several levels which has higher specificity than the rule for checkboxes to not have a marker.

| was | now |
| --- | --- |
| <img width="307" alt="Screenshot 2024-01-25 at 13 44 31" src="https://github.com/opf/openproject/assets/18144/7a6efe52-1fa1-49a1-9d0c-d9f5991cd51e"> | <img width="307" alt="Screenshot 2024-01-25 at 13 44 56" src="https://github.com/opf/openproject/assets/18144/c2b40155-75c9-4c5f-bb23-c76fdcd4ccd9"> |

https://community.openproject.org/projects/openproject/work_packages/51247/activity