### PR TITLE
[#53577] Use sidebar_enabled method on the overview page instead of project meta tags

### DIFF
--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -10,8 +10,7 @@
   <meta name="current_project"
         data-project-name="<%= h @project.name %>"
         data-project-id="<%= @project.id %>"
-        data-project-identifier="<%= @project.identifier %>"
-        data-project-custom-fields-count="<%= @project.project_custom_fields.visible.count %>"/>
+        data-project-identifier="<%= @project.identifier %>"/>
 <% end %>
 <meta name="current_user"
       data-name="<%= User.current.name %>"

--- a/frontend/src/app/core/current-project/current-project.service.ts
+++ b/frontend/src/app/core/current-project/current-project.service.ts
@@ -32,7 +32,7 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 
 @Injectable({ providedIn: 'root' })
 export class CurrentProjectService {
-  private current:{ id:string, identifier:string, name:string, customFieldsCount:string };
+  private current:{ id:string, identifier:string, name:string };
 
   constructor(
     private PathHelper:PathHelperService,
@@ -73,11 +73,7 @@ export class CurrentProjectService {
     return this.getCurrent('identifier');
   }
 
-  public get customFieldsCount():string|null {
-    return this.getCurrent('customFieldsCount');
-  }
-
-  private getCurrent(key:'id'|'identifier'|'name'|'customFieldsCount') {
+  private getCurrent(key:'id'|'identifier'|'name') {
     if (this.current && this.current[key]) {
       return this.current[key].toString();
     }
@@ -95,7 +91,6 @@ export class CurrentProjectService {
         id: element.dataset.projectId!,
         name: element.dataset.projectName!,
         identifier: element.dataset.projectIdentifier!,
-        customFieldsCount: element.dataset.projectCustomFieldsCount!,
       };
     }
   }

--- a/frontend/src/app/features/overview/overview.component.ts
+++ b/frontend/src/app/features/overview/overview.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { GridPageComponent } from 'core-app/shared/components/grids/grid/page/grid-page.component';
 import { GRID_PROVIDERS } from 'core-app/shared/components/grids/grid/grid.component';
 
 @Component({
   selector: 'overview',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: '../../shared/components/grids/grid/page/grid-page.component.html',
   styleUrls: ['../../shared/components/grids/grid/page/grid-page.component.sass'],
   providers: GRID_PROVIDERS,
@@ -14,7 +15,8 @@ export class OverviewComponent extends GridPageComponent {
   }
 
   protected isTurboFrameSidebarEnabled():boolean {
-    return this.currentProject.customFieldsCount !== '0';
+    const sidebarEnabledTag:HTMLMetaElement|null = document.querySelector('meta[name="sidebar_enabled"]');
+    return sidebarEnabledTag?.dataset.enabled === 'true';
   }
 
   protected turboFrameSidebarSrc():string {

--- a/modules/overviews/app/controllers/overviews/overviews_controller.rb
+++ b/modules/overviews/app/controllers/overviews/overviews_controller.rb
@@ -2,8 +2,8 @@ module ::Overviews
   class OverviewsController < ::Grids::BaseInProjectController
     include OpTurbo::ComponentStream
 
-    before_action :authorize
     before_action :jump_to_project_menu_item
+    before_action :set_sidebar_enabled
 
     menu_item :overview
 
@@ -55,6 +55,10 @@ module ::Overviews
 
     def find_project_custom_field_section
       ProjectCustomFieldSection.find(params[:section_id])
+    end
+
+    def set_sidebar_enabled
+      @sidebar_enabled = @project.project_custom_fields.visible.any?
     end
 
     def handle_errors(project_with_errors, section)

--- a/modules/overviews/app/views/overviews/overviews/show.html.erb
+++ b/modules/overviews/app/views/overviews/overviews/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for :header_tags do %>
+  <meta name="sidebar_enabled" data-enabled="<%= @sidebar_enabled %>">
+<% end -%>

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -96,11 +96,14 @@ RSpec.describe "Overview page managing", :js do
 
     # within top-left area, add an additional widget
     overview_page.add_widget(1, 1, :row, "Work packages table")
-
     # Actually there are two success messages displayed currently. One for the grid getting updated and one
     # for the query assigned to the new widget being created. A user will not notice it but the automated
-    # browser can get confused. Therefore we wait.
-    sleep(1)
+    # browser can get confused. Therefore we dismiss it twice.
+    overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+
+    # Fixing flaky spec: for some reason, the second request to load the table is not executed until
+    # some activity happens on the page. Sending an enter key to trigger the second request.
+    page.find("body").send_keys(:enter)
 
     overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
 

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -75,6 +75,7 @@ module Components
       end
 
       def expect_to_span(startRow, startColumn, endRow, endColumn)
+        expect_to_exist
         [["grid-row-start", startRow * 2],
          ["grid-column-start", startColumn * 2],
          ["grid-row-end", (endRow * 2) - 1],


### PR DESCRIPTION
https://community.openproject.org/work_packages/53577

Based on the comment https://github.com/opf/openproject/pull/15111#issuecomment-2019428730

Optimize the logic to not introduce an extra query for all the project related pages when calculating whether the Overview page sidebar should be enabled or not.