### PR TITLE
Fix/limit schedule reminder mail jobs

### DIFF
--- a/app/workers/cron/quarter_hour_schedule_job.rb
+++ b/app/workers/cron/quarter_hour_schedule_job.rb
@@ -40,6 +40,13 @@ module Cron::QuarterHourScheduleJob
       enqueue_limit: 1,
       perform_limit: 1
     )
+
+    # The job is scheduled to run every 15 minutes. If the job before takes longer
+    # than expected we retry two more times (at cron_at + 5 and cron_at + 15). Then the job is discarded.
+    # Once the job is discarded, the next job will be scheduled to run at the next quarter hour.
+    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+             wait: 5.minutes,
+             attempts: 3
   end
 
   private

--- a/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
+++ b/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
@@ -29,48 +29,92 @@
 require "spec_helper"
 
 RSpec.describe Notifications::ScheduleReminderMailsJob, type: :job do
-  let(:scheduled_job) { described_class.perform_later }
+  let(:scheduled_job) do
+    described_class.perform_later.tap do |job|
+      set_cron_time(job, job_cron_at)
+      GoodJob.perform_inline
+    end
+  end
+  let(:job_cron_at) { Time.current.then { |t| t.change(min: t.min / 15 * 15) } }
+
+  let(:previous_job) do
+    described_class.perform_later.tap do |job|
+      GoodJob.perform_inline
+      set_cron_time(job, previous_job_cron_at)
+    end
+  end
+
   let(:ids) { [23, 42] }
 
   before do
     # We need to access the job as stored in the database to get at the scheduled_at time persisted there
     ActiveJob::Base.disable_test_adapter
-    scheduled_job
 
     scope = instance_double(ActiveRecord::Relation)
     allow(User).to receive(:having_reminder_mail_to_send).and_return(scope)
     allow(scope).to receive(:pluck).with(:id).and_return(ids)
   end
 
+  def set_cron_time(job, cron_at)
+    GoodJob::Job
+      .where(id: job.job_id)
+      .update_all(cron_at:)
+  end
+
   describe "#perform" do
     shared_examples_for "schedules reminder mails" do
-      it "schedules reminder jobs for every user with a reminder mails to be sent" do
-        expect { GoodJob.perform_inline }.to change(GoodJob::Job, :count).by(2)
+      it "schedules reminder jobs for every user with a reminder mail to be sent" do
+        expect { scheduled_job }
+          .to change(GoodJob::Job.where(job_class: "Mails::ReminderJob"), :count)
+                .by(2)
 
         arguments_from_both_jobs =
           GoodJob::Job.where(job_class: "Mails::ReminderJob")
-                      .flat_map {|i| i.serialized_params["arguments"]}
+                      .flat_map { |i| i.serialized_params["arguments"] }
                       .sort
         expect(arguments_from_both_jobs).to eq(ids)
       end
 
       it "queries with the intended job execution time (which might have been missed due to high load)" do
-        GoodJob.perform_inline
+        scheduled_job
 
-        expect(User).to have_received(:having_reminder_mail_to_send).with(scheduled_job.job_scheduled_at)
+        expect(User)
+          .to have_received(:having_reminder_mail_to_send)
+                .with(expected_lower_boundary, expected_upper_boundary)
       end
     end
 
-    it_behaves_like "schedules reminder mails"
+    context "when there is no predecessor job" do
+      it_behaves_like "schedules reminder mails" do
+        let(:expected_lower_boundary) { job_cron_at }
+        let(:expected_upper_boundary) { job_cron_at }
+      end
+    end
 
-    context "with a job that missed some runs" do
+    context "when there is a predecessor job with a cron_at 15 min before" do
+      let(:previous_job_cron_at) { job_cron_at - 15.minutes }
+
       before do
-        GoodJob::Job
-          .where(id: scheduled_job.job_id)
-          .update_all(scheduled_at: scheduled_job.job_scheduled_at - 3.hours)
+        previous_job
       end
 
-      it_behaves_like "schedules reminder mails"
+      it_behaves_like "schedules reminder mails" do
+        let(:expected_lower_boundary) { previous_job_cron_at + 15.minutes }
+        let(:expected_upper_boundary) { job_cron_at }
+      end
+    end
+
+    context "when there is a predecessor job with a cron_at 2 hours before" do
+      let(:previous_job_cron_at) { job_cron_at - 2.hours }
+
+      before do
+        previous_job
+      end
+
+      it_behaves_like "schedules reminder mails" do
+        let(:expected_lower_boundary) { previous_job_cron_at + 15.minutes }
+        let(:expected_upper_boundary) { job_cron_at }
+      end
     end
   end
 end


### PR DESCRIPTION
Applies the same pattern as done for the `ScheduleDateAlertsNotificationsJob` in #15573 to the `ScheduleReminderMailsJob`. It now also takes the time between the two cron_at values to be the boundaries in which the job operates.

The similarities of the two jobs are now extracted into a shared module. 

In order to avoid a single job being retried indefinitely a [`retry_on` limit is added](https://github.com/opf/openproject/compare/release/14.1...fix/limit_schedule_reminder_mail_jobs?expand=1#diff-0fd1663714342168a70bbbd898374fb1a2609f3ad6767f36485275133dc44eeaR47-R49)

 