### PR TITLE
Add /api/v3/meetings index action

### DIFF
--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -32,7 +32,7 @@
         data-action="filters#toggleDisplayFilters"></a>
       <legend><%= t(:label_filter_plural) %></legend>
       <ul class="advanced-filters--filters">
-        <% each_filter do |filter, filter_active| %>
+        <% each_filter do |filter, filter_active, additional_options| %>
           <% filter_boolean = filter.is_a?(Queries::Filters::Shared::BooleanFilter) %>
 
           <li class="advanced-filters--filter <%= filter_active ? '' : 'hidden' %>"

--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -34,6 +34,7 @@
       <ul class="advanced-filters--filters">
         <% each_filter do |filter, filter_active, additional_options| %>
           <% filter_boolean = filter.is_a?(Queries::Filters::Shared::BooleanFilter) %>
+          <% autocomplete_filter = additional_options.key?(:autocomplete_options) %>
 
           <li class="advanced-filters--filter <%= filter_active ? '' : 'hidden' %>"
               filter-name="<%= filter.name %>"
@@ -59,7 +60,12 @@
                             } %>
             <% end %>
             <% value_visibility = operators_without_values.include?(selected_operator) ? 'hidden' : '' %>
-            <% if filter_boolean %>
+            <% if autocomplete_filter %>
+              <%= render partial: 'filters/autocomplete',
+                        locals: { value_visibility: value_visibility,
+                                  filter: filter,
+                                  autocomplete_options: additional_options[:autocomplete_options] } %>
+            <% elsif filter_boolean %>
               <%= render partial: 'filters/boolean',
                         locals: { value_visibility: value_visibility,
                                   filter: filter } %>

--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -1,5 +1,6 @@
 <div data-controller="filters"
      data-application-target="dynamic"
+     data-filters-output-format-value="<%= output_format %>"
      data-filters-display-filters-value="<%= show_filters_section? %>">
 
   <div class="op-filters-header">

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -30,6 +30,7 @@
 
 class FiltersComponent < ApplicationComponent
   options :query
+  options output_format: "params"
 
   renders_many :buttons, lambda { |**system_arguments|
     system_arguments[:ml] ||= 2

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -44,15 +44,9 @@ class FiltersComponent < ApplicationComponent
   # Returns filters, active and inactive.
   # In case a filter is active, the active one will be preferred over the inactive one.
   def each_filter
-    allowed_filters.map do |filter|
+    allowed_filters.each do |filter|
       active_filter = query.find_active_filter(filter.name)
-      filter_active = active_filter.present?
-
-      if filter_active
-        yield active_filter, filter_active
-      else
-        yield filter, filter_active
-      end
+      yield active_filter.presence || filter, active_filter.present?
     end
   end
 

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -69,6 +69,7 @@ class FiltersComponent < ApplicationComponent
       {
         autocomplete_options: {
           component: "opce-project-autocompleter",
+          resource: "projects",
           filters: [
             { name: "active", operator: "=", values: ["t"] }
           ]

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -58,7 +58,11 @@ class FiltersComponent < ApplicationComponent
   end
 
   def filters_count
-    query.filters.count
+    @filters_count ||= query
+                          .filters
+                          .map(&:class)
+                          .uniq
+                          .count
   end
 
   protected

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -63,7 +63,19 @@ class FiltersComponent < ApplicationComponent
 
   protected
 
-  def additional_filter_attributes(_filter)
-    {}
+  def additional_filter_attributes(filter)
+    case filter
+    when Queries::Filters::Shared::ProjectFilter
+      {
+        autocomplete_options: {
+          component: "opce-project-autocompleter",
+          filters: [
+            { name: "active", operator: "=", values: ["t"] }
+          ]
+        }
+      }
+    else
+      {}
+    end
   end
 end

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -63,6 +63,13 @@ class FiltersComponent < ApplicationComponent
 
   protected
 
+  # With this method we can pass additional options for each type of filter into the frontend. This is especially
+  # useful when we want to pass options for the autocompleter components.
+  #
+  # When the method is overwritten in a subclass, the subclass should call super(filter) to get the default attributes.
+  #
+  # @param filter [QueryFilter] the filter for which we want to pass additional attributes
+  # @return [Hash] the additional attributes for the filter, that will be yielded in the each_filter method
   def additional_filter_attributes(filter)
     case filter
     when Queries::Filters::Shared::ProjectFilter

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -46,7 +46,9 @@ class FiltersComponent < ApplicationComponent
   def each_filter
     allowed_filters.each do |filter|
       active_filter = query.find_active_filter(filter.name)
-      yield active_filter.presence || filter, active_filter.present?
+      additional_attributes = additional_filter_attributes(filter)
+
+      yield active_filter.presence || filter, active_filter.present?, additional_attributes
     end
   end
 
@@ -57,5 +59,11 @@ class FiltersComponent < ApplicationComponent
 
   def filters_count
     query.filters.count
+  end
+
+  protected
+
+  def additional_filter_attributes(_filter)
+    {}
   end
 end

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -57,7 +57,7 @@ class Queries::Filters::Base
   # Treat the constructor as private, as the filter MAY need to check
   # the options before accepting them as a filter.
   #
-  # Use +#create+ instead.
+  # Use +#create!+ instead.
   private_class_method :new
 
   ##

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -1,0 +1,20 @@
+<label class="advanced-filters--filter-value">
+<%= angular_component_tag autocomplete_options[:component],
+                          inputs: {
+                            filters: autocomplete_options[:filters],
+                            inputName: 'value'
+                          },
+                          class: 'form--field',
+                          data: {
+                            'filters-target': 'filterValueContainer',
+                            'filter-name': filter.name
+
+                          }
+%>
+
+</label>
+<div class="advanced-filters--filter-operator" style="visibility: hidden"></div>
+
+
+
+

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -3,7 +3,8 @@
                             inputs: {
                               inputName: 'value',
                               multiple: true,
-                              multipleAsSeparateInputs: false
+                              multipleAsSeparateInputs: false,
+                              inputValue: filter.values
                             }.merge(autocomplete_options.except(:component)),
                             class: 'form--field',
                             data: {

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -1,11 +1,10 @@
 <div class="advanced-filters--filter-value <%= value_visibility %>">
   <%= angular_component_tag autocomplete_options[:component],
                             inputs: {
-                              filters: autocomplete_options[:filters],
                               inputName: 'value',
                               multiple: true,
                               multipleAsSeparateInputs: false
-                            },
+                            }.merge(autocomplete_options.except(:component)),
                             class: 'form--field',
                             data: {
                               'filter-autocomplete': true,

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -1,20 +1,16 @@
-<label class="advanced-filters--filter-value">
-<%= angular_component_tag autocomplete_options[:component],
-                          inputs: {
-                            filters: autocomplete_options[:filters],
-                            inputName: 'value'
-                          },
-                          class: 'form--field',
-                          data: {
-                            'filters-target': 'filterValueContainer',
-                            'filter-name': filter.name
-
-                          }
-%>
-
-</label>
-<div class="advanced-filters--filter-operator" style="visibility: hidden"></div>
-
-
-
-
+<div class="advanced-filters--filter-value <%= value_visibility %>">
+  <%= angular_component_tag autocomplete_options[:component],
+                            inputs: {
+                              filters: autocomplete_options[:filters],
+                              inputName: 'value',
+                              multiple: true,
+                              multipleAsSeparateInputs: false
+                            },
+                            class: 'form--field',
+                            data: {
+                              'filter-autocomplete': true,
+                              'filters-target': 'filterValueContainer',
+                              'filter-name': filter.name
+                            }
+  %>
+</div>

--- a/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.html
+++ b/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.html
@@ -1,0 +1,58 @@
+<form
+  class="spot-modal loading-indicator--location"
+  data-indicator-name="modal"
+  name="modalSaveForm"
+  (submit)="saveQueryAs($event)"
+>
+  <h1 id="spotModalTitle" class="spot-modal--header">{{text.save_as}}</h1>
+
+  <div class="spot-divider"></div>
+
+  <div
+    name="modalSaveForm"
+    class="spot-modal--body spot-container"
+  >
+    <div class="form--field -required">
+      <label class="form--label -bold" for="save-query-name" [textContent]="text.label_name"></label>
+      <div class="form--field-container">
+        <div class="form--text-field-container">
+          <input
+            class="form--text-field"
+            type="text"
+            name="save-query-name"
+            id="save-query-name"
+            #queryNameField
+            [(ngModel)]="queryName"
+            required
+          />
+        </div>
+      </div>
+    </div>
+    <div class="spot-divider"></div>
+
+    <h2 class="spot-subheader-extra-small">{{ text.label_visibility_settings }}</h2>
+
+      <query-sharing-form
+        [isSave]="true"
+        (onChange)="setValues($event)"
+        [isStarred]="isStarred"
+        [isPublic]="isPublic">
+      </query-sharing-form>
+  </div>
+
+  <div class="spot-action-bar">
+    <div class="spot-action-bar--right">
+      <button
+        type="button"
+        class="button button_no-margin spot-modal--cancel-button spot-action-bar--action"
+        [textContent]="text.button_cancel"
+        (click)="closeMe($event)"
+      ></button>
+      <button
+        class="button button_no-margin -primary -with-icon icon-save spot-action-bar--action"
+        [textContent]="text.button_save"
+        [disabled]="isBusy || !queryName"
+      ></button>
+    </div>
+  </div>
+</form>

--- a/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
+++ b/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
@@ -1,0 +1,120 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2024 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectorRef, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
+import { QueryResource } from 'core-app/features/hal/resources/query-resource';
+import { ToastService } from 'core-app/shared/components/toaster/toast.service';
+import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
+import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
+import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { QuerySharingChange } from 'core-app/shared/components/modals/share-modal/query-sharing-form.component';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
+import { WorkPackagesListService } from 'core-app/features/work-packages/components/wp-list/wp-list.service';
+import { States } from 'core-app/core/states/states.service';
+import { WorkPackagesQueryViewService } from 'core-app/features/work-packages/components/wp-list/wp-query-view.service';
+
+@Component({
+  templateUrl: './view-settings.modal.html',
+})
+export class ViewSettingsModalComponent extends OpModalComponent {
+  public queryName = '';
+
+  public isStarred = false;
+
+  public isPublic = false;
+
+  public isBusy = false;
+
+  @ViewChild('queryNameField', { static: true }) queryNameField:ElementRef;
+
+  public text = {
+    title: this.I18n.t('js.modals.form_submit.title'),
+    text: this.I18n.t('js.modals.form_submit.text'),
+    save_as: this.I18n.t('js.label_save_as'),
+    label_name: this.I18n.t('js.modals.label_name'),
+    label_visibility_settings: this.I18n.t('js.label_visibility_settings'),
+    button_save: this.I18n.t('js.modals.button_save'),
+    button_cancel: this.I18n.t('js.button_cancel'),
+    close_popup: this.I18n.t('js.close_popup_title'),
+  };
+
+  constructor(
+    readonly elementRef:ElementRef,
+    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
+    readonly I18n:I18nService,
+    readonly states:States,
+    readonly querySpace:IsolatedQuerySpace,
+    readonly wpListService:WorkPackagesListService,
+    readonly wpView:WorkPackagesQueryViewService,
+    readonly halNotification:HalResourceNotificationService,
+    readonly cdRef:ChangeDetectorRef,
+    readonly toastService:ToastService,
+  ) {
+    super(locals, cdRef, elementRef);
+  }
+
+  public setValues(change:QuerySharingChange):void {
+    this.isStarred = change.isStarred;
+    this.isPublic = change.isPublic;
+  }
+
+  public onOpen():void {
+    this.queryNameField.nativeElement.focus();
+  }
+
+  public get afterFocusOn():HTMLElement {
+    return document.getElementById('work-packages-settings-button') as HTMLElement;
+  }
+
+  public saveQueryAs($event:Event):void {
+    $event.preventDefault();
+
+    if (this.isBusy || !this.queryName) {
+      return;
+    }
+
+    this.isBusy = true;
+    const query = this.querySpace.query.value!;
+    query.public = this.isPublic;
+
+    this.wpListService
+      .create(query, this.queryName)
+      .then((savedQuery:QueryResource):Promise<any> => {
+        if (this.isStarred && !savedQuery.starred) {
+          return this.wpListService.toggleStarred(savedQuery).then(() => this.closeMe($event));
+        }
+
+        this.closeMe($event);
+        return Promise.resolve(true);
+      })
+      .catch((error:any) => this.halNotification.handleRawError(error))
+      .then(() => this.isBusy = false); // Same as .finally()
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/filters.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filters.controller.ts
@@ -202,7 +202,7 @@ export default class FiltersController extends Controller {
     let filterParam;
 
     if (this.outputFormatValue === 'json') {
-      filterParam =JSON.stringify(filters.map((filter) => { return this.buildFilterJSON(filter); }));
+      filterParam = JSON.stringify(filters.map((filter) => { return this.buildFilterJSON(filter); }));
     } else {
       filterParam = filters.map((filter) => { return this.buildFilterString(filter); }).join('&');
     }
@@ -266,9 +266,14 @@ export default class FiltersController extends Controller {
 
     if (valueContainer) {
       const checkbox = valueContainer.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      const isAutocomplete = valueContainer.dataset.filterAutocomplete === 'true';
 
       if (checkbox) {
         return [checkbox.checked ? 't' : 'f'];
+      }
+
+      if (isAutocomplete) {
+        return (valueContainer.querySelector('input[name="value"]') as HTMLInputElement)?.value.split(',');
       }
 
       if (this.operatorsWithoutValues.includes(operator)) {

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -35,6 +35,31 @@ module Meetings
         .sort_by(&:human_name)
     end
 
+    protected
+
+    def additional_filter_attributes(filter)
+      case filter
+      when Queries::Meetings::Filters::ProjectFilter
+        {
+          autocomplete_options: {
+            resource: "projects",
+            component: "opce-autocompleter",
+            url: ::API::V3::Utilities::PathHelper::ApiV3Path.projects
+          }
+        }
+      when Queries::Meetings::Filters::AuthorFilter
+        {
+          autocomplete_options: {
+            resource: "principals",
+            component: "opce-user-autocompleter",
+            url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals
+          }
+        }
+      else
+        {}
+      end
+    end
+
     private
 
     def allowed_filter?(filter)

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+module Meetings
+  class MeetingFiltersComponent < FiltersComponent
+    def allowed_filters
+      super
+        .select { |f| allowed_filter?(f) }
+        .sort_by(&:human_name)
+    end
+
+    private
+
+    def allowed_filter?(filter)
+      allowlist = [
+        Queries::Meetings::Filters::ProjectFilter,
+        Queries::Meetings::Filters::TimeFilter,
+        Queries::Meetings::Filters::AttendedUserFilter,
+        Queries::Meetings::Filters::InvitedUserFilter,
+        Queries::Meetings::Filters::AuthorFilter,
+        Queries::Meetings::Filters::DatesIntervalFilter
+      ]
+
+      allowlist.detect { |clazz| filter.is_a? clazz }
+    end
+  end
+end

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -39,12 +39,12 @@ module Meetings
 
     def additional_filter_attributes(filter)
       case filter
-      when Queries::Meetings::Filters::AuthorFilter
+      when Queries::Meetings::Filters::AuthorFilter,
+           Queries::Meetings::Filters::AttendedUserFilter,
+           Queries::Meetings::Filters::InvitedUserFilter
         {
           autocomplete_options: {
-            resource: "principals",
-            component: "opce-user-autocompleter",
-            url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals
+            component: "opce-user-autocompleter"
           }
         }
       else
@@ -58,8 +58,8 @@ module Meetings
       allowlist = [
         Queries::Meetings::Filters::ProjectFilter,
         # Queries::Meetings::Filters::TimeFilter,
-        # Queries::Meetings::Filters::AttendedUserFilter,
-        # Queries::Meetings::Filters::InvitedUserFilter,
+        Queries::Meetings::Filters::AttendedUserFilter,
+        Queries::Meetings::Filters::InvitedUserFilter,
         Queries::Meetings::Filters::AuthorFilter
         # Queries::Meetings::Filters::DatesIntervalFilter
       ]

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -39,21 +39,6 @@ module Meetings
 
     def additional_filter_attributes(filter)
       case filter
-      when Queries::Meetings::Filters::ProjectFilter
-        ac_filters = [
-          { name: "active", operator: "=", values: ["t"] }
-        ]
-
-        # if query.project
-        #   ac_filters << { name: "id", operator: "=", values: [query.project.id] }
-        # end
-
-        {
-          autocomplete_options: {
-            component: "opce-project-autocompleter",
-            filters: ac_filters
-          }
-        }
       when Queries::Meetings::Filters::AuthorFilter
         {
           autocomplete_options: {
@@ -63,7 +48,7 @@ module Meetings
           }
         }
       else
-        {}
+        super(filter)
       end
     end
 

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -40,11 +40,18 @@ module Meetings
     def additional_filter_attributes(filter)
       case filter
       when Queries::Meetings::Filters::ProjectFilter
+        ac_filters = [
+          { name: "active", operator: "=", values: ["t"] }
+        ]
+
+        # if query.project
+        #   ac_filters << { name: "id", operator: "=", values: [query.project.id] }
+        # end
+
         {
           autocomplete_options: {
-            resource: "projects",
-            component: "opce-autocompleter",
-            url: ::API::V3::Utilities::PathHelper::ApiV3Path.projects
+            component: "opce-project-autocompleter",
+            filters: ac_filters
           }
         }
       when Queries::Meetings::Filters::AuthorFilter

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -39,12 +39,12 @@ module Meetings
 
     def allowed_filter?(filter)
       allowlist = [
-        Queries::Meetings::Filters::ProjectFilter,
-        Queries::Meetings::Filters::TimeFilter,
-        Queries::Meetings::Filters::AttendedUserFilter,
-        Queries::Meetings::Filters::InvitedUserFilter,
-        Queries::Meetings::Filters::AuthorFilter,
-        Queries::Meetings::Filters::DatesIntervalFilter
+        Queries::Meetings::Filters::ProjectFilter
+        # Queries::Meetings::Filters::TimeFilter,
+        # Queries::Meetings::Filters::AttendedUserFilter,
+        # Queries::Meetings::Filters::InvitedUserFilter,
+        # Queries::Meetings::Filters::AuthorFilter
+        # Queries::Meetings::Filters::DatesIntervalFilter
       ]
 
       allowlist.detect { |clazz| filter.is_a? clazz }

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -44,7 +44,8 @@ module Meetings
            Queries::Meetings::Filters::InvitedUserFilter
         {
           autocomplete_options: {
-            component: "opce-user-autocompleter"
+            component: "opce-user-autocompleter",
+            resource: "principals"
           }
         }
       else

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -29,10 +29,21 @@
 # ++
 module Meetings
   class MeetingFiltersComponent < FiltersComponent
+    options :project
+
     def allowed_filters
       super
         .select { |f| allowed_filter?(f) }
         .sort_by(&:human_name)
+    end
+
+    def filters_count
+      @filters_count ||= begin
+        count = super
+        count -= 1 if project.present?
+
+        count
+      end
     end
 
     protected
@@ -57,13 +68,15 @@ module Meetings
 
     def allowed_filter?(filter)
       allowlist = [
-        Queries::Meetings::Filters::ProjectFilter,
         Queries::Meetings::Filters::TimeFilter,
         Queries::Meetings::Filters::AttendedUserFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
-        Queries::Meetings::Filters::AuthorFilter,
-        Queries::Meetings::Filters::DatesIntervalFilter
+        Queries::Meetings::Filters::AuthorFilter
       ]
+
+      if project.nil?
+        allowlist << Queries::Meetings::Filters::ProjectFilter
+      end
 
       allowlist.detect { |clazz| filter.is_a? clazz }
     end

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -57,7 +57,7 @@ module Meetings
     def allowed_filter?(filter)
       allowlist = [
         Queries::Meetings::Filters::ProjectFilter,
-        # Queries::Meetings::Filters::TimeFilter,
+        Queries::Meetings::Filters::TimeFilter,
         Queries::Meetings::Filters::AttendedUserFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
         Queries::Meetings::Filters::AuthorFilter,

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -60,8 +60,8 @@ module Meetings
         # Queries::Meetings::Filters::TimeFilter,
         Queries::Meetings::Filters::AttendedUserFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
-        Queries::Meetings::Filters::AuthorFilter
-        # Queries::Meetings::Filters::DatesIntervalFilter
+        Queries::Meetings::Filters::AuthorFilter,
+        Queries::Meetings::Filters::DatesIntervalFilter
       ]
 
       allowlist.detect { |clazz| filter.is_a? clazz }

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -39,11 +39,11 @@ module Meetings
 
     def allowed_filter?(filter)
       allowlist = [
-        Queries::Meetings::Filters::ProjectFilter
+        Queries::Meetings::Filters::ProjectFilter,
         # Queries::Meetings::Filters::TimeFilter,
         # Queries::Meetings::Filters::AttendedUserFilter,
         # Queries::Meetings::Filters::InvitedUserFilter,
-        # Queries::Meetings::Filters::AuthorFilter
+        Queries::Meetings::Filters::AuthorFilter
         # Queries::Meetings::Filters::DatesIntervalFilter
       ]
 

--- a/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
@@ -27,8 +27,6 @@
 #++
 
 class Queries::Meetings::Filters::AuthorFilter < Queries::Meetings::Filters::MeetingFilter
-  def allowed_values = []
-
   def type
     :list_optional
   end

--- a/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
@@ -27,6 +27,8 @@
 #++
 
 class Queries::Meetings::Filters::AuthorFilter < Queries::Meetings::Filters::MeetingFilter
+  def allowed_values = []
+
   def type
     :list_optional
   end

--- a/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
@@ -28,4 +28,9 @@
 
 class Queries::Meetings::Filters::ProjectFilter < Queries::Meetings::Filters::MeetingFilter
   include Queries::Filters::Shared::ProjectFilter
+
+  def allowed_values
+    # We don't care for the first value as we do not display the values visibly
+    @allowed_values ||= ::Project.visible.pluck(:name, :id)
+  end
 end

--- a/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
@@ -28,9 +28,4 @@
 
 class Queries::Meetings::Filters::ProjectFilter < Queries::Meetings::Filters::MeetingFilter
   include Queries::Filters::Shared::ProjectFilter
-
-  def allowed_values
-    # We don't care for the first value as we do not display the values visibly
-    @allowed_values ||= ::Project.visible.pluck(:name, :id)
-  end
 end

--- a/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
@@ -34,8 +34,8 @@ class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::Meeti
 
   def allowed_values
     [
-      [PAST_VALUE],
-      [FUTURE_VALUE]
+      [I18n.t(:label_past_meetings_short), PAST_VALUE],
+      [I18n.t(:label_upcoming_meetings_short), FUTURE_VALUE]
     ]
   end
 

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -27,9 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title t(:label_meeting_plural) %>
+
 <%= toolbar title: t(:label_meeting_plural) do %>
+  <%= render(Meetings::MeetingFiltersComponent.new(query: @query)) %>
   <%= render Meetings::AddButtonComponent.new(current_project: @project) %>
 <% end %>
+
 <% if @meetings.empty? -%>
   <%= no_results_box %>
 <% else -%>

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render Meetings::AddButtonComponent.new(current_project: @project) %>
 <% end %>
 
-<%= render(Meetings::MeetingFiltersComponent.new(query: @query)) %>
+<%= render(Meetings::MeetingFiltersComponent.new(query: @query, output_format: 'json')) %>
 
 <% if @meetings.empty? -%>
   <%= no_results_box %>

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render Meetings::AddButtonComponent.new(current_project: @project) %>
 <% end %>
 
-<%= render(Meetings::MeetingFiltersComponent.new(query: @query, output_format: 'json')) %>
+<%= render(Meetings::MeetingFiltersComponent.new(query: @query, project: @project, output_format: 'json')) %>
 
 <% if @meetings.empty? -%>
   <%= no_results_box %>

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -29,9 +29,10 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_meeting_plural) %>
 
 <%= toolbar title: t(:label_meeting_plural) do %>
-  <%= render(Meetings::MeetingFiltersComponent.new(query: @query)) %>
   <%= render Meetings::AddButtonComponent.new(current_project: @project) %>
 <% end %>
+
+<%= render(Meetings::MeetingFiltersComponent.new(query: @query)) %>
 
 <% if @meetings.empty? -%>
   <%= no_results_box %>

--- a/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
@@ -29,28 +29,7 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          helpers do
-            def meeting
-              MeetingContent.find params[:id]
-            end
-          end
-
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          route_param :id, type: Integer, desc: "Activity ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-          end
-        end
+      class MeetingCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
       end
     end
   end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -171,6 +171,10 @@ module OpenProject::Meeting
       PermittedParams.permit(:search, :meetings)
     end
 
+    add_api_path :meetings do
+      "#{root}/meetings"
+    end
+
     add_api_path :meeting do |id|
       "#{root}/meetings/#{id}"
     end


### PR DESCRIPTION
Precursor for https://community.openproject.org/work_packages/4742

---

- [x] Make the project filter section a bit more generic
- [x] Add autocompleter option
  - [x] Fix that currently selected filter value is not shown in autocompleter
- [x] Make filter component output JSON data as well as new format
- [x] Add all filters that the meeting supports and add components for the values if needed
  - [x] Add UI for `Queries::Meetings::Filters::ProjectFilter`
  - [x] Add UI for `Queries::Meetings::Filters::TimeFilter`
  - [x] Add UI for `Queries::Meetings::Filters::AttendedUserFilter`
  - [x] Add UI for `Queries::Meetings::Filters::InvitedUserFilter`
  - [x] Add UI for `Queries::Meetings::Filters::AuthorFilter`
  - [x] Add UI for `Queries::Meetings::Filters::DatesIntervalFilter`
- [ ] Find a possibilty to not allow multi select in some cases