### PR TITLE
Fix CurrentUserService#loggedIn check

### DIFF
--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -14,6 +14,7 @@
 <% end %>
 <meta name="current_user"
       data-name="<%= User.current.name %>"
+      data-logged-in="<%= User.current.logged? %>"
       data-id="<%= User.current.id %>"/>
 
 <% if Setting.demo_projects_available %><meta name="demo_projects_available" content="true"/><% end %>

--- a/frontend/src/app/core/current-user/current-user.module.ts
+++ b/frontend/src/app/core/current-user/current-user.module.ts
@@ -19,6 +19,7 @@ export function bootstrapModule(injector:Injector):void {
   currentUserService.setUser({
     id: userMeta?.dataset.id || null,
     name: userMeta?.dataset.name || null,
+    loggedIn: userMeta?.dataset.loggedIn === 'true',
   });
 }
 

--- a/frontend/src/app/core/current-user/current-user.query.ts
+++ b/frontend/src/app/core/current-user/current-user.query.ts
@@ -8,7 +8,7 @@ export class CurrentUserQuery extends Query<CurrentUserState> {
     super(store);
   }
 
-  isLoggedIn$ = this.select((state) => !!state.id);
+  isLoggedIn$ = this.select((state) => !!state.loggedIn);
 
-  user$ = this.select(({ id, name }) => ({ id, name }));
+  user$ = this.select((user) => user);
 }

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -156,6 +156,7 @@ export class CurrentUserService {
   private _user:CurrentUser = {
     id: null,
     name: null,
+    loggedIn: false,
   };
 
   /** @deprecated Use the store mechanism `currentUserQuery.user$` */

--- a/frontend/src/app/core/current-user/current-user.store.ts
+++ b/frontend/src/app/core/current-user/current-user.store.ts
@@ -32,6 +32,7 @@ import { Store, StoreConfig } from '@datorama/akita';
 export interface CurrentUser {
   id:string|null;
   name:string|null;
+  loggedIn:boolean|null;
 }
 
 export interface CurrentUserState extends CurrentUser {
@@ -41,6 +42,7 @@ export function createInitialState():CurrentUserState {
   return {
     id: null,
     name: null,
+    loggedIn: null,
   };
 }
 


### PR DESCRIPTION
https://github.com/opf/openproject/pull/14672 introduced anonymous user output to the current_user meta tag.

This results in the id being always present even if the user is not logged in. Some of the application code depends on loggedIn checks by checking existence of this id.

These checks are now invalid, as anonymous is returned, but not logged in.

To fix this, a separate logged-in attribute is now used

https://community.openproject.org/work_packages/52752