### PR TITLE
[36521] Saving changes to user profile after handling error message leads to user profile instead of edit user page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -134,7 +134,7 @@ class UsersController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:notice] = I18n.t(:notice_successful_update)
-          redirect_back(fallback_location: edit_user_path(@user))
+          render action: :edit
         end
       end
     else

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -642,7 +642,7 @@ RSpec.describe UsersController do
       end
 
       it 'redirects to the edit page' do
-        expect(response).to redirect_to(edit_user_url(some_user))
+        expect(response).to render_template :edit
       end
 
       it 'is assigned their new values' do


### PR DESCRIPTION
instead of redirecting to user profile page, stay on edit page

Re-opens: https://github.com/opf/openproject/pull/9351

https://community.openproject.org/projects/openproject/work_packages/36521/activity