### PR TITLE
fix: Openproject / Open Project -> OpenProject

### DIFF
--- a/config/locales/crowdin/af.yml
+++ b/config/locales/crowdin/af.yml
@@ -3573,7 +3573,7 @@ af:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ar.yml
+++ b/config/locales/crowdin/ar.yml
@@ -2649,7 +2649,7 @@ ar:
       a: "Upgrade your payment plan ([here](upgrade_url))" #here turned into a link
       b: "Lock or delete an existing user ([here](users_url))" #here turned into a link
   more_actions: "المزيد من الوظائف"
-  noscript_description: "تحتاج إلى تفعيل جافا سكريبت لاستخدام open project!"
+  noscript_description: "تحتاج إلى تفعيل جافا سكريبت لاستخدام OpenProject!"
   noscript_heading: "جافا سكريبت"
   noscript_learn_more: "التعرف على المزيد"
   notice_accessibility_mode: من الممكن تمكين وضع إمكانية الوصول في [إعدادات الحساب](url).
@@ -2915,7 +2915,7 @@ ar:
     destroy:
       confirmation: "إذا قمت بالمتابعة، هذا إلى حذف المستودع المدارة بشكل دائم."
       info: "حذف حساب المستخدم إجراء لا يمكن التراجع عنه."
-      info_not_managed: "ملاحظة: هذا ليس حذف محتويات هذا المستودع، كما أنه لا يقوم بإدارة open project."
+      info_not_managed: "ملاحظة: هذا ليس حذف محتويات هذا المستودع، كما أنه لا يقوم بإدارة OpenProject."
       managed_path_note: "سيتم مسح الدليل التالي: %{path}"
       repository_verification: "أدخل %{identifier} المعرف للمشروع للتحقق من الحذف في المستودع."
       subtitle: "هل تريد حقاً حذف %{repository_type} %{project_name} المشروع؟"
@@ -2929,7 +2929,7 @@ ar:
       empty_repository: "المستودع موجود، ولكن فارغ. أنه لا يتضمن أي تنقيحات بعد."
       exists_on_filesystem: "الدليل مستودع موجود بالفعل في نظام الملفات."
       filesystem_access_failed: "حدث خطأ أثناء الوصول إلى المستودع في نظام الملفات: %{message}"
-      not_manageable: "لا يمكن إدارة هذا المورد المستودع قبل open project."
+      not_manageable: "لا يمكن إدارة هذا المورد المستودع قبل OpenProject."
       path_permission_failed: "حدث خطأ أثناء محاولة إنشاء المسار التالي: %{path}. الرجاء التأكد من أن openprojectقد كتب إلى هذا المجلد."
       unauthorized: "لن يسمح لك الوصول إلى المستودع أو بيانات الاعتماد غير صحيحة."
       unavailable: "المستودع غير متوفر."
@@ -2947,9 +2947,9 @@ ar:
         path_encoding: "تجاوز ترميز المسار بوابة (الافتراضي: UTF-8)"
       local_title: "ربط مستودع بوابة المحلية الموجودة"
       local_url: "رابط محلِّي"
-      local_introduction: "إذا كان لديك مستودع بوابة محلية, يمكنك ربطه مع open project للوصول إليها من داخل التطبيق."
-      managed_introduction: "واسمحوا open project إنشاء ودمج مستودع بوابة محلية تلقائياً."
-      managed_title: "بوابة مستودع متكاملة في open project"
+      local_introduction: "إذا كان لديك مستودع بوابة محلية, يمكنك ربطه مع OpenProject للوصول إليها من داخل التطبيق."
+      managed_introduction: "واسمحوا OpenProject إنشاء ودمج مستودع بوابة محلية تلقائياً."
+      managed_title: "بوابة مستودع متكاملة في OpenProject"
       managed_url: "محدد موقع المعلومات المدارة"
       path: "المسار إلى بوابة المستودع"
       path_encoding: "ترميز المسار"
@@ -2977,13 +2977,13 @@ ar:
       show_warning_details: "To use this file storage remember to activate the module and the specific storage in the project settings of each desired project."
     subversion:
       existing_title: "مستودع التخريب موجود"
-      existing_introduction: "إذا كان لديك مستودع بوابة محلية القائمة، يمكنك ربطه مع open project للوصول إليها من داخل التطبيق."
+      existing_introduction: "إذا كان لديك مستودع بوابة محلية القائمة، يمكنك ربطه مع OpenProject للوصول إليها من داخل التطبيق."
       existing_url: "رابط موجود مُسبقا"
       instructions:
         managed_url: "هذا هو عنوان url الخاص بالمستودع بوابة المدارة (المحلية)."
         url: "أدخل عنوان URL المستودع. وهذا قد تستهدف أما مستودع محلية (بدءاً من %{local_proto})، أو مستودع بعيد. يتم اعتماد أنظمة عناوين URL التالية:"
-      managed_title: "بوابة مستودع متكاملة في open project"
-      managed_introduction: "واسمحوا open project إنشاء ودمج مستودع بوابة محلية تلقائياً."
+      managed_title: "بوابة مستودع متكاملة في OpenProject"
+      managed_introduction: "واسمحوا OpenProject إنشاء ودمج مستودع بوابة محلية تلقائياً."
       managed_url: "محدد موقع المعلومات المدارة"
       password: "كلمة سر مستودع"
       username: "اسم مستخدم المستودع"
@@ -3216,7 +3216,7 @@ ar:
       sentence_connector: "و"
       skip_last_comma: "خاطئ"
   text_accessibility_hint: "The accessibility mode is designed for users who are blind, motorically handicaped or have a bad eyesight. For the latter focused elements are specially highlighted. Please notice, that the Backlogs module is not available in this mode."
-  text_access_token_hint: "رموز الوصول المميزة تسمح لك لمنح الوصول إلى تطبيقات خارجية للموارد في open project."
+  text_access_token_hint: "رموز الوصول المميزة تسمح لك لمنح الوصول إلى تطبيقات خارجية للموارد في OpenProject."
   text_analyze: "تحليل أبعد: %{subject}"
   text_are_you_sure: "هل أنت متأكد؟"
   text_are_you_sure_continue: "Are you sure you want to continue?"
@@ -3719,7 +3719,7 @@ ar:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/az.yml
+++ b/config/locales/crowdin/az.yml
@@ -3573,7 +3573,7 @@ az:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/be.yml
+++ b/config/locales/crowdin/be.yml
@@ -3647,7 +3647,7 @@ be:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/bg.yml
+++ b/config/locales/crowdin/bg.yml
@@ -3573,7 +3573,7 @@ bg:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ca.yml
+++ b/config/locales/crowdin/ca.yml
@@ -3562,7 +3562,7 @@ ca:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ckb-IR.yml
+++ b/config/locales/crowdin/ckb-IR.yml
@@ -3573,7 +3573,7 @@ ckb-IR:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/cs.yml
+++ b/config/locales/crowdin/cs.yml
@@ -3645,7 +3645,7 @@ cs:
   link: odkaz
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth pluginy"
-    description: "Integrace poskytovatelů strategie OmniAuth pro ověřování v Openproject."
+    description: "Integrace poskytovatelů strategie OmniAuth pro ověřování v OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Přidá poskytovatele SAML OmniAuth do OpenProject"

--- a/config/locales/crowdin/da.yml
+++ b/config/locales/crowdin/da.yml
@@ -3569,7 +3569,7 @@ da:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -3567,7 +3567,7 @@ de:
   link: Link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration von externen Authentifizierungsanbietern in Openproject."
+    description: "Integration von externen Authentifizierungsanbietern in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign An"
     description: "Fügt den OmniAuth SAML-Anbieter zu OpenProject hinzu"

--- a/config/locales/crowdin/el.yml
+++ b/config/locales/crowdin/el.yml
@@ -3567,7 +3567,7 @@ el:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/eo.yml
+++ b/config/locales/crowdin/eo.yml
@@ -3573,7 +3573,7 @@ eo:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/es.yml
+++ b/config/locales/crowdin/es.yml
@@ -3568,7 +3568,7 @@ es:
   link: enlace
   plugin_openproject_auth_plugins:
     name: "Plugins Auth de OpenProject"
-    description: "Integración de los proveedores de estrategia de OmniAuth para la autentificación en Openproject."
+    description: "Integración de los proveedores de estrategia de OmniAuth para la autentificación en OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Inicio de sesión único"
     description: "Añade el proveedor OmniAuth SAML a OpenProject"

--- a/config/locales/crowdin/et.yml
+++ b/config/locales/crowdin/et.yml
@@ -3573,7 +3573,7 @@ et:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/eu.yml
+++ b/config/locales/crowdin/eu.yml
@@ -3573,7 +3573,7 @@ eu:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/fa.yml
+++ b/config/locales/crowdin/fa.yml
@@ -3573,7 +3573,7 @@ fa:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/fi.yml
+++ b/config/locales/crowdin/fi.yml
@@ -3573,7 +3573,7 @@ fi:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/fil.yml
+++ b/config/locales/crowdin/fil.yml
@@ -3571,7 +3571,7 @@ fil:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/fr.yml
+++ b/config/locales/crowdin/fr.yml
@@ -3572,7 +3572,7 @@ fr:
   link: lien
   plugin_openproject_auth_plugins:
     name: "Plugins d'authentification OpenProject"
-    description: "Intégration des fournisseurs de stratégie OmniAuth pour l'authentification dans Openproject."
+    description: "Intégration des fournisseurs de stratégie OmniAuth pour l'authentification dans OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / authentification unique"
     description: "Ajoute le fournisseur SAML OmniAuth à OpenProject"

--- a/config/locales/crowdin/he.yml
+++ b/config/locales/crowdin/he.yml
@@ -3647,7 +3647,7 @@ he:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/hi.yml
+++ b/config/locales/crowdin/hi.yml
@@ -3571,7 +3571,7 @@ hi:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/hr.yml
+++ b/config/locales/crowdin/hr.yml
@@ -3610,7 +3610,7 @@ hr:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/hu.yml
+++ b/config/locales/crowdin/hu.yml
@@ -1525,7 +1525,7 @@ hu:
   error_token_authenticity: "Nem sikerült ellenőrizni a Cross-Site Request Forgery token-t. Megpróbált adatokat küldeni több böngészőn vagy lapon keresztül? Kérjük, zárja be az összes lapot, és próbálkozzon újra."
   error_work_package_not_found_in_project: "A feladatcsoport nem található, vagy nem tartozik ehhez a projekthez"
   error_must_be_project_member: "projekt tagnak kell lennie"
-  error_migrations_are_pending: "Az Openproject adatbázisainak költöztetése függőben van. Valószínűleg elmulasztotta lefuttatni az átvitelt a legutóbbi frissítéskor. Kérjük, a megfelelő frissítéshez kövesse a frissítési útmutatót."
+  error_migrations_are_pending: "Az OpenProject adatbázisainak költöztetése függőben van. Valószínűleg elmulasztotta lefuttatni az átvitelt a legutóbbi frissítéskor. Kérjük, a megfelelő frissítéshez kövesse a frissítési útmutatót."
   error_migrations_visit_upgrade_guides: "Kérjük, látogassa meg frissítési útmutatónkat"
   error_no_default_work_package_status: 'Nincs alapértelmezett feladatcsoport állapot meghatározva. Kérjük, ellenőrizze a konfigurációt ("Adminisztráció - feladatcsoport állapotok").'
   error_no_type_in_project: "Nincs típus hozzárendelve ehhez a projekthez. Kérjük, ellenőrizze a projekt beállításait."
@@ -3569,7 +3569,7 @@ hu:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/id.yml
+++ b/config/locales/crowdin/id.yml
@@ -3525,7 +3525,7 @@ id:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/it.yml
+++ b/config/locales/crowdin/it.yml
@@ -3570,7 +3570,7 @@ it:
   link: link
   plugin_openproject_auth_plugins:
     name: "Plugin Autenticazione OpenProject"
-    description: "Integrazione dei fornitori di strategie OmniAuth per l'autenticazione in Openproject."
+    description: "Integrazione dei fornitori di strategie OmniAuth per l'autenticazione in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Aggiunge il provider OmniAuth SAML a OpenProject"

--- a/config/locales/crowdin/ja.yml
+++ b/config/locales/crowdin/ja.yml
@@ -3531,7 +3531,7 @@ ja:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ka.yml
+++ b/config/locales/crowdin/ka.yml
@@ -3573,7 +3573,7 @@ ka:
   link: ბმული
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/kk.yml
+++ b/config/locales/crowdin/kk.yml
@@ -3573,7 +3573,7 @@ kk:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/lt.yml
+++ b/config/locales/crowdin/lt.yml
@@ -3639,7 +3639,7 @@ lt:
   link: nuoroda
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Priedai"
-    description: "Openproject autentifikacijos OmniAuth strategijos teikėjų integracija."
+    description: "OpenProject autentifikacijos OmniAuth strategijos teikėjų integracija."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Vienas prisijungimas"
     description: "Prideda OmniAuth SAML tiekėja į OpenProject"

--- a/config/locales/crowdin/lv.yml
+++ b/config/locales/crowdin/lv.yml
@@ -3610,7 +3610,7 @@ lv:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/mn.yml
+++ b/config/locales/crowdin/mn.yml
@@ -3573,7 +3573,7 @@ mn:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ms.yml
+++ b/config/locales/crowdin/ms.yml
@@ -3535,7 +3535,7 @@ ms:
   link: pautan
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ne.yml
+++ b/config/locales/crowdin/ne.yml
@@ -3573,7 +3573,7 @@ ne:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/nl.yml
+++ b/config/locales/crowdin/nl.yml
@@ -3568,7 +3568,7 @@ nl:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/no.yml
+++ b/config/locales/crowdin/no.yml
@@ -3573,7 +3573,7 @@
   link: kobling
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth utvidelse"
-    description: "Integrering av OmniAuth strategileverandører for autentisering i Openproject."
+    description: "Integrering av OmniAuth strategileverandører for autentisering i OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Enkeltpålogging på"
     description: "Legger til OmniAuth SAML leverandør til OpenProject"

--- a/config/locales/crowdin/pl.yml
+++ b/config/locales/crowdin/pl.yml
@@ -3641,7 +3641,7 @@ pl:
   link: link
   plugin_openproject_auth_plugins:
     name: "Wtyczki uwierzytelniające OpenProject"
-    description: "Integracja dostawców strategii OmniAuth w celu uwierzytelniania w Openproject."
+    description: "Integracja dostawców strategii OmniAuth w celu uwierzytelniania w OpenProject."
   plugin_openproject_auth_saml:
     name: "SAML OmniAuth / pojedyncze logowanie"
     description: "Dodaje dostawcę SAML OmniAuth do OpenProject"

--- a/config/locales/crowdin/pt-BR.yml
+++ b/config/locales/crowdin/pt-BR.yml
@@ -3569,7 +3569,7 @@ pt-BR:
   link: link
   plugin_openproject_auth_plugins:
     name: "Plugins OpenProject Auth"
-    description: "Integração de fornecedores de estratégias OmniAuth para autenticação no Openproject."
+    description: "Integração de fornecedores de estratégias OmniAuth para autenticação no OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML/Início de sessão único"
     description: "Adiciona o fornecedor SAML OmniAuth ao OpenProject"

--- a/config/locales/crowdin/pt-PT.yml
+++ b/config/locales/crowdin/pt-PT.yml
@@ -1213,7 +1213,7 @@ pt-PT:
       heading_reset: "Redefinir token de cópia de segurança "
       heading_create: "Criar token de cópia de segurança "
       implications: >
-        Ativar as cópias de segurança permite que qualquer utilizador com as permissões necessárias e com este token de cópia de segurança transfira um backup com todos os dados desta instalação do Open Project. Isto inclui os dados de todos os outros utilizadores.
+        Ativar as cópias de segurança permite que qualquer utilizador com as permissões necessárias e com este token de cópia de segurança transfira um backup com todos os dados desta instalação do OpenProject. Isto inclui os dados de todos os outros utilizadores.
       info: >
         Tem de gerar um token de cópia de segurança para poder criar uma cópia de segurança . Cada vez que solicitar uma cópia de segurança , terá de fornecer este token. Pode eliminar o token de cópia de segurança para desativar cópias de segurança deste utilizador.
       verification: >
@@ -3568,7 +3568,7 @@ pt-PT:
   link: link
   plugin_openproject_auth_plugins:
     name: "Plugins de autenticação OpenProject"
-    description: "Integração de fornecedores de estratégias OmniAuth para autenticação no Openproject."
+    description: "Integração de fornecedores de estratégias OmniAuth para autenticação no OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML/Início de sessão único"
     description: "Adiciona o fornecedor SAML OmniAuth ao OpenProject"

--- a/config/locales/crowdin/ro.yml
+++ b/config/locales/crowdin/ro.yml
@@ -3609,7 +3609,7 @@ ro:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/ru.yml
+++ b/config/locales/crowdin/ru.yml
@@ -1687,7 +1687,7 @@ ru:
       impressum: "Правовое уведомление"
       glossary: "Глоссарий"
       shortcuts: "Ярлыки"
-      blog: "Openproject блог"
+      blog: "OpenProject блог"
       forums: "Форум сообщества"
       newsletter: "Оповещения системы безопасности / Новости"
   image_conversion:
@@ -3642,7 +3642,7 @@ ru:
   link: ссылка
   plugin_openproject_auth_plugins:
     name: "Плагины аутентификации OpenProject"
-    description: "Интеграция поставщиков стратегий OmniAuth для аутентификации в Openproject."
+    description: "Интеграция поставщиков стратегий OmniAuth для аутентификации в OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Однозначный вход"
     description: "Добавляет поставщика OmniAuth SAML в OpenProject"

--- a/config/locales/crowdin/rw.yml
+++ b/config/locales/crowdin/rw.yml
@@ -3573,7 +3573,7 @@ rw:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/si.yml
+++ b/config/locales/crowdin/si.yml
@@ -3573,7 +3573,7 @@ si:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/sk.yml
+++ b/config/locales/crowdin/sk.yml
@@ -3646,7 +3646,7 @@ sk:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/sl.yml
+++ b/config/locales/crowdin/sl.yml
@@ -3644,7 +3644,7 @@ sl:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/sr.yml
+++ b/config/locales/crowdin/sr.yml
@@ -3610,7 +3610,7 @@ sr:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/sv.yml
+++ b/config/locales/crowdin/sv.yml
@@ -3569,7 +3569,7 @@ sv:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/th.yml
+++ b/config/locales/crowdin/th.yml
@@ -3536,7 +3536,7 @@ th:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/tr.yml
+++ b/config/locales/crowdin/tr.yml
@@ -3568,7 +3568,7 @@ tr:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/uk.yml
+++ b/config/locales/crowdin/uk.yml
@@ -1683,7 +1683,7 @@ uk:
       impressum: "Юридична інформація"
       glossary: "Глосарій"
       shortcuts: "Ярлики"
-      blog: "Openproject блог"
+      blog: "OpenProject блог"
       forums: "Форум спільноти"
       newsletter: "Сигнали безпеки / Інформаційний бюлетень"
   image_conversion:

--- a/config/locales/crowdin/uz.yml
+++ b/config/locales/crowdin/uz.yml
@@ -3573,7 +3573,7 @@ uz:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/vi.yml
+++ b/config/locales/crowdin/vi.yml
@@ -3537,7 +3537,7 @@ vi:
   link: link
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/crowdin/zh-TW.yml
+++ b/config/locales/crowdin/zh-TW.yml
@@ -1588,7 +1588,7 @@ zh-TW:
       impressum: "Legal notice"
       glossary: "術語表 "
       shortcuts: "快捷鍵"
-      blog: "Openproject 部落格"
+      blog: "OpenProject 部落格"
       forums: "社群討論區"
       newsletter: "安全警報 / 消息"
   image_conversion:
@@ -3534,7 +3534,7 @@ zh-TW:
   link: 連結
   plugin_openproject_auth_plugins:
     name: "OpenProject 認證外掛"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3857,7 +3857,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
 
   plugin_openproject_auth_plugins:
     name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in Openproject."
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
   plugin_openproject_auth_saml:
     name: "OmniAuth SAML / Single-Sign On"
     description: "Adds the OmniAuth SAML provider to OpenProject"

--- a/docs/api/apiv3/components/schemas/project_storage_model.yml
+++ b/docs/api/apiv3/components/schemas/project_storage_model.yml
@@ -80,12 +80,12 @@ properties:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              A link to open project strorage.
+              A link to OpenProject strorage.
       openWithConnectionEnsured:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              A link to open project storage with making sure user has access to it.
+              A link to OpenProject storage with making sure user has access to it.
 
               # Conditions
 

--- a/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/README.md
+++ b/docs/enterprise-guide/enterprise-cloud-guide/enterprise-cloud-faq/README.md
@@ -31,7 +31,7 @@ The data center (AWS) we use for Enterprise cloud edition is ISO27001 certified.
 
 For more information please visit the [information regarding security measures](https://www.openproject.org/legal/data-processing-agreement/technical-and-organizational-data-security-measures) on our website.
 
-## How to change the Open Project Enterprise cloud creators account?
+## How to change the OpenProject Enterprise cloud creators account?
 
 Users (who are administrators) can change email addresses and accounts of other users, but not their own account. Single administrators can change their own account/email address by creating a second administrator account and using the new administrator to change data of the first administrator. The second administrator could be deactivated again afterwards by the first administrator. Normal users CAN change their own email address, just not their login.
 

--- a/docs/enterprise-guide/support/script/op-support-data.sh
+++ b/docs/enterprise-guide/support/script/op-support-data.sh
@@ -210,7 +210,7 @@ echo "---"
 
 #CHECK FOR INSTALLED OPENPROJECT
 
-echo "Checking for Open Project installed packages and version..."
+echo "Checking for OpenProject installed packages and version..."
 
 yum_fp=`which yum` 
 if [ -z $yum_fp ]; then yum_fp="dummynonexists"; fi
@@ -223,6 +223,6 @@ if [ -z $openproject_fp ]; then openproject_fp="dummynonexists"; fi
 if [ -f $openproject_fp ];
   then echo OpenProject is installed in Version...; $openproject_fp run bundle exec rake version
 else
-  echo "Open Project seems not to be installed."
+  echo "OpenProject seems not to be installed."
 fi
 

--- a/docs/release-notes/12/12-2-1/README.md
+++ b/docs/release-notes/12/12-2-1/README.md
@@ -59,7 +59,7 @@ For more information on this setting and how to configure it for your installati
 - Fixed: Error message on subprojects boards \[[#43755](https://community.openproject.org/wp/43755)\]
 - Fixed: New HTTPS flag is poorly documented and breaks quick start docker containers \[[#43759](https://community.openproject.org/wp/43759)\]
 - Fixed: Wrong days highlighted as weekend in Gantt diagram \[[#43762](https://community.openproject.org/wp/43762)\]
-- Fixed: Open Project Docker Installation \[[#43767](https://community.openproject.org/wp/43767)\]
+- Fixed: OpenProject Docker Installation \[[#43767](https://community.openproject.org/wp/43767)\]
 - Fixed: Unable to see activities in work package \[[#43773](https://community.openproject.org/wp/43773)\]
 - Fixed: Timeline shows bar at wrong time after collapsing a group \[[#43775](https://community.openproject.org/wp/43775)\]
 

--- a/docs/system-admin-guide/authentication/openid-providers/README.md
+++ b/docs/system-admin-guide/authentication/openid-providers/README.md
@@ -91,7 +91,7 @@ After pressing **CREATE** you will get a pop-up window like the following
 
 ### Step 3: Add Google as an OpenID Provider to OpenProject
 
-1. Login as Open Project Administrator
+1. Login as OpenProject Administrator
 2. navigate to -> *Administration* -> *Authentication* and choose -> *OpenID providers*.
    1. **Name** Choose Google
    2. **Display Name** (e.g. **EXAMPLE.COM SSO**)

--- a/docs/system-admin-guide/integrations/README.md
+++ b/docs/system-admin-guide/integrations/README.md
@@ -73,7 +73,7 @@ Currently, there is no direct integration between OpenProject and Timesheet. If 
 
 ## Time Tracker for OpenProject
 
-[Time Tracker](https://open-time-tracker.com/) is a mobile app that records time spent on tasks and logs it to your Open Project instance. We provide a [short instruction](../../user-guide/time-and-costs/time-tracking/time-tracker-integration/) how to set it up and use it.  Please keep in mind that it is not developed by OpenProject and is not supported by us. 
+[Time Tracker](https://open-time-tracker.com/) is a mobile app that records time spent on tasks and logs it to your OpenProject instance. We provide a [short instruction](../../user-guide/time-and-costs/time-tracking/time-tracker-integration/) how to set it up and use it.  Please keep in mind that it is not developed by OpenProject and is not supported by us. 
 
 ## Toggl
 

--- a/modules/auth_plugins/openproject-auth_plugins.gemspec
+++ b/modules/auth_plugins/openproject-auth_plugins.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.authors     = "OpenProject GmbH"
   s.email       = "info@openproject.com"
   s.summary     = "OpenProject Auth Plugins"
-  s.description = "Integration of OmniAuth strategy providers for authentication in Openproject."
+  s.description = "Integration of OmniAuth strategy providers for authentication in OpenProject."
   s.license     = "GPLv3"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + %w(doc/CHANGELOG.md README.md)

--- a/modules/avatars/app/views/settings/_openproject_avatars.html.erb
+++ b/modules/avatars/app/views/settings/_openproject_avatars.html.erb
@@ -1,5 +1,5 @@
 <% manager = ::OpenProject::Avatars::AvatarManager %>
-<% html_title t(:label_administration), 'Openproject Avatars' %>
+<% html_title t(:label_administration), 'OpenProject Avatars' %>
 
 <fieldset class="form--fieldset">
   <legend class="form--fieldset-legend" title="<%= t 'avatars.label_gravatar'  %>"><%= t 'avatars.label_gravatar'  %></legend>

--- a/modules/gitlab_integration/README.md
+++ b/modules/gitlab_integration/README.md
@@ -139,7 +139,7 @@ A typical workflow on GitLab side would be:
 You will have to configure both **OpenProject** and **Gitlab** for the integration to work.
 
 In case of **Docker** installation, follow the official OpenProject documentation [here](https://www.openproject.org/docs/installation-and-operations/installation/docker/#openproject-plugins). If for some reason the installation with Docker described in the official documentation does not work for you, you can try building your own docker image:
-* Clone from the Openproject Repo: `git clone https://github.com/opf/openproject.git --branch=stable/14 --depth=1 .`
+* Clone from the OpenProject Repo: `git clone https://github.com/opf/openproject.git --branch=stable/14 --depth=1 .`
 * Clone the plugin inside the modules folder: `git clone https://github.com/btey/openproject-gitlab-integration.git --depth=1 modules/gitlab_integration`
 * Apply the changes below in Gemfile.lock and Gemfile.modules (the same ones you would do in a manual install).
 * Build the container: `docker build -t openproject-docker --file=docker/prod/Dockerfile .`

--- a/modules/openid_connect/config/locales/crowdin/af.yml
+++ b/modules/openid_connect/config/locales/crowdin/af.yml
@@ -1,7 +1,7 @@
 af:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ar.yml
+++ b/modules/openid_connect/config/locales/crowdin/ar.yml
@@ -1,7 +1,7 @@
 ar:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/az.yml
+++ b/modules/openid_connect/config/locales/crowdin/az.yml
@@ -1,7 +1,7 @@
 az:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/be.yml
+++ b/modules/openid_connect/config/locales/crowdin/be.yml
@@ -1,7 +1,7 @@
 be:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/bg.yml
+++ b/modules/openid_connect/config/locales/crowdin/bg.yml
@@ -1,7 +1,7 @@
 bg:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ca.yml
+++ b/modules/openid_connect/config/locales/crowdin/ca.yml
@@ -1,7 +1,7 @@
 ca:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     S'ha tancat la teva sessió. Es poden haver perdut els continguts de qualsevol formulari sotmès. Si us plau, [inicia sessió].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ckb-IR.yml
+++ b/modules/openid_connect/config/locales/crowdin/ckb-IR.yml
@@ -1,7 +1,7 @@
 ckb-IR:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/cs.yml
+++ b/modules/openid_connect/config/locales/crowdin/cs.yml
@@ -1,7 +1,7 @@
 cs:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Přidá poskytovatele strategie OmniAuth OpenID připojení do Openproject."
+    description: "Přidá poskytovatele strategie OmniAuth OpenID připojení do OpenProject."
   logout_warning: >
     Byli jste odhlášeni. Obsah formuláře může být ztracen. Prosím, [přihlaste se].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/da.yml
+++ b/modules/openid_connect/config/locales/crowdin/da.yml
@@ -1,7 +1,7 @@
 da:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/de.yml
+++ b/modules/openid_connect/config/locales/crowdin/de.yml
@@ -1,7 +1,7 @@
 de:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Fügt OmniAuth OpenID Connect Strategieanbieter zu Openproject hinzu."
+    description: "Fügt OmniAuth OpenID Connect Strategieanbieter zu OpenProject hinzu."
   logout_warning: >
     Sie wurden abgemeldet. Der Inhalt eines Formulars, das Sie uns übermitteln, kann verloren gehen. Bitte [einloggen].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/el.yml
+++ b/modules/openid_connect/config/locales/crowdin/el.yml
@@ -1,7 +1,7 @@
 el:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Έχετε αποσυνδεθεί. Τα περιεχόμενα οποιασδήποτε φόρμας που υποβάλετε ενδέχεται να χαθούν. Παρακαλούμε [συνδεθείτε].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/eo.yml
+++ b/modules/openid_connect/config/locales/crowdin/eo.yml
@@ -1,7 +1,7 @@
 eo:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/es.yml
+++ b/modules/openid_connect/config/locales/crowdin/es.yml
@@ -1,7 +1,7 @@
 es:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Añade proveedores de estrategia OmniAuth OpenID Connect a Openproject."
+    description: "Añade proveedores de estrategia OmniAuth OpenID Connect a OpenProject."
   logout_warning: >
     Se ha cerrado la sesión. Puede que se haya perdido el contenido de cualquier formulario que haya enviado. [Inicie la sesión].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/et.yml
+++ b/modules/openid_connect/config/locales/crowdin/et.yml
@@ -1,7 +1,7 @@
 et:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/eu.yml
+++ b/modules/openid_connect/config/locales/crowdin/eu.yml
@@ -1,7 +1,7 @@
 eu:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/fa.yml
+++ b/modules/openid_connect/config/locales/crowdin/fa.yml
@@ -1,7 +1,7 @@
 fa:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/fi.yml
+++ b/modules/openid_connect/config/locales/crowdin/fi.yml
@@ -1,7 +1,7 @@
 fi:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/fil.yml
+++ b/modules/openid_connect/config/locales/crowdin/fil.yml
@@ -1,7 +1,7 @@
 fil:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/he.yml
+++ b/modules/openid_connect/config/locales/crowdin/he.yml
@@ -1,7 +1,7 @@
 he:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/hi.yml
+++ b/modules/openid_connect/config/locales/crowdin/hi.yml
@@ -1,7 +1,7 @@
 hi:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/hr.yml
+++ b/modules/openid_connect/config/locales/crowdin/hr.yml
@@ -1,7 +1,7 @@
 hr:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/hu.yml
+++ b/modules/openid_connect/config/locales/crowdin/hu.yml
@@ -1,7 +1,7 @@
 hu:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Kijelentkeztél. A benyújtott űrlap tartalma elveszhet. Kérjük jelentkezz be.
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/id.yml
+++ b/modules/openid_connect/config/locales/crowdin/id.yml
@@ -1,7 +1,7 @@
 id:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Anda telah keluar.  Isi formulir apa pun yang Anda kirim mungkin akan hilang.  Silahkan [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/it.yml
+++ b/modules/openid_connect/config/locales/crowdin/it.yml
@@ -1,7 +1,7 @@
 it:
   plugin_openproject_openid_connect:
     name: "OpenID Connect OpenProject"
-    description: "Aggiunge i provider di strategia OmniAuth OpenID Connect a Openproject."
+    description: "Aggiunge i provider di strategia OmniAuth OpenID Connect a OpenProject."
   logout_warning: >
     Sei stato disconnesso. Il contenuto di qualsiasi modulo che invii potrebbe essere perso. Per favore [accedi].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ja.yml
+++ b/modules/openid_connect/config/locales/crowdin/ja.yml
@@ -1,7 +1,7 @@
 ja:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     ログアウトしています。送信したフォームの内容は失われる可能性があります。 [ログイン] してください。
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ka.yml
+++ b/modules/openid_connect/config/locales/crowdin/ka.yml
@@ -1,7 +1,7 @@
 ka:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/kk.yml
+++ b/modules/openid_connect/config/locales/crowdin/kk.yml
@@ -1,7 +1,7 @@
 kk:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ko.yml
+++ b/modules/openid_connect/config/locales/crowdin/ko.yml
@@ -1,7 +1,7 @@
 ko:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Openproject에 OmniAuth OpenID Connect 전략 공급자를 추가합니다."
+    description: "OpenProject에 OmniAuth OpenID Connect 전략 공급자를 추가합니다."
   logout_warning: >
     로그아웃되었습니다. 제출한 양식의 내용이 손실될 수 있습니다. [로그인]하십시오.
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/lv.yml
+++ b/modules/openid_connect/config/locales/crowdin/lv.yml
@@ -1,7 +1,7 @@
 lv:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/mn.yml
+++ b/modules/openid_connect/config/locales/crowdin/mn.yml
@@ -1,7 +1,7 @@
 mn:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ms.yml
+++ b/modules/openid_connect/config/locales/crowdin/ms.yml
@@ -1,7 +1,7 @@
 ms:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Anda telah log keluar. Apa-apa bentuk kandungan yang anda hantar mungkin hilang. Sila [log masuk].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ne.yml
+++ b/modules/openid_connect/config/locales/crowdin/ne.yml
@@ -1,7 +1,7 @@
 ne:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/nl.yml
+++ b/modules/openid_connect/config/locales/crowdin/nl.yml
@@ -1,7 +1,7 @@
 nl:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     U bent uitgelogd. De inhoud van uw formulier kan verloren gaan. Alstublieft [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/no.yml
+++ b/modules/openid_connect/config/locales/crowdin/no.yml
@@ -1,7 +1,7 @@
 "no":
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID tilkobling"
-    description: "Legger til OmniAuth OpenID Koble strategileverandører til Openproject."
+    description: "Legger til OmniAuth OpenID Koble strategileverandører til OpenProject."
   logout_warning: >
     Du har blitt logget ut. Innholdet kan gå tapt. Vennligst [logg in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/pt-BR.yml
+++ b/modules/openid_connect/config/locales/crowdin/pt-BR.yml
@@ -1,7 +1,7 @@
 pt-BR:
   plugin_openproject_openid_connect:
     name: "Conectar OpenProject OpenID"
-    description: "Adiciona provedores de estratégia OmniAuth OpenID Connect ao Openproject."
+    description: "Adiciona provedores de estratégia OmniAuth OpenID Connect ao OpenProject."
   logout_warning: >
     Você foi desconectado. O conteúdo de qualquer formulário que você enviar poderá ser perdido. Por favor [faça login].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/pt-PT.yml
+++ b/modules/openid_connect/config/locales/crowdin/pt-PT.yml
@@ -1,7 +1,7 @@
 pt-PT:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adiciona fornecedores da estratégia OmniAuth OpenID Connect ao Openproject."
+    description: "Adiciona fornecedores da estratégia OmniAuth OpenID Connect ao OpenProject."
   logout_warning: >
     A sua sessão foi terminada. O conteúdo de qualquer formulário que enviar poderá ser perdido. Por favor [inicie a sessão].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ro.yml
+++ b/modules/openid_connect/config/locales/crowdin/ro.yml
@@ -1,7 +1,7 @@
 ro:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Ați fost deconectat. Conținutul oricărui formular pe care îl trimiteți poate fi pierdut. Vă rugăm să [vă conectați].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/ru.yml
+++ b/modules/openid_connect/config/locales/crowdin/ru.yml
@@ -1,7 +1,7 @@
 ru:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Подключение"
-    description: "Добавляет в Openproject стратегических провайдеров OmniAuth OpenID Connect."
+    description: "Добавляет в OpenProject стратегических провайдеров OmniAuth OpenID Connect."
   logout_warning: >
     Вы вышли из системы. Содержимое любой формы, которую вы можете отправить, может быть потеряно. Пожалуйста [войдите в систему].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/rw.yml
+++ b/modules/openid_connect/config/locales/crowdin/rw.yml
@@ -1,7 +1,7 @@
 rw:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/si.yml
+++ b/modules/openid_connect/config/locales/crowdin/si.yml
@@ -1,7 +1,7 @@
 si:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/sk.yml
+++ b/modules/openid_connect/config/locales/crowdin/sk.yml
@@ -1,7 +1,7 @@
 sk:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/sl.yml
+++ b/modules/openid_connect/config/locales/crowdin/sl.yml
@@ -1,7 +1,7 @@
 sl:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Bili ste izpisani. Oddana vsebina katerekoli oblike se lahko izgubi. Prosim [prijavi se].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/sr.yml
+++ b/modules/openid_connect/config/locales/crowdin/sr.yml
@@ -1,7 +1,7 @@
 sr:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/sv.yml
+++ b/modules/openid_connect/config/locales/crowdin/sv.yml
@@ -1,7 +1,7 @@
 sv:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Du har loggats ut. Innehållet i alla formulär du skickar kan försvinna. Vänligen [logga in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/th.yml
+++ b/modules/openid_connect/config/locales/crowdin/th.yml
@@ -1,7 +1,7 @@
 th:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/tr.yml
+++ b/modules/openid_connect/config/locales/crowdin/tr.yml
@@ -1,7 +1,7 @@
 tr:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     Çıkış yaptınız. Gönderdiğiniz herhangi bir formun içeriği kaybolabilir. Lütfen giriş yapın].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/uz.yml
+++ b/modules/openid_connect/config/locales/crowdin/uz.yml
@@ -1,7 +1,7 @@
 uz:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/vi.yml
+++ b/modules/openid_connect/config/locales/crowdin/vi.yml
@@ -1,7 +1,7 @@
 vi:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost. Please [log in].
   activemodel:

--- a/modules/openid_connect/config/locales/crowdin/zh-TW.yml
+++ b/modules/openid_connect/config/locales/crowdin/zh-TW.yml
@@ -1,7 +1,7 @@
 zh-TW:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID 連接"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     你已被登出，你嘗試送出的內容可能都會遺失。請登入。
   activemodel:

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   plugin_openproject_openid_connect:
     name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost.
     Please [log in].

--- a/modules/openid_connect/openproject-openid_connect.gemspec
+++ b/modules/openid_connect/openproject-openid_connect.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.authors     = "OpenProject GmbH"
   s.email       = "info@openproject.com"
   s.summary     = "OpenProject OpenID Connect"
-  s.description = "Adds OmniAuth OpenID Connect strategy providers to Openproject."
+  s.description = "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
   s.license     = "GPLv3"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + %w(CHANGELOG.md README.md)


### PR DESCRIPTION
This fixes the spelling of OpenProject in a few places