### PR TITLE
[#52284] CostReportsController#destroy - wrong method name was rename

### DIFF
--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -148,7 +148,7 @@ class CostReportsController < ApplicationController
   # RecordNotFound if the query at :id does not exist
   def destroy
     if @query
-      @query.destroy if allowed_in_report(:destroy, @query)
+      @query.destroy if allowed_in_report?(:destroy, @query)
     else
       raise ActiveRecord::RecordNotFound
     end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/52284/activity

1. Fixed method name: `allowed_in_report` -> `allowed_in_report?` in CostReportsController#destroy
https://github.com/opf/openproject/blob/c3ef93974db15d1df0b9650ecf0e64613434fc46/modules/reporting/app/controllers/cost_reports_controller.rb#L151
3. Spec added and rewritten.