### PR TITLE
Attempt to stabilize flickering gantt menu spec by retrying

### DIFF
--- a/spec/features/work_packages/table/context_menu/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_spec.rb
@@ -74,7 +74,11 @@ RSpec.describe "Work package table context menu",
         # Open context menu
         menu.expect_closed
         menu.open_for(work_package)
-        menu.expect_options "Open details view", "Open fullscreen view", "Add predecessor", "Add follower", "Show relations"
+        menu.expect_options "Open details view",
+                            "Open fullscreen view",
+                            "Add predecessor",
+                            "Add follower",
+                            "Show relations"
         menu.expect_no_options "Log time"
 
         # Show relations tab when selecting show-relations from menu

--- a/spec/support/components/work_packages/context_menu.rb
+++ b/spec/support/components/work_packages/context_menu.rb
@@ -41,12 +41,16 @@ module Components
         find("body").send_keys :escape
         sleep 0.5 unless using_cuprite?
 
-        if card_view
-          page.find(".op-wp-single-card-#{work_package.id}").right_click
-        else
-          page.find(".wp-row-#{work_package.id}-table").right_click
-        end
+        retry_block do
+          if card_view
+            page.find(".op-wp-single-card-#{work_package.id}").right_click
+          else
+            page.find(".wp-row-#{work_package.id}-table").right_click
+          end
 
+          raise "Menu not open" unless page.find(:menu, work_package_context_menu_label)
+        end
+      rescue StandardError
         expect_open
       end
 


### PR DESCRIPTION
The flickering spec is 

```
rspec ./spec/features/work_packages/table/context_menu/context_menu_spec.rb:68
```

Unable to reproduce it locally. The attempt is thus based on retrying.