### PR TITLE
[fix] remove caching httpx sessions for reuse

### DIFF
--- a/lib/open_project.rb
+++ b/lib/open_project.rb
@@ -26,17 +26,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'redmine/menu_manager'
-require 'redmine/search'
-require 'open_project/custom_field_format'
-require 'open_project/logging'
-require 'open_project/patches'
-require 'open_project/mime_type'
-require 'open_project/custom_styles/design'
-require 'open_project/httpx_appsignal'
-require 'redmine/plugin'
+require "redmine/menu_manager"
+require "redmine/search"
+require "open_project/custom_field_format"
+require "open_project/logging"
+require "open_project/patches"
+require "open_project/mime_type"
+require "open_project/custom_styles/design"
+require "open_project/httpx_appsignal"
+require "redmine/plugin"
 
-require 'csv'
+require "csv"
 
 module OpenProject
   ##
@@ -47,25 +47,20 @@ module OpenProject
   end
 
   def self.httpx
-    # It is essential to reuse HTTPX session if persistent connections are enabled.
-    # Otherwise for every request there will be a new connections.
-    # And old connections will not be closed properly which could lead to EMFILE error.
-    Thread.current[:httpx_session] ||= begin
-      session = HTTPX
-        .plugin(:oauth)
-        .plugin(:basic_auth)
-        .plugin(:webdav)
-        .with(
-          timeout: {
-            connect_timeout: OpenProject::Configuration.httpx_connect_timeout,
-            operation_timeout: OpenProject::Configuration.httpx_operation_timeout,
-            request_timeout: OpenProject::Configuration.httpx_request_timeout,
-            write_timeout: OpenProject::Configuration.httpx_write_timeout,
-            read_timeout: OpenProject::Configuration.httpx_read_timeout,
-            keep_alive_timeout: OpenProject::Configuration.httpx_keep_alive_timeout
-          }
-        )
-      OpenProject::Appsignal.enabled? ? session.plugin(HttpxAppsignal) : session
-    end
+    session = HTTPX
+                .plugin(:oauth)
+                .plugin(:basic_auth)
+                .plugin(:webdav)
+                .with(
+                  timeout: {
+                    connect_timeout: OpenProject::Configuration.httpx_connect_timeout,
+                    operation_timeout: OpenProject::Configuration.httpx_operation_timeout,
+                    request_timeout: OpenProject::Configuration.httpx_request_timeout,
+                    write_timeout: OpenProject::Configuration.httpx_write_timeout,
+                    read_timeout: OpenProject::Configuration.httpx_read_timeout,
+                    keep_alive_timeout: OpenProject::Configuration.httpx_keep_alive_timeout
+                  }
+                )
+    OpenProject::Appsignal.enabled? ? session.plugin(HttpxAppsignal) : session
   end
 end


### PR DESCRIPTION
### Reasoning

- reused session caused under certain circumstances http requests to fail
- reusing sessions was mandatory for persistent connections, but those are not used anymore

### Example test execution:

- run on `dev` before this fix:

```
rspec './modules/storages/spec/common/storages/peripherals/registry_spec.rb[1:2:1]' './modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb[1:4:1]' --seed 8189
```