### PR TITLE
bug/storage-health-status-mails-are-send-for-every-failed-request

### DIFF
--- a/modules/storages/app/workers/storages/health_status_mailer_job.rb
+++ b/modules/storages/app/workers/storages/health_status_mailer_job.rb
@@ -36,7 +36,7 @@ module Storages
       total_limit: 2,
       enqueue_limit: 1,
       perform_limit: 1,
-      key: -> { "#{self.class.name}-#{arguments.last[:storage]}" }
+      key: -> { "#{self.class.name}-#{arguments.last[:storage].id}" }
     )
 
     discard_on ActiveJob::DeserializationError


### PR DESCRIPTION
Fixed concurrency key for HealthStatusMailerJob by adding `.id` to the storage. Before the storage object was stringifyed and lead to a different key every time. Which in turn caused GoodJob to enqueue a job for every failed request. Now the storage ID is used and the key stays the same.