### PR TITLE
increase robustness on non writable default module setting

### DIFF
--- a/db/migrate/20190507132517_add_board_view_to_roles.rb
+++ b/db/migrate/20190507132517_add_board_view_to_roles.rb
@@ -34,7 +34,7 @@ class AddBoardViewToRoles < ActiveRecord::Migration[5.2]
       .add(:view_work_packages,
            :show_board_views)
 
-    unless Setting.default_projects_modules.include?("board_view")
+    if Setting.default_projects_modules_writable? && Setting.default_projects_modules&.exclude?("board_view")
       Setting.default_projects_modules = Setting.default_projects_modules + ["board_view"]
     end
   end

--- a/db/migrate/20240201115019_add_gantt_module_to_default_modules.rb
+++ b/db/migrate/20240201115019_add_gantt_module_to_default_modules.rb
@@ -1,6 +1,6 @@
 class AddGanttModuleToDefaultModules < ActiveRecord::Migration[7.0]
   def up
-    unless Setting.default_projects_modules.include?("gantt")
+    if Setting.default_projects_modules_writable? && Setting.default_projects_modules&.exclude?("gantt")
       Setting.default_projects_modules = Setting.default_projects_modules + ["gantt"]
     end
   end


### PR DESCRIPTION
When QAing https://community.openproject.org/wp/53611, I noticed a similar problem to what was fixed in the seeders to exist in two migration files. When running, e.g.:

```
OPENPROJECT_DEFAULT__PROJECTS__MODULES=work_package_tracking rails db:migrate 
```

The migration would fail since the `default_projects_module` setting is not writable if set as an ENV variable.