### PR TITLE
use the remembered device when switching

### DIFF
--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -84,7 +84,7 @@ module ::TwoFactorAuthentication
     ##
     # Create a token service for the current user
     # with an optional override to use a non-default channel
-    def otp_service(user, use_channel: nil, use_device: nil)
+    def otp_service(user, use_channel: nil, use_device: remembered_device)
       session[:two_factor_authentication_device_id] = use_device.try(:id)
       ::TwoFactorAuthentication::TokenService.new user:, use_channel:, use_device:
     end
@@ -92,14 +92,16 @@ module ::TwoFactorAuthentication
     ##
     # Get the used device for verification
     def otp_service_for_verification(user)
-      use_device =
-        if session[:two_factor_authentication_device_id]
-          user.otp_devices.find(session[:two_factor_authentication_device_id])
-        end
-      otp_service(user, use_device:)
+      otp_service(user, use_device: remembered_device)
     rescue ActiveRecord::RecordNotFound
       render_404
       false
+    end
+
+    def remembered_device
+      if session[:two_factor_authentication_device_id]
+        user.otp_devices.find(session[:two_factor_authentication_device_id])
+      end
     end
 
     ##

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -84,7 +84,7 @@ module ::TwoFactorAuthentication
     ##
     # Create a token service for the current user
     # with an optional override to use a non-default channel
-    def otp_service(user, use_channel: nil, use_device: remembered_device)
+    def otp_service(user, use_channel: nil, use_device: remembered_device(user))
       session[:two_factor_authentication_device_id] = use_device.try(:id)
       ::TwoFactorAuthentication::TokenService.new user:, use_channel:, use_device:
     end
@@ -92,13 +92,13 @@ module ::TwoFactorAuthentication
     ##
     # Get the used device for verification
     def otp_service_for_verification(user)
-      otp_service(user, use_device: remembered_device)
+      otp_service(user, use_device: remembered_device(user))
     rescue ActiveRecord::RecordNotFound
       render_404
       false
     end
 
-    def remembered_device
+    def remembered_device(user)
       if session[:two_factor_authentication_device_id]
         user.otp_devices.find(session[:two_factor_authentication_device_id])
       end

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
@@ -21,14 +21,12 @@ module TwoFactorAuthentication
     def options_for_create(relying_party)
       @options_for_create ||= relying_party.options_for_registration(
         user: { id: user.webauthn_id, name: user.name },
-        exclude: TwoFactorAuthentication::Device::Webauthn.where(user:).pluck(:webauthn_external_id),
-        authenticator_selection: { user_verification: "discouraged" }
+        exclude: TwoFactorAuthentication::Device::Webauthn.where(user:).pluck(:webauthn_external_id)
       )
     end
 
     def options_for_get(relying_party)
       @options_for_get ||= relying_party.options_for_authentication(
-        user_verification: "discouraged", # we do not require user verification
         allow: [webauthn_external_id] # TODO: Maybe also allow all other tokens? Let's see
       )
     end


### PR DESCRIPTION
When switching to a separate login device (having multiple 2FA mechanisms registered), the webauthn challenge was not generated using the correct device.

https://community.openproject.org/projects/openproject/work_packages/53494/activity?query_id=5059