### PR TITLE
ugly hack to make member popup menu visible in firefox

### DIFF
--- a/app/components/members/table_component.rb
+++ b/app/components/members/table_component.rb
@@ -101,6 +101,10 @@ module Members
       { caption: }
     end
 
+    def container_class
+      "generic-table--container_visible-overflow"
+    end
+
     ##
     # Adjusts the order so that users are joined to support
     # sorting by their attributes

--- a/app/components/table_component.html.erb
+++ b/app/components/table_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<div class="generic-table--container" data-test-selector="<%= test_selector %>">
+<div class="generic-table--container <%= container_class %>" data-test-selector="<%= test_selector %>">
   <div class="generic-table--results-container">
     <table class="generic-table">
       <colgroup>

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -158,7 +158,7 @@ class TableComponent < ApplicationComponent
   end
 
   def container_class
-    self.class.container_class
+    nil
   end
 
   def columns

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -157,6 +157,10 @@ class TableComponent < ApplicationComponent
     self.class.row_class
   end
 
+  def container_class
+    self.class.container_class
+  end
+
   def columns
     self.class.columns
   end

--- a/frontend/src/global_styles/content/_members.sass
+++ b/frontend/src/global_styles/content/_members.sass
@@ -71,10 +71,3 @@
       max-width: 60%
       select
         max-width: 60%
-
-// Ugly hack copied from projects list. Firefox doesn't yet support popover
-// attribute by default, so popup menu is clipped by overflow
-body.controller-members.action-index
-  #content
-    .generic-table--container
-      overflow: visible

--- a/frontend/src/global_styles/content/_members.sass
+++ b/frontend/src/global_styles/content/_members.sass
@@ -71,3 +71,10 @@
       max-width: 60%
       select
         max-width: 60%
+
+// Ugly hack copied from projects list. Firefox doesn't yet support popover
+// attribute by default, so popup menu is clipped by overflow
+body.controller-members.action-index
+  #content
+    .generic-table--container
+      overflow: visible

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -102,17 +102,6 @@ $project-table--description-indention: 9px
     min-width: 1rem
     max-width: 1rem
 
-// Ugly hack for now, so expanded more-menus do not get cut off. Actually that
-// should be handled from the drop down implementation with absolute positions
-// just as in the work package table.
-body.controller-projects.action-index
-  #content
-    overflow: visible
-    .generic-table--container
-      min-height: 1
-      overflow: visible
-
-
 // project list in types configuration
 #type_project_ids
   ul

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -67,9 +67,7 @@ $toolbar-height--mobile: 100px
     padding-bottom: var(--generic-table--footer-height)
 
   &_visible-overflow
-    &,
-    .generic-table--results-container
-      overflow: visible
+    overflow: visible
 
 .generic-table--results-container
   height:       100%

--- a/modules/costs/app/views/cost_types/edit.html.erb
+++ b/modules/costs/app/views/cost_types/edit.html.erb
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 
   <h3><%= t :caption_rate_history %></h3>
-  <div class="generic-table--container generic-table--container_visible-overflow">
+  <div class="generic-table--container">
     <div class="generic-table--results-container">
       <table class="generic-table">
         <colgroup>


### PR DESCRIPTION
Firefox doesn't yet support popover attribute by default, so popup menu is clipped by overflow

Followup for #14721