### PR TITLE
Fix selector to target_top links

### DIFF
--- a/lib/open_project/text_formatting/filters/link_attribute_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_attribute_filter.rb
@@ -38,7 +38,7 @@ module OpenProject::TextFormatting
       end
 
       def links
-        doc.xpath(".//a[contains(@href,'/')]")
+        doc.css('a[href^="/"]')
       end
     end
   end

--- a/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe OpenProject::TextFormatting,
                           <li class="op-uc-list--item">
                             <input type="checkbox" class="op-uc-list--task-checkbox" disabled>
                             <span>asdfasdfasdf </span>
-                            <a class="op-uc-link" target="_top" href="https://example.com/" rel="noopener noreferrer">
+                            <a class="op-uc-link" href="https://example.com/" rel="noopener noreferrer">
                               <span>foobar</span>
                             </a>
                           </li>

--- a/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe OpenProject::TextFormatting,
               let(:expected) do
                 <<~EXPECTED
                   <p class="op-uc-p">
-                    Link to <a class="user-mention op-uc-link" target="_top" href="http://openproject.org/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
+                    Link to <a class="user-mention op-uc-link" href="http://openproject.org/users/#{user.id}" title="User Foo Barrit">Foo Barrit</a>
                   </p>
                 EXPECTED
               end

--- a/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
@@ -61,12 +61,10 @@ RSpec.describe OpenProject::TextFormatting,
           </p>
           <p class="op-uc-p">
             <a href="#{Rails.application.root_url}/foo/bar" rel="noopener noreferrer"
-               target="_top"
                class="op-uc-link">Link with setting</a>
           </p>
           <p class="op-uc-p">
             <a href="#{Rails.application.root_url}/foo/bar" rel="noopener noreferrer"
-               target="_top"
                class="op-uc-link">Saved and transformed link with setting</a>
           </p>
           <p class="op-uc-p">

--- a/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe OpenProject::TextFormatting,
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Link to <a href="http://openproject.org/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer">relative path</a>
+              Link to <a href="http://openproject.org/foo/bar" class="op-uc-link" rel="noopener noreferrer">relative path</a>
             </p>
           EXPECTED
         end

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -72,8 +72,7 @@ RSpec.describe 'API v3 Render resource' do
                 <<~HTML
                   <p class="op-uc-p">
                     Hello World! This <em>is</em> markdown with a
-                    <a target="_top"
-                       href="http://community.openproject.org"
+                    <a href="http://community.openproject.org"
                        rel="noopener noreferrer"
                        class="op-uc-link">link</a>
                     and ümläutß.</p>


### PR DESCRIPTION
To prevent trying to load something within a turbo frame, we set `target=_top` on all relative links rendered within markdown. The xpath wasn't correctly finding all links though, and was incorrectly targeting absolute links as well

https://community.openproject.org/work_packages/53935