### PR TITLE
[51772] Odd spacing in Notification and Email Reminder personal setting pages

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
@@ -4,8 +4,10 @@
   (ngSubmit)="saveChanges()"
   class="op-form"
 >
-  <h5>{{ text.notifyImmediately.title }}</h5>
-  <p>{{ text.notifyImmediately.description }}</p>
+  <div class="op-form--section-header">
+    <h3 class="op-form--section-header-title">{{ text.notifyImmediately.title }}</h3>
+    <p>{{ text.notifyImmediately.description }}</p>
+  </div>
 
   <spot-selector-field
     class="op-notifications-settings--bold-label"
@@ -65,8 +67,11 @@
     />
   </spot-selector-field>
 
-  <h5>{{ text.dateAlerts.title }}</h5>
-  <p>{{ text.dateAlerts.description }}</p>
+  <div class="op-form--section-header">
+    <h3 class="op-form--section-header-title">{{ text.dateAlerts.title }}</h3>
+    <p>{{ text.dateAlerts.description }}</p>
+  </div>
+
   <div *ngIf="!eeShowBanners">
     <div
       class="op-reminder-settings-date-alerts--row"
@@ -171,8 +176,11 @@
     class="op-date-alert-ee-banner">
   </op-enterprise-banner>
 
-  <h5>{{ text.alsoNotifyFor.title }}</h5>
-  <p>{{ text.alsoNotifyFor.description }}</p>
+
+  <div class="op-form--section-header">
+    <h3 class="op-form--section-header-title">{{ text.alsoNotifyFor.title }}</h3>
+    <p>{{ text.alsoNotifyFor.description }}</p>
+  </div>
 
   <spot-selector-field
     [label]="text.work_package_created"
@@ -230,8 +238,10 @@
   </spot-selector-field>
 
 
-  <h5>{{text.projectSpecific.title}}</h5>
-  <p>{{text.projectSpecific.description}}</p>
+  <div class="op-form--section-header">
+    <h3 class="op-form--section-header-title">{{ text.projectSpecific.title }}</h3>
+    <p>{{text.projectSpecific.description}}</p>
+  </div>
 
   <op-notification-settings-table
     *ngIf="userId"

--- a/frontend/src/app/features/user-preferences/reminder-settings/email-alerts/email-alerts-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/email-alerts/email-alerts-settings.component.html
@@ -1,6 +1,6 @@
 <ng-container [formGroup]="form">
   <div class="op-form--section-header">
-    <h5 [textContent]="text.title"></h5>
+    <h3 [textContent]="text.title" class="op-form--section-header-title"></h3>
     <p [textContent]="text.explanation"></p>
   </div>
 

--- a/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
@@ -1,6 +1,6 @@
 <ng-container [formGroup]="form">
   <div class="op-form--section-header">
-    <h5 [textContent]="text.title"></h5>
+    <h3 [textContent]="text.title" class="op-form--section-header-title"></h3>
   </div>
 
   <spot-selector-field

--- a/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.html
@@ -1,5 +1,9 @@
-<div class="title-container">
-  <h2 [textContent]="text.title"></h2>
+<div class="toolbar-container">
+  <div class="toolbar">
+    <div class="title-container">
+      <h2 [textContent]="text.title"></h2>
+    </div>
+  </div>
 </div>
 
 <form

--- a/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
@@ -3,7 +3,7 @@
   [formGroup]="form"
 >
   <div class="op-form--section-header">
-      <h5 [textContent]="text.title"></h5>
+      <h3 [textContent]="text.title" class="op-form--section-header-title"></h3>
       <p [textContent]="text.explanation"></p>
   </div>
 

--- a/frontend/src/app/features/user-preferences/reminder-settings/workdays/workdays-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/workdays/workdays-settings.component.html
@@ -1,6 +1,6 @@
 <ng-container [formGroup]="formGroup.control">
   <div class="op-form--section-header">
-    <h5 [textContent]="text.title"></h5>
+    <h3 [textContent]="text.title" class="op-form--section-header-title"></h3>
   </div>
 
   <spot-selector-field

--- a/frontend/src/app/shared/components/forms/form.sass
+++ b/frontend/src/app/shared/components/forms/form.sass
@@ -25,6 +25,13 @@
       &:not(:last-child)
         margin-bottom: 1rem
 
+  &--section-header
+    margin-top: 0.5rem
+
+  &--section-header-title
+    @extend %form--fieldset-legend-or-section-title
+    margin-bottom: 0.25rem
+
   &--field
     .spot-form-field
       margin-bottom: 1rem


### PR DESCRIPTION
Harmonise look and feel of notification settings page and email reminders settings page.

### Before
<img width="300" alt="Bildschirmfoto 2024-03-18 um 11 26 48" src="https://github.com/opf/openproject/assets/7457313/331fb090-3888-4eee-85c2-71daee290259">

<img width="300" alt="Bildschirmfoto 2024-03-18 um 11 26 40" src="https://github.com/opf/openproject/assets/7457313/c31a742c-c2da-4992-a952-9116f71fffef">

### After
<img width="300" alt="Bildschirmfoto 2024-03-18 um 11 26 12" src="https://github.com/opf/openproject/assets/7457313/90b51c3c-3d04-4edb-a9a4-640ce90d6004">

<img width="300" alt="Bildschirmfoto 2024-03-18 um 11 26 23" src="https://github.com/opf/openproject/assets/7457313/7f1cf630-3635-4031-bc1f-f9529ff099cd">


https://community.openproject.org/projects/openproject/work_packages/51772/activity