### PR TITLE
[54308] Make rounding consistent with 2 decimals in progress modal

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.ts
@@ -58,7 +58,6 @@ import { HalEventsService } from 'core-app/features/hal/services/hal-events.serv
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import * as moment from 'moment/moment';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 @Component({
@@ -137,7 +136,7 @@ export class ProgressPopoverEditFieldComponent extends ProgressEditFieldComponen
     if (value === null) {
       return '';
     }
-    return moment.duration(value).asHours().toFixed(1);
+    return `${this.timezoneService.toHours(value)}`;
   }
 
   public statusFormatter(value:null|string):string {

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -315,10 +315,10 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
     describe "field value format" do
       context "with all values set" do
-        before { update_work_package_with(work_package, estimated_hours: 10.0, remaining_hours: 2.5) }
+        before { update_work_package_with(work_package, estimated_hours: 10.0, remaining_hours: 2.543) }
 
         it "populates fields with correctly values formatted " \
-           "with the minimum fractional part if present" do
+           "with the minimum fractional part if present, and 2 decimals max" do
           work_package_table.visit_query(progress_query)
           work_package_table.expect_work_package_listed(work_package)
 
@@ -329,8 +329,8 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
           work_edit_field.activate!
 
           work_edit_field.expect_modal_field_value("10")
-          remaining_work_edit_field.expect_modal_field_value("2.5")
-          percent_complete_edit_field.expect_modal_field_value("75", readonly: true)
+          remaining_work_edit_field.expect_modal_field_value("2.54")
+          percent_complete_edit_field.expect_modal_field_value("74", readonly: true)
         end
       end
 


### PR DESCRIPTION
See https://community.openproject.org/wp/54308

2 decimals is what is used by default everywhere else.