### PR TITLE
Remove virtual delay column

### DIFF
--- a/db/migrate/20240410060041_remove_virtual_delay_column.rb
+++ b/db/migrate/20240410060041_remove_virtual_delay_column.rb
@@ -1,0 +1,5 @@
+class RemoveVirtualDelayColumn < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :relations, :delay, :virtual, type: :integer, as: 'lag', stored: true
+  end
+end


### PR DESCRIPTION
After 14.0 release branch has been branched of, we can merge this to remove the virtual delay column