### PR TITLE
Rubocop check

### DIFF
--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -18,9 +18,10 @@ jobs:
           # fetch head commit of base branch
           git fetch --deepen 1 origin "${{ github.ref }}"
       - uses: ruby/setup-ruby@v1
-      - uses: opf/action-rubocop@v2
+      - uses: opf/action-rubocop@master
         with:
           github_token: ${{ secrets.github_token }}
           rubocop_version: gemfile
           rubocop_extensions: rubocop-inflector:gemfile rubocop-performance:gemfile rubocop-rails:gemfile rubocop-rspec:gemfile
           reporter: github-pr-check
+          only_changed: true

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           rubocop_version: gemfile
-          rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
+          rubocop_extensions: rubocop-inflector:gemfile rubocop-performance:gemfile rubocop-rails:gemfile rubocop-rspec:gemfile
           reporter: github-pr-check

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -2,11 +2,6 @@ name: rubocop
 
 on:
   pull_request:
-    branches:
-      - dev
-      - release/*
-    paths:
-      - '**.rb'
 
 jobs:
   rubocop:

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -9,8 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - name: Fetch all commits for PR branch plus head commit of base branch
+        run: |
+          # fetch all commits of the PR branch
+          git fetch --shallow-exclude "${{ github.base_ref }}" origin "${{ github.ref }}"
+          # fix for "fatal: error in object: unshallow"
+          git repack -d
+          # fetch head commit of base branch
+          git fetch --deepen 1 origin "${{ github.ref }}"
       - uses: ruby/setup-ruby@v1
       - uses: opf/action-rubocop@v2
         with:

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
   subject(:response) { last_response }
 
-  # rubocop:disable RSpec/Rails/HaveHttpStatus
+  # rubocop:disable RSpecRails/HaveHttpStatus
   # those are mock responses that don't deal well with the rails helpers
   describe "#POST /api/v3/projects/:id/copy" do
     describe "with empty params" do
@@ -203,5 +203,5 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
       end
     end
   end
-  # rubocop:enable RSpec/Rails/HaveHttpStatus
+  # rubocop:enable RSpecRails/HaveHttpStatus
 end

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) } # rubocop:disable RSpec/Rails/HaveHttpStatus
+        it { expect(response.status).to eq(200) } # rubocop:disable RSpecRails/HaveHttpStatus
 
         it "responds with updated finish date" do
           expect(subject.body).to be_json_eql(duration.to_json).at_path("remainingTime")

--- a/spec/requests/oauth_clients/callback_flow_spec.rb
+++ b/spec/requests/oauth_clients/callback_flow_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "OAuthClient callback endpoint" do
       set_cookie "oauth_state_asdf1234=#{state_cookie}"
     end
 
-    # rubocop:disable RSpec/Rails/HaveHttpStatus
+    # rubocop:disable RSpecRails/HaveHttpStatus
     shared_examples "with errors and state param with cookie, not being admin" do
       it "redirects to URI referenced in the state param and held in a cookie" do
         expect(response.status).to eq(302)
@@ -185,6 +185,6 @@ RSpec.describe "OAuthClient callback endpoint" do
 
       it_behaves_like "fallback redirect"
     end
-    # rubocop:enable RSpec/Rails/HaveHttpStatus
+    # rubocop:enable RSpecRails/HaveHttpStatus
   end
 end


### PR DESCRIPTION
Enable rubocop check using reviewdog action that will comment on all PRs. It was silently failing, as not all dependencies were enabled.

~To not overwhelm with failures a todo file for all failures is included plus a separate file for disable directives (it is not generated automatically). The goal is to start checking all new changes and gradually empty the todo files.~

#15557 as an example of how many violations could there be, so removed todos (#15561 with the branch containing them)