### PR TITLE
Link error to current appsignal transaction if available

### DIFF
--- a/lib_static/open_project/appsignal.rb
+++ b/lib_static/open_project/appsignal.rb
@@ -36,8 +36,14 @@ module OpenProject
 
     def exception_handler(message, log_context = {})
       if (exception = log_context[:exception])
-        ::Appsignal.send_error(exception) do |transaction|
-          transaction.set_tags tags(log_context)
+        if Appsignal::Transaction.current?
+          ::Appsignal.set_error(exception) do |transaction|
+            transaction.set_tags tags(log_context)
+          end
+        else
+          ::Appsignal.send_error(exception) do |transaction|
+            transaction.set_tags tags(log_context)
+          end
         end
       else
         Rails.logger.warn "Ignoring non-exception message for appsignal #{message.inspect}"


### PR DESCRIPTION
Using `send_error` will always create a new transaction with a random request id, which is different from the real request id of the current web request and being present in log files.

Using `set_error` instead will link the error to the current transaction, adding a lot of extra context information to the error in the AppSignal web app like the correct request_id.