### PR TITLE
[50213][46215] Missing space between avatars and usernames

### DIFF
--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -46,7 +46,7 @@ module Users
     def login
       icon = helpers.avatar user, size: :mini
 
-      link = link_to h(user.login), helpers.allowed_management_user_profile_path(user)
+      link = link_to h(user.login), helpers.allowed_management_user_profile_path(user), class: "op-principal--name"
 
       icon + link
     end

--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -151,6 +151,7 @@ export class PrincipalRendererService {
     }
 
     const image = new Image();
+    image.classList.add('op-principal--avatar');
     image.classList.add('op-avatar');
     image.classList.add(`op-avatar_${options.size}`);
     image.src = url;

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -16,6 +16,7 @@
     flex-grow: 1
     flex-shrink: 1
     min-width: 0 // See: https://css-tricks.com/flexbox-truncated-text/
+    margin-left: $spot-spacing-0_25
 
   &_wrapped &--name
     white-space: normal
@@ -28,6 +29,3 @@
     @media screen and (max-width: $breakpoint-sm)
       &--name
         display: none
-
-  .op-avatar + .op-principal--name
-    margin-left: $spot-spacing-0_5

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.html
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.html
@@ -12,19 +12,21 @@
 
 <div class="op-pull-request--info">
   {{ text.label_created_by }}
-  <img
-    *ngIf="pullRequest._embedded.githubUser"
-    alt='PR author avatar'
-    class='op-pull-request--avatar op-avatar op-avatar_mini'
-    [src]="pullRequest._embedded.githubUser.avatarUrl"
-  />
-  <span class='op-pull-request--user'>
+
+  <div class="op-principal"
+       *ngIf="pullRequest._embedded.githubUser">
+    <img
+      alt='PR author avatar'
+      class='op-pull-request--avatar op-avatar op-avatar_mini op-principal--avatar'
+      [src]="pullRequest._embedded.githubUser.avatarUrl"
+    />
     <a
-      *ngIf="pullRequest._embedded.githubUser"
       [href]="pullRequest._embedded.githubUser.htmlUrl"
       [textContent]="pullRequest._embedded.githubUser.login"
-    ></a>.
-  </span>
+      class="op-principal--name"
+    ></a>
+  </div>
+  .
 
   <span class='op-pull-request--date'>
     {{ text.label_last_updated_on }}

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.sass
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.sass
@@ -33,6 +33,7 @@
   display: grid
   grid-template-columns: auto 1fr auto auto
   grid-template-areas: "link link link link" "title title title state" "info info info info" "checks-label checks-label checks-label checks-label" "checks checks checks checks"
+  align-items: center
   margin-bottom: 11px
   padding-bottom: 11px
   border-bottom: 1px solid #dddddd
@@ -48,26 +49,18 @@
     line-height: 32px
     margin-right: 20px
 
-  &--avatar
-    grid-area: info
-
   &--info
-    display: block
-    grid-area: info
-    margin-bottom: 3px
-    font-size: 0.9rem
+    display: inline-flex
     grid-area: info
     color: var(--color-fg-muted)
-    // The mini avatar is much higher than the text line. Compensate it.
-    margin-top: -4px
 
+  &--avatar,
   &--date
-    grid-area: info
+    margin-left: 0.25rem
 
   &--link
     grid-area: link
     margin-top: 6px
-    font-size: 0.9rem
 
   &--state
     grid-area: state
@@ -75,7 +68,6 @@
   &--checks-label
     grid-area: checks-label
     margin-top: 12px
-    font-size: 0.9rem
     font-weight: var(--base-text-weight-bold)
 
   &--checks


### PR DESCRIPTION
* Use the correct class of principal component at the administration → users table
* Within the github PR template: Use the same classes to ensure, that the principal looks like in the rest of the application

https://community.openproject.org/projects/openproject/work_packages/50213/activity
https://community.openproject.org/projects/openproject/work_packages/46215/activity