### PR TITLE
Documentation gitlab add local network settings

### DIFF
--- a/docs/system-admin-guide/attachments/virus-scanning/README.md
+++ b/docs/system-admin-guide/attachments/virus-scanning/README.md
@@ -63,7 +63,7 @@ As a quick-start, you can use this command to start clamav with local volume mou
 ```bash
 docker run -it --rm \
     --name clamav \
-    --publish 3310
+    --publish 3310 \
     --mount source=clam_db,target=/var/lib/clamav \
     clamav/clamav:stable_base
 ```

--- a/docs/system-admin-guide/integrations/gitlab-integration/README.md
+++ b/docs/system-admin-guide/integrations/gitlab-integration/README.md
@@ -82,6 +82,9 @@ https://myopenproject.com/webhooks/gitlab?key=4221687468163843
 > - Merge request events
 > - Pipeline events
 
+>**Note**: If you are in a local network you might need to allow requests to the local network in your GitLab instance.  
+>You can find this settings in the **Outbound requests** section when you navigate to **Admin area -> Settings -> Network**.
+
 We recommend that you enable the **SSL verification** before you **Add webhook**.
 
 Now the integration is set up on both sides and you can use it.


### PR DESCRIPTION
Add a hint in the Documentation for users who might run GitLab in a local network.

add missing backslash in example docker command for ruining clamav 