### PR TITLE
[53316] Change row break in email notifications

### DIFF
--- a/app/views/mailer/_notification_row.html.erb
+++ b/app/views/mailer/_notification_row.html.erb
@@ -67,11 +67,10 @@
             <td>
               <table <%= placeholder_table_styles(style: 'font-size:16px;font-weight:bold') %>>
                 <tr>
-                  <td style="color: <%= type_color(work_package.type, '#333333') %>;white-space: nowrap;">
-                    <%= work_package.type.to_s.upcase %>
-                  </td>
-                  <%= placeholder_cell('4px', vertical: true) %>
                   <td width="100%" style="color: #333333;">
+                    <span style="color: <%= type_color(work_package.type, '#333333') %>;white-space: nowrap;">
+                      <%= work_package.type.to_s.upcase %>
+                    </span>
                     <%= work_package.subject %>
                   </td>
                 </tr>


### PR DESCRIPTION
Move Type into the same cell as the subject so that they can wrap as one element

### After
<img width="435" alt="Bildschirmfoto 2024-03-08 um 08 32 40" src="https://github.com/opf/openproject/assets/7457313/15900f3f-1e3f-4243-afd7-8987a5b9d1be">

https://community.openproject.org/projects/openproject/work_packages/53316/activity