### PR TITLE
Bug/53391 project custom fields and project description no longer allows macros

### DIFF
--- a/app/components/open_project/common/attribute_component.rb
+++ b/app/components/open_project/common/attribute_component.rb
@@ -76,6 +76,14 @@ module OpenProject
 
       private
 
+      def first_paragraph_content
+        return unless first_paragraph_ast
+
+        first_paragraph_ast
+          .inner_html
+          .html_safe # rubocop:disable Rails/OutputSafety
+      end
+
       def first_paragraph
         @first_paragraph ||= if body_children.any?
                                body_children
@@ -85,6 +93,13 @@ module OpenProject
                              else
                                ""
                              end
+      end
+
+      def first_paragraph_ast
+        @first_paragraph_ast ||= text_ast
+                                 .xpath("html/body")
+                                 .children
+                                 .first
       end
 
       def text_ast
@@ -98,7 +113,10 @@ module OpenProject
       end
 
       def multi_type?
-        first_paragraph.include?("figure") || first_paragraph.include?("macro") || (body_children.any? && first_paragraph.blank?)
+        @multi_type ||= (description.present? && first_paragraph_ast.nil?) ||
+          %w[opce-macro-embedded-table figure macro].include?(first_paragraph_ast.name) ||
+          first_paragraph_ast.css("figure, macro, .op-uc-toc--list, .opce-macro-embedded-table")&.any? ||
+          (body_children.any? && first_paragraph.blank?)
       end
     end
   end

--- a/app/forms/custom_fields/inputs/text.rb
+++ b/app/forms/custom_fields/inputs/text.rb
@@ -33,7 +33,8 @@ class CustomFields::Inputs::Text < CustomFields::Inputs::Base::Input
 
   def rich_text_options
     {
-      resource: nil
+      resource: nil,
+      macros: "none"
     }
   end
 end

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -151,6 +151,7 @@ See COPYRIGHT and LICENSE files for more details.
                         cols: 100,
                         rows: 20,
                         class: 'wiki-edit',
+                        macros: "none",
                         with_text_formatting: true %>
       <% end %>
     </div>

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.component.ts
@@ -45,7 +45,10 @@ export class FormattableControlComponent implements ControlValueAccessor, OnInit
   public get ckEditorContext():ICKEditorContext {
     return {
       type: this.templateOptions.editorType,
-      macros: 'none',
+      // This is a very project resource specific hack to allow macros on description and statusExplanation but
+      // disable it for custom fields. As the formly based approach is currently limited to projects, and that is to be removed,
+      // such a "pragmatic" approach should be ok.
+      macros: (this.templateOptions.property as string).startsWith('customField') ? 'none' : 'resource',
       options: { rtl: this.templateOptions?.rtl },
     };
   }

--- a/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
@@ -27,4 +27,3 @@
     </div>
   </edit-form>
 </div>
-

--- a/frontend/src/global_styles/content/editor/_macros.sass
+++ b/frontend/src/global_styles/content/editor/_macros.sass
@@ -14,3 +14,4 @@
   border-color: var(--content-form-danger-zone-bg-color)
   padding: $nm-box-padding
   box-shadow: rem-calc(1px 2px 3px) rgba(0, 0, 0, 0.2)
+  display: inline-block

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Projects status administration", :js, :with_cuprite do
     status_field.select_option "On track"
 
     status_description.set_markdown "Everything is fine at the start"
-    status_description.expect_supports_no_macros
+    status_description.expect_supports_macros
 
     click_button "Save"
 

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -59,9 +59,9 @@ module Components
       expect(editor_element.text).to eq(value)
     end
 
-    def expect_supports_no_macros
+    def expect_supports_macros
       expect(container)
-          .to have_no_css(".ck-button", visible: :all, text: "Macros")
+          .to have_css(".ck-button", visible: :all, text: "Macros")
     end
 
     def within_enabled_preview


### PR DESCRIPTION
The PR will change the support for macros in project description as well as the status explanation. Both now support macros on the project settings form. This is in line with the project overview page where those two fields support macros as well. 

Custom fields no longer support macros (via the toolbar). The project settings and also on the overview page, macros had never been working (albeit briefly by the merging of the project attributes PR) but the custom field administration supported it for the default value. The last is no longer the case. This affects all custom fields.

Having macros for status explanation and description is poorly supported in the project list (see [#41338](https://community.openproject.org/wp/41338)). The PR only improves the stability and the design of the error message when this happens. 

-----

https://community.openproject.org/wp/53391
https://community.openproject.org/wp/53701

