### PR TITLE
[53611] Avoid seeding default_projects_modules setting if not writable

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/setting_seeder_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/setting_seeder_patch.rb
@@ -37,7 +37,7 @@ module OpenProject::Backlogs::Patches::SettingSeederPatch
     def data
       original_data = super
 
-      unless original_data['default_projects_modules'].include? 'backlogs'
+      if original_data['default_projects_modules']&.exclude? 'backlogs'
         original_data['default_projects_modules'] << 'backlogs'
       end
 

--- a/modules/bim/app/seeders/bim/basic_data/setting_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/setting_seeder.rb
@@ -30,7 +30,7 @@ module Bim
     class SettingSeeder < ::BasicData::SettingSeeder
       def data
         super.tap do |original_data|
-          unless original_data['default_projects_modules'].include? 'bim'
+          if original_data['default_projects_modules']&.exclude? 'bim'
             original_data['default_projects_modules'] << 'bim'
           end
 

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe RootSeeder,
       expect(Boards::Grid.count).to eq 2
     end
 
+    it "adds the BIM module to the default_projects_modules setting" do
+      default_modules = Setting.find_by(name: "default_projects_modules").value
+      expect(default_modules).to include("bim")
+    end
+
     it 'creates follows and parent-child relations' do
       expect(Relation.follows.count).to eq 35
       expect(WorkPackage.where.not(parent: nil).count).to eq 55
@@ -210,7 +215,13 @@ RSpec.describe RootSeeder,
 
     before_all do
       with_edition('bim') do
-        root_seeder.seed_data!
+        RSpec::Mocks.with_temporary_scope do
+          # opportunistic way to add a test for bug #53611 without extending the testing time
+          allow(Settings::Definition["default_projects_modules"])
+              .to receive(:writable?).and_return(false)
+
+          root_seeder.seed_data!
+        end
       end
     end
 

--- a/modules/boards/lib/open_project/boards/patches/setting_seeder_patch.rb
+++ b/modules/boards/lib/open_project/boards/patches/setting_seeder_patch.rb
@@ -35,7 +35,7 @@ module OpenProject::Boards::Patches::SettingSeederPatch
     def data
       original_data = super
 
-      unless original_data['default_projects_modules'].include? 'board_view'
+      if original_data['default_projects_modules']&.exclude? 'board_view'
         original_data['default_projects_modules'] << 'board_view'
       end
 

--- a/modules/costs/lib/costs/patches/setting_seeder_patch.rb
+++ b/modules/costs/lib/costs/patches/setting_seeder_patch.rb
@@ -35,7 +35,7 @@ module Costs::Patches::SettingSeederPatch
     def data
       original_data = super
 
-      unless original_data['default_projects_modules'].include? 'costs'
+      if original_data['default_projects_modules']&.exclude? 'costs'
         original_data['default_projects_modules'] << 'costs'
       end
 

--- a/modules/meeting/lib/open_project/meeting/patches/setting_seeder_patch.rb
+++ b/modules/meeting/lib/open_project/meeting/patches/setting_seeder_patch.rb
@@ -35,7 +35,7 @@ module OpenProject::Meeting::Patches::SettingSeederPatch
     def data
       original_data = super
 
-      unless original_data['default_projects_modules'].include? 'meetings'
+      if original_data['default_projects_modules']&.exclude? 'meetings'
         original_data['default_projects_modules'] << 'meetings'
       end
 

--- a/modules/reporting/lib/open_project/reporting/patches/setting_seeder_patch.rb
+++ b/modules/reporting/lib/open_project/reporting/patches/setting_seeder_patch.rb
@@ -35,7 +35,7 @@ module OpenProject::Reporting::Patches::SettingSeederPatch
     def data
       original_data = super
 
-      unless original_data['default_projects_modules'].include? 'reporting_module'
+      if original_data['default_projects_modules']&.exclude? 'reporting_module'
         original_data['default_projects_modules'] << 'reporting_module'
       end
 


### PR DESCRIPTION
Fixes https://community.openproject.org/wp/53611

It can happen that the `default_projects_modules` setting is not writable if set through env var or config file.