### PR TITLE
[55132] Disabled Primer button styles not displayed correctly

### DIFF
--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -40,6 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% if design_color.variable == "primary-button-color" %>
         --primary-button-color--major1: <%= design_color.darken 0.18 %>;
         --primary-button-color--minor1: <%= design_color.lighten 0.8 %>;
+        --primary-button-color--minor2: <%= design_color.lighten 0.6 %>;
     <% end %>
     <% if design_color.variable == "accent-color" %>
         --accent-color--major1: <%= design_color.darken 0.2 %>;

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -16,6 +16,7 @@
     --button-primary-bgColor-rest: var(--button--primary-background-color) !important;
     --button-primary-bgColor-hover: var(--button--primary-background-hover-color) !important;
     --button-primary-bgColor-disabled: var(--button--primary-background-disabled-color) !important;
+    --button-primary-borderColor-disabled: var(--button--primary-border-disabled-color) !important;
   }
   [data-light-theme=light_high_contrast]{
     --avatar-border-color: var(--avatar-borderColor);

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -31,6 +31,8 @@
 :root {
   --primary-button-color: #1F883D;
   --primary-button-color--major1: #197032;
+  --primary-button-color--minor1: #d2e7d8;
+  --primary-button-color--minor2: #a5cfb1;
 
   --control-checked-color: var(--accent-color);
   --control-checked-color--major1: var(--accent-color--major1);
@@ -128,7 +130,8 @@
   --button--active-border-color: #cacaca;
   --button--primary-background-color: var(--primary-button-color);
   --button--primary-background-hover-color: var(--primary-button-color--major1);
-  --button--primary-background-disabled-color: var(--primary-button-color--minor1);
+  --button--primary-background-disabled-color: var(--primary-button-color--minor2);
+  --button--primary-border-disabled-color: var(--primary-button-color--minor2);
   --button--primary-font-color: var(--font-color-on-primary);
   --generic-table--header-font-size: 0.875rem;
   --generic-table--header-height: 45px;


### PR DESCRIPTION
Use darker version for disabled primary button style and set border as well

https://community.openproject.org/projects/openproject/work_packages/55132/activity

### Before
<img width="113" alt="Bildschirmfoto 2024-05-17 um 13 10 23" src="https://github.com/opf/openproject/assets/7457313/2f3e43d6-fd8e-4fa6-81af-546ce2850747">


### After 
<img width="142" alt="Bildschirmfoto 2024-05-17 um 13 09 59" src="https://github.com/opf/openproject/assets/7457313/8486d85a-6bf1-4efb-b8bd-5908ad40e3f0">
