### PR TITLE
rename persisted project query

### DIFF
--- a/app/components/filters_component.html.erb
+++ b/app/components/filters_component.html.erb
@@ -6,6 +6,7 @@
   <div class="op-filters-header">
     <%= render(Primer::Beta::Button.new(
       scheme: :secondary,
+      disabled:,
       data: { 'filters-target': 'filterFormToggle',
             'action': 'filters#toggleDisplayFilters',
             'test-selector': 'filter-component-toggle' })) do %>

--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -30,6 +30,7 @@
 
 class FiltersComponent < ApplicationComponent
   options :query
+  options :disabled
   options output_format: "params"
 
   renders_many :buttons, lambda { |**system_arguments|

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -29,6 +29,15 @@
                                 "aria-label": t(:label_more),
                                 data: { "test-selector": "project-more-dropdown-menu" }
                               })  do |menu|
+        if can_rename?
+          menu.with_item(
+            label: t('button_rename'),
+            href: edit_projects_query_path(query),
+          ) do |item|
+            item.with_leading_visual_icon(icon: :pencil)
+          end
+        end
+
         if gantt_portfolio_project_ids.any?
           menu.with_item(
             tag: :a,
@@ -92,7 +101,7 @@
     render(Primer::OpenProject::PageHeader.new) do |header|
       header.with_title(data: { 'test-selector': 'project-query-name'}) do
         primer_form_with(model: query,
-                         url: projects_queries_path,
+                         url: @query.new_record? ? projects_queries_path : projects_query_path(@query),
                          scope: 'query',
                          data: {
                            controller: "params-from-query",
@@ -100,7 +109,7 @@
                            'params-from-query-allowed-value': '["filters", "columns", "query_id", "sortBy"]'
                          },
                          id: 'project-save-form') do |f|
-          render(Queries::Projects::Create.new(f))
+          render(Queries::Projects::Form.new(f, query:))
         end
       end
       header.with_breadcrumbs(breadcrumb_items)

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -32,7 +32,7 @@
         if can_rename?
           menu.with_item(
             label: t('button_rename'),
-            href: edit_projects_query_path(query),
+            href: rename_projects_query_path(query),
           ) do |item|
             item.with_leading_visual_icon(icon: :pencil)
           end

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -37,9 +37,7 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
                 :state,
                 :params
 
-  STATE_DEFAULT = :show
-  STATE_EDIT = :edit
-  STATE_OPTIONS = [STATE_DEFAULT, STATE_EDIT].freeze
+  STATE_OPTIONS = %i[show edit rename].freeze
 
   def initialize(current_user:, query:, params:, state: :show)
     super
@@ -74,7 +72,7 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def can_save? = can_save_as? && query.persisted? && query.user == current_user
 
-  def can_rename? = may_save_as? && query.persisted? && query.user == current_user
+  def can_rename? = may_save_as? && query.persisted? && query.user == current_user && !query.changed?
 
   def show_state?
     state == :show

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -75,6 +75,8 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def can_save? = can_save_as? && query.persisted? && query.user == current_user
 
+  def can_rename? = may_save_as? && query.persisted? && query.user == current_user
+
   def show_state?
     state == :show
   end

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -31,7 +31,6 @@
 class Projects::IndexPageHeaderComponent < ApplicationComponent
   include OpPrimer::ComponentHelpers
   include Primer::FetchOrFallbackHelper
-  include Menus::ProjectsHelper
 
   attr_accessor :current_user,
                 :query,
@@ -91,15 +90,19 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
   def current_breadcrumb_element
     return page_title if query.name.blank?
 
-    current_object = first_level_menu_items.find do |section|
-      section.children.any?(&:selected)
-    end
-
-    if current_object && current_object.header.present?
-      I18n.t("menus.breadcrumb.nested_element", section_header: current_object.header, title: query.name).html_safe
+    if current_section && current_section.header.present?
+      I18n.t("menus.breadcrumb.nested_element", section_header: current_section.header, title: query.name).html_safe
     else
       page_title
     end
+  end
+
+  def current_section
+    return @current_section if defined?(@current_section)
+
+    projects_menu = Menus::Projects.new(controller_path:, params:, current_user:)
+
+    @current_section = projects_menu.first_level_menu_items.find { |section| section.children.any?(&:selected) }
   end
 
   def header_save_action(header:, message:, label:, href:, method: nil)

--- a/app/controllers/projects/menus_controller.rb
+++ b/app/controllers/projects/menus_controller.rb
@@ -27,13 +27,14 @@
 # ++
 module Projects
   class MenusController < ApplicationController
-    include Menus::ProjectsHelper
-
     # No authorize as every user (or logged in user)
     # is allowed to see the menu.
 
     def show
-      @sidebar_menu_items = first_level_menu_items
+      projects_menu = Menus::Projects.new(controller_path: params[:controller_path], params:, current_user:)
+
+      @sidebar_menu_items = projects_menu.first_level_menu_items
+
       render layout: nil
     end
   end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -34,7 +34,7 @@ class Projects::QueriesController < ApplicationController
   before_action :find_query, only: %i[edit update destroy]
   before_action :build_query_or_deny_access, only: %i[new create]
 
-  current_menu_item [:new, :create] do
+  current_menu_item [:new, :edit, :create, :update] do
     :projects
   end
 

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -31,10 +31,10 @@ class Projects::QueriesController < ApplicationController
 
   # No need for a more specific authorization check. That is carried out in the contracts.
   before_action :require_login
-  before_action :find_query, only: %i[edit update destroy]
+  before_action :find_query, only: %i[rename update destroy]
   before_action :build_query_or_deny_access, only: %i[new create]
 
-  current_menu_item [:new, :edit, :create, :update] do
+  current_menu_item [:new, :rename, :create, :update] do
     :projects
   end
 
@@ -44,10 +44,10 @@ class Projects::QueriesController < ApplicationController
            locals: { query: @query, state: :edit }
   end
 
-  def edit
+  def rename
     render template: "/projects/index",
            layout: "global",
-           locals: { query: @query, state: :edit }
+           locals: { query: @query, state: :rename }
   end
 
   def create

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -31,7 +31,7 @@ class Projects::QueriesController < ApplicationController
 
   # No need for a more specific authorization check. That is carried out in the contracts.
   before_action :require_login
-  before_action :find_query, only: %i[update destroy]
+  before_action :find_query, only: %i[edit update destroy]
   before_action :build_query_or_deny_access, only: %i[new create]
 
   current_menu_item [:new, :create] do
@@ -39,6 +39,12 @@ class Projects::QueriesController < ApplicationController
   end
 
   def new
+    render template: "/projects/index",
+           layout: "global",
+           locals: { query: @query, state: :edit }
+  end
+
+  def edit
     render template: "/projects/index",
            layout: "global",
            locals: { query: @query, state: :edit }

--- a/app/forms/queries/projects/form.rb
+++ b/app/forms/queries/projects/form.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-class Queries::Projects::Create < ApplicationForm
+class Queries::Projects::Form < ApplicationForm
   include OpenProject::StaticRouting::UrlHelpers
 
   form do |query_form|
@@ -52,8 +52,13 @@ class Queries::Projects::Create < ApplicationForm
         label: I18n.t(:button_cancel),
         tag: :a,
         data: { "params-from-query-target": "anchor" },
-        href: OpenProject::StaticRouting::StaticUrlHelpers.new.projects_path
+        href: projects_path(query_id: @query)
       )
     end
+  end
+
+  def initialize(query:)
+    super()
+    @query = query
   end
 end

--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -35,6 +35,8 @@ class Queries::Projects::Factory
   STATIC_OFF_TRACK = "off_track".freeze
   STATIC_AT_RISK = "at_risk".freeze
 
+  DEFAULT_STATIC = STATIC_ACTIVE
+
   class << self
     def find(id, params:, user:, duplicate: false)
       find_static_query_and_set_attributes(id, params, user, duplicate:) ||

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -39,20 +39,24 @@ See COPYRIGHT and LICENSE files for more details.
       )
   %>
 
-  <%= render(Projects::ProjectsFiltersComponent.new(query:)) do |component|
-    if current_user.allowed_globally?(:add_project)
-      component.with_button(
-        tag: :a,
-        href: new_project_path,
-        scheme: :primary,
-        size: :medium,
-        aria: { label: I18n.t(:label_project_new) },
-        data: { 'test-selector': 'project-new-button' }) do |button|
-        button.with_leading_visual_icon(icon: :plus)
-        Project.model_name.human
+  <%=
+    disable_extra_controls = state == :rename
+
+    render(Projects::ProjectsFiltersComponent.new(query:, disabled: disable_extra_controls)) do |component|
+      if current_user.allowed_globally?(:add_project)
+        component.with_button(
+          tag: :a,
+          href: new_project_path,
+          scheme: :primary,
+          disabled: disable_extra_controls,
+          size: :medium,
+          aria: { label: I18n.t(:label_project_new) },
+          data: { 'test-selector': 'project-new-button' }) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          Project.model_name.human
+        end
       end
     end
-  end
   %>
 
 

--- a/app/views/projects/menus/_menu.html.erb
+++ b/app/views/projects/menus/_menu.html.erb
@@ -1,5 +1,8 @@
 <%= turbo_frame_tag "projects_sidemenu",
-                    src: projects_menu_path(params.permit(:filters, :sortBy, :query_id)),
+                    src: projects_menu_path(
+                      controller_path:,
+                      **params.permit(:filters, :columns, :sortBy, :id, :query_id)
+                    ),
                     target: '_top',
                     data: { turbo: false },
                     loading: :lazy %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,11 @@ Rails.application.routes.draw do
 
   namespace :projects do
     resource :menu, only: %i[show]
-    resources :queries, only: %i[new edit create update destroy]
+    resources :queries, only: %i[new create update destroy] do
+      member do
+        get :rename
+      end
+    end
   end
 
   resources :projects, except: %i[show edit create update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Rails.application.routes.draw do
 
   namespace :projects do
     resource :menu, only: %i[show]
-    resources :queries, only: %i[new create update destroy]
+    resources :queries, only: %i[new edit create update destroy]
   end
 
   resources :projects, except: %i[show edit create update] do

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -67,6 +67,39 @@ RSpec.describe Projects::QueriesController do
     end
   end
 
+  describe "#edit" do
+    it "requires login" do
+      get "edit", params: { id: 42 }
+
+      expect(response).not_to be_successful
+    end
+
+    context "when logged in" do
+      let(:query) { build_stubbed(:project_query) }
+      let(:query_id) { "42" }
+
+      before do
+        allow(Queries::Projects::ProjectQuery).to receive(:find).with(query_id).and_return(query)
+
+        login_as user
+      end
+
+      it "renders projects/index" do
+        get "edit", params: { id: 42 }
+
+        expect(response).to render_template("projects/index")
+      end
+
+      it "passes variables to template" do
+        allow(controller).to receive(:render).and_call_original
+
+        get "edit", params: { id: 42 }
+
+        expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+      end
+    end
+  end
+
   describe "#create" do
     let(:service_class) { Queries::Projects::ProjectQueries::CreateService }
 

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe Projects::QueriesController do
     end
   end
 
-  describe "#edit" do
+  describe "#rename" do
     it "requires login" do
-      get "edit", params: { id: 42 }
+      get "rename", params: { id: 42 }
 
       expect(response).not_to be_successful
     end
@@ -85,7 +85,7 @@ RSpec.describe Projects::QueriesController do
       end
 
       it "renders projects/index" do
-        get "edit", params: { id: 42 }
+        get "rename", params: { id: 42 }
 
         expect(response).to render_template("projects/index")
       end
@@ -93,9 +93,9 @@ RSpec.describe Projects::QueriesController do
       it "passes variables to template" do
         allow(controller).to receive(:render).and_call_original
 
-        get "edit", params: { id: 42 }
+        get "rename", params: { id: 42 }
 
-        expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+        expect(controller).to have_received(:render).with(include(locals: { query:, state: :rename }))
       end
     end
   end

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -333,12 +333,22 @@ RSpec.describe "Persisted lists on projects index page",
 
     it "allows renaming persisted query" do
       projects_page.set_sidebar_filter("Persisted query")
-      projects_page.rename_to("My renamed query")
+
+      projects_page.click_more_menu_item("Rename")
+      projects_page.fill_in_the_name("My renamed query")
+      # Can't open filter changing interface
+      expect(projects_page.filters_toggle).to be_disabled
+      projects_page.click_on "Save"
 
       projects_page.expect_no_sidebar_filter("Persisted query")
       projects_page.expect_sidebar_filter("My renamed query", selected: true)
       projects_page.expect_columns("Name")
       projects_page.expect_no_columns("Status", "Public")
+
+      projects_page.open_filters
+      projects_page.filter_by_membership("yes")
+      # Rename menu item is now shown after applying filters
+      projects_page.expect_no_menu_item("Rename", visible: false)
     end
 
     it "allows deleting persisted query" do

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -214,18 +214,20 @@ RSpec.describe "Persisted lists on projects index page",
     let!(:project_member) { create(:member, principal: user, project:, roles: [developer]) }
     let!(:development_project_member) { create(:member, principal: user, project: development_project, roles: [developer]) }
 
-    it "allows saving, loading and deleting persisted filters and columns" do
+    it "allows saving, renaming, loading and deleting persisted filters and columns" do
       projects_page.visit!
 
       # The default filter is active
       projects_page.expect_title("Active projects")
-      # Since the query is static, no save button is shown
+      # Since the query is static, no save button an no menu item is shown
       projects_page.expect_no_notification("Save")
       projects_page.expect_no_menu_item("Save", visible: false)
       # Since the query is unchanged, no save as button is shown
       projects_page.expect_no_notification("Save as")
       # But save as menu item is always present
       projects_page.expect_menu_item("Save as", visible: false)
+      # Since the query is not persisted, no rename button is shown
+      projects_page.expect_no_menu_item("Rename", visible: false)
 
       # Default filters are applied
       projects_page.expect_projects_listed(project, public_project, development_project)
@@ -238,12 +240,14 @@ RSpec.describe "Persisted lists on projects index page",
 
       # By applying another filter, the title is changed as it does not longer match the default filter
       projects_page.expect_title("Projects")
-      # Since the query is static, no save button is shown
+      # Since the query is static, no save button an no menu item is shown
       projects_page.expect_no_notification("Save")
       projects_page.expect_no_menu_item("Save", visible: false)
-      # Since the query changed, save as button is shown
+      # Since the query changed, save as button and menu item are shown
       projects_page.expect_notification("Save as")
       projects_page.expect_menu_item("Save as", visible: false)
+      # Since the query is not persisted, no rename button is shown
+      projects_page.expect_no_menu_item("Rename", visible: false)
 
       # The filters are applied
       projects_page.expect_projects_listed(project, development_project)
@@ -279,6 +283,8 @@ RSpec.describe "Persisted lists on projects index page",
       projects_page.expect_no_menu_item("Save", visible: false)
       # But save as menu item is always present
       projects_page.expect_menu_item("Save as", visible: false)
+      # Since the query is persisted, rename button is shown
+      projects_page.expect_menu_item("Rename", visible: false)
 
       # Modifying to save again
       projects_page.set_columns("Name", "Public")
@@ -292,6 +298,12 @@ RSpec.describe "Persisted lists on projects index page",
 
       # Duplicating (without changes)
       projects_page.save_query_as("My duplicated query")
+      projects_page.expect_sidebar_filter("My duplicated query", selected: false)
+
+      # Renaming
+      projects_page.rename_to("My renamed query")
+      projects_page.expect_no_sidebar_filter("My duplicated query")
+      projects_page.expect_sidebar_filter("My renamed query", selected: false)
 
       # Modifying to save as again
       projects_page.set_columns("Name", "Status", "Public")
@@ -303,8 +315,8 @@ RSpec.describe "Persisted lists on projects index page",
       projects_page.expect_columns("Name", "Public")
       projects_page.expect_no_columns("Status")
 
-      # Checked duplicated query
-      projects_page.set_sidebar_filter("My duplicated query")
+      # Checked renamed query
+      projects_page.set_sidebar_filter("My renamed query")
       projects_page.expect_columns("Name", "Public")
       projects_page.expect_no_columns("Status")
 

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -213,12 +213,20 @@ RSpec.describe "Persisted lists on projects index page",
 
     let!(:project_member) { create(:member, principal: user, project:, roles: [developer]) }
     let!(:development_project_member) { create(:member, principal: user, project: development_project, roles: [developer]) }
+    let!(:persisted_query) do
+      build(:project_query, user:, name: "Persisted query")
+        .where("active", "=", "t")
+        .select("name")
+        .save!
+    end
 
-    it "allows saving, renaming, loading and deleting persisted filters and columns" do
+    before do
       projects_page.visit!
+    end
 
-      # The default filter is active
+    it "starts at active projects static query" do
       projects_page.expect_title("Active projects")
+
       # Since the query is static, no save button an no menu item is shown
       projects_page.expect_no_notification("Save")
       projects_page.expect_no_menu_item("Save", visible: false)
@@ -229,17 +237,15 @@ RSpec.describe "Persisted lists on projects index page",
       # Since the query is not persisted, no rename button is shown
       projects_page.expect_no_menu_item("Rename", visible: false)
 
-      # Default filters are applied
       projects_page.expect_projects_listed(project, public_project, development_project)
       projects_page.expect_columns("Name", "Status")
       projects_page.expect_no_columns("Public")
+    end
 
-      # Adding some filters
+    it "allows changing filters" do
       projects_page.open_filters
       projects_page.filter_by_membership("yes")
 
-      # By applying another filter, the title is changed as it does not longer match the default filter
-      projects_page.expect_title("Projects")
       # Since the query is static, no save button an no menu item is shown
       projects_page.expect_no_notification("Save")
       projects_page.expect_no_menu_item("Save", visible: false)
@@ -249,18 +255,35 @@ RSpec.describe "Persisted lists on projects index page",
       # Since the query is not persisted, no rename button is shown
       projects_page.expect_no_menu_item("Rename", visible: false)
 
-      # The filters are applied
+      # By applying another filter, the title is changed as it does not longer match the default filter
+      projects_page.expect_title("Projects")
       projects_page.expect_projects_listed(project, development_project)
       projects_page.expect_projects_not_listed(public_project)
+    end
 
+    it "allows changing columns" do
       projects_page.set_columns("Name")
+
       projects_page.expect_columns("Name")
       projects_page.expect_no_columns("Status", "Public")
+    end
 
-      # Saving the query
+    it "allows saving static query as persisted list without changes" do
+      projects_page.save_query_as("Active project copy")
+
+      projects_page.expect_sidebar_filter("Active project copy", selected: true)
+      projects_page.expect_columns("Name", "Status")
+      projects_page.expect_no_columns("Public")
+    end
+
+    it "allows saving static query as user list" do
+      projects_page.open_filters
+      projects_page.filter_by_membership("yes")
+      projects_page.set_columns("Name")
       projects_page.save_query_as("My saved query")
+
       # It will be displayed in the sidebar
-      projects_page.expect_sidebar_filter("My saved query", selected: false)
+      projects_page.expect_sidebar_filter("My saved query", selected: true)
 
       # Opening the default filter again to reset the values
       projects_page.set_sidebar_filter("Active projects")
@@ -277,59 +300,53 @@ RSpec.describe "Persisted lists on projects index page",
       projects_page.expect_projects_not_listed(public_project)
       projects_page.expect_columns("Name")
       projects_page.expect_no_columns("Status", "Public")
+
       # Since the query was not changed, no save or save as button is shown
       projects_page.expect_no_notification("Save")
-      projects_page.expect_no_notification("Save as")
       projects_page.expect_no_menu_item("Save", visible: false)
+      projects_page.expect_no_notification("Save as")
       # But save as menu item is always present
       projects_page.expect_menu_item("Save as", visible: false)
       # Since the query is persisted, rename button is shown
       projects_page.expect_menu_item("Rename", visible: false)
+    end
 
-      # Modifying to save again
-      projects_page.set_columns("Name", "Public")
-      # Since the query was changed, there is a save button and both save and save as in the menu
-      projects_page.expect_notification("Save")
-      projects_page.expect_no_notification("Save as")
-      projects_page.expect_menu_item("Save", visible: false)
-      projects_page.expect_menu_item("Save as", visible: false)
-      # Save inplace
-      projects_page.save_query
-
-      # Duplicating (without changes)
-      projects_page.save_query_as("My duplicated query")
-      projects_page.expect_sidebar_filter("My duplicated query", selected: false)
-
-      # Renaming
-      projects_page.rename_to("My renamed query")
-      projects_page.expect_no_sidebar_filter("My duplicated query")
-      projects_page.expect_sidebar_filter("My renamed query", selected: false)
-
-      # Modifying to save as again
+    it "allows saving persisted query with new name" do
+      projects_page.set_sidebar_filter("Persisted query")
       projects_page.set_columns("Name", "Status", "Public")
       projects_page.save_query_as("My new saved query")
-      projects_page.expect_sidebar_filter("My new saved query", selected: false)
 
-      # Checked query saved inplace
-      projects_page.set_sidebar_filter("My saved query")
-      projects_page.expect_columns("Name", "Public")
-      projects_page.expect_no_columns("Status")
-
-      # Checked renamed query
-      projects_page.set_sidebar_filter("My renamed query")
-      projects_page.expect_columns("Name", "Public")
-      projects_page.expect_no_columns("Status")
-
-      # Checked second saved query
-      projects_page.set_sidebar_filter("My new saved query")
+      projects_page.expect_sidebar_filter("Persisted query", selected: false)
+      projects_page.expect_sidebar_filter("My new saved query", selected: true)
       projects_page.expect_columns("Name", "Status", "Public")
+    end
 
-      # The query can be deleted
+    it "allows duplicating persisted query without changes" do
+      projects_page.set_sidebar_filter("Persisted query")
+      projects_page.save_query_as("My duplicated query")
+
+      projects_page.expect_sidebar_filter("Persisted query", selected: false)
+      projects_page.expect_sidebar_filter("My duplicated query", selected: true)
+      projects_page.expect_columns("Name")
+      projects_page.expect_no_columns("Status", "Public")
+    end
+
+    it "allows renaming persisted query" do
+      projects_page.set_sidebar_filter("Persisted query")
+      projects_page.rename_to("My renamed query")
+
+      projects_page.expect_no_sidebar_filter("Persisted query")
+      projects_page.expect_sidebar_filter("My renamed query", selected: true)
+      projects_page.expect_columns("Name")
+      projects_page.expect_no_columns("Status", "Public")
+    end
+
+    it "allows deleting persisted query" do
+      projects_page.set_sidebar_filter("Persisted query")
       projects_page.delete_query
 
-      # It will then also be removed from the sidebar
       projects_page.expect_no_sidebar_filter("My new saved query")
-      # And the default filter will be active again
+      # Default filter will be active again
       projects_page.expect_title("Active projects")
       projects_page.expect_projects_listed(project, public_project, development_project)
       projects_page.expect_columns("Name", "Status")

--- a/spec/helpers/menus/projects_spec.rb
+++ b/spec/helpers/menus/projects_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Menus::Projects do
+  let(:instance) { described_class.new(controller_path:, params:, current_user:) }
+  let(:controller_path) { "foo" }
+  let(:params) { {} }
+
+  shared_let(:current_user) { build(:user) }
+
+  shared_let(:current_user_query) do
+    Queries::Projects::ProjectQuery.create!(name: "Current user query", user: current_user)
+  end
+
+  shared_let(:other_user_query) do
+    Queries::Projects::ProjectQuery.create!(name: "Other user query", user: build(:user))
+  end
+
+  subject(:first_level_menu_items) { instance.first_level_menu_items }
+
+  it "returns 3 menu groups" do
+    expect(first_level_menu_items).to all(be_a(OpenProject::Menu::MenuGroup))
+    expect(first_level_menu_items.length).to eq(3)
+  end
+
+  describe "children items" do
+    subject(:children_menu_items) { first_level_menu_items.flat_map(&:children) }
+
+    it "contains menu items" do
+      expect(children_menu_items).to all(be_a(OpenProject::Menu::MenuItem))
+    end
+
+    it "contains item for current user query" do
+      expect(children_menu_items).to include(have_attributes(title: "Current user query"))
+    end
+
+    it "doesn't contain item for other user query" do
+      expect(children_menu_items).not_to include(have_attributes(title: "Other user query"))
+    end
+  end
+
+  describe "selected children items" do
+    subject(:selected_menu_items) { first_level_menu_items.flat_map(&:children).select(&:selected) }
+
+    context "when on homescreen page" do
+      let(:controller_path) { "homescreen" }
+
+      context "without params" do
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+
+      context "with query_id param" do
+        let(:params) { { query_id: current_user_query.id.to_s } }
+
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+
+      context "with id param" do
+        let(:params) { { id: current_user_query.id.to_s } }
+
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+    end
+
+    context "when on projects page" do
+      let(:controller_path) { "projects" }
+
+      context "without params" do
+        it "has default item selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Active projects"))
+        end
+      end
+
+      context "with id param" do
+        let(:params) { { id: current_user_query.id.to_s } }
+
+        it "has default item selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Active projects"))
+        end
+      end
+
+      context "with query_id param for active projects" do
+        let(:params) { { query_id: "active" } }
+
+        it "has active projects selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Active projects"))
+        end
+      end
+
+      context "with query_id param for at_risk projects" do
+        let(:params) { { query_id: "at_risk" } }
+
+        it "has active projects selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "At risk"))
+        end
+      end
+
+      context "with query_id param for current user query" do
+        let(:params) { { query_id: current_user_query.id.to_s } }
+
+        it "has current user query selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Current user query"))
+        end
+      end
+
+      context "with query_id param for active projects and modifications to query" do
+        let(:params) { { query_id: "active", columns: "foo" } }
+
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+
+      context "with query_id param for current user query and modifications to query" do
+        let(:params) { { query_id: current_user_query.id.to_s, columns: "foo" } }
+
+        it "has current user query selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Current user query"))
+        end
+      end
+    end
+
+    context "when on project queries page" do
+      let(:controller_path) { "projects/queries" }
+
+      context "without params" do
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+
+      context "with query_id param" do
+        let(:params) { { query_id: current_user_query.id.to_s } }
+
+        it "has no selected items" do
+          expect(selected_menu_items).to be_empty
+        end
+      end
+
+      context "with id param for current user query" do
+        let(:params) { { id: current_user_query.id.to_s } }
+
+        it "has current user query selected" do
+          expect(selected_menu_items).to contain_exactly(have_attributes(title: "Current user query"))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -262,8 +262,12 @@ module Pages
         end
       end
 
+      def filters_toggle
+        page.find('[data-test-selector="filter-component-toggle"]')
+      end
+
       def toggle_filters_section
-        page.find('[data-test-selector="filter-component-toggle"]').click
+        filters_toggle.click
       end
 
       def set_columns(*columns)
@@ -329,21 +333,15 @@ module Pages
       def save_query_as(name)
         click_more_menu_item("Save as")
 
-        within '[data-test-selector="project-query-name"]' do
-          fill_in "Name", with: name
-        end
+        fill_in_the_name(name)
 
         click_on "Save"
       end
 
-      def rename_to(name)
-        click_more_menu_item("Rename")
-
+      def fill_in_the_name(name)
         within '[data-test-selector="project-query-name"]' do
           fill_in "Name", with: name
         end
-
-        click_on "Save"
       end
 
       def delete_query

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -334,6 +334,16 @@ module Pages
         click_on "Save"
       end
 
+      def rename_to(name)
+        click_more_menu_item("Rename")
+
+        within '[data-test-selector="project-query-name"]' do
+          fill_in "Name", with: name
+        end
+
+        click_on "Save"
+      end
+
       def delete_query
         click_more_menu_item("Delete")
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -77,7 +77,9 @@ module Pages
 
       def expect_sidebar_filter(filter_name, selected: false)
         within "#main-menu" do
-          expect(page).to have_css(".op-sidemenu--item-action#{selected ? '.selected' : ''}", text: filter_name)
+          selected_specifier = selected ? ".selected" : ":not(.selected)"
+
+          expect(page).to have_css(".op-sidemenu--item-action#{selected_specifier}", text: filter_name)
         end
       end
 


### PR DESCRIPTION
[OP#51673](https://community.openproject.org/projects/openproject/work_packages/51673)

Includes rework of projects menu, with two goals - properly marking list selected from both project and project queries controller for all actions and fixing the bug with marking menu item if there was query_id param even on unrelated pages (work_packages persisted lists) or marking the «Active projects» when there were no params.

Also split huge persisting queries spec into multiple smaller ones.