### PR TITLE
Hide storage link if user has no ':read_files' permission

### DIFF
--- a/frontend/src/app/core/state/project-storages/project-storage.model.ts
+++ b/frontend/src/app/core/state/project-storages/project-storage.model.ts
@@ -34,7 +34,8 @@ export interface IProjectStorageHalResourceLinks extends IHalResourceLinks {
   project:IHalResourceLink;
   creator:IHalResourceLink;
   projectFolder?:IHalOptionalTitledLink;
-  openWithConnectionEnsured:IHalResourceLink;
+  open?:IHalResourceLink;
+  openWithConnectionEnsured?:IHalResourceLink;
 }
 
 export interface IProjectStorage {

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
@@ -37,9 +37,7 @@ import { map } from 'rxjs/operators';
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { HookService } from 'core-app/features/plugins/hook-service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
-import { StoragesResourceService } from 'core-app/core/state/storages/storages.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ProjectStoragesResourceService } from 'core-app/core/state/project-storages/project-storages.service';
 import { IProjectStorage } from 'core-app/core/state/project-storages/project-storage.model';
@@ -66,9 +64,7 @@ export class WorkPackageFilesTabComponent implements OnInit {
 
   constructor(
     private readonly i18n:I18nService,
-    private readonly hook:HookService,
     private readonly currentUserService:CurrentUserService,
-    private readonly storagesResourceService:StoragesResourceService,
     private readonly projectStoragesResourceService:ProjectStoragesResourceService,
   ) { }
 

--- a/frontend/src/app/shared/components/storages/storage/storage.component.html
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.html
@@ -6,12 +6,12 @@
       class="op-tab-content--header-icon spot-icon spot-icon_{{icon.storageHeader((storage | async)?._links.type.href)}} op-files-tab--icon op-files-tab--icon_primary"
     ></span>
     <span class="op-tab-content--header-text" [textContent]="(storage | async)?.name"></span>
-    <a
+    <a *ngIf="openStorageLink"
       class="op-tab-content--header-action spot-link"
-      aria-label="{{text.openStorage(storageType | async)}}"
-      [title]="text.openStorage(storageType | async)"
-      [href]="projectStorage._links.openWithConnectionEnsured.href || (storage | async)?._links.open.href"
-      target="_blank"
+       aria-label="{{text.openStorage(storageType | async)}}"
+       [title]="text.openStorage(storageType | async)"
+       [href]="openStorageLink"
+       target="_blank"
     >
       <span class="spot-icon spot-icon_external-link"></span>
     </a>

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -208,6 +208,10 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
     this.cdRef.detectChanges();
   };
 
+  public get openStorageLink() {
+    return this.projectStorage._links.openWithConnectionEnsured?.href || this.projectStorage._links.open?.href;
+  }
+
   constructor(
     private readonly i18n:I18nService,
     private readonly cdRef:ChangeDetectorRef,

--- a/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
@@ -47,10 +47,14 @@ module API::V3::ProjectStorages
     end
 
     link :open do
+      next unless show_open_storage_links
+
       { href: api_v3_paths.project_storage_open(represented.id) }
     end
 
     link :openWithConnectionEnsured do
+      next unless show_open_storage_links
+
       { href: represented.open_with_connection_ensured }
     end
 
@@ -64,6 +68,16 @@ module API::V3::ProjectStorages
 
     def _type
       "ProjectStorage"
+    end
+
+    private
+
+    def show_open_storage_links
+      if represented.project_folder_automatic?
+        return current_user.allowed_in_project?(:read_files, represented.project)
+      end
+
+      true
     end
   end
 end

--- a/modules/storages/spec/lib/api/v3/project_storages/project_storage_representer_spec.rb
+++ b/modules/storages/spec/lib/api/v3/project_storages/project_storage_representer_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe API::V3::ProjectStorages::ProjectStorageRepresenter do
 
   subject { representer.to_json }
 
+  before do
+    allow(user).to receive("allowed_in_project?").and_return(true)
+  end
+
   describe "properties" do
     it_behaves_like "property", :_type do
       let(:value) { representer._type }
@@ -99,12 +103,28 @@ RSpec.describe API::V3::ProjectStorages::ProjectStorageRepresenter do
       end
     end
 
-    context "when storage is not configured" do
+    context "when storage is configured" do
       before { project_storage.storage = create(:nextcloud_storage_configured) }
 
       it_behaves_like "has an untitled link" do
         let(:link) { "openWithConnectionEnsured" }
         let(:href) { ensure_connection_path(project_storage) }
+      end
+    end
+
+    context "when user does not have read_files permission" do
+      let(:project_storage) { build_stubbed(:project_storage, project_folder_mode: "automatic", project_folder_id: "1337") }
+
+      before do
+        allow(user).to receive("allowed_in_project?").and_return(false)
+      end
+
+      it_behaves_like "has no link" do
+        let(:link) { "openWithConnectionEnsured" }
+      end
+
+      it_behaves_like "has no link" do
+        let(:link) { "open" }
       end
     end
   end


### PR DESCRIPTION
This PR implements a switch where the link next to the storage heading is hidden, when a user does not have the `:read_files` permission.

It is done by hiding the two links inside the response of the `ProjectStorages` response of the HAL API.