### PR TITLE
debounce requests to recalculate budget after updating count

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/costs/budget-subform.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/costs/budget-subform.controller.ts
@@ -55,11 +55,19 @@ export default class BudgetSubformController extends Controller {
     this.submitButtons = this.form.querySelectorAll("button[type='submit']");
   }
 
+  private debounceTimers:{ [id:string]:ReturnType<typeof setTimeout> } = {};
+
   valueChanged(evt:Event) {
     const row = this.eventRow(evt.target);
 
     if (row) {
-      void this.refreshRow(row.getAttribute('id') as string);
+      const id:string = row.getAttribute('id') as string;
+
+      clearTimeout(this.debounceTimers[id]);
+
+      this.debounceTimers[id] = setTimeout(() => {
+        void this.refreshRow(id);
+      }, 100);
     }
   }
 


### PR DESCRIPTION
Checked due to flaky test in modules/budgets/spec/features/budgets/update_budget_spec.rb. Problem was with the race of two requests (update to 0 then to value) triggered by fill_in in test. Debouncing will not only ensure test doesn't fail randomly, but also remove unnecessary requests in production.

Why simple operation of multiplying count by item cost requires a call to backend?