### PR TITLE
Make JobStatus API GoodJob::Batch aware

### DIFF
--- a/modules/job_status/app/workers/job_status/application_job_with_status.rb
+++ b/modules/job_status/app/workers/job_status/application_job_with_status.rb
@@ -27,7 +27,7 @@
 #++
 module JobStatus
   module ApplicationJobWithStatus
-    # Backgroun jobs can have a status JobStatus::Status
+    # Background jobs can have a status JobStatus::Status
     # which is related to the job via a reference which is an AR model instance.
     def status_reference
       nil

--- a/modules/job_status/lib/api/v3/job_status/job_status_representer.rb
+++ b/modules/job_status/lib/api/v3/job_status/job_status_representer.rb
@@ -53,7 +53,12 @@ module API
           batch = GoodJob::Job.find_by(id: represented.job_id)&.batch
           return represented.status unless batch
 
-          return "in_process" unless batch.finished?
+          unless batch.finished?
+            return "in_process" if batch.jobs.any?(&:running?)
+
+            return "in_queue"
+          end
+
           return "success" if batch.succeeded?
 
           "failure" if batch.discarded?

--- a/modules/job_status/spec/lib/api/v3/job_status/job_status_representer_spec.rb
+++ b/modules/job_status/spec/lib/api/v3/job_status/job_status_representer_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+class NoOpJob < ApplicationJob
+  discard_on StandardError
+
+  def store_status? = true
+
+  def perform(fail: false)
+    raise StandardError if fail
+
+    "I'll do nothing"
+  end
+end
+
+RSpec.describe API::V3::JobStatus::JobStatusRepresenter do
+  let(:user) { build_stubbed(:admin) }
+
+  describe "status", with_good_job_batches: [NoOpJob] do
+    subject(:status_json) { described_class.new(job_status, current_user: user).to_json }
+
+    context "when job is not part of a batch" do
+      let(:job) { NoOpJob.perform_later }
+      let(:job_status) { JobStatus::Status.find_by(job_id: job.job_id) }
+
+      it_behaves_like "property", :status do
+        let(:value) { "in_queue" }
+      end
+
+      it 'returns "succeeded" if the job has finished successfully' do
+        job = NoOpJob.perform_later
+        GoodJob.perform_inline
+        status = JobStatus::Status.find_by(job_id: job.job_id)
+
+        status_json = described_class.new(status, current_user: user).to_json
+        expect(status_json).to be_json_eql("success".to_json).at_path("status")
+      end
+    end
+
+    context "when job is part of a batch" do
+      it "returns in_process if the batch is running" do
+        GoodJob::Batch.enqueue { NoOpJob.perform_later }
+        status = JobStatus::Status.order(:created_at).last
+        status_json = described_class.new(status, current_user: user).to_json
+
+        expect(status_json).to be_json_eql("in_process".to_json).at_path("status")
+      end
+
+      it "returns success if the batch has finished and is successful" do
+        GoodJob::Batch.enqueue { NoOpJob.perform_later }
+        GoodJob.perform_inline
+        status = JobStatus::Status.order(:created_at).last
+
+        status_json = described_class.new(status, current_user: user).to_json
+        expect(status_json).to be_json_eql("success".to_json).at_path("status")
+      end
+
+      it "returns failure if the batch has finished and has been discarded" do
+        GoodJob::Batch.enqueue { NoOpJob.perform_later(fail: true) }
+        begin
+          GoodJob.perform_inline
+        rescue StandardError
+          # noop
+        end
+        status = JobStatus::Status.order(:created_at).last
+
+        status_json = described_class.new(status, current_user: user).to_json
+        expect(status_json).to be_json_eql("failure".to_json).at_path("status")
+      end
+    end
+  end
+end

--- a/modules/job_status/spec/lib/api/v3/job_status/job_status_representer_spec.rb
+++ b/modules/job_status/spec/lib/api/v3/job_status/job_status_representer_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe API::V3::JobStatus::JobStatusRepresenter do
         status = JobStatus::Status.order(:created_at).last
         status_json = described_class.new(status, current_user: user).to_json
 
-        expect(status_json).to be_json_eql("in_process".to_json).at_path("status")
+        expect(status_json).to be_json_eql("in_queue".to_json).at_path("status")
       end
 
       it "returns success if the batch has finished and is successful" do

--- a/modules/storages/app/workers/storages/copy_project_folders_job.rb
+++ b/modules/storages/app/workers/storages/copy_project_folders_job.rb
@@ -48,7 +48,7 @@ module Storages
                                           project_folder_mode: source.project_folder_mode)
                                     .on_failure { |failed| log_failure(failed) and return failed }
 
-      FileLinks::CopyFileLinksService.call(source: @source, target:, user:, work_packages_map:)
+      FileLinks::CopyFileLinksService.call(source: @source, target: target.reload, user:, work_packages_map:)
     end
 
     private

--- a/modules/storages/spec/workers/storages/copy_project_folders_job_spec.rb
+++ b/modules/storages/spec/workers/storages/copy_project_folders_job_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Storages::CopyProjectFoldersJob, :job, :webmock, with_good_job_ba
   describe "managed project folders" do
     before do
       Storages::Peripherals::Registry
-        .stub("#{storage.short_provider_type}.queries.file_path_to_id_map", ->(storage:, folder:) {
+        .stub("#{storage.short_provider_type}.queries.file_path_to_id_map", ->(storage:, auth_strategy:, folder:) {
           ServiceResult.success(result: target_deep_file_ids)
         })
 
@@ -177,7 +177,7 @@ RSpec.describe Storages::CopyProjectFoldersJob, :job, :webmock, with_good_job_ba
         })
 
       Storages::Peripherals::Registry
-        .stub("#{storage.short_provider_type}.queries.file_path_to_id_map", ->(storage:, folder:) {
+        .stub("#{storage.short_provider_type}.queries.file_path_to_id_map", ->(storage:, auth_strategy:, folder:) {
           ServiceResult.success(result: target_deep_file_ids)
         })
 

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
         expect(last_response.status).to eq(200)
 
         expect(last_response.body)
-          .to be_json_eql("in_process".to_json)
+          .to be_json_eql("in_queue".to_json)
                 .at_path("status")
 
         GoodJob.perform_inline

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
         expect(last_response.status).to eq(200)
 
         expect(last_response.body)
-          .to be_json_eql("in_queue".to_json)
+          .to be_json_eql("in_process".to_json)
                 .at_path("status")
 
         GoodJob.perform_inline


### PR DESCRIPTION

## The Issue

Since we added the usage of `GoodJob::Batch` on the `CopyProjectJob`, it initiates the redirect before the actual batch has ended.

## The fix

We have to alter the `status` property returned by the `API::V3::JobStatus` to `in_process` until the batch finishes.