### PR TITLE
[52958] Inconsistent green buttons / custom color settings are not applied to project create button

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -9,11 +9,13 @@
      configured design outside of high contrast mode  */
   [data-color-mode]:not([data-light-theme=light_high_contrast]) {
     --color-accent-fg: var(--content-link-color) !important;
+    --button-primary-bgColor-rest: var(--button--alt-highlight-background-color); !important;
+    --button-primary-bgColor-hover: var(--button--alt-highlight-background-hover-color) !important;
   }
   [data-light-theme=light_high_contrast]{
     --avatar-border-color: var(--color-avatar-border);
     --list-item-hover--border-color: var(--color-action-list-item-default-active-border);
-    --list-item-hover--color: var(--color-fg-default)
+    --list-item-hover--color: var(--color-fg-default);
     --inplace-edit--border-color: var(--color-border-default);
     --ck-color-toolbar-border: var(--color-border-default);
     --ck-color-base-border: var(--color-border-default);

--- a/db/migrate/20240306083241_change_default_value_of_alternative_color.rb
+++ b/db/migrate/20240306083241_change_default_value_of_alternative_color.rb
@@ -1,0 +1,19 @@
+class ChangeDefaultValueOfAlternativeColor < ActiveRecord::Migration[7.1]
+  class MigrationDesignColor < ApplicationRecord
+    self.table_name = 'design_colors'
+  end
+
+  def up
+    alternative_color = MigrationDesignColor.find_by(variable: 'alternative-color')
+    if alternative_color&.hexcode == OpenProject::CustomStyles::ColorThemes::DEPRECATED_ALTERNATIVE_COLOR
+      alternative_color.update(hexcode: OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR)
+    end
+  end
+
+  def down
+    alternative_color = MigrationDesignColor.find_by(variable: 'alternative-color')
+    if alternative_color&.hexcode == OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR
+      alternative_color.update(hexcode: OpenProject::CustomStyles::ColorThemes::DEPRECATED_ALTERNATIVE_COLOR)
+    end
+  end
+end

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -37,7 +37,7 @@
   --primary-color--major2: #103e62;
   --primary-color--major3: #0a2941;
   --primary-color-dark: #175A8E;
-  --alternative-color: #35C53F;
+  --alternative-color: var(--button-primary-bgColor-rest, var(--color-btn-primary-bg));
 
   /**
    * The 100vh bug on iOS is a well known issue that will not be addressed.

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -32,13 +32,16 @@ module OpenProject::CustomStyles
 
     OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = 'OpenProject'.freeze
 
+    DEPRECATED_ALTERNATIVE_COLOR = '#35C53F'.freeze
+    PRIMER_PRIMARY_BUTTON_COLOR = '#1F883D'.freeze
+
     THEMES = [
       {
         theme: OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME,
         colors: {
           'primary-color' => "#1A67A3",
           'primary-color-dark' => "#175A8E",
-          'alternative-color' => "#1F883D",
+          'alternative-color' => PRIMER_PRIMARY_BUTTON_COLOR,
           'content-link-color' => "#175A8E",
           'header-bg-color' => "#1A67A3",
           'header-item-bg-hover-color' => "#175A8E",
@@ -59,7 +62,7 @@ module OpenProject::CustomStyles
         colors: {
           'primary-color' => "#1A67A3",
           'primary-color-dark' => "#175A8E",
-          'alternative-color' => "#1F883D",
+          'alternative-color' => PRIMER_PRIMARY_BUTTON_COLOR,
           'content-link-color' => "#175A8E",
           'header-bg-color' => "#FAFAFA",
           'header-item-bg-hover-color' => "#E1E1E1",
@@ -81,7 +84,7 @@ module OpenProject::CustomStyles
         colors: {
           'primary-color' => "#3270DB",
           'primary-color-dark' => "#163473",
-          'alternative-color' => "#1F883D",
+          'alternative-color' => PRIMER_PRIMARY_BUTTON_COLOR,
           'content-link-color' => "#275BB5",
           'header-bg-color' => "#05002C",
           'header-item-bg-hover-color' => "#163473",

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -38,7 +38,7 @@ module OpenProject::CustomStyles
         colors: {
           'primary-color' => "#1A67A3",
           'primary-color-dark' => "#175A8E",
-          'alternative-color' => "#35C53F",
+          'alternative-color' => "#1F883D",
           'content-link-color' => "#175A8E",
           'header-bg-color' => "#1A67A3",
           'header-item-bg-hover-color' => "#175A8E",
@@ -59,7 +59,7 @@ module OpenProject::CustomStyles
         colors: {
           'primary-color' => "#1A67A3",
           'primary-color-dark' => "#175A8E",
-          'alternative-color' => "#138E1B",
+          'alternative-color' => "#1F883D",
           'content-link-color' => "#175A8E",
           'header-bg-color' => "#FAFAFA",
           'header-item-bg-hover-color' => "#E1E1E1",
@@ -81,7 +81,7 @@ module OpenProject::CustomStyles
         colors: {
           'primary-color' => "#3270DB",
           'primary-color-dark' => "#163473",
-          'alternative-color' => "#349939",
+          'alternative-color' => "#1F883D",
           'content-link-color' => "#275BB5",
           'header-bg-color' => "#05002C",
           'header-item-bg-hover-color' => "#163473",

--- a/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
@@ -26,7 +26,7 @@ module OpenProject::Bim
             colors: {
               'primary-color' => "#3270DB",
               'primary-color-dark' => "#163473",
-              'alternative-color' => "#1F883D",
+              'alternative-color' => OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR,
               'header-bg-color' => "#05002C",
               'header-item-bg-hover-color' => "#163473",
               'content-link-color' => "#275BB5",

--- a/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
@@ -26,7 +26,7 @@ module OpenProject::Bim
             colors: {
               'primary-color' => "#3270DB",
               'primary-color-dark' => "#163473",
-              'alternative-color' => "#349939",
+              'alternative-color' => "#1F883D",
               'header-bg-color' => "#05002C",
               'header-item-bg-hover-color' => "#163473",
               'content-link-color' => "#275BB5",

--- a/spec/migrations/change_default_value_of_alternative_color_spec.rb
+++ b/spec/migrations/change_default_value_of_alternative_color_spec.rb
@@ -1,0 +1,114 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require Rails.root.join("db/migrate/20240306083241_change_default_value_of_alternative_color.rb")
+
+RSpec.describe ChangeDefaultValueOfAlternativeColor, type: :model do
+  context 'when migrating up' do
+    context 'when there is no custom value set' do
+      let(:design_color) do
+        DesignColor.new variable: "alternative-color",
+                        hexcode: OpenProject::CustomStyles::ColorThemes::DEPRECATED_ALTERNATIVE_COLOR
+      end
+
+      before do
+        design_color.save!
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+      it "changes the default value" do
+        expect { subject }
+          .to change { DesignColor.where(variable: 'alternative-color').first.hexcode }
+                .from(OpenProject::CustomStyles::ColorThemes::DEPRECATED_ALTERNATIVE_COLOR)
+                .to(OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR)
+      end
+    end
+
+    context 'when there is a custom value set' do
+      let(:design_color) do
+        DesignColor.new variable: "alternative-color", hexcode: "#AB1234"
+      end
+
+      before do
+        design_color.save!
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+      it "does not change the default value" do
+        expect { subject }
+          .not_to change { DesignColor.where(variable: 'alternative-color').first.hexcode }
+      end
+    end
+  end
+
+  context 'when migrating down' do
+    context 'when there is no custom value set' do
+      let(:design_color) do
+        DesignColor.new variable: "alternative-color",
+                        hexcode: OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR
+      end
+
+      before do
+        design_color.save!
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.down } }
+
+      it "changes the default value" do
+        expect { subject }
+          .to change { DesignColor.where(variable: 'alternative-color').first.hexcode }
+                .from(OpenProject::CustomStyles::ColorThemes::PRIMER_PRIMARY_BUTTON_COLOR)
+                .to(OpenProject::CustomStyles::ColorThemes::DEPRECATED_ALTERNATIVE_COLOR)
+      end
+    end
+
+    context 'when there is a custom value set' do
+      let(:design_color) do
+        DesignColor.new variable: "alternative-color", hexcode: "#AB1234"
+      end
+
+      before do
+        design_color.save!
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.down } }
+
+      it "does not change the default value" do
+        expect { subject }
+          .not_to change { DesignColor.where(variable: 'alternative-color').first.hexcode }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Change the default value of the alternative color to the one of Primer in order to harmonise the button colors.

https://community.openproject.org/projects/openproject/work_packages/52958/activity