### PR TITLE
Enable project index page to work with v3 filter style

### DIFF
--- a/app/controllers/queries/params_parser/api_v3_filters_parser.rb
+++ b/app/controllers/queries/params_parser/api_v3_filters_parser.rb
@@ -27,37 +27,20 @@
 # ++
 module Queries
   class ParamsParser
-    class << self
-      def parse(params)
-        query_params = {}
+    class APIV3FiltersParser
+      class << self
+        def parse(filters_string)
+          filters = JSON.parse(filters_string)
 
-        query_params[:filters] = parse_filters_from_params(params) if params[:filters].present?
-        query_params[:orders] = parse_orders_from_params(params) if params[:sortBy].present?
-        query_params[:selects] = parse_columns_from_params(params) if params[:columns].present?
-
-        query_params
-      end
-
-      private
-
-      def parse_filters_from_params(params)
-        if params[:filters].present? && params[:filters].start_with?("[")
-          ::Queries::ParamsParser::APIV3FiltersParser.parse(params[:filters])
-        else
-          FiltersParser.new(params[:filters]).parse
+          filters.map do |filter|
+            attribute = filter.keys.first # there should only be one attribute per filter
+            {
+              attribute:,
+              operator: filter[attribute]["operator"],
+              values: filter[attribute]["values"]
+            }
+          end
         end
-      end
-
-      def parse_orders_from_params(params)
-        JSON.parse(params[:sortBy])
-            .to_h
-            .map { |k, v| { attribute: k, direction: v } }
-      rescue JSON::ParserError
-        [{ attribute: "invalid", direction: "asc" }]
-      end
-
-      def parse_columns_from_params(params)
-        params[:columns].split
       end
     end
   end

--- a/app/controllers/queries/params_parser/filters_parser.rb
+++ b/app/controllers/queries/params_parser/filters_parser.rb
@@ -1,0 +1,117 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+module Queries
+  class ParamsParser
+    class FiltersParser
+      def initialize(string)
+        @buffer = StringScanner.new(string)
+      end
+
+      def parse
+        filters = []
+
+        while !@buffer.eos?
+          filters << parse_filter
+        end
+
+        filters
+      end
+
+      private
+
+      def parse_filter
+        consume_ampersand
+
+        {
+          attribute: parse_name,
+          operator: parse_operator,
+          values: parse_values
+        }
+      end
+
+      def consume_ampersand
+        case @buffer.peek(1)
+        when "&", /\s/
+          @buffer.getch
+          consume_ampersand
+        end
+      end
+
+      def parse_name
+        @buffer.scan_until(/\s|\z/).strip
+      end
+
+      def parse_operator
+        @buffer.scan_until(/\s|\z/).strip
+      end
+
+      def parse_values
+        case @buffer.peek(1)
+        when '"'
+          parse_doublequoted_value
+        when "'"
+          parse_singlequoted_value
+        when "["
+          parse_array_value
+        when "&"
+          []
+        else
+          parse_unguarded_value
+        end
+      end
+
+      def parse_doublequoted_value
+        @buffer.getch
+        [@buffer.scan_until(/(?<!\\)"|\z/).delete_suffix('"').delete("\\")]
+      end
+
+      def parse_singlequoted_value
+        @buffer.getch
+        [@buffer.scan_until(/(?<!\\)'|\z/).delete_suffix("'").delete("\\")]
+      end
+
+      def parse_unguarded_value
+        value = @buffer
+                  .scan_until(/&|\z/)
+                  .delete_suffix("&")
+
+        [value]
+      end
+
+      def parse_array_value
+        @buffer
+          .scan_until(/]|\z/)
+          .delete_suffix("]")
+          .delete_prefix("[")
+          .scan(/(?:'([^']*)')|(?:"([^"]*)")/)
+          .flatten
+          .compact
+      end
+    end
+  end
+end

--- a/app/services/params_to_query_service.rb
+++ b/app/services/params_to_query_service.rb
@@ -54,10 +54,10 @@ class ParamsToQueryService
 
     filters = parse_filters_from_json(params[:filters])
 
-    filters[:attributes].each do |filter_name|
-      query = query.where(filter_name,
-                          filters[:operators][filter_name],
-                          filters[:values][filter_name])
+    filters.each do |filter|
+      query = query.where(filter[:attribute],
+                          filter[:operator],
+                          filter[:values])
     end
 
     query
@@ -94,21 +94,11 @@ class ParamsToQueryService
   #   { /* more filters if needed */}
   # ]
   def parse_filters_from_json(json)
-    filters = JSON.parse(json)
-    operators = {}
-    values = {}
-    filters.each do |filter|
-      attribute = filter.keys.first # there should only be one attribute per filter
-      ar_attribute = convert_attribute attribute, append_id: true
-      operators[ar_attribute] = filter[attribute]["operator"]
-      values[ar_attribute] = filter[attribute]["values"]
-    end
+    filters = Queries::ParamsParser::APIV3FiltersParser.parse(json)
 
-    {
-      attributes: values.keys,
-      operators:,
-      values:
-    }
+    filters.each do |filter|
+      filter[:attribute] = convert_attribute(filter[:attribute], append_id: true)
+    end
   end
 
   def parse_sorting_from_json(json)

--- a/spec/controllers/queries/params_parser_spec.rb
+++ b/spec/controllers/queries/params_parser_spec.rb
@@ -218,6 +218,24 @@ RSpec.describe Queries::ParamsParser, type: :model do
       end
     end
 
+    context "with an old (APIv3) style filter" do
+      let(:params) do
+        {
+
+          filters: JSON.dump([{ active: { operator: "=", values: ["f"] } },
+                              { cf_32: { operator: "=", values: ["63"] } }, # rubocop:disable Naming/VariableNumber
+                              { cf_34: { operator: "=", values: ["2006"] } }]) # rubocop:disable Naming/VariableNumber
+        }
+      end
+
+      it "returns the parsed filter" do
+        expect(subject[:filters])
+          .to contain_exactly({ attribute: "active", operator: "=", values: %w[f] },
+                              { attribute: "cf_32", operator: "=", values: %w[63] },
+                              { attribute: "cf_34", operator: "=", values: %w[2006] })
+      end
+    end
+
     context "with sortBy with a single value" do
       let(:params) do
         {

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -1176,4 +1176,30 @@ RSpec.describe "Projects index page",
       end
     end
   end
+
+  describe "calling the page with the API v3 style parameters",
+           with_settings: { enabled_projects_columns: %w[name created_at project_status] } do
+    let(:filters) do
+      JSON.dump([{ active: { operator: "=", values: ["t"] } },
+                 { name_and_identifier: { operator: "~", values: ["Plain"] } }])
+    end
+
+    current_user { admin }
+
+    it "applies the filters and displays the matching projects" do
+      visit "#{projects_page.path}?filters=#{filters}"
+
+      # Filters have the effect of filtering out projects
+      projects_page.expect_projects_listed(project)
+      projects_page.expect_projects_not_listed(public_project)
+
+      # Applies the filters to the filters section
+      projects_page.toggle_filters_section
+      projects_page.expect_filter_set "active"
+      projects_page.expect_filter_set "name_and_identifier"
+
+      # Columns are taken from the default set as defined by the setting
+      projects_page.expect_columns("Name", "Created on", "Status")
+    end
+  end
 end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -258,9 +258,13 @@ module Pages
 
       def open_filters
         retry_block do
-          page.find('[data-test-selector="filter-component-toggle"]').click
+          toggle_filters_section
           page.find_field("Add filter", visible: true)
         end
+      end
+
+      def toggle_filters_section
+        page.find('[data-test-selector="filter-component-toggle"]').click
       end
 
       def set_columns(*columns)


### PR DESCRIPTION
The project index page now also supports the v3 style of specifying the filters. This is done so that bookmarks still work.

The PR looks bigger than it is. The bulk of the changed lines are caused just moving the `FilterParser` to its own file without any changes. 

----

https://community.openproject.org/wp/54350