### PR TITLE
Require Base64 in the github_pr_errors script

### DIFF
--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -7,6 +7,7 @@ Bundler.setup(:default, :development)
 require 'colored2'
 require 'json'
 require 'optparse'
+require 'base64'
 require 'pathname'
 require 'pry'
 require 'yaml'


### PR DESCRIPTION
Fix the error while running `script/github_pr_errrors`

```
~/Projects/openproject(dev|✔) % script/github_pr_errors
Looking for the last 'Test suite' workflow run in current branch dev
Failed to perform API request GET https://api.github.com/repos/opf/openproject/actions/runs?branch=dev: uninitialized constant Base64
```