### PR TITLE
[#53945] added migration for storage access management

### DIFF
--- a/modules/storages/db/migrate/20240405135016_update_access_management_of_configured_one_drive_storages.rb
+++ b/modules/storages/db/migrate/20240405135016_update_access_management_of_configured_one_drive_storages.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 class UpdateAccessManagementOfConfiguredOneDriveStorages < ActiveRecord::Migration[7.1]
   def up
     execute <<-SQL.squish

--- a/modules/storages/db/migrate/20240405135016_update_access_management_of_configured_one_drive_storages.rb
+++ b/modules/storages/db/migrate/20240405135016_update_access_management_of_configured_one_drive_storages.rb
@@ -1,0 +1,11 @@
+class UpdateAccessManagementOfConfiguredOneDriveStorages < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL.squish
+      UPDATE storages
+      SET provider_fields = jsonb_set(provider_fields, '{automatically_managed}', 'false', true)
+      WHERE provider_type = 'Storages::OneDriveStorage' AND provider_fields->>'automatically_managed' is null;
+    SQL
+  end
+
+  def down; end
+end


### PR DESCRIPTION
[#53945](https://community.openproject.org/wp/53945)

- affects only one drive storages
- set `automatically_managed` to false for storages with null value