### PR TITLE
Also show time of updated on in Admin

### DIFF
--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -69,7 +69,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 
   if (updated_on = OpenProject::VERSION.updated_on).present?
-    component.with_attribute(key: t(:label_last_change_on), value: format_date(updated_on))
+    component.with_attribute(key: t(:label_last_change_on), value: format_time(updated_on))
   end
 end %>
 

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -108,15 +108,15 @@ module OpenProject
           path = Rails.root.join("RELEASE_DATE")
           if File.exist? path
             s = File.read(path)
-            Date.parse(s)
+            Time.zone.parse(s)
           end
         end
       end
 
       def release_date_from_git
         cached_or_block(:@release_date_from_git) do
-          date, = Open3.capture3("git", "log", "-1", "--format=%cd", "--date=short")
-          Date.parse(date) if date
+          date, = Open3.capture3("git", "log", "-1", "--format=%cd", "--date=iso8601")
+          Time.zone.parse(date) if date
         end
       end
 


### PR DESCRIPTION
The administration doesn't show the updated_on timestamp with time, even though we have that information in the RELEASE_DATE file