### PR TITLE
[54309] Display total work even when set to 0h

### DIFF
--- a/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
@@ -33,7 +33,7 @@ import { DateDisplayField } from 'core-app/shared/components/fields/display/fiel
 import { DateTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/datetime-display-field.module';
 import { DaysDurationDisplayField } from 'core-app/shared/components/fields/display/field-types/days-duration-display-field.module';
 import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
-import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
+import { WorkDisplayField } from 'core-app/shared/components/fields/display/field-types/work-display-field.module';
 import { FloatDisplayField } from 'core-app/shared/components/fields/display/field-types/float-display-field.module';
 import { FormattableDisplayField } from 'core-app/shared/components/fields/display/field-types/formattable-display-field.module';
 import { HighlightedResourceDisplayField } from 'core-app/shared/components/fields/display/field-types/highlighted-resource-display-field.module';
@@ -75,8 +75,8 @@ export function initializeCoreDisplayFields(displayFieldService:DisplayFieldServ
       .addFieldType(MultipleUserFieldModule, 'users', ['[]User'])
       .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])
       .addFieldType(DaysDurationDisplayField, 'duration', ['duration'])
-      .addFieldType(EstimatedTimeDisplayField, 'remainingTime', ['remainingTime'])
-      .addFieldType(EstimatedTimeDisplayField, 'estimatedTime', ['estimatedTime'])
+      .addFieldType(WorkDisplayField, 'remainingTime', ['remainingTime'])
+      .addFieldType(WorkDisplayField, 'estimatedTime', ['estimatedTime'])
       .addFieldType(DateDisplayField, 'date', ['Date'])
       .addFieldType(DateTimeDisplayField, 'datetime', ['DateTime'])
       .addFieldType(BooleanDisplayField, 'boolean', ['Boolean'])

--- a/frontend/src/app/shared/components/fields/display/field-types/work-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/work-display-field.module.ts
@@ -34,7 +34,7 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { uiStateLinkClass } from 'core-app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder';
 import { HierarchyQueryLinkHelperService } from 'core-app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service';
 
-export class EstimatedTimeDisplayField extends DisplayField {
+export class WorkDisplayField extends DisplayField {
   @InjectField() timezoneService:TimezoneService;
 
   @InjectField() PathHelper:PathHelperService;
@@ -80,7 +80,7 @@ export class EstimatedTimeDisplayField extends DisplayField {
     this.renderActual(element, displayText);
 
     const derived = this.derivedValue;
-    if (derived && this.timezoneService.toHours(derived) !== 0 && this.hasChildren()) {
+    if (derived && this.hasChildren()) {
       this.renderSeparator(element);
       this.renderDerived(element, this.derivedValueString);
     }

--- a/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -33,10 +33,10 @@ import * as URI from 'urijs';
 import { TimeEntryCreateService } from 'core-app/shared/components/time_entries/create/create.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
+import { WorkDisplayField } from 'core-app/shared/components/fields/display/field-types/work-display-field.module';
 import * as moment from 'moment-timezone';
 
-export class WorkPackageSpentTimeDisplayField extends EstimatedTimeDisplayField {
+export class WorkPackageSpentTimeDisplayField extends WorkDisplayField {
   public text = {
     linkTitle: this.I18n.t('js.work_packages.message_view_spent_time'),
     logTime: this.I18n.t('js.button_log_time'),

--- a/spec/features/work_packages/display_fields/work_display_spec.rb
+++ b/spec/features/work_packages/display_fields/work_display_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Estimated hours display", :js do
+RSpec.describe "Work display", :js do
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
   shared_let(:wiki_page) { create(:wiki_page, wiki: project.wiki) }
@@ -58,7 +58,7 @@ RSpec.describe "Estimated hours display", :js do
     login_as(user)
   end
 
-  shared_examples "estimated time display" do |expected_text:|
+  shared_examples "work display" do |expected_text:|
     it "work package index" do
       wp_table.visit_query query
       wp_table.expect_work_package_listed child
@@ -84,14 +84,14 @@ RSpec.describe "Estimated hours display", :js do
     end
   end
 
-  context "with both work and derived work" do
+  context "with both work and total work" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |   1h |
         child     |   3h |
     TABLE
 
-    include_examples "estimated time display", expected_text: "1 h·Σ 4 h"
+    include_examples "work display", expected_text: "1 h·Σ 4 h"
   end
 
   context "with just work" do
@@ -101,47 +101,57 @@ RSpec.describe "Estimated hours display", :js do
         child     |   0h |
     TABLE
 
-    include_examples "estimated time display", expected_text: "1 h"
+    include_examples "work display", expected_text: "1 h"
   end
 
-  context "with just derived work with (parent work 0 h)" do
+  context "with just total work with (parent work 0 h)" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |   0h |
         child     |   3h |
     TABLE
 
-    include_examples "estimated time display", expected_text: "0 h·Σ 3 h"
+    include_examples "work display", expected_text: "0 h·Σ 3 h"
   end
 
-  context "with just derived work (parent work unset)" do
+  context "with just total work (parent work unset)" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |      |
         child     |   3h |
     TABLE
 
-    include_examples "estimated time display", expected_text: "-·Σ 3 h"
+    include_examples "work display", expected_text: "-·Σ 3 h"
   end
 
-  context "with neither work nor derived work (both 0 h)" do
+  context "with neither work nor total work (both 0 h)" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |   0h |
         child     |   0h |
     TABLE
 
-    include_examples "estimated time display", expected_text: "0 h"
+    include_examples "work display", expected_text: "0 h"
   end
 
-  context "with neither work nor derived work (both unset)" do
+  context "with just total work being 0h" do
+    let_work_packages(<<~TABLE)
+      hierarchy   | work |
+      parent      |      |
+        child     |   0h |
+    TABLE
+
+    include_examples "work display", expected_text: "-·Σ 0 h"
+  end
+
+  context "with neither work nor total work (both unset)" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |      |
         child     |      |
     TABLE
 
-    include_examples "estimated time display", expected_text: "-"
+    include_examples "work display", expected_text: "-"
   end
 
   describe "link to detailed view" do
@@ -155,7 +165,7 @@ RSpec.describe "Estimated hours display", :js do
       other one          |   2h |
     TABLE
 
-    # Run UpdateAncestorsService on the grand child to update the whole hierarchy derived values
+    # Run UpdateAncestorsService on the grand child to update the whole hierarchy total values
     let(:initiator_work_package) { grand_child21 }
 
     it "displays a link to a detailed view explaining work calculation" do


### PR DESCRIPTION
See https://community.openproject.org/wp/54309

And renamed some files and descriptions from "estimated time" to "work".

![image](https://github.com/opf/openproject/assets/176055/561c57be-c00f-4909-86af-b2d207bfe39a)
