### PR TITLE
fix[Op#52098]: Invalidate form validity when direct upload is too large

### DIFF
--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -65,6 +65,13 @@ module Bim
       end
 
       def set_direct_upload_file_name
+        if params[:filesize].to_i > Setting.attachment_max_size.to_i.kilobytes
+          render json: { error: I18n.t("activerecord.errors.messages.file_too_large",
+                                       count: Setting.attachment_max_size.to_i.kilobytes) },
+                 status: :unprocessable_entity
+          return
+        end
+
         session[:pending_ifc_model_title] = params[:title]
         session[:pending_ifc_model_is_default] = params[:isDefault]
       end

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
@@ -62,6 +62,10 @@ See COPYRIGHT and LICENSE files for more details.
         fileName = fileNameField[0].files[0].name;
       }
 
+      <%# Reset the form validity %>
+      <%# See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity %>
+      fileNameField[0].setCustomValidity('');
+
       var titleField = jQuery("#bim_ifc_models_ifc_model_title");
 
       <%# When creating a new model, there is no titleField. %>
@@ -86,11 +90,19 @@ See COPYRIGHT and LICENSE files for more details.
         },
         data: {
           title: title,
-          isDefault: jQuery("#bim_ifc_models_ifc_model_is_default").is(":checked") ? 1 : 0
+          isDefault: jQuery("#bim_ifc_models_ifc_model_is_default").is(":checked") ? 1 : 0,
+          filesize: fileNameField[0].files[0].size
         },
         statusCode: {
           401: function(resp, status, error) {
             document.location.reload(); // reload to make user login again
+          }
+        },
+        error: function(jqXHR, ajaxOptions, errorThrown) {
+          if (jqXHR.status == 422) {
+            var errorMessage = jqXHR.responseJSON.error;
+            fileNameField[0].setCustomValidity(errorMessage);
+            fileNameField[0].reportValidity();
           }
         }
       });

--- a/modules/bim/spec/features/ifc_models/regular_ifc_upload_spec.rb
+++ b/modules/bim/spec/features/ifc_models/regular_ifc_upload_spec.rb
@@ -32,5 +32,17 @@ require_relative "ifc_upload_shared_examples"
 RSpec.describe "IFC upload", :js, with_config: { edition: "bim" } do
   it_behaves_like "can upload an IFC file" do
     let(:model_name) { "minimal.ifc" }
+
+    context "when the file size exceeds the allowed maximum", with_settings: { attachment_max_size: 1 } do
+      it "renders an error message" do
+        visit new_bcf_project_ifc_model_path(project_id: project.identifier)
+
+        page.attach_file("file", ifc_fixture.path, visible: :all)
+
+        click_on "Create"
+
+        expect(page).to have_content("IFC file is too large (maximum size is 1024 Bytes).")
+      end
+    end
   end
 end


### PR DESCRIPTION
### https://community.openproject.org/wp/52098

Backport https://github.com/opf/openproject/pull/15411