### PR TITLE
Add X-Forwarded-{Host,Proto} to sample Nginx configuration

### DIFF
--- a/docs/installation-and-operations/configuration/server/README.md
+++ b/docs/installation-and-operations/configuration/server/README.md
@@ -50,3 +50,30 @@ server {
         }
 }
 ```
+
+And the corresponding NginX configuration file would look like:
+
+```nginx
+# default.conf
+upstream web {
+    server web:8080;
+}
+
+server {
+        listen 80;
+        server_name _;
+
+        location / {
+            proxy_pass_header  Server;
+            proxy_set_header   Host $http_host;
+            proxy_redirect     off;
+            proxy_set_header   X-Forwarded-Host $host:$server_port;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Scheme $scheme;
+            proxy_pass         http://web/;
+        }
+}
+```
+
+```


### PR DESCRIPTION
This adds `X-Forwarded-Host` with value `$host:$server_port` and `X-Forwarded-Proto` with value `$scheme` to the sample Nginx configuration.

These two directives were recommended in [the article about enabling SSL](https://www.openproject.org/docs/installation-and-operations/configuration/ssl/). On my machine, they were required to make everything work, but they might not strictly be needed for plain HTTP connections. However, adding them to the documentation could save some headaches.