### PR TITLE
[#52916] URI prefix lost on adding storage button when

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -37,7 +37,9 @@ class ApplicationComponent < ViewComponent::Base
     @options = options
   end
 
-  delegate :url_helpers, to: 'Rails.application.routes'
+  def url_helpers
+    @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
+  end
 
   class << self
     ##


### PR DESCRIPTION
https://community.openproject.org/work_packages/52916

Switching `url_helpers` in **ApplicationComponent** from `Rails.application.routes` to `OpenProject::StaticRouting::StaticUrlHelpers.new` to respect `OPENPROJECT_RAILS__RELATIVE__URL__ROOT`

**Before**
<img width="1070" alt="Screenshot 2024-02-26 at 11 32 50" src="https://github.com/opf/openproject/assets/1113942/4fc27fde-3c6b-4b64-abb6-3c273c09e9c9">


**After**
<img width="1007" alt="Screenshot 2024-02-26 at 11 29 32" src="https://github.com/opf/openproject/assets/1113942/46d973dd-35d7-45ba-a00c-f66c1458690c">
