### PR TITLE
[#52921] Configure HTTPX timeouts. Merge to release 13.3.

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -716,6 +716,34 @@ module Settings
         format: :string,
         default: nil
       },
+      httpx_connect_timeout: {
+        description: '',
+        format: :float,
+        writable: false,
+        allowed: (0..),
+        default: 3
+      },
+      httpx_read_timeout: {
+        description: '',
+        format: :float,
+        writable: false,
+        allowed: (0..),
+        default: 3
+      },
+      httpx_write_timeout: {
+        description: '',
+        format: :float,
+        writable: false,
+        allowed: (0..),
+        default: 3
+      },
+      httpx_keep_alive_timeout: {
+        description: '',
+        format: :float,
+        writable: false,
+        allowed: (0..),
+        default: 20
+      },
       rate_limiting: {
         default: {},
         description: 'Configure rate limiting for various endpoint rules. See configuration documentation for details.'
@@ -833,7 +861,7 @@ module Settings
       sendmail_arguments: {
         description: 'Arguments to call sendmail with in case it is configured as outgoing email setup',
         format: :string,
-        default: "-i",
+        default: "-i"
       },
       sendmail_location: {
         description: 'Location of sendmail to call if it is configured as outgoing email setup',

--- a/modules/storages/spec/contracts/storages/storages/nextcloud_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/nextcloud_contract_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Storages::Storages::NextcloudContract, :storage_server_helpers, :
           expect(subject.errors.to_hash)
             .to eq({ password: ["could not be validated. Please check your storage connection and try again."] })
 
-          # will be twice when httpx persistent plugin enabled.
-          expect(credentials_request).to have_been_made.once
+          # twice due to HTTPX retry plugin being enabled.
+          expect(credentials_request).to have_been_made.twice
         end
       end
 

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -192,8 +192,8 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
 
             it 'retries failed request once' do
               contract.validate
-              # will be twice when httpx persistent plugin enabled.
-              expect(stub_server_capabilities).to have_been_made.once
+              # twice due to HTTPX retry plugin being enabled.
+              expect(stub_server_capabilities).to have_been_made.twice
             end
           end
 
@@ -205,8 +205,8 @@ RSpec.shared_examples_for 'nextcloud storage contract', :storage_server_helpers,
             it 'retries failed request once' do
               contract.validate
 
-              # will be twice when httpx persistent plugin enabled.
-              expect(stub_config_check).to have_been_made.once
+              # twice due to HTTPX retry plugin being enabled.
+              expect(stub_config_check).to have_been_made.twice
             end
           end
         end

--- a/modules/storages/spec/workers/storages/manage_nextcloud_integration_cron_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_nextcloud_integration_cron_job_spec.rb
@@ -33,7 +33,7 @@ require_module_spec_helper
 
 RSpec.describe Storages::ManageNextcloudIntegrationCronJob, :webmock, type: :job do
   it 'has a schedule set' do
-    expect(described_class.cron_expression).to eq('*/5 * * * *')
+    expect(described_class.cron_expression).to eq('1 * * * *')
   end
 
   describe '.ensure_scheduled!' do


### PR DESCRIPTION
https://community.openproject.org/work_packages/52921

- Configure HTTPX timeouts
- Reuse HTTPX session though lifetime of a process.
- Enable HTTPX persistent connections(with reusage of HTTPX session it should work as expected)
- Add HTTPXApsignal plugin to HTTPX if Appsignal enabled to track external requests. [Sample](https://appsignal.com/openproject-gmbh/sites/65d5f46a83eb679274de83f9/performance/incidents/30/samples/65d5f46a83eb679274de83f9-176837881530755131351708712520).
- Run Storages::ManageNextcloudIntegrationCronJob once per hour.