### PR TITLE
Fix/limit schedule date alert jobs

### DIFF
--- a/app/workers/notifications/schedule_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/schedule_date_alerts_notifications_job.rb
@@ -50,17 +50,17 @@ module Notifications
     # between scheduled time and current time need to be considered to match
     # with 1:00am in a time zone.
     def times_from_scheduled_to_execution
-      time = scheduled_time
-      times = []
-      begin
-        times << time
-        time += 15.minutes
-      end while time < Time.current
-      times
+      (scheduled_time.to_i..Time.current.to_i)
+        .step(15.minutes)
+        .map do |time|
+        Time.zone.at(time)
+      end
     end
 
     def scheduled_time
-      job_scheduled_at.then { |t| t.change(min: t.min / 15 * 15) }
+      GoodJob::Job
+        .find(job_id)
+        .cron_at
     end
   end
 end

--- a/app/workers/notifications/schedule_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/schedule_date_alerts_notifications_job.rb
@@ -28,39 +28,83 @@
 
 module Notifications
   # Creates date alert jobs for users whose local time is 1:00 am.
+  # The job is scheduled to run every 15 minutes.
   class ScheduleDateAlertsNotificationsJob < ApplicationJob
     include GoodJob::ActiveJobExtensions::Concurrency
+
+    def perform
+      return unless EnterpriseToken.allows_to?(:date_alerts)
+
+      Service.new(every_quater_hour_between_predecessor_cron_at_and_own_cron_at).call
+    end
+
+    # With good_job and the limit of only allowing a single job to be enqueued and
+    # also a single job being performed at the same time we end up having
+    # up to two jobs that are not yet finished.
 
     good_job_control_concurrency_with(
       enqueue_limit: 1,
       perform_limit: 1
     )
 
-    def perform
-      return unless EnterpriseToken.allows_to?(:date_alerts)
-
-      Service.new(times_from_scheduled_to_execution).call
-    end
-
-    # Returns times from scheduled execution time to current time in 15 minutes
-    # steps.
+    # What cannot be controlled however is the time at which a job is actually performed.
+    # A high load on the system can lead to a job being performed later than expected.
     #
-    # As scheduled execution time can be different from current time by more
-    # than 15 minutes when workers are busy, all times at 15 minutes interval
-    # between scheduled time and current time need to be considered to match
-    # with 1:00am in a time zone.
-    def times_from_scheduled_to_execution
-      (scheduled_time.to_i..Time.current.to_i)
+    # It might also happen that due to some outage of the background workers, cron
+    # jobs are not enqueued as they should be.
+    #
+    # But we want to achieve even under these circumstances that date alerts are sent out
+    # for all the users even if we cannot guarantee that they are sent out at the time where we want it to happen
+    # which would be 1:00 am. At the same time we want to prevent date alerts being sent out multiple times.
+    #
+    # There are three scenarios to consider which mostly circle around the predecessor
+    # of the job that is currently run:
+    # * The predecessor ran successfully within the 15 minutes interval between it being scheduled and the current job
+    #   having to run. If this is the case, then the current job will only have to handle only the point in time of
+    #   its cron_at value.
+    # * The predecessor took longer to run than 15 minutes or was scheduled to run at a later time (because its)
+    #   predecessor was delayed. This will potentially lead to the current job also being delayed. If this is the case,
+    #   then the current job will have to handle all the 15 minute slots between its cron_at value and the cron_at value
+    #   of its predecessor + 15 minutes.
+    # * There is no predecessor since it is the first job ever to run or for some reasons the GoodJob::Execution where
+    #   salvaged. In this case there is no certainty as to what is the right choice which is why the cron_at value of
+    #   the current job is again used as the sole point in time to consider.
+    #
+    # In other words, the current job will take the
+    # * cron_at value of the current job as the maximum time to consider.
+    # * Take the cron_at of the previous job + 15 minutes as the minimum time to consider.
+    # If no previous job exists, then the cron_at of the current job is the minimum.
+    #
+    # Using this pattern, between all the instances of this job, every time slot where there is the potential
+    # for 1:00 am local time are covered. The sole exception would be the case where previously finished jobs
+    # have been removed from the database and the current job took longer to start executing. This is for now
+    # an accepted shortcoming as the likelihood of this happening is considered to be very low.
+    def every_quater_hour_between_predecessor_cron_at_and_own_cron_at
+      (lower_boundary.to_i..upper_boundary.to_i)
         .step(15.minutes)
         .map do |time|
         Time.zone.at(time)
       end
     end
 
-    def scheduled_time
+    def upper_boundary
       GoodJob::Job
         .find(job_id)
         .cron_at
+    end
+
+    def lower_boundary
+      predecessor = GoodJob::Job
+                    .succeeded
+                    .where(job_class: self.class.name)
+                    .order(cron_at: :desc)
+                    .first
+
+      if predecessor
+        predecessor.cron_at + 15.minutes
+      else
+        upper_boundary
+      end
     end
   end
 end

--- a/app/workers/notifications/schedule_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/schedule_date_alerts_notifications_job.rb
@@ -29,6 +29,13 @@
 module Notifications
   # Creates date alert jobs for users whose local time is 1:00 am.
   class ScheduleDateAlertsNotificationsJob < ApplicationJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      enqueue_limit: 1,
+      perform_limit: 1
+    )
+
     def perform
       return unless EnterpriseToken.allows_to?(:date_alerts)
 


### PR DESCRIPTION
Safeguards against having too many `ScheduleDateAlertsNotificationsJob` instances by applying GoodJob's concurrency limitations. Doing so leads to always only having max one such job executed at the same time and max one such job queued. That queued job might get automatically rescheduled by GoodJob if the currently active job is still busy. 

The change also prevents multiple jobs covering the same time interval. Now, a job will only consider time zones which are between the `cron_at` value of the previous job + 15 minutes till the `cron_at` value of the currently executed job. The cron_at value is independent of when the job is actually run so it is safe against delays. It is also safe against cases where one or multiple jobs are missed to be scheduled.

There is more explanation within the comments next to the code

--- 

https://community.openproject.org/wp/55101