### PR TITLE
Show meetings in calendar widgets

### DIFF
--- a/frontend/src/app/core/apiv3/api-v3.service.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.ts
@@ -26,14 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Injectable,
-  Injector,
-} from '@angular/core';
-import {
-  ApiV3GettableResource,
-  ApiV3ResourceCollection,
-} from 'core-app/core/apiv3/paths/apiv3-resource';
+import { Injectable, Injector } from '@angular/core';
+import { ApiV3GettableResource, ApiV3ResourceCollection } from 'core-app/core/apiv3/paths/apiv3-resource';
 import { Constructor } from '@angular/cdk/table';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ApiV3GridsPaths } from 'core-app/core/apiv3/endpoints/grids/apiv3-grids-paths';
@@ -124,6 +118,9 @@ export class ApiV3Service {
 
   // /api/v3/capabilities
   public readonly capabilities = this.apiV3CustomEndpoint(ApiV3CapabilitiesPaths);
+
+  // /api/v3/meetings
+  public readonly meetings = this.apiV3CollectionEndpoint('meetings');
 
   // /api/v3/memberships
   public readonly memberships = this.apiV3CustomEndpoint(ApiV3MembershipsPaths);

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -100,6 +100,10 @@ export class PathHelperService {
     return `${this.staticBase}/topics/${messageIdentifier}`;
   }
 
+  public meetingPath(id:string):string {
+    return `${this.staticBase}/meetings/${id}`;
+  }
+
   public myPagePath() {
     return `${this.staticBase}/my/page`;
   }

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -26,7 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  OnInit,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
 import {
   CalendarOptions,
   DateSelectArg,
@@ -77,11 +85,16 @@ import {
   addBackgroundEvents,
   removeBackgroundEvents,
 } from 'core-app/features/team-planner/team-planner/planner/background-events';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import allLocales from '@fullcalendar/core/locales-all';
+import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Component({
   templateUrl: './wp-calendar.template.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./wp-calendar.sass'],
   selector: 'op-wp-calendar',
   providers: [
@@ -98,6 +111,8 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
   }
 
   @Input() static = false;
+
+  @Input() showMeetings = false;
 
   calendarOptions$ = new Subject<CalendarOptions>();
 
@@ -129,6 +144,8 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     readonly halNotification:HalResourceNotificationService,
     readonly weekdayService:WeekdayService,
     readonly dayService:DayResourceService,
+    readonly apiV3Service:ApiV3Service,
+    readonly pathHelper:PathHelperService,
   ) {
     super();
   }
@@ -175,6 +192,50 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     }
   }
 
+  public calendarMeetingsFunction(
+    fetchInfo:{ start:Date, end:Date, timeZone:string },
+    successCallback:(events:EventInput[]) => void,
+  ):void {
+    if (!this.showMeetings) {
+      successCallback([]);
+      return;
+    }
+
+    const startDate = moment(fetchInfo.start).format('YYYY-MM-DD');
+    const endDate = moment(fetchInfo.end).format('YYYY-MM-DD');
+
+    const filters = new ApiV3FilterBuilder();
+    filters.add('datesInterval', '<>d', [startDate, endDate]);
+
+    if (this.currentProject.id) {
+      filters.add('project', '=', [this.currentProject.id]);
+    }
+
+    this
+      .apiV3Service
+      .meetings
+      .filtered(filters, { pageSize: '-1' })
+      .get()
+      .subscribe((meetings) => {
+        const events = meetings.elements.map((meeting:MeetingResource) => {
+          const sameProject = this.currentProject.id === meeting.project.id;
+          const title:string = sameProject ? meeting.title : `${meeting.project.name}: ${meeting.title}`;
+          return {
+            title,
+            start: Date.parse(meeting.startTime),
+            end: Date.parse(meeting.endTime),
+            editable: false,
+            durationEditable: false,
+            allDay: false,
+            className: 'fc-event-clickable',
+            meeting,
+          };
+        });
+
+        successCallback(events);
+      });
+  }
+
   // eslint-disable-next-line @angular-eslint/use-lifecycle-interface
   ngOnDestroy():void {
     super.ngOnDestroy();
@@ -191,6 +252,11 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
         {
           id: 'work_packages',
           events: this.calendarEventsFunction.bind(this) as unknown,
+        },
+        {
+          id: 'meetings',
+          events: this.calendarMeetingsFunction.bind(this) as unknown,
+          eventDisplay: 'block',
         },
         {
           events: [],
@@ -211,9 +277,16 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       select: this.handleDateClicked.bind(this) as unknown,
       eventResizableFromStart: true,
       editable: true,
+      displayEventTime: true,
+      displayEventEnd: true,
+      eventTimeFormat: {
+        hour: 'numeric',
+        minute: '2-digit',
+        meridiem: 'short',
+      },
       eventDidMount: (evt:CalendarViewEvent) => {
         const { el, event } = evt;
-        if (event.source?.id === 'background') {
+        if (event.source?.id !== 'work_packages') {
           return;
         }
         const workPackage = event.extendedProps.workPackage as WorkPackageResource;
@@ -260,16 +333,23 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
         removeBackgroundEvents(this.ucCalendar.getApi());
       },
       eventClick: (evt:EventClickArg) => {
-        const workPackageId = (evt.event.extendedProps.workPackage as WorkPackageResource).id as string;
-        // Currently the calendar widget is shown on multiple pages,
-        // but only the calendar module itself is a partitioned query space which can deal with a split screen request
-        if (this.$state.includes('calendar')) {
-          this.workPackagesCalendar.openSplitView(workPackageId);
-        } else {
-          void this.$state.go(
-            'work-packages.show',
-            { workPackageId },
-          );
+        if (evt.event.extendedProps.meeting) {
+          const meeting = evt.event.extendedProps.meeting as MeetingResource;
+          window.location.href = this.pathHelper.meetingPath(meeting.id as string);
+        }
+
+        if (evt.event.extendedProps.workPackage) {
+          const workPackageId = (evt.event.extendedProps.workPackage as WorkPackageResource).id as string;
+          // Currently the calendar widget is shown on multiple pages,
+          // but only the calendar module itself is a partitioned query space which can deal with a split screen request
+          if (this.$state.includes('calendar')) {
+            this.workPackagesCalendar.openSplitView(workPackageId);
+          } else {
+            void this.$state.go(
+              'work-packages.show',
+              { workPackageId },
+            );
+          }
         }
       },
     };
@@ -327,7 +407,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
         durationEditable: this.workPackagesCalendar.eventDurationEditable(workPackage),
         end: exclusiveEnd,
         allDay: true,
-        className: `__hl_background_type_${workPackage.type.id || ''}`,
+        className: `fc-event-clickable __hl_background_type_${workPackage.type.id || ''}`,
         workPackage,
       };
     });

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
@@ -9,3 +9,6 @@
   &--notification
     font-style: italic
     margin-top: 0.5rem
+
+  .fc-event-clickable
+    cursor: pointer

--- a/frontend/src/app/features/hal/resources/meeting-resource.ts
+++ b/frontend/src/app/features/hal/resources/meeting-resource.ts
@@ -27,14 +27,8 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { Attachable } from 'core-app/features/hal/resources/mixins/attachable-mixin';
 
-export interface MeetingResourceLinks {
-  addAttachment(attachment:HalResource):Promise<unknown>;
+export class MeetingResource extends HalResource {
+  public title:string;
+  public project:HalResource;
 }
-
-class MeetingBaseResource extends HalResource {
-  public $links:MeetingResourceLinks;
-}
-
-export const MeetingResource = Attachable(MeetingBaseResource);

--- a/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
@@ -15,6 +15,7 @@
 
   <op-wp-calendar
     *ngIf="context.hasCapability === true"
+    [showMeetings]="true"
     [static]="true"
   ></op-wp-calendar>
 </ng-container>

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -31,14 +31,17 @@ require_relative "../../../overviews/spec/support/pages/overview"
 require_relative "../support/pages/calendar"
 
 RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_week: 1 } do
-  let(:project) do
-    create(:project, enabled_module_names: %w[work_package_tracking calendar_view])
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking calendar_view meetings])
   end
-  let!(:work_package) do
+  shared_let(:work_package) do
     create(:work_package,
            project:,
            start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
            due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday))
+  end
+  shared_let(:meeting) do
+    create(:structured_meeting, title: "Weekly", project:, start_time: Time.zone.today + 10.hours)
   end
 
   let(:overview_page) do
@@ -50,19 +53,26 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
   current_user do
     create(:user,
            member_with_permissions: {
-             project => %w[view_work_packages edit_work_packages view_calendar manage_overview]
+             project => %w[view_work_packages view_meetings edit_work_packages view_calendar manage_overview]
            })
   end
 
   before do
     overview_page.visit!
-  end
-
-  it "opens the work package full view when clicking a calendar entry" do
     # within top-left area, add an additional widget
     overview_page.add_widget(1, 1, :row, "Calendar")
 
     overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+  end
+
+  it 'shows the meeting' do
+    expect(page).to have_css('.fc-event', text: "Weekly", visible: :all)
+    page.find('.fc-event', text: "Weekly", visible: :all).click
+
+    expect(page).to have_current_path /meetings\/#{meeting.id}/
+  end
+
+  it "opens the work package full view when clicking a calendar entry" do
 
     # Clicking the calendar entry goes to work package full screen
     page.find(".fc-event-title", text: work_package.subject).click
@@ -73,11 +83,6 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
   end
 
   it "can resize the same work package twice (Regression #48333)", with_cuprite: false do
-    # within top-left area, add an additional widget
-    overview_page.add_widget(1, 1, :row, "Calendar")
-
-    overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
-
     expect(page).to have_css(".fc-event-title", text: work_package.subject)
 
     calendar.resize_date(work_package, work_package.due_date - 1.day)

--- a/modules/meeting/spec/models/queries/meetings/filters/dates_interval_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/meetings/filters/dates_interval_filter_spec.rb
@@ -26,13 +26,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Meetings
-  ::Queries::Register.register(MeetingQuery) do
-    filter Filters::ProjectFilter
-    filter Filters::TimeFilter
-    filter Filters::AttendedUserFilter
-    filter Filters::InvitedUserFilter
-    filter Filters::AuthorFilter
-    filter Filters::DatesIntervalFilter
+require "spec_helper"
+
+RSpec.describe Queries::Meetings::Filters::DatesIntervalFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :date }
+    let(:class_key) { :dates_interval }
+
+    describe "#available?" do
+      it "is true" do
+        expect(instance).to be_available
+      end
+    end
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
+
+    it_behaves_like "non ar filter"
   end
 end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/54286

*   [x] Calendar under My Page and Overview cannot be filtered or configured, showing all meetings there would be easy
*   [x] Calendar widget in My Page shows meetings from all visible projects
    *   [x] Calendar entries are rendered with &quot;HH:MM - HH:MM Project name: Title&quot;
*   [x] Calendar widget in overview page renders meetings from the current project
    *   [x] Calendar entries are rendered with &quot;HH:MM - HH:MM Title&quot;
*   [x] Clicking the event item opens the meeting