### PR TITLE
Backport into 13.4 [#53202]: Health status is not showing for OneDrive storages

### DIFF
--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -74,7 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 <% end %>
 
-<% if @storage.provider_type_nextcloud? && @storage.automatic_management_enabled? %>
+<% if @storage.automatic_management_enabled? %>
   <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
     <% component.with_main() do %>
       <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -44,19 +44,6 @@ FactoryBot.define do
     trait :as_generic do
       provider_type { 'Storages::Storage' }
     end
-  end
-
-  factory :nextcloud_storage,
-          parent: :storage,
-          class: '::Storages::NextcloudStorage' do
-    provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
-    sequence(:host) { |n| "https://host#{n}.example.com" }
-
-    trait :as_automatically_managed do
-      automatically_managed { true }
-      username { 'OpenProject' }
-      password { 'Password123' }
-    end
 
     trait :as_not_automatically_managed do
       automatically_managed { false }
@@ -88,6 +75,19 @@ FactoryBot.define do
       health_reason { nil }
       health_changed_at { Time.now.utc }
       health_checked_at { Time.now.utc }
+    end
+  end
+
+  factory :nextcloud_storage,
+          parent: :storage,
+          class: '::Storages::NextcloudStorage' do
+    provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
+    sequence(:host) { |n| "https://host#{n}.example.com" }
+
+    trait :as_automatically_managed do
+      automatically_managed { true }
+      username { 'OpenProject' }
+      password { 'Password123' }
     end
   end
 
@@ -155,6 +155,10 @@ FactoryBot.define do
     host { nil }
     tenant_id { SecureRandom.uuid }
     drive_id { SecureRandom.uuid }
+
+    trait :as_automatically_managed do
+      automatically_managed { true }
+    end
   end
 
   factory :sharepoint_dev_drive_storage,

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -227,8 +227,18 @@ RSpec.describe 'Admin Edit File storage',
     end
   end
 
-  context 'with OneDrive Storage' do
-    let(:storage) { create(:one_drive_storage, name: 'Test Drive') }
+  context 'with Nextcloud Storage and not automatically managed' do
+    let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed, name: 'Cloud Storage') }
+
+    it 'does not render health status information' do
+      visit edit_admin_settings_storage_path(storage)
+
+      expect(page).not_to have_test_selector('storage-health-label-pending', text: 'Pending')
+    end
+  end
+
+  context 'with OneDrive/SharePoint Storage' do
+    let(:storage) { create(:one_drive_storage, :as_automatically_managed, name: 'Test Drive') }
     let(:oauth_client) { create(:oauth_client, integration: storage) }
 
     before { oauth_client }
@@ -236,7 +246,9 @@ RSpec.describe 'Admin Edit File storage',
     it 'renders an edit view', :webmock do
       visit edit_admin_settings_storage_path(storage)
 
-      expect(page).to be_axe_clean.within '#content'
+      expect(page).to be_axe_clean
+        .within('#content')
+        .skipping('heading-order')
 
       expect(page).to have_test_selector('storage-new-page-header--title', text: 'Test Drive (OneDrive/SharePoint)')
 
@@ -313,6 +325,22 @@ RSpec.describe 'Admin Edit File storage',
         expect(page).to have_test_selector('label-storage_oauth_client_configured-status', text: 'Completed')
         expect(page).to have_test_selector('storage-oauth-client-id-description', text: "OAuth Client ID: 1234567890")
       end
+    end
+
+    it 'renders health status information' do
+      visit edit_admin_settings_storage_path(storage)
+
+      expect(page).to have_test_selector('storage-health-label-pending', text: 'Pending')
+    end
+  end
+
+  context 'with OneDrive/SharePoint Storage and not automatically managed' do
+    let(:storage) { create(:one_drive_storage, :as_not_automatically_managed, name: 'Cloud Storage') }
+
+    it 'does not render health status information' do
+      visit edit_admin_settings_storage_path(storage)
+
+      expect(page).not_to have_test_selector('storage-health-label-pending', text: 'Pending')
     end
   end
 end


### PR DESCRIPTION
Backport [#53202 Health status is not showing for OneDrive storages](https://community.openproject.org/work_packages/53202) from dev into release/13.4.


---
For context here the original PR into dev: #14911 