### PR TITLE
Link custom action to github webhook actions

### DIFF
--- a/modules/github_integration/app/controllers/admin/settings/github_integration_settings_controller.rb
+++ b/modules/github_integration/app/controllers/admin/settings/github_integration_settings_controller.rb
@@ -1,6 +1,6 @@
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,17 +24,34 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-en:
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+class Admin::Settings::GithubIntegrationSettingsController < ApplicationController
+  layout "admin"
+  menu_item :admin_github_integration
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
+  before_action :require_admin
 
-  github_integration:
-    settings:
-      reference_documentation: "OpenProject can be linked to the one or many GitHub repositories. The documentation explains how to set up the integration."
-      explanation_on_actions: "Aside from updates in the form of comments and linking a pull request to a work package, every action on a pull request can also trigger additional updates on a work package, e.g. updating a status and setting a date value. To do this, define a custom action and assign it to be executed on a GitHub action."
+  def show; end
+
+  def update
+    Setting.plugin_openproject_github_integration = update_settings
+    flash[:notice] = I18n.t(:notice_successful_update)
+
+    redirect_to action: :show
+  end
+
+  def show_local_breadcrumb
+    true
+  end
+
+  def default_breadcrumb
+    I18n.t(:project_module_github)
+  end
+
+  private
+
+  def update_settings
+    @update_settings ||= params.permit(custom_field_mappings: {}).to_h
+  end
+end

--- a/modules/github_integration/app/forms/admin/settings/github_integration_settings_form.rb
+++ b/modules/github_integration/app/forms/admin/settings/github_integration_settings_form.rb
@@ -1,0 +1,68 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class Admin::Settings::GithubIntegrationSettingsForm < ApplicationForm
+  # TODO: Recheck which GH actions we support and how they are mapped potentially (e.g. draft)
+  ACTIONS = OpenProject::GithubIntegration::NotificationHandler::PullRequest::COMMENT_ACTIONS +
+    %w[merged draft]
+
+  def custom_actions
+    @custom_actions ||= CustomAction.all.to_a
+  end
+
+  def selected?(github_action, custom_action)
+    # TODO: robustness
+    custom_action.id.to_s == Setting.plugin_openproject_github_integration["custom_field_mappings"][github_action]
+  end
+
+  def select_for(form, github_action)
+    # TODO: I18n
+    form.select_list(
+      name: "custom_field_mappings[#{github_action}]",
+      label: "For '#{github_action}'",
+      include_blank: true,
+      mb: 3
+    ) do |opened_list|
+      custom_actions.each do |action|
+        opened_list.option(value: action.id, label: action.name, selected: selected?(github_action, action))
+      end
+    end
+  end
+
+  form do |settings_form|
+    ACTIONS.each do |github_action|
+      select_for(settings_form, github_action)
+    end
+
+    settings_form.submit(
+      name: :submit,
+      label: I18n.t(:button_save),
+      scheme: :primary
+    )
+  end
+end

--- a/modules/github_integration/app/views/admin/settings/github_integration_settings/show.html.erb
+++ b/modules/github_integration/app/views/admin/settings/github_integration_settings/show.html.erb
@@ -1,0 +1,23 @@
+<% html_title t(:label_administration), t(:project_module_github) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title do
+      t(:project_module_github)
+    end
+  end
+%>
+
+<%=
+  render(Primer::Beta::Text.new(tag: :div, mb: 1)) { I18n.t(:'github_integration.settings.reference_documentation') }
+%>
+
+<%=
+  render(Primer::Beta::Text.new(tag: :div, mb: 4)) { I18n.t(:'github_integration.settings.explanation_on_actions') }
+%>
+
+<%=
+  primer_form_with(url: admin_settings_github_integration_path, method: :patch) do |f|
+    render(Admin::Settings::GithubIntegrationSettingsForm.new(f))
+  end
+%>

--- a/modules/github_integration/config/routes.rb
+++ b/modules/github_integration/config/routes.rb
@@ -1,6 +1,6 @@
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,17 +24,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-en:
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
-
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-
-  github_integration:
-    settings:
-      reference_documentation: "OpenProject can be linked to the one or many GitHub repositories. The documentation explains how to set up the integration."
-      explanation_on_actions: "Aside from updates in the form of comments and linking a pull request to a work package, every action on a pull request can also trigger additional updates on a work package, e.g. updating a status and setting a date value. To do this, define a custom action and assign it to be executed on a GitHub action."
+Rails.application.routes.draw do
+  namespace :admin do
+    namespace :settings do
+      resource :github_integration,
+               only: %i[show update],
+               controller: :github_integration_settings
+    end
+  end
+end

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -47,6 +47,13 @@ module OpenProject::GithubIntegration
                    {},
                    permissible_on: %i[work_package project])
       end
+
+      menu :admin_menu,
+           :admin_github_integration,
+           { controller: "admin/settings/github_integration_settings", action: :show },
+           if: Proc.new { User.current.admin? },
+           caption: :project_module_github,
+           icon: "github"
     end
 
     initializer "github.register_hook" do

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -37,7 +37,11 @@ module OpenProject::GithubIntegration
 
     register "openproject-github_integration",
              author_url: "https://www.openproject.org/",
-             bundled: true do
+             bundled: true,
+             settings: {
+               default: { "custom_field_mappings" => {} },
+               menu_item: :github_settings
+             } do
       project_module(:github, dependencies: :work_package_tracking) do
         permission(:show_github_content,
                    {},


### PR DESCRIPTION
Aims for a simple link between actions in GitHub webhook payloads and custom actions defined in OpenProject.

**Acceptance criteria**

* [ ] Administration to select a custom action for the currently supported GitHub payload actions
* [ ] Whenever a payload is received that has an action for which a custom action is defined, execute that custom action
  * This has quite some limitations e.g. it is not possible to set a user field like assignee based on the user that triggered the PR action

----------

https://community.openproject.org/wp/53569