### PR TITLE
[32764] Gantt chart fixes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2705,7 +2705,7 @@ en:
   project_module_news: "News"
   project_module_repository: "Repository"
   project_module_wiki: "Wiki"
-  permission_header_for_project_module_work_package_tracking: "Work packages and Gantt"
+  permission_header_for_project_module_work_package_tracking: "Work packages and Gantt charts"
 
   query:
     attribute_and_direction: "%{attribute} (%{direction})"

--- a/modules/gantt/app/controllers/gantt/menus_controller.rb
+++ b/modules/gantt/app/controllers/gantt/menus_controller.rb
@@ -84,11 +84,14 @@ module Gantt
     def base_query
       base_query ||= Query
                      .visible(current_user)
-                     .joins(:views, :project)
+                     .includes(:project)
+                     .joins(:views)
                      .where('views.type' => 'gantt')
 
       if @project.present?
         base_query = base_query.where('queries.project_id' => @project.id)
+      else
+        base_query = base_query.where('queries.project_id' => nil)
       end
 
       base_query

--- a/modules/gantt/app/services/gantt/default_query_generator_service.rb
+++ b/modules/gantt/app/services/gantt/default_query_generator_service.rb
@@ -36,7 +36,7 @@ module ::Gantt
     QUERY_OPTIONS = QUERY_MAPPINGS.keys
 
     PROJECT_DEFAULT_COLUMNS = %w[id type subject status startDate dueDate duration].freeze
-    GLOBAL_DEFAULT_COLUMNS = %w[id type subject status startDate dueDate duration project].freeze
+    GLOBAL_DEFAULT_COLUMNS = %w[id project type subject status startDate dueDate duration].freeze
 
     DEFAULT_PARAMS =
       {

--- a/modules/gantt/config/locales/en.yml
+++ b/modules/gantt/config/locales/en.yml
@@ -1,3 +1,3 @@
 # English strings go here
 en:
-  project_module_gantt: "Gantt"
+  project_module_gantt: "Gantt charts"

--- a/modules/gantt/spec/features/menu/global_gantt_menu_spec.rb
+++ b/modules/gantt/spec/features/menu/global_gantt_menu_spec.rb
@@ -1,0 +1,112 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe 'Gantt charts menu',
+               :js,
+               :selenium do
+  let(:user) { create(:admin) }
+  let(:enabled_module_names) { %i[work_package_tracking gantt] }
+  let(:project) { create(:project, enabled_module_names:) }
+  let(:wp_project_timeline) { Pages::WorkPackagesTimeline.new(project) }
+  let(:wp_global_timeline) { Pages::WorkPackagesTimeline.new }
+
+  let!(:global_private_query) do
+    query = build(:global_query, user_id: user.id)
+    query.timeline_visible = true
+    query.public = false
+
+    query.save!
+    create(:view_gantt,
+           query:)
+
+    query
+  end
+
+  let!(:global_public_query) do
+    query = build(:global_query, user_id: user.id)
+    query.timeline_visible = true
+
+    query.save!
+    create(:view_gantt,
+           query:)
+
+    query
+  end
+
+  let!(:global_starred_query) do
+    query = build(:global_query, user_id: user.id)
+    query.timeline_visible = true
+    query.starred = true
+
+    query.save!
+    create(:view_gantt,
+           query:)
+
+    query
+  end
+
+  let!(:private_project_query) do
+    query = create(:query_with_view_gantt, user:, project:)
+    query.timeline_visible = true
+
+    query.save!
+    query
+  end
+
+  before do
+    login_as(user)
+  end
+
+  describe 'on the global Gantt charts page' do
+    it 'shows all queries without a project' do
+      wp_global_timeline.visit!
+      loading_indicator_saveguard
+
+      # Show global queries only
+      expect(page).to have_css('.op-sidemenu--item-action', text: global_starred_query)
+      expect(page).to have_css('.op-sidemenu--item-action', text: global_public_query)
+      expect(page).to have_css('.op-sidemenu--item-action', text: global_private_query)
+      expect(page).to have_no_css('.op-sidemenu--item-action', text: private_project_query)
+    end
+  end
+
+  describe 'on the project Gantt charts page' do
+    it 'shows all queries that belong to the project' do
+      wp_project_timeline.visit!
+      loading_indicator_saveguard
+
+      # Show project queries only
+      expect(page).to have_no_css('.op-sidemenu--item-action', text: global_starred_query)
+      expect(page).to have_no_css('.op-sidemenu--item-action', text: global_public_query)
+      expect(page).to have_no_css('.op-sidemenu--item-action', text: global_private_query)
+      expect(page).to have_css('.op-sidemenu--item-action', text: private_project_query)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Rename "Work packages and Gantt" to "Work packages and Gantt charts" in the permission section (see [this comment](https://community.openproject.org/projects/openproject/work_packages/32764#activity-47))
- [x] Rename "Gantt" to "Gantt charts" in the project module selection (see [this comment](https://community.openproject.org/projects/openproject/work_packages/32764#activity-47))
- [x] Change position of the "project" column in the global Gantt module to be shown after ID and not at the end  (see [this comment](https://community.openproject.org/projects/openproject/work_packages/32764#activity-47))
- [x] Show all non-project queries visible to a user on the global Gantt menu (see [this comment](https://community.openproject.org/projects/openproject/work_packages/32764#activity-52))

https://community.openproject.org/projects/openproject/work_packages/32764/activity