### PR TITLE
[53644] Macros text should wrap

### DIFF
--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -280,8 +280,7 @@ $scrollbar-size: 10px
 
 @mixin macro--text-style
   @media screen
-    // Ensure width of contents is wrapped
-    display: inline-block
+    display: inline
     background: rgba(218,223,225,0.19)
     border: 1px solid transparent
     padding: 2px


### PR DESCRIPTION
Macros should be displayed inline, allowing it to wrap into multiple lines

### Before

<img width="500" alt="Bildschirmfoto 2024-03-25 um 12 40 09" src="https://github.com/opf/openproject/assets/7457313/f13fea57-9eb3-4ebd-a7c0-fa6e13724383">

### After
<img width="500" alt="Bildschirmfoto 2024-03-25 um 12 39 35" src="https://github.com/opf/openproject/assets/7457313/2bbf34fe-ea0e-4c84-aae0-a1a63ad8570f">


https://community.openproject.org/projects/openproject/work_packages/53644/activity