### PR TITLE
Feature/53330 disable profile fields for ldap user

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -187,8 +187,13 @@ class PermittedParams
   end
 
   def user(additional_params = [])
-    permitted_params = params.require(:user).permit(*self.class.permitted_attributes[:user] + additional_params)
-    permitted_params.merge(custom_field_values(:user))
+    if params[:user].present?
+      permitted_params = params.require(:user).permit(*self.class.permitted_attributes[:user] + additional_params)
+      permitted_params.merge(custom_field_values(:user))
+    else
+      # This happens on the Profile page for LDAP user, no "user" hash is sent.
+      {}.merge(custom_field_values(:user, required: false))
+    end
   end
 
   def placeholder_user

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -49,19 +49,31 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
     </div>
     <% login_via_provider = !!@user.identity_url %>
+    <% login_via_ldap = !!@user.ldap_auth_source_id %>
     <div class="form--field -required">
-      <%= f.text_field :firstname, required: true, container_class: '-middle', disabled: login_via_provider %>
+      <%= f.text_field :firstname, required: true, container_class: '-middle', disabled: login_via_provider || login_via_ldap %>
       <% if login_via_provider %>
         <span class="form--field-instructions"><%= t('user.text_change_disabled_for_provider_login') %></span>
       <% end %>
+      <% if login_via_ldap %>
+        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_ldap_login') %></span>
+      <% end %>
     </div>
     <div class="form--field -required">
-      <%= f.text_field :lastname, required: true, container_class: '-middle', disabled: login_via_provider %>
+      <%= f.text_field :lastname, required: true, container_class: '-middle', disabled: login_via_provider || login_via_ldap %>
       <% if login_via_provider %>
         <span class="form--field-instructions"><%= t('user.text_change_disabled_for_provider_login') %></span>
       <% end %>
+      <% if login_via_ldap %>
+        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_ldap_login') %></span>
+      <% end %>
     </div>
-    <div class="form--field -required"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
+    <div class="form--field -required">
+      <%= f.text_field :mail, required: true, container_class: '-middle', disabled: login_via_ldap %>
+      <% if login_via_ldap %>
+        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_ldap_login') %></span>
+      <% end %>
+    </div>
 
     <%= fields_for :pref, @user.pref, builder: TabularFormBuilder, lang: current_language do |pref_fields| %>
       <div class="form--field"><%= pref_fields.check_box :hide_mail %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3330,6 +3330,7 @@ en:
     status_user_and_brute_force: "%{user} and %{brute_force}"
     status_change: "Status change"
     text_change_disabled_for_provider_login: "The name is set by your login provider and can thus not be changed."
+    text_change_disabled_for_ldap_login: "The name and email is set by LDAP and can thus not be changed."
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
 

--- a/lib/open_project/ui/extensible_tabs.rb
+++ b/lib/open_project/ui/extensible_tabs.rb
@@ -63,7 +63,7 @@ module OpenProject
               path: ->(params) { edit_user_path(params[:user], tab: :general) },
               label: :label_general,
               only_if: ->(context) {
-                         Users::UpdateContract.new(context[:user], context[:current_user]).allowed_to_update?
+                         ::Users::UpdateContract.new(context[:user], context[:current_user]).allowed_to_update?
                        }
             },
             {

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'my', :js, :with_cuprite do
   end
 
   ##
-  # Expecations for a successful account change
+  # Expectations for a successful account change
   def expect_changed!
     expect(page).to have_content I18n.t(:notice_account_updated)
     expect(page).to have_content I18n.t(:notice_account_other_session_expired)
@@ -60,6 +60,24 @@ RSpec.describe 'my', :js, :with_cuprite do
     session.save
 
     expect(Sessions::UserSession.for_user(user).where(session_id: 'other').count).to eq 1
+  end
+
+  shared_examples 'common tests for normal and LDAP user' do
+    describe 'settings' do
+      context 'with a default time zone', with_settings: { user_default_timezone: 'Asia/Tokyo' } do
+        it 'can override a time zone' do
+          expect(user.pref.time_zone).to eq 'Asia/Tokyo'
+          visit my_settings_path
+
+          expect(page).to have_select 'pref_time_zone', selected: '(UTC+09:00) Tokyo'
+          select '(UTC+01:00) Paris', from: 'pref_time_zone'
+          click_on 'Save'
+
+          expect(page).to have_select 'pref_time_zone', selected: '(UTC+01:00) Paris'
+          expect(user.pref.time_zone).to eq 'Europe/Paris'
+        end
+      end
+    end
   end
 
   context 'user' do
@@ -108,21 +126,7 @@ RSpec.describe 'my', :js, :with_cuprite do
       end
     end
 
-    describe 'settings' do
-      context 'with a default time zone', with_settings: { user_default_timezone: 'Asia/Tokyo' } do
-        it 'can override a time zone' do
-          expect(user.pref.time_zone).to eq 'Asia/Tokyo'
-          visit my_settings_path
-
-          expect(page).to have_select 'pref_time_zone', selected: '(UTC+09:00) Tokyo'
-          select '(UTC+01:00) Paris', from: 'pref_time_zone'
-          click_on 'Save'
-
-          expect(page).to have_select 'pref_time_zone', selected: '(UTC+01:00) Paris'
-          expect(user.pref.time_zone).to eq 'Europe/Paris'
-        end
-      end
-    end
+    include_examples 'common tests for normal and LDAP user'
 
     describe "API tokens" do
       context 'when API access is disabled via global settings', with_settings: { rest_api_enabled: false } do
@@ -414,5 +418,44 @@ RSpec.describe 'my', :js, :with_cuprite do
         end
       end
     end
+  end
+
+  # Without password confirmation the test doesn't try to connect to the LDAP:
+  context 'LDAP user', with_config: { internal_password_confirmation: false } do
+    let(:ldap_auth_source) { create(:ldap_auth_source) }
+    let(:user) do
+      create(:user,
+             mail: 'old@mail.com',
+             login: 'bob',
+             ldap_auth_source:)
+    end
+
+    describe '#account' do
+      before do
+        visit my_account_path
+      end
+
+      it 'does not allow change of name and email but hide email can be changed' do
+        email_field = find_field('user[mail]', disabled: true)
+        firstname_field = find_field('user[firstname]', disabled: true)
+        lastname_field = find_field('user[lastname]', disabled: true)
+
+        expect(email_field).to be_disabled
+        expect(firstname_field).to be_disabled
+        expect(lastname_field).to be_disabled
+
+        expect(page).to have_text(I18n.t('user.text_change_disabled_for_ldap_login'), count: 3)
+
+        uncheck 'pref[hide_mail]'
+        click_on 'Save'
+
+        expect(page).to have_content I18n.t(:notice_account_updated)
+
+        user.reload
+        expect(user.pref.hide_mail).to be false
+      end
+    end
+
+    include_examples 'common tests for normal and LDAP user'
   end
 end

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -30,6 +30,7 @@ require 'spec_helper'
 
 RSpec.describe 'my', :js, :with_cuprite do
   let(:user_password) { 'bob' * 4 }
+  let!(:string_cf) { create(:user_custom_field, :string, name: 'Hobbies', is_required: false) }
   let(:user) do
     create(:user,
            mail: 'old@mail.com',
@@ -435,7 +436,7 @@ RSpec.describe 'my', :js, :with_cuprite do
         visit my_account_path
       end
 
-      it 'does not allow change of name and email but hide email can be changed' do
+      it 'does not allow change of name and email but other fields can be changed' do
         email_field = find_field('user[mail]', disabled: true)
         firstname_field = find_field('user[firstname]', disabled: true)
         lastname_field = find_field('user[lastname]', disabled: true)
@@ -446,12 +447,14 @@ RSpec.describe 'my', :js, :with_cuprite do
 
         expect(page).to have_text(I18n.t('user.text_change_disabled_for_ldap_login'), count: 3)
 
+        fill_in 'Hobbies', with: 'Ruby, DCS'
         uncheck 'pref[hide_mail]'
         click_on 'Save'
 
         expect(page).to have_content I18n.t(:notice_account_updated)
 
         user.reload
+        expect(user.custom_values.find_by(custom_field_id: string_cf).value).to eql 'Ruby, DCS'
         expect(user.pref.hide_mail).to be false
       end
     end


### PR DESCRIPTION
The UI fix was straightforward (as shown on [WP 53330](https://community.openproject.org/projects/openproject/work_packages/53330/activity)), but it also required a branch in the backend, because for LDAP user the Profile does not send any `user` hash. But the same backend call is used also for the Settings page. Please, suggest changes.

I had some strange resolution problems on the user edit page, so I also added one explict `::` prefix, I hope it's OK.