### PR TITLE
Avoid instantiating ProjectRepresenter if it is not embedded anyway

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
@@ -53,6 +53,8 @@ module API
                                end
                              },
                              getter: ->(*) {
+                               next unless embed_links
+
                                active_projects.map do |project|
                                  Projects::ProjectRepresenter.create(project, current_user:)
                                end


### PR DESCRIPTION
In case of a collection, embed_links will be false. But although it will prevent the embedded elements from being rendered, it does not stop the getter lambda from being executed resulting in ProjectRepresenters being created and then instantiated. Since the created class depends on the custom fields being active for the project, the custom fields are determined which can be costly if done once for each project.

The problem does not exist on the more formal project collections where the eager loading covers that costly behaviour.

----

https://community.openproject.org/wp/54142