### PR TITLE
Makes sure jobs are eventually discarded when concurrency happens

### DIFF
--- a/app/workers/mails/reminder_job.rb
+++ b/app/workers/mails/reminder_job.rb
@@ -28,6 +28,9 @@
 
 class Mails::ReminderJob < Mails::DeliverJob
   include ::Notifications::WithMarkedNotifications
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with total_limit: 1
 
   private
 

--- a/app/workers/mails/reminder_job.rb
+++ b/app/workers/mails/reminder_job.rb
@@ -30,7 +30,10 @@ class Mails::ReminderJob < Mails::DeliverJob
   include ::Notifications::WithMarkedNotifications
   include GoodJob::ActiveJobExtensions::Concurrency
 
-  good_job_control_concurrency_with total_limit: 1
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    key: -> { "#{self.class.name}-#{arguments.last}" }
+  )
 
   private
 

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -30,14 +30,7 @@ module Notifications
   class CreateDateAlertsNotificationsJob < ApplicationJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
-    good_job_control_concurrency_with(
-      enqueue_limit: 1,
-      perform_limit: 1
-    )
-
-    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
-             wait: 5.minutes,
-             attempts: 3
+    good_job_control_concurrency_with total_limit: 1
 
     def perform(user)
       return unless EnterpriseToken.allows_to?(:date_alerts)

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -28,6 +28,17 @@
 
 module Notifications
   class CreateDateAlertsNotificationsJob < ApplicationJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    good_job_control_concurrency_with(
+      enqueue_limit: 1,
+      perform_limit: 1
+    )
+
+    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+             wait: 5.minutes,
+             attempts: 3
+
     def perform(user)
       return unless EnterpriseToken.allows_to?(:date_alerts)
 

--- a/app/workers/notifications/create_date_alerts_notifications_job.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job.rb
@@ -30,7 +30,10 @@ module Notifications
   class CreateDateAlertsNotificationsJob < ApplicationJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
-    good_job_control_concurrency_with total_limit: 1
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      key: -> { "#{self.class.name}-#{arguments.last}" }
+    )
 
     def perform(user)
       return unless EnterpriseToken.allows_to?(:date_alerts)

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -34,6 +34,10 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     total_limit: 1
   )
 
+  retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+           wait: 5.minutes,
+           attempts: 3
+
   def perform(user_id:, previous_working_days:, previous_non_working_days:)
     user = User.find(user_id)
 

--- a/app/workers/work_packages/apply_working_days_change_job.rb
+++ b/app/workers/work_packages/apply_working_days_change_job.rb
@@ -34,10 +34,6 @@ class WorkPackages::ApplyWorkingDaysChangeJob < ApplicationJob
     total_limit: 1
   )
 
-  retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
-           wait: 5.minutes,
-           attempts: 3
-
   def perform(user_id:, previous_working_days:, previous_non_working_days:)
     user = User.find(user_id)
 

--- a/app/workers/work_packages/progress/job.rb
+++ b/app/workers/work_packages/progress/job.rb
@@ -39,4 +39,8 @@ class WorkPackages::Progress::Job < ApplicationJob
     perform_limit: 1,
     key: -> { "WorkPackagesProgressJob" }
   )
+
+  retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+           wait: 5.minutes,
+           attempts: 3
 end

--- a/app/workers/work_packages/progress/job.rb
+++ b/app/workers/work_packages/progress/job.rb
@@ -42,5 +42,5 @@ class WorkPackages::Progress::Job < ApplicationJob
 
   retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
            wait: 5.minutes,
-           attempts: 3
+           attempts: :unlimited
 end

--- a/modules/storages/app/workers/storages/health_status_mailer_job.rb
+++ b/modules/storages/app/workers/storages/health_status_mailer_job.rb
@@ -39,6 +39,10 @@ module Storages
       key: -> { "#{self.class.name}-#{arguments.last[:storage].id}" }
     )
 
+    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+             wait: 5.minutes,
+             attempts: 3
+
     discard_on ActiveJob::DeserializationError
 
     def perform(storage:)

--- a/modules/storages/app/workers/storages/manage_storage_integrations_job.rb
+++ b/modules/storages/app/workers/storages/manage_storage_integrations_job.rb
@@ -46,6 +46,11 @@ module Storages
       enqueue_limit: 1,
       perform_limit: 1
     )
+    S
+    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+             wait: 5.minutes,
+             attempts: 3
+
     SINGLE_THREAD_DEBOUNCE_TIME = 4.seconds.freeze
     KEY = :manage_nextcloud_integration_job_debounce_happened_at
     CRON_JOB_KEY = :"Storages::ManageStorageIntegrationsJob"

--- a/modules/storages/app/workers/storages/manage_storage_integrations_job.rb
+++ b/modules/storages/app/workers/storages/manage_storage_integrations_job.rb
@@ -46,7 +46,7 @@ module Storages
       enqueue_limit: 1,
       perform_limit: 1
     )
-    S
+
     retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
              wait: 5.minutes,
              attempts: 3


### PR DESCRIPTION
##### ⚠️ Related Work Package [OP#54984](https://community.openproject.org/projects/openproject/work_packages/54984)

This replicates the workaround to forever retrying jobs that @ulferts applied in #15602 to other jobs using concurrency controls.