### PR TITLE
Allow running turbo drive with reusing nonces in secure headers

### DIFF
--- a/app/helpers/secure_headers_helper.rb
+++ b/app/helpers/secure_headers_helper.rb
@@ -1,0 +1,38 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module SecureHeadersHelper
+  ##
+  # Output a rails +csp_meta_tag+ compatible tag
+  # while we're still using the +secure_headers+ gem.
+  def secure_header_csp_meta_tag
+    tag :meta,
+        name: "csp-nonce",
+        content: content_security_policy_script_nonce
+  end
+end

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -21,6 +21,7 @@
 <% if Setting.boards_demo_data_available %><meta name="boards_demo_data_available" content="true"/><% end %>
 <% if Setting.demo_view_of_type_team_planner_seeded %><meta name="demo_view_of_type_team_planner_seeded" content="true"/><% end %>
 <%= csrf_meta_tags %>
+<%= secure_header_csp_meta_tag %>
 <%= initializer_meta_tag %>
 
 <!-- global meta hooks before any scripts are loaded-->

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -38,8 +38,6 @@ See COPYRIGHT and LICENSE files for more details.
   <!-- page specific tags -->
   <%= content_for(:header_tags) if content_for?(:header_tags) %>
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
-  <%# Disable prefetching while we have data-turbo=false on body %>
-  <meta name="turbo-prefetch" content="false">
 </head>
 <body
   class="<%= body_css_classes %> __overflowing_element_container __overflowing_body"

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -307,6 +307,11 @@ export class OpenProjectModule {
     DynamicBootstrapper.bootstrapOptionalDocument(appRef, document);
     this.registerCustomElements(appRef.injector);
 
+    // Call bootstrapper when rendering document
+    document.addEventListener('turbo:render', () => {
+      DynamicBootstrapper.bootstrapOptionalDocument(appRef, document);
+    });
+
     // Call hook service to allow modules to bootstrap additional elements.
     // We can't use ngDoBootstrap in nested modules since they are not called.
     const hookService = (appRef as any)._injector.get(HookService);

--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -26,28 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  StateDeclaration,
-  StateService,
-  Transition,
-  TransitionService,
-  UIRouter,
-} from '@uirouter/core';
-import {
-  IToast,
-  ToastService,
-} from 'core-app/shared/components/toaster/toast.service';
+import { StateDeclaration, StateService, Transition, TransitionService, UIRouter } from '@uirouter/core';
+import { IToast, ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { Injector } from '@angular/core';
 import { FirstRouteService } from 'core-app/core/routing/first-route-service';
-import {
-  Ng2StateDeclaration,
-  StatesModule,
-} from '@uirouter/angular';
-import {
-  appBaseSelector,
-  ApplicationBaseComponent,
-} from 'core-app/core/routing/base/application-base.component';
+import { Ng2StateDeclaration, StatesModule } from '@uirouter/angular';
+import { appBaseSelector, ApplicationBaseComponent } from 'core-app/core/routing/base/application-base.component';
 import { BackRoutingService } from 'core-app/features/work-packages/components/back-routing/back-routing.service';
 import { MY_ACCOUNT_LAZY_ROUTES } from 'core-app/features/user-preferences/user-preferences.lazy-routes';
 import { IAN_LAZY_ROUTES } from 'core-app/features/in-app-notifications/in-app-notifications.lazy-routes';
@@ -224,13 +209,18 @@ export function initializeUiRouterListeners(injector:Injector) {
   const currentProject:CurrentProjectService = injector.get(CurrentProjectService);
   const firstRoute:FirstRouteService = injector.get(FirstRouteService);
   const backRoutingService:BackRoutingService = injector.get(BackRoutingService);
+  const uiRouter = injector.get(UIRouter);
+
+  // Connect ui router to turbo drive
+  document.addEventListener('turbo:render', (event) => {
+    uiRouter.urlService.sync(event);
+  });
 
   // Check whether we are running within our complete app, or only within some other bootstrapped
   // component
   const wpBase = document.querySelector(appBaseSelector);
 
   // Uncomment to trace route changes
-  // const uiRouter = injector.get(UIRouter);
   // uiRouter.trace.enable();
 
   // For some pages it makes no sense to display them on mobile (e.g. the split screen).

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -4,8 +4,9 @@ import { registerDialogStreamAction } from './dialog-stream-action';
 import { addTurboEventListeners } from './turbo-event-listeners';
 import { ModalDialogElement } from '@openproject/primer-view-components/app/components/primer/alpha/modal_dialog';
 
-// Disable default turbo-drive for now as we don't need it for now AND it breaks angular routing
-Turbo.session.drive = false;
+Turbo.session.drive = true;
+Turbo.setProgressBarDelay(100);
+
 // Start turbo
 Turbo.start();
 

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -10,4 +10,12 @@ export function addTurboEventListeners() {
       dialog && dialog.close();
     }
   });
+
+  // Append turbo nonce for drive requests
+  document.addEventListener('turbo:before-fetch-request', (event) => {
+    // Turbo Drive does not send a referrer like turbolinks used to, so let's simulate it here
+    const headers = event.detail.fetchOptions.headers as Record<string, string>;
+    headers['Turbo-Referrer'] = window.location.href;
+    headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
+  });
 }

--- a/frontend/src/typings/shims.d.ts
+++ b/frontend/src/typings/shims.d.ts
@@ -35,13 +35,16 @@ declare module '@hotwired/turbo' {
 
   export const navigator:{
     submitForm:(form:HTMLFormElement, submitter?:HTMLElement) => void;
-  }
+  };
 
   export interface StreamElement {
     templateElement:HTMLTemplateElement;
   }
 
   export function start():void;
+
+  export function setProgressBarDelay(delay:number):void;
+
 }
 
 declare global {

--- a/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
+++ b/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
@@ -1,0 +1,42 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+
+module OpenProject::Patches::SecureHeadersTurboAwareNonce
+  def content_security_policy_script_nonce(request)
+    if request.env["HTTP_TURBO_REFERRER"].present?
+      request.env["HTTP_X_TURBO_NONCE"]
+    else
+      super
+    end
+  end
+end
+
+OpenProject::Patches.patch_gem_version "secure_headers", "6.5.0" do
+  SecureHeaders.singleton_class.prepend OpenProject::Patches::SecureHeadersTurboAwareNonce
+end


### PR DESCRIPTION
Enables Turbo drive using nonce reuse with secure headers. This works quite nicely on Rails pages now, ~~but breaks apart as soon as the angular router is involved.~~ might work with ui-router if we tell it to sync manually on `turbo:render` events, same with DynamicBootstrapper.