### PR TITLE
Fix meeting being an attachable resource

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -88,8 +88,8 @@ import {
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import allLocales from '@fullcalendar/core/locales-all';
-import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
 
 @Component({
   templateUrl: './wp-calendar.template.html',

--- a/frontend/src/app/features/hal/resources/meeting-resource.ts
+++ b/frontend/src/app/features/hal/resources/meeting-resource.ts
@@ -27,8 +27,18 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { Attachable } from 'core-app/features/hal/resources/mixins/attachable-mixin';
 
-export class MeetingResource extends HalResource {
-  public title:string;
-  public project:HalResource;
+interface MeetingResourceLinks {
+  addAttachment(attachment:HalResource):Promise<unknown>;
 }
+
+class MeetingBaseResource extends HalResource {
+  title:string;
+  project:HalResource;
+  public $links:MeetingResourceLinks;
+}
+
+export const MeetingResource = Attachable(MeetingBaseResource);
+
+export interface MeetingResource extends MeetingBaseResource, MeetingResourceLinks {}


### PR DESCRIPTION
Without the Attachable Mixin, no attachments can be added to a meeting. 

This was caused by https://github.com/opf/openproject/commit/4304dde0d11d944bfab43d42a41fcaad67eb80d7#diff-27e32398874882fd70a15cbc19eb6fe76343b9f1b16a077a1a9ac706f0cd8283