### PR TITLE
Fix flaky add widget specs

### DIFF
--- a/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
@@ -16,14 +16,16 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 export class GridAddWidgetService {
   text = { add: this.i18n.t('js.grid.add_widget') };
 
-  constructor(readonly opModalService:OpModalService,
+  constructor(
+    readonly opModalService:OpModalService,
     readonly injector:Injector,
     readonly halResource:HalResourceService,
     readonly layout:GridAreaService,
     readonly drag:GridDragAndDropService,
     readonly move:GridMoveService,
     readonly resize:GridResizeService,
-    readonly i18n:I18nService) {
+    readonly i18n:I18nService
+  ) {
   }
 
   public isAddable(area:GridArea) {
@@ -120,6 +122,6 @@ export class GridAddWidgetService {
   }
 
   public get isAllowed() {
-    return this.layout.gridResource && this.layout.gridResource.updateImmediately;
+    return this.layout.gridResource && this.layout.gridResource.updateImmediately && this.layout.schema;
   }
 }

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
            due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday))
   end
   shared_let(:meeting) do
-    create(:structured_meeting, title: "Weekly", project:, start_time: Time.zone.today + 10.hours)
+    create(:structured_meeting, title: "Weekly", project:, start_time: Time.zone.tomorrow + 10.hours)
   end
 
   let(:overview_page) do

--- a/modules/grids/spec/support/pages/grid.rb
+++ b/modules/grids/spec/support/pages/grid.rb
@@ -83,15 +83,19 @@ module Pages
       area = area_of(row_number, column_number, location)
       area.hover
 
-      add_widget_button = if using_cuprite?
-                            area.find(".grid--widget-add")
-                          else
-                            area.find(".grid--widget-add", visible: :all)
-                          end
+      enable_add_widget_mode_for(area)
 
+      add_widget_button = area.find(".grid--widget-add")
       add_widget_button.click
 
       within(".spot-modal", &)
+    end
+
+    def enable_add_widget_mode_for(area)
+      within('.toolbar-items') do
+        button = find_button "Add widget"
+        button.click if button[:class].exclude? "-active"
+      end
     end
 
     def expect_widget_adding_prohibited_generally(row_number = 1, column_number = 1)


### PR DESCRIPTION
The fix consists of 2 parts:

1. The "Add widget" button on the overview page is not being displayed unless the available widgets are loaded from the api.
  In certain cases, when the test was running "too fast" and opened the "Add widgets" dialog before loading the the available widgets. In these cases the test failed due to the dialog being empty.
<details><summary>Screenshot</summary>
<p>

![image](https://github.com/opf/openproject/assets/83396/66430a88-c9ec-4fc9-ae3e-55b0af765fdd)


</p>
</details> 

2. The modules/calendar/spec/features/calendar_widget_spec.rb could fail due to the meeting start date being in the past. Having the `Time.zone.today + 10.hours` is not bulletproof, because when 10 hours past from the current day, the meeting becomes a past meeting, not showing up on the calendar widget anymore. Hence adjusted the start date for tomorrow. [Link to the failing spec.](https://github.com/opf/openproject/actions/runs/8786308355/job/24108885293)
<details><summary>Failing spec details</summary>
<p>

```shell
  1) Calendar Widget shows the meeting
     Failure/Error: example.run
       expected to find css ".fc-event" with text "Weekly" but there were no matches. Also found "WorkPackage No. 45", which matched the selector but not all filters. 
     # ./modules/calendar/spec/features/calendar_widget_spec.rb:69:in `block (2 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:199:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'

```

</p>
</details> 