### PR TITLE
prevent access to another user's queries

### DIFF
--- a/app/controllers/projects/menus_controller.rb
+++ b/app/controllers/projects/menus_controller.rb
@@ -51,16 +51,21 @@ module Projects
     def static_filters
       [
         query_menu_item(::Queries::Projects::Factory.static_query_active, selected: no_query_props_or_all?),
-        query_menu_item(::Queries::Projects::Factory.static_query_my, id: 'my'),
-        query_menu_item(::Queries::Projects::Factory.static_query_archived, id: 'archived')
+        query_menu_item(::Queries::Projects::Factory.static_query_my,
+                        id: ::Queries::Projects::Factory::STATIC_MY),
+        query_menu_item(::Queries::Projects::Factory.static_query_archived,
+                        id: ::Queries::Projects::Factory::STATIC_ARCHIVED)
       ]
     end
 
     def static_status_filters
       [
-        query_menu_item(::Queries::Projects::Factory.static_query_status_on_track, id: 'on_track'),
-        query_menu_item(::Queries::Projects::Factory.static_query_status_off_track, id: 'off_track'),
-        query_menu_item(::Queries::Projects::Factory.static_query_status_at_risk, id: 'at_risk')
+        query_menu_item(::Queries::Projects::Factory.static_query_status_on_track,
+                        id: ::Queries::Projects::Factory::STATIC_ON_TRACK),
+        query_menu_item(::Queries::Projects::Factory.static_query_status_off_track,
+                        id: ::Queries::Projects::Factory::STATIC_OFF_TRACK),
+        query_menu_item(::Queries::Projects::Factory.static_query_status_at_risk,
+                        id: ::Queries::Projects::Factory::STATIC_AT_RISK)
       ]
     end
 
@@ -90,8 +95,7 @@ module Projects
     end
 
     def no_query_props_or_all?
-      (params[:query_id].nil? && params[:filters].nil?) ||
-        params[:query_id] == 'all'
+      params[:query_id].nil? && params[:filters].nil? && params[:sortBy].nil?
     end
   end
 end

--- a/app/controllers/projects/menus_controller.rb
+++ b/app/controllers/projects/menus_controller.rb
@@ -50,7 +50,7 @@ module Projects
 
     def static_filters
       [
-        query_menu_item(::Queries::Projects::Factory.static_query_active, selected: no_query_props_or_all?),
+        query_menu_item(::Queries::Projects::Factory.static_query_active, selected: no_query_props?),
         query_menu_item(::Queries::Projects::Factory.static_query_my,
                         id: ::Queries::Projects::Factory::STATIC_MY),
         query_menu_item(::Queries::Projects::Factory.static_query_archived,
@@ -94,7 +94,7 @@ module Projects
       id.to_s == params[:query_id] && params[:filters].nil?
     end
 
-    def no_query_props_or_all?
+    def no_query_props?
       params[:query_id].nil? && params[:filters].nil? && params[:sortBy].nil?
     end
   end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -32,17 +32,16 @@ class Projects::QueriesController < ApplicationController
   # No need for a more specific authorization check. That is carried out in the contracts.
   before_action :require_login
   before_action :find_query, only: :destroy
+  before_action :load_query_or_deny_access, only: %i[new]
 
   current_menu_item [:new, :create] do
     :projects
   end
 
   def new
-    call = load_query(existing: false)
-
     render template: '/projects/index',
            layout: 'global',
-           locals: { query: call.result, state: :edit }
+           locals: { query: @query, state: :edit }
   end
 
   def create

--- a/app/views/projects/menus/_menu.html.erb
+++ b/app/views/projects/menus/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "projects_sidemenu",
-                    src: projects_menu_path(params.permit(:filters, :query_id)),
+                    src: projects_menu_path(params.permit(:filters, :sortBy, :query_id)),
                     target: '_top',
                     data: { turbo: false },
                     loading: :lazy %>

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -354,5 +354,14 @@ RSpec.describe 'Persisted lists on projects index page',
       projects_page.expect_projects_not_listed(another_project, # Because it is on the second page
                                                development_project) # Because it is on the second page
     end
+
+    it 'cannot access another user`s list' do
+      visit projects_path(query_id: another_users_projects_list.id)
+
+      expect(page)
+        .to have_no_text(another_users_projects_list.name)
+      expect(page)
+        .to have_text('You are not authorized to access this page.')
+    end
   end
 end

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -1,0 +1,631 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require 'spec_helper'
+require 'services/base_services/behaves_like_create_service'
+
+RSpec.describe Queries::Projects::Factory do
+  let(:current_user) { build_stubbed(:user) }
+  let!(:query_finder) do
+    scope = instance_double(ActiveRecord::Relation)
+
+    allow(Queries::Projects::ProjectQuery)
+      .to receive(:where)
+            .with(user: current_user)
+            .and_return(scope)
+
+    allow(scope)
+      .to receive(:find_by)
+            .with(id:)
+            .and_return(persisted_query)
+  end
+  let(:persisted_query) do
+    build_stubbed(:project_query) do |query|
+      query.order(id: :asc)
+      query.where(:project_status, '=', [Project.status_codes[:on_track].to_s])
+    end
+  end
+
+  let(:id) { nil }
+  let(:params) { {} }
+
+  describe '.find' do
+    subject(:find) { described_class.find(id, params:, user: current_user) }
+
+    context 'without id' do
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('projects.lists.active'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['t']]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'active\' id' do
+      let(:id) { 'active' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('projects.lists.active'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['t']]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'my\' id' do
+      let(:id) { 'my' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('projects.lists.my'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:member_of, '=', ['t']]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'archived\' id' do
+      let(:id) { 'archived' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('projects.lists.archived'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['f']]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'on_track\' id' do
+      let(:id) { 'on_track' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('activerecord.attributes.project.status_codes.on_track'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:project_status_code, '=', [Project.status_codes[:on_track].to_s]]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'off_track\' id' do
+      let(:id) { 'off_track' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('activerecord.attributes.project.status_codes.off_track'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:project_status_code, '=', [Project.status_codes[:off_track].to_s]]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with the \'at_risk\' id' do
+      let(:id) { 'at_risk' }
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has a name' do
+        expect(find.name)
+          .to eql(I18n.t('activerecord.attributes.project.status_codes.at_risk'))
+      end
+
+      it 'has a filter for active projects' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:project_status_code, '=', [Project.status_codes[:at_risk].to_s]]])
+      end
+
+      it 'is ordered by lft asc' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['lft', :asc]])
+      end
+    end
+
+    context 'with an integer id for which the user has a query' do
+      let(:id) { 42 }
+
+      it 'returns the persisted query' do
+        expect(find)
+          .to eql(persisted_query)
+      end
+    end
+
+    context 'with an integer id for which the user does not have a persisted query' do
+      let(:id) { 42 }
+      let(:persisted_query) { nil }
+
+      it 'returns nil' do
+        expect(find)
+          .to be_nil
+      end
+    end
+
+    context 'without an id and with params' do
+      let(:id) { nil }
+      let(:params) do
+        {
+          filters: [
+            {
+              attribute: 'active',
+              operator: '=',
+              values: ['f']
+            },
+            {
+              attribute: 'member_of',
+              operator: '=',
+              values: ['t']
+            }
+          ],
+          orders: [
+            {
+              attribute: 'id',
+              direction: 'asc'
+            },
+            {
+              attribute: 'name',
+              direction: 'desc'
+            }
+          ]
+        }
+      end
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has no name' do
+        expect(find.name)
+          .to be_nil
+      end
+
+      it 'has the filters applied' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['f']], [:member_of, '=', ['t']]])
+      end
+
+      it 'has the orders applied' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['id', :asc], ['name', :desc]])
+      end
+    end
+
+    context 'with the \'active\' id and with order params' do
+      let(:id) { 'active' }
+      let(:params) do
+        {
+          orders: [
+            {
+              attribute: 'id',
+              direction: 'asc'
+            },
+            {
+              attribute: 'name',
+              direction: 'desc'
+            }
+          ]
+        }
+      end
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has no name' do
+        expect(find.name)
+          .to be_nil
+      end
+
+      it 'has the filters of the default \'active\' query applied' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['t']]])
+      end
+
+      it 'has the orders overwritten' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([['id', :asc], ['name', :desc]])
+      end
+    end
+
+    context 'with the \'active\' id and with filter params' do
+      let(:id) { nil }
+      let(:params) do
+        {
+          filters: [
+            {
+              attribute: 'active',
+              operator: '=',
+              values: ['f']
+            },
+            {
+              attribute: 'member_of',
+              operator: '=',
+              values: ['t']
+            }
+          ]
+        }
+      end
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'has no name' do
+        expect(find.name)
+          .to be_nil
+      end
+
+      it 'has the filters overwritten' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['f']], [:member_of, '=', ['t']]])
+      end
+
+      it 'has the orders of the default \'active\' query applied' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq([%i[lft asc]])
+      end
+    end
+
+    context 'with an integer id for which the user has a query and with filter params' do
+      let(:id) { 42 }
+      let(:params) do
+        {
+          filters: [
+            {
+              attribute: 'active',
+              operator: '=',
+              values: ['f']
+            },
+            {
+              attribute: 'member_of',
+              operator: '=',
+              values: ['t']
+            }
+          ]
+        }
+      end
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'keeps the name' do
+        expect(find.name)
+          .to eql(persisted_query.name)
+      end
+
+      it 'has the filters overwritten' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq([[:active, '=', ['f']], [:member_of, '=', ['t']]])
+      end
+
+      it 'has the orders of the persisted query' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq(persisted_query.orders.map { |order| [order.attribute, order.direction] })
+      end
+    end
+
+    context 'with an integer id for which the user has a query and with order params' do
+      let(:id) { 42 }
+      let(:params) do
+        {
+          orders: [
+            {
+              attribute: 'id',
+              direction: 'asc'
+            },
+            {
+              attribute: 'name',
+              direction: 'desc'
+            }
+          ]
+        }
+      end
+
+      it 'returns a project query' do
+        expect(find)
+          .to be_a(Queries::Projects::ProjectQuery)
+      end
+
+      it 'keeps the name' do
+        expect(find.name)
+          .to eql(persisted_query.name)
+      end
+
+      it 'has the filters of the persisted query' do
+        expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+          .to eq(persisted_query.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+      end
+
+      it 'has the orders overwritten' do
+        expect(find.orders.map { |order| [order.attribute, order.direction] })
+          .to eq [["id", :asc], ["name", :desc]]
+      end
+    end
+
+    context 'with an integer id for which the user does not have a query and with params' do
+      let(:id) { 42 }
+      let(:persisted_query) { nil }
+      let(:params) do
+        {
+          filters: [
+            {
+              attribute: 'active',
+              operator: '=',
+              values: ['f']
+            },
+            {
+              attribute: 'member_of',
+              operator: '=',
+              values: ['t']
+            }
+          ],
+          orders: [
+            {
+              attribute: 'id',
+              direction: 'asc'
+            },
+            {
+              attribute: 'name',
+              direction: 'desc'
+            }
+          ]
+        }
+      end
+
+      it 'returns nil' do
+        expect(find)
+          .to be_nil
+      end
+    end
+  end
+
+  describe '.static_query_active' do
+    subject(:find) { described_class.static_query_active }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('projects.lists.active'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:active, '=', ['t']]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+
+  describe '.static_query_my' do
+    subject(:find) { described_class.static_query_my }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('projects.lists.my'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:member_of, '=', ['t']]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+
+  describe '.static_query_archived' do
+    subject(:find) { described_class.static_query_archived }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('projects.lists.archived'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:active, '=', ['f']]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+
+  describe '.static_query_status_on_track' do
+    subject(:find) { described_class.static_query_status_on_track }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('activerecord.attributes.project.status_codes.on_track'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:project_status_code, '=', [Project.status_codes[:on_track].to_s]]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+
+  describe '.static_query_status_off_track' do
+    subject(:find) { described_class.static_query_status_off_track }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('activerecord.attributes.project.status_codes.off_track'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:project_status_code, '=', [Project.status_codes[:off_track].to_s]]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+
+  describe '.static_query_status_at_risk' do
+    subject(:find) { described_class.static_query_status_at_risk }
+
+    it 'returns a project query' do
+      expect(find)
+        .to be_a(Queries::Projects::ProjectQuery)
+    end
+
+    it 'has a name' do
+      expect(find.name)
+        .to eql(I18n.t('activerecord.attributes.project.status_codes.at_risk'))
+    end
+
+    it 'has a filter for active projects' do
+      expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+        .to eq([[:project_status_code, '=', [Project.status_codes[:at_risk].to_s]]])
+    end
+
+    it 'is ordered by lft asc' do
+      expect(find.orders.map { |order| [order.attribute, order.direction] })
+        .to eq([['lft', :asc]])
+    end
+  end
+end

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Queries::Projects::Factory do
           .to eql(I18n.t('projects.lists.my'))
       end
 
-      it 'has a filter for active projects' do
+      it 'has a filter for projects the user is a member of' do
         expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
           .to eq([[:member_of, '=', ['t']]])
       end
@@ -140,7 +140,7 @@ RSpec.describe Queries::Projects::Factory do
           .to eql(I18n.t('projects.lists.archived'))
       end
 
-      it 'has a filter for active projects' do
+      it 'has a filter for archived projects' do
         expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
           .to eq([[:active, '=', ['f']]])
       end
@@ -164,7 +164,7 @@ RSpec.describe Queries::Projects::Factory do
           .to eql(I18n.t('activerecord.attributes.project.status_codes.on_track'))
       end
 
-      it 'has a filter for active projects' do
+      it 'has a filter for projects that are "on track"' do
         expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
           .to eq([[:project_status_code, '=', [Project.status_codes[:on_track].to_s]]])
       end
@@ -188,7 +188,7 @@ RSpec.describe Queries::Projects::Factory do
           .to eql(I18n.t('activerecord.attributes.project.status_codes.off_track'))
       end
 
-      it 'has a filter for active projects' do
+      it 'has a filter for projects that are "off track"' do
         expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
           .to eq([[:project_status_code, '=', [Project.status_codes[:off_track].to_s]]])
       end
@@ -212,7 +212,7 @@ RSpec.describe Queries::Projects::Factory do
           .to eql(I18n.t('activerecord.attributes.project.status_codes.at_risk'))
       end
 
-      it 'has a filter for active projects' do
+      it 'has a filter for projects that are "at risk"' do
         expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
           .to eq([[:project_status_code, '=', [Project.status_codes[:at_risk].to_s]]])
       end
@@ -522,7 +522,7 @@ RSpec.describe Queries::Projects::Factory do
         .to eql(I18n.t('projects.lists.my'))
     end
 
-    it 'has a filter for active projects' do
+    it 'has a filter for projects the user is a member of' do
       expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
         .to eq([[:member_of, '=', ['t']]])
     end
@@ -546,7 +546,7 @@ RSpec.describe Queries::Projects::Factory do
         .to eql(I18n.t('projects.lists.archived'))
     end
 
-    it 'has a filter for active projects' do
+    it 'has a filter for archived projects' do
       expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
         .to eq([[:active, '=', ['f']]])
     end
@@ -570,7 +570,7 @@ RSpec.describe Queries::Projects::Factory do
         .to eql(I18n.t('activerecord.attributes.project.status_codes.on_track'))
     end
 
-    it 'has a filter for active projects' do
+    it 'has a filter for project that are "on track"' do
       expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
         .to eq([[:project_status_code, '=', [Project.status_codes[:on_track].to_s]]])
     end
@@ -594,7 +594,7 @@ RSpec.describe Queries::Projects::Factory do
         .to eql(I18n.t('activerecord.attributes.project.status_codes.off_track'))
     end
 
-    it 'has a filter for active projects' do
+    it 'has a filter for projects that are "off track"' do
       expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
         .to eq([[:project_status_code, '=', [Project.status_codes[:off_track].to_s]]])
     end
@@ -618,7 +618,7 @@ RSpec.describe Queries::Projects::Factory do
         .to eql(I18n.t('activerecord.attributes.project.status_codes.at_risk'))
     end
 
-    it 'has a filter for active projects' do
+    it 'has a filter for projects that are "at risk"' do
       expect(find.filters.map { |filter| [filter.field, filter.operator, filter.values] })
         .to eq([[:project_status_code, '=', [Project.status_codes[:at_risk].to_s]]])
     end


### PR DESCRIPTION
When trying to access another user's project query, a 403 is returned now. 

To do so, more of the responsibilities is moved into the `Queries::ProjectQueries::Factory` which completely handles the loading and updating of static and persisted queries now.

https://community.openproject.org/wp/51666