### PR TITLE
extract PostgresEnvironment to share between BackupJob and backup rake tasks

### DIFF
--- a/lib/open_project/postgres_environment.rb
+++ b/lib/open_project/postgres_environment.rb
@@ -43,7 +43,7 @@ module OpenProject
     def pg_env
       database_config = ActiveRecord::Base.connection_db_config.configuration_hash
 
-      entries = PG_ENV_TO_CONNECTION_CONFIG.map do |key, config_key|
+      PG_ENV_TO_CONNECTION_CONFIG.filter_map do |key, config_key|
         possible_keys = Array(config_key)
         value = possible_keys
           .lazy
@@ -51,9 +51,7 @@ module OpenProject
           .first
 
         [key.to_s, value.to_s] if value.present?
-      end
-
-      entries.compact.to_h
+      end.to_h
     end
   end
 end

--- a/lib/open_project/postgres_environment.rb
+++ b/lib/open_project/postgres_environment.rb
@@ -1,0 +1,59 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module PostgresEnvironment
+    ##
+    # Maps the PG env variable name to the key in the AR connection config.
+    PG_ENV_TO_CONNECTION_CONFIG = {
+      PGHOST: :host,
+      PGPORT: :port,
+      PGUSER: %i[username user],
+      PGPASSWORD: :password,
+      PGDATABASE: :database
+    }.freeze
+
+    module_function
+
+    def pg_env
+      database_config = ActiveRecord::Base.connection_db_config.configuration_hash
+
+      entries = PG_ENV_TO_CONNECTION_CONFIG.map do |key, config_key|
+        possible_keys = Array(config_key)
+        value = possible_keys
+          .lazy
+          .filter_map { |key| database_config[key] }
+          .first
+
+        [key.to_s, value.to_s] if value.present?
+      end
+
+      entries.compact.to_h
+    end
+  end
+end

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -89,7 +89,7 @@ namespace :backup do
       hash = ActiveRecord::Base.connection_db_config.configuration_hash
 
       {
-        **hash.slice(:host, :port, :database, :password, :sslkey, :sslcert, :sslca),
+        **hash.slice(:host, :port, :database, :password),
         user: hash[:user] || hash[:username],
       }
     end

--- a/spec/tasks/backup_spec.rb
+++ b/spec/tasks/backup_spec.rb
@@ -56,16 +56,11 @@ RSpec.describe Rake::Task, 'backup:database' do
       end
     end
 
-    it 'writes the pg password file' do
-      # can't use have_received because password file is deleted after invocation
-      expect(Kernel).to receive(:system) do |*args| # rubocop:disable RSpec/MessageSpies
-        pass_file = args.first['PGPASSFILE']
-        expect(File.readable?(pass_file)).to be true
-
-        file_contents = File.read pass_file
-        expect(file_contents).to include('test_password')
-      end
+    it 'passes environment variables to the binary' do
       subject.invoke
+      expect(Kernel).to have_received(:system) do |*args|
+        expect(args[0]).to include('PGUSER' => 'test_user', 'PGPASSWORD' => 'test_password')
+      end
     end
 
     it 'uses the first task parameter as the target filename' do
@@ -96,22 +91,24 @@ RSpec.describe Rake::Task, 'backup:database' do
       end
     end
 
-    it 'writes the pg password file' do
-      # can't use have_received because password file is deleted after invocation
-      expect(Kernel).to receive(:system) do |*args| # rubocop:disable RSpec/MessageSpies
-        pass_file = args.first['PGPASSFILE']
-        expect(File.readable?(pass_file)).to be true
-
-        file_contents = File.read pass_file
-        expect(file_contents).to include('test_password')
-      end
+    it 'passes environment variables to the binary' do
       subject.invoke backup_file.path
+      expect(Kernel).to have_received(:system) do |*args|
+        expect(args[0]).to include('PGUSER' => 'test_user', 'PGPASSWORD' => 'test_password')
+      end
     end
 
     it 'uses the first task parameter as the target filename' do
       subject.invoke backup_file.path
       expect(Kernel).to have_received(:system) do |*args|
         expect(args.last).to eql(backup_file.path)
+      end
+    end
+
+    it 'specifies database name' do
+      subject.invoke backup_file.path
+      expect(Kernel).to have_received(:system) do |*args|
+        expect(args).to include '--dbname=openproject-database'
       end
     end
 

--- a/spec/workers/backup_job_spec.rb
+++ b/spec/workers/backup_job_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe BackupJob, type: :model do
       }
     }
   ) do
-    let(:dummy_path) { "/tmp/op_uploaded_files/1639754082-3468-0002-0911/file.ext" }
+    let(:dummy_path) { "#{LocalFileUploader.cache_dir}/1639754082-3468-0002-0911/file.ext" }
 
     before do
       FileUtils.mkdir_p Pathname(dummy_path).parent.to_s


### PR DESCRIPTION
Use same code in BackupJob and backup rake tasks to rely on environment variables to pass database config for `pg_dump` and `pg_restore` in rake tasks. It does look like concern about preferring temp files over environment variables for security reasons is outdated and environment variables were used for BackupJob already for several years.
Followup of #14701