### PR TITLE
Exclude text custom fields from sorting

### DIFF
--- a/app/components/queries/sort_by_field_component.html.erb
+++ b/app/components/queries/sort_by_field_component.html.erb
@@ -2,7 +2,7 @@
   <% flex.with_column(flex: 1) do %>
     <%#- We are just using the classes of the primer component here, because when using the primer component, we cannot detach the input element from the form %>
     <%#- The form="none" adds the input to a nonexistant form (as we do not have one with the ID="none" and thus the fields to not get appended to the query string %>
-    <%= select_tag 'sort_field', select_options, include_blank: true, form: "none", class: "FormControl-select FormControl-medium FormControl--fullWidth", data: { action: "change->sort-by-config#fieldChanged"} %>
+    <%= select_tag 'sort_field', select_options, prompt: "-", form: "none", class: "FormControl-select FormControl-medium FormControl--fullWidth", data: { action: "change->sort-by-config#fieldChanged"} %>
   <% end %>
   <% flex.with_column do %>
     <%= render(Primer::Alpha::SegmentedControl.new("aria-label": "Sort order", hide_labels: true, ml: 3)) do |sort_buttons| %>


### PR DESCRIPTION
As discussed in https://community.openproject.org/projects/openproject/work_packages/55015/activity we want to exclude long texts from custom field ordering

---

Also includes review feedback that the empty option is hardly selectable. So we use the `-` that we also use in WorkPackage configuríng