### PR TITLE
[Op#52605]: Add Loading state to Project Storage OAuth Grant Access nudge modal

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -42,6 +42,7 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
 
   static values = {
     closeButtonLabel: String,
+    loadingScreenReaderMessage: String,
   };
 
   declare readonly requestAccessFormTarget:HTMLFormElement;
@@ -53,6 +54,7 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   declare readonly hasRequestAccessButtonTarget:boolean;
 
   declare readonly closeButtonLabelValue:string;
+  declare readonly loadingScreenReaderMessageValue:string;
 
   connect() {
     this.element.showModal();
@@ -73,10 +75,15 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   // Hide the request access button and show the loading indicator
   private activateLoadingState() {
     this.requestAccessButtonTarget.classList.add('d-none');
-    this.closeButtonTarget.textContent = this.closeButtonLabelValue;
-    this.closeButtonTarget.setAttribute('aria-label', this.closeButtonLabelValue);
-    this.headerTarget.classList.add('d-none');
 
+    // Set the close button label to "Cancel"
+    this.closeButtonTarget.textContent = this.closeButtonLabelValue;
+
+    // Convey to screen readers that we're waiting for the request
+    this.headerTarget.classList.add('sr-only');
+    this.headerTarget.textContent = this.loadingScreenReaderMessageValue;
+
+    // Hide the request access body and show the loading indicator
     this.requestAccessBodyTarget.classList.add('d-none');
     this.loadingIndicatorTarget.classList.remove('d-none');
   }

--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -31,7 +31,31 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class OAuthAccessGrantNudgeModalController extends Controller<HTMLDialogElement> {
+  static targets = [
+    'requestAccessForm',
+    'requestAccessButton',
+  ];
+
+  declare readonly requestAccessFormTarget:HTMLFormElement;
+  declare readonly requestAccessButtonTarget:HTMLElement;
+  declare readonly hasRequestAccessFormTarget:boolean;
+  declare readonly hasRequestAccessButtonTarget:boolean;
+
   connect() {
     this.element.showModal();
+
+    if (this.hasRequestAccessButtonTarget) {
+      // Focus on the request access button
+      this.requestAccessButtonTarget.focus();
+    }
+  }
+
+  public requestAccess(evt:Event):void {
+    evt.preventDefault();
+
+    this.requestAccessButtonTarget.textContent = 'Requesting access...';
+    this.requestAccessButtonTarget.setAttribute('aria-disabled', 'true');
+
+    this.requestAccessFormTarget.requestSubmit();
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -34,12 +34,25 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   static targets = [
     'requestAccessForm',
     'requestAccessButton',
+    'header',
+    'loadingIndicator',
+    'requestAccessBody',
+    'cancelButton',
   ];
 
+  static values = {
+    closeButtonLabel: String,
+  };
+
   declare readonly requestAccessFormTarget:HTMLFormElement;
+  declare readonly requestAccessBodyTarget:HTMLElement;
+  declare readonly headerTarget:HTMLElement;
+  declare readonly loadingIndicatorTarget:HTMLElement;
   declare readonly requestAccessButtonTarget:HTMLElement;
-  declare readonly hasRequestAccessFormTarget:boolean;
+  declare readonly cancelButtonTarget:HTMLElement;
   declare readonly hasRequestAccessButtonTarget:boolean;
+
+  declare closeButtonLabelValue:string;
 
   connect() {
     this.element.showModal();
@@ -53,9 +66,18 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   public requestAccess(evt:Event):void {
     evt.preventDefault();
 
-    this.requestAccessButtonTarget.textContent = 'Requesting access...';
-    this.requestAccessButtonTarget.setAttribute('aria-disabled', 'true');
-
+    this.activateLoadingState();
     this.requestAccessFormTarget.requestSubmit();
+  }
+
+  // Hide the request access button and show the loading indicator
+  private activateLoadingState() {
+    this.requestAccessButtonTarget.classList.add('d-none');
+    this.cancelButtonTarget.textContent = this.closeButtonLabelValue;
+    this.cancelButtonTarget.setAttribute('aria-label', this.closeButtonLabelValue);
+    this.headerTarget.classList.add('d-none');
+
+    this.requestAccessBodyTarget.classList.add('d-none');
+    this.loadingIndicatorTarget.classList.remove('d-none');
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -37,7 +37,7 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
     'header',
     'loadingIndicator',
     'requestAccessBody',
-    'cancelButton',
+    'closeButton',
   ];
 
   static values = {
@@ -49,10 +49,10 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   declare readonly headerTarget:HTMLElement;
   declare readonly loadingIndicatorTarget:HTMLElement;
   declare readonly requestAccessButtonTarget:HTMLElement;
-  declare readonly cancelButtonTarget:HTMLElement;
+  declare readonly closeButtonTarget:HTMLElement;
   declare readonly hasRequestAccessButtonTarget:boolean;
 
-  declare closeButtonLabelValue:string;
+  declare readonly closeButtonLabelValue:string;
 
   connect() {
     this.element.showModal();
@@ -73,8 +73,8 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
   // Hide the request access button and show the loading indicator
   private activateLoadingState() {
     this.requestAccessButtonTarget.classList.add('d-none');
-    this.cancelButtonTarget.textContent = this.closeButtonLabelValue;
-    this.cancelButtonTarget.setAttribute('aria-label', this.closeButtonLabelValue);
+    this.closeButtonTarget.textContent = this.closeButtonLabelValue;
+    this.closeButtonTarget.setAttribute('aria-label', this.closeButtonLabelValue);
     this.headerTarget.classList.add('d-none');
 
     this.requestAccessBodyTarget.classList.add('d-none');

--- a/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/storages/oauth-access-grant-nudge-modal.controller.ts
@@ -69,7 +69,9 @@ export default class OAuthAccessGrantNudgeModalController extends Controller<HTM
     evt.preventDefault();
 
     this.activateLoadingState();
-    this.requestAccessFormTarget.requestSubmit();
+    // NOTE: Automated requestAccessFormTarget.requestSubmit() is not possible due to CSP restrictions
+    // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action
+    window.location.href = this.requestAccessFormTarget.action;
   }
 
   // Hide the request access button and show the loading indicator

--- a/lookbook/previews/storages/admin/oauth_access_grant_nudge_modal_component_preview.rb
+++ b/lookbook/previews/storages/admin/oauth_access_grant_nudge_modal_component_preview.rb
@@ -1,0 +1,13 @@
+module Storages
+  module Admin
+    # @logical_path Storages/Admin
+    class OAuthAccessGrantNudgeModalComponentPreview < Lookbook::Preview
+      # Renders a oauth access grant nudge modal component
+      # @param authorized toggle Denotes whether access has been granted and renders a success state
+      def default(authorized: false)
+        project_storage = FactoryBot.build_stubbed(:project_storage)
+        render_with_template(locals: { project_storage:, authorized:, confirm_button_url: '#' })
+      end
+    end
+  end
+end

--- a/lookbook/previews/storages/admin/oauth_access_grant_nudge_modal_component_preview/default.html.erb
+++ b/lookbook/previews/storages/admin/oauth_access_grant_nudge_modal_component_preview/default.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <strong>Default</strong><br/>
+  <%= render(Storages::Admin::OAuthAccessGrantNudgeModalComponent.new(project_storage:, authorized:, confirm_button_url:)) %>
+</p>

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -26,14 +26,27 @@
 
       unless authorized
         concat(
-          render(
-            Primer::Beta::Button.new(
-              scheme: :primary,
-              tag: :a,
-              href: confirm_button_url,
-              aria: { label: confirm_button_text }
-            )
-          ) { confirm_button_text }
+          primer_form_with(
+            model: @project_storage,
+            url: confirm_button_url,
+            method: :get,
+            data: {
+              'storages--oauth-access-grant-nudge-modal-target': 'requestAccessForm'
+            }
+          ) do |_form|
+            render(
+              Primer::Beta::Button.new(
+                scheme: :primary,
+                size: :medium,
+                type: :submit,
+                aria: { label: confirm_button_text },
+                data: {
+                  'storages--oauth-access-grant-nudge-modal-target': 'requestAccessButton',
+                  action: 'click->storages--oauth-access-grant-nudge-modal#requestAccess'
+                }
+              )
+            ) { confirm_button_text }
+          end
         )
       end
     end

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -51,7 +51,6 @@
           Primer::Beta::Button.new(
             scheme: :default,
             size: :medium,
-            aria: { label: cancel_button_text },
             data: {
               'close-dialog-id': dialog_id,
               'storages--oauth-access-grant-nudge-modal-target': 'closeButton'
@@ -75,7 +74,7 @@
                 scheme: :primary,
                 size: :medium,
                 type: :submit,
-                aria: { label: confirm_button_text },
+                aria: { label: confirm_button_aria_label },
                 data: {
                   'storages--oauth-access-grant-nudge-modal-target': 'requestAccessButton',
                   action: 'click->storages--oauth-access-grant-nudge-modal#requestAccess'

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -17,7 +17,12 @@
       }
     )
 
-    dialog.with_body(id: dialog_body_id, role: :status, aria: { live: :polite }) do
+    dialog.with_body(
+      id: dialog_body_id,
+      role: :status,
+      aria: { live: (authorized ? :assertive : :polite) },
+      test_selector: 'oauth-access-grant-nudge-modal-body'
+    ) do
       concat(
         render(
           Primer::Beta::Text.new(

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -5,7 +5,8 @@
       title:,
       data: {
         'application-target': 'dynamic',
-        controller: 'storages--oauth-access-grant-nudge-modal'
+        controller: 'storages--oauth-access-grant-nudge-modal',
+        'storages--oauth-access-grant-nudge-modal-close-button-label-value': I18n.t('button_close')
       },
       test_selector: 'oauth-access-grant-nudge-modal'
     )
@@ -53,8 +54,7 @@
             aria: { label: cancel_button_text },
             data: {
               'close-dialog-id': dialog_id,
-              'storages--oauth-access-grant-nudge-modal-target': 'cancelButton',
-              'storages--oauth-access-grant-nudge-modal-close-label-value': I18n.t('button_close')
+              'storages--oauth-access-grant-nudge-modal-target': 'closeButton'
             }
           )
         ) { cancel_button_text }

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -19,7 +19,6 @@
       data: {
         'storages--oauth-access-grant-nudge-modal-target': 'header'
       },
-      test_selector: 'oauth-access-grant-nudge-modal-header',
       visually_hide_title: authorized
     )
 

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -6,22 +6,24 @@
       data: {
         'application-target': 'dynamic',
         controller: 'storages--oauth-access-grant-nudge-modal',
-        'storages--oauth-access-grant-nudge-modal-close-button-label-value': I18n.t('button_close')
+        'storages--oauth-access-grant-nudge-modal-close-button-label-value': I18n.t('button_close'),
+        'storages--oauth-access-grant-nudge-modal-loading-screen-reader-message-value': waiting_title,
       },
       test_selector: 'oauth-access-grant-nudge-modal'
     )
   ) do |dialog|
     dialog.with_header(
       show_divider: false,
+      role: :alert,
+      aria: { live: :assertive },
       data: {
         'storages--oauth-access-grant-nudge-modal-target': 'header'
-      }
+      },
+      test_selector: 'oauth-access-grant-nudge-modal-header'
     )
 
     dialog.with_body(
       id: dialog_body_id,
-      role: :status,
-      aria: { live: (authorized ? :assertive : :polite) },
       test_selector: 'oauth-access-grant-nudge-modal-body'
     ) do
       concat(

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -19,12 +19,14 @@
       data: {
         'storages--oauth-access-grant-nudge-modal-target': 'header'
       },
-      test_selector: 'oauth-access-grant-nudge-modal-header'
+      test_selector: 'oauth-access-grant-nudge-modal-header',
+      visually_hide_title: authorized
     )
 
     dialog.with_body(
       id: dialog_body_id,
-      test_selector: 'oauth-access-grant-nudge-modal-body'
+      test_selector: 'oauth-access-grant-nudge-modal-body',
+      aria: { hidden: authorized }
     ) do
       concat(
         render(

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.html.erb
@@ -10,7 +10,34 @@
       test_selector: 'oauth-access-grant-nudge-modal'
     )
   ) do |dialog|
-    dialog.with_body(id: dialog_body_id) { body_text }
+    dialog.with_header(
+      show_divider: false,
+      data: {
+        'storages--oauth-access-grant-nudge-modal-target': 'header'
+      }
+    )
+
+    dialog.with_body(id: dialog_body_id, role: :status, aria: { live: :polite }) do
+      concat(
+        render(
+          Primer::Beta::Text.new(
+            display: :none,
+            data: {
+              'storages--oauth-access-grant-nudge-modal-target': 'loadingIndicator'
+            }
+          )
+        ) { render(Storages::OpenProjectStorageModalComponent::Body.new(:waiting, waiting_title:)) }
+      )
+      concat(
+        render(
+          Primer::Beta::Text.new(
+            data: {
+              'storages--oauth-access-grant-nudge-modal-target': 'requestAccessBody'
+            }
+          )
+        ) { body_text }
+      )
+    end
 
     dialog.with_footer(show_divider: false) do
       concat(
@@ -19,7 +46,11 @@
             scheme: :default,
             size: :medium,
             aria: { label: cancel_button_text },
-            data: { 'close-dialog-id': dialog_id }
+            data: {
+              'close-dialog-id': dialog_id,
+              'storages--oauth-access-grant-nudge-modal-target': 'cancelButton',
+              'storages--oauth-access-grant-nudge-modal-close-label-value': I18n.t('button_close')
+            }
           )
         ) { cancel_button_text }
       )

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -76,6 +76,10 @@ module Storages::Admin
       end
     end
 
+    def confirm_button_aria_label
+      I18n.t('storages.oauth_grant_nudge_modal.confirm_button_aria_label', storage: project_storage.storage.name)
+    end
+
     def confirm_button_url
       options[:confirm_button_url] || url_helpers.oauth_access_grant_project_settings_project_storage_path(
         project_id: project_storage.project.id,

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -32,7 +32,6 @@ module Storages::Admin
   class OAuthAccessGrantNudgeModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
     options dialog_id: 'storages--oauth-grant-nudge-modal-component',
             dialog_body_id: 'storages--oauth-grant-nudge-modal-body-component',
-            confirm_button_text: I18n.t('storages.oauth_grant_nudge_modal.confirm_button_label'),
             authorized: false
 
     attr_reader :project_storage
@@ -47,6 +46,10 @@ module Storages::Admin
     end
 
     private
+
+    def confirm_button_text
+      I18n.t('storages.oauth_grant_nudge_modal.confirm_button_label')
+    end
 
     def title
       if authorized

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -54,6 +54,10 @@ module Storages::Admin
       I18n.t('storages.oauth_grant_nudge_modal.title')
     end
 
+    def waiting_title
+      I18n.t('storages.oauth_grant_nudge_modal.requesting_access_to', storage: project_storage.storage.name)
+    end
+
     def cancel_button_text
       if authorized
         I18n.t('button_close')

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -37,8 +37,8 @@ module Storages::Admin
 
     attr_reader :project_storage
 
-    def initialize(project_storage_id:, **options)
-      @project_storage = ::Storages::ProjectStorage.find_by(id: project_storage_id)
+    def initialize(project_storage:, **options)
+      @project_storage = find_project_storage(project_storage)
       super(@project_storage, **options)
     end
 
@@ -77,10 +77,17 @@ module Storages::Admin
     end
 
     def confirm_button_url
-      url_helpers.oauth_access_grant_project_settings_project_storage_path(
+      options[:confirm_button_url] || url_helpers.oauth_access_grant_project_settings_project_storage_path(
         project_id: project_storage.project.id,
         id: project_storage
       )
+    end
+
+    def find_project_storage(project_storage_record_or_id)
+      return if project_storage_record_or_id.blank?
+      return project_storage_record_or_id if project_storage_record_or_id.is_a?(Storages::ProjectStorage)
+
+      Storages::ProjectStorage.find_by(id: project_storage_record_or_id)
     end
   end
 end

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -49,9 +49,11 @@ module Storages::Admin
     private
 
     def title
-      return if authorized
-
-      I18n.t('storages.oauth_grant_nudge_modal.title')
+      if authorized
+        I18n.t('storages.oauth_grant_nudge_modal.access_granted_screen_reader', storage: project_storage.storage.name)
+      else
+        I18n.t('storages.oauth_grant_nudge_modal.title')
+      end
     end
 
     def waiting_title

--- a/modules/storages/app/components/storages/open_project_storage_modal_component/body.html.erb
+++ b/modules/storages/app/components/storages/open_project_storage_modal_component/body.html.erb
@@ -7,10 +7,10 @@
       </div>
     <% end %>
     <% flex.with_row do %>
-      <%= render(Primer::Beta::Heading.new(tag: :h2, text_align: :center)) { I18n.t('storages.open_project_storage_modal.waiting.title') } %>
+      <%= render(Primer::Beta::Heading.new(tag: :h2, text_align: :center)) { waiting_title } %>
     <% end %>
     <% flex.with_row do %>
-      <%= render(Primer::Beta::Text.new(text_align: :center, color: :muted)) { I18n.t('storages.open_project_storage_modal.waiting.subtitle') } %>
+      <%= render(Primer::Beta::Text.new(text_align: :center, color: :muted)) { waiting_subtitle } %>
     <% end %>
   <% when :success %>
     <% flex.with_row do %>

--- a/modules/storages/app/components/storages/open_project_storage_modal_component/body.rb
+++ b/modules/storages/app/components/storages/open_project_storage_modal_component/body.rb
@@ -26,7 +26,9 @@
 
 class Storages::OpenProjectStorageModalComponent::Body < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
   options success_title: I18n.t('storages.open_project_storage_modal.success.title'),
-          success_subtitle: I18n.t('storages.open_project_storage_modal.success.subtitle')
+          success_subtitle: I18n.t('storages.open_project_storage_modal.success.subtitle'),
+          waiting_title: I18n.t('storages.open_project_storage_modal.waiting.title'),
+          waiting_subtitle: I18n.t('storages.open_project_storage_modal.waiting.subtitle')
 
   def initialize(state, **options)
     @state = state

--- a/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
@@ -214,7 +214,7 @@ class Storages::Admin::ProjectStoragesController < Projects::SettingsController
     {
       type: 'Storages::Admin::OAuthAccessGrantNudgeModalComponent',
       parameters: {
-        project_storage_id: @project_storage.id,
+        project_storage: @project_storage.id,
         authorized:
       }
     }

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -182,6 +182,7 @@ en:
       access_granted: Access granted
       body: To get access to the project folder you need to login to %{storage}.
       cancel_button_label: I will do it later
+      confirm_button_aria_label: Login to %{storage}
       confirm_button_label: Login
       requesting_access_to: Requesting access to %{storage}
       storage_ready: You are now ready to use %{storage}

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
       confirm_button_label: Login
       storage_ready: You are now ready to use %{storage}
       title: One more step...
+      requesting_access_to: Requesting access to %{storage}
     open_project_storage_modal:
       success:
         subtitle: You are being redirected

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -183,9 +183,9 @@ en:
       body: To get access to the project folder you need to login to %{storage}.
       cancel_button_label: I will do it later
       confirm_button_label: Login
+      requesting_access_to: Requesting access to %{storage}
       storage_ready: You are now ready to use %{storage}
       title: One more step...
-      requesting_access_to: Requesting access to %{storage}
     open_project_storage_modal:
       success:
         subtitle: You are being redirected

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
       of each desired project to use it.
     oauth_grant_nudge_modal:
       access_granted: Access granted
+      access_granted_screen_reader: Access granted. You are now ready to use %{storage}.
       body: To get access to the project folder you need to login to %{storage}.
       cancel_button_label: I will do it later
       confirm_button_aria_label: Login to %{storage}

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -41,7 +41,12 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
 
     it 'renders the nudge modal' do
       expect(page).to have_text('One more step...')
-      expect(page).to have_text("To get access to the project folder you need to login to #{project_storage.storage.name}.")
+      expect(page).to have_test_selector(
+        'oauth-access-grant-nudge-modal-body',
+        text: "To get access to the project folder you need to login to #{project_storage.storage.name}.",
+        aria: { live: :polite },
+        role: :status
+      )
 
       expect(page).to have_button('I will do it later')
       expect(page).to have_button('Login')
@@ -55,7 +60,12 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
 
     it 'renders a success modal' do
       expect(page).to have_text('Access granted')
-      expect(page).to have_text("You are now ready to use #{project_storage.storage.name}")
+      expect(page).to have_test_selector(
+        'oauth-access-grant-nudge-modal-body',
+        text: "You are now ready to use #{project_storage.storage.name}",
+        aria: { live: :assertive },
+        role: :status
+      )
 
       expect(page).to have_button('Close')
     end

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -40,12 +40,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
     let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage:) }
 
     it 'renders the nudge modal' do
-      expect(page).to have_test_selector(
-        'oauth-access-grant-nudge-modal-header',
-        text: 'One more step...',
-        aria: { live: :assertive },
-        role: :alert
-      )
+      expect(page).to have_css('[role="alert"]', text: 'One more step...', aria: { live: :assertive })
       expect(page).to have_test_selector(
         'oauth-access-grant-nudge-modal-body',
         text: "To get access to the project folder you need to login to #{project_storage.storage.name}.",

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
   end
 
   context 'with access pending authorization' do
-    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage_id: project_storage.id) }
+    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage: project_storage.id) }
 
     it 'renders the nudge modal' do
       expect(page).to have_text('One more step...')
@@ -72,7 +72,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
   end
 
   context 'with no project storage' do
-    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage_id: nil) }
+    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage: nil) }
 
     it 'does not render' do
       expect(page.text).to be_empty

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -40,12 +40,15 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
     let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage:) }
 
     it 'renders the nudge modal' do
-      expect(page).to have_text('One more step...')
+      expect(page).to have_test_selector(
+        'oauth-access-grant-nudge-modal-header',
+        text: 'One more step...',
+        aria: { live: :assertive },
+        role: :alert
+      )
       expect(page).to have_test_selector(
         'oauth-access-grant-nudge-modal-body',
         text: "To get access to the project folder you need to login to #{project_storage.storage.name}.",
-        aria: { live: :polite },
-        role: :status
       )
 
       expect(page).to have_button('I will do it later')
@@ -63,8 +66,6 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
       expect(page).to have_test_selector(
         'oauth-access-grant-nudge-modal-body',
         text: "You are now ready to use #{project_storage.storage.name}",
-        aria: { live: :assertive },
-        role: :status
       )
 
       expect(page).to have_button('Close')

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -30,14 +30,14 @@ require 'spec_helper'
 require_module_spec_helper
 
 RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :component do # rubocop:disable RSpec/SpecFilePathFormat
-  shared_let(:project_storage) { create(:project_storage) }
+  let(:project_storage) { build_stubbed(:project_storage) }
 
   before do
     render_inline(oauth_access_grant_nudge_modal_component)
   end
 
   context 'with access pending authorization' do
-    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage: project_storage.id) }
+    let(:oauth_access_grant_nudge_modal_component) { described_class.new(project_storage:) }
 
     it 'renders the nudge modal' do
       expect(page).to have_text('One more step...')
@@ -55,7 +55,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
 
   context 'with access authorized' do
     let(:oauth_access_grant_nudge_modal_component) do
-      described_class.new(project_storage_id: project_storage.id, authorized: true)
+      described_class.new(project_storage:, authorized: true)
     end
 
     it 'renders a success modal' do

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -30,8 +30,6 @@ require 'spec_helper'
 require_module_spec_helper
 
 RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :component do # rubocop:disable RSpec/SpecFilePathFormat
-  include Rails.application.routes.url_helpers
-
   shared_let(:project_storage) { create(:project_storage) }
 
   before do
@@ -46,10 +44,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
       expect(page).to have_text("To get access to the project folder you need to login to #{project_storage.storage.name}.")
 
       expect(page).to have_button('I will do it later')
-      expect(page).to have_link('Login',
-                                href: oauth_access_grant_project_settings_project_storage_path(
-                                  project_id: project_storage.project_id, id: project_storage
-                                ))
+      expect(page).to have_button('Login')
     end
   end
 

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
       expect(page).to have_test_selector(
         'oauth-access-grant-nudge-modal-body',
         text: "To get access to the project folder you need to login to #{project_storage.storage.name}.",
+        aria: { hidden: false }
       )
 
       expect(page).to have_button('I will do it later')
@@ -62,10 +63,20 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
     end
 
     it 'renders a success modal' do
-      expect(page).to have_text('Access granted')
+      expect(page).to have_css(
+        'h1.sr-only',
+        text: "Access granted. You are now ready to use #{project_storage.storage.name}"
+      )
+
+      expect(page).to have_test_selector(
+        'oauth-access-grant-nudge-modal-body',
+        text: 'Access granted',
+        aria: { hidden: true }
+      )
       expect(page).to have_test_selector(
         'oauth-access-grant-nudge-modal-body',
         text: "You are now ready to use #{project_storage.storage.name}",
+        aria: { hidden: true }
       )
 
       expect(page).to have_button('Close')

--- a/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_access_grant_nudge_modal_component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Storages::Admin::OAuthAccessGrantNudgeModalComponent, type: :comp
       )
 
       expect(page).to have_button('I will do it later')
-      expect(page).to have_button('Login')
+      expect(page).to have_button('Login', aria: { label: "Login to #{project_storage.storage.name}" })
     end
   end
 

--- a/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
+++ b/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
 
   current_user { user }
 
+  let(:nonce) { '57a17c3f-b2ed-446e-9dd8-651ba3aec37d' }
+  let(:redirect_uri) do
+    "#{CGI.escape(OpenProject::Application.root_url)}/oauth_clients/#{storage.oauth_client.client_id}/callback"
+  end
+
+  before do
+    allow(SecureRandom).to receive(:uuid).and_call_original.ordered
+    allow(SecureRandom).to receive(:uuid).and_return(nonce).ordered
+  end
+
   it 'adds a storage, nudges the project admin to grant OAuth access' do
     visit project_settings_project_storages_path(project_id: project)
 
@@ -62,11 +72,9 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
     expect(page).to have_select('Storage', options: ["#{storage.name} (nextcloud)"])
     click_on('Continue')
 
-    # by default automatic have to be choosen if storage has automatic management enabled
     expect(page).to have_checked_field("New folder with automatically managed permissions")
     click_on('Add')
 
-    # The list of enabled file storages should now contain Storage 1
     expect(page).to have_text('File storages available in this project')
     expect(page).to have_text(storage.name)
 
@@ -74,9 +82,8 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
       expect(page).to be_axe_clean
       expect(page).to have_text('One more step...')
       click_on('Login')
-
-      expect(page).to have_text("Requesting access to #{storage.name}")
-      expect(page).to be_axe_clean
+      wait_for(page).to have_current_path("/index.php/apps/oauth2/authorize?client_id=#{storage.oauth_client.client_id}&" \
+                                          "redirect_uri=#{redirect_uri}&response_type=code&state=#{nonce}")
     end
   end
 end

--- a/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
+++ b/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
@@ -54,16 +54,6 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
 
   current_user { user }
 
-  let(:nonce) { '57a17c3f-b2ed-446e-9dd8-651ba3aec37d' }
-  let(:redirect_uri) do
-    "#{CGI.escape(OpenProject::Application.root_url)}/oauth_clients/#{storage.oauth_client.client_id}/callback"
-  end
-
-  before do
-    allow(SecureRandom).to receive(:uuid).and_call_original.ordered
-    allow(SecureRandom).to receive(:uuid).and_return(nonce).ordered
-  end
-
   it 'adds a storage, nudges the project admin to grant OAuth access' do
     visit project_settings_project_storages_path(project_id: project)
 
@@ -82,10 +72,9 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
 
     within_test_selector('oauth-access-grant-nudge-modal') do
       expect(page).to have_text('One more step...')
-
       click_on('Login')
-      expect(page).to have_current_path("/index.php/apps/oauth2/authorize?client_id=#{storage.oauth_client.client_id}&" \
-                                        "redirect_uri=#{redirect_uri}&response_type=code&state=#{nonce}")
+
+      expect(page).to have_text("Requesting access to #{storage.name}")
     end
   end
 end

--- a/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
+++ b/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
@@ -71,10 +71,12 @@ RSpec.describe 'OAuth Access Grant Nudge upon adding a storage to a project',
     expect(page).to have_text(storage.name)
 
     within_test_selector('oauth-access-grant-nudge-modal') do
+      expect(page).to be_axe_clean
       expect(page).to have_text('One more step...')
       click_on('Login')
 
       expect(page).to have_text("Requesting access to #{storage.name}")
+      expect(page).to be_axe_clean
     end
   end
 end

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -1,0 +1,123 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_module_spec_helper
+
+RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :webmock do
+  shared_let(:user) { create(:user, preferences: { time_zone: 'Etc/UTC' }) }
+
+  shared_let(:role) do
+    create(:project_role, permissions: %i[manage_storages_in_project
+                                          oauth_access_grant
+                                          select_project_modules
+                                          edit_project])
+  end
+
+  shared_let(:storage) { create(:nextcloud_storage_with_complete_configuration) }
+
+  shared_let(:project) do
+    create(:project,
+           name: "Project name without sequence",
+           members: { user => role },
+           enabled_module_names: %i[storages work_package_tracking])
+  end
+  shared_let(:project_storage) { create(:project_storage, project:, storage:) }
+
+  describe '#oauth_access_grant' do
+    context 'when user is not logged in' do
+      it 'requires login' do
+        get oauth_access_grant_project_settings_project_storage_path(
+          project_id: project_storage.project.id,
+          id: project_storage
+        )
+        expect(last_response.status).to eq(401)
+      end
+    end
+
+    context 'when user is logged in' do
+      before { login_as(user) }
+
+      context 'when user is not "connected"' do
+        let(:nonce) { '57a17c3f-b2ed-446e-9dd8-651ba3aec37d' }
+        let(:redirect_uri) do
+          CGI.escape("#{OpenProject::Application.root_url}/oauth_clients/#{storage.oauth_client.client_id}/callback")
+        end
+
+        before do
+          allow(SecureRandom).to receive(:uuid).and_call_original.ordered
+          allow(SecureRandom).to receive(:uuid).and_return(nonce).ordered
+        end
+
+        it 'redirects to storage authorization_uri with oauth_state_* cookie set' do
+          get oauth_access_grant_project_settings_project_storage_path(
+            project_id: project_storage.project.id,
+            id: project_storage
+          )
+          expect(last_response.status).to eq(302)
+          expect(last_response.location).to eq(
+            "#{storage.host}/index.php/apps/oauth2/authorize?client_id=#{storage.oauth_client.client_id}&" \
+            "redirect_uri=#{redirect_uri}&response_type=code&state=#{nonce}"
+          )
+
+          expect(last_response.cookies["oauth_state_#{nonce}"])
+            .to eq([CGI.escape({ href: "http://example.org/projects/#{project.id}/settings/project_storages",
+                                 storageId: project_storage.storage_id }.to_json)])
+        end
+      end
+
+      context 'when user is "connected"' do
+        shared_let(:oauth_client_token) { create(:oauth_client_token, oauth_client: storage.oauth_client, user:) }
+
+        before do
+          oauth_client_token
+          stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/user")
+            .with(
+              headers: {
+                'Accept' => 'application/json',
+                'Authorization' => "Bearer #{oauth_client_token.access_token}",
+                'Ocs-Apirequest' => 'true'
+              }
+            ).to_return(status: 200, body: "", headers: {})
+        end
+
+        it 'redirects to destination_url' do
+          get oauth_access_grant_project_settings_project_storage_path(
+            project_id: project_storage.project.id,
+            id: project_storage
+          )
+
+          storage.oauth_client
+          expect(last_response.status).to eq(302)
+          expect(last_response.location).to eq("http://example.org/projects/#{project.id}/settings/project_storages")
+          expect(last_response.cookies.keys).to eq(["_open_project_session"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### https://community.openproject.org/wp/52605

On "Login" click, transition to loading state; render back on success (failure state to be handle in [#Bug/52798](https://community.openproject.org/wp/52798))

- [x] Update the "Login" button to a form button to preseve semantic A11ly focus & tab benefits. The previous implementaion with a "button link" breaks accessibility as ScreenReader can't tab to it. Also buttons have the advantage of executing via KYBD `Enter` or `Spacebar`
- [x]  On modal load, set focus on the "Login" button as the default action. The user can exit easily via `ESC` or tab back to the two close actions: Close button at the top OR the cancel "I will do it later" button.
- [x] Define loading state as an [`aria-live`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) region to enable screen readers to announce loading status 

Accessibility References:

_Key A11ly AC:_ Convey when login has started, while it's in progress and when it's completed or failed

* https://primer.style/ui-patterns/loading#accessibility
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions


https://github.com/opf/openproject/assets/17295175/3d8ea32d-92a9-4090-b761-0b96f62e621c


https://github.com/opf/openproject/assets/17295175/6fa46438-dd42-4b51-aa70-e7fcd2fc9424

