### PR TITLE
Fix lookup when assets proxied and manifest present

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -58,8 +58,13 @@ module FrontendAssetHelper
 
   private
 
-  def frontend_asset_path(unhashed_file_name)
-    "/assets/frontend/#{::OpenProject::Assets.lookup_asset(unhashed_file_name)}"
+  def lookup_frontend_asset(unhashed_file_name)
+    hashed_file_name = ::OpenProject::Assets.lookup_asset(unhashed_file_name)
+    frontend_asset_path(hashed_file_name)
+  end
+
+  def frontend_asset_path(file_name)
+    "/assets/frontend/#{file_name}"
   end
 
   def variable_asset_path(path)
@@ -72,7 +77,7 @@ module FrontendAssetHelper
     else
       # we do not need to take care about Rails.application.config.relative_url_root
       # because in this case javascript|stylesheet_include_tag will add it automatically.
-      frontend_asset_path(path)
+      lookup_frontend_asset(path)
     end
   end
 end


### PR DESCRIPTION
When proxying assets, we should never look into the asset manifest. It might provide wrong values and then it will endlessly redirect back between rails and webpack dev server.

To reproduce:


1. Put this file [frontend_assets.manifest.json](https://github.com/opf/openproject/files/15107216/frontend_assets.manifest.json) in config/ or simply run `bundle exec rake assets:precomple`
3. Try to start the usual dev server with proxied assets
4. Observe the network tab, you'll see redirects

FYI @Eric-Guo 