### PR TITLE
Replace manual job checking for GoodJob concurrency checks

### DIFF
--- a/app/contracts/settings/working_days_params_contract.rb
+++ b/app/contracts/settings/working_days_params_contract.rb
@@ -42,9 +42,7 @@ module Settings
     end
 
     def unique_job
-      if GoodJob::Job
-           .where(finished_at: nil)
-           .exists?(job_class: WorkPackages::ApplyWorkingDaysChangeJob.name)
+      WorkPackages::ApplyWorkingDaysChangeJob.new.check_concurrency do
         errors.add :base, :previous_working_day_changes_unprocessed
       end
     end

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -27,7 +27,12 @@
 #++
 
 class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
+  include JobConcurrency
   queue_with_priority :above_normal
+
+  good_job_control_concurrency_with(
+    total_limit: 1
+  )
 
   def perform(user_id:, previous_working_days:, previous_non_working_days:)
     user = User.find(user_id)


### PR DESCRIPTION
Replaces the manual query for the job with good_job concurrency controls. To make this work in the test environment, we have to enqueue the job with GoodJob itself, which is not the default.

https://community.openproject.org/work_packages/53122