### PR TITLE
[50615] Fix for Project Calender - Navigates to Previous Month w/ Every Filter Swap

### DIFF
--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -417,7 +417,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     void this.$state.go(
       '.',
       {
-        cdate: this.timezoneService.formattedISODate(dates.view.currentStart),
+        cdate: this.timezoneService.formattedISODate(dates.view.calendar.getDate()),
         // v6.beta3 fails to have type on the ViewAPI
         cview: (dates.view as unknown as { type:string }).type,
       },


### PR DESCRIPTION
~~Do not inherit the calendar params for currently selected date and view as it should not be shared between different calendars~~

Use "current date" of the calendar instead of first day displayed by the calendar.
Current date will not changed when switching the view between month and week, so will fix [50615](https://community.openproject.org/projects/openproject/work_packages/50615/activity)

Retrying #14459