### PR TITLE
[54299] Total values are unset for work packages without any children

### DIFF
--- a/app/services/work_packages/update_ancestors/loader.rb
+++ b/app/services/work_packages/update_ancestors/loader.rb
@@ -46,17 +46,6 @@ class WorkPackages::UpdateAncestors::Loader
     @descendants[queried_work_package]
   end
 
-  def leaves_of(queried_work_package)
-    @leaves ||= Hash.new do |hash, wp|
-      hash[wp] = replaced_related_of(wp, :leaves) do |leaf|
-        # Mimic work package by implementing the closed? interface
-        leaf.send(:"closed?=", leaf.is_closed)
-      end
-    end
-
-    @leaves[queried_work_package]
-  end
-
   def children_of(queried_work_package)
     @children ||= Hash.new do |hash, wp|
       hash[wp] = descendants_of(wp).select { |d| d.parent_id == wp.id }

--- a/app/workers/work_packages/update_progress_job.rb
+++ b/app/workers/work_packages/update_progress_job.rb
@@ -192,6 +192,8 @@ class WorkPackages::UpdateProgressJob < ApplicationJob
     SQL
   end
 
+  # Computes total work, total remaining work and total % complete for all work
+  # packages having children.
   def update_totals
     execute(<<~SQL)
       UPDATE temp_wp_progress_values
@@ -203,6 +205,7 @@ class WorkPackages::UpdateProgressJob < ApplicationJob
           END
       FROM (
         SELECT wp_tree.ancestor_id AS id,
+               MAX(generations) AS generations,
                SUM(estimated_hours) AS total_work,
                SUM(remaining_hours) AS total_remaining_work
         FROM work_package_hierarchies wp_tree
@@ -210,6 +213,7 @@ class WorkPackages::UpdateProgressJob < ApplicationJob
         GROUP BY wp_tree.ancestor_id
       ) totals
       WHERE temp_wp_progress_values.id = totals.id
+      AND totals.generations > 0
     SQL
   end
 

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
           context "when changing child status to a status with a default done ratio" do
             %i[status status_id].each do |field|
               context "with the #{field} field" do
-                it "recomputes child remaining work and update ancestors total % complete accordingly" do
+                it "recomputes child remaining work and updates ancestors total % complete accordingly" do
                   value =
                     case field
                     when :status then closed_status
@@ -98,7 +98,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                   expect_work_packages([parent, child], <<~TABLE)
                     | subject | work | total work | remaining work | total remaining work | % complete | total % complete |
                     | parent  |  10h |        15h |            10h |                  10h |         0% |              33% |
-                    | child   |   5h |         5h |             0h |                   0h |       100% |             100% |
+                    |   child |   5h |            |             0h |                      |       100% |                  |
                   TABLE
                 end
               end
@@ -126,7 +126,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
               expect_work_packages(table_work_packages, <<~TABLE)
                 hierarchy | status | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete
                 parent    | Open   |      |    15h |                |               0h |         0% |         100%
-                  child1  | Closed |  10h |    10h |             0h |               0h |       100% |         100%
+                  child1  | Closed |  10h |        |             0h |                  |       100% |
                   child2  | Closed |   5h |        |             0h |                  |       100% |
               TABLE
             end
@@ -858,10 +858,11 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
   end
 
-  describe "estimated_hours propagation" do
+  describe "work propagation" do
     shared_let(:parent) { create(:work_package, subject: "parent") }
+    shared_let(:child) { create(:work_package, subject: "child", parent:) }
 
-    context "when setting estimated hours of a work package" do
+    context "when setting work of a work package having children without any work value" do
       before do
         parent.estimated_hours = 2.0
       end
@@ -871,7 +872,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                        .call(%i(estimated_hours))
       end
 
-      it "sets its derived value to the same value" do
+      it "sets its total work to the same value" do
         expect { call_result }
           .to change(parent, :derived_estimated_hours).from(nil).to(2.0)
         expect(call_result).to be_success
@@ -880,7 +881,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
 
     context "for the new ancestors chain" do
-      context "with parent having no work" do
+      context "with parent having no work set" do
         let_work_packages(<<~TABLE)
           hierarchy | work |
           parent    |      |
@@ -894,17 +895,17 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(estimated_hours))
         end
 
-        it "sets parent derived remaining work to the sum of children remaining work" do
+        it "sets parent total work to the sum of children work" do
           expect(call_result).to be_success
           updated_work_packages = call_result.dependent_results.map(&:result)
           expect_work_packages(updated_work_packages, <<~TABLE)
-            subject | derived work |
-            parent  |         2.5h |
+            subject | total work |
+            parent  |       2.5h |
           TABLE
         end
       end
 
-      context "with parent having some remaining work" do
+      context "with parent having work set" do
         let_work_packages(<<~TABLE)
           hierarchy |  work |
           parent    | 5.25h |
@@ -918,12 +919,12 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(estimated_hours))
         end
 
-        it "sets parent derived work to the sum of itself and children remaining work" do
+        it "sets parent total work to the sum of itself and children work" do
           expect(call_result).to be_success
           updated_work_packages = call_result.dependent_results.map(&:result)
           expect_work_packages(updated_work_packages, <<~TABLE)
-            subject | derived work |
-            parent  |        7.75h |
+            subject | total work |
+            parent  |      7.75h |
           TABLE
         end
       end
@@ -941,22 +942,23 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(estimated_hours))
         end
 
-        it "does not update the parent derived work" do
+        it "does not update the parent total work" do
           expect(call_result).to be_success
           expect(call_result.dependent_results).to be_empty
           expect_work_packages([parent.reload], <<~TABLE)
-            subject | derived work |
-            parent  |              |
+            subject | total work |
+            parent  |            |
           TABLE
         end
       end
     end
   end
 
-  describe "remaining_hours propagation" do
+  describe "remaining work propagation" do
     shared_let(:parent) { create(:work_package, subject: "parent") }
+    shared_let(:child) { create(:work_package, subject: "child", parent:) }
 
-    context "when setting remaining hours of a work package" do
+    context "when setting remaining work of a work package having children without any remaining work value" do
       before do
         parent.remaining_hours = 2.0
       end
@@ -966,7 +968,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                        .call(%i(remaining_hours))
       end
 
-      it "sets its derived value to the same value" do
+      it "sets its total remaining work to the same value" do
         expect { call_result }
           .to change(parent, :derived_remaining_hours).from(nil).to(2.0)
         expect(call_result).to be_success
@@ -975,7 +977,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
     end
 
     context "for the new ancestors chain" do
-      context "with parent having no remaining work" do
+      context "with parent having no remaining work set" do
         let_work_packages(<<~TABLE)
           hierarchy | remaining work |
           parent    |                |
@@ -989,17 +991,17 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(remaining_hours))
         end
 
-        it "sets parent derived remaining work to the sum of children remaining work" do
+        it "sets parent total remaining work to the sum of children remaining work" do
           expect(call_result).to be_success
           updated_work_packages = call_result.dependent_results.map(&:result)
           expect_work_packages(updated_work_packages, <<~TABLE)
-            subject | derived remaining work
-            parent  |                   2.5h
+            subject | total remaining work
+            parent  |                 2.5h
           TABLE
         end
       end
 
-      context "with parent having some remaining work" do
+      context "with parent having remaining work set" do
         let_work_packages(<<~TABLE)
           hierarchy | remaining work |
           parent    |          5.25h |
@@ -1013,12 +1015,12 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(remaining_hours))
         end
 
-        it "sets parent derived remaining work to the sum of itself and children remaining work" do
+        it "sets parent total remaining work to the sum of itself and children remaining work" do
           expect(call_result).to be_success
           updated_work_packages = call_result.dependent_results.map(&:result)
           expect_work_packages(updated_work_packages, <<~TABLE)
-            subject | derived remaining work
-            parent  |                  7.75h
+            subject | total remaining work
+            parent  |                7.75h
           TABLE
         end
       end
@@ -1036,11 +1038,11 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
                          .call(%i(remaining_hours))
         end
 
-        it "does not update the parent derived remaining work" do
+        it "does not update the parent total remaining work" do
           expect(call_result).to be_success
           expect(call_result.dependent_results).to be_empty
           expect_work_packages([parent.reload], <<~TABLE)
-            subject | derived remaining work
+            subject | total remaining work
             parent  |
           TABLE
         end
@@ -1055,7 +1057,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
       let_work_packages(<<~TABLE)
         hierarchy | work | total work | remaining work | total remaining work
         parent    |      |        10h |             7h |
-          child1  |  10h |        10h |                |
+          child1  |  10h |            |                |
       TABLE
 
       subject(:call_result) do
@@ -1077,7 +1079,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService, type: :model do
       let_work_packages(<<~TABLE)
         hierarchy | work | total work | remaining work | total remaining work
         parent    |  10h |            |                |                   7h
-          child1  |      |            |             7h |                   7h
+          child1  |      |            |             7h |
       TABLE
 
       subject(:call_result) do


### PR DESCRIPTION
See https://community.openproject.org/wp/54299

When setting work or remaining work on a work package, it's odd to see "Total work set to __h" along with "Work set to __h" when this work package does not have any children. By not setting totals for "leaf" work packages, we avoid having it displayed in the activity stream.

Thus the update progress job (migration job) has been updated accordingly, as well as the `UpdateAncestorsService`.