### PR TITLE
[#53434] Incorrect spelling of `GitLab` module under project settings

### DIFF
--- a/modules/gitlab_integration/config/locales/crowdin/af.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/af.yml
@@ -32,8 +32,8 @@ af:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ar.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ar.yml
@@ -32,8 +32,8 @@ ar:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/az.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/az.yml
@@ -32,8 +32,8 @@ az:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/be.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/be.yml
@@ -32,8 +32,8 @@ be:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/bg.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/bg.yml
@@ -32,8 +32,8 @@ bg:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ca.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ca.yml
@@ -32,8 +32,8 @@ ca:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ckb-IR.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ckb-IR.yml
@@ -32,8 +32,8 @@ ckb-IR:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/cs.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/cs.yml
@@ -32,8 +32,8 @@ cs:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/da.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/da.yml
@@ -32,8 +32,8 @@ da:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/de.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/de.yml
@@ -32,8 +32,8 @@ de:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/el.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/el.yml
@@ -32,8 +32,8 @@ el:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/eo.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/eo.yml
@@ -32,8 +32,8 @@ eo:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/es.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/es.yml
@@ -32,8 +32,8 @@ es:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/et.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/et.yml
@@ -32,8 +32,8 @@ et:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/eu.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/eu.yml
@@ -32,8 +32,8 @@ eu:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/fa.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/fa.yml
@@ -32,8 +32,8 @@ fa:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/fi.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/fi.yml
@@ -32,8 +32,8 @@ fi:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/fil.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/fil.yml
@@ -32,8 +32,8 @@ fil:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/fr.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/fr.yml
@@ -32,8 +32,8 @@ fr:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/he.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/he.yml
@@ -32,8 +32,8 @@ he:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/hi.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/hi.yml
@@ -32,8 +32,8 @@ hi:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/hr.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/hr.yml
@@ -32,8 +32,8 @@ hr:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/hu.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/hu.yml
@@ -32,8 +32,8 @@ hu:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/id.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/id.yml
@@ -32,8 +32,8 @@ id:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/it.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/it.yml
@@ -32,8 +32,8 @@ it:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ja.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ja.yml
@@ -32,8 +32,8 @@ ja:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ka.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ka.yml
@@ -32,8 +32,8 @@ ka:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/kk.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/kk.yml
@@ -32,8 +32,8 @@ kk:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ko.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ko.yml
@@ -32,8 +32,8 @@ ko:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/lt.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/lt.yml
@@ -32,7 +32,7 @@ lt:
           attributes:
             labels:
               invalid_schema: "turi būti masyvas raktų: spalva, antraštė"
-  project_module_gitlab: "Gitlab"
+  project_module_gitlab: "GitLab"
   permission_show_gitlab_content: "Rodyti Gitlab turinį"
   gitlab_integration:
     merge_request_opened_comment: >

--- a/modules/gitlab_integration/config/locales/crowdin/lv.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/lv.yml
@@ -32,8 +32,8 @@ lv:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/mn.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/mn.yml
@@ -32,8 +32,8 @@ mn:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ms.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ms.yml
@@ -32,8 +32,8 @@ ms:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ne.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ne.yml
@@ -32,8 +32,8 @@ ne:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/nl.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/nl.yml
@@ -32,8 +32,8 @@ nl:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/no.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/no.yml
@@ -32,8 +32,8 @@
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/pl.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/pl.yml
@@ -32,8 +32,8 @@ pl:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/pt-BR.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/pt-BR.yml
@@ -32,8 +32,8 @@ pt:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ro.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ro.yml
@@ -32,8 +32,8 @@ ro:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/ru.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/ru.yml
@@ -32,8 +32,8 @@ ru:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/rw.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/rw.yml
@@ -32,8 +32,8 @@ rw:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/si.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/si.yml
@@ -32,8 +32,8 @@ si:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/sk.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/sk.yml
@@ -32,8 +32,8 @@ sk:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/sl.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/sl.yml
@@ -32,8 +32,8 @@ sl:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/sr.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/sr.yml
@@ -32,8 +32,8 @@ sr:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/sv.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/sv.yml
@@ -32,8 +32,8 @@ sv:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/th.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/th.yml
@@ -32,8 +32,8 @@ th:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/tr.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/tr.yml
@@ -32,8 +32,8 @@ tr:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/uk.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/uk.yml
@@ -32,8 +32,8 @@ uk:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/uz.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/uz.yml
@@ -32,8 +32,8 @@ uz:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/vi.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/vi.yml
@@ -32,8 +32,8 @@ vi:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/zh-CN.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/zh-CN.yml
@@ -32,8 +32,8 @@ zh-CN:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/crowdin/zh-TW.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/zh-TW.yml
@@ -32,8 +32,8 @@ zh-TW:
           attributes:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
   gitlab_integration:
     merge_request_opened_comment: >
       **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url}) has been opened by [%{gitlab_user}](%{gitlab_user_url}).

--- a/modules/gitlab_integration/config/locales/de.yml
+++ b/modules/gitlab_integration/config/locales/de.yml
@@ -28,8 +28,8 @@
 #++
 
 de:
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
 
   gitlab_integration:
     merge_request_opened_comment: >
@@ -47,32 +47,32 @@ de:
     note_commit_referenced_comment: >
       **Referenced in Commit:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
       a Commit Note [%{commit_id}](%{commit_url}) on [%{repository}](%{repository_url}):
-       
+
       %{commit_note}
     note_mr_referenced_comment: >
       **Referenced in MR:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
       Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
-      
+
       %{mr_note}
     note_mr_commented_comment: >
       **Commented in MR:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
       Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
-      
+
       %{mr_note}
     note_issue_referenced_comment: >
       **Referenced in Issue:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
       Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
-        
+
       %{issue_note}
     note_issue_commented_comment: >
       **Commented in Issue:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
       Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
-      
+
       %{issue_note}
     note_snippet_referenced_comment: >
       **Referenced in Snippet:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
       Snippet %{snippet_number} [%{snippet_title}](%{snippet_url}) on [%{repository}](%{repository_url}):
-        
+
       %{snippet_note}
     issue_opened_referenced_comment: >
       **Issue Opened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
@@ -84,12 +84,12 @@ de:
       **Issue Reopened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
       has been reopened by [%{gitlab_user}](%{gitlab_user_url}).
     push_single_commit_comment: >
-      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url}) 
+      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url})
       to [%{repository}](%{repository_url}) at %{commit_timestamp}:
-        
+
       %{commit_note}
     push_multiple_commits_comment: >
-      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed multiple commits [%{commit_number}](%{commit_url}) 
+      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed multiple commits [%{commit_number}](%{commit_url})
       to [%{repository}](%{repository_url}) at %{commit_timestamp}:
-        
+
       %{commit_note}

--- a/modules/gitlab_integration/config/locales/en.yml
+++ b/modules/gitlab_integration/config/locales/en.yml
@@ -40,8 +40,8 @@ en:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
 
-  project_module_gitlab: "Gitlab"
-  permission_show_gitlab_content: "Show Gitlab content"
+  project_module_gitlab: "GitLab"
+  permission_show_gitlab_content: "Show GitLab content"
 
   gitlab_integration:
     merge_request_opened_comment: >


### PR DESCRIPTION
https://community.openproject.org/work_packages/53434

Rename 'Gitlab' to 'GitLab'

![Screenshot 2024-03-18 at 5 42 39 PM](https://github.com/opf/openproject/assets/17295175/3a46eecf-ba61-4e32-bb3f-cad112a75ca5)
![Screenshot 2024-03-18 at 5 41 45 PM](https://github.com/opf/openproject/assets/17295175/30c81053-3405-4d71-bfae-d87b8a2f3825)
