### PR TITLE
Add failures explanation to the output

### DIFF
--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -263,6 +263,8 @@ def get_workflow_run(run_id)
   end
 end
 
+Report = Data.define(:errors, :failures_explanation)
+
 class Error
   attr_accessor :location, :page_html, :page_screenshot, :tests_group, :loading_error
 end
@@ -295,16 +297,19 @@ class JobErrorsFinder
   SCREENSHOT_PATTERN = /\{"message":"Screenshot captured for failed feature test"[^\n]+$/
   TESTS_GROUP_PATTERN = /Process \d+: TEST_ENV_NUMBER=\d+ [^\n]+$/
 
+  attr_reader :failures_explanation
+
   def self.scan_logs(logs)
     finder = new
     logs.each do |log|
       finder.scan_log(log)
     end
-    finder.errors
+    Report.new(errors: finder.errors, failures_explanation: finder.failures_explanation)
   end
 
   def scan_log(log)
     find_failures(log)
+    find_failures_explanation(log)
     find_loading_errors(log)
     find_screenshots(log)
     find_tests_groups(log)
@@ -342,6 +347,23 @@ class JobErrorsFinder
       .each do |rerun_location|
         create_error(rerun_location)
       end
+  end
+
+  def find_failures_explanation(log)
+    explanations = []
+    log.split("\n").each do |line|
+      if line.end_with?("Failures:") .. line.end_with?("Failed examples:")
+        explanations << line
+      end
+    end
+    explanations.map! { _1[29..] } # Remove leading timestamp (like "2024-02-05T08:37:54.5175930Z")
+    explanations.reject! do |line|
+      line == "Failures:" ||
+        line == "Failed examples:" ||
+        line.include?("gems/rspec-retry-") ||
+        line.include?("gems/webmock-")
+    end
+    @failures_explanation = explanations.join("\n")
   end
 
   def find_loading_errors(log)
@@ -418,6 +440,19 @@ class Formatter
 
   def display_job_status(job)
     warn "    #{status_line(job)}"
+  end
+
+  def display_report(report)
+    display_failures_explanation(report.failures_explanation)
+    display_errors(report.errors)
+  end
+
+  def display_failures_explanation(failures_explanation)
+    return if failures_explanation.nil? || failures_explanation.empty?
+
+    warn "Failures explanation:".bold
+    warn failures_explanation
+    warn ""
   end
 
   def display_errors(errors)
@@ -574,10 +609,10 @@ formatter = Formatter.new(compact: Options.compact)
 failed_jobs_logs = get_failed_jobs_logs(formatter)
 
 is_successful = failed_jobs_logs.none?
-errors = JobErrorsFinder.scan_logs(failed_jobs_logs)
+report = JobErrorsFinder.scan_logs(failed_jobs_logs)
 
 if is_successful
   warn "All jobs successful 🎉"
 else
-  formatter.display_errors(errors)
+  formatter.display_report(report)
 end


### PR DESCRIPTION
This avoids having to see the logs to see what failed exactly

The uninteresting part of the backtrace is also filtered out.

It now looks like this:

```
$ script/github_pr_errors https://github.com/opf/openproject/actions/runs/7782284021/job/21218381050
Looking for the workflow run with id 7782284021
  Branch: dev
  Commit SHA: 14d0f503ca233bb78d0e099005cc080556985cf0
  Commit message: Merge pull request #14708 from opf/dependabot/bundler/dev/nokogiri-1.16.2
  ✗ Test suite: failure  https://github.com/opf/openproject/actions/runs/7782284021
    ✗ Units + Features: failure  https://github.com/opf/openproject/actions/runs/7782284021/job/21218381050
Failures explanation:

  1) my user API tokens when API access is enabled via global settings API tokens can generated and revoked
     Failure/Error: expect(page).to have_content 'The API token has been deleted.'
       expected to find text "The API token has been deleted." in "Top Menu\nJump to content\nSelect a project\nHome\nSearch in OpenProject\nBB\nSide Menu\nProfile\nSettings\nChange password\nTwo-factor authentication\nAccess tokens\nSession management\nNotification settings\nEmail reminders\nContent\nAccess tokens\nAPI\nAPI tokens allow third-party applications to communicate with this OpenProject instance via REST APIs.\nNAME\n\t\nCREATED ON\n\t\nEXPIRES\n\t\nAPI token\t02/05/2024 09:52 AM\tNever\t\nICALENDAR\niCalendar tokens allow users to subscribe to OpenProject calendars and view up-to-date work package information from external clients.\n To add an iCalendar token, subscribe to a new or existing calendar from within the Calendar module of a project. You must have the necessary permissions.\nOAUTH\nOAuth tokens allow third-party applications to connect with this OpenProject instance.\n There is no third-party application access configured and active for you. Please contact your administrator to activate this feature.\nRSS\nRSS tokens allow users to keep up with the latest changes in this OpenProject instance via an external RSS reader.\nRSS token\nFILE STORAGES\nFile Storage tokens connect this OpenProject instance with an external File Storage.\n There is no storage access linked to your account."
     # ./spec/features/users/my_spec.rb:167:in `block (5 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'

  2) Filter by date with "is empty" works as intended for custom fields
     Failure/Error: select operator, from: "operators-#{id}"

     Capybara::ElementNotFound:
       Unable to find select box "operators-customField8" that is not disabled and Unable to find input box with datalist completion "operators-customField8" that is not disabled
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:319:in `rescue in rescue in block in find_select_or_datalist_input'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:316:in `rescue in block in find_select_or_datalist_input'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:312:in `block in find_select_or_datalist_input'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:311:in `find_select_or_datalist_input'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:204:in `select'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:774:in `select'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `select'
     # ./spec/support/components/work_packages/filters.rb:123:in `set_operator'
     # ./spec/support/components/work_packages/filters.rb:129:in `set_filter'
     # ./spec/support/components/work_packages/filters.rb:113:in `add_filter_by'
     # ./spec/features/work_packages/table/queries/date_is_empty_filter_spec.rb:108:in `block (2 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Capybara::ElementNotFound:
     #   Unable to find select box "operators-customField8" that is not disabled and Unable to find input box with datalist completion "operators-customField8" that is not disabled
     #   /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/actions.rb:319:in `rescue in rescue in block in find_select_or_datalist_input'

Finished in 6 minutes 5 seconds (files took 22.03 seconds to load)
1810 examples, 2 failures, 12 pending

'./spec/features/users/my_spec.rb:140'
    ↳ html: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-02-05-09-52-38.189.html
    ↳ screenshot: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-02-05-09-52-38.189.png
'./spec/features/work_packages/table/queries/date_is_empty_filter_spec.rb:105'
    ↳ html: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-02-05-09-57-12.666.html
    ↳ screenshot: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-02-05-09-57-12.666.png
```