### PR TITLE
Remove public permission adding when checking in Role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -84,7 +84,7 @@ class Role < ApplicationRecord
   def permissions
     # prefer map over pluck as we will probably always load
     # the permissions anyway
-    role_permissions.map(&:permission).map(&:to_sym)
+    role_permissions.map { |perm| perm.permission.to_sym }
   end
 
   def permissions=(perms)
@@ -143,7 +143,7 @@ class Role < ApplicationRecord
     if action.is_a? Hash
       allowed_actions.include? "#{action[:controller]}/#{action[:action]}"
     else
-      allowed_permissions.include? action
+      permissions.include? action
     end
   end
 
@@ -159,12 +159,8 @@ class Role < ApplicationRecord
 
   private
 
-  def allowed_permissions
-    @allowed_permissions ||= permissions + OpenProject::AccessControl.public_permissions.map(&:name)
-  end
-
   def allowed_actions
-    @allowed_actions ||= allowed_permissions.flat_map do |permission|
+    @allowed_actions ||= permissions.flat_map do |permission|
       OpenProject::AccessControl.allowed_actions(permission)
     end
   end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -136,16 +136,6 @@ RSpec.describe User, 'allowed_to?' do
             expect(user).not_to be_allowed_to(permission, project)
           end
         end
-
-        context 'and requesting a public permission' do
-          let(:permission) { :view_project } # a permission defined as public
-
-          before do
-            final_setup_step
-          end
-
-          it { expect(user).not_to be_allowed_to(permission, project) }
-        end
       end
 
       context 'and the project being public' do
@@ -174,16 +164,6 @@ RSpec.describe User, 'allowed_to?' do
             expect(user).to be_allowed_to(permission, project)
           end
         end
-
-        context 'and requesting a public permission' do
-          let(:permission) { :view_project } # a permission defined as public
-
-          before do
-            final_setup_step
-          end
-
-          it { expect(user).to be_allowed_to(permission, project) }
-        end
       end
     end
 
@@ -199,17 +179,6 @@ RSpec.describe User, 'allowed_to?' do
           before { final_setup_step }
 
           it { expect(user).not_to be_allowed_to(permission, project) }
-        end
-
-        context 'and requesting a public permission' do
-          let(:permission) { :view_project } # a permission defined as public
-
-          before do
-            project.update(public: false)
-            final_setup_step
-          end
-
-          it { expect(user).to be_allowed_to(permission, project) }
         end
       end
 
@@ -272,14 +241,6 @@ RSpec.describe User, 'allowed_to?' do
             anonymous_role.add_permission!(permission)
             final_setup_step
           end
-
-          it { expect(anonymous).to be_allowed_to(permission, project) }
-        end
-
-        context 'with a public permission' do
-          let(:permission) { :view_project }
-
-          before { final_setup_step }
 
           it { expect(anonymous).to be_allowed_to(permission, project) }
         end


### PR DESCRIPTION
Since #14010 we are always adding public permissions to ProjectRoles, this way we don't have to manually add them every time we check for a permission.

Implements https://community.openproject.org/projects/openproject/work_packages/50769