### PR TITLE
Bug/54552 changing project list column order is no longer possible from the administration

### DIFF
--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -109,8 +109,7 @@ class Queries::Projects::Factory
     def list_with(name)
       Queries::Projects::ProjectQuery.new(name: I18n.t(name)) do |query|
         query.order("lft" => "asc")
-        default_selects = %w[favored name]
-        query.select(*(default_selects + Setting.enabled_projects_columns).uniq, add_not_existing: false)
+        query.select(*Setting.enabled_projects_columns, add_not_existing: false)
 
         yield query
       end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -424,7 +424,7 @@ module Settings
         default: false
       },
       enabled_projects_columns: {
-        default: %w[project_status public created_at latest_activity_at required_disk_space],
+        default: %w[favored name project_status public created_at latest_activity_at required_disk_space],
         allowed: -> { Queries::Projects::ProjectQuery.new.available_selects.map { |s| s.attribute.to_s } }
       },
       enabled_scm: {
@@ -761,14 +761,14 @@ module Settings
         default: 3
       },
       httpx_operation_timeout: {
-        description: '',
+        description: "",
         format: :float,
         writable: false,
         allowed: (0..),
         default: 10
       },
       httpx_request_timeout: {
-        description: '',
+        description: "",
         format: :float,
         writable: false,
         allowed: (0..),

--- a/db/migrate/20200903064009_enable_current_project_custom_fields_columns.rb
+++ b/db/migrate/20200903064009_enable_current_project_custom_fields_columns.rb
@@ -28,7 +28,7 @@
 
 class EnableCurrentProjectCustomFieldsColumns < ActiveRecord::Migration[6.0]
   def up
-    return unless Setting.where(name: "enabled_projects_column").exists? # rubocop:disable Rails/WhereExists
+    return unless Setting.where(name: "enabled_projects_columns").exists? # rubocop:disable Rails/WhereExists
 
     columns = Setting.enabled_projects_columns
     cf_columns = ProjectCustomField.pluck(:id).map { |id| "cf_#{id}" }

--- a/db/migrate/20240430143313_update_default_project_columns.rb
+++ b/db/migrate/20240430143313_update_default_project_columns.rb
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class UpdateDefaultProjectColumns < ActiveRecord::Migration[7.1]
+  def up
+    return unless Setting.where(name: "enabled_projects_columns").exists? # rubocop:disable Rails/WhereExists
+
+    columns = Setting.enabled_projects_columns
+    columns.unshift("name") if columns.exclude?("name")
+    columns.unshift("favored") if columns.exclude?("favored")
+
+    Setting.enabled_projects_columns = columns
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/spec/migrations/update_default_project_columns_spec.rb
+++ b/spec/migrations/update_default_project_columns_spec.rb
@@ -1,0 +1,100 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20240430143313_update_default_project_columns.rb")
+
+RSpec.describe UpdateDefaultProjectColumns, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject(:run_migration) do
+    perform_enqueued_jobs do
+      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+    end
+  end
+
+  context "with no setting existing" do
+    it "does not create the setting" do
+      run_migration
+
+      expect(Setting.find_by(name: "enabled_projects_columns"))
+        .to be_nil
+    end
+  end
+
+  context "with the setting not having name nor favored column" do
+    before do
+      Setting.enabled_projects_columns = %w[project_status public]
+    end
+
+    it "prepends favored and name" do
+      run_migration
+
+      expect(Setting.find_by(name: "enabled_projects_columns").value)
+        .to eql %w[favored name project_status public]
+    end
+  end
+
+  context "with the setting having name but not the favored column" do
+    before do
+      Setting.enabled_projects_columns = %w[project_status name public]
+    end
+
+    it "prepends favored and name" do
+      run_migration
+
+      expect(Setting.find_by(name: "enabled_projects_columns").value)
+        .to eql %w[favored project_status name public]
+    end
+  end
+
+  context "with the setting not having name but the favored column" do
+    before do
+      Setting.enabled_projects_columns = %w[project_status favored public]
+    end
+
+    it "prepends favored and name" do
+      run_migration
+
+      expect(Setting.find_by(name: "enabled_projects_columns").value)
+        .to eql %w[name project_status favored public]
+    end
+  end
+
+  context "with the setting having both name and favored column" do
+    before do
+      Setting.enabled_projects_columns = %w[project_status favored public name]
+    end
+
+    it "prepends favored and name" do
+      run_migration
+
+      expect(Setting.find_by(name: "enabled_projects_columns").value)
+        .to eql %w[project_status favored public name]
+    end
+  end
+end

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 require "services/base_services/behaves_like_create_service"
 
 RSpec.describe Queries::Projects::Factory,
-               with_settings: { enabled_projects_columns: %w[name project_status] } do
+               with_settings: { enabled_projects_columns: %w[favored name project_status] } do
   let!(:query_finder) do
     scope = instance_double(ActiveRecord::Relation)
 
@@ -73,7 +73,7 @@ RSpec.describe Queries::Projects::Factory,
   let(:id) { nil }
   let(:params) { {} }
   let(:default_selects) do
-    %i[favored] + Setting.enabled_projects_columns.map(&:to_sym)
+    Setting.enabled_projects_columns.map(&:to_sym)
   end
 
   current_user { build_stubbed(:user) }
@@ -661,7 +661,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "has only the available fields (non admin only and only existing cf)" do
         expect(find.selects.map(&:attribute))
-          .to eq(%i[favored name cf_1]) # rubocop:disable Naming/VariableNumber
+          .to eq(%i[name cf_1]) # rubocop:disable Naming/VariableNumber
       end
     end
 


### PR DESCRIPTION
The "Favored" column becomes a column just like any other. It can be removed and is no longer prepended to the beginning of the table. 

Almost the same is now true for the "Name" column with the exception of it not being removable. For the user, there isn't a noticeable change but code wise, it is now ensured that the column will always be there so the factory does no longer have to take care of it.

-----

https://community.openproject.org/wp/54552