### PR TITLE
[#53704] BUG Visible=false project attribute values are deleted when a non-admin user edits the attributes (2/2)

### DIFF
--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -73,9 +73,7 @@ class CustomValue < ApplicationRecord
 
     # if a custom value is created for a project via CustomValue.create(...),
     # the custom field needs to be activated in the project
-    if customized&.available_custom_fields&.include?(custom_field) &&
-      customized&.project_custom_fields&.exclude?(custom_field)
-
+    if customized&.project_custom_fields&.exclude?(custom_field)
       customized.project_custom_fields << custom_field
     end
   end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -73,7 +73,9 @@ class CustomValue < ApplicationRecord
 
     # if a custom value is created for a project via CustomValue.create(...),
     # the custom field needs to be activated in the project
-    unless customized&.project_custom_fields&.include?(custom_field)
+    if customized&.available_custom_fields&.include?(custom_field) &&
+      customized&.project_custom_fields&.exclude?(custom_field)
+
       customized.project_custom_fields << custom_field
     end
   end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -73,7 +73,7 @@ class CustomValue < ApplicationRecord
 
     # if a custom value is created for a project via CustomValue.create(...),
     # the custom field needs to be activated in the project
-    if customized&.project_custom_fields&.exclude?(custom_field)
+    unless customized&.project_custom_fields&.include?(custom_field)
       customized.project_custom_fields << custom_field
     end
   end

--- a/app/models/projects/acts_as_customizable_patches.rb
+++ b/app/models/projects/acts_as_customizable_patches.rb
@@ -49,8 +49,8 @@ module Projects::ActsAsCustomizablePatches
     before_create :reject_section_scoped_validation_for_creation
     before_create :build_missing_project_custom_field_project_mappings
 
+    after_create :disable_custom_fields_with_empty_values
     after_save :reset_section_scoped_validation, :set_query_available_custom_fields_to_project_level
-    before_commit :disable_custom_fields_with_empty_values, on: :create
 
     def build_missing_project_custom_field_project_mappings
       # activate custom fields for this project (via mapping table) if values have been provided for custom_fields but no mapping exists

--- a/app/models/projects/acts_as_customizable_patches.rb
+++ b/app/models/projects/acts_as_customizable_patches.rb
@@ -49,8 +49,8 @@ module Projects::ActsAsCustomizablePatches
     before_create :reject_section_scoped_validation_for_creation
     before_create :build_missing_project_custom_field_project_mappings
 
-    after_create :disable_custom_fields_with_empty_values
     after_save :reset_section_scoped_validation, :set_query_available_custom_fields_to_project_level
+    after_save :disable_custom_fields_with_empty_values, if: :previously_new_record?
 
     def build_missing_project_custom_field_project_mappings
       # activate custom fields for this project (via mapping table) if values have been provided for custom_fields but no mapping exists
@@ -98,6 +98,11 @@ module Projects::ActsAsCustomizablePatches
       # this hook is required as acts_as_customizable build custom values with their default value even if a blank value was provided in the project creation form
       # `build_missing_project_custom_field_project_mappings` will then activate the custom field although the user explicitly provided a blank value
       # in order to not patch `acts_as_customizable` further, we simply identify these custom values and deactivate the custom field
+
+      # This callback should be an after_save callback, because the custom_values association has autosave
+      # and it has after_create callbacks in the model (CustomValue#activate_custom_field_in_customized_project).
+      # The after_create callback in the children objects are ran after the after_create callbacks on the parent.
+      # In order to make sure we execute this callback after the children's callbacks, the after_save hook must be used.
       custom_field_ids = project.custom_values.select { |cv| cv.value.blank? && !cv.required? }.pluck(:custom_field_id)
 
       project_custom_field_project_mappings

--- a/app/models/projects/acts_as_customizable_patches.rb
+++ b/app/models/projects/acts_as_customizable_patches.rb
@@ -49,8 +49,8 @@ module Projects::ActsAsCustomizablePatches
     before_create :reject_section_scoped_validation_for_creation
     before_create :build_missing_project_custom_field_project_mappings
 
-    after_create :disable_custom_fields_with_empty_values
     after_save :reset_section_scoped_validation, :set_query_available_custom_fields_to_project_level
+    before_commit :disable_custom_fields_with_empty_values, on: :create
 
     def build_missing_project_custom_field_project_mappings
       # activate custom fields for this project (via mapping table) if values have been provided for custom_fields but no mapping exists
@@ -100,7 +100,11 @@ module Projects::ActsAsCustomizablePatches
       # in order to not patch `acts_as_customizable` further, we simply identify these custom values and deactivate the custom field
       custom_field_ids = project.custom_values.select { |cv| cv.value.blank? && !cv.required? }.pluck(:custom_field_id)
 
-      project_custom_field_project_mappings.where(custom_field_id: custom_field_ids).destroy_all
+      project_custom_field_project_mappings
+        .where(custom_field_id: custom_field_ids)
+        .or(project_custom_field_project_mappings
+          .where.not(custom_field_id: available_custom_fields.select(:id)))
+        .destroy_all
     end
 
     def with_all_available_custom_fields

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -462,24 +462,9 @@ RSpec.describe Project, "customizable" do
       let(:user) { create(:user) }
 
       it "does not activate hidden custom fields" do
-        pending <<~REASON.squish
-          Due to backward compatibility for the API,
-          we have to activate the hidden_custom_field too,
-          but it won't receive any value, so its value is not changed.
-          The frontend will not send the hidden field anyway,
-          so this behaviour does not present a real problem.
-        REASON
         # project creation happens with an non-admin user as let(:project) called after setting the current user to an non-admin
         expect(project.project_custom_field_project_mappings.pluck(:custom_field_id))
           .to contain_exactly(text_custom_field.id, bool_custom_field.id)
-
-        expect(project.custom_value_for(hidden_custom_field)).to be_nil
-      end
-
-      it "does not set a value for the hidden custom fields" do
-        # project creation happens with an non-admin user as let(:project) called after setting the current user to an non-admin
-        expect(project.project_custom_field_project_mappings.pluck(:custom_field_id))
-          .to contain_exactly(text_custom_field.id, bool_custom_field.id, hidden_custom_field.id)
 
         expect(project.custom_value_for(hidden_custom_field)).to be_nil
       end


### PR DESCRIPTION
Part 2 of the https://community.openproject.org/wp/53704

Fixing the pending spec: https://github.com/opf/openproject/pull/15296/files#diff-fe00deb197cdde8955e039ce8b85ba36c57733622ad8753f4553379d57cc0e86R465-R471

### Description

The callback `Projects::ActsAsCustomizablePatches#disable_custom_fields_with_empty_values` should be an after_save callback, because the `custom_values` association has autosave enabled by default and it has an after_create callback in the model (CustomValue#activate_custom_field_in_customized_project).

The after_create callback in the children objects are ran after the after_create callbacks on the parent. In order to make sure we execute this callback after the children's callbacks, the after_save hook must be used.