### PR TITLE
set allow_concurrency to false in test config

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,6 +50,10 @@ Rails.application.configure do
   # loading is working properly before deploying your code.
   config.eager_load = %w[CI EAGER_LOAD].any? { |name| ENV[name].present? }
 
+  # Prevent race condition with session modification, when not set this is equal
+  # to allowing concurrency
+  config.allow_concurrency = false
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }


### PR DESCRIPTION
Prevent race condition with session modification that causes flaky test. There should be a better solution as the requests that are made in parallel are not supposed to modify session.

This reverts commit 24d5ed2f5548ae515b2bd2cda55e78aea865cb44.