### PR TITLE
fix user invitations via members view

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -40,7 +40,7 @@ class MembersController < ApplicationController
   def create
     overall_result = []
 
-    find_or_create_users(send_notification: false) do |member_params|
+    find_or_create_users(send_notification: true) do |member_params|
       service_call = Members::CreateService
                        .new(user: current_user)
                        .call(member_params)


### PR DESCRIPTION
WP [#52606](https://community.openproject.org/projects/openproject/work_packages/52606/activity)

This PR fixes the issue but I'm wondering what was intended.
Are no notifications in `WorkPackages::SharesController` too or was that by accident as well?