### PR TITLE
poc for morphing with keeping inputs in progress popover

### DIFF
--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -173,6 +173,10 @@ class WorkPackages::ProgressForm < ApplicationForm
              action: "input->work-packages--progress--touched-field-marker#markFieldAsTouched" }
     if @focused_field == name
       data[:"work-packages--progress--focus-field-target"] = "fieldToFocus"
+      # Prevent changes being morphed into the input that is currently focused.
+      # After this initial rendering, the preview-progress.controller takes over in maintaining
+      # the attribute on the input currently focused.
+      data["turbo-permanent"] = true
     end
     { data: }
   end


### PR DESCRIPTION
Fiddles around with keeping the DOM of the currently focused input unchanged when morphing which allows reducing the debounce time without user input being eaten up.

![recording](https://github.com/opf/openproject/assets/617519/9a047add-99b1-408b-bcf5-82fdd4e5e6dd)
