### PR TITLE
Create a temp branch and don't assign reviewer for automatic PR

### DIFF
--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -83,13 +83,19 @@ jobs:
                 gh pr close "$pr_number"
               done
 
+              TEMP_BRANCH="$RELEASE_BRANCH-$(date "+%Y%m%d%H%M%S")"
+
+              git branch "$TEMP_BRANCH" "$RELEASE_BRANCH"
+
+              git push origin "$TEMP_BRANCH"
+
               gh pr create \
                 --base "$BASE_BRANCH" \
-                --head "$RELEASE_BRANCH" \
+                --head "$TEMP_BRANCH" \
                 --title "Merge $RELEASE_BRANCH into $BASE_BRANCH" \
                 --body 'Created by GitHub action' \
                 --label create-merge-release-into-dev-pr
-              echo "Created a PR to merge $RELEASE_BRANCH into $BASE_BRANCH"
+              echo "Created a PR to merge $RELEASE_BRANCH ($TEMP_BRANCH) into $BASE_BRANCH"
             fi
           fi
         env:

--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -88,8 +88,7 @@ jobs:
                 --head "$RELEASE_BRANCH" \
                 --title "Merge $RELEASE_BRANCH into $BASE_BRANCH" \
                 --body 'Created by GitHub action' \
-                --label create-merge-release-into-dev-pr \
-                --reviewer opf/backend
+                --label create-merge-release-into-dev-pr
               echo "Created a PR to merge $RELEASE_BRANCH into $BASE_BRANCH"
             fi
           fi


### PR DESCRIPTION
As PR is created only for conflict resolution, a branch to which dev can be merged is needed and it can't be release branch itself. If using release branch, interface can (but didn't in all my test PRs) suggest to create a new branch, but defaults to committing to release branch.

Managing (updating) a Personal Access Token seem to much for the little benefit of possibly ignored notifications for review and assigning reviewers individually goes against the idea of making merging releases into dev a team responsibility.
