### PR TITLE
[52598] Fix untranslated work package roles

### DIFF
--- a/app/seeders/basic_data/model_seeder.rb
+++ b/app/seeders/basic_data/model_seeder.rb
@@ -46,6 +46,12 @@ module BasicData
       end
     end
 
+    def mapped_models_data
+      models_data.each_with_object({}) do |model_data, models|
+        models[model_data['reference']] = model_attributes(model_data)
+      end
+    end
+
     def models_data
       Array(seed_data.lookup(seed_data_model_key))
     end

--- a/app/seeders/root_seeder.rb
+++ b/app/seeders/root_seeder.rb
@@ -46,9 +46,16 @@ class RootSeeder < Seeder
     end
   end
 
+  def translated_seed_data_for(*keys)
+    set_locale! do
+      Source::SeedDataLoader.get_data(only: keys)
+    end
+  end
+
   def seed_data!
     reset_active_record!
     set_locale! do
+      print_status "*** Seeding for locale: '#{I18n.locale}'"
       prepare_seed! do
         ActiveRecord::Base.transaction do
           block_given? ? (yield self) : do_seed!
@@ -103,7 +110,6 @@ class RootSeeder < Seeder
 
   def set_locale!
     I18n.with_locale(desired_lang) do
-      print_status "*** Seeding for locale: '#{I18n.locale}'"
       @locale_set = true
       yield
     end

--- a/app/seeders/source/seed_data_loader.rb
+++ b/app/seeders/source/seed_data_loader.rb
@@ -37,18 +37,19 @@ class Source::SeedDataLoader
   include Source::Translate
 
   class << self
-    def get_data(edition: nil)
+    def get_data(edition: nil, only: nil)
       edition ||= OpenProject::Configuration['edition']
-      loader = new(seed_name: edition)
+      loader = new(seed_name: edition, only:)
       loader.seed_data
     end
   end
 
-  attr_reader :seed_name, :locale
+  attr_reader :seed_name, :locale, :only
 
-  def initialize(seed_name: 'standard', locale: I18n.locale)
+  def initialize(seed_name: 'standard', locale: I18n.locale, only: nil)
     @seed_name = seed_name
     @locale = locale
+    @only = only
   end
 
   def seed_data
@@ -70,6 +71,7 @@ class Source::SeedDataLoader
   end
 
   def translate_seed_file(seed_file)
-    translate(seed_file.raw_content, "#{Source::Translate::I18N_PREFIX}.#{seed_file.name}")
+    raw_content = only ? seed_file.raw_content.slice(*Array(only)) : seed_file.raw_content
+    translate(raw_content, "#{Source::Translate::I18N_PREFIX}.#{seed_file.name}")
   end
 end

--- a/app/seeders/source/seed_file.rb
+++ b/app/seeders/source/seed_file.rb
@@ -42,7 +42,7 @@ class Source::SeedFile
 
     def find_all_seed_files
       Pathname
-        .glob('**/app/seeders/*.yml')
+        .glob('{modules/*/,}app/seeders/*.yml')
         .map { |seed_file_path| new(seed_file_path) }
         .freeze
     end

--- a/db/migrate/20240206173841_fix_untranslated_work_package_roles.rb
+++ b/db/migrate/20240206173841_fix_untranslated_work_package_roles.rb
@@ -1,0 +1,14 @@
+class FixUntranslatedWorkPackageRoles < ActiveRecord::Migration[7.1]
+  def up
+    seed_work_package_roles_data.each_value do |work_package_role_data|
+      work_package_role = WorkPackageRole.find_by(builtin: work_package_role_data[:builtin])
+      work_package_role.update(name: work_package_role_data[:name])
+    end
+  end
+
+  def seed_work_package_roles_data
+    seed_data = RootSeeder.new.translated_seed_data_for('work_package_roles', 'modules_permissions')
+    seeder = BasicData::WorkPackageRoleSeeder.new(seed_data)
+    seeder.mapped_models_data
+  end
+end

--- a/spec/migrations/fix_untranslated_work_package_roles_spec.rb
+++ b/spec/migrations/fix_untranslated_work_package_roles_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require Rails.root.join("db/migrate/20240206173841_fix_untranslated_work_package_roles.rb")
+
+RSpec.describe FixUntranslatedWorkPackageRoles, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject(:run_migration) { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+  context 'when work package roles are already present' do
+    before do
+      create(:work_package_role, builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_EDITOR, name: 'foo')
+      create(:work_package_role, builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_COMMENTER, name: 'bar')
+      create(:work_package_role, builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_VIEWER, name: 'baz')
+    end
+
+    it 'updates them with correct names' do
+      expect { run_migration }
+        .not_to change(WorkPackageRole, :count).from(3)
+
+      expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_EDITOR))
+        .to have_attributes(name: 'Work package editor')
+      expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_COMMENTER))
+        .to have_attributes(name: 'Work package commenter')
+      expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_VIEWER))
+        .to have_attributes(name: 'Work package viewer')
+    end
+
+    [
+      'OPENPROJECT_SEED_LOCALE',
+      'OPENPROJECT_DEFAULT_LANGUAGE'
+    ].each do |env_var_name|
+      describe "when #{env_var_name} is set with a non-English language", :settings_reset do
+        it 'renames the work package roles in the language specified', :settings_reset do
+          with_env(env_var_name => 'de') do
+            reset(:default_language)
+            run_migration
+          ensure
+            reset(:default_language)
+          end
+
+          expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_EDITOR))
+            .to have_attributes(name: 'Arbeitspaket-Bearbeiter')
+          expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_COMMENTER))
+            .to have_attributes(name: 'Arbeitspaket-Kommentator')
+          expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_VIEWER))
+            .to have_attributes(name: 'Arbeitspaket-Betrachter')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/52598

During the initial migration, `I18n.t` always picks up English because the default language setting has not been set yet. By reusing the root seeder, the translated seed data is used to fix the work package role names.