### PR TITLE
Fix seeding on BIM edition

### DIFF
--- a/app/seeders/demo_data/global_query_seeder.rb
+++ b/app/seeders/demo_data/global_query_seeder.rb
@@ -33,6 +33,10 @@ module DemoData
       end
     end
 
+    def applicable?
+      Query.global.none?
+    end
+
     private
 
     def seed_global_queries

--- a/app/seeders/development_data/shared_work_packages_seeder.rb
+++ b/app/seeders/development_data/shared_work_packages_seeder.rb
@@ -81,8 +81,8 @@ module DevelopmentData
           reference: :save_gotham,
           description: "Gotham is in trouble. It's your job to save it!",
           status: seed_data.find_reference(:default_status_new),
-          type: seed_data.find_reference(:default_type_milestone),
-          priority: seed_data.find_reference(:default_priority_high)
+          type: seed_data.find_reference(:default_type_epic, :default_type_phase),
+          priority: seed_data.find_reference(:default_priority_immediate, :default_priority_high)
         },
         {
           project:,
@@ -92,7 +92,7 @@ module DevelopmentData
           description: 'Must be stopped before Gotham is doomed.',
           status: seed_data.find_reference(:default_status_new),
           type: seed_data.find_reference(:default_type_task),
-          priority: seed_data.find_reference(:default_priority_high)
+          priority: seed_data.find_reference(:default_priority_immediate, :default_priority_high)
         },
         {
           project:,

--- a/app/seeders/development_data/shared_work_packages_seeder.rb
+++ b/app/seeders/development_data/shared_work_packages_seeder.rb
@@ -81,8 +81,8 @@ module DevelopmentData
           reference: :save_gotham,
           description: "Gotham is in trouble. It's your job to save it!",
           status: seed_data.find_reference(:default_status_new),
-          type: seed_data.find_reference(:default_type_epic),
-          priority: seed_data.find_reference(:default_priority_immediate)
+          type: seed_data.find_reference(:default_type_milestone),
+          priority: seed_data.find_reference(:default_priority_high)
         },
         {
           project:,
@@ -92,7 +92,7 @@ module DevelopmentData
           description: 'Must be stopped before Gotham is doomed.',
           status: seed_data.find_reference(:default_status_new),
           type: seed_data.find_reference(:default_type_task),
-          priority: seed_data.find_reference(:default_priority_immediate)
+          priority: seed_data.find_reference(:default_priority_high)
         },
         {
           project:,

--- a/app/seeders/source/seed_data.rb
+++ b/app/seeders/source/seed_data.rb
@@ -43,15 +43,25 @@ class Source::SeedData
     registry[reference] = record
   end
 
-  def find_reference(reference, default: :__unset__)
+  # Finds and returns the value associated with the given reference.
+  #
+  # @param reference [Symbol] The reference to search for.
+  # @param fallbacks [Array<Symbol>] Optional fallback references to search for if the primary reference is not found.
+  # @param default [Object] The default value to return if no reference or fallbacks are found.
+  # @return [Object, nil] The value associated with the reference, or nil if the reference is nil.
+  # @raise [ArgumentError] If no reference or fallbacks are found and no default value is provided.
+  def find_reference(reference, *fallbacks, default: :__unset__)
     return if reference.nil?
 
-    registry.fetch(reference) do
-      if default == :__unset__
-        raise ArgumentError, "Nothing registered with reference #{reference.inspect}"
-      end
-
+    existing_ref = [reference, *fallbacks].find { |ref| registry.key?(ref) }
+    if existing_ref
+      registry[existing_ref]
+    elsif default != :__unset__
       default
+    else
+      references = [reference, *fallbacks].map(&:inspect)
+      message = "Nothing registered with #{'reference'.pluralize(references.count)} #{references.to_sentence(locale: false)}"
+      raise ArgumentError, message
     end
   end
 

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -27,14 +27,17 @@
 #++
 
 priorities:
-  - t_name: Low
+  - reference: :default_priority_low
+    t_name: Low
     color_name: cyan-1
     position: 1
-  - t_name: Normal
+  - reference: :default_priority_normal
+    t_name: Normal
     color_name: blue-3
     is_default: true
     position: 2
-  - t_name: High
+  - reference: :default_priority_high
+    t_name: High
     color_name: yellow-7
     position: 3
   - reference: :default_priority_immediate

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -47,17 +47,21 @@ modules_permissions:
     - :view_linked_issues
 
 priorities:
-  - t_name: Low
+  - reference: :default_priority_low
+    t_name: Low
     color_name: cyan-1
     is_default: true
     position: 1
-  - t_name: Normal
+  - reference: :default_priority_normal
+    t_name: Normal
     color_name: blue-3
     position: 2
-  - t_name: High
+  - reference: :default_priority_high
+    t_name: High
     color_name: yellow-7
     position: 3
-  - t_name: Critical
+  - reference: :default_priority_critical
+    t_name: Critical
     color_name: grape-5
     position: 4
 

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -204,4 +204,38 @@ RSpec.describe RootSeeder,
 
     include_examples 'creates BIM demo data'
   end
+
+  describe 'demo data with development data' do
+    shared_let(:root_seeder) { described_class.new(seed_development_data: true) }
+
+    before_all do
+      with_edition('bim') do
+        root_seeder.seed_data!
+      end
+    end
+
+    it 'creates 1 additional admin user with German locale' do
+      admins = User.not_builtin.where(admin: true)
+      expect(admins.count).to eq 2
+      expect(admins.pluck(:language)).to match_array(%w[en de])
+    end
+
+    it 'creates 5 additional projects for development' do
+      expect(Project.count).to eq 9
+    end
+
+    it 'creates 4 additional work packages for development' do
+      expect(WorkPackage.count).to eq 80
+    end
+
+    it 'creates 1 project with custom fields' do
+      expect(CustomField.count).to eq 12
+    end
+
+    it 'creates 2 additional types for development' do
+      expect(Type.count).to eq 9
+    end
+
+    include_examples 'no email deliveries'
+  end
 end

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -116,7 +116,9 @@ RSpec.describe RootSeeder,
 
     context 'when run a second time' do
       before_all do
-        described_class.new.seed_data!
+        with_edition('bim') do
+          described_class.new.seed_data!
+        end
       end
 
       it 'does not create additional data' do

--- a/spec/seeders/source/seed_data_spec.rb
+++ b/spec/seeders/source/seed_data_spec.rb
@@ -63,12 +63,24 @@ RSpec.describe Source::SeedData do
     it 'raises an error if the reference is not found' do
       expect { seed_data.find_reference(:ref) }
         .to raise_error(ArgumentError, 'Nothing registered with reference :ref')
+      expect { seed_data.find_reference(:ref, :other_ref) }
+        .to raise_error(ArgumentError, 'Nothing registered with references :ref and :other_ref')
+      expect { seed_data.find_reference(:ref, :other_ref, :yet_another_ref) }
+        .to raise_error(ArgumentError, 'Nothing registered with references :ref, :other_ref, and :yet_another_ref')
     end
 
     it 'returns the given default value if the reference is not found' do
       expect(seed_data.find_reference(:ref, default: 42)).to eq(42)
       expect(seed_data.find_reference(:ref, default: 'hello')).to eq('hello')
       expect(seed_data.find_reference(:ref, default: nil)).to be_nil
+    end
+
+    it 'tries with fallback references if the primary reference is not found' do
+      object = Object.new
+      seed_data.store_reference(:other_ref, object)
+      expect(seed_data.find_reference(:other_ref)).to be(object)
+      expect(seed_data.find_reference(:ref, :other_ref)).to be(object)
+      expect(seed_data.find_reference(:ref, :unknown_ref, :another_unknown, :other_ref)).to be(object)
     end
   end
 


### PR DESCRIPTION
Standardizes the Types and Priorities used in the SharedWorkPackageSeeder so seeding is agnostic of specific records present on either the standard or BIM edition of OpenProject.