### PR TITLE
Fix/transaction for update progress job

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -48,7 +48,7 @@ module Journals
       self.journable = journable
     end
 
-    def call(notes: '', cause: {})
+    def call(notes: "", cause: {})
       # JSON columns read from the database always have string keys. As we do not know what is passed in here,
       # and we want to compare it to values read from the DB, we need to stringify the keys here as well
       normalized_cause = cause.deep_stringify_keys

--- a/app/workers/work_packages/apply_statuses_p_complete_job.rb
+++ b/app/workers/work_packages/apply_statuses_p_complete_job.rb
@@ -88,10 +88,12 @@ class WorkPackages::ApplyStatusesPCompleteJob < ApplicationJob
   end
 
   def with_temporary_progress_table
-    create_temporary_progress_table
-    yield
-  ensure
-    drop_temporary_progress_table
+    WorkPackage.transaction do
+      create_temporary_progress_table
+      yield
+    ensure
+      drop_temporary_progress_table
+    end
   end
 
   def create_temporary_progress_table

--- a/db/migrate/20240402072213_update_progress_calculation.rb
+++ b/db/migrate/20240402072213_update_progress_calculation.rb
@@ -8,7 +8,7 @@ class UpdateProgressCalculation < ActiveRecord::Migration[7.1]
       current_mode = "field"
     end
 
-    perform_method = Rails.env.production? ? :perform_later : :perform_now
+    perform_method = Rails.env.development? ? :perform_now : :perform_later
     WorkPackages::UpdateProgressJob.public_send(perform_method, current_mode:, previous_mode:)
   end
 

--- a/spec/migrations/update_progress_calculation_spec.rb
+++ b/spec/migrations/update_progress_calculation_spec.rb
@@ -31,7 +31,11 @@ require Rails.root.join("db/migrate/20240402072213_update_progress_calculation.r
 
 RSpec.describe UpdateProgressCalculation, type: :model do
   # Silencing migration logs, since we are not interested in that during testing
-  subject(:run_migration) { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+  subject(:run_migration) do
+    perform_enqueued_jobs do
+      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+    end
+  end
 
   shared_let(:author) { create(:user) }
   shared_let(:priority) { create(:priority, name: "Normal") }
@@ -684,6 +688,48 @@ RSpec.describe UpdateProgressCalculation, type: :model do
           TABLE
         )
       end
+    end
+  end
+
+  describe "error during job execution" do
+    before do
+      Setting.work_package_done_ratio = "field"
+      allow(Journals::CreateService)
+              .to receive(:new)
+                    .with(wp_breaking, User.system)
+                    .and_return(nil)
+
+      allow(Journals::CreateService)
+        .to receive(:new)
+              .with(wp_working, User.system)
+              .and_call_original
+
+      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+
+      begin
+        perform_enqueued_jobs
+      rescue StandardError
+      end
+    end
+
+    let_work_packages(<<~TABLE)
+      subject     | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
+      wp working  |      |             4h |        60% |    10h |               4h |          60%
+      wp breaking |      |             4h |        60% |    10h |               4h |          60%
+    TABLE
+
+    it "does not create a journal entry" do
+      table_work_packages.each do |wp|
+        expect(wp.journals.count).to eq(1)
+      end
+    end
+
+    it "does not update the work packages" do
+      expect_work_packages(WorkPackage.all, <<~TABLE)
+        subject     | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
+        wp working  |      |             4h |        60% |    10h |               4h |          60%
+        wp breaking |      |             4h |        60% |    10h |               4h |          60%
+      TABLE
     end
   end
 end


### PR DESCRIPTION
Wraps both jobs changing progress & work first and then creating journals for it in a transaction to avoid inconsistent states.