### PR TITLE
[#51794] Bump version number in Project details widget.

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/project-details/project-details.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-details/project-details.component.html
@@ -13,7 +13,7 @@
     <strong>Project details have now moved to a column on the right edge of this page.</strong>
   </p>
   <p>
-    Starting with version 13.5, project attributes can be grouped in sections and enabled and disabled at a project level. <a href="#">Learn more</a>
+    Starting with version 14.0, project attributes can be grouped in sections and enabled and disabled at a project level. <a href="#">Learn more</a>
   </p>
   <i>This widget can now be removed or replaced. It will be deleted in subsequent versions.</i>
 </div>

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Project details widget on dashboard", :js do
           .to have_content("Project details have now moved to a column on the right edge of this page.")
         expect(page).to have_content(
           <<~TEXT.strip
-            Starting with version 13.5, project attributes can be grouped \
+            Starting with version 14.0, project attributes can be grouped \
             in sections and enabled and disabled at a project level.
           TEXT
         )
@@ -121,7 +121,7 @@ RSpec.describe "Project details widget on dashboard", :js do
           .to have_content("Project details have now moved to a column on the right edge of this page.")
         expect(page).to have_content(
           <<~TEXT.strip
-            Starting with version 13.5, project attributes can be grouped \
+            Starting with version 14.0, project attributes can be grouped \
             in sections and enabled and disabled at a project level.
           TEXT
         )


### PR DESCRIPTION
Related to https://community.openproject.org/wp/51794
Updating the version number to 14.0 in the Project details widget deprecation message.