### PR TITLE
[#53474] Having custom columns on Sharepoint blocks the copying of dr…

### DIFF
--- a/docs/system-admin-guide/integrations/one-drive/README.md
+++ b/docs/system-admin-guide/integrations/one-drive/README.md
@@ -44,8 +44,6 @@ Please note these minimum version requirements for the integration to work with 
 We recommend using the latest versions of both OneDrive/SharePoint and OpenProject to be able to use the latest
 features.
 
-
-
 ## Set up the integration
 
 > **Important**: You need administrator privileges in the Azure portal for your Microsoft Entra ID and in your
@@ -84,6 +82,8 @@ Finally, copy the *Redirect URl* and click the green *Done, complete setup* butt
 You will see the following message confirming the successful setup on top of the page. 
 
 ![System message on successful OneDrive/SharePoint file storages setup in OpenProject](openproject_system_guide_new_onedrive_message_successful_setup.png)
+
+> **Important note**: in Sharepoint you can add (custom) columns in addition to the ones shown by default (*Modified* and *Modified by*). Please keep in mind if these custom columns are added, OpenProject integration can no longer copy the automatically managed project folders. The columns will have to be de-activated, or ideally not be created in the first place.
 
 ## Using the integration
 

--- a/docs/user-guide/file-management/file-management-faq/README.md
+++ b/docs/user-guide/file-management/file-management-faq/README.md
@@ -23,6 +23,8 @@ Yes, that is possible. If you work with automatically managed folders, the corre
 
 Yes, you can. If the OneDrive/SharePoint file storage in your project had the automatically managed folders selected during the set-up, the folder with all files will be copied. If the file storage was added with manual managed folders, the new copy of the project will have the same file storage setup and reference the original folder without copying it. Read more about copying projects [here](../../projects/#copy-a-project).
 
+> **Important note**: in Sharepoint you can add (custom) columns in addition to the ones shown by default (*Modified* and *Modified by*). Please keep in mind if these custom columns are added, OpenProject integration can no longer copy the automatically managed project folders. The columns will have to be de-activated, or ideally not be created in the first place.
+
 
 ## Is there a virus scanner for the files attachments in OpenProject?
 


### PR DESCRIPTION
…ive items. In other words, Document Libraries for AMPF must not have custom columns.  https://community.openproject.org/work_packages/53474

[#53474] Having custom columns on Sharepoint blocks the copying of drive items. In other words, Document Libraries for AMPF must not have custom columns.

https://community.openproject.org/work_packages/53474