### PR TITLE
[54306] Left align the progress modal to the field

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.html
@@ -1,7 +1,7 @@
 <spot-drop-modal
   [opened]="opened"
   (closed)="onModalClosed()"
-  alignment="bottom-center"
+  alignment="bottom-start"
 >
   <input
     slot="trigger"

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -40,8 +40,8 @@ export class SpotDropModalComponent implements OnDestroy {
   @Input() public allowRepositioning = true;
 
   /**
-   * The default alignment of the drop modal. There are twelve alignments in total. You can check which ones they are
-   * from the `SpotDropAlignmentOption` Enum that is available in 'core-app/spot/drop-alignment-options'.
+   * The default alignment of the drop modal. There are twelve alignments in total. You can check which ones they are in
+   * @floating-ui/utils: `Placement` in floating-ui.utils.d.ts
    */
   @Input() public alignment:Placement = 'bottom-start';
 

--- a/frontend/src/app/spot/styles/sass/components/drop-modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/drop-modal.sass
@@ -6,7 +6,6 @@
 
     position: absolute
     @include spot-z-index("drop-modal", 1)
-    pointer-events: none
 
     pointer-events: all
     opacity: 1


### PR DESCRIPTION
Left align the progress modal per default to avoid that users have to move their mouse too much

See comment: https://community.openproject.org/projects/openproject/work_packages/54306#activity-12