### PR TITLE
set the correct css selector for styles of an arrow in select

### DIFF
--- a/frontend/src/global_styles/openproject/_forms.sass
+++ b/frontend/src/global_styles/openproject/_forms.sass
@@ -157,8 +157,8 @@ select
   border-radius: 0
   border: $input-border
 
-select:not(.FormControl-select)
-  @if $select-arrow
-    background: transparent url(image-triangle($select-arrow-color)) right 10px center no-repeat
-    background-size: 8px 8px
-    padding-right: rem-calc(18px) + $form-padding
+  &:not(.FormControl-select)
+    @if $select-arrow
+      background: transparent url(image-triangle($select-arrow-color)) right 10px center no-repeat
+      background-size: 8px 8px
+      padding-right: rem-calc(18px) + $form-padding


### PR DESCRIPTION
'select' is selected some lines above, so we can use '&' instead of repeating select as a selector.