### PR TITLE
Bump primer_view_components to 0.29.0 and primer/css to 21.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -383,4 +383,4 @@ end
 
 gem "openproject-octicons", "~>19.10.0"
 gem "openproject-octicons_helper", "~>19.10.0"
-gem "openproject-primer_view_components", "~>0.28.1"
+gem "openproject-primer_view_components", "~>0.29.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
       actionview
       openproject-octicons (= 19.10.0)
       railties
-    openproject-primer_view_components (0.28.1)
+    openproject-primer_view_components (0.29.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.9.0)
@@ -1268,7 +1268,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.10.0)
   openproject-octicons_helper (~> 19.10.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.28.1)
+  openproject-primer_view_components (~> 0.29.0)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!

--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -39,6 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <% if design_color.variable == "primary-button-color" %>
         --primary-button-color--major1: <%= design_color.darken 0.18 %>;
+        --primary-button-color--minor1: <%= design_color.lighten 0.8 %>;
     <% end %>
     <% if design_color.variable == "accent-color" %>
         --accent-color--major1: <%= design_color.darken 0.2 %>;

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -2,57 +2,58 @@
 
   /* Overwrite Primer primitives */
   [data-color-mode] {
-      --body-background: var(--color-canvas-default);
-      --body-font-color: var(--color-fg-default);
+      --body-background: var(--bgColor-default);
+      --body-font-color: var(--fgColor-default);
   }
   /* Override Primer variable to ensure compatibility with currently
      configured design outside of high contrast mode  */
   [data-color-mode]:not([data-light-theme=light_high_contrast]) {
-    --color-accent-fg: var(--accent-color) !important;
+    --fgColor-accent: var(--accent-color) !important;
     --control-checked-bgColor-rest: var(--control-checked-color) !important;
     --control-checked-bgColor-active: var(--control-checked-color) !important;
     --control-checked-bgColor-hover: var(--control-checked-color--major1) !important;
     --controlKnob-borderColor-checked: var(--control-checked-color) !important;
     --button-primary-bgColor-rest: var(--button--primary-background-color) !important;
     --button-primary-bgColor-hover: var(--button--primary-background-hover-color) !important;
+    --button-primary-bgColor-disabled: var(--button--primary-background-disabled-color) !important;
   }
   [data-light-theme=light_high_contrast]{
-    --avatar-border-color: var(--color-avatar-border);
-    --list-item-hover--border-color: var(--color-action-list-item-default-active-border);
-    --list-item-hover--color: var(--color-fg-default);
-    --inplace-edit--border-color: var(--color-border-default);
-    --ck-color-toolbar-border: var(--color-border-default);
-    --ck-color-base-border: var(--color-border-default);
-    --table-border-color: var(--color-border-default);
-    --toolbar-item--bg-color: var(--color-btn-bg);
-    --toolbar-item--border-color: var(--color-border-default);
+    --avatar-border-color: var(--avatar-borderColor);
+    --list-item-hover--border-color: var(--control-transparent-borderColor-hover);
+    --list-item-hover--color: var(--fgColor-default);
+    --inplace-edit--border-color: var(--borderColor-default);
+    --ck-color-toolbar-border: var(--borderColor-default);
+    --ck-color-base-border: var(--borderColor-default);
+    --table-border-color: var(--borderColor-default);
+    --toolbar-item--bg-color: var(--button-default-bgColor-rest);
+    --toolbar-item--border-color: var(--borderColor-default);
     --header-border-bottom-width: 1px;
-    --header-bg-color: var(--color-page-header-bg);
-    --header-item-font-color: var(--color-fg-default);
-    --header-item-bg-hover-color: var(--color-action-list-item-default-hover-bg);
-    --header-item-font-hover-color: var(--color-fg-default);
-    --header-border-bottom-color: var(--color-border-muted) !important;
-    --main-menu-bg-color: var(--color-page-header-bg);
-    --main-menu-hover-font-color: var(--color-fg-default);
-    --main-menu-bg-selected-background: var(--color-action-list-item-default-hover-bg);
-    --main-menu-bg-hover-background: var(--color-action-list-item-default-hover-bg);
-    --main-menu-font-color: var(--color-fg-default);
-    --main-menu-selected-font-color: var(--color-fg-default);
-    --main-menu-border-color: var(--color-border-muted);
-    --main-menu-resizer-color: var(--color-border-muted);
-    --main-menu-bg-selected-border: var(--color-border-muted);
-    --main-menu-hover-border-color: var(--color-fg-default) !important;
-    --main-menu-fieldset-header-color: var(--color-fg-subtle) !important;
+    --header-bg-color: var(--page-header-bgColor);
+    --header-item-font-color: var(--fgColor-default);
+    --header-item-bg-hover-color: var(--control-transparent-bgColor-hover);
+    --header-item-font-hover-color: var(--fgColor-default);
+    --header-border-bottom-color: var(--borderColor-muted) !important;
+    --main-menu-bg-color: var(--page-header-bgColor);
+    --main-menu-hover-font-color: var(--fgColor-default);
+    --main-menu-bg-selected-background: var(--control-transparent-bgColor-hover);
+    --main-menu-bg-hover-background: var(--control-transparent-bgColor-hover);
+    --main-menu-font-color: var(--fgColor-default);
+    --main-menu-selected-font-color: var(--fgColor-default);
+    --main-menu-border-color: var(--borderColor-muted);
+    --main-menu-resizer-color: var(--borderColor-muted);
+    --main-menu-bg-selected-border: var(--borderColor-muted);
+    --main-menu-hover-border-color: var(--fgColor-default) !important;
+    --main-menu-fieldset-header-color: var(--fgColor-muted) !important;
     --main-menu-border-width: 1px;
-    --button--border-color: var(--color-border-default);
-    --button--primary-background-hover-color: var(--color-btn-primary-hover-bg);
-    --button--primary-background-color: var(--color-btn-primary-bg);
-    --button--active-border-color: var(--color-border-default);
-    --button--background-hover-color: var(--color-btn-hover-bg);
-    --button--background-color: var(--color-btn-bg);
-    --accent-color: var(--color-accent-fg);
-    --primary-button-color: var(--color-btn-primary-bg);
-    --status-selector-border-color: var(--button--border-color);
+    --button-default-borderColor-rest: var(--borderColor-default);
+    --button--primary-background-hover-color: var(--button-primary-bgColor-hover);
+    --button--primary-background-color: var(--button-primary-bgColor-rest);
+    --button--active-border-color: var(--borderColor-default);
+    --button--background-hover-color: var(--button-default-bgColor-hover);
+    --button--background-color: var(--button-default-bgColor-rest);
+    --accent-color: var(--fgColor-accent);
+    --primary-button-color: var(--button-primary-bgColor-rest);
+    --status-selector-border-color: var(--button-default-borderColor-rest);
     --link-text-decoration: underline;
   }
 </style>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,10 +47,10 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.10.0",
-        "@openproject/primer-view-components": "^0.28.1",
+        "@openproject/primer-view-components": "^0.29.0",
         "@openproject/reactivestates": "^3.0.1",
-        "@primer/css": "^21.1.1",
         "@types/hotwired__turbo": "^8.0.1",
+        "@primer/css": "^21.2.2",
         "@uirouter/angular": "^13.0.0",
         "@uirouter/core": "^6.1.0",
         "@uirouter/rx": "^1.0.0",
@@ -4746,9 +4746,9 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.28.1.tgz",
-      "integrity": "sha512-vnVvCHK24uyu8278DTEG+NBK9uwZzimPgAAcN6290MQl0IVKN1PlEkKmqomP69gfXzpZkVIS1rxy0nejKnuXpw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.29.0.tgz",
+      "integrity": "sha512-ZLdCCpyruHSq9/ibAfmWoS8D0CZh6hk9SrtIqHP7Gdc+q7QFjk9pYOzia5OMzeQkuZBSWW+NADwcrD7+iBp6Dg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -4813,9 +4813,9 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.28.1.tgz",
-      "integrity": "sha512-vnVvCHK24uyu8278DTEG+NBK9uwZzimPgAAcN6290MQl0IVKN1PlEkKmqomP69gfXzpZkVIS1rxy0nejKnuXpw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.29.0.tgz",
+      "integrity": "sha512-ZLdCCpyruHSq9/ibAfmWoS8D0CZh6hk9SrtIqHP7Gdc+q7QFjk9pYOzia5OMzeQkuZBSWW+NADwcrD7+iBp6Dg==",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25373,9 +25373,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.28.1.tgz",
-      "integrity": "sha512-vnVvCHK24uyu8278DTEG+NBK9uwZzimPgAAcN6290MQl0IVKN1PlEkKmqomP69gfXzpZkVIS1rxy0nejKnuXpw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.29.0.tgz",
+      "integrity": "sha512-ZLdCCpyruHSq9/ibAfmWoS8D0CZh6hk9SrtIqHP7Gdc+q7QFjk9pYOzia5OMzeQkuZBSWW+NADwcrD7+iBp6Dg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25421,7 +25421,7 @@
       "integrity": "sha512-Mcpt9CyajnPW8TJmZYIUhnctdLk7rfsoyvh8w4qDydu2C7HHOHa0wKQjf0zofQ+AyJOIW1Gfa9xvBfwAeNkgoQ==",
       "requires": {
         "@primer/primitives": "^7.15.12",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.28.1"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.29.0"
       }
     },
     "@primer/primitives": {
@@ -25430,9 +25430,9 @@
       "integrity": "sha512-ujAsbRB5Xw6rrxizbTgv1bxpraZ091stPMsO6pqGxzc+zIyhrojpGVBuCKJ+RYkpbKK7T4bZzgOT/KyWBAFwwg=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.28.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.28.1.tgz",
-      "integrity": "sha512-vnVvCHK24uyu8278DTEG+NBK9uwZzimPgAAcN6290MQl0IVKN1PlEkKmqomP69gfXzpZkVIS1rxy0nejKnuXpw==",
+      "version": "npm:@openproject/primer-view-components@0.29.0",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.29.0.tgz",
+      "integrity": "sha512-ZLdCCpyruHSq9/ibAfmWoS8D0CZh6hk9SrtIqHP7Gdc+q7QFjk9pYOzia5OMzeQkuZBSWW+NADwcrD7+iBp6Dg==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,9 +98,9 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.10.0",
-    "@openproject/primer-view-components": "^0.28.1",
+    "@openproject/primer-view-components": "^0.29.0",
     "@openproject/reactivestates": "^3.0.1",
-    "@primer/css": "^21.1.1",
+    "@primer/css": "^21.2.2",
     "@types/hotwired__turbo": "^8.0.1",
     "@uirouter/angular": "^13.0.0",
     "@uirouter/core": "^6.1.0",
@@ -177,6 +177,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.28.1"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.29.0"
   }
 }

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -118,7 +118,7 @@ $search-input-height: 30px
       height: auto
 
     .ng-option
-      border-bottom: 1px solid var(--color-border-muted)
+      border-bottom: 1px solid var(--borderColor-muted)
       white-space: normal
       padding: 5px 10px
       // We do not want the default highlighting of ng-select to take place as

--- a/frontend/src/app/core/global_search/input/global-search.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search.component.sass
@@ -32,7 +32,7 @@
   &--project-scope
     flex-grow: 0
     flex-shrink: 1
-    border: 1px solid var(--button--border-color)
+    border: 1px solid var(--button-default-borderColor-rest)
     font-size: 13px
     background: var(--button--background-color)
     border-radius: 2px
@@ -59,7 +59,7 @@
     grid-area: idlink
     place-self: right
     font-style: italic
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     font-size: 13px
     white-space: nowrap
 

--- a/frontend/src/app/features/backlogs/backlogs-page/styles/dialogues.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/dialogues.sass
@@ -6,4 +6,4 @@
 
   .ui-dialog
     background: #FFFFFF
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)

--- a/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/master_backlog.sass
@@ -52,7 +52,7 @@
     top: 1px
     width: 100px
   #backlogs_container .backlog
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     display: block
     margin: 0 0 10px 0
     width: 100%
@@ -74,7 +74,7 @@
     position: relative
     width: 100%
   .backlog .header .backlog-menu
-    border-right: 1px solid var(--color-border-muted)
+    border-right: 1px solid var(--borderColor-muted)
     cursor: pointer
     height: 30px
     overflow: visible
@@ -95,7 +95,7 @@
     .items
       display: none
       background-color: #EEEEEE
-      border: 1px solid var(--color-border-muted)
+      border: 1px solid var(--borderColor-muted)
       position: absolute
       top: 30px
       right: -2px

--- a/frontend/src/app/features/backlogs/backlogs-page/styles/taskboard.sass
+++ b/frontend/src/app/features/backlogs/backlogs-page/styles/taskboard.sass
@@ -69,7 +69,7 @@
     /* Must be the same as min-width */
   #board_header
     background-color: #EBEBEB
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     margin-bottom: 0
     margin-right: 10px
     td
@@ -88,7 +88,7 @@
 
   .board
     background-color: #FCFCFC
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     border-top: none
     margin-right: 10px
     /* IE7 table fix */

--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.sass
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.sass
@@ -31,7 +31,7 @@ ngx-gallery ::ng-deep
   // Disable red border on active thumbnails
   .ngx-gallery-active,
   .ngx-gallery-thumbnail
-    border: 1px solid var(--color-border-muted) !important
+    border: 1px solid var(--borderColor-muted) !important
 
   .ngx-gallery-preview-img
     background-color: white

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/generic.sass
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/generic.sass
@@ -54,7 +54,7 @@
   vertical-align: middle
   padding: .375rem .75rem
   border-radius: 2px
-  border: 1px solid var(--button--border-color)
+  border: 1px solid var(--button-default-borderColor-rest)
   @include default-transition
 
   &:hover

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/loading_modal.sass
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/loading_modal.sass
@@ -17,7 +17,7 @@
   background-color: #fefefe
   margin: auto
   padding: 0
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   border-radius: 0.5em
   width: 50%
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
@@ -47,4 +47,4 @@
 
 .xeokit-busy-modal-body
   padding: 2px 16px
-  margin: 20px 2px  
+  margin: 20px 2px

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
@@ -40,7 +40,7 @@ $board-list-top-offset: 18px
   line-height: 42px
   font-size: 14px
   cursor: pointer
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
 
   .boards-list--add-item-text
     padding: 5px 15px 0 15px

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
@@ -100,7 +100,7 @@ op-time-entries-calendar
         opacity: 1
         transition: opacity 1s ease
         background: #EAEAEA
-        border: 1px solid var(--color-fg-muted)
+        border: 1px solid var(--fgColor-muted)
 
       .te-calendar--add-icon
         color: black

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
@@ -1,5 +1,5 @@
 .op-wp-calendar
-  --fc-border-color: var(--color-border-muted)
+  --fc-border-color: var(--borderColor-muted)
 
   // Ensure some sane min-height
   // to ensure fullcalendar has something to render

--- a/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.sass
@@ -12,7 +12,7 @@
     position: absolute
 
   &--content-text
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     font-size: 18px
 
   &--content-image

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -40,7 +40,7 @@
       height: 100%
 
   &-loading-text
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     font-size: 18px
 
   &-loading-image

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.sass
@@ -5,7 +5,7 @@
   grid-template-columns: auto 1fr
   grid-column-gap: $spot-spacing-0_25
   align-items: center
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
 
   &--date
     @include text-shortener

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
@@ -1,5 +1,5 @@
 .op-ian-date-alert
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
 
   &_overdue
     color: var(--warn)

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -17,7 +17,7 @@ $subject-font-size: 14px
   margin: 0
   padding: 15px 10px
   font-size: 0.9rem
-  border-top: 1px solid var(--color-border-muted)
+  border-top: 1px solid var(--borderColor-muted)
   border-radius: 2px
   height: $ian-height
 
@@ -25,7 +25,7 @@ $subject-font-size: 14px
     background: $ian-bg-hover-color
 
   &:last-of-type
-    border-bottom: 1px solid var(--color-border-muted)
+    border-bottom: 1px solid var(--borderColor-muted)
 
   &_selected
     background: $ian-bg-selected-color
@@ -78,12 +78,12 @@ $subject-font-size: 14px
 
   &--project
     grid-area: project
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     @include text-shortener
 
   &--project-link,
   &--work-package-id-link
-    color: ar(--color-fg-muted)
+    color: ar(--fgColor-muted)
     font-weight: var(--base-text-weight-bold)
 
   &--reason-count
@@ -95,7 +95,7 @@ $subject-font-size: 14px
   &--reason-wrapper
     grid-area: reason
     @include text-shortener
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
   &--status
     grid-area: status

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.sass
@@ -6,7 +6,7 @@
   grid-row-gap: 10px
   background: #F3F3F3
   padding: 8px
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
 
 .op-add-existing-pane
   &--results

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -82,7 +82,7 @@ $op-team-planner-resource-width: 180px
     flex-direction: column
     justify-content: center
     align-items: center
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     border-top: 0px
 
 

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.sass
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.sass
@@ -16,6 +16,6 @@
     margin: auto
 
 .op-table--cell--date-alerts
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   text-align: center
   padding: $spot-spacing-0_75 $spot-spacing-1

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -7,7 +7,7 @@
   user-select: none
   // Leave space for the shadow to be displayed
   width: calc(100% - 2px)
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   border-radius: 2px
   padding: 10px
   position: relative
@@ -86,7 +86,7 @@
     &-project-name
       grid-area: project
       font-style: italic
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       font-size: 12px
       @include text-shortener
     &-type
@@ -99,11 +99,11 @@
       margin-right: auto
       grid-area: avatar
       max-width: 140px
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       font-size: 12px
     &-id
       grid-area: id
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       font-size: 12px
     &-status-baseline
       grid-area: status
@@ -130,12 +130,12 @@
       grid-area: dates
       place-self: center end
       white-space: nowrap
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       font-size: 12px
 
     &-inline-date
       font-size: 12px
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       margin: 0 8px
       white-space: nowrap
 

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.sass
@@ -9,7 +9,7 @@
     margin-right: 5px
     margin-bottom: 5px
     min-width: 50px
-    border: 1px solid var(--color-border-default)
+    border: 1px solid var(--borderColor-default)
     background: #F8F8F8
     cursor: move
     display: flex

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.sass
@@ -14,4 +14,4 @@
   // Unfortunately, ng-select is extremely specific with its selectors
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-disabled
     cursor: default
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)

--- a/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.sass
+++ b/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.sass
@@ -31,8 +31,8 @@
   color: #5F5F5F
 
   &:focus
-    border-color: var(--color-accent-fg)
-    box-shadow: 0 0 0 1px var(--color-accent-fg)
+    border-color: var(--fgColor-accent)
+    box-shadow: 0 0 0 1px var(--fgColor-accent)
 
   &.-changed
     font-style: italic
@@ -51,7 +51,7 @@
 // Here we make sure the shim layouts like the normal input
 // This is an element selector so the specificity stays lower than other selectors that might write here.
 // The rules are taken from input[type="text"]
-input-shim 
+input-shim
   border: 1px solid transparent
   padding: 0.375rem
   margin: 0

--- a/frontend/src/app/shared/components/op-content-loader/op-wp-loading-skeleton/op-wp-loading-skeleton.component.sass
+++ b/frontend/src/app/shared/components/op-content-loader/op-wp-loading-skeleton/op-wp-loading-skeleton.component.sass
@@ -1,6 +1,6 @@
 .op-wp-loading-skeleton
   width: calc(100% - 2px)
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   border-radius: 2px
   padding: 10px
   position: relative

--- a/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.sass
+++ b/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.sass
@@ -1,3 +1,3 @@
 a, a:hover
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
   text-decoration: none

--- a/frontend/src/app/shared/components/table/table.sass
+++ b/frontend/src/app/shared/components/table/table.sass
@@ -4,7 +4,7 @@
 
   &--cell
     padding: 12px 16px
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     text-align: center
 
     &_heading

--- a/frontend/src/app/spot/styles/sass/components/checkbox.sass
+++ b/frontend/src/app/spot/styles/sass/components/checkbox.sass
@@ -62,7 +62,7 @@
     transform: translateX(1px) rotate(-45deg)
 
   &--input:disabled + &--fake
-    border-color: var(--color-fg-muted)
+    border-color: var(--fgColor-muted)
     cursor: default
 
   &--input:disabled:checked + &--fake
@@ -70,4 +70,4 @@
 
   &--input:disabled + &--fake::before,
   &--input:disabled + &--fake::after
-    background-color: var(--color-fg-muted)
+    background-color: var(--fgColor-muted)

--- a/frontend/src/app/spot/styles/sass/components/filter-chip.sass
+++ b/frontend/src/app/spot/styles/sass/components/filter-chip.sass
@@ -25,5 +25,5 @@
     padding: $spot-spacing-0_25
 
   &_disabled
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     background-color: $spot-color-basic-gray-5

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -42,7 +42,7 @@
           color: $spot-color-basic-gray-1
 
       &_active#{&}_disabled
-        color: var(--color-fg-muted)
+        color: var(--fgColor-muted)
         background-color: $spot-color-basic-gray-6
 
       &_link:not(&_disabled)

--- a/frontend/src/app/spot/styles/sass/components/switch.sass
+++ b/frontend/src/app/spot/styles/sass/components/switch.sass
@@ -27,7 +27,7 @@
     height: $spot-spacing-1 + $spot-spacing-0_25
     width: $spot-spacing-2 + $spot-spacing-0_25
     border-radius: math.div($spot-spacing-1 + $spot-spacing-0_25, 2)
-    border: 1px solid var(--color-fg-muted)
+    border: 1px solid var(--fgColor-muted)
     background-color: $spot-color-basic-gray-5
     cursor: pointer
 
@@ -39,7 +39,7 @@
       left: 1px
       height: $spot-spacing-1
       width: $spot-spacing-1
-      background-color: var(--color-fg-muted)
+      background-color: var(--fgColor-muted)
       border-radius: 50%
       transition-property: left, background-color
       transition-duration: 0.2s

--- a/frontend/src/app/spot/styles/sass/components/text-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/text-field.sass
@@ -1,7 +1,7 @@
 .spot-text-field
   @include spot-body-small
 
-  border: 1px solid var(--color-fg-muted)
+  border: 1px solid var(--fgColor-muted)
   color: $spot-color-basic-black
   border-radius: 4px
   padding: $spot-spacing-0_5
@@ -11,7 +11,7 @@
   align-items: center
 
   &::placeholder
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
   &:focus,
   &_focused
@@ -20,7 +20,7 @@
 
   &:disabled,
   &_disabled
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     border-color: $spot-color-basic-gray-4
 
   &:disabled,
@@ -45,7 +45,7 @@
 
     &:disabled,
     &:disabled:hover
-      color: var(--color-fg-subtle)
+      color: var(--fgColor-muted)
       background-color: $spot-color-basic-white
 
     &:focus,
@@ -58,7 +58,7 @@
     padding: 0
     display: flex
     align-items: center
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
     &:focus
       @include spot-focus

--- a/frontend/src/global_styles/common/input/input.sass
+++ b/frontend/src/global_styles/common/input/input.sass
@@ -1,6 +1,6 @@
 .op-input
   background: white
-  border: 1px solid var(--color-border-default)
+  border: 1px solid var(--borderColor-default)
   border-radius: 2px
   min-height: 2rem
   display: flex

--- a/frontend/src/global_styles/common/menu/menu.sass
+++ b/frontend/src/global_styles/common/menu/menu.sass
@@ -48,10 +48,10 @@
 
   &--headline
     font-size: 12px
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     text-transform: uppercase
 
   &--separator
-    border-bottom: 1px solid var(--color-border-muted)
+    border-bottom: 1px solid var(--borderColor-muted)
     margin: 0 0 10px
     background: none

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -71,7 +71,7 @@
     // from http://codepen.io/ericrasch/pen/Irlpm
 
     &:after
-      border-bottom: 2px solid var(--color-border-muted)
+      border-bottom: 2px solid var(--borderColor-muted)
       content: ""
       // this centers the line to the full width specified
       margin: 0 auto

--- a/frontend/src/global_styles/content/_attributes_group.sass
+++ b/frontend/src/global_styles/content/_attributes_group.sass
@@ -33,7 +33,7 @@
 .attributes-group--header
   @include grid-block
   margin: 0 0 0.5rem 0
-  border-bottom: 1px solid var(--color-border-muted)
+  border-bottom: 1px solid var(--borderColor-muted)
   align-items: flex-end
 
 

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -45,9 +45,9 @@ div.autocomplete
       padding: 2px
       cursor: pointer
       font-size: 90%
-      border: 1px solid var(--color-border-muted)
-      border-left: 1px solid var(--color-border-muted)
-      border-right: 1px solid var(--color-border-muted)
+      border: 1px solid var(--borderColor-muted)
+      border-left: 1px solid var(--borderColor-muted)
+      border-right: 1px solid var(--borderColor-muted)
       background-color: white
       &.selected
         background-color: #ffb
@@ -80,14 +80,14 @@ div.autocomplete
     z-index: auto !important
     height: 30px !important
     min-height: 30px !important
-    border-color: var(--color-border-default) !important
+    border-color: var(--borderColor-default) !important
 
     .ng-value-container
       overflow: visible !important
 
       .ng-placeholder
         top: 1px !important
-        color: var(--color-fg-subtle)
+        color: var(--fgColor-muted)
         @include text-shortener
 
       input
@@ -101,13 +101,13 @@ div.autocomplete
     line-height: 22px
 
 .ng-select .ng-arrow-wrapper .ng-arrow
-  border-color: var(--color-fg-muted) transparent transparent
+  border-color: var(--fgColor-muted) transparent transparent
 
 .ng-select.ng-select-opened>.ng-select-container .ng-arrow
-  border-color: transparent transparent var(--color-fg-muted)
+  border-color: transparent transparent var(--fgColor-muted)
 
 .ng-select .ng-clear-wrapper
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
 
 .ng-select.ng-select-multiple .ng-select-container
   height: initial !important

--- a/frontend/src/global_styles/content/_badges.sass
+++ b/frontend/src/global_styles/content/_badges.sass
@@ -61,7 +61,7 @@ $badge-color: var(--font-color-on-primary)
     @include badge-style($badge-secondary-background, auto)
 
   &.-border-only
-    border-color: var(--button--border-color)
+    border-color: var(--button-default-borderColor-rest)
     color: var(--body-font-color)
     background: transparent
     border-width: 1px

--- a/frontend/src/global_styles/content/_boxes.sass
+++ b/frontend/src/global_styles/content/_boxes.sass
@@ -30,7 +30,7 @@
   padding: 6px
   margin-bottom: 10px
   line-height: 1.5em
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
 
 .box p
   padding-top: 5px

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -48,7 +48,7 @@ $button--text-icon-spacing: 0.65em
 a.button
   @extend %button
   @include button-style(var(--button--background-color), var(--button--background-hover-color), var(--button--font-color))
-  border: 1px solid var(--button--border-color)
+  border: 1px solid var(--button-default-borderColor-rest)
 
   position: relative
   transition-property: background, border
@@ -189,4 +189,4 @@ html.-browser-windows.-browser-chrome
   &[disabled], &[disabled]:hover
     cursor: not-allowed
     background: none
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)

--- a/frontend/src/global_styles/content/_context_menu.sass
+++ b/frontend/src/global_styles/content/_context_menu.sass
@@ -32,7 +32,7 @@
     list-style-type: none
     margin: 0
     min-width: 240px
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     padding: 3px 0
     background: #ffffff
 
@@ -112,4 +112,3 @@ html:not(.-browser-mobile)
   &:hover, &:focus
     .context-menu--icon
       opacity: 100
-

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -30,7 +30,7 @@ $datepicker--selected-border-radius: 5px
 
 @mixin disabled-day
   background: $spot-color-basic-white
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
   pointer-events: none
   cursor: not-allowed
 
@@ -39,7 +39,7 @@ $datepicker--selected-border-radius: 5px
 
 @mixin non-working-day
   background: $spot-color-basic-gray-6
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
   border-radius: 0
   pointer-events: none
 
@@ -141,7 +141,7 @@ $datepicker--selected-border-radius: 5px
         box-shadow: none !important
 
         &:hover
-          border-color: var(--color-fg-muted)
+          border-color: var(--fgColor-muted)
 
         &.flatpickr-non-working-day
           @include non-working-day
@@ -156,7 +156,7 @@ $datepicker--selected-border-radius: 5px
 
           &:hover
             color: $spot-color-basic-gray-1
-            border-color: var(--color-fg-muted)
+            border-color: var(--fgColor-muted)
 
         &.selected:not(.startRange, .endRange)
           border-radius: $datepicker--selected-border-radius
@@ -200,31 +200,31 @@ $datepicker--selected-border-radius: 5px
 
           &.flatpickr-non-working-day
             background: $spot-color-basic-gray-6
-            color: var(--color-fg-muted)
+            color: var(--fgColor-muted)
 
           &.flatpickr-non-working-day_enabled
             background: $spot-color-basic-gray-6
-            color: var(--color-fg-muted)
+            color: var(--fgColor-muted)
 
             &.inRange
-              color: var(--color-fg-muted)
+              color: var(--fgColor-muted)
               background: $spot-color-basic-gray-6
               border-color: $spot-color-basic-gray-6
 
           &.selected,
           &.startRange,
           &.endRange
-            background: var(--color-fg-muted)
-            border-color: var(--color-fg-muted)
+            background: var(--fgColor-muted)
+            border-color: var(--fgColor-muted)
             color: $spot-color-basic-gray-5
 
           &.inRange
             background: $spot-color-basic-gray-5
             border-color: $spot-color-basic-gray-5
-            color: var(--color-fg-muted)
+            color: var(--fgColor-muted)
 
           &.today
-            color: var(--color-fg-muted)
+            color: var(--fgColor-muted)
             background: $spot-color-indication-current-date
             border-color: $spot-color-indication-current-date
 
@@ -239,7 +239,7 @@ $datepicker--selected-border-radius: 5px
 
     &.flatpickr-non-working-day:not(.today,.selected)
       background: $spot-color-basic-gray-6 !important
-      color: var(--color-fg-muted) !important
+      color: var(--fgColor-muted) !important
 
     &.flatpickr-non-working-day_enabled:not(.today,.selected)
       background: $spot-color-basic-gray-6 !important

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -11,7 +11,7 @@
     margin-bottom: 20px
     box-shadow: 4px 4px 10px rgb(0 0 0 / 15%)
     border-radius: 25px
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
 
   .widget-box--teaser-image_default
     width: 30%

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -29,7 +29,7 @@
 $form--field-types: (text-field, text-area, select, check-box, radio-button, range-field, search, file, date-picker)
 $base-line-height: 1.5
 $form-label-color: var(--body-font-color)
-$content-form-input-border: 1px solid var(--color-border-default)
+$content-form-input-border: 1px solid var(--borderColor-default)
 
 %input-style
   border: $content-form-input-border
@@ -78,7 +78,7 @@ form
   &.-bordered
     padding: 30px 20px
     background-color: var(--content-form-bg-color)
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
 
     &.-compressed
       padding: 10px 20px 0 20px
@@ -181,7 +181,7 @@ hr
   border: 0
 
   &.form--separator
-    border-bottom: 1px solid var(--color-border-muted)
+    border-bottom: 1px solid var(--borderColor-muted)
     margin: 0 0 30px
     background: none
 
@@ -231,7 +231,7 @@ hr
   font-weight: var(--base-text-weight-bold)
   line-height: 1.8
   text-transform: uppercase
-  border-bottom: 1px solid var(--color-border-muted)
+  border-bottom: 1px solid var(--borderColor-muted)
 
 // HACK. TODO: Remove fieldset element rules in various places.
 .form--fieldset,
@@ -616,7 +616,7 @@ select
   font-size: var(--body-font-size)
 
   &:focus, &:active
-    border-color: var(--color-accent-fg)
+    border-color: var(--fgColor-accent)
 
 .-hide-placeholder-on-focus
   &:focus::placeholder
@@ -914,7 +914,7 @@ input[readonly].-clickable
 
   .form--field-inline-button
     margin-right: 0
-    border: 1px solid var(--button--border-color)
+    border: 1px solid var(--button-default-borderColor-rest)
     border-left-width: 0px
     border-radius: 0px
 

--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -93,7 +93,7 @@ body.widget-grid-layout
 .grid--resizer
   position: absolute
   height: 20px
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
   cursor: nwse-resize
   opacity: 0
   right: 0
@@ -116,7 +116,7 @@ body.widget-grid-layout
 
   &:before
     padding: 0
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
   .grid--area.-widgeted:hover &
     opacity: 1

--- a/frontend/src/global_styles/content/_icon_control.sass
+++ b/frontend/src/global_styles/content/_icon_control.sass
@@ -36,7 +36,7 @@
   text-align:     center
   cursor:         pointer
   border-radius:  50%
-  color:          var(--color-fg-muted)
+  color:          var(--fgColor-muted)
 
   &:hover, &.-active
     text-decoration:  none
@@ -44,7 +44,7 @@
     background:       var(--button--primary-background-color)
 
   &.-active:hover
-    color:            var(--color-fg-muted)
+    color:            var(--fgColor-muted)
     background:       white
 
 .icon-control--icon

--- a/frontend/src/global_styles/content/_news.sass
+++ b/frontend/src/global_styles/content/_news.sass
@@ -38,7 +38,7 @@
 
 .news-author
   font-size: 0.8rem
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
   display: block
   line-height: 1.25
 

--- a/frontend/src/global_styles/content/_pagination.sass
+++ b/frontend/src/global_styles/content/_pagination.sass
@@ -81,7 +81,7 @@ $pagination--font-size: 0.8125rem
       padding: 3px 3px
       background: #f8f8f8
       border-radius: 2px
-      border: 1px solid var(--button--border-color)
+      border: 1px solid var(--button-default-borderColor-rest)
       color: var(--body-font-color)
       font-weight: normal
       cursor: pointer

--- a/frontend/src/global_styles/content/_project_list_modal.sass
+++ b/frontend/src/global_styles/content/_project_list_modal.sass
@@ -27,5 +27,5 @@
   &--no-results
     @include spot-body-small(normal, italic)
     margin: $spot-spacing-1-5 $spot-spacing-1
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     flex-grow: 1

--- a/frontend/src/global_styles/content/_project_status.sass
+++ b/frontend/src/global_styles/content/_project_status.sass
@@ -4,7 +4,7 @@ $project-status_off-track: var(--fgColor-danger, var(--color-danger-fg))
 $project-status_at-risk: var(--fgColor-severe, var(--color-severe-fg))
 $project-status_on-track: var(--fgColor-success, var(--color-success-fg))
 $project-status_discontinued: var(--fgColor-attention, var(--color-attention-fg))
-$project-status_not-started: var(--fgColor-accent, var(--color-accent-fg))
+$project-status_not-started: var(--fgColor-accent, var(--fgColor-accent))
 $project-status_finished: var(--fgColor-done, var(--color-done-fg))
 $project-status-background-color: RGBA(var(--fgColor-subtle, var(--color-subtle-fg)), 0.3)
 

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -72,7 +72,7 @@ $content-padding: 10px
         display: inline
 
     .archived
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       span.archived-label
         text-transform: uppercase
 

--- a/frontend/src/global_styles/content/_scrollable_tabs.sass
+++ b/frontend/src/global_styles/content/_scrollable_tabs.sass
@@ -1,6 +1,6 @@
 .op-scrollable-tabs
   display: flex
-  border-bottom: 1px solid var(--color-border-muted)
+  border-bottom: 1px solid var(--borderColor-muted)
   margin-bottom: 1.5rem
 
   &--tab-container

--- a/frontend/src/global_styles/content/_simple_filters.sass
+++ b/frontend/src/global_styles/content/_simple_filters.sass
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-$filters--border-color: var(--color-border-muted) !default
+$filters--border-color: var(--borderColor-muted) !default
 
 %filters--container
   border: 1px solid $filters--border-color

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -330,7 +330,7 @@ thead.-sticky th
 
 .generic-table--no-results-container
   background:   var(--gray-light)
-  border:       1px solid var(--color-border-muted)
+  border:       1px solid var(--borderColor-muted)
   border-radius: 4px
   padding:      14px 14px 14px 36px
   display:      block

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -139,7 +139,7 @@ tr
 
   &.user
     &.locked, &.registered, &.locked a, &.registered a
-      color: var(--color-fg-subtle)
+      color: var(--fgColor-muted)
 
 td
   &.hours

--- a/frontend/src/global_styles/content/_tabs.sass
+++ b/frontend/src/global_styles/content/_tabs.sass
@@ -52,4 +52,4 @@
       cursor: default
       pointer-events: none
       border-bottom-width: 0
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)

--- a/frontend/src/global_styles/content/_tiles.sass
+++ b/frontend/src/global_styles/content/_tiles.sass
@@ -42,7 +42,7 @@
     background: #f7fafc
     min-height: 150px
     padding: 1rem
-    border: 1px solid var(--button--border-color)
+    border: 1px solid var(--button-default-borderColor-rest)
 
     &:disabled
       background: #fafafa

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -47,7 +47,7 @@
 
 
 #type-form-conf-inactive-group
-  background: var(--color-fg-muted)
+  background: var(--fgColor-muted)
   .visibility-check,
   .delete-group,
   .delete-attribute

--- a/frontend/src/global_styles/content/_user_mention.sass
+++ b/frontend/src/global_styles/content/_user_mention.sass
@@ -34,7 +34,7 @@
 
   &:before
     content: '@'
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
 span.user-mention
   // Remove text selection cursor for group

--- a/frontend/src/global_styles/content/menus/_menu_blocks.sass
+++ b/frontend/src/global_styles/content/menus/_menu_blocks.sass
@@ -14,7 +14,7 @@
     justify-items: center
     text-align: center
     background: #cccccc30
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
 
     &:hover
       outline: 1px solid grey

--- a/frontend/src/global_styles/content/modules/_bim.sass
+++ b/frontend/src/global_styles/content/modules/_bim.sass
@@ -9,7 +9,7 @@
     padding: 10px
 
     &.-failed
-      border: 1px solid var(--color-border-muted)
+      border: 1px solid var(--borderColor-muted)
 
   img
     width: 100%

--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -15,7 +15,7 @@ $view-select-dropdown-width: 8rem
         display: none !important
 
 .op-team-planner
-  --fc-border-color: var(--color-border-muted)
+  --fc-border-color: var(--borderColor-muted)
 
   &--calendar_empty
     .fc-scrollgrid-section-body,

--- a/frontend/src/global_styles/content/user-content/_code-block.sass
+++ b/frontend/src/global_styles/content/user-content/_code-block.sass
@@ -6,7 +6,7 @@
   overflow-x: auto
   overflow-y: hidden
   background-color: #fafafa
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
 
   > *
     background-color: transparent
@@ -27,6 +27,6 @@
   font-weight: normal
   color: #333739
   background-color: #fafafa
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   padding: 0.125em 0.3125em
   break-inside: avoid

--- a/frontend/src/global_styles/content/user-content/_placeholder.sass
+++ b/frontend/src/global_styles/content/user-content/_placeholder.sass
@@ -4,4 +4,4 @@
   color: #6f6f6f
   padding: 1rem
   background-color: #fafafa
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)

--- a/frontend/src/global_styles/content/user-content/_toc.sass
+++ b/frontend/src/global_styles/content/user-content/_toc.sass
@@ -2,7 +2,7 @@
   break-inside: avoid
   font-size: var(--wiki-default-font-size)
   background-color: #fafafa
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   float: right
   margin: 1rem 0rem 1rem 2rem
   padding: 1.5rem 1.5rem 1.5rem 0rem

--- a/frontend/src/global_styles/content/user-content/_typography.sass
+++ b/frontend/src/global_styles/content/user-content/_typography.sass
@@ -23,7 +23,7 @@
 
 .op-uc-h1
   margin-bottom: 0.5rem
-  border-bottom: 1px solid var(--color-border-muted)
+  border-bottom: 1px solid var(--borderColor-muted)
 
   .op-uc-container_reduced-headings
     border-bottom: none

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -123,7 +123,7 @@ html:not(.-browser-mobile)
     color: var(--accent-color)
     padding: 0 0 0 0.25rem
   &.-disabled .icon:before
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
   &:hover
     text-decoration: none
 

--- a/frontend/src/global_styles/content/work_packages/_table_hierarchy.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_hierarchy.sass
@@ -65,7 +65,7 @@
 body
   .wp-table--hierarchy-aditional-row,
   .wp-table--hierarchy-aditional-row .wp-table--hierarchy-indicator-icon
-    color: var(--color-fg-subtle)
+    color: var(--fgColor-muted)
 
 .hierarchy-header--icon
   cursor: pointer

--- a/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
@@ -54,7 +54,7 @@
       @include spot-caption()
 
       line-height: 1.5rem
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       flex-shrink: 0
 
       &:not(:last-child)

--- a/frontend/src/global_styles/content/work_packages/shared/_file_picker.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_picker.sass
@@ -49,7 +49,7 @@
     justify-content: center
     height: 100%
     text-align: center
-    color: var(--color-fg-subtle)
+    color: var(--fgColor-muted)
 
     & &-icon
       width: 9.5rem

--- a/frontend/src/global_styles/content/work_packages/shared/_file_section.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_section.sass
@@ -50,7 +50,7 @@
     margin-top: $spot-spacing-0_25
     padding: 20px
     cursor: pointer
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     background: rgba($spot-color-basic-white, 0.9)
 
     &::after
@@ -61,7 +61,7 @@
       height: 100%
       left: 0
       width: 100%
-      border: 2px dashed var(--color-border-default)
+      border: 2px dashed var(--borderColor-default)
 
     &_float
       display: none
@@ -94,7 +94,7 @@
         height: calc(100% - #{$spot-spacing-1})
         left: $spot-spacing-0_5
         width: calc(100% - #{$spot-spacing-1})
-        border: 2px dashed var(--color-border-default)
+        border: 2px dashed var(--borderColor-default)
 
     &_dragging
       display: flex
@@ -123,7 +123,7 @@
 
     &-text
       cursor: pointer
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       font-size: 0.9rem
       font-weight: var(--base-text-weight-bold)
       line-height: 1.4
@@ -140,4 +140,4 @@
     @include spot-body-small($style: italic)
 
     margin-top: $spot-spacing-0_75
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)

--- a/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files_tab.sass
@@ -37,7 +37,7 @@
     grid-template: "icon text" "button button" / auto 1fr
 
     .info-icon-box
-      color: var(--color-fg-muted)
+      color: var(--fgColor-muted)
       grid-area: icon
       font-size: 3.375rem
       margin-right: $spot-spacing-0_5
@@ -52,7 +52,7 @@
       .text-box-content
         @include spot-body-small()
 
-        color: var(--color-fg-muted)
+        color: var(--fgColor-muted)
 
     .button-box
       grid-area: button

--- a/frontend/src/global_styles/layout/_colors.sass
+++ b/frontend/src/global_styles/layout/_colors.sass
@@ -65,7 +65,7 @@
   // Square items
   flex: 0 0 150px
   height: 150px
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   margin: 10px
 
 

--- a/frontend/src/global_styles/layout/_drop_down.sass
+++ b/frontend/src/global_styles/layout/_drop_down.sass
@@ -99,7 +99,7 @@
       margin-left: 19.09px //for whatever reasons it is the right dimension
 
   LI > .inactive
-    color: var(--color-fg-subtle)
+    color: var(--fgColor-muted)
 
   LI > .selected
     background: var(--drop-down-selected-bg-color)

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -39,14 +39,14 @@
   &--split-container
     display: flex
     flex-shrink: 8
-    border-top: 1px solid var(--color-border-muted)
+    border-top: 1px solid var(--borderColor-muted)
     overflow: visible
     height: 100%
     // Important for Firefox to let 'flex-shrink' work correctly.
     min-height: 0
 
   &--split-left
-    border-right: 1px solid var(--color-border-muted)
+    border-right: 1px solid var(--borderColor-muted)
     overflow-y: auto
     overflow-x: hidden
     flex: 2

--- a/frontend/src/global_styles/openproject/_forms.sass
+++ b/frontend/src/global_styles/openproject/_forms.sass
@@ -47,7 +47,7 @@ $form-padding: 0.5rem !default
 
 // Text fields
 $input-color: #000 !default
-$input-border: 1px solid var(--color-border-default) !default
+$input-border: 1px solid var(--borderColor-default) !default
 $input-border-focus: 1px solid #999 !default
 
 // Labels

--- a/frontend/src/global_styles/openproject/_generic.sass
+++ b/frontend/src/global_styles/openproject/_generic.sass
@@ -79,7 +79,7 @@
 
 .other-formats
   font-size: 0.9em
-  color: var(--color-fg-muted)
+  color: var(--fgColor-muted)
 
   span + span:before
     content: "| "

--- a/frontend/src/global_styles/openproject/_homescreen.sass
+++ b/frontend/src/global_styles/openproject/_homescreen.sass
@@ -31,7 +31,7 @@
 .controller-homescreen #content-wrapper
   .widget-box
     box-shadow: none
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
 
     &.upsale
       background: $spot-color-feedback-info-light

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -83,7 +83,7 @@
 @mixin widget-box--style
   background: var(--body-background)
   margin: 10px
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   box-shadow: 0px 1px 5px 0px rgba(0,0,0,0.1)
 
 @mixin widget-box--hover-style
@@ -287,7 +287,7 @@ $scrollbar-size: 10px
 
     &:hover
       cursor: default
-      border-color: var(--color-fg-muted)
+      border-color: var(--fgColor-muted)
       background: rgba(218,223,225,0.75)
 
 @mixin unset-button-styles

--- a/frontend/src/global_styles/openproject/_scm.sass
+++ b/frontend/src/global_styles/openproject/_scm.sass
@@ -93,17 +93,17 @@ li.change
 
   &::before
     content: '▸'
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
 table.filecontent
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   border-collapse: collapse
   width: 98%
   background-color: #fafafa
   line-height: initial
 
   th
-    border: 1px solid var(--color-border-muted)
+    border: 1px solid var(--borderColor-muted)
     background-color: #eee
     &.filename
       background-color: #e4e4d4

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -29,7 +29,7 @@
 
 // use CSS4 variables for easier theming
 :root {
-  --primary-button-color: var(--button-primary-bgColor-rest, var(--color-btn-primary-bg));
+  --primary-button-color: #1F883D;
   --primary-button-color--major1: #197032;
 
   --control-checked-color: var(--accent-color);
@@ -47,6 +47,7 @@
 
   --app-height: 100vh;
   --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --body-font-size: var(--text-body-size-medium);
 
   --gray: #EAEAEA;
   --gray-light: #F8F8F8;
@@ -91,7 +92,7 @@
   --main-menu-selected-font-color: var(--main-menu-font-color);
   --main-menu-font-size: 14px;
   --main-menu-fieldset-header-color: #B0B2B3;
-  --main-menu-hover-border-color: var(--color-canvas-default-transparent);
+  --main-menu-hover-border-color: transparent;
   --toolbar-title-color: #5F5F5F;
   --toolbar-item--bg-color: #F8F8F8;
   --toolbar-item--bg-color-pressed: var(--gray-lighter);
@@ -122,12 +123,12 @@
   --button--font-color: #222222;
   --button--background-color: var(--gray-light);
   --button--background-hover-color: #ededed;
-  --button--border-color: #dddddd;
   --button--active-font-color: #666666;
   --button--active-background-color: #eeeeee;
   --button--active-border-color: #cacaca;
   --button--primary-background-color: var(--primary-button-color);
   --button--primary-background-hover-color: var(--primary-button-color--major1);
+  --button--primary-background-disabled-color: var(--primary-button-color--minor1);
   --button--primary-font-color: var(--font-color-on-primary);
   --generic-table--header-font-size: 0.875rem;
   --generic-table--header-height: 45px;
@@ -140,7 +141,7 @@
   --warn:#C92A2A;
   --grid-background-color: #F3F6F8;
   --avatar-border-color: transparent;
-  --list-item-hover--border-color: var(--color-canvas-default-transparent);
+  --list-item-hover--border-color: transparent;
   --list-item-hover--color: var(--accent-color);
   --link-text-decoration: none;
 }

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -128,7 +128,7 @@
         height: 34px
         background: var(--button--background-color)
         color: var(--button--font-color)
-        border-color: var(--button--border-color)
+        border-color: var(--button-default-borderColor-rest)
         margin-bottom: 0
 
         &:focus

--- a/frontend/src/global_styles/vendor/_index.sass
+++ b/frontend/src/global_styles/vendor/_index.sass
@@ -3,3 +3,4 @@
 @import dragula
 @import enjoyhint
 @import full_calendar
+@import primer

--- a/frontend/src/global_styles/vendor/_primer.sass
+++ b/frontend/src/global_styles/vendor/_primer.sass
@@ -1,0 +1,26 @@
+// Needed for the support of the basic mixins (e.g "breakpoint"),
+// and styles which are still part of the CSS repo and not moved over yet (e.g. part of the Button style (e.g. "ellipsis-expander"))
+@import "@primer/css/core/index"
+
+// Needed for accessing Primer variables inside our sass files
+@import "@primer/primitives/dist/css/base/size/size.css"
+@import "@primer/primitives/dist/css/base/typography/typography.css"
+@import "@primer/primitives/dist/css/functional/size/border.css"
+@import "@primer/primitives/dist/css/functional/size/breakpoints.css"
+@import "@primer/primitives/dist/css/functional/size/size-coarse.css"
+@import "@primer/primitives/dist/css/functional/size/size-fine.css"
+@import "@primer/primitives/dist/css/functional/size/size.css"
+@import "@primer/primitives/dist/css/functional/size/viewport.css"
+@import "@primer/primitives/dist/css/functional/typography/typography.css"
+@import "@primer/primitives/dist/css/functional/themes/dark-colorblind.css"
+@import "@primer/primitives/dist/css/functional/themes/dark-dimmed.css"
+@import "@primer/primitives/dist/css/functional/themes/dark-high-contrast.css"
+@import "@primer/primitives/dist/css/functional/themes/dark-tritanopia.css"
+@import "@primer/primitives/dist/css/functional/themes/dark.css"
+@import "@primer/primitives/dist/css/functional/themes/light-colorblind.css"
+@import "@primer/primitives/dist/css/functional/themes/light-high-contrast.css"
+@import "@primer/primitives/dist/css/functional/themes/light-tritanopia.css"
+@import "@primer/primitives/dist/css/functional/themes/light.css"
+
+// Style of the ViewComponents
+@import "@openproject/primer-view-components/app/assets/styles/primer_view_components.css"

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,8 +1,5 @@
 // You can add global styles to this file, and also import other style files
 @import "~@ng-select/ng-select/themes/default.theme.css";
-@import "@primer/css/index.scss";
-@import "@primer/css/primitives/index.scss";
-@import "@openproject/primer-view-components/app/assets/styles/primer_view_components.css";
 
 // Variables
 @import "global_styles/openproject/_variable_defaults.scss";

--- a/lookbook/docs/patterns/15-colors.md.erb
+++ b/lookbook/docs/patterns/15-colors.md.erb
@@ -57,7 +57,7 @@ The following variables of Primer are overwritten with the `--accent-color`:
 ```css
 /* --primer-variable: var(--openProject-variable) */
 
---color-accent-fg: var(--accent-color) !important;
+--fgColor-accent: var(--accent-color) !important;
 --control-checked-bgColor-rest: var(--accent-color) !important;
 --control-checked-bgColor-active: var(--accent-color) !important;
 --control-checked-bgColor-hover: var(--accent-color--major1) !important;
@@ -86,11 +86,11 @@ The goal is to use Primer variables all over the application. Once we get to tha
 ```css
 /* --openProject-variable: var(--primer-variable) */
 
- --avatar-border-color: var(--color-avatar-border);
- --ck-color-base-border: var(--color-border-default);
- --header-bg-color: var(--color-page-header-bg);
- --main-menu-bg-color: var(--color-page-header-bg);
- --accent-color: var(--color-accent-fg);
- --primary-button-color: var(--color-btn-primary-bg);
+ --avatar-border-color: var(--avatar-borderColor);
+ --ck-color-base-border: var(--borderColor-default);
+ --header-bg-color: var(--page-header-bgColor);
+ --main-menu-bg-color: var(--page-header-bgColor);
+ --accent-color: var(--fgColor-accent);
+ --primary-button-color: var(--button-primary-bgColor-rest);
  ...
 ```

--- a/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -1,6 +1,6 @@
 .git-actions-menu
   background-color: var(--body-background)
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   padding: 1rem 1rem 2rem 1rem
   min-width: 25rem
   box-shadow: .1em .1em .4em rgba(0,0,0,0.1)
@@ -19,7 +19,7 @@
     min-height: calc(2 * 0.65em + 0.9em + 1px)
     border-radius: 2px 0 0 2px
     padding: 0.65em
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     white-space: pre
     resize: none
     font-size: 0.9rem
@@ -27,7 +27,7 @@
 
   .copy-button
     margin: 0
-    border: 1px solid var(--color-border-default)
+    border: 1px solid var(--borderColor-default)
     border-radius: 0 2px 2px 0
     vertical-align: top
     left: -1px
@@ -47,7 +47,7 @@
     position: absolute
     right: 0
     top: calc(2 * 0.65em + 0.9em + 1px + 9px)
-    box-shadow: 1px 1px 4px var(--color-fg-muted)
+    box-shadow: 1px 1px 4px var(--fgColor-muted)
     z-index: 1
 
     &:before

--- a/modules/github_integration/frontend/module/pull-request/pr-check.component.sass
+++ b/modules/github_integration/frontend/module/pull-request/pr-check.component.sass
@@ -4,7 +4,7 @@
   grid-template-columns: 28px 33px 1fr auto
   grid-template-areas: "check-state-icon check-avatar check-info check-details"
   list-style-type: none
-  border: 1px solid var(--color-border-muted)
+  border: 1px solid var(--borderColor-muted)
   padding: 0.3rem 1rem
   background: rgba(0, 0, 0, 0.05)
   font-size: 0.9rem
@@ -29,7 +29,7 @@
     grid-area: check-info
 
   &--state
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
     font-style: italic
     margin-left: 1em
 

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.sass
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.sass
@@ -52,7 +52,7 @@
   &--info
     display: inline-flex
     grid-area: info
-    color: var(--color-fg-muted)
+    color: var(--fgColor-muted)
 
   &--avatar,
   &--date


### PR DESCRIPTION
* Bump primer_view_components to 0.29.0
* Bump primer/css to 21.2.2
* Replace deprecated Primer variables with their new names from primer/primitives v8 


Includes the fix for https://community.openproject.org/projects/openproject/work_packages/54357/activity