### PR TITLE
Show no results message in project header if no favored is found

### DIFF
--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -57,7 +57,7 @@
 
       <ng-container *ngIf="(loading$ | async) === false; else loadingTemplate">
         <ul
-          *ngIf="(displayMode === 'all' && projects.length > 0) || (displayMode === 'favored' && (favorites$ | async).length > 0); else noResultsTemplate"
+          *ngIf="anyProjectsFound(projects, (favorites$ | async)); else noResultsTemplate"
           op-header-project-select-list
           [ngClass]="{ 'spot-list_active': textFieldFocused }"
           [projects]="projects"
@@ -70,7 +70,7 @@
         ></ul>
 
         <ng-template #noResultsTemplate>
-          <div *ngIf="displayMode === 'favored'"
+          <div *ngIf="displayMode === 'favored' && (favorites$ | async).length === 0"
                class="op-header-project-select--no-favorites"
           >
             <svg
@@ -84,7 +84,7 @@
                     [textContent]="text.no_favorites_subtext"></span>
             </p>
           </div>
-          <span *ngIf="displayMode === 'all'"
+          <span *ngIf="!(displayMode === 'favored' && (favorites$ | async).length === 0)"
                 class="op-project-list-modal--no-results">
             {{ text.no_results }}
           </span>

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -30,7 +30,7 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ChangeDetectionStrategy, Component, HostBinding, ViewEncapsulation } from '@angular/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
-import { combineLatest } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { debounceTime, defaultIfEmpty, filter, map, mergeMap, shareReplay, take } from 'rxjs/operators';
 import { IProject } from 'core-app/core/state/projects/project.model';
 import { insertInList } from 'core-app/shared/components/project-include/insert-in-list';
@@ -105,7 +105,7 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin {
     shareReplay(),
   );
 
-  public favorites$ = this
+  public favorites$:Observable<string[]> = this
     .apiV3Service
     .projects
     .signalled(
@@ -216,5 +216,13 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin {
   newProjectPath():string {
     const parentParam = this.currentProject.id ? `?parent_id=${this.currentProject.id}` : '';
     return `${this.pathHelper.projectsNewPath()}${parentParam}`;
+  }
+
+  anyProjectsFound(projects:IProjectData[], favorites:string[]):boolean {
+    if (this.displayMode === 'all') {
+      return projects.length > 0;
+    }
+
+    return projects.some((project) => favorites.includes(project.id.toString()));
   }
 }


### PR DESCRIPTION
Assuming you have at least one favored projects "let's call it X", and you search for anything but X, the favored view will be empty, but not have a no results message