### PR TITLE
Fix #43520 Search bar doesn't have focus state and the first element on the list seams always selected

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -133,15 +133,13 @@ $search-input-height: 30px
         color: var(--header-drop-down-item-font-hover-color)
       &.ng-option-disabled
         display: none
-      &.ng-option-selected
-        color: var(--header-drop-down-item-font-hover-color)
 
     &.-markable
       .ng-option
         &.ng-option-marked
           background-color: var(--drop-down-hover-bg-color)
         &.ng-option-selected
-          background-color: var(--drop-down-selected-bg-color)
+          background-color: unset
 
   &--input
     // Fix position of the spinner

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -59,6 +59,9 @@ $search-input-height: 30px
       background: transparent
       border-color: var(--header-item-font-color) !important
 
+      &:focus-within
+        @include spot-focus
+
     .ng-arrow-wrapper
       display: none
 

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -251,6 +251,7 @@ RSpec.describe 'Search', :js, with_settings: { per_page_options: '5' } do
         context 'when submitting without autocomplete' do
           it 'loads the WP in full view' do
             global_search.search "##{work_package.id}"
+            global_search.expect_work_package_marked(work_package)
             global_search.submit_with_enter
 
             wp_page = Pages::FullWorkPackage.new(work_package)


### PR DESCRIPTION
| was | now |
| --- | --- |
| <img width="374" alt="image" src="https://github.com/opf/openproject/assets/18144/f566b4ab-f121-4bd2-af0b-30bba1009edc"> | <img width="374" alt="image" src="https://github.com/opf/openproject/assets/18144/a3e82744-4e66-4bd2-aca2-06db433dcd9a"> |
| <img width="374" alt="image" src="https://github.com/opf/openproject/assets/18144/0bae4c4e-e3e7-4022-968f-338935849446"> | <img width="374" alt="image" src="https://github.com/opf/openproject/assets/18144/a2411632-b168-4c36-ae53-e377f6d815c0"> |

Related to #8225 