### PR TITLE
fix test fail caused by stale shared object

### DIFF
--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -415,6 +415,8 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
   describe "When % Complete is set + work and remaining work are unset coming from a migration" do
     before_all do
+      work_package.reload
+
       work_package.estimated_hours = nil
       work_package.remaining_hours = nil
       work_package.done_ratio = 5.0


### PR DESCRIPTION
Not sure what is the best way, following fails:

```shell
rspec './spec/features/work_packages/progress_modal_spec.rb[1:4:1:1:1,1:6:1:1,1:6:2:1]' --seed 33667
```