### PR TITLE
Require rubocop-rspec_rails to fix rubocop warning.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
   - ./lib_static/rubocop/cop/open_project/add_preview_for_view_component.rb
   - ./lib_static/rubocop/cop/open_project/no_do_end_block_with_rspec_capybara_matcher_in_expect.rb
   - ./lib_static/rubocop/cop/open_project/use_service_result_factory_methods.rb


### PR DESCRIPTION
Fix rubocop warning

```bash
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-rspec_rails
```