### PR TITLE
fix auth source label in user form

### DIFF
--- a/app/views/users/form/authentication/_auth_source.html.erb
+++ b/app/views/users/form/authentication/_auth_source.html.erb
@@ -5,7 +5,7 @@
                             :id,
                             :name,
                             {
-                              label: :'activerecord.attributes.user.ldap_auth_source',
+                              label: :'activerecord.attributes.user.auth_source',
                               container_class: '-middle',
                               include_blank: t(:label_internal)
                             },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,7 +231,7 @@ en:
       editable: "Allow the field to be editable by users themselves."
       visible: "Make field visible for all users (non-admins) in the project overview and displayed in the project details widget on the Project Overview."
       is_filter: >
-        Allow the custom field to be used in a filter in work package views. 
+        Allow the custom field to be used in a filter in work package views.
         Note that only with 'For all projects' selected, the custom field will show up in global views.
 
     tab:
@@ -656,6 +656,7 @@ en:
         color: "Color"
       user:
         admin: "Administrator"
+        auth_source: "Authentication source"
         ldap_auth_source: "LDAP connection"
         identity_url: "Identity URL"
         current_password: "Current password"

--- a/spec/support/pages/new_user.rb
+++ b/spec/support/pages/new_user.rb
@@ -43,7 +43,7 @@ module Pages
       form.fill! 'Last name', :last_name
       form.fill! 'Email', :email
 
-      form.select! 'LDAP connection', :ldap_auth_source
+      form.select! 'Authentication source', :ldap_auth_source
       form.fill! 'Username', :login
 
       form.set_checked! 'Administrator', :admin


### PR DESCRIPTION
"internal" is not LDAP, so the label is wrong

I'm open for suggestions for better names than "Authentication source".

![image](https://github.com/opf/openproject/assets/158871/7fee448a-9fb2-4ddd-afa8-c67077f75572)
