### PR TITLE
[54306] Excessive field length for work/remaining work  

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -88,12 +88,12 @@ display-field
 
   &.split-time-field
     display: inline-block
-    width: 100%
     vertical-align: middle
     white-space: nowrap
 
     // Table specific styles
     .wp-table--cell-container &
+      width: 100%
       .-actual-value,
       .-derived-value
         @include wp-table--time-values


### PR DESCRIPTION
The split field should only span the complete width in the table to ensure that the separators are correctly aligned and no content is cut off. In the full view, we don't need that.

https://community.openproject.org/projects/openproject/work_packages/54306/activity