### PR TITLE
Tie work and remaining work together

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -360,18 +360,16 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     work && remaining_work && remaining_work > work
   end
 
-  # rubocop:disable Metrics/AbcSize
   def update_estimated_hours
     return unless WorkPackage.use_field_for_done_ratio?
     return if work_package.estimated_hours_changed?
     return if work_package.estimated_hours.present?
     return unless work_package.remaining_hours_changed?
 
-    if work_package.remaining_hours.present? && work_package.done_ratio.present?
+    if work_package.remaining_hours.present?
       work_package.estimated_hours = estimated_hours_from_done_ratio_and_remaining_hours
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   # When in "Status-based" mode for % Complete, remaining hours are based
   # on the computation of it derived from the status's default done ratio
@@ -397,7 +395,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   # rubocop:enable Metrics/AbcSize,Metrics/PerceivedComplexity
 
   def estimated_hours_from_done_ratio_and_remaining_hours
-    remaining_ratio = 1.0 - (work_package.done_ratio / 100.0)
+    remaining_ratio = 1.0 - ((work_package.done_ratio || 0) / 100.0)
     work_package.remaining_hours / remaining_ratio
   end
 

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -403,7 +403,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     return nil if work_package.done_ratio.nil? || work_package.estimated_hours.nil?
 
     completed_work = work_package.estimated_hours * work_package.done_ratio / 100.0
-    work_package.estimated_hours - completed_work
+    (work_package.estimated_hours - completed_work).round(2)
   end
 
   def set_version_to_nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1024,10 +1024,12 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
               only_same_project_categories_allowed: "The category of a work package must be within the same project as the work package."
               does_not_exist: "The specified category does not exist."
             estimated_hours:
+              cant_be_inferior_to_remaining_work: "can't be inferior to 'Remaining work'."
+              must_be_set_when_remaining_work_is_set: "must be set when 'Remaining work' is set."
               only_values_greater_or_equal_zeroes_allowed: "must be >= 0."
-              cant_be_inferior_to_remaining_work: "can't be inferior to 'Remaining work'"
             remaining_hours:
-              cant_exceed_work: "can't exceed 'Work'"
+              cant_exceed_work: "can't exceed 'Work'."
+              must_be_set_when_work_is_set: "must be set when 'Work' is set."
           readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
         type:
           attributes:

--- a/db/migrate/20240328154805_change_status_default_done_ratio_to_zero.rb
+++ b/db/migrate/20240328154805_change_status_default_done_ratio_to_zero.rb
@@ -1,0 +1,11 @@
+class ChangeStatusDefaultDoneRatioToZero < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :statuses, :default_done_ratio, from: nil, to: 0
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE statuses SET default_done_ratio = 0 WHERE default_done_ratio IS NULL"
+      end
+    end
+    change_column_null :statuses, :default_done_ratio, false
+  end
+end

--- a/modules/backlogs/spec/api/work_package_resource_spec.rb
+++ b/modules/backlogs/spec/api/work_package_resource_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "API v3 Work package resource" do
     create(:work_package,
            project:,
            story_points: 8,
+           estimated_hours: 5,
            remaining_hours: 5)
   end
   let(:wp_path) { "/api/v3/work_packages/#{work_package.id}" }

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -466,6 +466,13 @@ RSpec.describe WorkPackages::SetAttributesService,
 
           it_behaves_like "service call", description: "remaining work is set to the same value and % complete is set to 0%"
         end
+
+        context "when remaining work is set" do
+          let(:call_attributes) { { remaining_hours: 10.0 } }
+          let(:expected_attributes) { { estimated_hours: 10.0, done_ratio: 0 } }
+
+          it_behaves_like "service call", description: "work is set to the same value and % complete is set to 0%"
+        end
       end
     end
   end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -246,8 +246,8 @@ RSpec.describe WorkPackages::SetAttributesService,
       context "given a work package with work, remaining work, and % complete being set" do
         before do
           work_package.estimated_hours = 10.0
-          work_package.remaining_hours = 6.0
-          work_package.done_ratio = 40
+          work_package.remaining_hours = 3.0
+          work_package.done_ratio = 70
           work_package.send(:clear_changes_information)
         end
 
@@ -276,7 +276,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           # work changed by +10h
           let(:call_attributes) { { estimated_hours: 10.0 + 10.0 } }
           let(:expected_attributes) do
-            { remaining_hours: 6.0 + 10.0, done_ratio: 20 }
+            { remaining_hours: 3.0 + 10.0, done_ratio: 35 }
           end
 
           it_behaves_like "service call",
@@ -287,7 +287,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           # work changed by -2h
           let(:call_attributes) { { estimated_hours: 10.0 - 2.0 } }
           let(:expected_attributes) do
-            { remaining_hours: 6.0 - 2.0, done_ratio: 50 }
+            { remaining_hours: 3.0 - 2.0, done_ratio: 87 }
           end
 
           it_behaves_like "service call",
@@ -339,6 +339,14 @@ RSpec.describe WorkPackages::SetAttributesService,
           let(:expected_attributes) { call_attributes.merge(done_ratio: 90) }
 
           it_behaves_like "service call", description: "updates % complete accordingly"
+        end
+
+        context "when work is changed and remaining work is unset" do
+          let(:call_attributes) { { estimated_hours: 8.0, remaining_hours: nil } }
+          let(:expected_attributes) { { remaining_hours: 2.4 } } # would be 2.4000000000000004 without rounding
+          let(:expected_kept_attributes) { %w[done_ratio] }
+
+          it_behaves_like "service call", description: "% complete is kept and remaining work is recomputed (and rounded)"
         end
       end
 


### PR DESCRIPTION
Having work being unset while remaining work is set, or having remaining work unset while work is set is problematic: as they are summed in the parent work packages, an unset value is like being "0 h", and it leads to a wrong or surprising total % complete.

The adopted solution is to avoid having Remaining work being unset when Work is set:
* in status-based mode statuses with unset default % complete value would lead to remaining work being unset while work is set
  * => so we change it so that all statuses have a default % complete (0 by default)
* in work based mode, when all fields are set, it's possible to unset Remaining work only, leading to the issue described above
  * => so we raise an error in the work package contract each time the remaining work is unset while the work is set.

See https://community.openproject.org/wp/40749 for full details

**Problems**

* in backlogs module, the tasks creation/update modal has a "remaining work" field
  * => trying solution: when work is unset and remaining work is being set, then set work field with same value as remaining work, and set % complete to 0%.