### PR TITLE
Fix Gem::InvalidSpecificationException in rake generated plugin

### DIFF
--- a/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
+++ b/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
@@ -1,10 +1,12 @@
 $:.push File.expand_path("../lib", __FILE__)
 $:.push File.expand_path("../../lib", __dir__)
 
+require 'open_project/<%= plugin_name %>/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "<%= full_name %>"
+  s.version     = OpenProject::<%= plugin_name.camelcase %>::VERSION
 
   s.authors     = "OpenProject GmbH"
   s.email       = "info@openproject.org"


### PR DESCRIPTION
Fixes Gem::InvalidSpecificationException while loading empty plugin.