### PR TITLE
Rewrite allowed_to scope for permitted work packages using CTE

### DIFF
--- a/spec/services/authorization/user_permissible_service_spec.rb
+++ b/spec/services/authorization/user_permissible_service_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Authorization::UserPermissibleService do
       expect(Project)
         .to have_received(:allowed_to) do |user, perm|
         expect(user).to eq(queried_user)
-        expect(perm[0]).to be_a(OpenProject::AccessControl::Permission)
-        expect(perm[0].name).to eq permission
+        expect(perm).to be_a(OpenProject::AccessControl::Permission)
+        expect(perm.name).to eq permission
       end
     end
   end


### PR DESCRIPTION
The query to retrieve allowed work packages is a bottleneck, when a project has a very very high amount of work packages. This was created when we added the permission checks for work packages, because a part of the subquery also returned all work packages the user had access to via a project and that could potentially yield a very high amount. 

Since we recently switched to Rails 7.1. (#14440) we got access to the `with` function to quickly introduce CTEs into queries. This PR takes advantage of this and selects the permitted projects and single work packages via a CTE and then simply queries that CTE.
This model could also be used in the future for other queries, as we can for example do filtering in a CTE and then query that result. It could simplify some of our query construction. Interesting to investigate for the future.

---
Total number of work packages: 2.192.975
Number of work packages in project: 1.152.981
Number of work packages in parent project: 20.010


| Query | Runtime **OLD** | Runtime **NEW** |
|-------|-----------------|-----------------|
| `COUNT(DISTINCT)` | 4190.5ms | 434.8ms |
| `SELECT id LIMIT 100`| 4325.4ms |  45.5ms |
| `SELECT` with all related things | 2755.2ms | 151.5ms |

---

Closes https://community.openproject.org/work_packages/50850
Closes https://community.openproject.org/work_packages/52022
Closes https://community.openproject.org/work_packages/52156
