### PR TITLE
Allow anonymous users to access public boards

### DIFF
--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -12,12 +12,9 @@
         data-project-id="<%= @project.id %>"
         data-project-identifier="<%= @project.identifier %>"/>
 <% end %>
-<% unless User.current.anonymous? %>
-  <meta name="current_user"
-        data-name="<%= User.current.name %>"
-        data-mail="<%= User.current.mail %>"
-        data-id="<%= User.current.id %>" />
-<% end %>
+<meta name="current_user"
+      data-name="<%= User.current.name %>"
+      data-id="<%= User.current.id %>"/>
 
 <% if Setting.demo_projects_available %><meta name="demo_projects_available" content="true"/><% end %>
 <% if Setting.boards_demo_data_available %><meta name="boards_demo_data_available" content="true"/><% end %>

--- a/frontend/src/app/core/current-user/current-user.module.ts
+++ b/frontend/src/app/core/current-user/current-user.module.ts
@@ -1,7 +1,4 @@
-import {
-  Injector,
-  NgModule,
-} from '@angular/core';
+import { Injector, NgModule } from '@angular/core';
 
 import { CurrentUserService } from './current-user.service';
 import { CurrentUserStore } from './current-user.store';
@@ -22,7 +19,6 @@ export function bootstrapModule(injector:Injector):void {
   currentUserService.setUser({
     id: userMeta?.dataset.id || null,
     name: userMeta?.dataset.name || null,
-    mail: userMeta?.dataset.mail || null,
   });
 }
 

--- a/frontend/src/app/core/current-user/current-user.query.ts
+++ b/frontend/src/app/core/current-user/current-user.query.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Query } from '@datorama/akita';
-import {
-  CurrentUserState,
-  CurrentUserStore,
-} from './current-user.store';
+import { CurrentUserState, CurrentUserStore } from './current-user.store';
 
 @Injectable()
 export class CurrentUserQuery extends Query<CurrentUserState> {
@@ -13,5 +10,5 @@ export class CurrentUserQuery extends Query<CurrentUserState> {
 
   isLoggedIn$ = this.select((state) => !!state.id);
 
-  user$ = this.select(({ id, name, mail }) => ({ id, name, mail }));
+  user$ = this.select(({ id, name }) => ({ id, name }));
 }

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -28,20 +28,11 @@
 
 import { Injectable } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import {
-  CurrentUser,
-  CurrentUserStore,
-} from './current-user.store';
+import { CurrentUser, CurrentUserStore } from './current-user.store';
 import { CurrentUserQuery } from './current-user.query';
 import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 import { Observable } from 'rxjs';
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  switchMap,
-  take,
-} from 'rxjs/operators';
+import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators';
 import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
 
@@ -80,7 +71,7 @@ export class CurrentUserService {
       .principalFilter$()
       .pipe(
         map((userFilter) => {
-          const filters:ApiV3ListFilter[] = [userFilter];
+          const filters:ApiV3ListFilter[] = _.compact([userFilter]);
 
           if (projectContext) {
             filters.push(['context', '=', [projectContext === 'global' || projectContext === 'projects' ? 'g' : `p${projectContext}`]]);
@@ -133,13 +124,18 @@ export class CurrentUserService {
   /**
    * Returns a principal filter for the current user.
    */
-  private principalFilter$():Observable<ApiV3ListFilter> {
+  private principalFilter$():Observable<ApiV3ListFilter|null> {
     return this
       .user$
       .pipe(
-        filter((user) => !!user.id),
         take(1),
-        map((user) => ['principal', '=', [user.id as string]]),
+        map((user) => {
+          if (user.id === null) {
+            return null;
+          }
+
+          return ['principal', '=', [user.id]];
+        }),
       );
   }
 
@@ -160,7 +156,6 @@ export class CurrentUserService {
   private _user:CurrentUser = {
     id: null,
     name: null,
-    mail: null,
   };
 
   /** @deprecated Use the store mechanism `currentUserQuery.user$` */
@@ -171,11 +166,6 @@ export class CurrentUserService {
   /** @deprecated Use the store mechanism `currentUserQuery.user$` */
   public get name():string {
     return this._user.name || '';
-  }
-
-  /** @deprecated Use the store mechanism `currentUserQuery.user$` */
-  public get mail():string {
-    return this._user.mail || '';
   }
 
   /** @deprecated Use the store mechanism `currentUserQuery.user$` */

--- a/frontend/src/app/core/current-user/current-user.store.ts
+++ b/frontend/src/app/core/current-user/current-user.store.ts
@@ -27,15 +27,11 @@
 //++
 
 import { Injectable } from '@angular/core';
-import {
-  Store,
-  StoreConfig,
-} from '@datorama/akita';
+import { Store, StoreConfig } from '@datorama/akita';
 
 export interface CurrentUser {
   id:string|null;
   name:string|null;
-  mail:string|null;
 }
 
 export interface CurrentUserState extends CurrentUser {
@@ -45,7 +41,6 @@ export function createInitialState():CurrentUserState {
   return {
     id: null,
     name: null,
-    mail: null,
   };
 }
 

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -15,7 +15,9 @@ import {
   LoadingIndicatorService,
   withLoadingIndicator,
 } from 'core-app/core/loading-indicator/loading-indicator.service';
-import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
+import {
+  WorkPackageInlineCreateService,
+} from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
 import { BoardInlineCreateService } from 'core-app/features/boards/board/board-list/board-inline-create.service';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -23,45 +25,54 @@ import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { Board } from 'core-app/features/boards/board/board';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
-import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
-import { WorkPackageCardViewComponent } from 'core-app/features/work-packages/components/wp-card-view/wp-card-view.component';
-import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
+import {
+  Highlighting,
+} from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
+import {
+  WorkPackageCardViewComponent,
+} from 'core-app/features/work-packages/components/wp-card-view/wp-card-view.component';
+import {
+  WorkPackageStatesInitializationService,
+} from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
 import { BoardService } from 'core-app/features/boards/board/board.service';
-import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
+import {
+  HalResourceEditingService,
+} from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
-import { BoardActionsRegistryService } from 'core-app/features/boards/board/board-actions/board-actions-registry.service';
+import {
+  BoardActionsRegistryService,
+} from 'core-app/features/boards/board/board-actions/board-actions-registry.service';
 import { BoardActionService } from 'core-app/features/boards/board/board-actions/board-action.service';
 import { ComponentType } from '@angular/cdk/portal';
 import { CausedUpdatesService } from 'core-app/features/boards/board/caused-updates/caused-updates.service';
 import { BoardListMenuComponent } from 'core-app/features/boards/board/board-list/board-list-menu.component';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
-import { WorkPackageCardDragAndDropService } from 'core-app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service';
+import {
+  WorkPackageCardDragAndDropService,
+} from 'core-app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service';
 import { BoardFiltersService } from 'core-app/features/boards/board/board-filter/board-filters.service';
+import { StateService, TransitionService } from '@uirouter/core';
 import {
-  StateService,
-  TransitionService,
-} from '@uirouter/core';
-import { WorkPackageViewFocusService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
-import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
-import { BoardListCrossSelectionService } from 'core-app/features/boards/board/board-list/board-list-cross-selection.service';
+  WorkPackageViewFocusService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
 import {
-  debounceTime,
-  filter,
-  map,
-  take,
-} from 'rxjs/operators';
+  WorkPackageViewSelectionService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
+import {
+  BoardListCrossSelectionService,
+} from 'core-app/features/boards/board/board-list/board-list-cross-selection.service';
+import { debounceTime, filter, map } from 'rxjs/operators';
 import { ChangeItem } from 'core-app/shared/components/fields/changeset/changeset';
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ApiV3Filter } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
-import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
+import {
+  KeepTabService,
+} from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import {
-  HalEvent,
-  HalEventsService,
-} from 'core-app/features/hal/services/hal-events.service';
+import { HalEvent, HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { firstValueFrom } from 'rxjs';
 import {

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -236,8 +236,8 @@ RSpec.describe 'layouts/base' do
     context 'with the user being anonymous' do
       let(:current_user) { anonymous }
 
-      it 'has no current_user metatag' do
-        expect(rendered).to have_no_css('meta[name=current_user]', visible: false)
+      it 'has a current_user metatag' do
+        expect(rendered).to have_css('meta[name=current_user]', visible: false)
       end
     end
   end


### PR DESCRIPTION
Currently, we're no passing through any capabilities request for anonymous users, as we don't have the appropriate user ID (even though capability API allows these requests). Removing the restriction there solves the issue. I also removed the unused email field which did not exist for anonymous users.

Since there's some potential for additional unnoticed changes here, I've assigned this to dev / 13.3

https://community.openproject.org/work_packages/51850