### PR TITLE
Show modified warning and save as button in project list

### DIFF
--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -3,6 +3,33 @@
     <% header.with_title(data: { 'test-selector': 'project-query-name'}) { page_title } %>
 
     <% header.with_actions do %>
+      <% if query_saveable? %>
+        <%= render(
+              Primer::Beta::Text.new(tag: :span,
+                                     mr: BUTTON_MARGIN_RIGHT,
+                                     color: :muted)) do
+            t('lists.can_be_saved_as')
+          end
+        %>
+
+        <%= render(
+              Primer::Beta::Button.new(scheme: :invisible,
+                                       size: :medium,
+                                       mr: BUTTON_MARGIN_RIGHT,
+                                       tag: :a,
+                                       href: new_projects_query_path,
+                                       data: {
+                                         controller: "params-from-query",
+                                         'application-target': "dynamic",
+                                         'params-from-query-allowed-value': '["filters"]'
+                                       },
+                                       classes: 'Button--invisibleOP')) do |button|
+          button.with_leading_visual_icon(icon: :'op-save')
+
+          t('button_save_as')
+        end %>
+      <% end %>
+
       <%= render(Primer::Alpha::ActionMenu.new) do |menu|
         menu.with_show_button(icon: 'op-kebab-vertical', 'aria-label': t(:label_more), data: { 'test-selector': 'project-more-dropdown-menu' })
 
@@ -22,13 +49,13 @@
           tag: :a,
           label: t(:label_overall_activity),
           href: activities_path
-        )do |item|
-        item.with_leading_visual_icon(icon: 'tasklist')
-      end
+        ) do |item|
+          item.with_leading_visual_icon(icon: 'tasklist')
+        end
 
-        if current_user.logged? && query_saveable?
+        if query_saveable?
           menu.with_item(
-            label: t('button_save'),
+            label: t('button_save_as'),
             href: new_projects_query_path,
             content_arguments: {
             data: {

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -72,7 +72,7 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
   end
 
   def query_saveable?
-    query.name.blank?
+    current_user.logged? && query.name.blank?
   end
 
   def show_state?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,9 @@ en:
       storage:
         no_results_title_text: There is no additional recorded disk space consumed by this project.
 
+  lists:
+    can_be_saved_as: "The modifications can only be saved in a new list."
+
   members:
     index:
       no_results_title_text: There are currently no members part of this project.
@@ -1280,6 +1283,7 @@ en:
   button_reset: "Reset"
   button_rollback: "Rollback to this version"
   button_save: "Save"
+  button_save_as: "Save as"
   button_apply_changes: "Apply changes"
   button_save_back: "Save and back"
   button_show: "Show"

--- a/frontend/src/global_styles/openproject/_primer-adjustments.sass
+++ b/frontend/src/global_styles/openproject/_primer-adjustments.sass
@@ -55,3 +55,20 @@ ul.tabnav-tabs
   .breadcrumb-item.breadcrumb-item-selected
     a
       pointer-events: none
+
+/* TODO: The actions within the PageHeader are currently not aligned correctly.
+   The pageHeader itself already uses center alignment but the actions themselves default to 'normal'.
+   Will be added to our primer repository */
+.PageHeader-actions
+  align-items: center
+
+/* Primer uses the fgColor (blue) for Buttons having the :invisible schema unless they receive an trailing/leading icon.
+   Then, the color changes to gray. This seems inconsistent. An issue has been opened with Primer to discuss this behavior.
+   Until then, we will override the fgColor for the invisible schema.
+   No all invisible schema buttons are overwritten though and need to apply this modifier themselves. */
+.Button--invisibleOP,
+.Button--invisibleOP:hover:not(:disabled,.Button--inactive)
+  color: var(--button-invisible-fgColor-rest,var(--color-btn-outline-text))
+
+  .Button-visual
+    color: var(--button-invisible-fgColor-rest,var(--color-btn-outline-text))

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -219,6 +219,8 @@ RSpec.describe 'Persisted lists on projects index page',
 
       # The default filter is active
       projects_page.expect_title('Active projects')
+      # Since the page is unchanged, no save as button is shown
+      projects_page.expect_no_save_as_notification
 
       # Adding some filters
       projects_page.open_filters
@@ -226,6 +228,7 @@ RSpec.describe 'Persisted lists on projects index page',
 
       # By applying another filter, the title is changed as it does not longer match the default filter
       projects_page.expect_title('Projects')
+      projects_page.expect_save_as_notification
 
       # The filters are applied
       projects_page.expect_projects_listed(project, development_project)

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -144,6 +144,16 @@ module Pages
         end
       end
 
+      def expect_no_save_as_notification
+        expect(page)
+          .to have_no_link('Save as')
+      end
+
+      def expect_save_as_notification
+        expect(page)
+          .to have_link('Save as')
+      end
+
       def filter_by_active(value)
         set_filter('active',
                    'Active',
@@ -310,7 +320,7 @@ module Pages
       end
 
       def save_query(name)
-        click_more_menu_item('Save')
+        click_more_menu_item('Save as')
 
         within '[data-test-selector="project-query-name"]' do
           fill_in 'Name', with: name


### PR DESCRIPTION
**Acceptance criteria**

* [x] Changing a persisted or static list:
  * [x] An information message is displayed next to the page header that the list was manipulated
  * [x] A "Save as" button appears in the top left toolbar
* [x] Pressing on the "Save as" button opens an input field for the name of the new list (same as clicking on the "Save as" entry in the menu)
* [x] All selections of the current list are saved (filters, columns sort order) 
* [x] Clarify what to do about the button styles overwritten from Primer
* [x] Check acceptance of altered message

**Notes**

The acceptance criteria deviate from what is specified in the work package as the code does not yet support sharing of lists and the storage of filters and sort order. The PRs implementing that will have to provide the functionality at the placed now added to the code later.

---------------

https://community.openproject.org/wp/52152