### PR TITLE
[#53345] Synchronize only configured storages.

### DIFF
--- a/modules/storages/app/workers/storages/manage_nextcloud_integration_job_mixin.rb
+++ b/modules/storages/app/workers/storages/manage_nextcloud_integration_job_mixin.rb
@@ -40,6 +40,8 @@ module Storages
         transaction: false
       ) do
         ::Storages::Storage.automatic_management_enabled.includes(:oauth_client).find_each do |storage|
+          next unless storage.configured?
+
           result = service_for(storage).call(storage)
           result.match(
             on_success: ->(_) do

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -37,10 +37,6 @@ FactoryBot.define do
       oauth_client
     end
 
-    trait :with_oauth_application do
-      oauth_application
-    end
-
     trait :as_generic do
       provider_type { 'Storages::Storage' }
     end
@@ -64,11 +60,6 @@ FactoryBot.define do
 
     trait :as_not_automatically_managed do
       automatically_managed { false }
-    end
-
-    trait :configured do
-      with_oauth_application
-      with_oauth_client
     end
 
     trait :as_healthy do

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -33,12 +33,13 @@ FactoryBot.define do
     sequence(:name) { |n| "Storage #{n}" }
     creator factory: :user
 
-    # rubocop:disable FactoryBot/FactoryAssociationWithStrategy
-    # For some reason the order of saving breaks STI
     trait :with_oauth_client do
-      oauth_client { build(:oauth_client) }
+      oauth_client
     end
-    # rubocop:enable FactoryBot/FactoryAssociationWithStrategy
+
+    trait :with_oauth_application do
+      oauth_application
+    end
 
     trait :as_generic do
       provider_type { 'Storages::Storage' }
@@ -63,6 +64,11 @@ FactoryBot.define do
 
     trait :as_not_automatically_managed do
       automatically_managed { false }
+    end
+
+    trait :configured do
+      with_oauth_application
+      with_oauth_client
     end
 
     trait :as_healthy do

--- a/modules/storages/spec/workers/storages/manage_nextcloud_integration_cron_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_nextcloud_integration_cron_job_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Storages::ManageNextcloudIntegrationCronJob, :webmock, type: :job
     subject { described_class.new.perform }
 
     context 'when lock is free' do
-      let(:storage1) { create(:nextcloud_storage, :as_automatically_managed, :configured) }
+      let(:storage1) { create(:nextcloud_storage_configured, :as_automatically_managed) }
 
       it 'responds with true' do
         expect(subject).to be(true)
@@ -93,6 +93,7 @@ RSpec.describe Storages::ManageNextcloudIntegrationCronJob, :webmock, type: :job
 
       it 'calls GroupFolderPropertiesSyncService for each automatically managed storage' do
         storage2 = create(:nextcloud_storage, :as_not_automatically_managed)
+        storage3 = create(:nextcloud_storage, :as_automatically_managed)
 
         allow(Storages::NextcloudGroupFolderPropertiesSyncService)
           .to receive(:call).with(storage1).and_return(ServiceResult.success)
@@ -101,6 +102,7 @@ RSpec.describe Storages::ManageNextcloudIntegrationCronJob, :webmock, type: :job
 
         expect(Storages::NextcloudGroupFolderPropertiesSyncService).to have_received(:call).with(storage1).once
         expect(Storages::NextcloudGroupFolderPropertiesSyncService).not_to have_received(:call).with(storage2)
+        expect(Storages::NextcloudGroupFolderPropertiesSyncService).not_to have_received(:call).with(storage3)
       end
 
       it 'marks storage as healthy if sync was successful' do


### PR DESCRIPTION
https://community.openproject.org/work_packages/53345

It solves the problem when background job tries to "synchronize" not configured storage and raises a run time exception.