### PR TITLE
don't assign reviewer, as assigning a team requires a PAT

### DIFF
--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -88,8 +88,7 @@ jobs:
                 --head "$RELEASE_BRANCH" \
                 --title "Merge $RELEASE_BRANCH into $BASE_BRANCH" \
                 --body 'Created by GitHub action' \
-                --label create-merge-release-into-dev-pr \
-                --reviewer opf/backend
+                --label create-merge-release-into-dev-pr
               echo "Created a PR to merge $RELEASE_BRANCH into $BASE_BRANCH"
             fi
           fi


### PR DESCRIPTION
Managing (updating) a Personal Access Token seem to much for the little benefit of possibly ignored notifications for review and assigning reviewers individually goes against the idea of making merging releases into dev a team responsibility.