### PR TITLE
[52252] Exclude derived_remaining_time from work package form

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -35,6 +35,7 @@ module Type::Attributes
                 derived_start_date
                 derived_due_date
                 derived_estimated_time
+                derived_remaining_time
                 ignore_non_working_days
                 duration
                 description
@@ -80,6 +81,7 @@ module Type::Attributes
 
       OpenProject::Cache.fetch('all_work_package_form_attributes',
                                *wp_cf_cache_parts,
+                               EXCLUDED.length,
                                merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Shared Work Package Access',
       %i[type subject description
          assignee responsible
          estimatedTime remainingTime
-         combinedDate percentageDone category version derivedRemainingTime
+         combinedDate percentageDone category version
          overallCosts laborCosts].each do |field|
         work_package_page.edit_field(field).expect_read_only
       end
@@ -174,7 +174,7 @@ RSpec.describe 'Shared Work Package Access',
       %i[type subject description
          assignee responsible
          estimatedTime remainingTime
-         combinedDate percentageDone category version derivedRemainingTime
+         combinedDate percentageDone category version
          overallCosts laborCosts].each do |field|
         work_package_page.edit_field(field).expect_read_only
       end
@@ -258,7 +258,7 @@ RSpec.describe 'Shared Work Package Access',
           .to be_editable
       end
       # Except for
-      %i[version derivedRemainingTime
+      %i[version
          overallCosts laborCosts].each do |field|
         work_package_page.edit_field(field).expect_read_only
       end


### PR DESCRIPTION
https://community.openproject.org/work_packages/52252

`Derived Remaining Time` attribute was accidentaly added to the work package form when it was introduced in #13401. This PR removes it (actually, it hides it).

It includes the number of `EXCLUDED` attributes in the cache key for the work package form attributes. This ensures that the cache is invalidated when the number of excluded attributes changes. Without it, one may still see the same attribute groups.