### PR TITLE
[54179] Total Remaining work of parent should be updated when children are closed in status-based mode

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -123,8 +123,7 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
     },
     done_ratio: {
       sortable: "#{WorkPackage.table_name}.done_ratio",
-      groupable: true,
-      if: ->(*) { !WorkPackage.done_ratio_disabled? }
+      groupable: true
     },
     created_at: {
       sortable: "#{WorkPackage.table_name}.created_at",

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -206,10 +206,6 @@ class WorkPackage < ApplicationRecord
   include WorkPackage::Journalized
   prepend Journable::Timestamps
 
-  def self.done_ratio_disabled?
-    Setting.work_package_done_ratio == "disabled"
-  end
-
   def self.use_status_for_done_ratio?
     Setting.work_package_done_ratio == "status"
   end

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -116,8 +116,6 @@ class WorkPackages::UpdateAncestorsService
   end
 
   def derive_done_ratio(ancestor, loader)
-    return if WorkPackage.done_ratio_disabled?
-
     ancestor.derived_done_ratio = compute_derived_done_ratio(ancestor, loader)
   end
 

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -119,12 +119,12 @@ class WorkPackages::UpdateAncestorsService
     ancestor.derived_done_ratio = compute_derived_done_ratio(ancestor, loader)
   end
 
-  def compute_derived_done_ratio(work_package, loader)
+  def compute_derived_done_ratio(work_package, _loader)
     return if work_package.derived_estimated_hours.nil? || work_package.derived_remaining_hours.nil?
 
-    leaves = loader.leaves_of(work_package)
-
-    if leaves.size.positive?
+    if work_package.derived_estimated_hours.zero?
+      nil
+    else
       work_done = (work_package.derived_estimated_hours - work_package.derived_remaining_hours)
       progress = (work_done.to_f / work_package.derived_estimated_hours) * 100
       progress.round
@@ -151,22 +151,20 @@ class WorkPackages::UpdateAncestorsService
   def derive_total_estimated_and_remaining_hours(work_package, loader)
     descendants = loader.descendants_of(work_package)
 
-    work_package.derived_estimated_hours = not_zero(all_estimated_hours([work_package] + descendants).sum.to_f)
-    work_package.derived_remaining_hours = not_zero(all_remaining_hours([work_package] + descendants).sum.to_f)
+    work_package.derived_estimated_hours = total(all_estimated_hours([work_package] + descendants))
+    work_package.derived_remaining_hours = total(all_remaining_hours([work_package] + descendants))
   end
 
-  def not_zero(value)
-    value unless value.zero?
+  def total(hours)
+    hours.empty? ? nil : hours.sum.to_f
   end
 
   def all_estimated_hours(work_packages)
-    work_packages
-      .map(&:estimated_hours)
-      .reject { |hours| hours.to_f.zero? }
+    work_packages.filter_map(&:estimated_hours)
   end
 
   def all_remaining_hours(work_packages)
-    work_packages.map(&:remaining_hours).reject { |hours| hours.to_f.zero? }
+    work_packages.filter_map(&:remaining_hours)
   end
 
   def modified_attributes_justify_derivation?(attributes)

--- a/app/views/work_package_mailer/_work_package_details.html.erb
+++ b/app/views/work_package_mailer/_work_package_details.html.erb
@@ -40,10 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
   <li><%= WorkPackage.human_attribute_name(:start_date)    %>: <%= work_package.start_date    %></li>
   <li><%= WorkPackage.human_attribute_name(:due_date)      %>: <%= work_package.due_date      %></li>
   <li><%= WorkPackage.human_attribute_name(:estimated_hours)%>: <%= work_package.estimated_hours %></li>
-
-  <% if Setting.work_package_done_ratio != 'disabled' %>
-    <li><%= WorkPackage.human_attribute_name(:done_ratio)    %>: <%= work_package.done_ratio    %></li>
-  <% end %>
+  <li><%= WorkPackage.human_attribute_name(:done_ratio)    %>: <%= work_package.done_ratio    %></li>
 
   <% work_package.custom_field_values.each do |value| %>
     <li><%= value.custom_field.name %>: <%= show_value(value) %></li>

--- a/app/views/work_package_mailer/_work_package_details.text.erb
+++ b/app/views/work_package_mailer/_work_package_details.text.erb
@@ -40,9 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= WorkPackage.human_attribute_name(:start_date)    %>: <%= work_package.start_date    %>
 <%= WorkPackage.human_attribute_name(:due_date)      %>: <%= work_package.due_date      %>
 <%= WorkPackage.human_attribute_name(:estimated_hours)%>: <%= work_package.estimated_hours %>
-<% if Setting.work_package_done_ratio != 'disabled' %>
-<%=  WorkPackage.human_attribute_name(:done_ratio) %>: <%= work_package.done_ratio %>
-<% end %>
+<%= WorkPackage.human_attribute_name(:done_ratio) %>: <%= work_package.done_ratio %>
 <% work_package.custom_field_values.each do |value| %>
 <%=  value.custom_field.name %>: <%= show_value(value) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3668,9 +3668,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
         unsupported_context: "The resource given is not supported as context."
         context_object_not_found: "Cannot find the resource given as the context."
       validation:
-        done_ratio: "% Complete cannot be set on parent work packages, when it is inferred by status or when it is disabled."
         due_date: "Finish date cannot be set on parent work packages."
-        estimated_hours: "Work cannot be set on parent work packages." # feel like this one should be removed eventually
         invalid_user_assigned_to_work_package: "The chosen user is not allowed to be '%{property}' for this work package."
         start_date: "Start date cannot be set on parent work packages."
       eprops:

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -188,13 +188,11 @@ module API
           schema :percentage_done,
                  type: "Integer",
                  name_source: :done_ratio,
-                 show_if: ->(*) { Setting.work_package_done_ratio != "disabled" },
                  required: false
 
           schema :derived_percentage_done,
                  type: "Integer",
                  name_source: :derived_done_ratio,
-                 show_if: ->(*) { Setting.work_package_done_ratio != "disabled" },
                  required: false
 
           schema :readonly,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -444,13 +444,11 @@ module API
 
         property :done_ratio,
                  as: :percentageDone,
-                 render_nil: true,
-                 if: ->(*) { Setting.work_package_done_ratio != "disabled" }
+                 render_nil: true
 
         property :derived_done_ratio,
                  as: :derivedPercentageDone,
-                 render_nil: true,
-                 if: ->(*) { Setting.work_package_done_ratio != "disabled" }
+                 render_nil: true
 
         date_time_property :created_at
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -725,13 +725,6 @@ RSpec.describe WorkPackages::BaseContract do
             with_settings: { work_package_done_ratio: "status" } do
       it_behaves_like "invalid if changed", :done_ratio
     end
-
-    context "when % Complete disabled",
-            with_settings: { work_package_done_ratio: "disabled" } do
-      let(:changed_values) { [:done_ratio] }
-
-      it_behaves_like "invalid if changed", :done_ratio
-    end
   end
 
   describe "version" do

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -674,16 +674,6 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:required) { false }
         let(:writable) { false }
       end
-
-      context "as disabled" do
-        before do
-          allow(Setting).to receive(:work_package_done_ratio).and_return("disabled")
-        end
-
-        it "is hidden" do
-          expect(subject).not_to have_json_path("percentageDone")
-        end
-      end
     end
 
     describe "derivedPercentageDone" do
@@ -693,16 +683,6 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:name) { I18n.t("activerecord.attributes.work_package.derived_done_ratio") }
         let(:required) { false }
         let(:writable) { false }
-      end
-
-      context "as disabled" do
-        before do
-          allow(Setting).to receive(:work_package_done_ratio).and_return("disabled")
-        end
-
-        it "is hidden" do
-          expect(subject).not_to have_json_path("derivedPercentageDone")
-        end
       end
     end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -401,16 +401,6 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
         context "when setting enabled" do
           it { expect(parse_json(subject)["percentageDone"]).to eq(50) }
         end
-
-        context "when setting disabled" do
-          before do
-            allow(Setting)
-              .to receive(:work_package_done_ratio)
-                    .and_return("disabled")
-          end
-
-          it { is_expected.not_to have_json_path("percentageDone") }
-        end
       end
     end
 

--- a/spec/models/custom_actions/actions/done_ratio_spec.rb
+++ b/spec/models/custom_actions/actions/done_ratio_spec.rb
@@ -88,14 +88,7 @@ RSpec.describe CustomActions::Actions::DoneRatio do
     end
 
     describe ".all" do
-      context "with field disabled", with_settings: { work_package_done_ratio: "disabled" } do
-        it "is empty" do
-          expect(described_class.all)
-            .to be_empty
-        end
-      end
-
-      context "with field derived", with_settings: { work_package_done_ratio: "status" } do
+      context "in status-based progress calculation mode", with_settings: { work_package_done_ratio: "status" } do
         it "is empty" do
           expect(described_class.all)
             .to be_empty

--- a/spec/models/queries/work_packages/selects/property_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/property_select_spec.rb
@@ -35,24 +35,8 @@ RSpec.describe Queries::WorkPackages::Selects::PropertySelect do
   it_behaves_like "query column"
 
   describe "instances" do
-    context "when done_ratio disabled" do
-      it "the done ratio column does not exist" do
-        allow(WorkPackage)
-          .to receive(:done_ratio_disabled?)
-          .and_return(true)
-
-        expect(described_class.instances.map(&:name)).not_to include :done_ratio
-      end
-    end
-
-    context "when done_ratio enabled" do
-      it "the done ratio column exists" do
-        allow(WorkPackage)
-          .to receive(:done_ratio_disabled?)
-          .and_return(false)
-
-        expect(described_class.instances.map(&:name)).to include :done_ratio
-      end
+    it "the done_ratio column exists" do
+      expect(described_class.instances.map(&:name)).to include :done_ratio
     end
 
     context "when duration feature flag enabled" do

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -319,20 +319,8 @@ RSpec.describe Query,
   end
 
   describe "#available_columns" do
-    context "with work_package_done_ratio NOT disabled" do
-      it "includes the done_ratio column" do
-        expect(query.displayable_columns.map(&:name)).to include :done_ratio
-      end
-    end
-
-    context "with work_package_done_ratio disabled" do
-      before do
-        allow(WorkPackage).to receive(:done_ratio_disabled?).and_return(true)
-      end
-
-      it "does not include the done_ratio column" do
-        expect(query.displayable_columns.map(&:name)).not_to include :done_ratio
-      end
+    it "includes the done_ratio column" do
+      expect(query.displayable_columns.map(&:name)).to include :done_ratio
     end
 
     context "results caching" do

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
   shared_association_default(:author, factory_name: :user) { create(:user) }
   shared_association_default(:project_with_types) { create(:project_with_types) }
   shared_association_default(:priority) { create(:priority) }
-  shared_association_default(:open_status, factory_name: :status) { create(:status) }
-  shared_let(:closed_status) { create(:closed_status) }
+  shared_association_default(:open_status, factory_name: :status) { create(:status, name: "Open", default_done_ratio: 0) }
+  shared_let(:closed_status) { create(:closed_status, name: "Closed", default_done_ratio: 100) }
   shared_let(:user) { create(:user) }
 
   let(:estimated_hours) { [nil, nil, nil] }
@@ -56,11 +56,14 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
 
   describe "done_ratio/estimated_hours/remaining_hours propagation" do
     context "when setting the status of a work package" do
-      shared_let(:open_status) { create(:status, name: "open", default_done_ratio: 0) }
-      shared_let(:complete_status_with_100p_done_ratio) { create(:status, name: "complete", default_done_ratio: 100) }
-
       context 'when using the "status-based" % complete mode',
               with_settings: { work_package_done_ratio: "status" } do
+        def call_update_ancestors_service(work_package)
+          changed_attributes = work_package.changes.keys.map(&:to_sym)
+          described_class.new(user:, work_package:)
+                          .call(changed_attributes)
+        end
+
         context "with both parent and children having estimated hours set" do
           shared_let(:parent) do
             create(:work_package,
@@ -80,19 +83,14 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                    status: open_status)
           end
 
-          def call_update_ancestors_service(work_package)
-            changed_attributes = work_package.changes.keys.map(&:to_sym)
-            described_class.new(user:, work_package:)
-                           .call(changed_attributes)
-          end
           context "when changing child status to a status with a default done ratio" do
             %i[status status_id].each do |field|
               context "with the #{field} field" do
                 it "recomputes child remaining work and update ancestors total % complete accordingly" do
                   value =
                     case field
-                    when :status then complete_status_with_100p_done_ratio
-                    when :status_id then complete_status_with_100p_done_ratio.id
+                    when :status then closed_status
+                    when :status_id then closed_status.id
                     end
                   set_attributes_on(child, field => value)
                   call_update_ancestors_service(child)
@@ -100,10 +98,37 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                   expect_work_packages([parent, child], <<~TABLE)
                     | subject | work | total work | remaining work | total remaining work | % complete | total % complete |
                     | parent  |  10h |        15h |            10h |                  10h |         0% |              33% |
-                    | child   |   5h |         5h |             0h |                      |       100% |                  |
+                    | child   |   5h |         5h |             0h |                   0h |       100% |             100% |
                   TABLE
                 end
               end
+            end
+          end
+        end
+
+        context "with parent having nothing set, and 2 children having values set (bug #54179)" do
+          let_work_packages(<<~TABLE)
+            hierarchy | status | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete
+            parent    | Open   |      |    15h |                |              10h |         0% |          33%
+              child1  | Open   |  10h |        |            10h |                  |         0% |
+              child2  | Closed |   5h |        |             0h |                  |       100% |
+          TABLE
+
+          context "when changing children to all have 100% complete" do
+            before do
+              set_attributes_on(child1, status: closed_status)
+              call_update_ancestors_service(child1)
+            end
+
+            it "sets parent total % complete to 100% and its total remaining work to 0h, " \
+               "and computes totals for the updated children too" do
+              table_work_packages.map(&:reload)
+              expect_work_packages(table_work_packages, <<~TABLE)
+                hierarchy | status | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete
+                parent    | Open   |      |    15h |                |               0h |         0% |         100%
+                  child1  | Closed |  10h |    10h |             0h |               0h |       100% |         100%
+                  child2  | Closed |   5h |        |             0h |                  |       100% |
+              TABLE
             end
           end
         end
@@ -224,7 +249,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
             end
           end
 
-          context "with all tasks having estimated hours and no tasks having any progress done yet" do
+          context "with all tasks having estimated hours and no tasks having any remaining hours" do
             it_behaves_like "attributes of parent having children" do
               let(:estimated_hours) do
                 [10.0, 2.0, 3.0]
@@ -237,10 +262,10 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                 15.0
               end
               let(:aggregate_remaining_hours) do
-                nil # zero-values aren't accounted for
+                0.0
               end
               let(:aggregate_done_ratio) do
-                nil
+                100
               end
             end
           end
@@ -431,7 +456,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
             end
           end
 
-          context "with all tasks having estimated hours and no tasks having any progress done yet" do
+          context "with all tasks having estimated hours and no tasks having remaining hours" do
             it_behaves_like "attributes of parent having children" do
               let(:estimated_hours) do
                 [10.0, 2.0, 3.0]
@@ -444,10 +469,10 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                 15.0
               end
               let(:aggregate_remaining_hours) do
-                nil # zero-values aren't accounted for
+                0.0
               end
               let(:aggregate_done_ratio) do
-                nil
+                100
               end
             end
           end


### PR DESCRIPTION
https://community.openproject.org/wp/54179

With this change, the total values are not discarded anymore when the total is 0h. Before this change, having total remaining work == 0h would unset it, which leads to not having total % complete either.

This is now fixed.

As a side-effect, the total % complete is now set for leaf work packages, which is consistent with how the update progress job migration behaves.