### PR TITLE
prefix temp branch to not be considered in workflows as release branch

### DIFF
--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -83,7 +83,7 @@ jobs:
                 gh pr close "$pr_number"
               done
 
-              TEMP_BRANCH="$RELEASE_BRANCH-$(date "+%Y%m%d%H%M%S")"
+              TEMP_BRANCH="merge-$RELEASE_BRANCH-$(date "+%Y%m%d%H%M%S")"
 
               git branch "$TEMP_BRANCH" "$RELEASE_BRANCH"
 


### PR DESCRIPTION
Like for https://github.com/opf/openproject/actions/runs/8640900918 and https://github.com/opf/openproject/actions?query=branch%3Arelease%2F13.4-20240327164503