### PR TITLE
[51379] Baseline change columns display grey color dot for priority but not for status

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table_baseline_overrides.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline_overrides.sass
@@ -27,8 +27,8 @@
 //++
 
 .op-table-baseline--old-field
-  // Hide status bubbles in old values
-  &[class^=__hl_inline_status]:before
+  // Hide highlighting bubbles in old values
+  &[class^=__hl_inline_]:before
     display: none
 
   // Hide avatars in old values


### PR DESCRIPTION
Remove highlighting bubbles for old values in baseline comparison

https://community.openproject.org/projects/openproject/work_packages/51379/activity