### PR TITLE
[53651][54116] iOS bug fixes

### DIFF
--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -68,5 +68,6 @@
     // when focused.
     select,
     textarea,
-    input
+    input,
+    .op-uc-container.op-uc-container_editing
       font-size: 16px !important

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
@@ -72,6 +72,10 @@
   height: 29px
   background: none
 
+  // Needed especially for iOS, because it would otherwise add a automatic padding for button resulting in the icon being misplaced
+  // see: https://stackoverflow.com/a/57420996/8900797
+  padding: 0
+
   // Center save/cancel links
   line-height: 27px
   border: 1px solid transparent
@@ -84,4 +88,3 @@
 
   .icon-context:before
     padding: 0
-


### PR DESCRIPTION
* Add ckEditor selectors to the special rules for mobile safari to avoid a zoom when entering the field
* Add special rule for Safari to avoid that the button is too wide and the icon thus misplaced


https://community.openproject.org/projects/openproject/work_packages/53651/activity
https://community.openproject.org/projects/openproject/work_packages/54116/activity