### PR TITLE
fix time entries endpoint to return ongoing time entries while lacking log own time permission

### DIFF
--- a/modules/costs/app/models/time_entries/scopes/ongoing.rb
+++ b/modules/costs/app/models/time_entries/scopes/ongoing.rb
@@ -37,7 +37,12 @@ module TimeEntries::Scopes
 
       def visible_ongoing(user = User.current)
         TimeEntry
-          .where(work_package_id: WorkPackage.allowed_to(user, :log_own_time), user:, ongoing: true)
+          .where(work_package_id: visible_work_packages(user).select(:id), user:, ongoing: true)
+      end
+
+      def visible_work_packages(user)
+        WorkPackage.allowed_to(user, :log_own_time).or(
+          WorkPackage.where(project_id: Project.allowed_to(User.current, :log_time)))
       end
 
       def not_ongoing

--- a/modules/costs/spec/models/queries/time_entries/time_entry_query_integration_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/time_entry_query_integration_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe Queries::TimeEntries::TimeEntryQuery, 'integration' do
       it 'only returns the users own time entries' do
         expect(subject).to contain_exactly(user_timer)
       end
+
+      context 'when user has log_time permission' do
+        let(:user) { create(:user, member_with_permissions: { project => %i[log_time] }) }
+
+        it 'still returns the users own time entries' do
+          expect(subject).to contain_exactly(user_timer)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This might actually be exactly the problem in [#50025](https://community.openproject.org/projects/openproject/work_packages/50025/activity).

The steps to reproduce are the following:

1. Start logging some time for oneself
2. Remove "log own time" permission from role in project
3. Try logging time again

The user won't see that there is an ongoing time entry already.

I initially hoped to include the fix in 13.3.0 but that won't be enough time anymore, now.
This PR still needs tests and QA. Let's put this into 13.3.1 then.

I will continue with this and confirm it when I'm back on Wednesday.