### PR TITLE
[53812] Meeting agenda item overflow with long work package subject

### DIFF
--- a/modules/meeting/app/components/_index.sass
+++ b/modules/meeting/app/components/_index.sass
@@ -1,5 +1,4 @@
 @import "./meeting_agenda_items/item_component/show_component.sass"
 @import "./meeting_agenda_items/form_component.sass"
 @import "./meetings/sidebar/state_component.sass"
-@import "./meetings/sidebar/participants_component.sass"
 @import "./meetings/sidebar/details_component.sass"

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.sass
@@ -2,13 +2,17 @@
 
 .op-meeting-agenda-item-form
   display: grid
-  grid-template-columns: 2fr 1fr 140px
+  grid-template-columns: 2fr 1fr 100px
   grid-template-areas: "title presenter duration" "notes notes notes" "add_note actions actions"
   grid-gap: 8px
 
   &--actions
     justify-self: end
 
-  @media screen and (max-width: $breakpoint-sm)
-    grid-template-columns: 1fr auto
+  &--title,
+  &--notes
+    overflow: hidden
+
+  @media screen and (max-width: $breakpoint-md)
+    grid-template-columns: 100px auto
     grid-template-areas: "title title" "duration presenter" "notes notes" "add_note actions"

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.sass
@@ -2,8 +2,8 @@
 
 .op-meeting-agenda-item-form
   display: grid
-  grid-template-columns: 2fr 1fr 100px
-  grid-template-areas: "title presenter duration" "notes notes notes" "add_note actions actions"
+  grid-template-columns: 2fr 100px 1fr
+  grid-template-areas: "title duration presenter" "notes notes notes" "add_note actions actions"
   grid-gap: 8px
 
   &--actions

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -16,7 +16,7 @@ $meeting-agenda-item--presenter-width: 300px
   &--actions
     justify-self: end
 
-  &--responsbile
+  &--presenter
     max-width: $meeting-agenda-item--presenter-width
     justify-self: end
 
@@ -27,8 +27,8 @@ $meeting-agenda-item--presenter-width: 300px
     @include text-shortener
 
   @media screen and (max-width: $breakpoint-lg)
-    grid-template-columns: 20px auto 1fr 50px
-    grid-template-areas: "drag-handle content content actions" ".presenter presenter duration" ".notes notes notes"
+    grid-template-columns: 20px auto 1fr calc($meeting-agenda-item--presenter-width - 50px) 50px
+    grid-template-areas: "drag-handle content content content actions" ". duration . presenter presenter" ". notes notes notes notes"
 
     &--author
       justify-self: stretch

--- a/modules/meeting/app/components/meetings/show_component.html.erb
+++ b/modules/meeting/app/components/meetings/show_component.html.erb
@@ -12,7 +12,7 @@
     end
 
     show_page.with_row do
-      render(Primer::Alpha::Layout.new(stacking_breakpoint: :sm)) do |content|
+      render(Primer::Alpha::Layout.new(stacking_breakpoint: :md)) do |content|
         content.with_main do
           flex_layout do |agenda|
             agenda.with_row do
@@ -23,7 +23,7 @@
               render(MeetingAgendaItems::NewButtonComponent.new(meeting: @meeting))
             end
 
-            agenda.with_row(mt: 3, classes: 'hidden-for-desktop') do
+            agenda.with_row(mt: 3, display: [:block, nil, :none]) do
               resource = ::API::V3::Meetings::MeetingRepresenter.new(@meeting, current_user: User.current, embed_links: false)
               concat render(Primer::Beta::Heading.new(tag: :h4)) { I18n.t(:label_attachment_plural) }
               concat helpers.list_attachments(resource,

--- a/modules/meeting/app/components/meetings/sidebar/attachments_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/attachments_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  flex_layout(classes: 'hidden-for-mobile') do |attachments_container|
+  flex_layout do |attachments_container|
     attachments_container.with_row do
       render(Primer::Beta::Heading.new(tag: :h4)) { I18n.t(:label_attachment_plural) }
     end

--- a/modules/meeting/app/components/meetings/sidebar/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/details_component.html.erb
@@ -86,7 +86,7 @@
             end
           end
 
-          details.with_row(mt: 2, classes: 'meeting-detail-participants') do
+          details.with_row(mt: 2, classes: 'meeting-detail-participants', display: [nil, nil, :none]) do
             render_meeting_attribute_row(:people) do
               flex_layout do |duration|
                 duration.with_column(mr: 2) do

--- a/modules/meeting/app/components/meetings/sidebar/details_component.sass
+++ b/modules/meeting/app/components/meetings/sidebar/details_component.sass
@@ -1,11 +1,6 @@
 .meeting-detail-participants
-  visibility: collapse
   // The modal is rendered inside the mobile participant list element and it can be
   // triggered from both mobile and desktop views. The mobile participant list is hidden
   // when the desktop view is active, but the modal inside it should still be visible.
   .Overlay-backdrop--center
-    visibility: visible
-
-@media screen and (max-width: $breakpoint-sm)
-  .meeting-detail-participants
     visibility: visible

--- a/modules/meeting/app/components/meetings/sidebar/participants_component.sass
+++ b/modules/meeting/app/components/meetings/sidebar/participants_component.sass
@@ -1,6 +1,0 @@
-@import 'helpers'
-
-@media screen and (max-width: $breakpoint-sm)
-  #meetings-sidebar-component
-    .BorderGrid-row:nth-child(3)
-      display: none

--- a/modules/meeting/app/components/meetings/sidebar/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/state_component.html.erb
@@ -17,7 +17,7 @@
           end
         end
 
-        open_state.with_row(mt: 3, classes:'hidden-for-mobile') do
+        open_state.with_row(mt: 3, display: [:none, nil, :block]) do
           render(Primer::Beta::Text.new(color: :subtle)) do
             t("text_meeting_open_description")
           end
@@ -66,7 +66,7 @@
         end
 
         closed_state.with_row(mt: 3) do
-          render(Primer::Beta::Text.new(color: :subtle, classes:'hidden-for-mobile')) do
+          render(Primer::Beta::Text.new(color: :subtle, display: [:none, nil, :block])) do
             t("text_meeting_closed_description")
           end
         end

--- a/modules/meeting/app/components/meetings/sidebar/state_component.sass
+++ b/modules/meeting/app/components/meetings/sidebar/state_component.sass
@@ -1,6 +1,6 @@
 @import 'helpers'
 
-@media screen and (max-width: $breakpoint-sm)
+@media screen and (max-width: $breakpoint-md)
   .op-meeting-sidebar-state
     flex-direction: row !important
     justify-content: space-between

--- a/modules/meeting/app/components/meetings/sidebar_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar_component.html.erb
@@ -3,8 +3,8 @@
     render(Primer::OpenProject::BorderGrid.new) do |border_grid|
       border_grid.with_row { render(Meetings::Sidebar::DetailsComponent.new(meeting: @meeting)) }
       border_grid.with_row { render(Meetings::Sidebar::StateComponent.new(meeting: @meeting)) }
-      border_grid.with_row { render(Meetings::Sidebar::ParticipantsComponent.new(meeting: @meeting)) }
-      border_grid.with_row { render(Meetings::Sidebar::AttachmentsComponent.new(meeting: @meeting)) }
+      border_grid.with_row(display: [:none, nil, :"table_cell"]) { render(Meetings::Sidebar::ParticipantsComponent.new(meeting: @meeting)) }
+      border_grid.with_row(display: [:none, nil, :"table_cell"]) { render(Meetings::Sidebar::AttachmentsComponent.new(meeting: @meeting)) }
     end
   end
 %>

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
       meeting_agenda_item:
         title: "Title"
         author: "Author"
-        duration_in_minutes: "Duration (min)"
+        duration_in_minutes: "min"
         description: "Notes"
         presenter: "Presenter"
     errors:

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "history",
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "Duration (min)", with: "25"
+      fill_in "min", with: "25"
     end
 
     show_page.expect_agenda_item(title: "My agenda item")

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "history",
     item = MeetingAgendaItem.find_by(title: "My agenda item")
     show_page.edit_agenda_item(item) do
       fill_in "Title", with: "Updated title"
-      fill_in "Duration", with: "5"
+      fill_in "min", with: "5"
       click_on "Save"
     end
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Structured meetings CRUD",
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "Duration (min)", with: "25"
+      fill_in "min", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -168,7 +168,7 @@ RSpec.describe "Structured meetings CRUD",
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "Duration (min)", with: "25"
+      fill_in "min", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -233,7 +233,7 @@ RSpec.describe "Structured meetings CRUD",
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "Duration (min)", with: "25"
+      fill_in "min", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -257,7 +257,7 @@ RSpec.describe "Structured meetings CRUD",
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "Duration (min)", with: "25"
+      fill_in "min", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"


### PR DESCRIPTION
* Change layout breakpoint for the meetings page from `sm` to `md`
  * Use system_arguments for that instead of multiple different implementations (predefined classes, custom CSS, system_arguments..)
  * Some optimisations to the grids to ensure that long agenda items are handled correctly

https://community.openproject.org/projects/openproject/work_packages/53812/activity

* Further, it already changes the order of the presenter and the duration in the edit state of an agenda item as requested here: https://community.openproject.org/projects/openproject/work_packages/53977/activity