### PR TITLE
Get rid of type enums

### DIFF
--- a/db/migrate/20240206085104_remove_enums.rb
+++ b/db/migrate/20240206085104_remove_enums.rb
@@ -1,0 +1,73 @@
+class RemoveEnums < ActiveRecord::Migration[7.1]
+  def up
+    change_column(:storages, :health_status, :string, default: 'pending')
+    add_check_constraint(:storages,
+                         'health_status IN (\'pending\', \'healthy\', \'unhealthy\')',
+                         name: 'storages_health_status_check')
+
+    change_column(:last_project_folders, :mode, :string, default: 'inactive')
+    add_check_constraint(:last_project_folders,
+                         'mode IN (\'inactive\', \'manual\', \'automatic\')',
+                         name: 'last_project_folders_mode_check')
+
+    change_column(:project_storages, :project_folder_mode, :string)
+    add_check_constraint(:project_storages,
+                         'project_folder_mode IN (\'inactive\', \'manual\', \'automatic\')',
+                         name: 'project_storages_project_folder_mode_check')
+
+    change_column(:delayed_job_statuses, :status, :string, default: 'in_queue')
+    add_check_constraint(:delayed_job_statuses,
+                         'status IS NULL OR status IN (\'in_queue\', \'error\', \'in_process\', \'success\', \'failure\', \'cancelled\')',
+                         name: 'delayed_job_statuses_status_check')
+
+    execute <<~SQL.squish
+      DROP TYPE public.delayed_job_status RESTRICT;
+      DROP TYPE public.project_folder_modes RESTRICT;
+      DROP TYPE public.storage_health_statuses RESTRICT;
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      CREATE TYPE public.delayed_job_status AS ENUM (
+          'in_queue',
+          'error',
+          'in_process',
+          'success',
+          'failure',
+          'cancelled'
+      );
+
+      CREATE TYPE public.project_folder_modes AS ENUM (
+          'inactive',
+          'manual',
+          'automatic'
+      );
+
+      CREATE TYPE public.storage_health_statuses AS ENUM (
+          'pending',
+          'healthy',
+          'unhealthy'
+      );
+    SQL
+
+    remove_check_constraint(:storages, name: 'storages_health_status_check')
+    change_column(:storages, :health_status, :storage_health_statuses, default: nil,
+                                                                       using: 'health_status::storage_health_statuses')
+
+    remove_check_constraint(:last_project_folders, name: 'last_project_folders_mode_check')
+
+    change_column_default(:storages, :health_status, 'pending')
+
+    change_column(:last_project_folders, :mode, :project_folder_modes, default: nil, using: 'mode::project_folder_modes')
+    change_column_default(:last_project_folders, :mode, 'inactive')
+
+    remove_check_constraint(:project_storages, name: 'project_storages_project_folder_mode_check')
+    change_column(:project_storages, :project_folder_mode, :project_folder_modes, default: nil,
+                                                                                  using: 'project_folder_mode::project_folder_modes')
+
+    remove_check_constraint(:delayed_job_statuses, name: 'delayed_job_statuses_status_check')
+    change_column(:delayed_job_statuses, :status, :delayed_job_status, default: nil, using: 'status::delayed_job_status')
+    change_column_default(:delayed_job_statuses, :status, 'in_queue')
+  end
+end

--- a/db/migrate/20240206085104_remove_enums.rb
+++ b/db/migrate/20240206085104_remove_enums.rb
@@ -21,15 +21,15 @@ class RemoveEnums < ActiveRecord::Migration[7.1]
                          name: 'delayed_job_statuses_status_check')
 
     execute <<~SQL.squish
-      DROP TYPE public.delayed_job_status RESTRICT;
-      DROP TYPE public.project_folder_modes RESTRICT;
-      DROP TYPE public.storage_health_statuses RESTRICT;
+      DROP TYPE delayed_job_status RESTRICT;
+      DROP TYPE project_folder_modes RESTRICT;
+      DROP TYPE storage_health_statuses RESTRICT;
     SQL
   end
 
   def down
     execute <<~SQL.squish
-      CREATE TYPE public.delayed_job_status AS ENUM (
+      CREATE TYPE delayed_job_status AS ENUM (
           'in_queue',
           'error',
           'in_process',
@@ -38,13 +38,13 @@ class RemoveEnums < ActiveRecord::Migration[7.1]
           'cancelled'
       );
 
-      CREATE TYPE public.project_folder_modes AS ENUM (
+      CREATE TYPE project_folder_modes AS ENUM (
           'inactive',
           'manual',
           'automatic'
       );
 
-      CREATE TYPE public.storage_health_statuses AS ENUM (
+      CREATE TYPE storage_health_statuses AS ENUM (
           'pending',
           'healthy',
           'unhealthy'

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -40,10 +40,6 @@ class Storages::ProjectStorage < ApplicationRecord
   # There should be only one ProjectStorage per project and storage.
   validates :project, uniqueness: { scope: :storage }
 
-  # The enum type detection fails in the multitenancy context for unknown
-  # reasons. So we declare it explicitly here. @TODO remove once fixed properly
-  attribute :project_folder_mode, :string
-
   enum project_folder_mode: {
     inactive: 'inactive',
     manual: 'manual',

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -82,10 +82,6 @@ module Storages
 
     scope :automatic_management_enabled, -> { where("provider_fields->>'automatically_managed' = 'true'") }
 
-    # The enum type detection fails in the multitenancy context for unknown
-    # reasons. So we declare it explicitly here. @TODO remove once fixed properly
-    attribute :health_status, :string
-
     enum health_status: {
       pending: 'pending',
       healthy: 'healthy',

--- a/modules/storages/spec/models/storages/last_project_folder_spec.rb
+++ b/modules/storages/spec/models/storages/last_project_folder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Storages::LastProjectFolder do
     it do
       expect(last_project_folder).to define_enum_for(:mode)
         .with_values(inactive: 'inactive', manual: 'manual', automatic: 'automatic')
-        .backed_by_column_of_type(:enum)
+        .backed_by_column_of_type(:string)
     end
   end
 end

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Storages::ProjectStorage do
       expect(project_storage).to define_enum_for(:project_folder_mode)
         .with_values(inactive: 'inactive', manual: 'manual', automatic: 'automatic')
         .with_prefix(:project_folder)
-        .backed_by_column_of_type(:enum)
+        .backed_by_column_of_type(:string)
     end
   end
 


### PR DESCRIPTION
Rails 7.1 now validate that enums are backed by a database column. If our application is run in multi-tenancy mode, like it is on our hosted offering, this check fails because Rails does not properly detect the column if it is defined as an enum internally.

We have pjut a band-aid on the problem by fixing the column to map to a string in the rails application in #14713 but we have discussed again if we really need the database level security offered by enums. The general decision was that the only sanctioned interface to the database is via the rails app and the rails app ensures that only allowed values are put in the DB.

To mimick the current behavior, we have added contraints to the columns, but in the future we should revisit if we **REALLY** need that level of security on the DB side or if we can live without such strict constraints, as we do not use them in other areas of the database that would be even more critical.