### PR TITLE
[54128] Hide overflowing textareas but not select fields

### DIFF
--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/formattable-textarea-input.component.scss
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/formattable-textarea-input.component.scss
@@ -1,0 +1,3 @@
+:host {
+  overflow: hidden;
+}

--- a/frontend/src/app/spot/styles/sass/components/form-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/form-field.sass
@@ -45,7 +45,6 @@
 
     > *
       flex-grow: 1
-      overflow: hidden
 
   &--description
     @include spot-caption


### PR DESCRIPTION
Make overflow rule more specific to the textarea field where it is needed. Otherwise the dropdown of select fields will also be hidden

https://community.openproject.org/projects/openproject/work_packages/54128/activity