### PR TITLE
Use `parallel_split_test` for CI feature spec runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -282,6 +282,7 @@ group :test do
   gem 'shoulda-matchers', '~> 6.0', require: nil
 
   gem 'parallel_tests', '~> 4.0'
+  gem 'parallel_split_test', '~> 0.10'
 end
 
 group :ldap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -769,6 +769,9 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.24.0)
+    parallel_split_test (0.10.0)
+      parallel (>= 0.5.13)
+      rspec-core (>= 3.9.0)
     parallel_tests (4.4.0)
       parallel
     parser (3.3.0.5)
@@ -1239,6 +1242,7 @@ DEPENDENCIES
   overviews!
   ox
   paper_trail (~> 15.1.0)
+  parallel_split_test (~> 0.10)
   parallel_tests (~> 4.0)
   pdf-inspector (~> 1.2)
   pg (~> 1.5.0)

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -5,6 +5,7 @@ export PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH"
 export JOBS="${CI_JOBS:=$(nproc)}"
 # for parallel rspec
 export PARALLEL_TEST_PROCESSORS=$JOBS
+export PARALLEL_SPLIT_TEST_PROCESSES=$JOBS
 export PARALLEL_TEST_FIRST_IS_1=true
 export DISABLE_DATABASE_ENVIRONMENT_CHECK=1
 # export NODE_OPTIONS="--max-old-space-size=8192"
@@ -131,7 +132,7 @@ run_units() {
 run_features() {
 	shopt -s extglob
 	reset_dbs
-	execute "time bundle exec turbo_tests --verbose -n $JOBS --runtime-log spec/support/runtime-logs/turbo_runtime_features.log spec/features modules/**/spec/features"
+	execute "time bundle exec parallel_split_test spec/features modules/**/spec/features"
 	cleanup
 }
 


### PR DESCRIPTION
The `parallel_split_test` gem allows parallelizing on an example-by-example basis instead of a file-by-file basis. This removes the un-evenness in overall group runtime because we get a much more even split among all 32-cores on the CI.

**Notes:**
I decided not running unit specs with `parallel_split_test` as the
penalty for executing `before(:all)` hooks before every example is way too
noticeable in the overall execution time.

This however, is a negligible amount in the overall execution time for
feature specs. Being able to not pay a penalty for having a really long
feature spec file is a plus as this can help better balance the total
CI time.