### PR TITLE
Attempt to fix flickering spent time widget spec

### DIFF
--- a/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
+++ b/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
@@ -31,7 +31,6 @@ require "spec_helper"
 require_relative "../../support/pages/my/page"
 
 RSpec.describe "My spent time widget with a negative time zone", :js,
-               driver: :chrome_headless_new,
                with_settings: { start_of_week: 1 } do
   let(:beginning_of_week) { monday }
   let(:end_of_week) { sunday }
@@ -39,7 +38,7 @@ RSpec.describe "My spent time widget with a negative time zone", :js,
   let(:tuesday) { beginning_of_week + 1.day }
   let(:thursday) { beginning_of_week + 3.days }
   let(:sunday) { beginning_of_week + 6.days }
-  let(:time_zone) { "America/Phoenix" }
+  let(:time_zone) { "America/New_York" }
 
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type]) }
@@ -68,19 +67,13 @@ RSpec.describe "My spent time widget with a negative time zone", :js,
   let!(:week_days) { week_with_saturday_and_sunday_as_weekend }
   let!(:non_working_day) { create(:non_working_day, date: tuesday) }
 
-  # Configure the time zone of the browser
-  # @param [String] time_zone The time zone to set, for instance 'Europe/Paris'
-  def set_browser_time_zone(time_zone)
-    page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: time_zone)
-  end
-
   before do
     login_as user
-    set_browser_time_zone(time_zone)
     my_page.visit!
   end
 
-  it "correctly displays non-working days and prefills day when logging time [fix #49779]" do
+  it "correctly displays non-working days and prefills day when logging time [fix #49779]",
+     driver: :chrome_new_york_time_zone do
     my_page.add_widget(1, 1, :within, "My spent time")
 
     my_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)

--- a/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
+++ b/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
@@ -78,15 +78,18 @@ RSpec.describe "My spent time widget with a negative time zone", :js,
 
     my_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
 
+    expect(page)
+      .to have_content time_entry.spent_on.strftime("%-m/%-d")
+
     aggregate_failures("non-working days are displayed properly") do
       expect(page).to have_button("Today", disabled: true)
-      expect(page).to have_no_css(".fc-day-mon.fc-non-working-day", wait: 0)
-      expect(page).to have_css(".fc-day-tue.fc-non-working-day", wait: 0)
-      expect(page).to have_no_css(".fc-day-wed.fc-non-working-day", wait: 0)
-      expect(page).to have_no_css(".fc-day-thu.fc-non-working-day", wait: 0)
-      expect(page).to have_no_css(".fc-day-fri.fc-non-working-day", wait: 0)
-      expect(page).to have_css(".fc-day-sat.fc-non-working-day", wait: 0)
-      expect(page).to have_css(".fc-day-sun.fc-non-working-day", wait: 0)
+      expect(page).to have_no_css(".fc-day-mon.fc-non-working-day")
+      expect(page).to have_css(".fc-day-tue.fc-non-working-day")
+      expect(page).to have_no_css(".fc-day-wed.fc-non-working-day")
+      expect(page).to have_no_css(".fc-day-thu.fc-non-working-day")
+      expect(page).to have_no_css(".fc-day-fri.fc-non-working-day")
+      expect(page).to have_css(".fc-day-sat.fc-non-working-day")
+      expect(page).to have_css(".fc-day-sun.fc-non-working-day")
     end
 
     aggregate_failures("when clicking a day, time entry day is set to the day clicked (Thursday)") do

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -96,19 +96,6 @@ Billy.configure do |c|
   end
 end
 
-# Register Chrome with new headless implementation
-#
-# Our tests are not that stable with the new headless mode, but since
-# Chrome 120 the old headless mode has browser name
-# "chrome-headless-shell". This name is not recognized by the current
-# selenium-webdriver and so some extensions like `execute_cdp` are
-# missing. This wil be fixed in next selenium-webdriver version. See
-# https://github.com/SeleniumHQ/selenium/pull/13271 for more information.
-#
-# In the meantime, registering a :chrome_headless_new driver which uses the
-# `headless=new` flag for tests that need it.
-register_chrome "en", name: :chrome_headless_new, headless: "new"
-
 # Register mocking proxy driver
 register_chrome "en", name: :chrome_billy do |options|
   options.add_argument("proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")


### PR DESCRIPTION
`rspec ./modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb:83`

is flickering on test runs on the CI. Haven't been able to reproduce it locally once. So the change for now is just a cleanup which might or might not have anything to do with the issue.