### PR TITLE
[52669] Position of status selector too high after opening the drop down

### DIFF
--- a/frontend/src/global_styles/content/work_packages/new/_type_status_row.sass
+++ b/frontend/src/global_styles/content/work_packages/new/_type_status_row.sass
@@ -3,6 +3,7 @@
 .wp-new-top-row
   color: var(--accent-color)
   display: flex
+  align-items: center
   font-size: 24px
 
   // Add some minor margin between active status and type field


### PR DESCRIPTION
Align type and status in the WP create form

https://community.openproject.org/projects/openproject/work_packages/52669/activity