### PR TITLE
[54193] Inconsistent UX with commas for time unit when inputting remaining work or work

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -310,6 +310,11 @@ class WorkPackage < ApplicationRecord
     write_attribute :estimated_hours, !!converted_hours ? converted_hours : hours
   end
 
+  def remaining_hours=(hours)
+    converted_hours = (hours.is_a?(String) ? hours.to_hours : hours)
+    write_attribute :remaining_hours, !!converted_hours ? converted_hours : hours
+  end
+
   def duration_in_hours
     duration ? duration * 24 : nil
   end


### PR DESCRIPTION
Convert remaining hours string value to the right hour format,
for example: 
passed value: 1h30 -> converted value: 1.5 
passed value: 1,50 -> converted value: 1.5 

https://community.openproject.org/projects/openproject/work_packages/54193/activity