### PR TITLE
[#53039] undefined method `check_clamav` for `Admin::Settings::AttachmentsSettingsController`

### DIFF
--- a/app/controllers/admin/settings/attachments_settings_controller.rb
+++ b/app/controllers/admin/settings/attachments_settings_controller.rb
@@ -30,8 +30,6 @@ module Admin::Settings
   class AttachmentsSettingsController < ::Admin::SettingsController
     menu_item :attachments_settings
 
-    before_action :check_clamav, only: %i[update]
-
     def default_breadcrumb
       t(:'attributes.attachments')
     end


### PR DESCRIPTION
#### https://community.openproject.org/work_packages/53039


Remove seemingly erroneous `check_clamav` before action in attachments settings controller causing internal server errors.

https://github.com/opf/openproject/assets/17295175/e9f3156a-4a2b-4e1a-989a-e2426b7f93e0

