### PR TITLE
Update Primer to version 0.22.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -382,4 +382,4 @@ end
 
 gem 'openproject-octicons', '~>19.8.0'
 gem 'openproject-octicons_helper', '~>19.8.0'
-gem 'openproject-primer_view_components', '~>0.20.0'
+gem 'openproject-primer_view_components', '~>0.22.1'

--- a/Gemfile
+++ b/Gemfile
@@ -382,4 +382,4 @@ end
 
 gem 'openproject-octicons', '~>19.8.0'
 gem 'openproject-octicons_helper', '~>19.8.0'
-gem 'openproject-primer_view_components', '~>0.22.1'
+gem 'openproject-primer_view_components', '~>0.22.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -756,7 +756,7 @@ GEM
       actionview
       openproject-octicons (= 19.8.0)
       railties
-    openproject-primer_view_components (0.20.0)
+    openproject-primer_view_components (0.22.1)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.8.0)
@@ -1227,7 +1227,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.8.0)
   openproject-octicons_helper (~> 19.8.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.20.0)
+  openproject-primer_view_components (~> 0.22.1)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -756,7 +756,7 @@ GEM
       actionview
       openproject-octicons (= 19.8.0)
       railties
-    openproject-primer_view_components (0.22.1)
+    openproject-primer_view_components (0.22.2)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.8.0)
@@ -1227,7 +1227,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.8.0)
   openproject-octicons_helper (~> 19.8.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.22.1)
+  openproject-primer_view_components (~> 0.22.2)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!

--- a/app/views/augmented/_autocomplete_select_decoration.html.erb
+++ b/app/views/augmented/_autocomplete_select_decoration.html.erb
@@ -2,9 +2,10 @@
   <%= content_tag :'opce-select-decoration',
                   {},
                   data: {
-                      "multiselect": multiple,
+                      multiple:,
                       "input-name": input_name,
                       "input-id": input_id,
+                      "append-to": defined?(append_to) ? append_to : 'body',
                       key:,
                       options: JSON.dump(select_options),
                   } %>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.8.0",
-        "@openproject/primer-view-components": "^0.20.0",
+        "@openproject/primer-view-components": "^0.22.1",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.1.1",
         "@uirouter/angular": "^12.0.0",
@@ -4491,9 +4491,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.7.tgz",
-      "integrity": "sha512-WNthEIPPXnFQkumLby6yVxhyOcA/GtMnlByHwEglMO9WZckoaqidnpLp2JFzAh2RDOZxn+Xt3ffSMKId9cPjOQ=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "node_modules/@openproject/octicons-angular": {
       "version": "19.8.0",
@@ -4510,9 +4510,9 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.20.0.tgz",
-      "integrity": "sha512-RWSLLS3PvyXyqXB53l4foQcb4hfOd8l+LWVedOHbYa+8nWVotkgi1TUrZCeIRjIOuTQrmLNx2xyBcmANcktQAw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
+      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -4523,7 +4523,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.6",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       }
     },
@@ -4595,9 +4595,9 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.20.0.tgz",
-      "integrity": "sha512-RWSLLS3PvyXyqXB53l4foQcb4hfOd8l+LWVedOHbYa+8nWVotkgi1TUrZCeIRjIOuTQrmLNx2xyBcmANcktQAw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
+      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -4608,7 +4608,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.6",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       }
     },
@@ -23681,9 +23681,9 @@
       "optional": true
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.7.tgz",
-      "integrity": "sha512-WNthEIPPXnFQkumLby6yVxhyOcA/GtMnlByHwEglMO9WZckoaqidnpLp2JFzAh2RDOZxn+Xt3ffSMKId9cPjOQ=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "@openproject/octicons-angular": {
       "version": "19.8.0",
@@ -23694,9 +23694,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.20.0.tgz",
-      "integrity": "sha512-RWSLLS3PvyXyqXB53l4foQcb4hfOd8l+LWVedOHbYa+8nWVotkgi1TUrZCeIRjIOuTQrmLNx2xyBcmANcktQAw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
+      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -23707,7 +23707,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.6",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       }
     },
@@ -23752,7 +23752,7 @@
       "integrity": "sha512-1XRx8FwWxrr8SSZit2C9KxaofTi0CELKbGmHGpmYQmRIAECIa912Emp4BlAC7iQmf3Tb5oZOkke5zuAt+seDxg==",
       "requires": {
         "@primer/primitives": "^7.12.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.20.0"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.1"
       }
     },
     "@primer/primitives": {
@@ -23761,9 +23761,9 @@
       "integrity": "sha512-tiJEMxy5hDi9a3YxgrBeJScLPUQSLuWsKDNuoXXiX7zLzejnYdxXXG3qOaNHzNyyn8TkSQkzmKx0ioaSLR2zNw=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.20.0.tgz",
-      "integrity": "sha512-RWSLLS3PvyXyqXB53l4foQcb4hfOd8l+LWVedOHbYa+8nWVotkgi1TUrZCeIRjIOuTQrmLNx2xyBcmANcktQAw==",
+      "version": "npm:@openproject/primer-view-components@0.22.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
+      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -23774,7 +23774,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.6",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.8.0",
-        "@openproject/primer-view-components": "^0.22.1",
+        "@openproject/primer-view-components": "^0.22.2",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.1.1",
         "@uirouter/angular": "^12.0.0",
@@ -4510,9 +4510,9 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
-      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.2.tgz",
+      "integrity": "sha512-Tiasv9lc/Ey87PuU4ZffzWhZwxp+RBQULD4bFWjOB/03yPGHejHuzl47Ak2IxT/laUUotVFZsIWvo2a5/7H0Kg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -4595,9 +4595,9 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
-      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.2.tgz",
+      "integrity": "sha512-Tiasv9lc/Ey87PuU4ZffzWhZwxp+RBQULD4bFWjOB/03yPGHejHuzl47Ak2IxT/laUUotVFZsIWvo2a5/7H0Kg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -23694,9 +23694,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
-      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.2.tgz",
+      "integrity": "sha512-Tiasv9lc/Ey87PuU4ZffzWhZwxp+RBQULD4bFWjOB/03yPGHejHuzl47Ak2IxT/laUUotVFZsIWvo2a5/7H0Kg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",
@@ -23752,7 +23752,7 @@
       "integrity": "sha512-1XRx8FwWxrr8SSZit2C9KxaofTi0CELKbGmHGpmYQmRIAECIa912Emp4BlAC7iQmf3Tb5oZOkke5zuAt+seDxg==",
       "requires": {
         "@primer/primitives": "^7.12.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.1"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.2"
       }
     },
     "@primer/primitives": {
@@ -23761,9 +23761,9 @@
       "integrity": "sha512-tiJEMxy5hDi9a3YxgrBeJScLPUQSLuWsKDNuoXXiX7zLzejnYdxXXG3qOaNHzNyyn8TkSQkzmKx0ioaSLR2zNw=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.22.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.1.tgz",
-      "integrity": "sha512-WYGvo5j60fhe0wQAQBLTekQbpOFQERAszMXN8H5Koil2GkTmyBnsGhYvujAbapb0JuFigtZ9YMLby6D6f6j7FA==",
+      "version": "npm:@openproject/primer-view-components@0.22.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.22.2.tgz",
+      "integrity": "sha512-Tiasv9lc/Ey87PuU4ZffzWhZwxp+RBQULD4bFWjOB/03yPGHejHuzl47Ak2IxT/laUUotVFZsIWvo2a5/7H0Kg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.8.0",
-    "@openproject/primer-view-components": "^0.22.1",
+    "@openproject/primer-view-components": "^0.22.2",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.1.1",
     "@uirouter/angular": "^12.0.0",
@@ -175,6 +175,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.1"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.8.0",
-    "@openproject/primer-view-components": "^0.20.0",
+    "@openproject/primer-view-components": "^0.22.1",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.1.1",
     "@uirouter/angular": "^12.0.0",
@@ -175,6 +175,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.20.0"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.22.1"
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -195,7 +195,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   @Input() public clearOnBackspace?:boolean = true;
 
-  @Input() public labelForId ? = null;
+  @Input() public labelForId?:string;
 
   @Input() public inputAttrs?:{ [key:string]:string } = {};
 

--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -29,10 +29,9 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { ModalDialogElement } from '@openproject/primer-view-components/app/components/primer/alpha/modal_dialog';
 
-export default class OAuthAccessGrantNudgeModalController extends Controller<ModalDialogElement> {
+export default class OAuthAccessGrantNudgeModalController extends Controller<HTMLDialogElement> {
   connect() {
-    this.element.open = true;
+    this.element.showModal();
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/storages/open-project-storage-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/open-project-storage-modal.controller.ts
@@ -30,9 +30,8 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { renderStreamMessage } from '@hotwired/turbo';
-import { ModalDialogElement } from '@openproject/primer-view-components/app/components/primer/alpha/modal_dialog';
 
-export default class OpenProjectStorageModalController extends Controller<ModalDialogElement> {
+export default class OpenProjectStorageModalController extends Controller<HTMLDialogElement> {
   static values = {
     projectStorageOpenUrl: String,
     redirectUrl: String,
@@ -43,7 +42,7 @@ export default class OpenProjectStorageModalController extends Controller<ModalD
   redirectUrlValue:string;
 
   connect() {
-    this.element.open = true;
+    this.element.showModal();
     this.interval = 0;
     this.load();
     this.element.addEventListener('close', () => { this.disconnect(); });

--- a/lib/primer/open_project/forms/autocompleter.html.erb
+++ b/lib/primer/open_project/forms/autocompleter.html.erb
@@ -6,7 +6,8 @@
                  input_id: builder.field_id(@input.name),
                  select_options: select_options.map(&:to_h),
                  multiple: @autocomplete_options.fetch(:multiple, false),
-                 key: @autocomplete_options.fetch(:resource, '')
+                 key: @autocomplete_options.fetch(:resource, ''),
+                 append_to: @autocomplete_options.fetch(:append_to, 'body')
                } %>
   <% else %>
     <%= angular_component_tag 'opce-autocompleter',

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
@@ -16,7 +16,7 @@
                 end
               end
               flex.with_row do
-                render(MeetingAgendaItem::MeetingForm.new(f))
+                render(MeetingAgendaItem::MeetingForm.new(f, wrapper_id: 'add-work-package-to-meeting-dialog'))
               end
               flex.with_row(mt: 3) do
                 render(MeetingAgendaItem::Notes.new(f))

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -38,7 +38,8 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
       caption: I18n.t("label_meeting_selection_caption"),
       autocomplete_options: {
         multiple: false,
-        decorated: true
+        decorated: true,
+        append_to: append_to_container
       }
     ) do |select|
       MeetingAgendaItems::CreateContract
@@ -53,8 +54,13 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
     end
   end
 
-  def initialize(disabled: false)
+  def initialize(disabled: false, wrapper_id: nil)
     super()
     @disabled = disabled
+    @wrapper_id = wrapper_id
+  end
+
+  def append_to_container
+    @wrapper_id.nil? ? 'body' : "##{@wrapper_id}"
   end
 end


### PR DESCRIPTION
**Known issues**

- [x] The dropdown of  the autocompleter is hidden behind Primer::Dialog (e.g. in the meetings dialog on the WP page)
  - [x] Therefore the implementation of the `autocomplete_select_decorator` was changed to how it is defined [here](https://community.openproject.org/projects/openproject/work_packages/50486/activity)
- [x] Dialogs that are rendered without a trigger action are not correctly positioned. That is actually a bug in Primer itself, tracked [here](https://github.com/primer/view_components/issues/2581). Results in this:
<img width="500" alt="Bildschirmfoto 2024-02-09 um 08 40 44" src="https://github.com/opf/openproject/assets/7457313/021589d8-e0a9-427b-864a-36417d520541">

