### PR TITLE
[53497] Login links are in the wrong position

### DIFF
--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -55,10 +55,11 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
   <% end %>
 
-  <%= submit_tag t(:button_login),
-                 name: :login,
-                 class: 'button -primary button_no-margin',
-                 data: { disable_with: t(:label_loading) } %>
+  <div class="login-form--footer">
+    <%= submit_tag t(:button_login),
+                   name: :login,
+                   class: 'button -primary button_no-margin',
+                   data: { disable_with: t(:label_loading) } %>
 
     <div class="login-options-container">
       <div class="login-links">
@@ -76,6 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
       </div>
     </div>
+  </div>
 <% end %>
 
 <section data-augmented-model-wrapper

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
@@ -11,8 +11,8 @@
         <%= styled_text_field_tag 'backup_code', nil, required: true, autocomplete: 'off', size: 20, maxlength: 20, tabindex: 1, autofocus: true  %>
       </div>
     </div>
-
-    <input type="submit" name="login" value="<%=t(:button_submit)%>" class="button -primary button_no-margin" tabindex="2" />
+    <div class="login-form--footer">
+      <input type="submit" name="login" value="<%=t(:button_submit)%>" class="button -primary button_no-margin" tabindex="2" />
+    </div>
   <% end %>
-  </div>
 </div>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
@@ -43,20 +43,24 @@
         </label>
       </div>
     <% end %>
-    <input type="submit" name="login" value="<%= t(:button_login) %>" class="button -primary button_no-margin" tabindex="2"/>
-    <% if resend_supported || has_other_devices || has_backup_codes %>
-      <div class="login-options-container">
-        <div class="login-links">
-          <%= link_to(
-                t(:text_otp_not_receive),
-                '#',
-                id: 'toggle_resend_form',
-                tabindex: 3,
-                data: { action: 'two-factor-authentication#toggleResendOptions' }
-              ) %>
+    <div class="login-form--footer">
+      <input type="submit" name="login" value="<%= t(:button_login) %>" class="button -primary button_no-margin" tabindex="2"/>
+      <% if resend_supported || has_other_devices || has_backup_codes %>
+        <div class="login-options-container">
+          <div class="login-links">
+            <%= link_to(
+                  t(:text_otp_not_receive),
+                  '#',
+                  id: 'toggle_resend_form',
+                  tabindex: 3,
+                  data: { action: 'two-factor-authentication#toggleResendOptions' },
+                  class: 'login-form--footer-link'
+                ) %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+
   <% end %>
   <div
     id="resend_otp_container"

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
@@ -13,7 +13,7 @@
       <%= styled_text_field_tag 'otp', nil, required: true, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, autofocus: true  %>
     </div>
   </div>
-  <div>
+  <div class="login-form--footer">
     <input type="submit" name="login" value="<%= t 'button_continue' %>" class="button -primary button_no-margin" tabindex="2" />
   </div>
 <% end %>


### PR DESCRIPTION
Re-add correct classes to the login forms. They were accidentally removed while resolving merge conflicts

Original PR: https://github.com/opf/openproject/pull/14969

https://community.openproject.org/projects/openproject/work_packages/53497/activity
