### PR TITLE
[53948] New GitLab integration tab content is displayed in front of all popups

### DIFF
--- a/modules/gitlab_integration/frontend/module/gitlab-tab/gitlab-tab.component.sass
+++ b/modules/gitlab_integration/frontend/module/gitlab-tab/gitlab-tab.component.sass
@@ -29,8 +29,6 @@
 
 @import "helpers"
 
-:host,
 .gitlab-header
   position: sticky
   top: 0
-  z-index: 850 // Ensure the header is above other content


### PR DESCRIPTION
* Remove extraordinary high z-index which prevented any menu to lay over the content of the GitLab tab.
* Further, I removed the `:host` selector as only the header os sticky, not the whole tab. This crashed in Firefox.

https://community.openproject.org/projects/openproject/work_packages/53948/activity