### PR TITLE
[54370] Prevent error when saving unset progress modal

### DIFF
--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -133,6 +133,6 @@ class WorkPackages::ProgressController < ApplicationController
   end
 
   def formatted_duration(hours)
-    API::V3::Utilities::DateTimeFormatter.format_duration_from_hours(hours)
+    API::V3::Utilities::DateTimeFormatter.format_duration_from_hours(hours, allow_nil: true)
   end
 end

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
   shared_let(:type_task) { create(:type_task) }
   shared_let(:project) { create(:project, types: [type_task]) }
+  shared_let(:priority) { create(:default_priority, name: "Normal") }
   shared_let(:open_status_with_0p_done_ratio) do
     create(:status, name: "open", default_done_ratio: 0)
   end
@@ -294,6 +295,19 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
           work_field.activate!
           modal_status_field.expect_modal_field_value("in progress (50%)", disabled: true)
+        end
+
+        it "can open the modal, then save without modifying anything" do
+          work_package_create_page.visit!
+          work_package_create_page.set_attributes({ subject: "hello" })
+
+          work_field = work_package_create_page.edit_field(:estimatedTime)
+          work_field.activate!
+          work_field.submit_by_clicking_save
+          work_package_create_page.expect_no_toaster(type: "error")
+
+          work_package_create_page.save!
+          work_package_table.expect_and_dismiss_toaster(message: "Successful creation.")
         end
       end
     end

--- a/spec/support/edit_fields/progress_edit_field.rb
+++ b/spec/support/edit_fields/progress_edit_field.rb
@@ -93,6 +93,12 @@ class ProgressEditField < EditField
     input_element.native.send_keys :return
   end
 
+  def submit_by_clicking_save
+    within modal_element do
+      click_on("Save")
+    end
+  end
+
   def close!
     page.find("[data-test-selector='op-progress-modal--close-icon']").click
   end


### PR DESCRIPTION
See https://community.openproject.org/wp/54370

A 500 is produced when being on a work package creation form, opening the progress modal, and clicking save without setting any values.