### PR TITLE
Fix autocompleter query for WorkPackages relation setup so it only returns visible columns

### DIFF
--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -43,6 +43,8 @@ module WorkPackages
 
     validate :can_move_to_milestone
 
+    validate :user_allowed_to_change_parent
+
     default_attribute_permission :edit_work_packages
     attribute_permission :project_id, :move_work_packages
 
@@ -76,6 +78,15 @@ module WorkPackages
 
       if model.children.any?
         errors.add :type, :cannot_be_milestone_due_to_children
+      end
+    end
+
+    def user_allowed_to_change_parent
+      return if model.parent_id.nil?
+      return unless model.parent_id_changed?
+
+      unless model.parent.visible?
+        errors.add :parent_id, :error_unauthorized
       end
     end
   end

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -82,7 +82,7 @@ module WorkPackages
     end
 
     def user_allowed_to_change_parent
-      return if model.parent_id.nil?
+      return if model.parent_id.nil? || model.parent.nil?
       return unless model.parent_id_changed?
 
       unless model.parent.visible?

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -50,8 +50,8 @@ class ::Query::Results
 
   def sorted_work_packages_matching_the_filters_today
     sorted_work_packages
-      .visible
       .merge(filtered_work_packages.merge(filter_merges))
+      .visible
   end
 
   # For filtering on historic data, this returns the work packages

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -291,8 +291,11 @@ RSpec.describe WorkPackages::UpdateContract do
   describe 'parent_id' do
     shared_let(:parent) { create(:work_package) }
 
+    let(:parent_visible) { true }
+
     before do
       work_package.parent_id = parent.id
+      allow(work_package.parent).to receive(:visible?).and_return(parent_visible)
       contract.validate
     end
 
@@ -338,6 +341,12 @@ RSpec.describe WorkPackages::UpdateContract do
 
         it { expect(contract.errors.symbols_for(:subject)).to include(:error_readonly) }
       end
+    end
+
+    context 'when the user does not have access to the parent' do
+      let(:parent_visible) { false }
+
+      it { expect(contract.errors.symbols_for(:parent_id)).to include(:error_unauthorized) }
     end
   end
 

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
     request
     JSON.parse last_response.body
   end
-  let(:subjects) { work_packages.pluck("subject") }
+  let(:subjects) { work_packages.pluck("id") }
 
   def work_packages
     result["_embedded"]["elements"]
@@ -82,7 +82,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
           with_settings: { cross_project_work_package_relations: false } do
     describe "relation candidates for wp1 (in hierarchy)" do
       it "returns an empty list" do
-        expect(subjects).to contain_exactly("WP 1.2.1")
+        expect(subjects).to contain_exactly(wp1_2_1.id)
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP" }
 
       it "returns WP 2.1 and 2.2" do
-        expect(subjects).to contain_exactly("WP 2.1", "WP 2.2")
+        expect(subjects).to contain_exactly(wp2_1.id, wp2_2.id)
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=wp" }
 
       it "returns WP 2.1 and 2.2" do
-        expect(subjects).to contain_exactly("WP 2.1", "WP 2.2")
+        expect(subjects).to contain_exactly(wp2_1.id, wp2_2.id)
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       let(:href) { "/api/v3/work_packages/#{wp2_2.id}/available_relation_candidates?query=WP" }
 
       it "returns just WP 2, not WP 2.1" do
-        expect(subjects).to contain_exactly("WP 2")
+        expect(subjects).to contain_exactly(wp2.id)
       end
     end
   end
@@ -117,7 +117,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       let(:href) { "/api/v3/work_packages/#{wp1.id}/available_relation_candidates?query=WP" }
 
       it "returns WP 2 and all WP 2.x as well at the grandchild WP 1.2.1" do
-        expect(subjects).to contain_exactly("WP 2", "WP 2.1", "WP 2.2", "WP 1.2.1")
+        expect(subjects).to contain_exactly(wp2.id, wp2_1.id, wp2_2.id, wp1_2_1.id)
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       end
 
       it "returns WP 2 and all WP 2.x sorted by updated_at DESC" do
-        expect(subjects).to match ["WP 2.1", "WP 1.2.1", "WP 2", "WP 2.2"]
+        expect(subjects).to match [wp2_1.id, wp1_2_1.id, wp2.id, wp2_2.id]
       end
     end
 
@@ -138,7 +138,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=follows" }
 
       it "returns WP 2.1 and 2.2, WP 1 and all WP 1.x" do
-        expect(subjects).to contain_exactly("WP 1", "WP 1.1", "WP 1.2", "WP 1.2.1", "WP 2.1", "WP 2.2")
+        expect(subjects).to contain_exactly(wp1.id, wp1_1.id, wp1_2.id, wp1_2_1.id, wp2_1.id, wp2_2.id)
       end
 
       describe 'with an already existing relationship from the work package' do
@@ -151,7 +151,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
         end
         context 'for a follows relationship' do
           it 'does not contain the work packages already related in the opposite direction nor the parent' do
-            expect(subjects).to contain_exactly("WP 1.2", "WP 1.2.1", "WP 2.1")
+            expect(subjects).to contain_exactly(wp1_2.id, wp1_2_1.id, wp2_1.id)
           end
         end
 
@@ -159,7 +159,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
           let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=precedes" }
 
           it 'does not contain the work packages already related but the parent' do
-            expect(subjects).to contain_exactly("WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1")
+            expect(subjects).to contain_exactly(wp1.id, wp1_2.id, wp1_2_1.id, wp2_1.id)
           end
         end
 
@@ -167,7 +167,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
           let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=parent" }
 
           it 'does not contain the work packages already related but the parent' do
-            expect(subjects).to contain_exactly("WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1")
+            expect(subjects).to contain_exactly(wp1.id, wp1_2.id, wp1_2_1.id, wp2_1.id)
           end
         end
 
@@ -175,7 +175,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
           let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=child" }
 
           it 'does not contain the work packages already related nor the parent' do
-            expect(subjects).to contain_exactly("WP 1.2", "WP 1.2.1", "WP 2.1")
+            expect(subjects).to contain_exactly(wp1_2.id, wp1_2_1.id, wp2_1.id)
           end
         end
 
@@ -183,7 +183,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
           let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP&type=relates" }
 
           it 'does not contain the work packages already related but the parent' do
-            expect(subjects).to contain_exactly("WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1")
+            expect(subjects).to contain_exactly(wp1.id, wp1_2.id, wp1_2_1.id, wp2_1.id)
           end
         end
       end
@@ -197,10 +197,17 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
       end
 
       it 'does not return work packages from that project' do
-        # TODO: Remove and fix before merge
-        pending "Temporary disable"
-        expect(subjects).to contain_exactly("WP 2.1", "WP 2.2")
+        expect(subjects).to contain_exactly(wp2_1.id, wp2_2.id)
       end
+    end
+  end
+
+  context 'when the user is not an admin and has access to just one project' do
+    let(:user) { create(:user, member_with_permissions: { project2 => %i[view_work_packages edit_work_packages] }) }
+    let(:href) { "/api/v3/work_packages/#{wp2.id}/available_relation_candidates?query=WP" }
+
+    it 'only includes work packages from the first project' do
+      expect(subjects).to contain_exactly(wp2_1.id, wp2_2.id)
     end
   end
 end

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe API::V3::WorkPackages::AvailableRelationCandidatesAPI do
   context "without cross project relations",
           with_settings: { cross_project_work_package_relations: false } do
     describe "relation candidates for wp1 (in hierarchy)" do
-      it "returns an empty list" do
+      it "returns WP 1.2.1" do
         expect(subjects).to contain_exactly(wp1_2_1.id)
       end
     end

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -824,10 +824,10 @@ RSpec.describe 'API v3 Work package resource',
 
           it_behaves_like 'multiple errors', 422
 
-          it_behaves_like 'multiple errors of the same type', 2, 'PropertyConstraintViolation'
+          it_behaves_like 'multiple errors of the same type', 3, 'PropertyConstraintViolation'
 
           it_behaves_like 'multiple errors of the same type with messages' do
-            let(:message) { ['Subject can\'t be blank.', 'Parent does not exist.'] }
+            let(:message) { ['Subject can\'t be blank.', 'Parent does not exist.', 'Parent may not be accessed.'] }
           end
         end
 


### PR DESCRIPTION
We discovered, that when entering a work package ID or even a title in the auto completer for i.e. setting the work package's parent, it would also list work packages that you do not have access to. It does not disclose any information about the work package itself apart from its ID, but it would then allow assigning that work package as a parent and if for example using time tracking this would edit certain information (i.e. start- and end-date and duration) on that parent.

This PR
- [x] identifies why the not visible WorkPackages are even shown
- [x] fix the issue and not display those WorkPackages anymore
- [x] throw an error when trying to assign a work package as a parent, when you do not really have access to it 

---

Fixes https://community.openproject.org/work_packages/52556