### PR TITLE
Change confirmation text when section is empty

### DIFF
--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -145,11 +145,17 @@ module MeetingSections
     end
 
     def delete_action_item(menu)
+      confirm_text =
+        if @meeting_section.agenda_items.any?
+          t("meeting_section.delete_confirmation")
+        else
+          t("text_are_you_sure")
+        end
       menu.with_item(label: t("text_destroy"),
                      scheme: :danger,
                      href: meeting_section_path(@meeting_section.meeting, @meeting_section),
                      form_arguments: {
-                       method: :delete, data: { confirm: t("meeting_section.delete_confirmation"), "turbo-stream": true,
+                       method: :delete, data: { confirm: confirm_text, "turbo-stream": true,
                                                 test_selector: "meeting-section-delete" }
                      }) do |item|
         item.with_leading_visual_icon(icon: :trash)


### PR DESCRIPTION
We decided to not show the warning with agenda items, when there are no agenda items contained in the section