### PR TITLE
[#52526] update project storage form to handle automatic management enabled

### DIFF
--- a/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
@@ -109,7 +109,7 @@ module Storages
       Peripherals::Registry.resolve("commands.one_drive.set_permissions")
                            .call(storage: @storage, path:, permissions:)
                            .result_or do |error|
-        format_and_log_error(error, folder: project_folder_id.project_folder_id)
+        format_and_log_error(error, folder: path)
       end
     end
 

--- a/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
+++ b/modules/storages/app/services/storages/project_storages/set_attributes_service.rb
@@ -36,7 +36,7 @@ module Storages::ProjectStorages
       project_storage.creator ||= user
 
       project_storage.project_folder_mode ||=
-        if storage.present? && storage.provider_type_nextcloud? && storage.automatic_management_enabled?
+        if storage.present? && storage.automatic_management_enabled?
           "automatic"
         else
           "inactive"


### PR DESCRIPTION
[#52526](https://community.openproject.org/wp/52526)

### WAT?

- show the decision of automatically managed project folders when adding a project storage of a one drive storage
  - only if the storage was configured as `automatical_management_enabled`