### PR TITLE
[46346] Missing space on the left of the advanced filter

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -123,5 +123,6 @@
     #content
       padding: 15px 0 !important
 
-      .toolbar-container
+      .toolbar-container,
+      .work-packages--filters-optional-container
         margin-left: 15px


### PR DESCRIPTION
Add spacing to left side of the advanced filters. This was accidentally removed during the refactoring of the layout CSS some time ago.

https://community.openproject.org/projects/openproject/work_packages/46346/activity