### PR TITLE
Renamed disk usage component

### DIFF
--- a/app/components/projects/disk_usage_information_component.html.erb
+++ b/app/components/projects/disk_usage_information_component.html.erb
@@ -1,0 +1,6 @@
+<p class="information-section">
+  <%= helpers.op_icon('icon-info1') %>
+  <%= t(:label_projects_disk_usage_information,
+        count: Project.count,
+        used_disk_space: number_to_human_size(Project.total_projects_size, precision: 2)) %>
+</p>

--- a/app/components/projects/disk_usage_information_component.rb
+++ b/app/components/projects/disk_usage_information_component.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-class Projects::StorageInformationComponent < ApplicationComponent
+class Projects::DiskUsageInformationComponent < ApplicationComponent
   options :current_user
 
   def render?

--- a/app/components/projects/storage_information_component.html.erb
+++ b/app/components/projects/storage_information_component.html.erb
@@ -1,6 +1,0 @@
-<p class="information-section">
-  <%= helpers.op_icon('icon-info1') %>
-  <%= t(:label_projects_storage_information,
-        count: Project.count,
-        storage: number_to_human_size(Project.total_projects_size, precision: 2)) %>
-</p>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -48,11 +48,11 @@ See COPYRIGHT and LICENSE files for more details.
         size: :medium,
         aria: { label: I18n.t(:label_project_new) },
         data: { 'test-selector': 'project-new-button' }) do |button|
-          button.with_leading_visual_icon(icon: :plus)
-          Project.model_name.human
-        end
+        button.with_leading_visual_icon(icon: :plus)
+        Project.model_name.human
       end
     end
+  end
   %>
 
 
@@ -61,6 +61,5 @@ See COPYRIGHT and LICENSE files for more details.
     current_user: current_user,
     params:) %>
 
-  <%= render Projects::StorageInformationComponent.new(
-    current_user: current_user) %>
+  <%= render Projects::DiskUsageInformationComponent.new(current_user: current_user) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2270,7 +2270,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   label_project_attributes_settings: "Project attributes settings"
   label_project_storage_plural: "File Storages"
   label_project_storage_project_folder: "File Storages: Project folders"
-  label_projects_storage_information: "%{count} projects using %{storage} disk storage"
+  label_projects_disk_usage_information: "%{count} projects using %{used_disk_space} disk space"
   label_project_view_all: "View all projects"
   label_project_show_details: "Show project details"
   label_project_hide_details: "Hide project details"


### PR DESCRIPTION
To keep storage related terms and wording concise to the storages topic of integrating file storage providers into OpenProject. I renamed the small `StorageInformationComponent` to `DiskUsageInformationComponent` and adjusted a word in the translations from `disk storage` to `disk space`.