### PR TITLE
Historic attributes: Fix accessing custom_field_id nil when eager loading

### DIFF
--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journable_differ.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journable_differ.rb
@@ -110,7 +110,7 @@ module Acts::Journalized
       end
 
       def merge_reference_journals_by_id(new_journals, old_journals, id_key, value)
-        all_associated_journal_ids = new_journals.pluck(id_key) | old_journals.pluck(id_key)
+        all_associated_journal_ids = (new_journals.pluck(id_key) | old_journals.pluck(id_key)).compact
 
         all_associated_journal_ids.index_with do |id|
           [select_and_combine_journals(old_journals, id, id_key, value),

--- a/spec/lib/acts_as_journalized/journable_differ_spec.rb
+++ b/spec/lib/acts_as_journalized/journable_differ_spec.rb
@@ -131,5 +131,31 @@ RSpec.describe Acts::Journalized::JournableDiffer do
           )
       end
     end
+
+    context "with a default custom value" do
+      let(:original) do
+        build(:work_package,
+              custom_values: [
+                build_stubbed(:work_package_custom_value, custom_field_id: nil, value: nil),
+                build_stubbed(:work_package_custom_value, custom_field_id: nil, value: ""),
+                build_stubbed(:work_package_custom_value, custom_field_id: 2, value: 1)
+              ])
+      end
+
+      let(:changed) do
+        build(:work_package,
+              custom_values: [
+                build_stubbed(:work_package_custom_value, custom_field_id: 1, value: "t"),
+                build_stubbed(:work_package_custom_value, custom_field_id: 2, value: 2)
+              ])
+      end
+
+      it "returns the changes" do
+        params = [original, changed, "custom_values", "custom_field", :custom_field_id, :value]
+        expect(described_class.association_changes(*params))
+          .to eql("custom_field_1" => [nil, "t"],
+                "custom_field_2" => ["1", "2"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Using the eager loading wrapper, custom_values might have an empty custom_field if that field is not available (e.g., disabled in the project).

This results in trying to compare values for a `nil` id_key which fails.

https://community.openproject.org/work_packages/53617