### PR TITLE
Build RelyingParty on the fly to support our hosted environment

### DIFF
--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
@@ -18,15 +18,15 @@ module TwoFactorAuthentication
     end
     validates_inclusion_of :channel, in: supported_channels
 
-    def options_for_create
-      @options_for_create ||= WebAuthn::Credential.options_for_create(
+    def options_for_create(relying_party)
+      @options_for_create ||= relying_party.options_for_registration(
         user: { id: user.webauthn_id, name: user.name },
         exclude: TwoFactorAuthentication::Device::Webauthn.where(user:).pluck(:webauthn_external_id)
       )
     end
 
-    def options_for_get
-      @options_for_get ||= WebAuthn::Credential.options_for_get(
+    def options_for_get(relying_party)
+      @options_for_get ||= relying_party.options_for_authentication(
         allow: webauthn_external_id # TODO: Maybe also allow all other tokens? Let's see
       )
     end

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
@@ -61,12 +61,6 @@ module OpenProject::TwoFactorAuthentication
                                                           }) do
         two_factor_authentication_request_path
       end
-
-      WebAuthn.configure do |config|
-        # TODO: Real settings here
-        config.origin = "http://localhost:3000"
-        config.rp_name = "Example Inc."
-      end
     end
   end
 end

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/webauthn.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/webauthn.rb
@@ -3,14 +3,13 @@ require 'webauthn'
 module OpenProject::TwoFactorAuthentication
   module TokenStrategy
     class Webauthn < Base
-      def verify(webauthn_credential, webauthn_challenge:)
-        credential = WebAuthn::Credential.from_get(JSON.parse(webauthn_credential))
-
+      def verify(webauthn_credential, webauthn_challenge:, webauthn_relying_party:)
         # This will raise WebAuthn::Error
-        credential.verify(
+        credential = webauthn_relying_party.verify_authentication(
+          webauthn_credential,
           webauthn_challenge,
-          public_key: device.webauthn_public_key,
-          sign_count: device.webauthn_sign_count
+          sign_count: device.webauthn_sign_count,
+          public_key: device.webauthn_public_key
         )
 
         device.update!(webauthn_sign_count: credential.sign_count)


### PR DESCRIPTION
Followed the guide at https://github.com/cedarcode/webauthn-ruby/blob/master/docs/advanced_configuration.md#instance-based-configuration to switch to instance based RelyingParty.

This will make WebAuthn also work on our hosted environments