### PR TITLE
Applied retry_on for ManageNextcloudIntegrationJob

### DIFF
--- a/modules/storages/app/common/storages/errors.rb
+++ b/modules/storages/app/common/storages/errors.rb
@@ -48,6 +48,16 @@ module Storages
       end
     end
 
+    class IntegrationJobError < BaseError
+      attr_reader :errors, :storage
+
+      def initialize(storage:, errors:)
+        super(errors.log_message)
+        @storage = storage
+        @errors = errors
+      end
+    end
+
     def self.registry_error_for(key)
       case key.split('.')
       in [storage, 'contracts', model]

--- a/modules/storages/spec/workers/storages/manage_nextcloud_integration_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_nextcloud_integration_job_spec.rb
@@ -134,12 +134,16 @@ RSpec.describe Storages::ManageNextcloudIntegrationJob, :webmock, type: :job do
           storage1.reload
         end.to(
           change(storage1, :health_changed_at).to(Time.now.utc)
-              .and(change(storage1, :health_status).from("pending").to("healthy"))
+                                              .and(change(storage1, :health_status).from("pending").to("healthy"))
         )
       end
     end
 
     it "marks storage as unhealthy if sync was unsuccessful" do
+      job = class_double(Storages::HealthStatusMailerJob)
+      allow(Storages::HealthStatusMailerJob).to receive(:set).and_return(job)
+      allow(job).to receive(:perform_later)
+
       allow(Storages::NextcloudGroupFolderPropertiesSyncService)
         .to receive(:call)
               .with(storage1)
@@ -147,12 +151,42 @@ RSpec.describe Storages::ManageNextcloudIntegrationJob, :webmock, type: :job do
 
       Timecop.freeze("2023-03-14T15:17:00Z") do
         expect do
-          subject
+          perform_enqueued_jobs { described_class.perform_later }
           storage1.reload
         end.to(
           change(storage1, :health_changed_at).to(Time.now.utc)
-              .and(change(storage1, :health_status).from("pending").to("unhealthy"))
-                    .and(change(storage1, :health_reason).from(nil).to("not_found"))
+                                              .and(change(storage1, :health_status).from("pending").to("unhealthy"))
+                                              .and(change(storage1, :health_reason).from(nil).to("not_found"))
+        )
+      end
+    end
+
+    context "when Storages::Errors::IntegrationJobError is raised" do
+      before do
+        allow(Storages::NextcloudGroupFolderPropertiesSyncService)
+          .to receive(:call).with(storage1)
+                            .and_return(ServiceResult.failure(errors: Storages::StorageError.new(code: :custom_error)))
+      end
+
+      it "retries the job" do
+        allow(OpenProject::Notifications).to receive(:send)
+
+        perform_enqueued_jobs { described_class.perform_later }
+
+        expect(described_class
+                 .queue_adapter.performed_jobs
+                 .last.dig("exception_executions", "[Storages::Errors::IntegrationJobError]")).to eq(5)
+      end
+
+      it "sends a notification after the maximum number of attempts" do
+        allow(OpenProject::Notifications).to receive(:send)
+
+        perform_enqueued_jobs { described_class.perform_later }
+
+        expect(OpenProject::Notifications).to have_received(:send).with(
+          OpenProject::Events::STORAGE_TURNED_UNHEALTHY,
+          storage: storage1,
+          reason: "custom_error"
         )
       end
     end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/54046/activity

## WAT?

To have the `ManageNextcloudINtegrationJob` retry failing outbound requests, we introduced raising a custom error (`::Storages::Errors::IntegrationJobError`) in case of a failure response. This error is then caught by the `retry_on` configuration of the job. The health status of the storage is only updated after the 5th atempt failed.