### PR TITLE
[54108] Share modal layout is broken

### DIFF
--- a/frontend/src/global_styles/openproject.sass
+++ b/frontend/src/global_styles/openproject.sass
@@ -21,7 +21,6 @@
 @import "../../../modules/meeting/app/components/_index.sass"
 @import "../../../modules/overviews/app/components/_index.sass"
 @import "../../../modules/storages/app/components/_index.sass"
-@import "../app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.sass"
 
 // Component specific Styles
 @import "../../../app/components/_index.sass"


### PR DESCRIPTION
Remove the global linking of the progress edit field styles as it will affect all other modals as well. Since the sass file is already linked in the component itself it is not necessary to import it again. Due to the ViewEncapsulation the style is thus only applied inside the component.


https://community.openproject.org/projects/openproject/work_packages/54108/activity