### PR TITLE
[52779] Add port of Nextcloud storage to CSP directives

### DIFF
--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -174,7 +174,8 @@ module Storages
     end
 
     def connect_src
-      ["#{uri.scheme}://#{uri.host}"]
+      port_part = [80, 443].include?(uri.port) ? "" : ":#{uri.port}"
+      ["#{uri.scheme}://#{uri.host}#{port_part}"]
     end
 
     def oauth_configuration


### PR DESCRIPTION
https://community.openproject.org/wp/52779

Only if the port is not 443 or 80. Mostly useful for local development when Nextcloud is on port 8080 for instance.