### PR TITLE
Warn about migration-related PRs on release branches

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,26 @@
+name: migration-warning-on-release-branches
+
+on:
+  pull_request:
+    branches:
+      - release/*
+    paths:
+      - 'db/migrate/**.rb'
+      - 'modules/**/db/migrate/*.rb'
+
+jobs:
+  danger:
+    if: github.repository == 'opf/openproject'
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.3'
+      - uses: MeilCli/danger-action@v5
+        with:
+          danger_file: 'Dangerfile'
+          danger_id: 'danger-pr'
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,9 @@
+CORE_OR_MODULE_MIGRATIONS_REGEX = %r{(modules/.*)?db/migrate/.*\.rb}
+
+def added_or_modified_migrations?
+  (git.modified_files + git.added_files).grep(CORE_OR_MODULE_MIGRATIONS_REGEX)
+end
+
+if added_or_modified_migrations?
+  warn "This PR has migration-related changes on a release branch. Ping @opf/operations"
+end


### PR DESCRIPTION
Adds a Dangerfile and Github action to warn when a PR opened against a release branch involves migration-related changes.