### PR TITLE
Allow ProjectQuery to be marked as public

### DIFF
--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -81,6 +81,28 @@
         end
 
         if query.persisted?
+          if can_publish?
+            if query.public?
+              menu.with_item(
+                label: t(:button_unpublish),
+                scheme: :danger,
+                href: unpublish_projects_query_path(query),
+                content_arguments: { data: { method: :post } }
+              ) do |item|
+                item.with_leading_visual_icon(icon: 'eye-closed')
+              end
+            else
+              menu.with_item(
+                label: t(:button_publish),
+                scheme: :default,
+                href: publish_projects_query_path(query),
+                content_arguments: { data: { method: :post } }
+              ) do |item|
+                item.with_leading_visual_icon(icon: 'eye')
+              end
+            end
+          end
+
           menu.with_item(
             label: t(:button_delete),
             scheme: :danger,
@@ -92,7 +114,6 @@
       end
     end
   %>
-
   <%= render(Projects::ConfigureViewModalComponent.new(query:)) %>
   <%= render(Projects::DeleteListModalComponent.new(query:)) if query.persisted? %>
   <%= render(Projects::ExportListModalComponent.new(query:)) %>

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -81,7 +81,7 @@
         end
 
         if query.persisted?
-          if can_publish? && OpenProject::FeatureDecisions.project_list_sharing_active?
+          if can_publish?
             if query.public?
               menu.with_item(
                 label: t(:button_unpublish),

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -81,6 +81,7 @@
         end
 
         if query.persisted?
+          # TODO: Remove section when the sharing modal is implemented (https://community.openproject.org/projects/openproject/work_packages/55163)
           if can_publish?
             if query.public?
               menu.with_item(

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -81,7 +81,7 @@
         end
 
         if query.persisted?
-          if can_publish?
+          if can_publish? && OpenProject::FeatureDecisions.project_list_sharing_active?
             if query.public?
               menu.with_item(
                 label: t(:button_unpublish),

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -70,7 +70,17 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def can_save_as? = may_save_as? && query.changed?
 
-  def can_save? = can_save_as? && query.persisted? && query.user == current_user
+  def can_save?
+    return false unless current_user.logged?
+    return false unless query.persisted?
+    return false unless query.changed?
+
+    if query.public?
+      current_user.allowed_globally?(:manage_public_project_queries)
+    else
+      query.user == current_user
+    end
+  end
 
   def can_rename? = may_save_as? && query.persisted? && query.user == current_user && !query.changed?
 

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -82,7 +82,17 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
     end
   end
 
-  alias can_rename? can_save?
+  def can_rename?
+    return false unless current_user.logged?
+    return false unless query.persisted?
+    return false if query.changed?
+
+    if query.public?
+      current_user.allowed_globally?(:manage_public_project_queries)
+    else
+      query.user == current_user
+    end
+  end
 
   def can_publish?
     OpenProject::FeatureDecisions.project_list_sharing_active? &&

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -82,7 +82,7 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
     end
   end
 
-  def can_rename? = may_save_as? && query.persisted? && query.user == current_user && !query.changed?
+  alias can_rename? can_save?
 
   def can_publish?
     OpenProject::FeatureDecisions.project_list_sharing_active? &&

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -85,7 +85,9 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
   def can_rename? = may_save_as? && query.persisted? && query.user == current_user && !query.changed?
 
   def can_publish?
-    current_user.allowed_globally?(:manage_public_project_queries) && query.persisted?
+    OpenProject::FeatureDecisions.project_list_sharing_active? &&
+    current_user.allowed_globally?(:manage_public_project_queries) &&
+    query.persisted?
   end
 
   def show_state?

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -74,6 +74,10 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def can_rename? = may_save_as? && query.persisted? && query.user == current_user && !query.changed?
 
+  def can_publish?
+    current_user.allowed_globally?(:manage_public_project_queries) && query.persisted?
+  end
+
   def show_state?
     state == :show
   end

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -46,19 +46,19 @@ module Projects
 
     def favored
       render(Primer::Beta::IconButton.new(
-        icon: currently_favored? ? "star-fill" : "star",
-        scheme: :invisible,
-        mobile_icon: currently_favored? ? "star-fill" : "star",
-        size: :medium,
-        tag: :a,
-        tooltip_direction: :e,
-        href: helpers.build_favorite_path(project, format: :html),
-        data: { method: currently_favored? ? :delete : :post },
-        classes: currently_favored? ? "op-primer--star-icon " : "op-project-row-component--favorite",
-        label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite),
-        aria: { label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite) },
-        test_selector: 'project-list-favorite-button'
-      ))
+               icon: currently_favored? ? "star-fill" : "star",
+               scheme: :invisible,
+               mobile_icon: currently_favored? ? "star-fill" : "star",
+               size: :medium,
+               tag: :a,
+               tooltip_direction: :e,
+               href: helpers.build_favorite_path(project, format: :html),
+               data: { method: currently_favored? ? :delete : :post },
+               classes: currently_favored? ? "op-primer--star-icon " : "op-project-row-component--favorite",
+               label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite),
+               aria: { label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite) },
+               test_selector: "project-list-favorite-button"
+             ))
     end
 
     def currently_favored?
@@ -197,7 +197,7 @@ module Projects
     def additional_css_class(column)
       if column.attribute == :name
         "project--hierarchy #{project.archived? ? 'archived' : ''}"
-      elsif [:status_explanation, :description].include?(column.attribute)
+      elsif %i[status_explanation description].include?(column.attribute)
         "project-long-text-container"
       elsif custom_field_column?(column)
         cf = column.custom_field
@@ -254,7 +254,7 @@ module Projects
         href: helpers.build_favorite_path(project, format: :html),
         data: { method: :post },
         label: I18n.t(:button_favorite),
-        aria: { label: I18n.t(:button_favorite) },
+        aria: { label: I18n.t(:button_favorite) }
       }
     end
 
@@ -269,7 +269,7 @@ module Projects
         data: { method: :delete },
         classes: "op-primer--star-icon",
         label: I18n.t(:button_unfavorite),
-        aria: { label: I18n.t(:button_unfavorite) },
+        aria: { label: I18n.t(:button_unfavorite) }
       }
     end
 
@@ -302,7 +302,7 @@ module Projects
           scheme: :default,
           icon: :check,
           label: I18n.t(:label_project_activity),
-          href: project_activity_index_path(project, event_types: ["project_attributes"]),
+          href: project_activity_index_path(project, event_types: ["project_attributes"])
         }
       end
     end
@@ -317,7 +317,7 @@ module Projects
           data: {
             confirm: t("project.archive.are_you_sure", name: project.name),
             method: :post
-          },
+          }
         }
       end
     end
@@ -340,7 +340,7 @@ module Projects
           scheme: :default,
           icon: :copy,
           label: I18n.t(:button_copy),
-          href: copy_project_path(project),
+          href: copy_project_path(project)
         }
       end
     end
@@ -351,7 +351,7 @@ module Projects
           scheme: :danger,
           icon: :trash,
           label: I18n.t(:button_delete),
-          href: confirm_destroy_project_path(project),
+          href: confirm_destroy_project_path(project)
         }
       end
     end
@@ -361,7 +361,7 @@ module Projects
     end
 
     def custom_field_column?(column)
-      column.is_a?(Queries::Projects::Selects::CustomField)
+      column.is_a?(::Queries::Projects::Selects::CustomField)
     end
   end
 end

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -64,11 +64,18 @@ module Projects
     # We don't return the project row
     # but the [project, level] array from the helper
     def rows
+<<<<<<< HEAD
       @rows ||=
         begin
           projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
           instance_exec(model, &projects_enumerator)
         end
+=======
+      @rows ||= begin
+        projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
+        instance_exec(model, &projects_enumerator)
+      end
+>>>>>>> 0e1a80b408 (Add methods to publish and unpublish a project list based on permission)
     end
 
     def initialize_sorted_model
@@ -113,12 +120,11 @@ module Projects
     end
 
     def columns
-      @columns ||=
-        begin
-          columns = query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
+      @columns ||= begin
+        columns = query.selects.reject { |select| select.is_a?(::Queries::Selects::NotExistingSelect) }
 
-          index = columns.index { |column| column.attribute == :name }
-          columns.insert(index, Queries::Projects::Selects::Default.new(:hierarchy)) if index
+        index = columns.index { |column| column.attribute == :name }
+        columns.insert(index, ::Queries::Projects::Selects::Default.new(:hierarchy)) if index
 
           columns
         end
@@ -156,7 +162,7 @@ module Projects
     end
 
     def favored_project_ids
-      @favored_projects ||= Favorite.where(user: current_user, favored_type: 'Project').pluck(:favored_id)
+      @favored_projects ||= Favorite.where(user: current_user, favored_type: "Project").pluck(:favored_id)
     end
 
     def sorted_by_lft?

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -162,7 +162,7 @@ module Projects
     end
 
     def favored_project_ids
-      @favored_projects ||= Favorite.where(user: current_user, favored_type: "Project").pluck(:favored_id)
+      @favored_project_ids ||= Favorite.where(user: current_user, favored_type: "Project").pluck(:favored_id)
     end
 
     def sorted_by_lft?

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -64,18 +64,10 @@ module Projects
     # We don't return the project row
     # but the [project, level] array from the helper
     def rows
-<<<<<<< HEAD
-      @rows ||=
-        begin
-          projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
-          instance_exec(model, &projects_enumerator)
-        end
-=======
       @rows ||= begin
         projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
         instance_exec(model, &projects_enumerator)
       end
->>>>>>> 0e1a80b408 (Add methods to publish and unpublish a project list based on permission)
     end
 
     def initialize_sorted_model
@@ -126,8 +118,8 @@ module Projects
         index = columns.index { |column| column.attribute == :name }
         columns.insert(index, ::Queries::Projects::Selects::Default.new(:hierarchy)) if index
 
-          columns
-        end
+        columns
+      end
     end
 
     def projects(query)

--- a/app/contracts/projects/queries/publish_contract.rb
+++ b/app/contracts/projects/queries/publish_contract.rb
@@ -1,6 +1,6 @@
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2010-2024 the OpenProject GmbH
+# Copyright (C) 2012-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,40 +24,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
-module Projects
-  module QueryLoading
-    private
+#++
 
-    def load_query(duplicate:)
-      ::Queries::Projects::Factory.find(params[:query_id],
-                                        params: permitted_query_params,
-                                        user: current_user,
-                                        duplicate:)
-    end
+class Projects::Queries::PublishContract < BaseContract
+  validate :allowed_to_modify_public_flag
 
-    def load_query_or_deny_access
-      @query = load_query(duplicate: false)
+  protected
 
-      render_403 unless @query
-    end
-
-    def build_query_or_deny_access
-      @query = load_query(duplicate: true)
-
-      render_403 unless @query
-    end
-
-    def permitted_query_params
-      query_params = {}
-
-      if params[:query]
-        query_params.merge!(params.require(:query).permit(:name))
-      end
-
-      query_params.merge!(::Queries::ParamsParser.parse(params))
-
-      query_params.with_indifferent_access
+  def allowed_to_modify_public_flag
+    unless user.allowed_globally?(:manage_public_project_queries)
+      errors.add :base, :error_unauthorized
     end
   end
 end

--- a/app/contracts/queries/projects/project_queries/base_contract.rb
+++ b/app/contracts/queries/projects/project_queries/base_contract.rb
@@ -43,10 +43,17 @@ module Queries::Projects::ProjectQueries
 
     validate :name_select_included
     validate :existing_selects
+    validate :user_is_logged_in
     validate :allowed_to_modify_private_query
     validate :allowed_to_modify_public_query
 
     protected
+
+    def user_is_logged_in
+      if !user.logged?
+        errors.add :base, :error_unauthorized
+      end
+    end
 
     def allowed_to_modify_private_query
       return if model.public?

--- a/app/contracts/queries/projects/project_queries/base_contract.rb
+++ b/app/contracts/queries/projects/project_queries/base_contract.rb
@@ -50,7 +50,7 @@ module Queries::Projects::ProjectQueries
     protected
 
     def user_is_logged_in
-      if !user.logged?
+      unless user.logged?
         errors.add :base, :error_unauthorized
       end
     end

--- a/app/contracts/queries/projects/project_queries/publish_contract.rb
+++ b/app/contracts/queries/projects/project_queries/publish_contract.rb
@@ -26,14 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Projects::Queries::PublishContract < BaseContract
-  validate :allowed_to_modify_public_flag
-
-  protected
-
-  def allowed_to_modify_public_flag
-    unless user.allowed_globally?(:manage_public_project_queries)
-      errors.add :base, :error_unauthorized
-    end
+module Queries::Projects::ProjectQueries
+  class PublishContract < BaseContract
+    attribute :public
   end
 end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -106,6 +106,6 @@ class Projects::QueriesController < ApplicationController
   end
 
   def find_query
-    @query = Queries::Projects::ProjectQuery.find(params[:id])
+    @query = Queries::Projects::ProjectQuery.visible(user: current_user).find(params[:id])
   end
 end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -112,6 +112,6 @@ class Projects::QueriesController < ApplicationController
   end
 
   def find_query
-    @query = Queries::Projects::ProjectQuery.visible(user: current_user).find(params[:id])
+    @query = Queries::Projects::ProjectQuery.visible(current_user).find(params[:id])
   end
 end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -31,11 +31,15 @@ class Projects::QueriesController < ApplicationController
 
   # No need for a more specific authorization check. That is carried out in the contracts.
   before_action :require_login
-  before_action :find_query, only: %i[rename update destroy publish unpublish]
+  before_action :find_query, only: %i[show rename update destroy publish unpublish]
   before_action :build_query_or_deny_access, only: %i[new create]
 
   current_menu_item [:new, :rename, :create, :update] do
     :projects
+  end
+
+  def show
+    redirect_to projects_path(query_id: @query.id)
   end
 
   def new

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -91,17 +91,19 @@ class Projects::QueriesController < ApplicationController
 
   private
 
-  def render_result(service_call, success_i18n_key:, error_i18n_key:)
+  def render_result(service_call, success_i18n_key:, error_i18n_key:) # rubocop:disable Metrics/AbcSize
+    modified_query = service_call.result
+
     if service_call.success?
       flash[:notice] = I18n.t(success_i18n_key)
 
-      redirect_to projects_path(query_id: service_call.result.id)
+      redirect_to modified_query.visible? ? projects_path(query_id: modified_query.id) : projects_path
     else
       flash[:error] = I18n.t(error_i18n_key, errors: service_call.errors.full_messages.join("\n"))
 
       render template: "/projects/index",
              layout: "global",
-             locals: { query: service_call.result, state: :edit }
+             locals: { query: modified_query, state: :edit }
     end
   end
 

--- a/app/helpers/menus/projects.rb
+++ b/app/helpers/menus/projects.rb
@@ -44,6 +44,8 @@ module Menus
       [
         OpenProject::Menu::MenuGroup.new(header: nil,
                                          children: main_static_filters),
+        OpenProject::Menu::MenuGroup.new(header: I18n.t(:"projects.lists.public"),
+                                         children: public_filters),
         OpenProject::Menu::MenuGroup.new(header: I18n.t(:"projects.lists.my_private"),
                                          children: my_filters),
         OpenProject::Menu::MenuGroup.new(header: I18n.t(:"activerecord.attributes.project.status_code"),
@@ -76,9 +78,16 @@ module Menus
       end
     end
 
+    def public_filters
+      ::Queries::Projects::ProjectQuery
+        .public_lists
+        .order(:name)
+        .map { |query| query_menu_item(query) }
+    end
+
     def my_filters
       ::Queries::Projects::ProjectQuery
-        .where(user: current_user)
+        .private_lists(user: current_user)
         .order(:name)
         .map { |query| query_menu_item(query) }
     end

--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -133,7 +133,7 @@ class Queries::Projects::Factory
     end
 
     def find_persisted_query_and_set_attributes(id, params, user, duplicate:)
-      query = Queries::Projects::ProjectQuery.where(user:).find_by(id:)
+      query = Queries::Projects::ProjectQuery.visible(user:).find_by(id:)
 
       return unless query
 

--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -133,7 +133,7 @@ class Queries::Projects::Factory
     end
 
     def find_persisted_query_and_set_attributes(id, params, user, duplicate:)
-      query = Queries::Projects::ProjectQuery.visible(user:).find_by(id:)
+      query = Queries::Projects::ProjectQuery.visible(user).find_by(id:)
 
       return unless query
 

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -39,11 +39,11 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   scope :public_lists, -> { where(public: true) }
   scope :private_lists, ->(user: User.current) { where(public: false, user:) }
 
-  scope :visible, ->(user: User.current) {
+  scope :visible, ->(user = User.current) {
                     public_lists.or(private_lists(user:))
                   }
 
-  def visible?(user: User.current)
+  def visible?(user = User.current)
     public? || user == self.user
   end
 

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -37,7 +37,7 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   serialize :selects, coder: Queries::Serialization::Selects.new(self)
 
   scope :public_lists, -> { where(public: true) }
-  scope :private_lists, ->(user = User.current) { where(public: false, user:) }
+  scope :private_lists, ->(user: User.current) { where(public: false, user:) }
 
   def self.model
     Project

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -36,8 +36,8 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   serialize :orders, coder: Queries::Serialization::Orders.new(self)
   serialize :selects, coder: Queries::Serialization::Selects.new(self)
 
-  scope :public, -> { where(public: true) }
-  scope :private, ->(user = User.current) { where(public: false, user:) }
+  scope :public_lists, -> { where(public: true) }
+  scope :private_lists, ->(user = User.current) { where(public: false, user:) }
 
   def self.model
     Project

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -36,6 +36,9 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   serialize :orders, coder: Queries::Serialization::Orders.new(self)
   serialize :selects, coder: Queries::Serialization::Selects.new(self)
 
+  scope :public, -> { where(public: true) }
+  scope :private, ->(user = User.current) { where(public: false, user:) }
+
   def self.model
     Project
   end

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -39,6 +39,14 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   scope :public_lists, -> { where(public: true) }
   scope :private_lists, ->(user: User.current) { where(public: false, user:) }
 
+  scope :visible, ->(user: User.current) {
+                    public_lists.or(private_lists(user:))
+                  }
+
+  def visible?(user: User.current)
+    public? || user == self.user
+  end
+
   def self.model
     Project
   end

--- a/app/services/queries/projects/project_queries/publish_service.rb
+++ b/app/services/queries/projects/project_queries/publish_service.rb
@@ -1,6 +1,6 @@
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2010-2024 the OpenProject GmbH
+# Copyright (C) 2012-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,40 +24,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
-module Projects
-  module QueryLoading
-    private
+#++
 
-    def load_query(duplicate:)
-      ::Queries::Projects::Factory.find(params[:query_id],
-                                        params: permitted_query_params,
-                                        user: current_user,
-                                        duplicate:)
-    end
+class Queries::Projects::ProjectQueries::PublishService < BaseServices::BaseContracted
+  include Contracted
 
-    def load_query_or_deny_access
-      @query = load_query(duplicate: false)
+  def initialize(user:, model:, contract_class: Projects::Queries::PublishContract)
+    super(user:, contract_class:)
+    self.model = model
+  end
 
-      render_403 unless @query
-    end
+  private
 
-    def build_query_or_deny_access
-      @query = load_query(duplicate: true)
+  def after_validate(params, service_call)
+    model.public = params[:public]
 
-      render_403 unless @query
-    end
+    service_call
+  end
 
-    def permitted_query_params
-      query_params = {}
+  def persist(service_call)
+    model.save
 
-      if params[:query]
-        query_params.merge!(params.require(:query).permit(:name))
-      end
-
-      query_params.merge!(::Queries::ParamsParser.parse(params))
-
-      query_params.with_indifferent_access
-    end
+    service_call
   end
 end

--- a/app/services/queries/projects/project_queries/publish_service.rb
+++ b/app/services/queries/projects/project_queries/publish_service.rb
@@ -26,25 +26,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::Projects::ProjectQueries::PublishService < BaseServices::BaseContracted
-  include Contracted
+module Queries::Projects::ProjectQueries
+  class PublishService < BaseServices::Update
+    private
 
-  def initialize(user:, model:, contract_class: Projects::Queries::PublishContract)
-    super(user:, contract_class:)
-    self.model = model
-  end
+    def after_validate(params, service_call)
+      model.public = params[:public]
 
-  private
+      service_call
+    end
 
-  def after_validate(params, service_call)
-    model.public = params[:public]
+    def persist(service_call)
+      model.save
 
-    service_call
-  end
+      service_call
+    end
 
-  def persist(service_call)
-    model.save
-
-    service_call
+    def default_contract_class
+      Queries::Projects::ProjectQueries::PublishContract
+    end
   end
 end

--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -38,3 +38,5 @@ require_relative "../../lib_static/open_project/feature_decisions"
 #   initializer 'the_engine.feature_decisions' do
 #     OpenProject::FeatureDecisions.add :some_flag
 #   end
+
+OpenProject::FeatureDecisions.add :project_list_sharing

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -183,7 +183,7 @@ Rails.application.reloader.to_prepare do
                      {
                        "projects/queries": %i[publish unpublish]
                      },
-                     permissible_on: :globa,
+                     permissible_on: :global,
                      require: :loggedin,
                      grant_to_admin: true
     end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -112,7 +112,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :select_project_custom_fields,
                      {
-                       'projects/settings/project_custom_fields': %i[show toggle enable_all_of_section disable_all_of_section]
+                       "projects/settings/project_custom_fields": %i[show toggle enable_all_of_section disable_all_of_section]
                      },
                      permissible_on: :project,
                      require: :member
@@ -176,6 +176,14 @@ Rails.application.reloader.to_prepare do
                        attribute_help_texts: %i[index new edit upsale create update destroy]
                      },
                      permissible_on: :global,
+                     require: :loggedin,
+                     grant_to_admin: true
+
+      map.permission :manage_public_project_queries,
+                     {
+                       "projects/queries": %i[publish unpublish]
+                     },
+                     permissible_on: :globa,
                      require: :loggedin,
                      grant_to_admin: true
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -991,6 +991,8 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
               nonexistent: "The column '%{column}' does not exist."
               format: "%{message}"
           group_by_hierarchies_exclusive: "is mutually exclusive with group by '%{group_by}'. You cannot activate both."
+          can_only_be_modified_by_owner: "The query can only be modified by its owner."
+          need_permission_to_modify_public_query: "You cannot modify a public query."
           filters:
             custom_fields:
               inexistent: "There is no custom field for the filter."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2832,6 +2832,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   permission_save_bcf_queries: "Save BCF queries"
   permission_manage_public_bcf_queries: "Manage public BCF queries"
   permission_edit_attribute_help_texts: "Edit attribute help texts"
+  permission_manage_public_project_queries: "Manage public project lists"
 
   placeholders:
     default: "-"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,7 @@ en:
       my: "My projects"
       favored: "Favorite projects"
       archived: "Archived projects"
+      public: "Public project lists"
       my_private: "My private project lists"
       new:
         placeholder: "New project list"
@@ -345,6 +346,12 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
     update:
       success: "The modified list has been saved"
       failure: "The modified list cannot be saved: %{errors}"
+    publish:
+      success: "The list has been made public"
+      failure: "The list cannot be made public: %{errors}"
+    unpublish:
+      success: "The list has been made private"
+      failure: "The list cannot be made private: %{errors}"
     can_be_saved: "List modified:"
     can_be_saved_as: "The modifications can only be saved in a new list:"
 
@@ -1402,6 +1409,8 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   button_revoke_access: "Revoke access"
   button_revoke_all: "Revoke all"
   button_revoke_only: "Revoke only %{shared_role_name}"
+  button_publish: "Make public"
+  button_unpublish: "Make private"
 
   consent:
     checkbox_label: I have noted and do consent to the above.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,9 @@ Rails.application.routes.draw do
     resources :queries, only: %i[new create update destroy] do
       member do
         get :rename
+
+        post :publish
+        post :unpublish
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Rails.application.routes.draw do
 
   namespace :projects do
     resource :menu, only: %i[show]
-    resources :queries, only: %i[new create update destroy] do
+    resources :queries, only: %i[show new create update destroy] do
       member do
         get :rename
 

--- a/db/migrate/20240519123921_add_public_to_project_queries.rb
+++ b/db/migrate/20240519123921_add_public_to_project_queries.rb
@@ -1,0 +1,6 @@
+class AddPublicToProjectQueries < ActiveRecord::Migration[7.1]
+  def change
+    add_column :project_queries, :public, :boolean, default: false, null: false
+    add_index :project_queries, :public
+  end
+end

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe Projects::QueriesController do
       let(:query_id) { "42" }
 
       before do
-        allow(Queries::Projects::ProjectQuery).to receive(:find).with(query_id).and_return(query)
+        scope = instance_double(ActiveRecord::Relation)
+        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(scope).to receive(:find).with(query_id).and_return(query)
 
         login_as user
       end

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Projects::QueriesController do
     end
 
     context "when logged in" do
-      let(:query) { build_stubbed(:project_query) }
+      let(:query) { build_stubbed(:project_query, user:) }
       let(:query_id) { "42" }
       let(:query_params) { double }
 
@@ -110,7 +110,7 @@ RSpec.describe Projects::QueriesController do
     end
 
     context "when logged in" do
-      let(:query) { build_stubbed(:project_query) }
+      let(:query) { build_stubbed(:project_query, user:) }
       let(:query_params) { double }
       let(:service_instance) { instance_double(service_class) }
       let(:service_result) { instance_double(ServiceResult, success?: success?, result: query) }
@@ -181,7 +181,7 @@ RSpec.describe Projects::QueriesController do
     end
 
     context "when logged in" do
-      let(:query) { build_stubbed(:project_query) }
+      let(:query) { build_stubbed(:project_query, user:) }
       let(:query_id) { "42" }
       let(:query_params) { double }
       let(:service_instance) { instance_double(service_class) }
@@ -190,7 +190,9 @@ RSpec.describe Projects::QueriesController do
 
       before do
         allow(controller).to receive(:permitted_query_params).and_return(query_params)
-        allow(Queries::Projects::ProjectQuery).to receive(:find).with(query_id).and_return(query)
+        scope = instance_double(ActiveRecord::Relation)
+        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(scope).to receive(:find).with(query_id).and_return(query)
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
         allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
 
@@ -252,12 +254,15 @@ RSpec.describe Projects::QueriesController do
     end
 
     context "when logged in" do
-      let(:query) { build_stubbed(:project_query) }
+      let(:query) { build_stubbed(:project_query, user:) }
       let(:query_id) { "42" }
       let(:service_instance) { instance_spy(service_class) }
 
       before do
-        allow(Queries::Projects::ProjectQuery).to receive(:find).with(query_id).and_return(query)
+        scope = instance_double(ActiveRecord::Relation)
+        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(scope).to receive(:find).with(query_id).and_return(query)
+
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
 
         login_as user

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Projects::QueriesController do
 
     before do
       scope = instance_double(ActiveRecord::Relation)
-      allow(Queries::Projects::ProjectQuery).to receive(:visible).with(user:).and_return(scope)
+      allow(Queries::Projects::ProjectQuery).to receive(:visible).with(user).and_return(scope)
       allow(scope).to receive(:find).with(query.id.to_s).and_return(query)
 
       login_as user

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -31,6 +31,23 @@ require "rails_helper"
 RSpec.describe Projects::QueriesController do
   shared_let(:user) { create(:user) }
 
+  describe "#show" do
+    let(:query) { build_stubbed(:project_query, user:) }
+
+    before do
+      scope = instance_double(ActiveRecord::Relation)
+      allow(Queries::Projects::ProjectQuery).to receive(:visible).with(user:).and_return(scope)
+      allow(scope).to receive(:find).with(query.id.to_s).and_return(query)
+
+      login_as user
+    end
+
+    it "redirects to the projects page" do
+      get :show, params: { id: query.id }
+      expect(response).to redirect_to(projects_path(query_id: query.id))
+    end
+  end
+
   describe "#new" do
     it "requires login" do
       get "new"
@@ -237,6 +254,152 @@ RSpec.describe Projects::QueriesController do
           allow(controller).to receive(:render).and_call_original
 
           put "update", params: { id: 42 }
+
+          expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+        end
+      end
+    end
+  end
+
+  describe "#publish" do
+    let(:service_class) { Queries::Projects::ProjectQueries::PublishService }
+
+    it "requires login" do
+      put "publish", params: { id: 42 }
+
+      expect(response).not_to be_successful
+    end
+
+    context "when logged in" do
+      let(:query) { build_stubbed(:project_query, user:) }
+      let(:query_id) { "42" }
+      let(:query_params) { { public: true } }
+      let(:service_instance) { instance_double(service_class) }
+      let(:service_result) { instance_double(ServiceResult, success?: success?, result: query) }
+      let(:success?) { true }
+
+      before do
+        allow(controller).to receive(:permitted_query_params).and_return(query_params)
+        scope = instance_double(ActiveRecord::Relation)
+        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(scope).to receive(:find).with(query_id).and_return(query)
+        allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
+        allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
+
+        login_as user
+      end
+
+      it "calls publish service on query" do
+        put "publish", params: { id: 42 }
+
+        expect(service_instance).to have_received(:call).with(query_params)
+      end
+
+      context "when service call succeeds" do
+        it "redirects to projects" do
+          allow(I18n).to receive(:t).with("lists.publish.success").and_return("foo")
+
+          put "publish", params: { id: 42 }
+
+          expect(flash[:notice]).to eq("foo")
+          expect(response).to redirect_to(projects_path(query_id: query.id))
+        end
+      end
+
+      context "when service call fails" do
+        let(:success?) { false }
+        let(:errors) { instance_double(ActiveModel::Errors, full_messages: ["something", "went", "wrong"]) }
+
+        before do
+          allow(service_result).to receive(:errors).and_return(errors)
+        end
+
+        it "renders projects/index" do
+          allow(I18n).to receive(:t).with("lists.publish.failure", errors: "something\nwent\nwrong").and_return("bar")
+
+          put "publish", params: { id: 42 }
+
+          expect(flash[:error]).to eq("bar")
+          expect(response).to render_template("projects/index")
+        end
+
+        it "passes variables to template" do
+          allow(controller).to receive(:render).and_call_original
+
+          put "update", params: { id: 42 }
+
+          expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+        end
+      end
+    end
+  end
+
+  describe "#unpublish" do
+    let(:service_class) { Queries::Projects::ProjectQueries::PublishService }
+
+    it "requires login" do
+      put "unpublish", params: { id: 42 }
+
+      expect(response).not_to be_successful
+    end
+
+    context "when logged in" do
+      let(:query) { build_stubbed(:project_query, user:) }
+      let(:query_id) { "42" }
+      let(:query_params) { { public: false } }
+      let(:service_instance) { instance_double(service_class) }
+      let(:service_result) { instance_double(ServiceResult, success?: success?, result: query) }
+      let(:success?) { true }
+
+      before do
+        allow(controller).to receive(:permitted_query_params).and_return(query_params)
+        scope = instance_double(ActiveRecord::Relation)
+        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(scope).to receive(:find).with(query_id).and_return(query)
+        allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
+        allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
+
+        login_as user
+      end
+
+      it "calls publish service on query" do
+        put "unpublish", params: { id: 42 }
+
+        expect(service_instance).to have_received(:call).with(query_params)
+      end
+
+      context "when service call succeeds" do
+        it "redirects to projects" do
+          allow(I18n).to receive(:t).with("lists.unpublish.success").and_return("foo")
+
+          put "unpublish", params: { id: 42 }
+
+          expect(flash[:notice]).to eq("foo")
+          expect(response).to redirect_to(projects_path(query_id: query.id))
+        end
+      end
+
+      context "when service call fails" do
+        let(:success?) { false }
+        let(:errors) { instance_double(ActiveModel::Errors, full_messages: ["something", "went", "wrong"]) }
+
+        before do
+          allow(service_result).to receive(:errors).and_return(errors)
+        end
+
+        it "renders projects/index" do
+          allow(I18n).to receive(:t).with("lists.unpublish.failure", errors: "something\nwent\nwrong").and_return("bar")
+
+          put "unpublish", params: { id: 42 }
+
+          expect(flash[:error]).to eq("bar")
+          expect(response).to render_template("projects/index")
+        end
+
+        it "passes variables to template" do
+          allow(controller).to receive(:render).and_call_original
+
+          put "unpublish", params: { id: 42 }
 
           expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
         end

--- a/spec/factories/queries/project_query_factory.rb
+++ b/spec/factories/queries/project_query_factory.rb
@@ -29,6 +29,8 @@
 FactoryBot.define do
   factory :project_query, class: "Queries::Projects::ProjectQuery" do
     sequence(:name) { |n| "Project query #{n}" }
+    public { false }
+
     transient do
       select { [] }
     end

--- a/spec/helpers/menus/projects_spec.rb
+++ b/spec/helpers/menus/projects_spec.rb
@@ -45,11 +45,15 @@ RSpec.describe Menus::Projects do
     Queries::Projects::ProjectQuery.create!(name: "Other user query", user: build(:user))
   end
 
+  shared_let(:public_query) do
+    Queries::Projects::ProjectQuery.create!(name: "Public query", user: build(:user), public: true)
+  end
+
   subject(:first_level_menu_items) { instance.first_level_menu_items }
 
-  it "returns 3 menu groups" do
+  it "returns 4 menu groups" do
     expect(first_level_menu_items).to all(be_a(OpenProject::Menu::MenuGroup))
-    expect(first_level_menu_items.length).to eq(3)
+    expect(first_level_menu_items.length).to eq(4)
   end
 
   describe "children items" do
@@ -65,6 +69,10 @@ RSpec.describe Menus::Projects do
 
     it "doesn't contain item for other user query" do
       expect(children_menu_items).not_to include(have_attributes(title: "Other user query"))
+    end
+
+    it "contains item for public query" do
+      expect(children_menu_items).to include(have_attributes(title: "Public query"))
     end
   end
 

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Queries::Projects::Factory,
 
     allow(Queries::Projects::ProjectQuery)
       .to receive(:visible)
-            .with(user: current_user)
+            .with(current_user)
             .and_return(scope)
 
     allow(scope)

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -31,11 +31,11 @@ require "services/base_services/behaves_like_create_service"
 
 RSpec.describe Queries::Projects::Factory,
                with_settings: { enabled_projects_columns: %w[favored name project_status] } do
-  let!(:query_finder) do
+  before do
     scope = instance_double(ActiveRecord::Relation)
 
     allow(Queries::Projects::ProjectQuery)
-      .to receive(:where)
+      .to receive(:visible)
             .with(user: current_user)
             .and_return(scope)
 
@@ -44,6 +44,7 @@ RSpec.describe Queries::Projects::Factory,
             .with(id:)
             .and_return(persisted_query)
   end
+
   let(:persisted_query) do
     build_stubbed(:project_query, name: "My query") do |query|
       query.order(id: :asc)

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Queries::Projects::ProjectQuery do
       it "returns only public lists" do
         public_query = create(:project_query, public: true)
         public_query_other_user = create(:project_query, public: true)
-        private_query = create(:project_query, public: false)
+        create(:project_query, public: false)
 
         expect(described_class.public_lists).to contain_exactly(public_query, public_query_other_user)
       end
@@ -401,9 +401,9 @@ RSpec.describe Queries::Projects::ProjectQuery do
 
     describe ".private_lists" do
       it "returns only private lists owned by the user" do
-        public_query = create(:project_query, public: true)
+        create(:project_query, public: true)
         private_query = create(:project_query, public: false)
-        private_query_other_user = create(:project_query, public: false)
+        create(:project_query, public: false)
 
         expect(described_class.private_lists(user: private_query.user)).to contain_exactly(private_query)
       end
@@ -414,7 +414,7 @@ RSpec.describe Queries::Projects::ProjectQuery do
         public_query = create(:project_query, public: true)
         public_query_other_user = create(:project_query, public: true)
         private_query = create(:project_query, public: false)
-        private_query_other_user = create(:project_query, public: false)
+        create(:project_query, public: false)
 
         expect(described_class.visible(user: private_query.user)).to contain_exactly(public_query, public_query_other_user,
                                                                                      private_query)

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -416,8 +416,8 @@ RSpec.describe Queries::Projects::ProjectQuery do
         private_query = create(:project_query, public: false)
         create(:project_query, public: false)
 
-        expect(described_class.visible(user: private_query.user)).to contain_exactly(public_query, public_query_other_user,
-                                                                                     private_query)
+        expect(described_class.visible(private_query.user)).to contain_exactly(public_query, public_query_other_user,
+                                                                               private_query)
       end
     end
   end
@@ -430,7 +430,7 @@ RSpec.describe Queries::Projects::ProjectQuery do
     context "when the user is the owner" do
       let(:owner) { user }
 
-      it { is_expected.to be_visible(user:) }
+      it { is_expected.to be_visible(user) }
     end
 
     context "when the user is not the owner" do
@@ -439,13 +439,13 @@ RSpec.describe Queries::Projects::ProjectQuery do
       context "and the query is public" do
         let(:public) { true }
 
-        it { is_expected.to be_visible(user:) }
+        it { is_expected.to be_visible(user) }
       end
 
       context "and the query is private" do
         let(:public) { false }
 
-        it { is_expected.not_to be_visible(user:) }
+        it { is_expected.not_to be_visible(user) }
       end
     end
   end


### PR DESCRIPTION
This implements the portion of making project lists public. 

- [x] Add DB migration to add a `public` flag
- [x] Add `public` and `private` scopes to the `ProjectQuery` model
- [x] Add a global `manage_public_project_queries` permission
- [x] Add a **temporary** link to the `...` menu to change public status of a query
- [x] Add a section to the projects sidebar, to show all the public queries
- [x] Change loading of the queries from `where(user:)` to `public.or(private)`
- [x] When a user changes a public query and they do not have the permission to change them offer **save as** instead of **save** option
- [x] Add tests for contract, service, new scopes
- [x] Add tests for behaviors

It is intended to be a self contained spike that is not relying on the modal or anything, hence why we are **temporarily** adding the menu items.

---

Implements https://community.openproject.org/work_packages/55159