### PR TITLE
Attempt to fix flaky specs where the toast might disappear before the page finishes loading

### DIFF
--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -72,6 +72,8 @@ module Pages
       new_board_page.set_board_type action
       new_board_page.click_on_submit
 
+      new_board_page.expect_and_dismiss_toaster(message: "Successful creation.")
+
       if expect_empty
         expect(page).to have_css(".boards-list--add-item-text", wait: 10)
         expect(page).to have_no_css(".boards-list--item")

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -72,7 +72,7 @@ module Pages
       new_board_page.set_board_type action
       new_board_page.click_on_submit
 
-      new_board_page.expect_and_dismiss_toaster(message: "Successful creation.")
+      new_board_page.expect_and_dismiss_toaster
 
       if expect_empty
         expect(page).to have_css(".boards-list--add-item-text", wait: 10)

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe MeetingMailer do
     end
 
     context "with a recipient with another time zone" do
-      let!(:preference) { create(:user_preference, user: watcher1, time_zone: "Asia/Tokyo") }
+      let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
 
       it "renders the mail with the correcet locale" do
         expect(mail.text_part.body).to include("Tokyo")
@@ -119,7 +119,7 @@ RSpec.describe MeetingMailer do
       end
 
       describe "it renders november 10th for Tokyo zone" do
-        let!(:preference) { create(:user_preference, user: watcher1, time_zone: "Asia/Tokyo") }
+        let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
         let(:mail) { described_class.invited(meeting, watcher1, author) }
 
         it "renders the mail with the correct locale" do
@@ -203,7 +203,7 @@ RSpec.describe MeetingMailer do
     end
 
     context "with a recipient with another time zone" do
-      let!(:preference) { create(:user_preference, user: watcher1, time_zone: "Asia/Tokyo") }
+      let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
       let(:mail) { described_class.icalendar_notification(meeting, watcher1, author) }
 
       it "renders the mail with the correct locale" do
@@ -237,7 +237,7 @@ RSpec.describe MeetingMailer do
 
       describe "it renders november 10th for Tokyo zone" do
         let(:mail) { described_class.icalendar_notification(meeting, watcher1, author) }
-        let!(:preference) { create(:user_preference, user: watcher1, time_zone: "Asia/Tokyo") }
+        let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
 
         it "renders the mail with the correct locale" do
           expect(mail.text_part.body).to include("11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo")

--- a/modules/meeting/spec/services/meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/ical_service_spec.rb
@@ -30,11 +30,8 @@ require "spec_helper"
 
 RSpec.describe Meetings::ICalService, type: :model do # rubocop:disable RSpec/SpecFilePathFormat
   shared_let(:user) do
-    create(:user, firstname: "Bob", lastname: "Barker", mail: "bob@example.com").tap do |u|
-      u.pref[:time_zone] = "America/New_York"
-
-      u.save!
-    end
+    create(:user, firstname: "Bob", lastname: "Barker",
+                  mail: "bob@example.com", preferences: { time_zone: "America/New_York" })
   end
   shared_let(:user2) { create(:user, firstname: "Foo", lastname: "Fooer", mail: "foo@example.com") }
   shared_let(:project) { create(:project, name: "My Project") }

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -232,6 +232,7 @@ module Pages
         page.find("#{page.test_selector('tp-add-assignee')} input")
         select_user_to_add(name)
       end
+      expect_and_dismiss_toaster(message: "Successful update.")
     end
 
     def search_assignee(name)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -232,7 +232,7 @@ module Pages
         page.find("#{page.test_selector('tp-add-assignee')} input")
         select_user_to_add(name)
       end
-      expect_and_dismiss_toaster(message: "Successful update.")
+      expect_and_dismiss_toaster
     end
 
     def search_assignee(name)

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -62,7 +62,11 @@ FactoryBot.define do
 
     callback(:after_stub) do |user, evaluator|
       if evaluator.preferences.present?
-        user.preference = build_stubbed(:user_preference, user:, settings: evaluator.preferences)
+        # The assign_attributes workaround is required, because assigning user.preference will trigger
+        # creating a new database record, which raises an error in the build_stubbed context
+        user.pref.assign_attributes(
+          build_stubbed(:user_preference, user:, settings: evaluator.preferences).attributes
+        )
       end
     end
 

--- a/spec/services/notifications/mail_service_spec.rb
+++ b/spec/services/notifications/mail_service_spec.rb
@@ -35,12 +35,11 @@ RSpec.describe Notifications::MailService, type: :model do
 
   let(:recipient) do
     build_stubbed(:user,
-                  preference: build_stubbed(:user_preference,
-                                            settings: {
-                                              immediate_reminders: {
-                                                mentioned: immediate_reminders_mentioned
-                                              }
-                                            }))
+                  preferences: {
+                    immediate_reminders: {
+                      mentioned: immediate_reminders_mentioned
+                    }
+                  })
   end
   let(:actor) do
     build_stubbed(:user)

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -69,10 +69,15 @@ def get_week_days(*days)
   end
 end
 
+def default_auto_hide_popups_false
+  Setting.default_auto_hide_popups = false
+end
+
 RSpec.configure do |config|
   config.before(:suite) do
     # The test suite assumes the default of all days working.
     # Since the Setting default is with Sat-Sun non-working, we update it before the tests.
     week_with_all_days_working
+    default_auto_hide_popups_false
   end
 end


### PR DESCRIPTION
Let's consider the following scenario:

We are saving a form by clicking the submit button. The page redirects, the toast message is shown, but the page still loads some requests in the background. Capybara will not consider the page submission with the "click_on" command done, unless the page is loaded. Hence it will not go to the next expectation unless the page is loaded. If the page takes too long to load, the toast message might already disappear by the time capybara runs the next expectation for the toast's presence. This will make the expectation fail.

Attempt to fix flaky spec on [./modules/budgets/spec/features/budgets/add_budget_spec.rb:59](https://github.com/opf/openproject/actions/runs/8873891332/job/24360406463?pr=15401) 

Some specs got broken alongside while applying the fix. Those cases were prone to toast timing and fixed those too.