### PR TITLE
Do not write or update sessions or their cookies for API access

### DIFF
--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -331,10 +331,10 @@ module API
 
     # run authentication before each request
     after_validation do
+      skip_session_write
       authenticate
       set_localization
       enforce_content_type
-      skip_session_write
       ::OpenProject::Appsignal.tag_request(request:)
     end
   end

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -90,6 +90,12 @@ module API
         %w(application/json application/hal+json)
       end
 
+      # Prevent committing the session
+      # This prevents an unnecessary write when accessing the API
+      def skip_session_write
+        request.session_options[:skip] = true
+      end
+
       def enforce_content_type
         # Content-Type is not present in GET or DELETE requests
         return if request.get? || request.delete?
@@ -328,6 +334,7 @@ module API
       authenticate
       set_localization
       enforce_content_type
+      skip_session_write
       ::OpenProject::Appsignal.tag_request(request:)
     end
   end


### PR DESCRIPTION
Accessing the API currently does not, and should not update the user's session. Still, currently we're using it to access the session for authenticating the user.

As a result, the session is loaded and we're currently outputting a Set-Cookie header as well as writing the user session on every API request.

By using session_options[:skip], we can tell rack to avoid saving the session after the request