### PR TITLE
[51619] Meetings: Title of linked work packages are truncated too early

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -4,7 +4,7 @@ $meeting-agenda-item--author-width: 300px
 
 .op-meeting-agenda-item
   display: grid
-  grid-template-columns: 20px auto 1fr minmax(auto, $meeting-agenda-item--author-width) fit-content(40px)
+  grid-template-columns: 20px auto 1fr fit-content($meeting-agenda-item--author-width) fit-content(40px)
   grid-template-areas: "drag-handle content duration author actions" ". notes notes notes notes"
 
   &--drag-handle,
@@ -29,7 +29,6 @@ $meeting-agenda-item--author-width: 300px
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr 50px
     grid-template-areas: "drag-handle content content actions" ". author author duration" ". notes notes notes"
- 
+
     &--author
       justify-self: stretch
-


### PR DESCRIPTION
Change the grid definition so that the author takes 300px only when it is really needed

https://community.openproject.org/projects/openproject/work_packages/51619/activity