### PR TITLE
Bug/52676 Do not render oauth access grant modal when the project storage no longer exists

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -54,7 +54,7 @@ class OAuthClientsController < ApplicationController
     service_result = @connection_manager.code_to_token(@code)
 
     if service_result.success?
-      flash[:modal] = session[:oauth_callback_flash_modal] if session[:oauth_callback_flash_modal].present?
+      flash[:modal] = session.delete(:oauth_callback_flash_modal) if session[:oauth_callback_flash_modal].present?
       # Redirect the user to the page that initially wanted to access the OAuth2 resource.
       # "state" is a nonce that identifies a cookie which holds that page's URL.
       redirect_to @redirect_uri

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -38,8 +38,12 @@ module Storages::Admin
     attr_reader :project_storage
 
     def initialize(project_storage_id:, **options)
-      @project_storage = ::Storages::ProjectStorage.find(project_storage_id)
+      @project_storage = ::Storages::ProjectStorage.find_by(id: project_storage_id)
       super(@project_storage, **options)
+    end
+
+    def render?
+      @project_storage.present?
     end
 
     private

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -65,4 +65,12 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
       expect(page).to have_button('Close')
     end
   end
+
+  context 'with no project storage' do
+    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage_id: nil) }
+
+    it 'does not render' do
+      expect(page.text).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/52676

- [x] Ensure modal session is cleaned up on render to prevent stale state
- [x] Have the modal check whether a valid a project storage is present for render