### PR TITLE
[#47169] PDF doesn't contain cell color

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem 'structured_warnings', '~> 0.4.0'
 # don't require by default, instead load on-demand when actually configured
 gem 'airbrake', '~> 13.0.0', require: false
 
-gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '4952148f930a3292051efbadd9ac115d9c721157'
+gem 'md_to_pdf', git: 'https://github.com/opf/md-to-pdf', ref: '04d22bfa73fbeb549fb1f215a6b9a81cfe820814'
 gem 'prawn', '~> 2.4'
 # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
 gem 'matrix', '~> 0.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 4952148f930a3292051efbadd9ac115d9c721157
-  ref: 4952148f930a3292051efbadd9ac115d9c721157
+  revision: 04d22bfa73fbeb549fb1f215a6b9a81cfe820814
+  ref: 04d22bfa73fbeb549fb1f215a6b9a81cfe820814
   specs:
-    md_to_pdf (0.0.23)
+    md_to_pdf (0.0.24)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.1)


### PR DESCRIPTION
This PR updates md_to_pdf to support:
* background color of empty cells
* custom header cell color is not overwritten by the default styling

https://community.openproject.org/work_packages/47169