### PR TITLE
Allow previewing on meeting contents

### DIFF
--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -35,7 +35,7 @@ module API
 
         resources :render do
           helpers do
-            SUPPORTED_CONTEXT_NAMESPACES ||= %w(work_packages projects news posts wiki_pages).freeze
+            SUPPORTED_CONTEXT_NAMESPACES ||= %w(work_packages projects news posts wiki_pages meeting_contents).freeze
             SUPPORTED_MEDIA_TYPE ||= 'text/plain'.freeze
 
             def allowed_content_types

--- a/modules/meeting/app/models/meeting_content.rb
+++ b/modules/meeting/app/models/meeting_content.rb
@@ -50,6 +50,12 @@ class MeetingContent < ApplicationRecord
                 title: Proc.new { |o| "#{o.class.model_name.human}: #{o.meeting.title}" },
                 url: Proc.new { |o| { controller: '/meetings', action: 'show', id: o.meeting } }
 
+  scope :visible, ->(*args) {
+    includes(meeting: :project)
+      .references(:projects)
+      .merge(Project.allowed_to(args.first || User.current, :view_meetings))
+  }
+
   def editable?
     true
   end


### PR DESCRIPTION
Since MeetingMinutes/MeetingContent have their own API, they get their own preview context. But for that to work, we need to whitelist it and add a visible check on the content.

https://community.openproject.org/work_packages/48210