### PR TITLE
[Op#53021] Define Gitlab CE local docker compose setup with TLS

### DIFF
--- a/docker/dev/gitlab/.gitignore
+++ b/docker/dev/gitlab/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml

--- a/docker/dev/gitlab/docker-compose.yml
+++ b/docker/dev/gitlab/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:latest
+    restart: no
+    volumes:
+      - gitlab-etc:/etc/gitlab
+      - gitlab-logs:/var/log/gitlab
+      - gitlab-opt:/var/opt/gitlab
+      # Linux
+      - /etc/ssl/certs:/etc/ssl/certs:ro
+      - /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro
+      # In case of MacOS, you need to mount the certs from the host machine
+      # having them previously bundled via `sudo update-ca-certificates`
+      #
+      # - ~/.step/certs:/etc/ssl/certs
+      # - ~/.step/certs:/usr/local/share/ca-certificates
+    networks:
+      - external
+    extra_hosts:
+      - "openproject.local:host-gateway"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.gitlab.rule=Host(`gitlab.local`)"
+      - "traefik.http.routers.gitlab.entrypoints=websecure"
+      - "traefik.http.services.gitlab.loadbalancer.server.port=80"
+
+volumes:
+  gitlab-etc:
+  gitlab-logs:
+  gitlab-opt:
+
+networks:
+  external:
+    name: gateway
+    external: true

--- a/docker/dev/tls/docker-compose.override.example.yml
+++ b/docker/dev/tls/docker-compose.override.example.yml
@@ -8,3 +8,5 @@ services:
           # by connecting to them, and we'd like it to go through traefik, instead
           # of calling the service containers directly.
           - openproject.local
+          - nextcloud.local
+          - gitlab.local

--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -99,7 +99,7 @@ cp docker-compose.override.example.yml docker-compose.override.yml
 # and will install all required server dependencies
 docker compose run --rm backend setup
 
-# This will install the web dependencies 
+# This will install the web dependencies
 docker compose run --rm frontend npm install
 ```
 
@@ -307,7 +307,7 @@ On Debian, you need to add the generated root CA to system certificates bundle.
 docker compose --project-directory docker/dev/tls cp \
  step:/home/step/certs/root_ca.crt /usr/local/share/ca-certificates/OpenProject_Development_Root_CA.crt
 
-# Create symbolic link   
+# Create symbolic link
 ln -s /usr/local/share/ca-certificates/OpenProject_Development_Root_CA.crt /etc/ssl/certs/OpenProject_Development_Root_CA.pem
 
 # Update certificate bundle
@@ -392,6 +392,33 @@ suspended and continued at a later time. To fix it, restart your proxy stack.
 ```shell
 docker compose --project-directory docker/dev/tls down
 docker compose --project-directory docker/dev/tls up -d
+```
+
+## GitLab CE Service
+
+Within `docker/dev/gitlab` a compose file is provided for running local Gitlab instance with TLS support. The provides
+a production like environment for testing the OpenProject GitLab integration against a community edition gitlab instance
+accessible on `https://gitlab.local`.
+
+> NOTE: Configure [TLS Support](#tls-support) first before starting the GitLab service
+
+See [Install GitLab using Docker Compose](https://docs.gitlab.com/ee/install/docker.html#install-gitlab-using-docker-compose)
+official GitLab documentation.
+
+### Running the GitLab Instance
+
+Start up the docker compose service for gitlab as follows:
+
+```shell
+docker compose --project-directory docker/dev/gitlab up -d
+```
+
+### Initial password
+
+Once the GitLab service is started and running, you can access the initial `root` user password as follows:
+
+```shell
+docker compose --project-directory docker/dev/gitlab exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
 ```
 
 ## Local files

--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -396,8 +396,8 @@ docker compose --project-directory docker/dev/tls up -d
 
 ## GitLab CE Service
 
-Within `docker/dev/gitlab` a compose file is provided for running local Gitlab instance with TLS support. The provides
-a production like environment for testing the OpenProject GitLab integration against a community edition gitlab instance
+Within `docker/dev/gitlab` a compose file is provided for running local Gitlab instance with TLS support. This provides
+a production like environment for testing the OpenProject GitLab integration against a community edition GitLab instance
 accessible on `https://gitlab.local`.
 
 > NOTE: Configure [TLS Support](#tls-support) first before starting the GitLab service

--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -421,6 +421,12 @@ Once the GitLab service is started and running, you can access the initial `root
 docker compose --project-directory docker/dev/gitlab exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
 ```
 
+Should you need to reset your root password, execute the following command:
+
+```shell
+docker compose --project-directory docker/dev/gitlab exec -it gitlab gitlab-rake "gitlab:password:reset[root]"
+```
+
 ## Local files
 
 Running the docker images will change some of your local files in the mounted code directory. The


### PR DESCRIPTION
#### https://community.openproject.org/wp/53021

## GitLab CE Service

Within `docker/dev/gitlab` a compose file is provided for running local Gitlab instance with TLS support. The provides
a production like environment for testing the OpenProject GitLab integration against a community edition gitlab instance
accessible on `https://gitlab.local`.

> NOTE: Configure [TLS Support](https://www.openproject.org/docs/development/development-environment-docker/#tls-support) first before starting the GitLab service

See [Install GitLab using Docker Compose](https://docs.gitlab.com/ee/install/docker.html#install-gitlab-using-docker-compose)
official GitLab documentation.

### Running the GitLab Instance

Start up the docker compose service for gitlab as follows:

```shell
docker compose --project-directory docker/dev/gitlab up -d
```

### Initial password

Once the GitLab service is started and running, you can access the initial `root` user password as follows:

```shell
docker compose --project-directory docker/dev/gitlab exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
```

![Screenshot 2024-02-27 at 6 12 53 PM](https://github.com/opf/openproject/assets/17295175/5d294ff1-cc42-4ba2-9de9-49d2e0514619)
