### PR TITLE
[51447] Use same headings for permissions report and role forms

### DIFF
--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -44,4 +44,13 @@ module RolesHelper
     perms.group_by { |p| p.project_module.to_s }
          .slice(*enabled_module_names)
   end
+
+  def permission_header_for_project_module(mod)
+    if mod.blank?
+      Project.model_name.human
+    else
+      I18n.t("permission_header_for_project_module_#{mod}",
+             default: [:"project_module_#{mod}", mod.humanize])
+    end
+  end
 end

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -29,13 +29,13 @@ See COPYRIGHT and LICENSE files for more details.
 <% permissions.each do |mod, mod_permissions| %>
   <% global_prefix = show_global_role ? 'fieldset--global--' : 'fieldset--' %>
   <% module_name = mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : global_prefix + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>
-  <% module_id = module_name.parameterize  %>
+  <% module_id = module_name.parameterize %>
   <fieldset class="form--fieldset -collapsible" id="<%= module_id %>">
     <legend class="form--fieldset-legend">
-      <% if mod.blank? %>
-        <%= show_global_role ? t(:label_global) : Project.model_name.human %>
+      <% if show_global_role && mod.blank? %>
+        <%= t(:label_global) %>
       <% else %>
-        <%= I18n.t("permission_header_for_project_module_#{mod}", default: l_or_humanize(mod, prefix: 'project_module_')) %>
+        <%= permission_header_for_project_module(mod) %>
       <% end %>
     </legend>
     <div class="form--toolbar">

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -40,9 +40,9 @@ See COPYRIGHT and LICENSE files for more details.
   <% group_permissions_by_module(@permissions).each do |mod, mod_permissions| %>
     <% module_name = mod.blank? ? "form--" + I18n.t('attributes.project') : "form--" + l_or_humanize(mod, prefix: 'project_module_').gsub(' ','_') %>
     <% escaped_name = module_name.parameterize %>
-    <fieldset class="form--fieldset -collapsible" id= "<%= escaped_name %>">
-      <legend class="form--fieldset-legend" >
-        <%= mod.blank? ? I18n.t('attributes.project') : l_or_humanize(mod, prefix: 'project_module_') %>
+    <fieldset class="form--fieldset -collapsible" id="<%= escaped_name %>">
+      <legend class="form--fieldset-legend">
+        <%= permission_header_for_project_module(mod) %>
       </legend>
       <div class="form--toolbar">
         <span class="form--toolbar-item">

--- a/modules/storages/spec/features/storages_module_spec.rb
+++ b/modules/storages/spec/features/storages_module_spec.rb
@@ -44,11 +44,19 @@ RSpec.describe "Storages module", :js, :with_cuprite do
 
   current_user { user }
 
-  shared_examples_for "content section has storages module" do |is_upcase = false|
+  shared_examples_for "content section has storages module" do
     it 'must show "storages" in content section' do
       within "#content" do
         text = I18n.t(:project_module_storages)
-        expect(page).to have_text(is_upcase ? text.upcase : text)
+        expect(page).to have_text(text)
+      end
+    end
+  end
+
+  shared_examples_for "content section has storages permission header" do
+    it 'must show "Automatically managed project folders" in content section' do
+      within "#content" do
+        expect(page).to have_text(I18n.t(:permission_header_for_project_module_storages).upcase)
       end
     end
   end
@@ -61,10 +69,10 @@ RSpec.describe "Storages module", :js, :with_cuprite do
     end
   end
 
-  shared_examples_for "has storages module" do |sections: %i[content sidebar], is_upcase: false|
+  shared_examples_for "has storages module" do |sections: %i[content sidebar]|
     before { visit(path) }
 
-    include_examples "content section has storages module", is_upcase if sections.include?(:content)
+    include_examples "content section has storages module" if sections.include?(:content)
     include_examples "sidebar has storages module" if sections.include?(:sidebar)
   end
 
@@ -90,29 +98,21 @@ RSpec.describe "Storages module", :js, :with_cuprite do
     end
 
     context "when creating a new role" do
-      it 'must have appropriate storage permissions header in content section' do
-        visit new_role_path
+      before { visit new_role_path }
 
-        within "#content" do
-          expect(page).to have_text(I18n.t(:permission_header_for_project_module_storages).upcase)
-        end
-      end
+      include_examples "content section has storages permission header"
     end
 
     context "when editing a role" do
-      it 'must have appropriate storage permissions header in content section' do
-        visit edit_role_path(role)
+      before { visit edit_role_path(role) }
 
-        within "#content" do
-          expect(page).to have_text(I18n.t(:permission_header_for_project_module_storages).upcase)
-        end
-      end
+      include_examples "content section has storages permission header"
     end
 
-    context "when showing the role permissions report" do
-      it_behaves_like "has storages module", sections: [:content], is_upcase: true do
-        let(:path) { report_roles_path(role) }
-      end
+    context "when showing the permissions report" do
+      before { visit report_roles_path }
+
+      include_examples "content section has storages permission header"
     end
   end
 


### PR DESCRIPTION
https://community.openproject.org/wp/51447

The pages are now showing the same headings (and using the same code to render them)

Before:

![image](https://github.com/opf/openproject/assets/176055/5a5c5286-2618-412b-8530-e19e0ab219d5)

After:

![image](https://github.com/opf/openproject/assets/176055/9375a51c-9030-4536-ba0e-6e2afec32ad1)
