### PR TITLE
Fix summing of a integer grouped custom field

### DIFF
--- a/app/models/queries/work_packages/selects/work_package_select.rb
+++ b/app/models/queries/work_packages/selects/work_package_select.rb
@@ -48,6 +48,13 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
     new
   end
 
+  def self.select_group_by(group_by_statement)
+    group_by = group_by_statement
+    group_by = group_by.first if group_by.is_a?(Array)
+
+    "#{group_by} id"
+  end
+
   def self.scoped_column_sum(scope, select, group_by)
     scope = scope
               .except(:order, :select)
@@ -55,7 +62,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
     if group_by
       scope
         .group(group_by)
-        .select("#{group_by} id", select)
+        .select(select_group_by(group_by), select)
     else
       scope
         .select(select)

--- a/app/models/query/results/sums.rb
+++ b/app/models/query/results/sums.rb
@@ -107,13 +107,18 @@ module ::Query::Results::Sums
   end
 
   def sums_work_package_scope_selects(grouped)
-    select = if grouped
-               ["#{query.group_by_statement} id"]
-             else
-               []
-             end
+    group_statement =
+      if grouped
+        [Queries::WorkPackages::Selects::WorkPackageSelect.select_group_by(query.group_by_statement)]
+      else
+        []
+      end
 
-    select + query.summed_up_columns.filter_map(&:summable_work_packages_select).map { |c| "SUM(#{c}) #{c}" }
+    group_statement + summed_columns
+  end
+
+  def summed_columns
+    query.summed_up_columns.filter_map(&:summable_work_packages_select).map { |c| "SUM(#{c}) #{c}" }
   end
 
   def callable_summed_up_columns

--- a/spec/models/query/group_sums_custom_fields_spec.rb
+++ b/spec/models/query/group_sums_custom_fields_spec.rb
@@ -1,0 +1,101 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Query::Results, "Grouping and summing integer/float custom field (Regression #53609)" do
+  let(:query_results) do
+    Query::Results.new query
+  end
+  let(:user) do
+    create(:user,
+           firstname: "user",
+           lastname: "1",
+           member_with_permissions: { project => [:view_work_packages] })
+  end
+
+  let(:float_custom_field) do
+    create(:float_wp_custom_field, name: "MyFloat")
+  end
+  let(:int_custom_field) do
+    create(:integer_wp_custom_field, name: "MyInt")
+  end
+
+  let(:type) { create(:type_standard, custom_fields: [float_custom_field, int_custom_field]) }
+  let(:project) do
+    create(:project,
+           types: [type],
+           work_package_custom_fields: [float_custom_field, int_custom_field])
+  end
+  let(:wp1) do
+    create(:work_package,
+           type:,
+           project:,
+           custom_values: { float_custom_field.id => "6.25", int_custom_field.id => "6" })
+  end
+
+  let(:wp2) do
+    create(:work_package,
+           type:,
+           project:,
+           custom_values: { float_custom_field.id => "15.0", int_custom_field.id => "1" })
+  end
+
+  let(:query) do
+    build(:query,
+          user:,
+          show_hierarchies: false,
+          project:).tap do |q|
+      q.filters.clear
+      q.column_names = ["id", "subject", int_custom_field.column_name, float_custom_field.column_name]
+      q.group_by = int_custom_field.column_name
+      q.display_sums = true
+    end
+  end
+
+  let(:int_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == int_custom_field.column_name } }
+  let(:float_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == float_custom_field.column_name } }
+
+  before do
+    login_as(user)
+    wp1
+    wp2
+  end
+
+  it "returns the correctly grouped sums" do
+    expect(query_results.work_packages.pluck(:id))
+      .to contain_exactly(wp1.id, wp2.id)
+
+    expect(query_results.all_group_sums.keys).to contain_exactly(1, 6)
+    expect(query_results.all_group_sums[1][float_cf_column]).to eq 15.0
+    expect(query_results.all_group_sums[6][float_cf_column]).to eq 6.25
+
+    expect(query_results.all_total_sums[float_cf_column]).to eq 21.25
+    expect(query_results.all_total_sums[int_cf_column]).to eq 7
+  end
+end


### PR DESCRIPTION
The order statements for custom fields are returning arrays, but the `group_by_statement` in the query groups is simply referencing that as a string

https://community.openproject.org/work_packages/53609