### PR TITLE
[53059] Replace Primer Flash with Primer Banner as Flash is deprecated

### DIFF
--- a/app/components/work_packages/share/invite_user_form_component.html.erb
+++ b/app/components/work_packages/share/invite_user_form_component.html.erb
@@ -94,7 +94,7 @@
         end
       end
     else
-      render(Primer::Beta::Flash.new(icon: :info)) { I18n.t('work_package.sharing.permissions.denied') }
+      render(Primer::Alpha::Banner.new(icon: :info)) { I18n.t('work_package.sharing.permissions.denied') }
     end
   end
 %>

--- a/modules/meeting/app/components/base_errors_component.rb
+++ b/modules/meeting/app/components/base_errors_component.rb
@@ -43,7 +43,7 @@ class BaseErrorsComponent < ApplicationComponent
   end
 
   def call
-    render(Primer::Beta::Flash.new(scheme: :danger, icon: :stop, spacious: true)) do
+    render(Primer::Alpha::Banner.new(scheme: :danger, icon: :stop, spacious: true)) do
       joined_messages
     end
   end

--- a/modules/meeting/app/components/flash_message_component.rb
+++ b/modules/meeting/app/components/flash_message_component.rb
@@ -31,13 +31,12 @@ class FlashMessageComponent < ApplicationComponent
   include OpTurbo::Streamable
   include OpPrimer::ComponentHelpers
 
-  def initialize(message: nil, full: false, spacious: false, dismissible: false, icon: nil, scheme: :default)
+  def initialize(message: nil, full: false, dismiss_scheme: :none, icon: nil, scheme: :default)
     super
 
     @message = message
     @full = full
-    @spacious = spacious
-    @dismissible = dismissible # TODO: not working yet -> JS dependency not provided?
+    @dismiss_scheme = dismiss_scheme
     @icon = icon
     @scheme = scheme
   end
@@ -55,8 +54,8 @@ class FlashMessageComponent < ApplicationComponent
   private
 
   def flash_partial
-    render(Primer::Beta::Flash.new(
-             full: @full, spacious: @spacious, dismissible: @dismissible, icon: @icon, scheme: @scheme
+    render(Primer::Alpha::Banner.new(
+             full: @full, dismiss_scheme: @dismiss_scheme, icon: @icon, scheme: @scheme
            )) { @message }
   end
 end

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
@@ -12,7 +12,7 @@
             flex_layout(my: 3) do |flex|
               flex.with_row do
                 if @base_errors&.any?
-                  render(Primer::Beta::Flash.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
+                  render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
                 end
               end
               flex.with_row do

--- a/modules/storages/app/components/storages/admin/oauth_application_info_copy_component.html.erb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_copy_component.html.erb
@@ -2,7 +2,7 @@
   render(Primer::Beta::Text.new(tag: :div, test_selector: 'storage-openproject-oauth-application-form')) do
     flex_layout(flex_items: :center) do |credentials_row|
       credentials_row.with_row(mb: 3, test_selector: 'storage-openproject_oauth_application_warning') do
-        render(Primer::Beta::Flash.new(icon: :alert, scheme: :warning)) do
+        render(Primer::Alpha::Banner.new(icon: :alert, scheme: :warning)) do
           I18n.t('storages.instructions.oauth_application_details', oauth_application_details_link: oauth_application_details_link).html_safe
         end
       end


### PR DESCRIPTION
* Replace `Flash` with `Banner` as suggested by Primer (see https://github.com/primer/view_components/issues/2599)
* Change the used attributes to those of `Alpha::Banner`


https://community.openproject.org/projects/openproject/work_packages/53059/activity