### PR TITLE
[#52929] Require `:view_work_packages` as a dependency of `:add_work_packages`

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -187,6 +187,7 @@ Rails.application.reloader.to_prepare do
       wpt.permission :add_work_packages,
                      {},
                      permissible_on: :project,
+                     dependencies: :view_work_packages,
                      contract_actions: { work_packages: %i[create] }
 
       wpt.permission :edit_work_packages,


### PR DESCRIPTION
Related work package: https://community.openproject.org/work_packages/52929
