### PR TITLE
[52389] Dynamic meeting HTML titles missing

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -46,6 +46,7 @@ class MeetingsController < ApplicationController
   include OpTurbo::ComponentStream
   include ApplicationComponentStreams
   include Meetings::AgendaComponentStreams
+  include MetaTagsHelper
 
   menu_item :new_meeting, only: %i[new create]
 
@@ -60,6 +61,7 @@ class MeetingsController < ApplicationController
   end
 
   def show
+    html_title "#{t(:label_meeting)}: #{@meeting.title}"
     if @meeting.is_a?(StructuredMeeting)
       render(Meetings::ShowComponent.new(meeting: @meeting))
     elsif @meeting.agenda.present? && @meeting.agenda.locked?

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -27,7 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title "#{t(:label_meeting)}: #{@meeting.title}" %>
 <%= toolbar title: t(:label_meeting),
             link_to: link_to(@meeting),
             html: { class: 'meeting--main-toolbar -with-dropdown' } do %>


### PR DESCRIPTION
Add html title to meetings pages

https://community.openproject.org/projects/openproject/work_packages/52389/activity