### PR TITLE
Bug/53344 cannot modify a query that was created by a deleted user

### DIFF
--- a/frontend/src/app/features/hal/resources/query-resource.ts
+++ b/frontend/src/app/features/hal/resources/query-resource.ts
@@ -33,6 +33,7 @@ import { QueryOrder } from 'core-app/core/apiv3/endpoints/queries/apiv3-query-or
 import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/wp-collection-resource';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
+import { UserResource } from 'core-app/features/hal/resources/user-resource';
 import { QuerySortByResource } from 'core-app/features/hal/resources/query-sort-by-resource';
 import { QueryGroupByResource } from 'core-app/features/hal/resources/query-group-by-resource';
 
@@ -41,6 +42,7 @@ export interface QueryResourceEmbedded {
   columns:QueryColumn[];
   groupBy:QueryGroupByResource|undefined;
   project:ProjectResource;
+  user:UserResource;
   sortBy:QuerySortByResource[];
   filters:QueryFilterInstanceResource[];
 }
@@ -95,6 +97,8 @@ export class QueryResource extends HalResource {
   public public:boolean;
 
   public hidden:boolean;
+
+  public user:UserResource;
 
   public project:ProjectResource;
 


### PR DESCRIPTION
https://community.openproject.org/wp/53344

Addresses the issue reported [here](https://community.openproject.org/projects/openproject/work_packages/53344#activity-12).

When an admin makes another user's public query private, it will no longer have access to it. Currently the logic is to reload the changed query, but since the admin user doesn't have access to the query anymore, the page renders a permission error.
This can be a confusing behaviour, and this PR changes the logic to navigate the browser to the default work packages view, instead of refreshing the inaccessible query.