### PR TITLE
[#53976] Editing a wp does not show clearly in meetings history

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -55,6 +55,7 @@ class Journal < ApplicationRecord
   register_journal_formatter :meeting_start_time, OpenProject::JournalFormatter::MeetingStartTime
   register_journal_formatter :agenda_item_position, OpenProject::JournalFormatter::AgendaItemPosition
   register_journal_formatter :agenda_item_duration, OpenProject::JournalFormatter::AgendaItemDuration
+  register_journal_formatter :meeting_work_package_id, OpenProject::JournalFormatter::MeetingWorkPackageId
 
   # Attributes related to the cause are stored in a JSONB column so we can easily add new relations and related
   # attributes without a heavy database migration. Fields will be prefixed with `cause_` but are stored in the JSONB

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1150,6 +1150,8 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
           updated: "changed from %{old_value} to %{value}"
         position:
           updated: "reordered"
+        work_package:
+          updated: "changed from %{old_value} to %{value}"
     filter:
       changeset: "Changesets"
       message: "Forums"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1146,12 +1146,15 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
       meeting_agenda_item:
         duration:
           added: "set to %{value}"
+          added_html: "set to <i>%{value}</i>"
           removed: "removed"
           updated: "changed from %{old_value} to %{value}"
+          updated_html: "changed from <i>%{old_value}</i> to <i>%{value}</i>"
         position:
           updated: "reordered"
         work_package:
           updated: "changed from %{old_value} to %{value}"
+          updated_html: "changed from <i>%{old_value}</i> to <i>%{value}</i>"
     filter:
       changeset: "Changesets"
       message: "Forums"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1145,7 +1145,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
         logged_for: "Logged for"
       meeting_agenda_item:
         duration:
-          added: "set to %{value} minutes"
+          added: "set to %{value}"
           removed: "removed"
           updated: "changed from %{old_value} to %{value}"
         position:

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -12,6 +12,7 @@
           flex_layout(align_items: :center) do |flex|
             flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
               render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
+                                            test_selector: 'op-meeting-agenda-title',
                                             font_size: :normal, font_weight: :bold, target: "_blank")) do
                 @meeting_agenda_item.work_package.subject
               end
@@ -30,11 +31,11 @@
             end
           end
         elsif @meeting_agenda_item.linked_work_package?
-          render(Primer::Beta::Text.new(font_size: :small, mr: 2, color: :subtle)) do
+          render(Primer::Beta::Text.new(font_size: :small, mr: 2, color: :subtle, test_selector: 'op-meeting-agenda-title')) do
             I18n.t(:label_agenda_item_undisclosed_wp, id: @meeting_agenda_item.work_package_id)
           end
         elsif @meeting_agenda_item.deleted_work_package?
-          render(Primer::Beta::Text.new(tag: :s, font_size: :small, mr: 2, color: :danger)) do
+          render(Primer::Beta::Text.new(tag: :s, font_size: :small, mr: 2, color: :danger, test_selector: 'op-meeting-agenda-title')) do
             I18n.t(:label_agenda_item_deleted_wp)
           end
         else

--- a/modules/meeting/app/models/meeting/journalized.rb
+++ b/modules/meeting/app/models/meeting/journalized.rb
@@ -51,6 +51,7 @@ module Meeting::Journalized
     register_journal_formatted_fields(:agenda_item_duration, "duration")
     register_journal_formatted_fields(:agenda_item_duration, "duration_in_minutes")
     register_journal_formatted_fields(:agenda_item_position, "position")
+    register_journal_formatted_fields(:meeting_work_package_id, "work_package_id")
 
     def touch_and_save_journals
       update_column(:updated_at, Time.current)

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -191,6 +191,8 @@ en:
   label_agenda_item_move_down: "Move down"
   label_agenda_item_add_notes: "Add notes"
 
+  label_agenda_item_work_package: "Agenda item work package"
+
   text_agenda_item_title: 'Agenda item "%{title}"'
   text_agenda_work_package_title: 'Agenda item for %{work_package}"'
   text_agenda_work_package_deleted: 'Agenda item for deleted work package'

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_duration.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_duration.rb
@@ -40,20 +40,22 @@ class OpenProject::JournalFormatter::AgendaItemDuration < JournalFormatter::Base
       end
     end
 
-    value = value(mapped.first, mapped.last)
+    value = value(options[:html], mapped.first, mapped.last)
 
     I18n.t(:text_journal_of, label: label_text, value:)
   end
 
   private
 
-  def value(old_value, value)
+  def value(html, old_value, value)
+    html = html ? "_html" : ""
+
     if old_value.nil?
-      I18n.t(:"activity.item.meeting_agenda_item.duration.added", value:)
+      I18n.t(:"activity.item.meeting_agenda_item.duration.added#{html}", value:)
     elsif value.nil?
       I18n.t(:"activity.item.meeting_agenda_item.duration.removed")
     else
-      I18n.t(:"activity.item.meeting_agenda_item.duration.updated", value:, old_value:)
+      I18n.t(:"activity.item.meeting_agenda_item.duration.updated#{html}", value:, old_value:)
     end
   end
 end

--- a/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
@@ -31,16 +31,18 @@ class OpenProject::JournalFormatter::MeetingWorkPackageId < JournalFormatter::Ba
     label_text = I18n.t(:label_agenda_item_work_package)
     label_text = content_tag(:strong, label_text) if options[:html]
 
-    I18n.t(:text_journal_of, label: label_text, value: value(values))
+    I18n.t(:text_journal_of, label: label_text, value: value(options[:html], values))
   end
 
   private
 
-  def value(values)
+  def value(html, values)
+    html = html ? "_html" : ""
+
     new = visible(values.last)
     old = visible(values.first)
 
-    I18n.t(:"activity.item.meeting_agenda_item.work_package.updated",
+    I18n.t(:"activity.item.meeting_agenda_item.work_package.updated#{html}",
            value: new ? new.name : I18n.t(:label_agenda_item_undisclosed_wp, id: values.last),
            old_value: old ? old.name : I18n.t(:label_agenda_item_undisclosed_wp, id: values.first))
   end

--- a/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
@@ -1,0 +1,51 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OpenProject::JournalFormatter::MeetingWorkPackageId < JournalFormatter::Base
+  def render(_key, values, options = { html: true })
+    label_text = I18n.t(:label_agenda_item_work_package)
+    label_text = content_tag(:strong, label_text) if options[:html]
+
+    I18n.t(:text_journal_of, label: label_text, value: value(values))
+  end
+
+  private
+
+  def value(values)
+    new = visible(values.last)
+    old = visible(values.first)
+
+    I18n.t(:"activity.item.meeting_agenda_item.work_package.updated",
+           value: new ? new.name : I18n.t(:label_agenda_item_undisclosed_wp, id: values.last),
+           old_value: old ? old.name : I18n.t(:label_agenda_item_undisclosed_wp, id: values.first))
+  end
+
+  def visible(work_package_id)
+    WorkPackage.visible.find_by(id: work_package_id)
+  end
+end

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -228,8 +228,10 @@ RSpec.describe "history",
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
                           query: "Changed task",
                           results_selector: "body")
+      click_link_or_button "Save"
     end
 
+    show_page.expect_agenda_item title: "Changed task"
     wp_item = MeetingAgendaItem.find_by!(work_package_id: changed_wp.id)
     expect(wp_item).to be_present
 
@@ -246,7 +248,7 @@ RSpec.describe "history",
     history_page.open_history_modal
 
     item = history_page.first_item
-    expect(item).to have_css(".op-activity-list--item-title", text: work_package.to_s.strip)
+    expect(item).to have_css(".op-activity-list--item-title", text: changed_wp.to_s.strip)
     expect(item).to have_css(".op-activity-list--item-subtitle", text: "deleted by")
     expect(item).to have_css(".op-activity-list--item-subtitle", text: user.name)
 

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe "history",
   shared_let(:work_package) do
     create(:work_package, project:, subject: "Important task")
   end
-
+  shared_let(:changed_wp) do
+    create(:work_package, project:, subject: "Changed task")
+  end
   shared_let(:other_wp) do
     create(:work_package, project: other_project, subject: "Private WP")
   end
@@ -200,12 +202,12 @@ RSpec.describe "history",
     expect(item).to have_css(".op-activity-list--item-subtitle", text: "deleted by")
     expect(item).to have_css(".op-activity-list--item-subtitle", text: user.name)
 
-    # Add + Remove linked work package
+    # Add linked work package
     show_page.visit!
 
     show_page.add_agenda_item(type: WorkPackage) do
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
-                          query: "task",
+                          query: "Important task",
                           results_selector: "body")
     end
 
@@ -219,6 +221,26 @@ RSpec.describe "history",
     expect(item).to have_css(".op-activity-list--item-subtitle", text: "created by")
     expect(item).to have_css(".op-activity-list--item-subtitle", text: user.name)
 
+    # Update linked work package
+    show_page.visit!
+
+    show_page.edit_agenda_item(wp_item) do
+      select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
+                          query: "Changed task",
+                          results_selector: "body")
+    end
+
+    wp_item = MeetingAgendaItem.find_by!(work_package_id: changed_wp.id)
+    expect(wp_item).to be_present
+
+    history_page.open_history_modal
+    item = history_page.first_item
+    expect(item).to have_css(".op-activity-list--item-title", text: changed_wp.to_s.strip)
+    expect(item).to have_css(".op-activity-list--item-subtitle", text: "updated by")
+    expect(item).to have_css(".op-activity-list--item-subtitle", text: user.name)
+    expect(item).to have_css("li", text: "Agenda item work package changed from Important task to Changed task")
+
+    # Remove linked work package
     show_page.visit!
     show_page.remove_agenda_item wp_item
     history_page.open_history_modal
@@ -227,7 +249,6 @@ RSpec.describe "history",
     expect(item).to have_css(".op-activity-list--item-title", text: work_package.to_s.strip)
     expect(item).to have_css(".op-activity-list--item-subtitle", text: "deleted by")
     expect(item).to have_css(".op-activity-list--item-subtitle", text: user.name)
-
 
     # With a work package linked in another project
     show_page.visit!


### PR DESCRIPTION
https://community.openproject.org/wp/53976

In addition to the bugfix, this also fixes some other issues spotted such as inconsistent italics and and a buggy label for duration