### PR TITLE
Fix css typo

### DIFF
--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.sass
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.sass
@@ -39,5 +39,5 @@
     gap: 0
 
   .op-grid-page--sidebar
-    diplay: none
+    display: none
 


### PR DESCRIPTION
Tried to compile the css and this was shown as warning. I think this was a typo here: https://github.com/opf/openproject/commit/e1c9266eaeb26655c9f23d885e24e7ef54dbe66d