### PR TITLE
[54137] Doubled scrollbar and weird white space below the project list

### DIFF
--- a/app/components/members/row_component.rb
+++ b/app/components/members/row_component.rb
@@ -226,6 +226,7 @@ module Members
     def view_work_package_shares_action_options
       {
         scheme: :default,
+        tag: :a,
         icon: "op-view-list",
         label: I18n.t(:button_view_shared_work_packages),
         href: shared_work_packages_url

--- a/app/components/projects/row_component.html.erb
+++ b/app/components/projects/row_component.html.erb
@@ -37,19 +37,8 @@ See COPYRIGHT and LICENSE files for more details.
     </td>
   <% end %>
   <td class="buttons">
-    <% if more_menu_items.any?  %>
-      <ul class="project-actions">
-        <li aria-haspopup="true" title="<%= I18n.t(:label_open_menu) %>" class="drop-down">
-          <a class="icon icon-show-more-horizontal context-menu--icon" title="<%= t(:label_open_menu) %>" href></a>
-          <ul style="display:none;" class="menu-drop-down-container">
-            <% more_menu_items.each do |item| %>
-              <li>
-                <%= link_to(*item) %>
-              </li>
-            <% end %>
-          </ul>
-        </li>
-      </ul>
+    <% button_links.each do |link| %>
+      <%= link %>
     <% end %>
   </td>
 </tr>

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -263,7 +263,6 @@ module Projects
           scheme: :default,
           icon: :lock,
           label: I18n.t(:button_archive),
-          rel: "nofollow",
           href: project_archive_path(project, status: params[:status]),
           data: {
             confirm: t("project.archive.are_you_sure", name: project.name),
@@ -279,7 +278,6 @@ module Projects
           scheme: :default,
           icon: :unlock,
           label: I18n.t(:button_unarchive),
-          rel: "nofollow",
           href: project_archive_path(project, status: params[:status]),
           data: { method: :delete }
         }

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -179,6 +179,40 @@ module Projects
       end
     end
 
+    def button_links
+      return [] if more_menu_items.empty?
+
+      if more_menu_items.one?
+        more_menu_items.first => {label:, **button_options}
+
+        [render(Primer::Beta::IconButton.new(**button_options,
+                                             size: :small,
+                                             tag: :a,
+                                             scheme: button_options[:scheme] == :default ? :invisible : button_options[:scheme],
+                                             "aria-label": label,
+                                             test_selector: "project-list-row--single-action"))]
+      else
+        [
+          render(Primer::Alpha::ActionMenu.new(test_selector: "project-list-row--action-menu")) do |menu|
+            menu.with_show_button(scheme: :invisible,
+                                  size: :small,
+                                  icon: :"kebab-horizontal",
+                                  "aria-label": t(:label_open_menu),
+                                  tooltip_direction: :w)
+            more_menu_items.each do |action_options|
+              action_options => {scheme:, label:, icon:, **button_options}
+              menu.with_item(scheme:,
+                             label:,
+                             test_selector: "project-list-row--action-menu-item",
+                             content_arguments: button_options) do |item|
+                item.with_leading_visual_icon(icon:)
+              end
+            end
+          end
+        ]
+      end
+    end
+
     def more_menu_items
       @more_menu_items ||= [more_menu_subproject_item,
                             more_menu_settings_item,
@@ -191,70 +225,86 @@ module Projects
 
     def more_menu_subproject_item
       if User.current.allowed_in_project?(:add_subprojects, project)
-        [t(:label_subproject_new),
-         new_project_path(parent_id: project.id),
-         { class: "icon-context icon-add",
-           title: t(:label_subproject_new) }]
+        {
+          scheme: :default,
+          icon: :plus,
+          label: I18n.t(:label_subproject_new),
+          href: new_project_path(parent_id: project.id)
+        }
       end
     end
 
     def more_menu_settings_item
       if User.current.allowed_in_project?({ controller: "/projects/settings/general", action: "show", project_id: project.id },
                                           project)
-        [t(:label_project_settings),
-         project_settings_general_path(project),
-         { class: "icon-context icon-settings",
-           title: t(:label_project_settings) }]
+        {
+          scheme: :default,
+          icon: :gear,
+          label: I18n.t(:label_project_settings),
+          href: project_settings_general_path(project)
+        }
       end
     end
 
     def more_menu_activity_item
       if User.current.allowed_in_project?(:view_project_activity, project)
-        [
-          t(:label_project_activity),
-          project_activity_index_path(project, event_types: ["project_attributes"]),
-          { class: "icon-context icon-checkmark",
-            title: t(:label_project_activity) }
-        ]
+        {
+          scheme: :default,
+          icon: :check,
+          label: I18n.t(:label_project_activity),
+          href: project_activity_index_path(project, event_types: ["project_attributes"]),
+        }
       end
     end
 
     def more_menu_archive_item
       if User.current.allowed_in_project?(:archive_project, project) && project.active?
-        [t(:button_archive),
-         project_archive_path(project, status: params[:status]),
-         { data: { confirm: t("project.archive.are_you_sure", name: project.name) },
-           method: :post,
-           class: "icon-context icon-locked",
-           title: t(:button_archive) }]
+        {
+          scheme: :default,
+          icon: :lock,
+          label: I18n.t(:button_archive),
+          rel: "nofollow",
+          href: project_archive_path(project, status: params[:status]),
+          data: {
+            confirm: t("project.archive.are_you_sure", name: project.name),
+            method: :post
+          },
+        }
       end
     end
 
     def more_menu_unarchive_item
       if User.current.admin? && project.archived? && (project.parent.nil? || project.parent.active?)
-        [t(:button_unarchive),
-         project_archive_path(project, status: params[:status]),
-         { method: :delete,
-           class: "icon-context icon-unlocked",
-           title: t(:button_unarchive) }]
+        {
+          scheme: :default,
+          icon: :unlock,
+          label: I18n.t(:button_unarchive),
+          rel: "nofollow",
+          href: project_archive_path(project, status: params[:status]),
+          data: { method: :delete }
+        }
       end
     end
 
     def more_menu_copy_item
       if User.current.allowed_in_project?(:copy_projects, project) && !project.archived?
-        [t(:button_copy),
-         copy_project_path(project),
-         { class: "icon-context icon-copy",
-           title: t(:button_copy) }]
+        {
+          scheme: :default,
+          icon: :copy,
+          label: I18n.t(:button_copy),
+          href: copy_project_path(project),
+        }
       end
     end
 
     def more_menu_delete_item
       if User.current.admin
-        [t(:button_delete),
-         confirm_destroy_project_path(project),
-         { class: "icon-context icon-delete",
-           title: t(:button_delete) }]
+        {
+          scheme: :danger,
+          icon: :trash,
+          label: I18n.t(:button_delete),
+          href: confirm_destroy_project_path(project),
+        }
       end
     end
 

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% columns.each do |column| %>
             <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
           <% end %>
-          <col opHighlightCol>
+          <col>
         </colgroup>
         <thead class="-sticky">
         <tr>
@@ -71,8 +71,8 @@ See COPYRIGHT and LICENSE files for more details.
               </th>
             <% end %>
           <% end %>
-          <th class="-right">
-            <div class="generic-table--header-outer">
+          <th>
+            <div class="generic-table--empty-header">
             </div>
           </th>
         </tr>

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -26,79 +26,81 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-
-<div class="generic-table--flex-container">
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
-        <colgroup>
-          <% columns.each do |column| %>
-            <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
-          <% end %>
-          <col>
-        </colgroup>
-        <thead class="-sticky">
-        <tr>
-          <% columns.each do |column| %>
-            <% if column.attribute == :hierarchy %>
-              <th id="project-table--hierarchy-header">
-                <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
-                  <div class="generic-table--sort-header"
-                       data-controller="params-from-query"
-                       data-application-target="dynamic"
-                       data-params-from-query-all-anchors-value="true"
-                       data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
-                    <%= content_tag :a,
-                                    helpers.op_icon("icon-hierarchy"),
-                                    href: href_only_when_not_sort_lft,
-                                    class: "spot-link #{deactivate_class_on_lft_sort}",
-                                    title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
-                  </div>
-                </div>
-              </th>
-            <% elsif sortable_column?(column) %>
-              <%= build_sort_header column.attribute,
-                                    order_options(column) %>
-            <% else %>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= column.caption %>
-                    </span>
-                  </div>
-                </div>
-              </th>
+<div class="project-list-page--table">
+  <div class="generic-table--flex-container">
+    <div class="generic-table--container <%= container_class %>">
+      <div class="generic-table--results-container">
+        <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
+          <colgroup>
+            <% columns.each do |column| %>
+              <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
             <% end %>
-          <% end %>
-          <th>
-            <div class="generic-table--empty-header">
-            </div>
-          </th>
-        </tr>
-        </thead>
-        <tbody>
-        <% if rows.empty? %>
-          <tr class="generic-table--empty-row">
-            <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+            <col>
+          </colgroup>
+          <thead class="-sticky">
+          <tr>
+            <% columns.each do |column| %>
+              <% if column.attribute == :hierarchy %>
+                <th id="project-table--hierarchy-header">
+                  <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
+                    <div class="generic-table--sort-header"
+                         data-controller="params-from-query"
+                         data-application-target="dynamic"
+                         data-params-from-query-all-anchors-value="true"
+                         data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
+                      <%= content_tag :a,
+                                      helpers.op_icon("icon-hierarchy"),
+                                      href: href_only_when_not_sort_lft,
+                                      class: "spot-link #{deactivate_class_on_lft_sort}",
+                                      title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
+                    </div>
+                  </div>
+                </th>
+              <% elsif sortable_column?(column) %>
+                <%= build_sort_header column.attribute,
+                                      order_options(column) %>
+              <% else %>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= column.caption %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+              <% end %>
+            <% end %>
+            <th>
+              <div class="generic-table--empty-header">
+              </div>
+            </th>
           </tr>
+          </thead>
+          <tbody>
+          <% if rows.empty? %>
+            <tr class="generic-table--empty-row">
+              <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+            </tr>
+          <% end %>
+          <%= render_collection rows %>
+          </tbody>
+        </table>
+        <% if inline_create_link && show_inline_create %>
+          <div class="wp-inline-create-button">
+            <%= inline_create_link %>
+          </div>
         <% end %>
-        <%= render_collection rows %>
-        </tbody>
-      </table>
-      <% if inline_create_link && show_inline_create %>
-        <div class="wp-inline-create-button">
-          <%= inline_create_link %>
-        </div>
-      <% end %>
+      </div>
     </div>
   </div>
-  <% if paginated? %>
-    <div data-controller="params-from-query"
-         data-application-target="dynamic"
-         data-params-from-query-all-anchors-value="true"
-         data-params-from-query-allowed-value='["query_id", "columns"]'>
-      <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
-    </div>
-  <% end %>
 </div>
+
+<% if paginated? %>
+  <div data-controller="params-from-query"
+       data-application-target="dynamic"
+       data-params-from-query-all-anchors-value="true"
+       data-params-from-query-allowed-value='["query_id", "columns"]'>
+    <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
+  </div>
+<% end %>

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -51,6 +51,10 @@ module Projects
       "project-table"
     end
 
+    def container_class
+      "generic-table--container_visible-overflow"
+    end
+
     ##
     # The project sort by is handled differently
     def build_sort_header(column, options)

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -28,36 +28,39 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title(t(:label_project_plural)) -%>
 
-<%= render(
-      Projects::IndexPageHeaderComponent.new(
-        query:,
-        current_user:,
-        state:,
-        params:
+<div class="project-list-page">
+  <%= render(
+        Projects::IndexPageHeaderComponent.new(
+          query:,
+          current_user:,
+          state:,
+          params:
+        )
       )
-    )
-%>
+  %>
 
-<%= render(Projects::ProjectsFiltersComponent.new(query:)) do |component|
-  if current_user.allowed_globally?(:add_project)
-    component.with_button(
-      tag: :a,
-      href: new_project_path,
-      scheme: :primary,
-      size: :medium,
-      aria: { label: I18n.t(:label_project_new) },
-      data: { 'test-selector': 'project-new-button' }) do |button|
-        button.with_leading_visual_icon(icon: :plus)
-        Project.model_name.human
+  <%= render(Projects::ProjectsFiltersComponent.new(query:)) do |component|
+    if current_user.allowed_globally?(:add_project)
+      component.with_button(
+        tag: :a,
+        href: new_project_path,
+        scheme: :primary,
+        size: :medium,
+        aria: { label: I18n.t(:label_project_new) },
+        data: { 'test-selector': 'project-new-button' }) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          Project.model_name.human
+        end
       end
     end
-  end
-%>
+  %>
 
-<%= render Projects::TableComponent.new(
-  query:,
-  current_user: current_user,
-  params:) %>
 
-<%= render Projects::StorageInformationComponent.new(
-  current_user: current_user) %>
+  <%= render Projects::TableComponent.new(
+    query:,
+    current_user: current_user,
+    params:) %>
+
+  <%= render Projects::StorageInformationComponent.new(
+    current_user: current_user) %>
+</div>

--- a/frontend/src/app/core/setup/globals/global-listeners.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners.ts
@@ -152,7 +152,7 @@ export function initializeGlobalListeners():void {
   setupToggableFieldsets();
 
   // Action menu logic
-  jQuery('.project-actions, .toolbar-items').each((idx:number, menu:HTMLElement) => {
+  jQuery('.toolbar-items').each((idx:number, menu:HTMLElement) => {
     installMenuLogic(jQuery(menu));
   });
 

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -69,11 +69,6 @@ $project-table--description-indention: 9px
       .expand
         display: inline
 
-      .project-actions
-        display: inline-block
-        margin: 0
-        .menu-drop-down-container
-          text-align: left
     .archived
       color: var(--color-fg-muted)
       span.archived-label

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -31,6 +31,8 @@ $project-table--child-indentation: 1.1em
 $project-table--icon-distance: 5px
 $project-table--description-indention: 9px
 
+$content-padding: 10px
+
 @mixin calc-indentation-name($indentation)
   // This does not work for big font-sizes
   padding-left: calc(#{$indentation} * #{$project-table--child-indentation} + #{$project-table--start-indentation} - #{$project-table--icon-distance})
@@ -102,3 +104,19 @@ $project-table--description-indention: 9px
     padding-left: 1em
   li
     list-style-type: none
+
+// Firefox does not support the popover attribute yet. Thus, the Primer action menus create an ugly scroll inside the table
+// Follow https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover#browser_compatibility to see when this can be removed
+body:not(.-browser-firefox)
+  .project-list-page
+    display: flex
+    flex-direction: column
+    max-height: calc(100vh - #{var(--header-height)} - #{$content-padding} - #{$content-padding})
+
+    &--table
+      display: flex
+      flex-grow: 1
+      overflow: auto
+
+    .generic-table--results-container
+      overflow-x: hidden

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -74,8 +74,6 @@ $project-table--description-indention: 9px
       span.archived-label
         text-transform: uppercase
 
-
-
   td.name
     @include text-shortener
     a

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -37,6 +37,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 .generic-table--flex-container
   display: flex
   flex-direction: column
+  flex: 1
 
 .generic-table--container
   position:     relative

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -34,8 +34,9 @@
 
 $input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix', 'a.button'
 
-$toolbar-height: 80px
-$toolbar-height--mobile: 100px
+// These values are based on the new Primer::OpenProject::PageHeader implementation
+$toolbar-height: 195px
+$toolbar-height--mobile: 180px
 
 .generic-table--flex-container
   display: flex
@@ -45,9 +46,6 @@ $toolbar-height--mobile: 100px
 
   @media screen and (max-width: $breakpoint-sm)
     max-height: calc(100vh - #{var(--header-height)} - #{$toolbar-height--mobile})
-
-  .generic-table--results-container
-    padding-bottom: $spot-spacing-10
 
   .generic-table--container
     display: contents

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -34,24 +34,9 @@
 
 $input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix', 'a.button'
 
-// These values are based on the new Primer::OpenProject::PageHeader implementation
-$toolbar-height: 195px
-$toolbar-height--mobile: 180px
-
 .generic-table--flex-container
   display: flex
   flex-direction: column
-  // Calculate table size by subtracting the space above
-  max-height: calc(100vh - #{var(--header-height)} - #{$toolbar-height})
-
-  @media screen and (max-width: $breakpoint-sm)
-    max-height: calc(100vh - #{var(--header-height)} - #{$toolbar-height--mobile})
-
-  .generic-table--container
-    display: contents
-
-  .generic-table
-    position: relative
 
 .generic-table--container
   position:     relative

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -177,16 +177,13 @@ RSpec.describe "Projects index page",
         expect(page).to have_text(project.name)
 
         # Test visibility of 'more' menu list items
-        item = page.first("tbody tr .icon-show-more-horizontal", visible: :all)
-        item.hover
-        item.click
-
-        menu = page.first("tbody tr .project-actions")
-        expect(menu).to have_text("Copy")
-        expect(menu).to have_text("Project settings")
-        expect(menu).to have_text("New subproject")
-        expect(menu).to have_text("Delete")
-        expect(menu).to have_text("Archive")
+        projects_page.activate_menu_of(project) do |menu|
+          expect(menu).to have_text("Copy")
+          expect(menu).to have_text("Project settings")
+          expect(menu).to have_text("New subproject")
+          expect(menu).to have_text("Delete")
+          expect(menu).to have_text("Archive")
+        end
 
         # Test visibility of admin only properties
         within("#project-table") do
@@ -909,9 +906,9 @@ RSpec.describe "Projects index page",
 
       expect(page).to have_text(parent_project.name)
 
-      # 'More' does not become visible on hover
-      page.find("tbody tr").hover
-      expect(page).to have_no_css(".icon-show-more-horizontal")
+      # 'More' does not become visible
+      expect(page).to have_no_css('[data-test-selector="project-list-row--single-action"]')
+      expect(page).to have_no_css('[data-test-selector="project-list-row--action-menu"]')
 
       # For a project member with :copy_projects privilege the 'More' menu is visible.
       login_as(can_copy_projects_manager)
@@ -919,37 +916,15 @@ RSpec.describe "Projects index page",
 
       expect(page).to have_text(parent_project.name)
 
-      # 'More' becomes visible on hover
-      # because we use css opacity we can not test for the visibility changes
-      page.find("tbody tr").hover
-      expect(page).to have_css(".icon-show-more-horizontal")
-
       # Test visibility of 'more' menu list items
-      page.find("tbody tr .icon-show-more-horizontal").click
-      menu = page.find("tbody tr .project-actions")
-      expect(menu).to have_text("Copy")
-      expect(menu).to have_no_text("New subproject")
-      expect(menu).to have_no_text("Delete")
-      expect(menu).to have_no_text("Archive")
-      expect(menu).to have_no_text("Unarchive")
+      expect(page).to have_css('[data-test-selector="project-list-row--single-action"] .octicon-copy')
 
       # For a project member with :add_subprojects privilege the 'More' menu is visible.
       login_as(can_add_subprojects_manager)
       visit projects_path
 
-      # 'More' becomes visible on hover
-      # because we use css opacity we can not test for the visibility changes
-      page.find("tbody tr").hover
-      expect(page).to have_css(".icon-show-more-horizontal")
-
       # Test visibility of 'more' menu list items
-      page.find("tbody tr .icon-show-more-horizontal").click
-      menu = page.find("tbody tr .project-actions")
-      expect(menu).to have_text("New subproject")
-      expect(menu).to have_no_text("Copy")
-      expect(menu).to have_no_text("Delete")
-      expect(menu).to have_no_text("Archive")
-      expect(menu).to have_no_text("Unrchive")
+      expect(page).to have_css('[data-test-selector="project-list-row--single-action"] .octicon-plus')
 
       # Test admin only properties are invisible
       within("#project-table") do
@@ -1189,20 +1164,11 @@ RSpec.describe "Projects index page",
 
         expect(page).to have_text(project.name)
 
-        # 'More' becomes visible on hover
-        # because we use css opacity we can not test for the visibility changes
-        page.find("tbody tr", text: project.name).hover
-        expect(page).to have_css(".icon-show-more-horizontal")
-
-        # "Project activity" item should be displayed in the 'more' menu
-        page.find("tbody tr .icon-show-more-horizontal").click
-
-        menu = page.find("tbody tr .project-actions")
-        expect(menu).to have_text(I18n.t(:label_project_activity))
+        expect(page).to have_css('[data-test-selector="project-list-row--single-action"] .octicon-check')
 
         # Clicking the menu item should redirect to project activity page
         # with only project attributes displayed
-        menu.find_link(text: I18n.t(:label_project_activity)).click
+        page.find('[data-test-selector="project-list-row--single-action"]').click
 
         expect(page).to have_current_path(project_activity_index_path(project_with_activity_enabled), ignore_query: true)
         expect(page).to have_checked_field(id: "event_types_project_attributes")

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -307,10 +307,11 @@ module Pages
       def activate_menu_of(project)
         within_row(project) do |row|
           row.hover
-          menu = find("ul.project-actions")
-          menu.click
+          menu = find("[data-test-selector='project-list-row--action-menu']")
+          menu_button = find("[data-test-selector='project-list-row--action-menu'] button")
+          menu_button.click
           wait_for_network_idle if using_cuprite?
-          expect(page).to have_css(".menu-drop-down-container")
+          expect(page).to have_css("[data-test-selector='project-list-row--action-menu-item']")
           yield menu
         end
       end


### PR DESCRIPTION
* Remove doubled scrollbar on the project lists page
* Remove extra white space below the table which was added originally to create space for the dropdown
  * In that scope, the old action menu was replaced by a `Primer::Alpha::ActionMenu`
* Accept that the sticky headers will not work in Firefox as it does not support the `popover` attribute of the action menu yet and thus results in conflicts with the scroll behavior of the sticky table header (see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover#browser_compatibility)

https://community.openproject.org/projects/openproject/work_packages/54137/activity
