### PR TITLE
Fix translated mail subject lines

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -120,8 +120,9 @@ class ApplicationMailer < ActionMailer::Base
     format.text
   end
 
-  def send_mail(user, subject)
+  def send_localized_mail(user)
     with_locale_for(user) do
+      subject = yield
       mail to: user.mail, subject:
     end
   end

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -72,11 +72,8 @@ class DigestMailer < ApplicationMailer
 
     return if @aggregated_notifications.empty?
 
-    with_locale_for(recipient) do
-      subject = "#{Setting.app_title} - #{digest_summary_text(notification_ids.size, @mentioned_count)}"
-
-      mail to: recipient.mail,
-           subject:
+    send_localized_mail(recipient) do
+      "#{Setting.app_title} - #{digest_summary_text(notification_ids.size, @mentioned_count)}"
     end
   end
 

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -32,10 +32,11 @@ class ProjectMailer < ApplicationMailer
                          Author: user.login
 
     message_id project, user
-    with_locale_for(user) do
-      @project = project
-      @dependent_projects = dependent_projects
-      mail to: user.mail, subject: I18n.t('projects.delete.completed', name: project.name)
+    @project = project
+    @dependent_projects = dependent_projects
+
+    send_localized_mail(user) do
+      I18n.t('projects.delete.completed', name: project.name)
     end
   end
 
@@ -44,10 +45,10 @@ class ProjectMailer < ApplicationMailer
                          Author: user.login
 
     message_id project, user
-    with_locale_for(user) do
-      @project = project
+    @project = project
 
-      mail to: user.mail, subject: I18n.t('projects.delete.failed', name: project.name)
+    send_localized_mail(user) do
+      I18n.t('projects.delete.failed', name: project.name)
     end
   end
 
@@ -61,10 +62,8 @@ class ProjectMailer < ApplicationMailer
 
     message_id source_project, user
 
-    with_locale_for(user) do
-      subject = I18n.t('copy_project.failed', source_project_name: source_project.name)
-
-      mail to: user.mail, subject:
+    send_localized_mail(user) do
+      I18n.t('copy_project.failed', source_project_name: source_project.name)
     end
   end
 
@@ -79,10 +78,8 @@ class ProjectMailer < ApplicationMailer
 
     message_id target_project, user
 
-    with_locale_for(user) do
-      subject = I18n.t('copy_project.succeeded', target_project_name: target_project.name)
-
-      mail to: user.mail, subject:
+    send_localized_mail(user) do
+      I18n.t('copy_project.succeeded', target_project_name: target_project.name)
     end
   end
 end

--- a/app/mailers/sharing_mailer.rb
+++ b/app/mailers/sharing_mailer.rb
@@ -20,10 +20,8 @@ class SharingMailer < ApplicationMailer
     set_open_project_headers(@work_package)
     message_id(membership, sharer)
 
-    with_locale_for(@shared_with_user) do
-      mail to: @shared_with_user.mail,
-           subject: I18n.t('mail.sharing.work_packages.subject',
-                           id: @work_package.id)
+    send_localized_mail(@shared_with_user) do
+      I18n.t('mail.sharing.work_packages.subject', id: @work_package.id)
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -36,17 +36,13 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Test'
 
-    send_mail(user,
-              'OpenProject Test')
+    send_localized_mail(user) { "#{Setting.app_title} Test" }
   end
 
   def backup_ready(user)
-    User.execute_as user do
-      @download_url = admin_backups_url
+    @download_url = admin_backups_url
 
-      send_mail(user,
-                I18n.t("mail_subject_backup_ready"))
-    end
+    send_localized_mail(user) { I18n.t(:mail_subject_backup_ready) }
   end
 
   def backup_token_reset(recipient, user:, waiting_period: OpenProject::Configuration.backup_initial_waiting_period)
@@ -54,10 +50,7 @@ class UserMailer < ApplicationMailer
     @user_login = user.login
     @waiting_period = waiting_period
 
-    User.execute_as recipient do
-      send_mail(recipient,
-                I18n.t("mail_subject_backup_token_reset"))
-    end
+    send_localized_mail(recipient) { I18n.t(:mail_subject_backup_token_reset) }
   end
 
   def password_lost(token)
@@ -70,8 +63,7 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Account'
 
-    send_mail(token.user,
-              t(:mail_subject_lost_password, value: Setting.app_title))
+    send_localized_mail(token.user) { I18n.t(:mail_subject_lost_password, value: Setting.app_title) }
   end
 
   def password_change_not_possible(user)
@@ -84,7 +76,7 @@ class UserMailer < ApplicationMailer
       end
     open_project_headers 'Type' => 'Account'
 
-    send_mail(user, t('mail_password_change_not_possible.title'))
+    send_localized_mail(user) { I18n.t('mail_password_change_not_possible.title') }
   end
 
   def news_added(user, news)
@@ -96,10 +88,8 @@ class UserMailer < ApplicationMailer
     message_id @news, user
     references @news
 
-    subject = "#{News.model_name.human}: #{@news.title}"
-    subject = "[#{@news.project.name}] #{subject}" if @news.project
-
-    send_mail(user, subject)
+    project = @news.project ? "#{@news.project.name}] " : ''
+    send_localized_mail(user) { "#{project}#{News.model_name.human}: #{@news.title}" }
   end
 
   def user_signed_up(token)
@@ -113,8 +103,7 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Account'
 
-    send_mail(token.user,
-              t(:mail_subject_register, value: Setting.app_title))
+    send_localized_mail(token.user) { I18n.t(:mail_subject_register, value: Setting.app_title) }
   end
 
   def news_comment_added(user, comment)
@@ -127,9 +116,11 @@ class UserMailer < ApplicationMailer
     references @news, @comment
 
     subject = "#{News.model_name.human}: #{@news.title}"
-    subject = "Re: [#{@news.project.name}] #{subject}" if @news.project
 
-    send_mail(user, subject)
+    project = @news.project ? "#{@news.project.name}] " : ''
+    send_localized_mail(user) do
+      "Re: #{project}#{subject}"
+    end
   end
 
   def wiki_page_added(user, wiki_page)
@@ -138,8 +129,9 @@ class UserMailer < ApplicationMailer
     open_project_wiki_headers @wiki_page
     message_id @wiki_page, user
 
-    send_mail(user,
-              "[#{@wiki_page.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_page.title)}")
+    send_localized_mail(user) do
+      "[#{@wiki_page.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_page.title)}"
+    end
   end
 
   def wiki_page_updated(user, wiki_page)
@@ -153,8 +145,9 @@ class UserMailer < ApplicationMailer
     open_project_wiki_headers @wiki_page
     message_id @wiki_page, user
 
-    send_mail(user,
-              "[#{@wiki_page.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_page.title)}")
+    send_localized_mail(user) do
+      "[#{@wiki_page.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_page.title)}"
+    end
   end
 
   def message_posted(user, message)
@@ -164,8 +157,9 @@ class UserMailer < ApplicationMailer
     message_id @message, user
     references *[@message.parent, @message].compact
 
-    send_mail(user,
-              "[#{@message.forum.project.name} - #{@message.forum.name} - msg#{@message.root.id}] #{@message.subject}")
+    send_localized_mail(user) do
+      "[#{@message.forum.project.name} - #{@message.forum.name} - msg#{@message.root.id}] #{@message.subject}"
+    end
   end
 
   def account_activated(user)
@@ -173,8 +167,7 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Account'
 
-    send_mail(user,
-              t(:mail_subject_register, value: Setting.app_title))
+    send_localized_mail(user) { t(:mail_subject_register, value: Setting.app_title) }
   end
 
   def account_information(user, password)
@@ -183,8 +176,7 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Account'
 
-    send_mail(user,
-              t(:mail_subject_register, value: Setting.app_title))
+    send_localized_mail(user) { t(:mail_subject_register, value: Setting.app_title) }
   end
 
   def account_activation_requested(admin, user)
@@ -196,8 +188,7 @@ class UserMailer < ApplicationMailer
 
     open_project_headers 'Type' => 'Account'
 
-    send_mail(admin,
-              t(:mail_subject_account_activation_request, value: Setting.app_title))
+    send_localized_mail(admin) { t(:mail_subject_account_activation_request, value: Setting.app_title) }
   end
 
   ##
@@ -208,7 +199,7 @@ class UserMailer < ApplicationMailer
   def activation_limit_reached(user_email, admin)
     @email = user_email
 
-    send_mail(admin, t("mail_user_activation_limit_reached.subject"))
+    send_localized_mail(admin) { t("mail_user_activation_limit_reached.subject") }
   end
 
   ##
@@ -229,7 +220,9 @@ class UserMailer < ApplicationMailer
     headers['References'] = ["<#{mail[:message_id]}>"]
     headers['In-Reply-To'] = ["<#{mail[:message_id]}>"]
 
-    send_mail user, mail[:subject].present? ? "Re: #{mail[:subject]}" : I18n.t("mail_subject_incoming_email_error")
+    send_localized_mail(user) do
+      mail[:subject].present? ? "Re: #{mail[:subject]}" : I18n.t("mail_subject_incoming_email_error")
+    end
   end
 
   private

--- a/app/mailers/work_package_mailer.rb
+++ b/app/mailers/work_package_mailer.rb
@@ -42,12 +42,11 @@ class WorkPackageMailer < ApplicationMailer
       message_id journal, recipient
       references journal
 
-      with_locale_for(recipient) do
-        mail to: recipient.mail,
-             subject: I18n.t(:'mail.mention.subject',
-                             user_name: author.name,
-                             id: @work_package.id,
-                             subject: @work_package.subject)
+      send_localized_mail(recipient) do
+        I18n.t(:'mail.mention.subject',
+               user_name: author.name,
+               id: @work_package.id,
+               subject: @work_package.subject)
       end
     end
   end
@@ -62,8 +61,8 @@ class WorkPackageMailer < ApplicationMailer
       message_id work_package, user
       references work_package
 
-      with_locale_for(user) do
-        mail to: user.mail, subject: subject_for_work_package(work_package)
+      send_localized_mail(user) do
+        subject_for_work_package(work_package)
       end
     end
   end

--- a/modules/documents/app/mailers/documents_mailer.rb
+++ b/modules/documents/app/mailers/documents_mailer.rb
@@ -33,9 +33,8 @@ class DocumentsMailer < UserMailer
     open_project_headers 'Project' => @document.project.identifier,
                          'Type' => 'Document'
 
-    with_locale_for(user) do
-      subject = "[#{@document.project.name}] #{t(:label_document_new)}: #{@document.title}"
-      mail to: user.mail, subject:
+    send_localized_mail(user) do
+      "[#{@document.project.name}] #{t(:label_document_new)}: #{@document.title}"
     end
   end
 


### PR DESCRIPTION
While `send_mail` uses the user's own locale inside, the subject was oftentimes not translated correctly. To make this easier, pass the subject as a block to send_mail so can use the locale of the user.

https://community.openproject.org/work_packages/52976