### PR TITLE
LDAP user can't be created if optional attributes are not mapped

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,20 +244,10 @@ class User < Principal
   def self.try_authentication_and_create_user(login, password)
     return nil if OpenProject::Configuration.disable_password_login?
 
-    attrs = LdapAuthSource.authenticate(login, password)
-    return unless attrs
+    user = LdapAuthSource.authenticate(login, password)
 
-    call = Users::CreateService
-      .new(user: User.system)
-      .call(attrs)
-
-    user = call.result
-
-    call.on_failure do |result|
-      Rails.logger.error "Failed to auto-create user from auth-source: #{result.message}"
-
-      # TODO We have no way to pass back the contract errors in this place
-      user.errors.merge! call.errors
+    if user&.new_record?
+      Rails.logger.error "Failed to auto-create user from auth-source, as data is missing."
     end
 
     user

--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -61,6 +61,7 @@ module Ldap
       if call.success?
         Rails.logger.info { "[LDAP user sync] User '#{call.result.login}' created." }
       else
+        # Ensure contract errors are merged into the user
         call.result.errors.merge! call.errors
         Rails.logger.error { "[LDAP user sync] User '#{attrs[:login]}' could not be created: #{call.message}" }
       end

--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -61,6 +61,7 @@ module Ldap
       if call.success?
         Rails.logger.info { "[LDAP user sync] User '#{call.result.login}' created." }
       else
+        call.result.errors.merge! call.errors
         Rails.logger.error { "[LDAP user sync] User '#{attrs[:login]}' could not be created: #{call.message}" }
       end
 

--- a/modules/ldap_groups/lib/tasks/ldap_groups.rake
+++ b/modules/ldap_groups/lib/tasks/ldap_groups.rake
@@ -58,36 +58,6 @@ namespace :ldap_groups do
       ldif = ENV.fetch('LDIF_FILE') { Rails.root.join('spec/fixtures/ldap/users.ldif') }
       ldap_server = Ladle::Server.new(quiet: false, port: '12389', domain: 'dc=example,dc=com', ldif:).start
 
-      puts <<~INFO
-        LDAP server ready at localhost:12389
-        Users Base dn: ou=people,dc=example,dc=com
-        Admin account: uid=admin,ou=system
-        Admin password: secret
-
-        --------------------------------------------------------
-
-        Attributes
-        Login: uid
-        First name: givenName
-        Last name: sn
-        Email: mail
-        Admin: isAdmin
-        memberOf: (Hard-coded, not virtual)
-
-        --------------------------------------------------------
-
-        Users:
-        uid=aa729,ou=people,dc=example,dc=com (Password: smada)
-        uid=bb459,ou=people,dc=example,dc=com (Password: niwdlab)
-        uid=cc414,ou=people,dc=example,dc=com (Password: retneprac)
-
-        --------------------------------------------------------
-
-        Groups:
-        cn=foo,ou=groups,dc=example,dc=com (Members: aa729)
-        cn=bar,ou=groups,dc=example,dc=com (Members: aa729, bb459, cc414)
-      INFO
-
       puts "Creating a connection called ladle"
       source = LdapAuthSource.find_or_initialize_by(name: 'ladle local development')
 
@@ -117,6 +87,36 @@ namespace :ldap_groups do
       filter.save!
 
       LdapGroups::SynchronizationJob.perform_now
+
+      puts <<~INFO
+        LDAP server ready at localhost:12389
+        Users Base dn: ou=people,dc=example,dc=com
+        Admin account: uid=admin,ou=system
+        Admin password: secret
+
+        --------------------------------------------------------
+
+        Attributes
+        Login: uid
+        First name: givenName
+        Last name: sn
+        Email: mail
+        Admin: isAdmin
+        memberOf: (Hard-coded, not virtual)
+
+        --------------------------------------------------------
+
+        Users:
+        uid=aa729,ou=people,dc=example,dc=com (Password: smada)
+        uid=bb459,ou=people,dc=example,dc=com (Password: niwdlab)
+        uid=cc414,ou=people,dc=example,dc=com (Password: retneprac)
+
+        --------------------------------------------------------
+
+        Groups:
+        cn=foo,ou=groups,dc=example,dc=com (Members: aa729)
+        cn=bar,ou=groups,dc=example,dc=com (Members: aa729, bb459, cc414)
+      INFO
 
       puts "Send CTRL+D to stop the server"
       require 'irb'

--- a/spec/requests/auth/ldap_sso_spec.rb
+++ b/spec/requests/auth/ldap_sso_spec.rb
@@ -1,0 +1,102 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.describe AuthSourceSSO, :skip_2fa_stage, # Prevent redirects to 2FA stage
+               type: :rails_request do
+  let(:sso_config) do
+    {
+      header: "X-Remote-User",
+      optional: true
+    }
+  end
+
+  before do
+    allow(OpenProject::Configuration)
+      .to receive(:auth_source_sso)
+            .and_return(sso_config)
+  end
+
+  include_context 'with temporary LDAP'
+
+  context 'when LDAP is onthefly_register' do
+    let(:onthefly_register) { true }
+
+    it 'creates the user on the fly' do
+      expect(User.find_by(login: 'aa729')).to be_nil
+
+      expect do
+        get '/projects', headers: { 'X-Remote-User' => 'aa729' }
+      end.to change(User.not_builtin, :count).by(1)
+
+      user = User.find_by(login: 'aa729')
+      expect(user).to be_present
+      expect(user).to be_active
+      expect(session[:user_id]).to eq user.id
+      expect(session[:user_from_auth_header]).to eq true
+      expect(response).to redirect_to '/projects'
+    end
+  end
+
+  context 'when LDAP is not onthefly_register' do
+    let(:onthefly_register) { false }
+
+    it 'returns an error when the user does not exist' do
+      get '/projects', headers: { 'X-Remote-User' => 'nonexistent' }
+
+      expect(response).to redirect_to '/sso'
+      expect(session[:auth_source_sso_failure]).to be_present
+    end
+
+    context 'when the user exists, but is outdated' do
+      let(:user) { create(:user, login: 'ldap_admin', admin: false, ldap_auth_source:) }
+
+      it 'redirects the user to that URL' do
+        expect(user).not_to be_admin
+        get '/projects?foo=bar', headers: { 'X-Remote-User' => user.login }
+        expect(response).to redirect_to '/projects?foo=bar'
+
+        user.reload
+        expect(user).to be_admin
+      end
+    end
+
+    context 'when the user exists in another auth source that is inaccessible' do
+      let(:other_ldap) { create(:ldap_auth_source, name: 'other_ldap') }
+      let(:user) { create(:user, login: 'ldap_admin', admin: false, ldap_auth_source: other_ldap) }
+
+      it 'returns an error when the user does not exist' do
+        get '/projects', headers: { 'X-Remote-User' => 'nonexistent' }
+
+        expect(response).to redirect_to '/sso'
+        expect(session[:auth_source_sso_failure]).to be_present
+      end
+    end
+  end
+end

--- a/spec/support/shared/with_test_ldap.rb
+++ b/spec/support/shared/with_test_ldap.rb
@@ -54,12 +54,16 @@ RSpec.shared_context 'with temporary LDAP' do
            onthefly_register:,
            filter_string: ldap_filter,
            attr_login: 'uid',
-           attr_firstname: 'givenName',
-           attr_lastname: 'sn',
-           attr_mail: 'mail',
-           attr_admin: 'isAdmin')
+           attr_firstname:,
+           attr_lastname:,
+           attr_mail:,
+           attr_admin:)
   end
 
   let(:onthefly_register) { false }
   let(:ldap_filter) { nil }
+  let(:attr_firstname) { 'givenName' }
+  let(:attr_lastname) { 'sn' }
+  let(:attr_mail) { 'mail' }
+  let(:attr_admin) { 'isAdmin' }
 end


### PR DESCRIPTION
Due to heavy stubbing in the account controller spec, the onthefly creation flow of users failed when users were created with errors. I fixed the underlying issue and replaced them with request specs and an actual test LDAP connection.

https://community.openproject.org/work_packages/53327