### PR TITLE
[#52667] Fix spacing between name and ActionMenu button on agenda items

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -67,6 +67,7 @@
             menu.with_show_button(icon: "kebab-horizontal",
                                   'aria-label': I18n.t(:label_agenda_item_actions),
                                   scheme: :invisible,
+                                  ml: 2,
                                   test_selector: 'op-meeting-agenda-actions')
             edit_action_item(menu) if @meeting_agenda_item.editable?
             add_note_action_item(menu) if @meeting_agenda_item.editable?

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -61,15 +61,20 @@
         end
       end
 
-    grid.with_area(:actions, tag: :div, justify_self: :end) do
-      render(Primer::Alpha::ActionMenu.new) do |menu|
-        menu.with_show_button(icon: "kebab-horizontal", 'aria-label': t("label_agenda_item_actions"), scheme: :invisible, test_selector: 'op-meeting-agenda-actions')
-        edit_action_item(menu) if @meeting_agenda_item.editable?
-        add_note_action_item(menu) if @meeting_agenda_item.editable?
-        move_actions(menu)
-        delete_action_item(menu)
-      end if edit_enabled?
-    end
+      grid.with_area(:actions, tag: :div, justify_self: :end) do
+        if edit_enabled?
+          render(Primer::Alpha::ActionMenu.new) do |menu|
+            menu.with_show_button(icon: "kebab-horizontal",
+                                  'aria-label': I18n.t(:label_agenda_item_actions),
+                                  scheme: :invisible,
+                                  test_selector: 'op-meeting-agenda-actions')
+            edit_action_item(menu) if @meeting_agenda_item.editable?
+            add_note_action_item(menu) if @meeting_agenda_item.editable?
+            move_actions(menu)
+            delete_action_item(menu)
+          end
+        end
+      end
 
       grid.with_area(:notes, tag: :div) do
         if @meeting_agenda_item.notes.present?


### PR DESCRIPTION
Related work package: https://community.openproject.org/work_packages/52667

<img width="287" alt="image" src="https://github.com/opf/openproject/assets/61627014/e9649c7e-c945-4579-8f22-ab0355888c96">


Apologies for the awkward commit history, mistakenly committed directly onto dev.