### PR TITLE
Allow creating users from the authSource link

### DIFF
--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -184,7 +184,7 @@ module API
         ##
         # Used while parsing JSON to initialize `ldap_auth_source_id` through the given link.
         def initialize_embedded_links!(data)
-          ldap_auth_source_id = parse_auth_source_id data, "auth_source"
+          ldap_auth_source_id = parse_auth_source_id(data, "authSource") || parse_auth_source_id(data, "auth_source")
 
           if ldap_auth_source_id
             auth_source = LdapAuthSource.find_by_unique(ldap_auth_source_id) # rubocop:disable Rails/DynamicFindBy


### PR DESCRIPTION
For historical erroneous reasons, we allowed parsing auth source links from "auth_source", not "authSource".