### PR TITLE
[#52287] Consent always shown in Browser language despite user's language being set differently

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -220,7 +220,15 @@ class ApplicationController < ActionController::Base
   end
 
   def set_localization
-    SetLocalizationService.new(User.current, request.env['HTTP_ACCEPT_LANGUAGE']).call
+    # 1. Use completely autheticated user
+    # 2. Use user with some authenticated stages not compelted.
+    #    In this case user is not considered logged in, but identified.
+    #    It covers localization for extra authentication stages(like :consent, for example)
+    # 3. Use anonymous instance.
+    user = RequestStore[:current_user] ||
+           (session[:authenticated_user_id].present? && User.find_by(id: session[:authenticated_user_id])) ||
+           User.anonymous
+    SetLocalizationService.new(user, request.env['HTTP_ACCEPT_LANGUAGE']).call
   end
 
   def deny_access(not_found: false)

--- a/app/controllers/concerns/accounts/authentication_stages.rb
+++ b/app/controllers/concerns/accounts/authentication_stages.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 module Accounts::AuthenticationStages
   def successful_authentication(user, reset_stages: true, just_registered: false)
     stages = authentication_stages after_activation: just_registered, reset: reset_stages

--- a/app/helpers/user_consent_helper.rb
+++ b/app/helpers/user_consent_helper.rb
@@ -52,6 +52,8 @@ module ::UserConsentHelper
     I18n.t('consent.checkbox_label', locale:)
   end
 
+  private
+
   def consent_configured?
     if Setting.consent_info.count == 0
       Rails.logger.error 'Instance is configured to require consent, but no consent_info has been set.'

--- a/app/helpers/user_consent_helper.rb
+++ b/app/helpers/user_consent_helper.rb
@@ -37,16 +37,14 @@ module ::UserConsentHelper
   end
 
   ##
-  # Gets consent instructions for the given user.
+  # Gets consent instructions.
   #
-  # @param user [User] The user to get instructions for.
   # @param locale [String] ISO-639-1 code for the desired locale (e.g. de, en, fr).
   #                        `I18n.locale` is set for each request individually depending
   #                        among other things on the user's Accept-Language headers.
   # @return [String] Instructions in the respective language.
-  def user_consent_instructions(_user, locale: I18n.locale)
+  def user_consent_instructions(locale)
     all = Setting.consent_info
-
     all.fetch(locale.to_s) { all.values.first }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -470,6 +470,17 @@ class User < Principal
     !logged?
   end
 
+  def consent_expired?
+    # Always if the user has not consented
+    return true if consented_at.blank?
+
+    # Did not expire if no consent_time set, but user has consented at some point
+    return false if Setting.consent_time.blank?
+
+    # Otherwise, expires when consent_time is newer than last consented_at
+    consented_at < Setting.consent_time
+  end
+
   # Cheap version of Project.visible.count
   def number_of_known_projects
     if admin?

--- a/app/services/set_localization_service.rb
+++ b/app/services/set_localization_service.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 class SetLocalizationService
   attr_reader :user, :http_accept_header
 

--- a/app/views/account/_register.html.erb
+++ b/app/views/account/_register.html.erb
@@ -90,7 +90,7 @@ See COPYRIGHT and LICENSE files for more details.
 
       <% if user_consent_required? %>
         <hr/>
-        <%= render partial: 'account/user_consent_check', locals: { consenting_user: @user } %>
+        <%= render partial: 'account/user_consent_check' %>
       <% end %>
 
       <%= render partial: 'account/auth_providers', locals: { omniauth_title: I18n.t('account.signup_with_auth_provider'), wide: true } %>

--- a/app/views/account/_user_consent_check.html.erb
+++ b/app/views/account/_user_consent_check.html.erb
@@ -1,6 +1,6 @@
 <section class="form--section op-user-consent-form">
   <p>
-    <%= format_text user_consent_instructions(consenting_user), { target: '_blank' } %>
+    <%= format_text(user_consent_instructions(consenting_user.language || ::I18n.locale), { target: '_blank' }) %>
   </p>
 
   <label class="form--label-with-check-box -required -no-ellipsis op-user-consent-form--agreement">

--- a/app/views/account/_user_consent_check.html.erb
+++ b/app/views/account/_user_consent_check.html.erb
@@ -1,6 +1,6 @@
 <section class="form--section op-user-consent-form">
   <p>
-    <%= format_text(user_consent_instructions(consenting_user.language || ::I18n.locale), { target: '_blank' }) %>
+    <%= format_text(user_consent_instructions(::I18n.locale), { target: '_blank' }) %>
   </p>
 
   <label class="form--label-with-check-box -required -no-ellipsis op-user-consent-form--agreement">

--- a/app/views/account/consent.html.erb
+++ b/app/views/account/consent.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 
   <%= form_tag(account_confirm_consent_path, method: :post, class: "form -wide-labels") do %>
-    <%= render partial: 'user_consent_check', locals: { consenting_user: consenting_user } %>
+    <%= render partial: 'user_consent_check' %>
     <section class="form--section">
       <button type="submit" class="button -highlight">
       <span class="button--text"><%= t(:button_continue) %></span>

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -39,17 +39,11 @@ RSpec.describe MembersController do
                     roles: [role])
   end
 
-  before do
-    allow(User).to receive(:current).and_return(admin)
-  end
+  before { login_as(admin) }
 
   describe 'create' do
     shared_let(:admin) { create(:admin) }
     let(:project_2) { create(:project) }
-
-    before do
-      allow(User).to receive(:current).and_return(admin)
-    end
 
     it 'works for multiple users' do
       post :create,
@@ -88,10 +82,6 @@ RSpec.describe MembersController do
       )
     end
 
-    before do
-      allow(User).to receive(:current).and_return(admin)
-    end
-
     it 'however,s allow roles to be updated through mass assignment' do
       put 'update',
           params: {
@@ -110,9 +100,7 @@ RSpec.describe MembersController do
   describe '#autocomplete_for_member' do
     let(:params) { { 'project_id' => project.identifier.to_s } }
 
-    before do
-      login_as(user)
-    end
+    before { login_as(user) }
 
     describe "WHEN the user is authorized
               WHEN a project is provided" do

--- a/spec/features/auth/consent_auth_stage_spec.rb
+++ b/spec/features/auth/consent_auth_stage_spec.rb
@@ -100,18 +100,26 @@ RSpec.describe 'Authentication Stages' do
             consent_required: true,
             consent_info: { de: '# Einwilligung', en: '# Consent header!' }
           } do
-    around do |example|
-      Capybara.current_session.driver.header('Accept-Language', 'de')
-      example.call
-    ensure
-      Capybara.current_session.driver.header('Accept-Language', 'en')
+    context 'users language is en' do
+      let(:language) { 'en' }
+
+      it 'shows consent en' do
+        login_with user.login, user_password
+
+        expect(page).to have_css('.account-consent')
+        expect(page).to have_css('h1', text: 'Consent header!')
+      end
     end
 
-    it 'shows localized consent as defined by the accept language header (ignoring users language)' do
-      login_with user.login, user_password
+    context 'users language is de' do
+      let(:language) { 'de' }
 
-      expect(page).to have_css('.account-consent')
-      expect(page).to have_css('h1', text: 'Einwilligung')
+      it 'shows consent in de' do
+        login_with user.login, user_password
+
+        expect(page).to have_css('.account-consent')
+        expect(page).to have_css('h1', text: 'Einwilligung')
+      end
     end
   end
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -49,7 +49,8 @@ module AuthenticationHelpers
       end
     end
 
-    allow(User).to receive(:current).and_return(user)
+    allow(RequestStore).to receive(:[]).and_call_original
+    allow(RequestStore).to receive(:[]).with(:current_user).and_return(user)
   end
 
   def login_with(login, password, autologin: false, visit_signin_path: true)

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe 'account/register' do
     let(:locale) { raise "you have to define the locale" }
 
     before do
-      I18n.with_locale(locale) do
-        render
-      end
+      I18n.with_locale(locale) { render }
     end
 
     context "for English (locale: en) users" do


### PR DESCRIPTION
https://community.openproject.org/work_packages/52287

### What is the problem?
User consent text is displayed in browser language instead of in user's language. It happens because user consent is rendered at the moment when user is not considered as logged in user `User.current == User.anonymous`.  Then `SetLocalizationService` relies on browser sent header.

### Solution
In the problematic moment described above user is not logged in, but identified. Its id is stored in `session[:authenticated_user_id]`. It happens because consent rendering it is an intermediary authentication stage([details](https://github.com/opf/openproject/blob/dev/lib_static/open_project/authentication.rb#L138)). I suggest to rely on this session value to identify user and pass it to `SetLocalizationService`.
It happens in `ApplicationController`. We use `SetLocalizationService` in `root_api.rb` as well. I have not touched `root_api.rb`, because I think this modification is not needed there. Let me know if you think it makes sense.
An important outcome of the PR is that any other authentication stages will respect user configured locale.

