### PR TITLE
Improve toast message when enabling virus scanning

### DIFF
--- a/app/controllers/admin/settings/virus_scanning_settings_controller.rb
+++ b/app/controllers/admin/settings/virus_scanning_settings_controller.rb
@@ -87,7 +87,7 @@ module Admin::Settings
     end
 
     def rescan_files
-      flash[:info] = t('settings.antivirus.remaining_rescanned_files',
+      flash[:notice] = t('settings.antivirus.remaining_rescanned_files',
                        file_count: t(:label_x_files, count: Attachment.status_uploaded.count))
       Attachment.status_uploaded.update_all(status: :rescan)
 

--- a/app/controllers/admin/settings/virus_scanning_settings_controller.rb
+++ b/app/controllers/admin/settings/virus_scanning_settings_controller.rb
@@ -79,7 +79,7 @@ module Admin::Settings
     def success_callback(_call)
       if Setting.antivirus_scan_mode == :disabled && Attachment.status_quarantined.any?
         remaining_quarantine_warning
-      elsif scan_enabled?
+      elsif scan_enabled? && Attachment.status_uploaded.any?
         rescan_files
       else
         super

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3019,7 +3019,8 @@ en:
         Remaining files have been scanned. There are %{file_count} in quarantine.
         You are being redirected to the quarantine page. Use this page to delete or override quarantined files.
       remaining_rescanned_files: >
-        With virus scanning now active, there are %{file_count} that need to be rescanned. 
+        Virus scanning has been enabled successfuly.
+        There are %{file_count} that were uploaded previously and still need to be scanned. 
         This process has been scheduled in the background. The files will remain accessible during the scan.
       upsale:
         description: "Ensure uploaded files in OpenProject are scanned for viruses before being accessible by other users."


### PR DESCRIPTION
Improve the message and use :notice to mark it as a successful operation.

https://community.openproject.org/notifications/details/52909/activity