### PR TITLE
Remove -10 offset in ckeditor header

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -92,12 +92,6 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
     top: 0px
     z-index: 2
 
-    // Adjust top offset to match if globally
-    // scrolling (content-wrapper)
-    .ckeditor--content-scrollable &,
-    .form--field.-visible-overflow &
-      top: -10px
-
   .ck.ck-toolbar.ck-rounded-corners
     border-bottom-left-radius: 0
     border-bottom-right-radius: 0


### PR DESCRIPTION
https://community.openproject.org/work_packages/53365

This was introduced in https://github.com/opf/openproject/commit/5eb6fbf676e11154d7e3cda2aab3bae914b55ce4, but all the places that I changed there do not exhibit a problem when removing the `-10px` override.