### PR TITLE
[#52456] Rename "Managed folder status" heading in Storage form

### DIFF
--- a/modules/storages/app/components/storages/admin/health_status_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health_status_component.html.erb
@@ -1,5 +1,6 @@
 <%= render(Primer::Box.new) do %>
   <%= render(Primer::Beta::Heading.new(tag: :h4, mb: 2)) { I18n.t('storages.health.title') } %>
+  <%= render(Primer::Beta::Text.new(tag: :div, mb: 2, font_weight: :bold)) { I18n.t('storages.health.subtitle') } %>
 
   <%= render(Primer::Box.new(py: 1)) do %>
     <%= render(Primer::Beta::Text.new(test_selector: "storage-health-checked-at")) {

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -92,8 +92,8 @@ en:
       label_healthy: Healthy
       label_pending: Pending
       since: since %{datetime}
-      title: Health status
       subtitle: Automatic managed project folders
+      title: Health status
     help_texts:
       project_folder: The project folder is the default folder for file uploads for this project. Users can nevertheless still upload files to other locations.
     instructions:

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -92,7 +92,8 @@ en:
       label_healthy: Healthy
       label_pending: Pending
       since: since %{datetime}
-      title: Managed folders status
+      title: Health status
+      subtitle: Automatic managed project folders
     help_texts:
       project_folder: The project folder is the default folder for file uploads for this project. Users can nevertheless still upload files to other locations.
     instructions:


### PR DESCRIPTION
Changes heading of sidebar in Edit Storage page (only relevant for storages with automatically managed project folder activated)

OP WP: https://community.openproject.org/work_packages/52456

**Before**
<img width="338" alt="Screenshot 2024-02-07 at 15 27 37" src="https://github.com/opf/openproject/assets/1113942/df1871a0-9a07-4925-9186-0e1227d02cd1">


**After**
<img width="329" alt="Screenshot 2024-02-07 at 14 31 04" src="https://github.com/opf/openproject/assets/1113942/628213d3-0955-47ea-a438-e6c59a9f6d76">
