### PR TITLE
[54184] Progress popover: header font size too big, excessive margins

### DIFF
--- a/app/components/work_packages/progress/status_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/status_based/modal_body_component.html.erb
@@ -18,9 +18,10 @@
       <% end %>
 
       <% modal_body.with_row(mt: 3) do |_actions_row| %>
-        <%= flex_layout(mt: 3, justify_content: :flex_end) do |action_buttons| %>
+        <%= flex_layout(justify_content: :flex_end) do |action_buttons| %>
           <%= action_buttons.with_column do %>
-            <%= f.submit t(:button_save), class: "btn btn-primary" %>
+            <%= render(Primer::Beta::Button.new(scheme: :primary,
+                                                type: :submit)) { t(:button_save) } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/work_packages/progress/work_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.html.erb
@@ -24,9 +24,10 @@
       <% end %>
 
       <% modal_body.with_row(mt: 3) do |_actions_row| %>
-        <%= flex_layout(mt: 3, justify_content: :flex_end) do |action_buttons| %>
+        <%= flex_layout(justify_content: :flex_end) do |action_buttons| %>
           <%= action_buttons.with_column do %>
-            <%= f.submit t(:button_save), class: "btn btn-primary" %>
+            <%= render(Primer::Beta::Button.new(scheme: :primary,
+                                                type: :submit)) { t(:button_save) } %>
           <% end %>
         <% end %>
       <% end %>

--- a/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.html
@@ -16,25 +16,25 @@
 
   <ng-container slot="body">
     <div
-      class="spot-modal--header"
+      class="spot-drop-modal--header"
     >
       <div
         id="spotModalTitle"
-        class="spot-modal--header-title"
+        class="spot-drop-modal--header-title"
         [textContent]="this.text.title">
       </div>
 
       <button
-        class="button button_no-margin -transparent spot-modal--header-close-button"
+        class="button button_no-margin -transparent spot-drop-modal--header-close-button"
         [attr.aria-label]="text.button_close"
         (click)="closeMe()"
         data-test-selector="op-progress-modal--close-icon"
       >
-        <svg x-icon size="small" class="spot-modal--header-close-button-icon"></svg>
+        <svg x-icon size="small" class="spot-drop-modal--header-close-button-icon"></svg>
       </button>
     </div>
 
-    <div class="spot-modal--body spot-container">
+    <div class="spot-drop-modal--content">
       <turbo-frame
         #frameElement
         id="work_package_progress_modal"

--- a/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.sass
+++ b/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.sass
@@ -1,5 +1,5 @@
 @import "../../global_styles/openproject/variables"
 
 @media screen and (min-width: $breakpoint-lg)
-  .spot-modal--body
+  .spot-drop-modal--content
     width: 500px

--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -67,6 +67,22 @@
     @media #{$spot-mq-drop-modal-in-context}
       display: none
 
+  &--header
+    @extend .spot-modal--header
+    font-size: var(--body-font-size) !important
+
+  &--header-title
+    @extend .spot-modal--header-title
+
+  &--header-close-button
+    @extend .spot-modal--header-close-button
+
+  &--header-close-button-icon
+    @extend .spot-modal--header-close-button-icon
+
+  &--content
+    margin: $spot-spacing-1
+
   &--close-button
     display: block
     position: fixed


### PR DESCRIPTION
* Fix spacing issues on the progress drop-modal which occured because of the mixture of classes of the drop-modal and the "normal" modal
* Use Primer buttons in the progress modal



https://community.openproject.org/projects/openproject/work_packages/54184/activity