### PR TITLE
[#53799] Overview page crashes if there have been project custom fiel…

### DIFF
--- a/db/migrate/20231123111357_create_custom_field_sections.rb
+++ b/db/migrate/20231123111357_create_custom_field_sections.rb
@@ -1,4 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "migration_utils/utils"
+
 class CreateCustomFieldSections < ActiveRecord::Migration[7.0]
+  include ::Migration::Utils
+
   def up
     create_table :custom_field_sections do |t|
       t.integer :position
@@ -23,24 +55,33 @@ class CreateCustomFieldSections < ActiveRecord::Migration[7.0]
   private
 
   def create_and_assign_default_section
-    # for project custom fields only
-    section = ProjectCustomFieldSection.create!(
-      name: "Project attributes"
-    )
+    create_section_sql = <<~SQL.squish
+      INSERT INTO "custom_field_sections" ("position", "name", "type", "created_at", "updated_at")
+      VALUES (:position, :name, :type, :created_at, :updated_at)
+      RETURNING "id"
+    SQL
 
-    ActiveRecord::Base.connection.execute <<~SQL.squish
-       UPDATE "custom_fields"
-       SET
-         "position_in_custom_field_section" = "mapping"."new_position",
-         "custom_field_section_id" = #{section.id}
-       FROM (
-         SELECT
-           id,
-           ROW_NUMBER() OVER (ORDER BY updated_at) AS new_position
-         FROM "custom_fields"
-         WHERE "custom_fields"."type" = 'ProjectCustomField'
-       ) AS "mapping"
-       WHERE "custom_fields"."id" = "mapping"."id";
-     SQL
+    now = Time.current
+
+    insert_result =
+      execute_sql create_section_sql, type: "ProjectCustomFieldSection", name: "Project attributes",
+                                      position: 1, created_at: now, updated_at: now
+
+    update_sql = <<~SQL.squish
+      UPDATE "custom_fields"
+      SET
+        "position_in_custom_field_section" = "mapping"."new_position",
+        "custom_field_section_id" = :section_id
+      FROM (
+        SELECT
+         id,
+         ROW_NUMBER() OVER (ORDER BY updated_at) AS new_position
+        FROM "custom_fields"
+        WHERE "custom_fields"."type" = 'ProjectCustomField'
+      ) AS "mapping"
+      WHERE "custom_fields"."id" = "mapping"."id";
+    SQL
+
+    execute_sql(update_sql, section_id: insert_result.first["id"])
   end
 end

--- a/spec/migrations/create_custom_field_sections_spec.rb
+++ b/spec/migrations/create_custom_field_sections_spec.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20231123111357_create_custom_field_sections.rb")
+
+RSpec.describe CreateCustomFieldSections, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject(:run_migration) do
+    ActiveRecord::Migration.suppress_messages { described_class.new.tap(&:down).tap(&:up) }
+  end
+
+  it "creates the custom field section" do
+    create_list(:project_custom_field, 2)
+    create_list(:wp_custom_field, 2)
+
+    run_migration
+
+    expect(ProjectCustomFieldSection.count).to eq 1
+    expect(ProjectCustomFieldSection.first.name).to eq "Project attributes"
+    expect(WorkPackageCustomField.pluck(:custom_field_section_id)).to all be_nil
+    expect(WorkPackageCustomField.pluck(:position_in_custom_field_section)).to all be_nil
+    expect(ProjectCustomField.pluck(:custom_field_section_id))
+      .to all eq ProjectCustomFieldSection.first.id
+    expect(ProjectCustomField.pluck(:position_in_custom_field_section)).to eq [1, 2]
+  end
+end


### PR DESCRIPTION
Addresses both tickets: https://community.openproject.org/wp/53728 and https://community.openproject.org/wp/53799 .
## The problem

Backfilling the data in the migration `20231123111357_create_custom_field_sections.rb` is unreliable due to using `acts_as_list` callbacks during migrations. Sometimes it does not fill the `custom_field_section_id`.

## The solution
A better approach is to use plain SQL for data backfilling, avoiding eventual problems of the newly migrated field not being backfilled. This approach should also be a lot faster, because we are executing a single update query instead of loading all the models into memory, then updating them one by one.

**Additionally:** The `position_in_custom_field_section` is also being filled in order to have an initial value for the `acts_as_list` plugin. The calculation of the current row's position happens in an SQL subquery as the [acts_as_list](https://github.com/brendon/acts_as_list?tab=readme-ov-file#adding-acts_as_list-to-an-existing-model) gem recommends.

## The expectation 

The expectation is to have all the `ProjectCustomField#custom_field_section_id` set to the newly created `ProjectCustomFieldSection` and to have an incremental position set in the `position_in_custom_field_section` field **only** for the `custom_fields` with the `type='ProjectCustomField'`.