### PR TITLE
[#54558] openDesk setup script fails

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/o_auth_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/o_auth_user_token.rb
@@ -44,7 +44,7 @@ module Storages
           # rubocop:disable Metrics/AbcSize
           def call(storage:, http_options: {}, &)
             config = storage.oauth_configuration
-            current_token = OAuthClientToken.find_by(user_id: @user, oauth_client_id: config.oauth_client.id)
+            current_token = OAuthClientToken.find_by(user: @user, oauth_client: config.oauth_client)
             if current_token.nil?
               data = ::Storages::StorageErrorData.new(source: self.class)
               return Failures::Builder.call(code: :unauthorized,


### PR DESCRIPTION
[#54558](https://community.openproject.org/work_packages/54558)

### WAT?

- hardened prod code to not fall into an exception
- added test case

### INFO

The issue occurred due to the fact that the created storage in the script is incomplete (missing oauth client configuration). A code change in 14.0 did not take into account, that this code can run on incomplete storages. The code was improved, so that this case no longer creates exceptions.