### PR TITLE
[51772] Odd spacing in Notification and Email Reminder personal setting pages (2)

### DIFF
--- a/app/views/admin/settings/work_packages_settings/show.html.erb
+++ b/app/views/admin/settings/work_packages_settings/show.html.erb
@@ -58,7 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
                  } %>
     </div>
     <% if EnterpriseToken.allows_to? :conditional_highlighting %>
-      <div class="form--field -indented -vertical settings--primaryed-attributes" style="<%= 'display: none' unless Setting[:work_package_list_default_highlighting_mode] == 'inline' %>">
+      <div class="form--field -indented -vertical settings--highlighted-attributes" style="<%= 'display: none' unless Setting[:work_package_list_default_highlighting_mode] == 'inline' %>">
         <%= setting_multiselect :work_package_list_default_highlighted_attributes,
                               Query.available_columns(nil).select(&:highlightable).map { |column|
                                 [column.caption, column.name.to_s]

--- a/frontend/src/app/features/projects/components/new-project/new-project.component.html
+++ b/frontend/src/app/features/projects/components/new-project/new-project.component.html
@@ -2,7 +2,7 @@
   class="op-form"
   [formGroup]="templateForm"
 >
-  <div [ngClass]="{ 'op-primaryed-input': true, 'op-primaryed-input_active': !!templateControl?.value }">
+  <div [ngClass]="{ 'op-highlighted-input': true, 'op-highlighted-input_active': !!templateControl?.value }">
     <spot-form-field
       [label]="text.use_template"
       data-qa-field-name="use_template"

--- a/frontend/src/app/shared/components/forms/form.sass
+++ b/frontend/src/app/shared/components/forms/form.sass
@@ -20,7 +20,7 @@
     > .spot-form-field,
     > .spot-selector-field,
     > .op-option-list,
-    > .op-primaryed-input,
+    > .op-highlighted-input,
     > .button
       &:not(:last-child)
         margin-bottom: 1rem

--- a/frontend/src/app/shared/components/forms/form.sass
+++ b/frontend/src/app/shared/components/forms/form.sass
@@ -25,8 +25,13 @@
       &:not(:last-child)
         margin-bottom: 1rem
 
+  &--fieldset,
   &--section-header
-    margin-top: 0.5rem
+    width: 100%
+    margin-top: 1.5rem
+
+    &:first-child
+      margin-top: 0
 
   &--section-header-title
     @extend %form--fieldset-legend-or-section-title

--- a/frontend/src/app/shared/components/forms/highlighted-input.sass
+++ b/frontend/src/app/shared/components/forms/highlighted-input.sass
@@ -1,4 +1,4 @@
-.op-primaryed-input
+.op-highlighted-input
   padding: 1rem 1rem 0.5rem 0.75rem
   display: flex
   flex-direction: column


### PR DESCRIPTION
Changes affect the personal notification settings page and the personal email reminders settings page:

* Let the headers span the complete width of the screen
* Add more spacing between the sections

Further, this PR fixes some class names that were wrongly renamed.

https://community.openproject.org/projects/openproject/work_packages/51772/activity

#### Notification settings
**Before**
<img width="500" alt="Bildschirmfoto 2024-03-22 um 09 15 49" src="https://github.com/opf/openproject/assets/7457313/b8f73d5b-f7c3-4bf5-87de-e7eca819aa34">

**After**
<img width="500" alt="Bildschirmfoto 2024-03-22 um 09 11 30" src="https://github.com/opf/openproject/assets/7457313/7a7b56ba-719f-4f4a-824c-130850db0452">

#### Email reminders
**Before**
<img width="500" alt="Bildschirmfoto 2024-03-22 um 09 16 00" src="https://github.com/opf/openproject/assets/7457313/a49a225e-02da-459c-be3c-6ab32cd8bda0">

**After**
<img width="500" alt="Bildschirmfoto 2024-03-22 um 09 11 38" src="https://github.com/opf/openproject/assets/7457313/ab667fc9-533e-44f9-aa57-6374c6c5d871">

