### PR TITLE
Lookbook is missing Primer styles

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -38,7 +38,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= content_tag :body,
                 class: 'viewcomponent-preview',
-                data: { controller: "application" },
+                data: {
+                  controller: "application",
+                  "color-mode": "auto",
+                  "light-theme": "light",
+                },
                 style: styles.join(";") do %>
   <section class="viewcomponent-preview--content">
     <%= yield %>


### PR DESCRIPTION
Set data attributes on the preview body to ensure that the correct Primer variables are loaded

### Before
<img width="1068" alt="Bildschirmfoto 2024-05-14 um 11 52 42" src="https://github.com/opf/openproject/assets/7457313/543a50e9-ad66-43de-8159-705331691030">

### After
<img width="1069" alt="Bildschirmfoto 2024-05-14 um 11 54 13" src="https://github.com/opf/openproject/assets/7457313/08930550-d348-4317-8431-1525e9340f06">

