### PR TITLE
[#52155] Duplicate scrollbars on project list page

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -28,36 +28,38 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title(t(:label_project_plural)) -%>
 
-<%= render Projects::IndexPageHeaderComponent.new(
-  projects: @projects,
-  query: @query,
-  current_user:
-) %>
+<div class="project-list-container">
+  <%= render Projects::IndexPageHeaderComponent.new(
+    projects: @projects,
+    query: @query,
+    current_user:
+  ) %>
 
-<%= render(Projects::ProjectsFiltersComponent.new(query: @query)) do |component|
-  if current_user.allowed_globally?(:add_project)
-    component.with_button( 
-      tag: :a,
-      href: new_project_path,
-      scheme: :primary,
-      size: :medium,
-      aria: { label: I18n.t(:label_project_new) },
-      data: { 'test-selector': 'project-new-button' }) do |button|
-        button.with_leading_visual_icon(icon: :plus)
-        Project.model_name.human
+  <%= render(Projects::ProjectsFiltersComponent.new(query: @query)) do |component|
+    if current_user.allowed_globally?(:add_project)
+      component.with_button(
+        tag: :a,
+        href: new_project_path,
+        scheme: :primary,
+        size: :medium,
+        aria: { label: I18n.t(:label_project_new) },
+        data: { 'test-selector': 'project-new-button' }) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          Project.model_name.human
+        end
       end
     end
-  end
-%>
+  %>
 
-<div data-controller="project"
-  data-application-target="dynamic">
-  <%= render Projects::TableComponent.new(
-    rows: @projects,
-    current_user: current_user,
-    orders: @orders,
-    params: params) %>
+  <div data-controller="project"
+    data-application-target="dynamic" class="project-list">
+    <%= render Projects::TableComponent.new(
+      rows: @projects,
+      current_user: current_user,
+      orders: @orders,
+      params: params) %>
+  </div>
+
+  <%= render Projects::StorageInformationComponent.new(
+    current_user: current_user) %>
 </div>
-
-<%= render Projects::StorageInformationComponent.new(
-  current_user: current_user) %>

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -31,6 +31,9 @@ $project-table--child-indentation: 1.1em
 $project-table--icon-distance: 5px
 $project-table--description-indention: 9px
 
+$toolbar-height: 80px
+$toolbar-height--mobile: 100px
+
 @mixin calc-indentation-name($indentation)
   // This does not work for big font-sizes
   padding-left: calc(#{$indentation} * #{$project-table--child-indentation} + #{$project-table--start-indentation} - #{$project-table--icon-distance})
@@ -134,3 +137,14 @@ body.controller-projects.action-index
     padding-left: 1em
   li
     list-style-type: none
+
+.project-list-container
+  display: flex
+  flex-direction: column
+  max-height: calc(100vh - #{$toolbar-height})
+
+.project-list
+  display: flex
+  flex-grow: 1
+  overflow: scroll
+

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -34,17 +34,9 @@
 
 $input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix', 'a.button'
 
-$toolbar-height: 80px
-$toolbar-height--mobile: 100px
-
 .generic-table--flex-container
   display: flex
   flex-direction: column
-  // Calculate table size by subtracting the space above
-  max-height: calc(100vh - #{var(--header-height)} - #{$toolbar-height})
-
-  @media screen and (max-width: $breakpoint-sm)
-    max-height: calc(100vh - #{var(--header-height)} - #{$toolbar-height--mobile})
 
   .generic-table--results-container
     padding-bottom: $spot-spacing-10


### PR DESCRIPTION
OP WP: [#52155](https://community.openproject.org/work_packages/52155) 

To stop duplicate scrollbars to appear the project list height needed to be adjusted.

The height calculation got moved out of the table component and into the project list index page.
The project list is dynamically growing (`flex-grow: 1`) now and fills up the available space without being too high.

I am not sure if `$toolbar-height--mobile: 100px` is still in use. I could not see a difference in toolbar height.