### PR TITLE
Do not expose updatedAt changing for admins in work packages

### DIFF
--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -31,7 +31,7 @@ require "work_packages/base_contract"
 module WorkPackages
   class CreateContract < BaseContract
     include AdminWritableTimestamps
-    allow_writable_timestamps
+    allow_writable_timestamps :created_at
 
     attribute :author_id,
               writable: -> { default_attributes_admin_writable? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2900,7 +2900,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   setting_apiv3_write_readonly_attributes: "Write access to read-only attributes"
   setting_apiv3_write_readonly_attributes_instructions_html: >
     If enabled, the API will allow administrators to write static read-only attributes during creation,
-    such as createdAt and updatedAt timestamps.
+    such as createdAt and author.
     <br/>
     <strong>Warning:</strong> This setting has a use-case for e.g., importing data, but allows
     administrators to impersonate the creation of items as other users. All creation requests are being

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -109,7 +109,7 @@ properties:
   updatedAt:
     type: string
     format: date-time
-    description: Time of the most recent change to the work package. Can be writable by admins with the `apiv3_write_readonly_attributes` setting enabled.
+    description: Time of the most recent change to the work package.
     readOnly: true
   _links:
     type: object

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe WorkPackages::CreateContract do
       let(:user) { build_stubbed(:admin) }
 
       it_behaves_like "can write", :created_at, 1.day.ago
-      it_behaves_like "can write", :updated_at, 1.day.ago
+      it_behaves_like "can not write", :updated_at, 1.day.ago
       it_behaves_like "can write", :author_id, 1234
     end
 

--- a/spec/services/work_packages/create_service_integration_spec.rb
+++ b/spec/services/work_packages/create_service_integration_spec.rb
@@ -231,25 +231,41 @@ RSpec.describe WorkPackages::CreateService, "integration", type: :model do
       shared_let(:other_user) { create(:user) }
 
       let(:created_at) { 11.days.ago }
-      let(:updated_at) { 10.days.ago }
 
       let(:attributes) do
         {
           subject: "child",
           project:,
           author: other_user,
-          created_at:,
-          updated_at:
+          created_at:
         }
       end
 
       context "when enabled", with_settings: { apiv3_write_readonly_attributes: true } do
-        it "updates the timestamps correctly" do
+        it "sets created_at accordingly" do
           expect(service_result)
             .to be_success
 
           expect(new_work_package.created_at).to be_within(1.second).of(created_at)
-          expect(new_work_package.updated_at).to be_within(1.second).of(updated_at)
+        end
+      end
+
+      context "when enabled, but disallowed field", with_settings: { apiv3_write_readonly_attributes: true } do
+        let(:attributes) do
+          {
+            subject: "child",
+            project:,
+            author: other_user,
+            updated_at: created_at
+          }
+        end
+
+        it "rejects updated_at" do
+          expect(service_result)
+            .not_to be_success
+
+          expect(new_work_package.errors.symbols_for(:updated_at))
+            .to contain_exactly(:error_readonly)
         end
       end
 
@@ -259,9 +275,6 @@ RSpec.describe WorkPackages::CreateService, "integration", type: :model do
             .not_to be_success
 
           expect(new_work_package.errors.symbols_for(:created_at))
-            .to contain_exactly(:error_readonly)
-
-          expect(new_work_package.errors.symbols_for(:updated_at))
             .to contain_exactly(:error_readonly)
         end
       end


### PR DESCRIPTION
The field may be updating due to external changes (causes, default values, rescheduling)

https://community.openproject.org/work_packages/53423