### PR TITLE
[54128] Text editor is partially out of view on mobile

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/form-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/form-field.sass
@@ -45,6 +45,7 @@
 
     > *
       flex-grow: 1
+      overflow: hidden
 
   &--description
     @include spot-caption


### PR DESCRIPTION
Avoid ckEditor (and other inputs) to overflow on mobile

https://community.openproject.org/projects/14/work_packages/54128/activity