### PR TITLE
[53977] Change placeholder of user autocompleter in agenda item form

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -87,7 +87,7 @@ div.autocomplete
 
       .ng-placeholder
         top: 1px !important
-        color: var(--color-fg-muted)
+        color: var(--color-fg-subtle)
         @include text-shortener
 
       input

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.sass
@@ -9,6 +9,14 @@
   &--actions
     justify-self: end
 
+  // Render an icon in front of the placeholder
+  &--presenter
+    .ng-placeholder
+      @extend .icon-user
+      &:before
+        @include icon-font-common
+        margin-right: 10px
+
   @media screen and (max-width: $breakpoint-md)
     grid-template-columns: 100px minmax(0, 100%)
     grid-template-areas: "title title" "duration presenter" "notes notes" "add_note actions"

--- a/modules/meeting/app/forms/meeting_agenda_item/presenter.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/presenter.rb
@@ -44,6 +44,7 @@ class MeetingAgendaItem::Presenter < ApplicationForm
         focusDirectly: false,
         multiple: false,
         appendTo: "body",
+        placeholder: I18n.t("activerecord.attributes.meeting_agenda_item.presenter"),
         disabled: @disabled
       }
     )


### PR DESCRIPTION
* Add a placeholder icon in front of the responsible autocompleter of an agenda item
* Change text of the placeholder


https://community.openproject.org/projects/openproject/work_packages/53977/activity