### PR TITLE
Bug/46490 number of displayed assignees in team planner wrongly restricted by objects per page

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
@@ -85,9 +85,9 @@ export class AddAssigneeComponent {
       .apiV3Service
       .principals
       .filtered(filters)
-      .get()
+      .getPaginatedResults()
       .pipe(
-        map((collection) => collection.elements.filter(
+        map((elements) => elements.filter(
           (user) => !this.alreadySelected.find((selected) => selected === user.id),
         )),
       );

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -82,6 +82,7 @@ import {
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { MAGIC_PAGE_NUMBER } from 'core-app/core/apiv3/helpers/get-paginated-results';
 import { CalendarDragDropService } from 'core-app/features/team-planner/team-planner/calendar-drag-drop.service';
 import { StatusResource } from 'core-app/features/hal/resources/status-resource';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
@@ -223,7 +224,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
 
         return this
           .capabilitiesResourceService
-          .fetchCapabilities({ pageSize: -1, filters });
+          .fetchCapabilities({ pageSize: MAGIC_PAGE_NUMBER, filters });
       }),
       map((result) => result
         ._embedded
@@ -250,6 +251,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       filter((ids) => ids.length > 0),
       map((ids) => ({
         filters: [['id', '=', ids]],
+        pageSize: MAGIC_PAGE_NUMBER,
       }) as ApiV3ListParameters),
     );
 

--- a/modules/team_planner/spec/features/team_planner_context_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_context_menu_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe 'Work package table context menu',
         team_planner.visit!
         loading_indicator_saveguard
 
-        retry_block do
-          team_planner.add_assignee user
-        end
+        team_planner.add_assignee user
 
         team_planner.within_lane(user) do
           team_planner.expect_event work_package

--- a/modules/team_planner/spec/features/team_planner_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_create_spec.rb
@@ -77,11 +77,7 @@ RSpec.describe 'Team planner create new work package', :js, with_ee: %i[team_pla
 
       team_planner.expect_assignee(user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
     end
 
     it_behaves_like 'can create a new work package'
@@ -119,23 +115,9 @@ RSpec.describe 'Team planner create new work package', :js, with_ee: %i[team_pla
       team_planner.expect_assignee(other_user, present: false)
       team_planner.expect_assignee(third_user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add other_user.name
-      end
-
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add third_user.name
-      end
-
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee other_user.name
+      team_planner.add_assignee third_user.name
+      team_planner.add_assignee user.name
     end
 
     it_behaves_like 'can create a new work package'

--- a/modules/team_planner/spec/features/team_planner_dates_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_dates_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe 'Team planner working days', :js,
       team_planner.visit!
 
       team_planner.expect_empty_state
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       # Initially, in the "Work week" view, non working days are hidden
       expect(page).to have_css('.fc-day-mon')

--- a/modules/team_planner/spec/features/team_planner_project_include_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_project_include_spec.rb
@@ -56,15 +56,11 @@ RSpec.describe 'Team planner project include', :js, with_ee: %i[team_planner_vie
       work_package_view.expect_assignee(other_user, present: false)
 
       retry_block do
-        work_package_view.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        work_package_view.select_user_to_add user.name
+        work_package_view.add_assignee user.name
       end
 
       retry_block do
-        work_package_view.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        work_package_view.select_user_to_add other_user.name
+        work_package_view.add_assignee other_user.name
       end
 
       work_package_view.expect_assignee user

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -155,19 +155,11 @@ RSpec.describe 'Team planner',
       team_planner.expect_assignee(user, present: false)
       team_planner.expect_assignee(other_user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       team_planner.expect_empty_state(present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add other_user.name
-      end
+      team_planner.add_assignee other_user.name
 
       team_planner.expect_assignee user
       team_planner.expect_assignee other_user
@@ -249,21 +241,13 @@ RSpec.describe 'Team planner',
       team_planner.expect_assignee(user, present: false)
       team_planner.expect_assignee(other_user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       team_planner.expect_empty_state(present: false)
       team_planner.expect_assignee(user)
       team_planner.expect_assignee(other_user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add other_user.name
-      end
+      team_planner.add_assignee other_user.name
 
       team_planner.expect_assignee(user)
       team_planner.expect_assignee(other_user)
@@ -280,11 +264,7 @@ RSpec.describe 'Team planner',
       team_planner.expect_empty_state
 
       # Try one more time to make sure deleting the full filter didn't kill the functionality
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       team_planner.expect_assignee(user)
       team_planner.expect_assignee(other_user, present: false)
@@ -293,11 +273,7 @@ RSpec.describe 'Team planner',
     it 'filters possible assignees correctly' do
       team_planner.visit!
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.search_user_to_add user_outside_project.name
-      end
+      team_planner.add_assignee user_outside_project.name
 
       expect(page).to have_css('.ng-option-disabled', text: "No items found")
 
@@ -307,11 +283,7 @@ RSpec.describe 'Team planner',
 
       team_planner.expect_assignee(user)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.search_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       expect(page).to have_css('.ng-option-disabled', text: "No items found")
     end
@@ -372,11 +344,7 @@ RSpec.describe 'Team planner',
       team_planner.expect_empty_state
       team_planner.expect_assignee(user, present: false)
 
-      retry_block do
-        team_planner.click_add_user
-        page.find("#{test_selector('tp-add-assignee')} input")
-        team_planner.select_user_to_add user.name
-      end
+      team_planner.add_assignee user.name
 
       team_planner.expect_empty_state(present: false)
       team_planner.expect_assignee user

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe 'Team planner',
     it 'filters possible assignees correctly' do
       team_planner.visit!
 
-      team_planner.add_assignee user_outside_project.name
+      team_planner.search_assignee(user_outside_project.name)
 
       expect(page).to have_css('.ng-option-disabled', text: "No items found")
 
@@ -283,7 +283,7 @@ RSpec.describe 'Team planner',
 
       team_planner.expect_assignee(user)
 
-      team_planner.add_assignee user.name
+      team_planner.search_assignee user.name
 
       expect(page).to have_css('.ng-option-disabled', text: "No items found")
     end

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -315,6 +315,41 @@ RSpec.describe 'Team planner',
 
       expect(page).to have_css('.ng-option-disabled', text: "No items found")
     end
+
+    context 'when the page size is smaller than the number of assignees' do
+      before do
+        allow(Setting)
+          .to receive(:per_page_options_array)
+          .and_return([1])
+      end
+
+      it 'renders assignees and assignee dropdown correctly' do
+        team_planner.visit!
+        team_planner.wait_for_loaded
+
+        # Render all the available users in the select dropdown regardless of the page size
+        team_planner.click_add_user
+
+        team_planner.expect_user_selectable user
+        team_planner.expect_user_selectable other_user
+
+        team_planner.add_assignee user
+        team_planner.add_assignee other_user
+
+        team_planner.save_as('TP1')
+        page.refresh
+        team_planner.wait_for_loaded
+
+        # Render all the available users in the team planner regardless of the page size
+        team_planner.expect_assignee user
+        team_planner.expect_assignee other_user
+
+        # Do not render any available users in the select
+        team_planner.click_add_user
+        team_planner.expect_user_selectable user, present: false
+        team_planner.expect_user_selectable other_user, present: false
+      end
+    end
   end
 
   context 'with a readonly work package' do

--- a/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
@@ -58,9 +58,7 @@ RSpec.describe 'Team planner constraints for a subproject',
     team_planner.visit!
 
     team_planner.add_assignee user
-    retry_block do
-      team_planner.add_assignee other_user
-    end
+    team_planner.add_assignee other_user
 
     # Include the subproject
     project_include.toggle!

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -79,9 +79,7 @@ RSpec.describe 'Team planner drag&dop and resizing',
       team_planner.visit!
 
       team_planner.add_assignee user
-      retry_block do
-        team_planner.add_assignee other_user
-      end
+      team_planner.add_assignee other_user
 
       team_planner.within_lane(user) do
         team_planner.expect_event first_wp, present: false
@@ -247,9 +245,7 @@ RSpec.describe 'Team planner drag&dop and resizing',
       team_planner.visit!
 
       team_planner.add_assignee user
-      retry_block do
-        team_planner.add_assignee other_user
-      end
+      team_planner.add_assignee other_user
     end
 
     it 'allows neither dragging nor resizing any wp' do

--- a/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
@@ -36,11 +36,7 @@ RSpec.describe 'Team planner', :js, with_ee: %i[team_planner_view] do
     team_planner.visit!
 
     team_planner.expect_empty_state
-    retry_block do
-      team_planner.click_add_user
-      page.find("#{test_selector('tp-add-assignee')} input")
-      team_planner.select_user_to_add user.name
-    end
+    team_planner.add_assignee user.name
 
     team_planner.expect_view_mode 'Work week'
     expect(page).to have_css('.fc-timeline-slot-frame', count: 5)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -226,9 +226,21 @@ module Pages
 
     def add_assignee(name)
       retry_block do
+        return if page.has_selector?('.fc-resource', text: name, wait: 0)
+
         click_add_user
         page.find("#{page.test_selector('tp-add-assignee')} input")
-        select_user_to_add name
+        select_user_to_add(name)
+      end
+    end
+
+    def search_assignee(name)
+      retry_block do
+        click_add_user
+        page.find("#{page.test_selector('tp-add-assignee')} input")
+        search_autocomplete page.find('[data-test-selector="tp-add-assignee"]'),
+                            query: name,
+                            results_selector: 'body'
       end
     end
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -225,9 +225,11 @@ module Pages
     end
 
     def add_assignee(name)
-      click_add_user
-      page.find("#{page.test_selector('tp-add-assignee')} input")
-      select_user_to_add name
+      retry_block do
+        click_add_user
+        page.find("#{page.test_selector('tp-add-assignee')} input")
+        select_user_to_add name
+      end
     end
 
     def click_add_user
@@ -243,10 +245,13 @@ module Pages
                           results_selector: 'body'
     end
 
-    def search_user_to_add(name)
-      search_autocomplete page.find('[data-test-selector="tp-add-assignee"]'),
-                          query: name,
-                          results_selector: 'body'
+    def expect_user_selectable(user, present: true)
+      name = user.is_a?(User) ? user.name : user.to_s
+
+      expect_ng_option page.find('[data-test-selector="tp-add-assignee"]'),
+                       name,
+                       results_selector: 'body',
+                       present:
     end
 
     def change_wp_date_by_resizing(work_package, number_of_days:, is_start_date:)

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -45,9 +45,9 @@ module Components::Autocompleter
       end
     end
 
-    def expect_ng_option(element, option, results_selector: nil)
+    def expect_ng_option(element, option, results_selector: nil, present: true)
       within(ng_find_dropdown(element, results_selector:)) do
-        expect(page).to have_css('.ng-option', text: option)
+        expect(page).to have_conditional_selector(present, '.ng-option', text: option)
       end
     end
 


### PR DESCRIPTION
https://community.openproject.org/wp/46490