### PR TITLE
forbidden links proof of concept

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -100,7 +100,10 @@ class MessagesController < ApplicationController
 
     if call.success?
       call_hook(:controller_messages_reply_after_save, params:, message: @reply)
+    else
+      flash[:error] = call.message
     end
+
     redirect_to topic_path(@topic, r: @reply)
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -28,6 +28,7 @@
 
 class Message < ApplicationRecord
   include OpenProject::Journal::AttachmentHelper
+  include Mixins::RestrictLinks
 
   belongs_to :forum
   has_one :project, through: :forum
@@ -127,6 +128,10 @@ class Message < ApplicationRecord
   end
 
   private
+
+  def restricted_attributes
+    [:content]
+  end
 
   def update_ancestors
     with_id = Message.where(id: root.id)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -40,6 +40,7 @@ class WorkPackage < ApplicationRecord
   include WorkPackages::Costs
   include WorkPackages::Relations
   include ::Scopes::Scoped
+  include Mixins::RestrictLinks
 
   include OpenProject::Journal::AttachmentHelper
 
@@ -520,6 +521,10 @@ class WorkPackage < ApplicationRecord
   end
 
   private
+
+  def restricted_attributes
+    %i(subject description)
+  end
 
   def add_time_entry_for(user, attributes)
     return if time_entry_blank?(attributes)

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -489,6 +489,16 @@ module Settings
         description: "Forced page size for manually sorted work package views",
         default: 250
       },
+      forum_allowed_link_hosts: {
+        description: "List of hosts allowed to link to in the forum. 'self' refers to OpenProject itself. * allows any host.",
+        format: :array,
+        default: [
+          "'self'",
+          "www.openproject.org",
+          "github.com",
+          "gitlab.com"
+        ]
+      },
       good_job_queues: {
         description: "",
         format: :string,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -790,6 +790,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
         exclusion: "is reserved."
         file_too_large: "is too large (maximum size is %{count} Bytes)."
         filter_does_not_exist: "filter does not exist."
+        forbidden_link: "contains a forbidden link"
         format: "does not match the expected format '%{expected}'."
         format_nested: "does not match the expected format '%{expected}' at path '%{path}'."
         greater_than: "must be greater than %{count}."

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -194,4 +194,21 @@ RSpec.describe MessagesController, with_settings: { journal_aggregation_time_min
       end
     end
   end
+
+  context "Setting.forum_allowed_link_hosts" do
+    describe '#create' do
+      before do
+        put :create, params: { message: { forum_id: forum.id, content: "hallo", author_id: user.id } }
+      end
+
+      it "works" do
+        binding.pry
+        expect(2).to eq 3
+      end
+    end
+
+    describe '#update' do
+
+    end
+  end
 end


### PR DESCRIPTION
This is a proof of concept for a suggested minimal fix that may reduce spam on public installations by preventing users from posting only whitelisted links in forum posts, news entry comments, work packages and work package comments. Custom field values should also be covered additionally but aren't implemented yet.

![image](https://github.com/opf/openproject/assets/158871/7d1bd30a-1538-4ee8-9262-288dd4b94287)
