### PR TITLE
Implement deploy status checks for github integration

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="menu-blocks--container" data-test-selector="menu-blocks--container">
   <% @menu_nodes.each do |menu_node| -%>
     <%= link_to menu_node.url, { class: 'menu-block', 'data-test-selector': 'menu-block' } do %>
-      <%= op_icon("menu-block--icon icon3 icon-#{(menu_node.icon || '')}") %>
+      <%= spot_icon("#{(menu_node.icon || '')}", classnames: "menu-block--icon icon3") %>
       <span class="menu-block--title"> <%= menu_node.caption %> </span>
     <% end %>
   <% end %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -567,10 +567,6 @@ module Settings
         description: "Require password confirmations for certain administrative actions",
         default: true
       },
-      introspection_enabled: {
-        description: "If enabled, expose detailed information the running OpenProject environment to users with the necessary permissions.",
-        default: true
-      },
       invitation_expiration_days: {
         default: 7
       },

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -567,6 +567,10 @@ module Settings
         description: "Require password confirmations for certain administrative actions",
         default: true
       },
+      introspection_enabled: {
+        description: "If enabled, expose detailed information the running OpenProject environment to users with the necessary permissions.",
+        default: true
+      },
       invitation_expiration_days: {
         default: 7
       },

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -61,14 +61,6 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin,
                      contract_actions: { users: %i[read create] }
 
-      map.permission :introspection,
-                     {
-                       admin: %i[info]
-                     },
-                     permissible_on: :global,
-                     require: :loggedin,
-                     enabled: -> { Setting.introspection_enabled? }
-
       map.permission :manage_user,
                      {
                        users: %i[index show edit update change_status change_status_info],

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -61,6 +61,14 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin,
                      contract_actions: { users: %i[read create] }
 
+      map.permission :introspection,
+                     {
+                       admin: %i[info]
+                     },
+                     permissible_on: :global,
+                     require: :loggedin,
+                     enabled: -> { Setting.introspection_enabled? }
+
       map.permission :manage_user,
                      {
                        users: %i[index show edit update change_status change_status_info],

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -111,11 +111,6 @@ module API
                getter: ->(*) { OpenProject::VERSION.to_semver },
                if: ->(*) { current_user.admin? || current_user.allowed_globally?(:introspection) }
 
-      property :core_sha,
-               exec_context: :decorator,
-               getter: ->(*) { OpenProject::VERSION.core_sha },
-               if: ->(*) { current_user.admin? || current_user.allowed_globally?(:introspection) }
-
       def _type
         "Root"
       end

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -109,7 +109,7 @@ module API
       property :core_version,
                exec_context: :decorator,
                getter: ->(*) { OpenProject::VERSION.to_semver },
-               if: ->(*) { current_user.admin? || current_user.allowed_globally?(:introspection) }
+               if: ->(*) { current_user.admin? }
 
       def _type
         "Root"

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -109,7 +109,12 @@ module API
       property :core_version,
                exec_context: :decorator,
                getter: ->(*) { OpenProject::VERSION.to_semver },
-               if: ->(*) { current_user.admin? }
+               if: ->(*) { current_user.admin? || current_user.allowed_globally?(:introspection) }
+
+      property :core_sha,
+               exec_context: :decorator,
+               getter: ->(*) { OpenProject::VERSION.core_sha },
+               if: ->(*) { current_user.admin? || current_user.allowed_globally?(:introspection) }
 
       def _type
         "Root"

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -138,7 +138,7 @@ module OpenProject
       def read_optional(file)
         path = Rails.root.join(file)
         if File.exist? path
-          File.read(path)
+          String(File.read(path)).strip
         end
       end
 

--- a/modules/github_integration/app/components/deploy_targets/row_component.rb
+++ b/modules/github_integration/app/components/deploy_targets/row_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -26,23 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+module DeployTargets
+  class RowComponent < ::RowComponent
+    property :host, :type
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+    def deploy_target
+      model
+    end
+
+    def created_at
+      helpers.format_time deploy_target.created_at
+    end
+
+    def button_links
+      [delete_link]
+    end
+
+    def delete_link
+      link_to "Delete",
+              deploy_target_path(deploy_target, back_url: request.fullpath),
+              method: :delete,
+              class: "icon icon-delete"
+    end
+  end
+end

--- a/modules/github_integration/app/components/deploy_targets/row_component.rb
+++ b/modules/github_integration/app/components/deploy_targets/row_component.rb
@@ -45,7 +45,7 @@ module DeployTargets
     end
 
     def delete_link
-      link_to "Delete",
+      link_to I18n.t(:button_delete),
               deploy_target_path(deploy_target, back_url: request.fullpath),
               method: :delete,
               class: "icon icon-delete"

--- a/modules/github_integration/app/components/deploy_targets/row_component.rb
+++ b/modules/github_integration/app/components/deploy_targets/row_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module DeployTargets
-  class RowComponent < ::RowComponent
+  class RowComponent < ::RowComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
     property :host, :type
 
     def deploy_target

--- a/modules/github_integration/app/components/deploy_targets/table_component.rb
+++ b/modules/github_integration/app/components/deploy_targets/table_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -26,23 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+module DeployTargets
+  class TableComponent < ::TableComponent
+    columns :host, :type, :created_at
+    options :current_user
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+    def initial_sort
+      %i[id asc]
+    end
+
+    def headers
+      columns.map do |name|
+        [name.to_s, header_options(name)]
+      end
+    end
+
+    def header_options(name)
+      { caption: User.human_attribute_name(name) }
+    end
+  end
+end

--- a/modules/github_integration/app/components/deploy_targets/table_component.rb
+++ b/modules/github_integration/app/components/deploy_targets/table_component.rb
@@ -29,7 +29,7 @@
 #++
 
 module DeployTargets
-  class TableComponent < ::TableComponent
+  class TableComponent < ::TableComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
     columns :host, :type, :created_at
     options :current_user
 

--- a/modules/github_integration/app/controllers/deploy_targets_controller.rb
+++ b/modules/github_integration/app/controllers/deploy_targets_controller.rb
@@ -48,11 +48,11 @@ class DeployTargetsController < ApplicationController
     @deploy_target = DeployTarget.create **args
 
     if @deploy_target.persisted?
-      flash[:success] = "Deploy target created"
+      flash[:success] = I18n.t(:notice_deploy_target_created)
 
       redirect_to deploy_targets_path
     else
-      render 'new'
+      render "new"
     end
   end
 
@@ -61,7 +61,7 @@ class DeployTargetsController < ApplicationController
 
     deploy_target.destroy!
 
-    flash[:success] = "Deploy target deleted"
+    flash[:success] = I18n.t(:notice_deploy_target_destroyed)
 
     redirect_to deploy_targets_path
   end

--- a/modules/github_integration/app/controllers/deploy_targets_controller.rb
+++ b/modules/github_integration/app/controllers/deploy_targets_controller.rb
@@ -26,23 +26,43 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+class DeployTargetsController < ApplicationController
+  layout "admin"
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+  before_action :require_admin
+
+  def index
+    @deploy_targets = DeployTarget.all
+  end
+
+  def new
+    @deploy_target = DeployTarget.new type: "OpenProject"
+  end
+
+  def create
+    args = params
+      .permit("deploy_target" => ["host", "type", "api_key"])[:deploy_target]
+      .to_h
+      .merge(type: "OpenProject")
+
+    @deploy_target = DeployTarget.create **args
+
+    if @deploy_target.persisted?
+      flash[:success] = "Deploy target created"
+
+      redirect_to deploy_targets_path
+    else
+      render 'new'
+    end
+  end
+
+  def destroy
+    deploy_target = DeployTarget.find params[:id]
+
+    deploy_target.destroy!
+
+    flash[:success] = "Deploy target deleted"
+
+    redirect_to deploy_targets_path
+  end
+end

--- a/modules/github_integration/app/models/deploy_status_check.rb
+++ b/modules/github_integration/app/models/deploy_status_check.rb
@@ -26,23 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+class DeployStatusCheck < ApplicationRecord
+  belongs_to :github_pull_request
+  belongs_to :deploy_target
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+  validates_presence_of :core_sha
+
+  delegate :merge_commit_sha, to: :github_pull_request
+
+  def pull_request
+    github_pull_request
+  end
+end

--- a/modules/github_integration/app/models/deploy_target.rb
+++ b/modules/github_integration/app/models/deploy_target.rb
@@ -34,7 +34,7 @@ class DeployTarget < ApplicationRecord
   has_many :deploy_status_checks, dependent: :destroy
 
   validates_presence_of :host
-
+  validates_presence_of :type
   # this is very much specific to the only type of target we support for now, OpenProject
   validates_presence_of :api_key
 end

--- a/modules/github_integration/app/models/deploy_target.rb
+++ b/modules/github_integration/app/models/deploy_target.rb
@@ -34,7 +34,10 @@ class DeployTarget < ApplicationRecord
   has_many :deploy_status_checks, dependent: :destroy
 
   validates_presence_of :host
+  validates_uniqueness_of :host
+
   validates_presence_of :type
+
   # this is very much specific to the only type of target we support for now, OpenProject
   validates_presence_of :api_key
 end

--- a/modules/github_integration/app/models/deploy_target.rb
+++ b/modules/github_integration/app/models/deploy_target.rb
@@ -26,23 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+class DeployTarget < ApplicationRecord
+  self.inheritance_column = nil
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+  store_accessor :options, :api_key
+
+  has_many :deploy_status_checks, dependent: :destroy
+
+  validates_presence_of :host
+
+  # this is very much specific to the only type of target we support for now, OpenProject
+  validates_presence_of :api_key
+end

--- a/modules/github_integration/app/models/github_pull_request.rb
+++ b/modules/github_integration/app/models/github_pull_request.rb
@@ -31,12 +31,14 @@ class GithubPullRequest < ApplicationRecord
 
   has_and_belongs_to_many :work_packages
   has_many :github_check_runs, dependent: :destroy
+  has_many :deploy_status_checks, dependent: :destroy
   belongs_to :github_user, optional: true
   belongs_to :merged_by, optional: true, class_name: "GithubUser"
 
   enum state: {
     open: "open",
-    closed: "closed"
+    closed: "closed",
+    deployed: "deployed"
   }
 
   validates_presence_of :github_html_url,

--- a/modules/github_integration/app/views/deploy_targets/_form.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/_form.html.erb
@@ -1,0 +1,58 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+<section class="form--section" id="deploy_target_form">
+  <div class="form--field -required" id="deploy_target_host_attributes">
+    <%= f.text_field :host, required: true, container_class: '-middle' %>
+  </div>
+
+  <div class="form--field -required">
+    <%= f.select :type,
+                 ['OpenProject'],
+                 { container_class: '-slim' },
+                 disabled: true,
+                 required: true
+    %>
+    <span class="form--field-instructions">
+      <%= t(:text_deploy_target_type_info) %>
+    </span>
+  </div>
+
+  <%# This field is specific to the only type of DeployTarget we support for now, which is OpenProject. %>
+  <div class="form--field">
+    <%= f.text_field "api_key", container_class: '-wide' %>
+    <span class="form--field-instructions">
+      <%= link_translate(
+        :text_deploy_target_api_key_info,
+        links: {
+          docs_url: "https://www.openproject.org/docs/api/introduction/#api-key-through-basic-auth"
+        }
+      ) %>
+    </span>
+  </div>
+</section>

--- a/modules/github_integration/app/views/deploy_targets/index.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/index.html.erb
@@ -1,0 +1,40 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), t(:label_github_integration) %>
+<%= toolbar title: t(:label_deploy_target_plural) do %>
+  <li class="toolbar-item">
+    <a href="<%= new_deploy_target_path %>" aria-label="<%= t(:button_add_deploy_target) %>" title="<%= t(:button_add_deploy_target) %>" class="button -primary">
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t(:label_deploy_target) %></span>
+    </a>
+  </li>
+<% end %>
+
+<%= render DeployTargets::TableComponent.new(rows: @deploy_targets, current_user: ) %>

--- a/modules/github_integration/app/views/deploy_targets/new.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/new.html.erb
@@ -1,0 +1,40 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), t("label_deploy_target_new") %>
+<% local_assigns[:additional_breadcrumb] = t(:label_deploy_target_new) %>
+
+<%= toolbar title: t(:label_deploy_target_new) %>
+
+<%= error_messages_for @deploy_target %>
+
+<%= labelled_tabular_form_for @deploy_target, url: deploy_targets_path do |f| %>
+  <%= render partial: 'deploy_targets/form', locals: { f: f, deploy_target: @deploy_target } %>
+  <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+<% end %>

--- a/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
+++ b/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
@@ -90,13 +90,13 @@ module Cron
     end
 
     def delete_status_check(pull_request, deploy_target)
-      # we use `find` and delete it this way to also cover
+      # we use `select` and delete it this way to also cover
       # not-yet-persisted records
-      check = pull_request
+      checks = pull_request
         .deploy_status_checks
-        .find { |c| c.deploy_target == deploy_target }
+        .select { |c| c.deploy_target == deploy_target }
 
-      pull_request.deploy_status_checks.delete(check)
+      pull_request.deploy_status_checks.delete(checks)
     end
 
     ##
@@ -143,6 +143,16 @@ module Cron
 
       return false if data.nil?
 
+      status_identical?(data) || status_behind?(data)
+    end
+
+    def status_identical?(data)
+      status = data["status"].presence
+
+      status == "identical"
+    end
+
+    def status_behind?(data)
       status = data["status"].presence
       ahead_by = data["ahead_by"].presence
       behind_by = data["behind_by"].presence

--- a/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
+++ b/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
@@ -1,0 +1,183 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Cron
+  class CheckDeployStatusJob < ApplicationJob
+    include OpenProject::GithubIntegration::NotificationHandler::Helper
+
+    priority_number :low
+
+    def perform
+      deploy_targets.find_each do |deploy_target|
+        sha = openproject_core_sha deploy_target.host, deploy_target.api_key
+
+        if sha.present?
+          pull_requests.find_each do |pull_request|
+            check_deploy_status deploy_target, pull_request, sha
+          end
+        else
+          OpenProject.logger.error "Failed to retrieve core SHA for deploy target #{deploy_target.host}"
+        end
+      end
+    end
+
+    def deploy_targets
+      DeployTarget.all
+    end
+
+    def pull_requests
+      GithubPullRequest
+        .closed
+        .where.not(merge_commit_sha: nil)
+    end
+
+    def check_deploy_status(deploy_target, pull_request, core_sha)
+      status_check = deploy_status_check deploy_target, pull_request
+
+      # we already checked this PR against the given core SHA, so no need to check again
+      return if status_check.core_sha == core_sha
+
+      # if the commit is contained, it has been deployed
+      if commit_contains? core_sha, pull_request.merge_commit_sha
+        update_deploy_status pull_request, deploy_target
+      else
+        status_check.update core_sha: # remember last checked SHA to not check twice
+      end
+    end
+
+    ##
+    # Marks the given PR as deployed and removes the last status check
+    # as it won't be needed anymore. This is because only closed (not yet deployed)
+    # PRs are ever checked for their deployment status.
+    def update_deploy_status(pull_request, deploy_target)
+      host = deploy_target.host
+
+      ActiveRecord::Base.transaction do
+        delete_status_check pull_request, deploy_target
+        pull_request.update! state: "deployed"
+
+        comment_on_referenced_work_packages(
+          pull_request.work_packages,
+          comment_user,
+          "[#{pull_request.repository}##{pull_request.number}](#{pull_request.github_html_url}) deployed to [#{host}](https://#{host})"
+        )
+      end
+    end
+
+    def delete_status_check(pull_request, deploy_target)
+      # we use `find` and delete it this way to also cover
+      # not-yet-persisted records
+      check = pull_request
+        .deploy_status_checks
+        .find { |c| c.deploy_target == deploy_target }
+
+      pull_request.deploy_status_checks.delete(check)
+    end
+
+    ##
+    # Ideally this would be the github user, but we don't really have a way
+    # to identify it outside of the webhook request cycle.
+    def comment_user
+      User.system
+    end
+
+    def deploy_status_check(deploy_target, pull_request)
+      pull_request
+        .deploy_status_checks
+        .find_or_initialize_by(
+          deploy_target:,
+          github_pull_request: pull_request
+        )
+    end
+
+    def openproject_core_sha(host, api_token)
+      res = introspection_request(host, api_token)
+
+      return nil if handle_request_error res, "Could not get OpenProject core SHA"
+
+      info = JSON.parse res.body.to_s
+
+      info["coreSha"].presence
+    end
+
+    def introspection_request(host, api_token)
+      OpenProject.httpx.basic_auth("apikey", api_token).get("http://#{host}/api/v3")
+    end
+
+    ##
+    # Uses the GitHub APIs compare endpoint to compare the currently deployed base commit
+    # and a merge commit from a PR.
+    #
+    # If the latter is included in the former, there will be 'ahead_by' and 'behind_by'
+    # in the response. 'aheady_by' will be 0, 'behind_by' greater than 0.
+    #
+    # If the commits are not included in the same branch, these fields
+    # will not be present at all.
+    def commit_contains?(base_commit_sha, merge_commit_sha)
+      data = compare_commits base_commit_sha, merge_commit_sha
+
+      return false if data.nil?
+
+      status = data["status"].presence
+      ahead_by = data["ahead_by"].presence
+      behind_by = data["behind_by"].presence
+
+      status == "behind" && ahead_by == 0 && (behind_by.present? && behind_by > 0)
+    end
+
+    def compare_commits(sha_a, sha_b)
+      res = compare_commits_request sha_a, sha_b
+
+      return nil if handle_request_error res, "Failed to compare commits"
+
+      JSON.parse res.body.read
+    end
+
+    def handle_request_error(res, error_prefix)
+      if res.is_a? HTTPX::ErrorResponse
+        OpenProject.logger.error "#{error_prefix}: #{res.error}"
+      elsif res.status == 404
+        OpenProject.logger.error "#{error_prefix}: not found"
+      elsif res.status != 200
+        OpenProject.logger.error "#{error_prefix}: #{res.body}"
+      else
+        return false
+      end
+
+      true
+    end
+
+    def compare_commits_request(sha_a, sha_b)
+      OpenProject.httpx.get(compare_commits_url(sha_a, sha_b))
+    end
+
+    def compare_commits_url(sha_a, sha_b)
+      "https://api.github.com/repos/opf/openproject/compare/#{sha_a}...#{sha_b}"
+    end
+  end
+end

--- a/modules/github_integration/config/routes.rb
+++ b/modules/github_integration/config/routes.rb
@@ -26,23 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
-
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+Rails.application.routes.draw do
+  resources :deploy_targets, only: %i[index new edit update create destroy]
+end

--- a/modules/github_integration/config/routes.rb
+++ b/modules/github_integration/config/routes.rb
@@ -27,5 +27,5 @@
 #++
 
 Rails.application.routes.draw do
-  resources :deploy_targets, only: %i[index new edit update create destroy]
+  resources :deploy_targets, only: %i[index new create destroy]
 end

--- a/modules/github_integration/db/migrate/20240501083852_create_deploy_targets.rb
+++ b/modules/github_integration/db/migrate/20240501083852_create_deploy_targets.rb
@@ -1,0 +1,13 @@
+class CreateDeployTargets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :deploy_targets do |t|
+      t.text :type, null: false
+      t.text :host, null: false
+      t.jsonb :options, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :deploy_targets, :host, unique: true
+  end
+end

--- a/modules/github_integration/db/migrate/20240501093751_create_deploy_status_checks.rb
+++ b/modules/github_integration/db/migrate/20240501093751_create_deploy_status_checks.rb
@@ -1,0 +1,12 @@
+class CreateDeployStatusChecks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :deploy_status_checks do |t|
+      t.references :deploy_target
+      t.references :github_pull_request
+
+      t.text :core_sha, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/modules/github_integration/db/migrate/20240502081436_add_merge_commit_sha_to_github_pull_requests.rb
+++ b/modules/github_integration/db/migrate/20240502081436_add_merge_commit_sha_to_github_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddMergeCommitShaToGithubPullRequests < ActiveRecord::Migration[7.1]
+  def change
+    add_column :github_pull_requests, :merge_commit_sha, :text
+  end
+end

--- a/modules/github_integration/frontend/module/pull-request/pull-request-state.component.sass
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-state.component.sass
@@ -49,3 +49,6 @@
 
   &_closed
     background-color: #d73a49
+
+  &_deployed
+    background-color: #d73af9

--- a/modules/github_integration/frontend/module/pull-request/pull-request-state.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-state.component.ts
@@ -35,7 +35,7 @@ import {
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
-export type PullRequestState = 'opened'|'closed'|'referenced'|'ready_for_review'|'merged'|'draft';
+export type PullRequestState = 'opened'|'closed'|'referenced'|'ready_for_review'|'merged'|'draft'|'deployed';
 
 @Component({
   selector: 'op-github-pull-request-state',

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.ts
@@ -71,6 +71,9 @@ export class PullRequestComponent {
     if (this.pullRequest.state === 'open') {
       return (this.pullRequest.draft ? 'draft' : 'open');
     }
+    if (this.pullRequest.state === 'deployed') {
+      return 'deployed';
+    }
     return (this.pullRequest.merged ? 'merged' : 'closed');
   }
 

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
@@ -70,6 +70,7 @@ module OpenProject::GithubIntegration::Services
                                     .fetch("repo")
                                     .fetch("html_url"),
         draft: payload.fetch("draft"),
+        merge_commit_sha: payload.fetch("merge_commit_sha"),
         merged: payload.fetch("merged"),
         merged_by: github_user_id(payload["merged_by"]),
         merged_at: payload["merged_at"],

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
@@ -70,7 +70,7 @@ module OpenProject::GithubIntegration::Services
                                     .fetch("repo")
                                     .fetch("html_url"),
         draft: payload.fetch("draft"),
-        merge_commit_sha: payload.fetch("merge_commit_sha"),
+        merge_commit_sha: payload["merge_commit_sha"],
         merged: payload.fetch("merged"),
         merged_by: github_user_id(payload["merged_by"]),
         merged_at: payload["merged_at"],

--- a/modules/github_integration/spec/factories/deploy_status_check_factory.rb
+++ b/modules/github_integration/spec/factories/deploy_status_check_factory.rb
@@ -26,23 +26,9 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
-
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+FactoryBot.define do
+  factory :deploy_status_check do
+    deploy_target
+    github_pull_request
+  end
+end

--- a/modules/github_integration/spec/factories/deploy_target_factory.rb
+++ b/modules/github_integration/spec/factories/deploy_target_factory.rb
@@ -32,6 +32,6 @@ FactoryBot.define do
 
     sequence(:host) { |n| "https://qa-#{n}.openproject-edge.com" }
 
-    api_key { '4p1k3y' }
+    api_key { "4p1k3y" }
   end
 end

--- a/modules/github_integration/spec/factories/deploy_target_factory.rb
+++ b/modules/github_integration/spec/factories/deploy_target_factory.rb
@@ -31,5 +31,7 @@ FactoryBot.define do
     type { "OpenProject" }
 
     sequence(:host) { |n| "https://qa-#{n}.openproject-edge.com" }
+
+    api_key { '4p1k3y' }
   end
 end

--- a/modules/github_integration/spec/factories/deploy_target_factory.rb
+++ b/modules/github_integration/spec/factories/deploy_target_factory.rb
@@ -26,23 +26,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+FactoryBot.define do
+  factory :deploy_target do
+    type { "OpenProject" }
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+    sequence(:host) { |n| "https://qa-#{n}.openproject-edge.com" }
+  end
+end

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::PullRequest 
         "merged" => pr_merged,
         "merged_by" => nil,
         "merged_at" => nil,
-        "merge_commit_sha" => "955af2f83de81c39fcf912376855eb3ee5e38f26",
+        "merge_commit_sha" => nil,
         "comments" => 1,
         "review_comments" => 2,
         "additions" => 3,

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::PullRequest 
         "merged" => pr_merged,
         "merged_by" => nil,
         "merged_at" => nil,
+        "merge_commit_sha" => "955af2f83de81c39fcf912376855eb3ee5e38f26",
         "comments" => 1,
         "review_comments" => 2,
         "additions" => 3,

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe OpenProject::GithubIntegration::Services::UpsertPullRequest do
         "merged" => true,
         "merged_by" => user_payload,
         "merged_at" => "20210410T09:45:03Z",
-        "merge_commit_sha" => "955af2f83de81c39fcf912376855eb3ee5e38f26",
+        "merge_commit_sha" => "955af2f83de81c39fcf912376855eb3ee5e38f26"
       }
     end
 

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
@@ -181,7 +181,8 @@ RSpec.describe OpenProject::GithubIntegration::Services::UpsertPullRequest do
       {
         "merged" => true,
         "merged_by" => user_payload,
-        "merged_at" => "20210410T09:45:03Z"
+        "merged_at" => "20210410T09:45:03Z",
+        "merge_commit_sha" => "955af2f83de81c39fcf912376855eb3ee5e38f26",
       }
     end
 
@@ -195,7 +196,8 @@ RSpec.describe OpenProject::GithubIntegration::Services::UpsertPullRequest do
         github_user:,
         merged: true,
         merged_by: github_user,
-        merged_at: Time.zone.parse("20210410T09:45:03Z")
+        merged_at: Time.zone.parse("20210410T09:45:03Z"),
+        merge_commit_sha: "955af2f83de81c39fcf912376855eb3ee5e38f26"
       )
     end
   end

--- a/modules/github_integration/spec/requests/extended_root_resource_spec.rb
+++ b/modules/github_integration/spec/requests/extended_root_resource_spec.rb
@@ -1,0 +1,90 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Root resource with the github integration extension", with_flag: { deploy_targets: true } do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    create(:user, member_with_roles: { project => role })
+  end
+  let(:role) { create(:project_role, permissions: []) }
+  let(:project) { create(:project, public: false) }
+
+  before do
+    # reset permissions cache, otherwise the introspection permissions enabled with the
+    # deploy_targets feature flag won't be registered
+    OpenProject::AccessControl.instance_variable_set(:@permissions, nil)
+  end
+
+  describe "#get" do
+    let(:response) { last_response }
+    let(:get_path) { api_v3_paths.root }
+
+    subject { response.body }
+
+    context "without introspection permission" do
+      before do
+        allow(User).to receive(:current).and_return(current_user)
+
+        get get_path
+      end
+
+      it "responds with 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "does not include the core SHA in the res" do
+        expect(subject).not_to have_json_path("coreSha")
+      end
+    end
+
+    context "with introspection permission" do
+      let(:current_user) { create(:user, global_permissions: [:introspection]) }
+      let(:core_sha) { "b86f391bf02c345e934ca8a945d83fc82d2063ef" }
+
+      before do
+        allow(OpenProject::VERSION).to receive(:core_sha).and_return core_sha
+        allow(User).to receive(:current).and_return(current_user)
+
+        get get_path
+      end
+
+      it "responds with 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "does includes the core SHA in the response" do
+        expect(subject).to be_json_eql(core_sha.to_json ).at_path("coreSha")
+      end
+    end
+  end
+end

--- a/modules/github_integration/spec/requests/extended_root_resource_spec.rb
+++ b/modules/github_integration/spec/requests/extended_root_resource_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "API v3 Root resource with the github integration extension", wit
       end
 
       it "responds with 200" do
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(200) # rubocop:disable RSpecRails/HaveHttpStatus
       end
 
       it "does not include the core SHA in the res" do
@@ -79,11 +79,11 @@ RSpec.describe "API v3 Root resource with the github integration extension", wit
       end
 
       it "responds with 200" do
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(200) # rubocop:disable RSpecRails/HaveHttpStatus
       end
 
       it "does includes the core SHA in the response" do
-        expect(subject).to be_json_eql(core_sha.to_json ).at_path("coreSha")
+        expect(subject).to be_json_eql(core_sha.to_json).at_path("coreSha")
       end
     end
   end

--- a/modules/github_integration/spec/workers/cron/check_deploy_status_job_spec.rb
+++ b/modules/github_integration/spec/workers/cron/check_deploy_status_job_spec.rb
@@ -26,23 +26,20 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-en:
-  button_add_deploy_target: Add deploy target
-  label_deploy_target: Deploy target
-  label_deploy_target_new: New deploy target
-  label_deploy_target_plural: Deploy targets
-  label_github_integration: GitHub Integration
-  notice_deploy_target_created: Deploy target created
-  notice_deploy_target_destroyed: Deploy target deleted
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
+require "spec_helper"
 
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+RSpec.describe Cron::CheckDeployStatusJob, type: :job, with_flags { deploy_targets: true } do
+  let!(:deploy_target) { create(:deploy_target) }
+
+  let(:deploy_status_check) { create(:deploy_status_check, deploy_target:, pull_request:) }
+  let(:pull_request) { create(:github_pull_request, work_packages: [work_package]) }
+  let(:work_package) { create(:work_package) }
+
+  let(:job) { described_class.new }
+
+  context "with no prior checks" do
+    before do
+      job.run
+    end
+  end
+end


### PR DESCRIPTION
WP [55425](https://community.openproject.org/projects/openproject/work_packages/55425/activity)

This introduces a new state for pull requests called `'deployed'`. 
A cron job checks the deploy status of every pull request regularly and updates the state accordingly once deployed.
It will also add a comment to each relevant work package to let users know where the pull request was deployed to.

![image](https://github.com/opf/openproject/assets/158871/37157cc1-ddc7-4aa5-8ebe-62df3ce47b4f)

To make this work an `introspection` permission is introduced and the APIv3 root endpoint amended with the deployed core SHA that is running.

Lastly, next to the `deploy_targets` table another table `github_deploy_status_checks` is created used to make sure the deploy status is only checked as often as necessary and not more.

**To do**
- [x] implement deploy status job doing the actual work
- [x] add `deployed` state in frontend
- [x] add UI to allow configuring deploy targets
- [x] add tests 

**Remarks**
- it would be nice if it was the github user who comments on the work packages with the deploy status updates, however, outside of the pull request webhook request cycle we simply don't know who the github user is and I didn't want to add any more code than necessary for the time being