### PR TITLE
[#50011] Word "Description" should be higher position in new document

### DIFF
--- a/modules/documents/app/views/documents/_form.html.erb
+++ b/modules/documents/app/views/documents/_form.html.erb
@@ -41,6 +41,9 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="form--field -visible-overflow">
   <%= f.text_area :description,
                   container_class: '-xxwide',
+                  label_options: {
+                    class: '-top'
+                  },
                   with_text_formatting: true,
                   resource: api_v3_document_resource(f.object),
                   preview_context: preview_context(f.object.project) %>


### PR DESCRIPTION
https://community.openproject.org/work_packages/50011

Move description label to top

**Before**
<img width="1442" alt="Screenshot 2024-02-26 at 18 35 30" src="https://github.com/opf/openproject/assets/1113942/cc47fc16-2454-4ee9-b0c6-049b9a1972a1">


**After**
<img width="1445" alt="Screenshot 2024-02-26 at 18 35 06" src="https://github.com/opf/openproject/assets/1113942/629af545-0dba-44be-a946-98898fd74da1">
