### PR TITLE
remove forgotten check for push event from pullpreview workflow

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write # to remove labels
       statuses: write # to create commit status
 
-    if: github.repository == 'opf/openproject' && ( github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview') )
+    if: github.repository == 'opf/openproject' && ( github.event_name == 'schedule' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview') )
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Pullpreview is not triggered for push events since #9109