### PR TITLE
Fix calender translations

### DIFF
--- a/frontend/src/app/core/setup/init-vendors.ts
+++ b/frontend/src/app/core/setup/init-vendors.ts
@@ -67,6 +67,3 @@ require('@openproject/primer-view-components/app/assets/javascripts/primer_view_
 
 require('expose-loader?URI!urijs');
 require('urijs/src/URITemplate');
-
-// Localization for fullcalendar
-require('@fullcalendar/core/locales-all');

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -61,6 +61,7 @@ import { OpCalendarService } from 'core-app/features/calendar/op-calendar.servic
 import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { IDay } from 'core-app/core/state/days/day.model';
 import { DayResourceService } from 'core-app/core/state/days/day.service';
+import allLocales from '@fullcalendar/core/locales-all';
 
 export interface CalendarViewEvent {
   el:HTMLElement;
@@ -341,6 +342,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
   private defaultOptions():CalendarOptionsWithDayGrid {
     return {
       editable: false,
+      locales: allLocales,
       locale: this.I18n.locale,
       fixedWeekCount: false,
       firstDay: this.configuration.startOfWeek(),

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -34,7 +34,9 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import interactionPlugin from '@fullcalendar/interaction';
-import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
+import {
+  HalResourceEditingService,
+} from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { TimeEntryEditService } from 'core-app/shared/components/time_entries/edit/edit.service';
 import { TimeEntryCreateService } from 'core-app/shared/components/time_entries/create/create.service';
 import { ColorsService } from 'core-app/shared/components/colors/colors.service';
@@ -50,10 +52,11 @@ import { SchemaResource } from 'core-app/features/hal/resources/schema-resource'
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { VerboseFormattingArg } from '@fullcalendar/common';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Subject, firstValueFrom } from 'rxjs';
+import { firstValueFrom, Subject } from 'rxjs';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { IDay } from 'core-app/core/state/days/day.model';
 import { DayResourceService } from 'core-app/core/state/days/day.service';
+import allLocales from '@fullcalendar/core/locales-all';
 
 interface TimeEntrySchema extends SchemaResource {
   activity:IFieldSchema;
@@ -138,6 +141,7 @@ export class TimeEntryCalendarComponent {
 
   public additionalOptions:CalendarOptionsWithDayGrid = {
     editable: false,
+    locales: allLocales,
     locale: this.i18n.locale,
     fixedWeekCount: false,
     headerToolbar: {

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -77,6 +77,7 @@ import {
   addBackgroundEvents,
   removeBackgroundEvents,
 } from 'core-app/features/team-planner/team-planner/planner/background-events';
+import allLocales from '@fullcalendar/core/locales-all';
 
 @Component({
   templateUrl: './wp-calendar.template.html',
@@ -104,6 +105,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
 
   text = {
     cannot_drag_to_non_working_day: this.I18n.t('js.team_planner.cannot_drag_to_non_working_day'),
+    today: this.I18n.t('js.team_planner.today'),
   };
 
   constructor(
@@ -181,6 +183,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
 
   private initializeCalendar() {
     const additionalOptions:{ [key:string]:unknown } = {
+      locales: allLocales,
       locale: this.I18n.locale,
       height: '100%',
       headerToolbar: this.buildHeader(),

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -114,6 +114,7 @@ import {
   removeBackgroundEvents,
 } from 'core-app/features/team-planner/team-planner/planner/background-events';
 import * as moment from 'moment-timezone';
+import allLocales from '@fullcalendar/core/locales-all';
 
 export type TeamPlannerViewOptionKey = 'resourceTimelineWorkWeek'|'resourceTimelineWeek'|'resourceTimelineTwoWeeks'|'resourceTimelineFourWeeks'|'resourceTimelineEightWeeks';
 export type TeamPlannerViewOptions = { [K in TeamPlannerViewOptionKey]:RawOptionsFromRefiners<Required<ViewOptionRefiners>> };
@@ -483,12 +484,12 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       .then(() => {
         this.calendarOptions$.next(
           this.workPackagesCalendar.calendarOptions({
+            locales: allLocales,
             locale: this.I18n.locale,
             schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
             selectable: true,
             plugins: [resourceTimelinePlugin, interactionPlugin],
             titleFormat: { year: 'numeric', month: 'long', day: 'numeric' },
-            buttonText: { today: this.text.today },
             initialView: this.initialCalendarView,
             headerToolbar: {
               left: '',

--- a/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
+++ b/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
@@ -27,6 +27,7 @@ import { ConfirmDialogService } from 'core-app/shared/components/modals/confirm-
 import { ConfirmDialogOptions } from '../modals/confirm-dialog/confirm-dialog.modal';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import * as moment from 'moment-timezone';
+import allLocales from '@fullcalendar/core/locales-all';
 
 export const nonWorkingDaysListSelector = 'op-non-working-days-list';
 
@@ -75,6 +76,7 @@ export class OpNonWorkingDaysListComponent implements OnInit {
   selectedNonWorkingDayName= '';
 
   calendarOptions:CalendarOptions = {
+    locales: allLocales,
     locale: this.I18n.locale,
     plugins: [listPlugin],
     initialView: 'listYear',


### PR DESCRIPTION
The translations need to be passed as options, otherwise the load order is not defined correctly.

https://community.openproject.org/work_packages/53422