### PR TITLE
[54746] Typeahead options overlying typed in field in column selection

### DIFF
--- a/app/components/projects/configure_view_modal_component.html.erb
+++ b/app/components/projects/configure_view_modal_component.html.erb
@@ -20,20 +20,18 @@
         <% tab_panel.with_tab(selected: true, id: "tab-selects") do |tab| %>
           <% tab.with_text { I18n.t("label_columns") } %>
           <% tab.with_panel do %>
-            <div id="op-draggable-autocomplete-container">
-              <%= helpers.angular_component_tag 'opce-draggable-autocompleter',
-                                            inputs: {
-                                              options: helpers.projects_columns_options,
-                                              selected: selected_columns,
-                                              protected: helpers.protected_projects_columns_options,
-                                              name: COLUMN_HTML_NAME,
-                                              id: 'columns-select',
-                                              inputLabel: I18n.t(:'queries.configure_view.columns.input_label'),
-                                              inputPlaceholder: I18n.t(:'queries.configure_view.columns.input_placeholder'),
-                                              dragAreaLabel: I18n.t(:'queries.configure_view.columns.drag_area_label'),
-                                              appendToComponent: true
-                                            }%>
-            </div>
+            <%= helpers.angular_component_tag 'opce-draggable-autocompleter',
+                                          inputs: {
+                                            options: helpers.projects_columns_options,
+                                            selected: selected_columns,
+                                            protected: helpers.protected_projects_columns_options,
+                                            name: COLUMN_HTML_NAME,
+                                            id: 'columns-select',
+                                            inputLabel: I18n.t(:'queries.configure_view.columns.input_label'),
+                                            inputPlaceholder: I18n.t(:'queries.configure_view.columns.input_placeholder'),
+                                            dragAreaLabel: I18n.t(:'queries.configure_view.columns.drag_area_label'),
+                                            appendToComponent: true
+                                          }%>
           <% end %>
         <% end %>
         <% tab_panel.with_tab(id: "tab-selects") do |tab| %>


### PR DESCRIPTION
Remove ID from the container around the draggable autocompleter as the component will do that itself. The doubled ID caused confusion in the positioning of the dropdown

https://community.openproject.org/projects/openproject/work_packages/54746/activity