### PR TITLE
Revert to display: flex, but fix outer container

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/multiple-user-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/multiple-user-display-field.module.ts
@@ -36,6 +36,9 @@ export class MultipleUserFieldModule extends ResourcesDisplayField {
 
   public render(element:HTMLElement):void {
     const users = this.value as HalResource[];
+    // The flex display of the nested op-principal-list breaks the height if
+    // this element's display is set to "initial".
+    element.style.display = 'block';
     element.innerHTML = '';
     element.setAttribute('title', users.map((el) => el.name).join(', '));
 

--- a/frontend/src/global_styles/content/_principal-list.sass
+++ b/frontend/src/global_styles/content/_principal-list.sass
@@ -1,7 +1,7 @@
 @import "helpers"
 
 .op-principal-list
-  display: inline-flex
+  display: flex
   align-items: center
 
   &--principals


### PR DESCRIPTION
display: inline-flex does not properly truncate the principals names,
but display: flex breaks the height of the inline container.

https://community.openproject.org/projects/openproject/work_packages/52289/activity?query_id=4930