### PR TITLE
[#52906] Seeding the BIM edition in a development environment fails

### DIFF
--- a/app/seeders/development_data/shared_work_packages_seeder.rb
+++ b/app/seeders/development_data/shared_work_packages_seeder.rb
@@ -81,8 +81,9 @@ module DevelopmentData
           reference: :save_gotham,
           description: "Gotham is in trouble. It's your job to save it!",
           status: seed_data.find_reference(:default_status_new),
-          type: seed_data.find_reference(:default_type_epic),
-          priority: seed_data.find_reference(:default_priority_immediate)
+          type: seed_data.find_reference(:default_type_epic, default: seed_data.find_reference(:default_type_phase)),
+          priority: seed_data.find_reference(:default_priority_immediate,
+                                             default: seed_data.find_reference(:default_priority_high))
         },
         {
           project:,
@@ -92,7 +93,8 @@ module DevelopmentData
           description: 'Must be stopped before Gotham is doomed.',
           status: seed_data.find_reference(:default_status_new),
           type: seed_data.find_reference(:default_type_task),
-          priority: seed_data.find_reference(:default_priority_immediate)
+          priority: seed_data.find_reference(:default_priority_immediate,
+                                             default: seed_data.find_reference(:default_priority_high))
         },
         {
           project:,

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -27,14 +27,17 @@
 #++
 
 priorities:
-  - t_name: Low
+  - reference: :default_priority_low
+    t_name: Low
     color_name: cyan-1
     position: 1
-  - t_name: Normal
+  - reference: :default_priority_normal
+    t_name: Normal
     color_name: blue-3
     is_default: true
     position: 2
-  - t_name: High
+  - reference: :default_priority_high
+    t_name: High
     color_name: yellow-7
     position: 3
   - reference: :default_priority_immediate

--- a/modules/bim/app/seeders/bim.yml
+++ b/modules/bim/app/seeders/bim.yml
@@ -47,17 +47,21 @@ modules_permissions:
     - :view_linked_issues
 
 priorities:
-  - t_name: Low
+  - reference: :default_priority_low
+    t_name: Low
     color_name: cyan-1
     is_default: true
     position: 1
-  - t_name: Normal
+  - reference: :default_priority_normal
+    t_name: Normal
     color_name: blue-3
     position: 2
-  - t_name: High
+  - reference: :default_priority_high
+    t_name: High
     color_name: yellow-7
     position: 3
-  - t_name: Critical
+  - reference: :default_priority_critical
+    t_name: Critical
     color_name: grape-5
     position: 4
 


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/52906

In the bim edition `OPENPROJECT_EDITION=bim`, only select types are available. For instance EPIC types are not used in the BIM edition, rather those would be PHASEs.

This PR sets up default fallbacks relevant for the BIM edition.

#### Testing

(1) Enable the BIM edition

```
#.env
OPENPROJECT_EDITION=bim
```

(2) Seed or replant your database

```sh
$ docker compose exec backend bin/rails db:seed:replant
```