### PR TITLE
fix lefthook documentation link

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@
 # Add commit hooks with `bundle exec lefthook install`
 #
 # Refer for explanation to following link:
-# https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md
+# https://github.com/evilmartians/lefthook/blob/master/docs/usage.md
 
 pre-commit:
   parallel: true


### PR DESCRIPTION
https://github.com/evilmartians/lefthook/commit/7c62002abc4d180c6c7d0abe704adc9473dd0dbd split documentation from full_guide.md to configuration.md and usage.md, I assume we want usage here