### PR TITLE
[53584] Fix Portuguese languages mapping

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -78,6 +78,9 @@ jobs:
         env:
           OPENPROJECT_CROWDIN_PROJECT: ${{ secrets.OPENPROJECT_CROWDINV2_PROJECT }}
           OPENPROJECT_CROWDIN_API_KEY: ${{ secrets.OPENPROJECT_CROWDINV2_API_KEY }}
+      - name: "Fix root key in Portuguese crowdin translation files"
+        run: |
+          script/i18n/fix_crowdin_pt_language_root_key
       - name: "Commit translations"
         run: |
           git config user.name "OpenProject Actions CI"

--- a/config/locales/crowdin/js-pt-BR.yml
+++ b/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     ajax:
       hide: "Ocultar"

--- a/config/locales/crowdin/js-pt-PT.yml
+++ b/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     ajax:
       hide: "Ocultar"

--- a/config/locales/crowdin/pt-BR.seeders.yml
+++ b/config/locales/crowdin/pt-BR.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-BR:
   seeds:
     common:
       colors:

--- a/config/locales/crowdin/pt-BR.yml
+++ b/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   no_results_title_text: Atualmente, não há o que exibir.
   activities:
     index:

--- a/config/locales/crowdin/pt-PT.seeders.yml
+++ b/config/locales/crowdin/pt-PT.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-PT:
   seeds:
     common:
       colors:

--- a/config/locales/crowdin/pt-PT.yml
+++ b/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   no_results_title_text: Atualmente, não há nada para exibir.
   activities:
     index:

--- a/modules/avatars/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/avatars/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     label_preview: 'Pré-visualizar'
     button_update: 'Atualizar'

--- a/modules/avatars/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/avatars/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     label_preview: 'Pré visualizar'
     button_update: 'Atualizar'

--- a/modules/avatars/config/locales/crowdin/pt-BR.yml
+++ b/modules/avatars/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   plugin_openproject_avatars:
     name: "Imagens do perfil"
     description: >-

--- a/modules/avatars/config/locales/crowdin/pt-PT.yml
+++ b/modules/avatars/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   plugin_openproject_avatars:
     name: "Avatares"
     description: >-

--- a/modules/backlogs/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/backlogs/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     work_packages:
       properties:

--- a/modules/backlogs/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/backlogs/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     work_packages:
       properties:

--- a/modules/backlogs/config/locales/crowdin/pt-BR.yml
+++ b/modules/backlogs/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_openproject_backlogs:
     name: "Backlogs OpenProject"
     description: "Este módulo acrescenta recursos que permitem que as equipes ágeis trabalhem com o OpenProject em projetos Scrum."

--- a/modules/backlogs/config/locales/crowdin/pt-PT.yml
+++ b/modules/backlogs/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_openproject_backlogs:
     name: "Repositórios OpenProject"
     description: "Este módulo acrescenta funcionalidades que permitem às equipas Agile trabalhar com o OpenProject em projetos Scrum."

--- a/modules/bim/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/bim/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     bcf:
       label_bcf: 'BCF'

--- a/modules/bim/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/bim/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     bcf:
       label_bcf: 'BCF'

--- a/modules/bim/config/locales/crowdin/pt-BR.seeders.yml
+++ b/modules/bim/config/locales/crowdin/pt-BR.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-BR:
   seeds:
     bim:
       priorities:

--- a/modules/bim/config/locales/crowdin/pt-BR.yml
+++ b/modules/bim/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-BR:
   plugin_openproject_bim:
     name: "Funcionalidade BIM e BCF do OpenProject"
     description: "Este plugin do OpenProject introduz a funcionalidade BIM e BCF."

--- a/modules/bim/config/locales/crowdin/pt-PT.seeders.yml
+++ b/modules/bim/config/locales/crowdin/pt-PT.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-PT:
   seeds:
     bim:
       priorities:

--- a/modules/bim/config/locales/crowdin/pt-PT.yml
+++ b/modules/bim/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-PT:
   plugin_openproject_bim:
     name: "Funcionalidade BIM e BCF do OpenProject"
     description: "Este plugin do OpenProject introduz a funcionalidade BIM e BCF."

--- a/modules/boards/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/boards/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     boards:
       create_new: 'Criar novo quadro'

--- a/modules/boards/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/boards/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     boards:
       create_new: 'Criar novo quadro'

--- a/modules/boards/config/locales/crowdin/pt-BR.seeders.yml
+++ b/modules/boards/config/locales/crowdin/pt-BR.seeders.yml
@@ -5,4 +5,4 @@
 #located in the modules directories are needed to have crowdin cli correctly
 #compute the path to the uploaded source file.
 #This file does not contain any i18n strings.
-pt:
+pt-BR:

--- a/modules/boards/config/locales/crowdin/pt-BR.yml
+++ b/modules/boards/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   plugin_openproject_boards:
     name: "Quadros do OpenProject"
     description: "Fornece visualizações do quadro."

--- a/modules/boards/config/locales/crowdin/pt-PT.seeders.yml
+++ b/modules/boards/config/locales/crowdin/pt-PT.seeders.yml
@@ -5,4 +5,4 @@
 #located in the modules directories are needed to have crowdin cli correctly
 #compute the path to the uploaded source file.
 #This file does not contain any i18n strings.
-pt:
+pt-PT:

--- a/modules/boards/config/locales/crowdin/pt-PT.yml
+++ b/modules/boards/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   plugin_openproject_boards:
     name: "Quadros do OpenProject"
     description: "Fornece vistas do quadro."

--- a/modules/budgets/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/budgets/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     work_packages:
       properties:

--- a/modules/budgets/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/budgets/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     work_packages:
       properties:

--- a/modules/budgets/config/locales/crowdin/pt-BR.yml
+++ b/modules/budgets/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_budgets_engine:
     name: 'Orçamentos'
   activerecord:

--- a/modules/budgets/config/locales/crowdin/pt-PT.yml
+++ b/modules/budgets/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_budgets_engine:
     name: 'Orçamentos'
   activerecord:

--- a/modules/calendar/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/calendar/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     calendar:
       create_new: 'Criar novo calendário'

--- a/modules/calendar/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/calendar/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     calendar:
       create_new: 'Criar novo calendário'

--- a/modules/calendar/config/locales/crowdin/pt-BR.yml
+++ b/modules/calendar/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   plugin_openproject_calendar:
     name: "Calendário OpenProject"
     description: "Fornece visualizações do calendário."

--- a/modules/calendar/config/locales/crowdin/pt-PT.yml
+++ b/modules/calendar/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   plugin_openproject_calendar:
     name: "Calendário OpenProject"
     description: "Fornece visualizações do calendário."

--- a/modules/costs/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/costs/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     work_packages:
       property_groups:

--- a/modules/costs/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/costs/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     work_packages:
       property_groups:

--- a/modules/costs/config/locales/crowdin/pt-BR.yml
+++ b/modules/costs/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_costs:
     name: "Tempo e custos"
     description: "Este módulo acrescenta recursos para planejar e monitorar os custos dos projetos."

--- a/modules/costs/config/locales/crowdin/pt-PT.yml
+++ b/modules/costs/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_costs:
     name: "Tempo e custos"
     description: "Este módulo acrescenta funcionalidades para planear e acompanhar os custos dos projetos."

--- a/modules/dashboards/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/dashboards/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     dashboards:
       label: 'Painel'

--- a/modules/dashboards/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/dashboards/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     dashboards:
       label: 'Painel de Controlo'

--- a/modules/dashboards/config/locales/crowdin/pt-BR.yml
+++ b/modules/dashboards/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   dashboards:
     label: 'Painéis'
   project_module_dashboards: 'Painéis'

--- a/modules/dashboards/config/locales/crowdin/pt-PT.yml
+++ b/modules/dashboards/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   dashboards:
     label: 'Painéis de controlo'
   project_module_dashboards: 'Painéis de controle'

--- a/modules/documents/config/locales/crowdin/pt-BR.yml
+++ b/modules/documents/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_openproject_documents:
     name: "Documentos do OpenProject"
     description: "Um plugin OpenProject para permitir a criação de documentos em projetos."

--- a/modules/documents/config/locales/crowdin/pt-PT.yml
+++ b/modules/documents/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_openproject_documents:
     name: "Documentos do OpenProject"
     description: "Um plugin OpenProject para permitir a criação de documentos em projetos."

--- a/modules/gantt/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/gantt/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     queries:
       all_open: 'Tudo aberto'

--- a/modules/gantt/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/gantt/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     queries:
       all_open: 'Tudo aberto'

--- a/modules/gantt/config/locales/crowdin/pt-BR.yml
+++ b/modules/gantt/config/locales/crowdin/pt-BR.yml
@@ -1,3 +1,3 @@
 #English strings go here
-pt:
+pt-BR:
   project_module_gantt: "Gráficos de Gantt"

--- a/modules/gantt/config/locales/crowdin/pt-PT.yml
+++ b/modules/gantt/config/locales/crowdin/pt-PT.yml
@@ -1,3 +1,3 @@
 #English strings go here
-pt:
+pt-PT:
   project_module_gantt: "Gráficos de Gantt"

--- a/modules/github_integration/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/github_integration/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     github_integration:
       work_packages:

--- a/modules/github_integration/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/github_integration/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     github_integration:
       work_packages:

--- a/modules/github_integration/config/locales/crowdin/pt-BR.yml
+++ b/modules/github_integration/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_openproject_github_integration:
     name: "Integração do OpenProject GitHub"
     description: "Integra o OpenProject e o GitHub para um melhor fluxo de trabalho"

--- a/modules/github_integration/config/locales/crowdin/pt-PT.yml
+++ b/modules/github_integration/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_openproject_github_integration:
     name: "Integração do OpenProject GitHub"
     description: "Integra o OpenProject e o GitHub para um melhor fluxo de trabalho"

--- a/modules/gitlab_integration/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/js-pt-BR.yml
@@ -20,7 +20,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See docs/COPYRIGHT.rdoc for more details.
 #++
-pt:
+pt-BR:
   js:
     gitlab_integration:
       work_packages:

--- a/modules/gitlab_integration/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/js-pt-PT.yml
@@ -20,7 +20,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See docs/COPYRIGHT.rdoc for more details.
 #++
-pt:
+pt-PT:
   js:
     gitlab_integration:
       work_packages:

--- a/modules/gitlab_integration/config/locales/crowdin/pt-BR.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/pt-BR.yml
@@ -20,7 +20,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See docs/COPYRIGHT.rdoc for more details.
 #++
-pt:
+pt-BR:
   activerecord:
     errors:
       models:

--- a/modules/gitlab_integration/config/locales/crowdin/pt-PT.yml
+++ b/modules/gitlab_integration/config/locales/crowdin/pt-PT.yml
@@ -20,7 +20,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See docs/COPYRIGHT.rdoc for more details.
 #++
-pt:
+pt-PT:
   activerecord:
     errors:
       models:

--- a/modules/grids/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/grids/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     grid:
       add_widget: 'Adicionar widget'

--- a/modules/grids/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/grids/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     grid:
       add_widget: 'Adicionar widget'

--- a/modules/grids/config/locales/crowdin/pt-BR.yml
+++ b/modules/grids/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   grids:
     label_widget_in_grid: "Widget contido na Grade %{grid_name}"
   activerecord:

--- a/modules/grids/config/locales/crowdin/pt-PT.yml
+++ b/modules/grids/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   grids:
     label_widget_in_grid: "Widget contido na Grelha %{grid_name}"
   activerecord:

--- a/modules/job_status/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/job_status/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     job_status:
       download_starts: 'O download deve iniciar automaticamente.'

--- a/modules/job_status/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/job_status/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     job_status:
       download_starts: 'O download deve iniciar automaticamente.'

--- a/modules/job_status/config/locales/crowdin/pt-BR.yml
+++ b/modules/job_status/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   plugin_openproject_job_status:
     name: "Situação do trabalho OpenProject"
     description: "Listagem e situação dos trabalhos em segundo plano."

--- a/modules/job_status/config/locales/crowdin/pt-PT.yml
+++ b/modules/job_status/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   plugin_openproject_job_status:
     name: "Estado do trabalho OpenProject"
     description: "Listagem e estado dos trabalhos em segundo plano."

--- a/modules/ldap_groups/config/locales/crowdin/pt-BR.yml
+++ b/modules/ldap_groups/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   plugin_openproject_ldap_groups:
     name: "Grupos LDAP do OpenProject"
     description: "Sincronização de associações de grupos LDAP."

--- a/modules/ldap_groups/config/locales/crowdin/pt-PT.yml
+++ b/modules/ldap_groups/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   plugin_openproject_ldap_groups:
     name: "Grupos LDAP do OpenProject"
     description: "Sincronização de associações de grupos LDAP."

--- a/modules/meeting/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/meeting/config/locales/crowdin/js-pt-BR.yml
@@ -19,6 +19,6 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     label_meetings: 'Reuniões'

--- a/modules/meeting/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/meeting/config/locales/crowdin/js-pt-PT.yml
@@ -19,6 +19,6 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     label_meetings: 'Reuniões'

--- a/modules/meeting/config/locales/crowdin/pt-BR.seeders.yml
+++ b/modules/meeting/config/locales/crowdin/pt-BR.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-BR:
   seeds:
     standard:
       projects:

--- a/modules/meeting/config/locales/crowdin/pt-BR.yml
+++ b/modules/meeting/config/locales/crowdin/pt-BR.yml
@@ -20,7 +20,7 @@
 #See COPYRIGHT and LICENSE files for more details.
 #++
 #English strings go here for Rails i18n
-pt:
+pt-BR:
   plugin_openproject_meeting:
     name: "Reunião do OpenProject"
     description: >-

--- a/modules/meeting/config/locales/crowdin/pt-PT.seeders.yml
+++ b/modules/meeting/config/locales/crowdin/pt-PT.seeders.yml
@@ -2,7 +2,7 @@
 #Please do not edit directly.
 #This file is part of the sources sent to crowdin for translation.
 ---
-pt:
+pt-PT:
   seeds:
     standard:
       projects:

--- a/modules/meeting/config/locales/crowdin/pt-PT.yml
+++ b/modules/meeting/config/locales/crowdin/pt-PT.yml
@@ -20,7 +20,7 @@
 #See COPYRIGHT and LICENSE files for more details.
 #++
 #English strings go here for Rails i18n
-pt:
+pt-PT:
   plugin_openproject_meeting:
     name: "Reunião do OpenProject"
     description: >-

--- a/modules/my_page/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/my_page/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     my_page:
       label: "Minha página"

--- a/modules/my_page/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/my_page/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     my_page:
       label: "A minha página"

--- a/modules/openid_connect/config/locales/crowdin/pt-BR.yml
+++ b/modules/openid_connect/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   plugin_openproject_openid_connect:
     name: "Conectar OpenProject OpenID"
     description: "Adiciona provedores de estratégia OmniAuth OpenID Connect ao Openproject."

--- a/modules/openid_connect/config/locales/crowdin/pt-PT.yml
+++ b/modules/openid_connect/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
     description: "Adiciona fornecedores da estratégia OmniAuth OpenID Connect ao Openproject."

--- a/modules/overviews/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/overviews/config/locales/crowdin/js-pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   js:
     overviews:
       label: 'Visão geral'

--- a/modules/overviews/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/overviews/config/locales/crowdin/js-pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   js:
     overviews:
       label: 'Sinopse'

--- a/modules/overviews/config/locales/crowdin/pt-BR.yml
+++ b/modules/overviews/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   overviews:
     label: 'Visão geral'
   permission_manage_overview: 'Gerenciar página de visão geral'

--- a/modules/overviews/config/locales/crowdin/pt-PT.yml
+++ b/modules/overviews/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   overviews:
     label: 'Visão geral'
   permission_manage_overview: 'Gerir página de visão geral'

--- a/modules/recaptcha/config/locales/crowdin/pt-BR.yml
+++ b/modules/recaptcha/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-BR:
   plugin_openproject_recaptcha:
     name: "ReCaptcha do OpenProject"
     description: "Este módulo fornece verificações recaptcha durante o início de sessão."

--- a/modules/recaptcha/config/locales/crowdin/pt-PT.yml
+++ b/modules/recaptcha/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-PT:
   plugin_openproject_recaptcha:
     name: "ReCaptcha do OpenProject"
     description: "Este módulo fornece verificações recaptcha durante o início de sessão."

--- a/modules/reporting/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/reporting/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     reporting_engine:
       label_remove: "Excluir"

--- a/modules/reporting/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/reporting/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     reporting_engine:
       label_remove: "Eliminar"

--- a/modules/reporting/config/locales/crowdin/pt-BR.yml
+++ b/modules/reporting/config/locales/crowdin/pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   plugin_openproject_reporting:
     name: "Relatórios do OpenProject"
     description: "Este plugin permite a criação de relatórios de custos personalizados com filtragem e agrupamento criados pelo plugin OpenProject Time e custos."

--- a/modules/reporting/config/locales/crowdin/pt-PT.yml
+++ b/modules/reporting/config/locales/crowdin/pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   plugin_openproject_reporting:
     name: "Relatórios do OpenProject"
     description: "Este plugin permite criar relatórios de custos personalizados com filtragem e agrupamento criados pelo plugin OpenProject Time e custos."

--- a/modules/storages/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/storages/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     storages:
       link_files_in_storage: "Vincular arquivos em %{storageType}"

--- a/modules/storages/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/storages/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     storages:
       link_files_in_storage: "Vincular ficheiros em %{storageType}"

--- a/modules/storages/config/locales/crowdin/pt-BR.yml
+++ b/modules/storages/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activerecord:
     attributes:
       storages/file_link:

--- a/modules/storages/config/locales/crowdin/pt-PT.yml
+++ b/modules/storages/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   activerecord:
     attributes:
       storages/file_link:

--- a/modules/team_planner/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/team_planner/config/locales/crowdin/js-pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   js:
     team_planner:
       add_existing: 'Adicionar existente'

--- a/modules/team_planner/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/team_planner/config/locales/crowdin/js-pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   js:
     team_planner:
       add_existing: 'Adicionar existente'

--- a/modules/team_planner/config/locales/crowdin/pt-BR.yml
+++ b/modules/team_planner/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-BR:
   plugin_openproject_team_planner:
     name: "Planejador de equipes OpenProject"
     description: "Fornece visualizações do planejador de equipes."

--- a/modules/team_planner/config/locales/crowdin/pt-PT.yml
+++ b/modules/team_planner/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here
-pt:
+pt-PT:
   plugin_openproject_team_planner:
     name: "Planeador de equipas OpenProject"
     description: "Fornece visualizações do planeador de equipas."

--- a/modules/two_factor_authentication/config/locales/crowdin/js-pt-BR.yml
+++ b/modules/two_factor_authentication/config/locales/crowdin/js-pt-BR.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-BR:
   js:
     two_factor_authentication:
       errors:

--- a/modules/two_factor_authentication/config/locales/crowdin/js-pt-PT.yml
+++ b/modules/two_factor_authentication/config/locales/crowdin/js-pt-PT.yml
@@ -19,7 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #See COPYRIGHT and LICENSE files for more details.
 #++
-pt:
+pt-PT:
   js:
     two_factor_authentication:
       errors:

--- a/modules/two_factor_authentication/config/locales/crowdin/pt-BR.yml
+++ b/modules/two_factor_authentication/config/locales/crowdin/pt-BR.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-BR:
   plugin_openproject_two_factor_authentication:
     name: "Autenticação de dois fatores do OpenProject"
     description: >-

--- a/modules/two_factor_authentication/config/locales/crowdin/pt-PT.yml
+++ b/modules/two_factor_authentication/config/locales/crowdin/pt-PT.yml
@@ -1,5 +1,5 @@
 #English strings go here for Rails i18n
-pt:
+pt-PT:
   plugin_openproject_two_factor_authentication:
     name: "Autenticação de dois fatores do OpenProject"
     description: >-

--- a/modules/webhooks/config/locales/crowdin/pt-BR.yml
+++ b/modules/webhooks/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   plugin_openproject_webhooks:
     name: "Webhooks do OpenProject"
     description: "Fornece uma API de plug-in para dar suporte aos webhooks do OpenProject para uma melhor integração de terceiros."

--- a/modules/webhooks/config/locales/crowdin/pt-PT.yml
+++ b/modules/webhooks/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   plugin_openproject_webhooks:
     name: "Webhooks do OpenProject"
     description: "Fornece uma API de plug-in para suportar webhooks do OpenProject para uma melhor integração de terceiros."

--- a/modules/xls_export/config/locales/crowdin/pt-BR.yml
+++ b/modules/xls_export/config/locales/crowdin/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   plugin_openproject_xls_export:
     name: "Exportação XLS do OpenProject"
     description: "Exportar listas de problemas como planilhas Excel (.xls)."

--- a/modules/xls_export/config/locales/crowdin/pt-PT.yml
+++ b/modules/xls_export/config/locales/crowdin/pt-PT.yml
@@ -1,4 +1,4 @@
-pt:
+pt-PT:
   plugin_openproject_xls_export:
     name: "Exportação XLS do OpenProject"
     description: "Exportar listas de problemas como folhas de cálculo do Excel (.xls)."

--- a/script/i18n/fix_crowdin_pt_language_root_key
+++ b/script/i18n/fix_crowdin_pt_language_root_key
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Fixing language root key in pt-BR and pt-PT crowdin files to match the filename"
+if [ "$(uname -s)" = "Darwin" ]; then
+  sed -i '' 's/^pt:/pt-BR:/' config/locales/crowdin/*pt-BR*.yml modules/*/config/locales/crowdin/*pt-BR*.yml
+  sed -i '' 's/^pt:/pt-PT:/' config/locales/crowdin/*pt-PT*.yml modules/*/config/locales/crowdin/*pt-PT*.yml
+else
+  sed -i 's/^pt:/pt-BR:/' config/locales/crowdin/*pt-BR*.yml modules/*/config/locales/crowdin/*pt-BR*.yml
+  sed -i 's/^pt:/pt-PT:/' config/locales/crowdin/*pt-PT*.yml modules/*/config/locales/crowdin/*pt-PT*.yml
+fi


### PR DESCRIPTION
https://community.openproject.org/wp/53584
https://community.openproject.org/wp/53586

When making Portuguese Brazilian and Portuguese Portugal translations apart from each other in https://community.openproject.org/wp/53374, we missed that the root key in the `pt-BR.yml` and `pt-PT.yml` files is still `pt`. The backend is gracefully falling back to the `pt` translations but the frontend just fails to translate and falls back to the English strings, leading to mixed English and Portuguese in the user interface.

A script fixes the root key in the `pt-BR.yml` and `pt-PT.yml` files. This script is executed each time the translations are updated from crowdin.