### PR TITLE
valid_subset! for all queries

### DIFF
--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -9,7 +9,11 @@
             'action': 'filters#toggleDisplayFilters',
             'test-selector': 'filter-component-toggle' })) do %>
       <%= t(:label_filter) %>
-      <%= render(Primer::Beta::Counter.new(count: filters_count, round: true, hide_if_zero: false, scheme: :default)) %>
+      <%= render(Primer::Beta::Counter.new(count: filters_count,
+                                           round: true,
+                                           hide_if_zero: false,
+                                           scheme: :default,
+                                           data: { "test-selector": "filters-button-counter" })) %>
     <% end %>
     <div class="op-filters-header-actions">
       <% buttons.each do |button| %>

--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -13,7 +13,7 @@
                                            round: true,
                                            hide_if_zero: false,
                                            scheme: :default,
-                                           data: { "test-selector": "filters-button-counter" })) %>
+                                           test_selector: "filters-button-counter" )) %>
     <% end %>
     <div class="op-filters-header-actions">
       <% buttons.each do |button| %>

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -34,6 +34,7 @@ module Queries::BaseQuery
     include Queries::Selects::AvailableSelects
     include Queries::Orders::AvailableOrders
     include Queries::GroupBys::AvailableGroupBys
+    include Queries::ValidSubset
     include ActiveModel::Validations
 
     validate :filters_valid,

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -62,6 +62,10 @@ module Queries
         attribute
       end
 
+      def available?
+        true
+      end
+
       private
 
       def order

--- a/app/models/queries/orders/not_existing_order.rb
+++ b/app/models/queries/orders/not_existing_order.rb
@@ -35,6 +35,10 @@ module Queries
         :inexistent
       end
 
+      def available?
+        false
+      end
+
       private
 
       def always_false

--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -36,7 +36,10 @@ class Queries::Projects::Factory
 
   class << self
     def find(id, params:, user:)
-      find_and_update_static_query(id, params, user) || find_and_update_persisted_query(id, params, user)
+      query = find_and_update_static_query(id, params, user) || find_and_update_persisted_query(id, params, user)
+      query&.valid_subset!
+
+      query
     end
 
     def static_query(id)

--- a/app/models/queries/projects/filters/created_at_filter.rb
+++ b/app/models/queries/projects/filters/created_at_filter.rb
@@ -30,4 +30,10 @@ class Queries::Projects::Filters::CreatedAtFilter < Queries::Projects::Filters::
   def type
     :datetime_past
   end
+
+  def available?
+    # The column is only available for admins.
+    # When the filter is used, one could get the same information as with the column.
+    User.current.admin?
+  end
 end

--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -54,7 +54,7 @@ module Queries
 
         def type_strategy
           # Instead of getting the IDs of all the projects a user is allowed
-          # to see we only check that the value is an integer.  Non valid ids
+          # to see we only check that the value is an integer. Non valid ids
           # will then simply create an empty result but will not cause any
           # harm.
           @type_strategy ||= ::Queries::Filters::Strategies::IntegerList.new(self)

--- a/app/models/queries/projects/orders/custom_field_order.rb
+++ b/app/models/queries/projects/orders/custom_field_order.rb
@@ -47,6 +47,10 @@ class Queries::Projects::Orders::CustomFieldOrder < Queries::Orders::Base
     super.select(custom_field.order_statements)
   end
 
+  def available?
+    custom_field.present?
+  end
+
   private
 
   def order

--- a/app/models/queries/selects/not_existing_select.rb
+++ b/app/models/queries/selects/not_existing_select.rb
@@ -39,6 +39,10 @@ module Queries
         I18n.t("activerecord.errors.messages.does_not_exist")
       end
 
+      def available?
+        false
+      end
+
       private
 
       def always_false

--- a/app/models/queries/valid_subset.rb
+++ b/app/models/queries/valid_subset.rb
@@ -33,6 +33,7 @@ module Queries
     def valid_subset!
       valid_filters_subset!
       valid_selects_subset!
+      valid_orders_subset!
     end
 
     private
@@ -45,6 +46,10 @@ module Queries
 
     def valid_selects_subset!
       selects.select!(&:available?)
+    end
+
+    def valid_orders_subset!
+      orders.select!(&:available?)
     end
   end
 end

--- a/app/models/queries/valid_subset.rb
+++ b/app/models/queries/valid_subset.rb
@@ -1,6 +1,6 @@
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,42 +24,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-require "spec_helper"
+module Queries
+  module ValidSubset
+    extend ActiveSupport::Concern
 
-RSpec.describe Queries::Projects::Filters::CreatedAtFilter do
-  it_behaves_like "basic query filter" do
-    let(:class_key) { :created_at }
-    let(:type) { :datetime_past }
-    let(:model) { Project }
-    let(:attribute) { :created_at }
-    let(:values) { ["3"] }
-    let(:admin) { build_stubbed(:admin) }
-    let(:user) { build_stubbed(:user) }
+    def valid_subset!
+      valid_filters_subset!
+      valid_selects_subset!
+    end
 
-    describe "#available?" do
-      context "for an admin" do
-        before do
-          login_as admin
-        end
+    private
 
-        it "is true" do
-          expect(instance)
-            .to be_available
-        end
+    def valid_filters_subset!
+      filters.each(&:valid_values!).select! do |filter|
+        filter.available? && filter.valid?
       end
+    end
 
-      context "for non admin" do
-        before do
-          login_as user
-        end
-
-        it "is false" do
-          expect(instance)
-            .not_to be_available
-        end
-      end
+    def valid_selects_subset!
+      selects.select!(&:available?)
     end
   end
 end

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
               direction: "desc"
             }
           ],
-          selects: %w[created_at name]
+          selects: %w[description name]
         }
       end
 
@@ -364,7 +364,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
 
       it "has the selects" do
         expect(find.selects.map(&:attribute))
-          .to eq(%i[created_at name])
+          .to eq(%i[description name])
       end
     end
 
@@ -460,7 +460,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
       let(:id) { nil }
       let(:params) do
         {
-          selects: %w[created_at project_status]
+          selects: %w[description project_status]
         }
       end
 
@@ -486,7 +486,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
 
       it "has the selects overwritten" do
         expect(find.selects.map(&:attribute))
-          .to eq(%i[created_at project_status])
+          .to eq(%i[description project_status])
       end
     end
 
@@ -582,7 +582,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
       let(:id) { 42 }
       let(:params) do
         {
-          selects: %w[created_at project_status]
+          selects: %w[description project_status]
         }
       end
 
@@ -608,7 +608,7 @@ RSpec.describe Queries::Projects::Factory, with_settings: { enabled_projects_col
 
       it "has the selects specified by the params" do
         expect(find.selects.map(&:attribute))
-          .to eq(%i[created_at project_status])
+          .to eq(%i[description project_status])
       end
     end
 

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -149,4 +149,179 @@ RSpec.describe Queries::Projects::ProjectQuery do
       # rubocop:enable Naming/VariableNumber
     end
   end
+
+  describe "#valid_subset!" do
+    context "with filters" do
+      let(:valid_project_ids) do
+        project_scope = instance_double(ActiveRecord::Relation)
+
+        allow(Project)
+          .to receive(:visible)
+                .and_return(project_scope)
+
+        allow(project_scope)
+          .to receive(:pluck)
+                .with(:id)
+                .and_return([1, 2, 3])
+
+        [1, 2, 3]
+      end
+
+      context "with them being valid" do
+        current_user { admin }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("member_of", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("created_at", ">t-", ["6"])
+
+          instance.valid_subset!
+        end
+
+        it "leaves the values untouched" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]], [:member_of, "=", ["t"]], [:created_at, ">t-", ["6"]]])
+        end
+      end
+
+      context "with one of them being invalid as it is a made up filter name" do
+        current_user { user }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("bogus", ">t-", ["6"])
+
+          instance.valid_subset!
+        end
+
+        it "leaves only the valid filters" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]]])
+        end
+      end
+
+      context "with one of them being invalid as it is admin only" do
+        current_user { user }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("created_at", ">t-", ["6"])
+
+          instance.valid_subset!
+        end
+
+        it "leaves only the valid filters" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]]])
+        end
+      end
+
+      context "with one of them being invalid as it has one invalid value" do
+        current_user { user }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("parent_id", "=", valid_project_ids.map(&:to_s) + %w[42])
+
+          instance.valid_subset!
+        end
+
+        it "keeps the invalid filter but removes the invalid value" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]], [:parent_id, "=", valid_project_ids.map(&:to_s)]])
+        end
+      end
+
+      context "with one of them being invalid as it has only invalid values" do
+        current_user { user }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          valid_project_ids
+          instance.where("parent_id", "=", %w[23 42])
+
+          instance.valid_subset!
+        end
+
+        it "keeps only the valid filters" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]]])
+        end
+      end
+
+      context "with one of them being invalid as it has an invalid operator" do
+        current_user { user }
+
+        before do
+          instance.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("parent_id", "d=", valid_project_ids.map(&:to_s))
+
+          instance.valid_subset!
+        end
+
+        it "keeps only the valid filters" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to eq([[:active, "=", ["t"]]])
+        end
+      end
+
+      context "with all of them being invalid" do
+        current_user { user }
+
+        before do
+          instance.where("created_at", "=", OpenProject::Database::DB_VALUE_TRUE)
+          instance.where("parent_id", "d=", valid_project_ids.map(&:to_s))
+
+          instance.valid_subset!
+        end
+
+        it "keeps only the valid filters" do
+          expect(instance.filters.map { |filter| [filter.field, filter.operator, filter.values] })
+            .to be_empty
+        end
+      end
+    end
+
+    context "with selects" do
+      let(:current_user) { user }
+
+      current_user { user }
+
+      before do
+        instance.select(*columns)
+
+        instance.valid_subset!
+      end
+
+      context "with them being valid" do
+        let(:current_user) { admin }
+        let(:columns) { %i(name description created_at) }
+
+        it "leaves the values untouched" do
+          expect(instance.selects.map(&:attribute))
+            .to eq columns
+        end
+      end
+
+      context "with them being invalid" do
+        # No admin, hence no created_at column. CF column does not exist.
+        let(:columns) { %i(bogus created_at cf_1) } # rubocop:disable Naming/VariableNumber
+
+        it "removes the values" do
+          expect(instance.selects.map(&:attribute))
+            .to be_empty
+        end
+      end
+
+      context "with them being partially invalid" do
+        let(:current_user) { admin }
+        let(:columns) { %i(bogus name created_at cf_1 description) } # rubocop:disable Naming/VariableNumber
+
+        it "removes only the offending values" do
+          expect(instance.selects.map(&:attribute))
+            .to eq %i(name created_at description)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -120,6 +120,11 @@ module Pages
                                  visible: :hidden)
       end
 
+      def expect_filter_count(count)
+        expect(page)
+          .to have_css('[data-test-selector="filters-button-counter"]', text: count)
+      end
+
       def expect_no_project_create_button
         expect(page).to have_no_css('[data-test-selector="project-new-button"]')
       end


### PR DESCRIPTION
Employs the `valid_subset!` functionality previously only present on the (WorkPackage) `Query` to the rest of the queries as well. Currently it is then only called for project queries and only when calling via the UI. The API is excluded.

It also changes the behaviour of the `created_at` filter in that is only available to admins. The `created_at` column is protected likewise and using the filter, a non admin could easily deduce the value.

## Todos

* [x] Feature spec for reduction of filters
* [x] Add valid_subset! to queries for
  * [x] removal of selects
  * [x] removal of filters
  * [x] removal of orders
* [x] Call `valid_subset!` in factory so that only valid queries are returned
  * [x] Write specs for factory   

----

https://community.openproject.org/wp/53585