### PR TITLE
Bump carrierwave to v1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,7 +187,7 @@ gem "rack-timeout", "~> 0.6.3", require: "rack/timeout/base"
 
 gem "nokogiri", "~> 1.16.0"
 
-gem "carrierwave", "~> 1.3.1"
+gem "carrierwave", "~> 1.3.4"
 gem "carrierwave_direct", "~> 2.1.0"
 gem "fog-aws"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,11 +400,11 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    carrierwave (1.3.2)
+    carrierwave (1.3.4)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-      ssrf_filter (~> 1.0)
+      ssrf_filter (~> 1.0, < 1.1.0)
     carrierwave_direct (2.1.0)
       carrierwave (>= 1.0.0)
       fog-aws
@@ -1060,7 +1060,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    ssrf_filter (1.1.2)
+    ssrf_filter (1.0.8)
     stackprof (0.2.26)
     store_attribute (1.2.0)
       activerecord (>= 6.0)
@@ -1184,7 +1184,7 @@ DEPENDENCIES
   capybara (~> 3.40.0)
   capybara-screenshot (~> 1.0.17)
   capybara_accessible_selectors!
-  carrierwave (~> 1.3.1)
+  carrierwave (~> 1.3.4)
   carrierwave_direct (~> 2.1.0)
   climate_control
   closure_tree (~> 7.4.0)

--- a/lib/open_project/patches/carrierwave_sanitized_file.rb
+++ b/lib/open_project/patches/carrierwave_sanitized_file.rb
@@ -37,6 +37,6 @@ module OpenProject::Patches::FogFile
   end
 end
 
-OpenProject::Patches.patch_gem_version "carrierwave", "1.3.2" do
+OpenProject::Patches.patch_gem_version "carrierwave", "1.3.4" do
   CarrierWave::Storage::Fog::File.include OpenProject::Patches::FogFile
 end

--- a/lib/open_project/patches/fog_file.rb
+++ b/lib/open_project/patches/fog_file.rb
@@ -14,6 +14,6 @@ module OpenProject::Patches::CarrierwaveSanitizedFile
   end
 end
 
-OpenProject::Patches.patch_gem_version "carrierwave", "1.3.2" do
+OpenProject::Patches.patch_gem_version "carrierwave", "1.3.4" do
   CarrierWave::SanitizedFile.include OpenProject::Patches::CarrierwaveSanitizedFile
 end

--- a/nix/gemset.nix
+++ b/nix/gemset.nix
@@ -3314,10 +3314,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0flmg6f444liaxjgdwdrwcfwyyhc54a7wp26kqih2cklwll5gp40";
+      sha256 = "03f49f54837e407d43ee93ec733a8a94dc1bcf8185647ac61606e63aaedaa0db";
       type = "gem";
     };
-    version = "1.0.7";
+    version = "1.0.8";
   };
   stackprof = {
     groups = ["development" "test"];


### PR DESCRIPTION
Check [carrier wave v1.x](https://github.com/carrierwaveuploader/carrierwave/commits/1.x-stable/) commit history, safe to bump.