### PR TITLE
[55123] Fixed empty project attribute mapping list unlink response

### DIFF
--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -27,44 +27,43 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= component_wrapper(tag: "div", data: { turbo: true }) do %>
-  <div class="project-list-page--table">
-    <div class="generic-table--flex-container">
-      <div class="generic-table--container <%= container_class %>">
-        <div class="generic-table--results-container">
-          <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
-            <colgroup>
-              <% columns.each do |column| %>
-                <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
-              <% end %>
-              <col>
-            </colgroup>
-            <thead class="-sticky">
-            <tr>
-              <% columns.each do |column| %>
-                <% if column.attribute == :hierarchy %>
-                  <th id="project-table--hierarchy-header">
-                    <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
-                      <div class="generic-table--sort-header"
-                           data-controller="params-from-query"
-                           data-application-target="dynamic"
-                           data-params-from-query-all-anchors-value="true"
-                           data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
-                        <%= content_tag :a,
-                                        helpers.op_icon("icon-hierarchy"),
-                                        href: href_only_when_not_sort_lft,
-                                        class: "spot-link #{deactivate_class_on_lft_sort}",
-                                        title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
-                      </div>
+<div class="project-list-page--table">
+  <div class="generic-table--flex-container">
+    <div class="generic-table--container <%= container_class %>">
+      <div class="generic-table--results-container">
+        <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
+          <colgroup>
+            <% columns.each do |column| %>
+              <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
+            <% end %>
+            <col>
+          </colgroup>
+          <thead class="-sticky">
+          <tr>
+            <% columns.each do |column| %>
+              <% if column.attribute == :hierarchy %>
+                <th id="project-table--hierarchy-header">
+                  <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
+                    <div class="generic-table--sort-header"
+                         data-controller="params-from-query"
+                         data-application-target="dynamic"
+                         data-params-from-query-all-anchors-value="true"
+                         data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
+                      <%= content_tag :a,
+                                      helpers.op_icon("icon-hierarchy"),
+                                      href: href_only_when_not_sort_lft,
+                                      class: "spot-link #{deactivate_class_on_lft_sort}",
+                                      title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
                     </div>
-                  </th>
-                <% elsif sortable_column?(column) %>
-                  <%= build_sort_header column.attribute,
-                                        order_options(column) %>
-                <% else %>
-                  <th>
-                    <div class="generic-table--sort-header-outer">
-                      <div class="generic-table--sort-header">
+                  </div>
+                </th>
+              <% elsif sortable_column?(column) %>
+                <%= build_sort_header column.attribute,
+                                      order_options(column) %>
+              <% else %>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
                       <span>
                         <% if column.attribute == :favored %>
                         <%= render(Primer::Beta::Octicon.new(icon: "star-fill", color: :subtle, ml: 2, "aria-label": I18n.t(:label_favorite))) %>
@@ -72,42 +71,41 @@ See COPYRIGHT and LICENSE files for more details.
                         <%= column.caption %>
                       <% end %>
                       </span>
-                      </div>
                     </div>
-                  </th>
-                <% end %>
+                  </div>
+                </th>
               <% end %>
-              <th>
-                <div class="generic-table--empty-header">
-                </div>
-              </th>
-            </tr>
-            </thead>
-            <tbody>
-            <% if rows.empty? %>
-              <tr class="generic-table--empty-row">
-                <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
-              </tr>
             <% end %>
-            <%= render_collection rows %>
-            </tbody>
-          </table>
-          <% if inline_create_link && show_inline_create %>
-            <div class="wp-inline-create-button">
-              <%= inline_create_link %>
-            </div>
+            <th>
+              <div class="generic-table--empty-header">
+              </div>
+            </th>
+          </tr>
+          </thead>
+          <tbody>
+          <% if rows.empty? %>
+            <tr class="generic-table--empty-row">
+              <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+            </tr>
           <% end %>
-        </div>
+          <%= render_collection rows %>
+          </tbody>
+        </table>
+        <% if inline_create_link && show_inline_create %>
+          <div class="wp-inline-create-button">
+            <%= inline_create_link %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
+</div>
 
-  <% if paginated? %>
-    <div data-controller="params-from-query"
-         data-application-target="dynamic"
-         data-params-from-query-all-anchors-value="true"
-         data-params-from-query-allowed-value='["query_id", "columns"]'>
-      <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
-    </div>
-  <% end %>
+<% if paginated? %>
+  <div data-controller="params-from-query"
+       data-application-target="dynamic"
+       data-params-from-query-all-anchors-value="true"
+       data-params-from-query-allowed-value='["query_id", "columns"]'>
+    <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
+  </div>
 <% end %>

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -26,43 +26,45 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<div class="project-list-page--table">
-  <div class="generic-table--flex-container">
-    <div class="generic-table--container <%= container_class %>">
-      <div class="generic-table--results-container">
-        <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
-          <colgroup>
-            <% columns.each do |column| %>
-              <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
-            <% end %>
-            <col>
-          </colgroup>
-          <thead class="-sticky">
-          <tr>
-            <% columns.each do |column| %>
-              <% if column.attribute == :hierarchy %>
-                <th id="project-table--hierarchy-header">
-                  <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
-                    <div class="generic-table--sort-header"
-                         data-controller="params-from-query"
-                         data-application-target="dynamic"
-                         data-params-from-query-all-anchors-value="true"
-                         data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
-                      <%= content_tag :a,
-                                      helpers.op_icon("icon-hierarchy"),
-                                      href: href_only_when_not_sort_lft,
-                                      class: "spot-link #{deactivate_class_on_lft_sort}",
-                                      title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
+
+<%= component_wrapper(tag: "div", data: { turbo: true }) do %>
+  <div class="project-list-page--table">
+    <div class="generic-table--flex-container">
+      <div class="generic-table--container <%= container_class %>">
+        <div class="generic-table--results-container">
+          <table class="generic-table" <%= table_id ? "id=\"#{table_id}\"".html_safe : '' %>>
+            <colgroup>
+              <% columns.each do |column| %>
+                <col <%= "opHighlightCol" unless column.attribute == :hierarchy %> >
+              <% end %>
+              <col>
+            </colgroup>
+            <thead class="-sticky">
+            <tr>
+              <% columns.each do |column| %>
+                <% if column.attribute == :hierarchy %>
+                  <th id="project-table--hierarchy-header">
+                    <div class="generic-table--sort-header-outer generic-table--sort-header-outer_no-highlighting">
+                      <div class="generic-table--sort-header"
+                           data-controller="params-from-query"
+                           data-application-target="dynamic"
+                           data-params-from-query-all-anchors-value="true"
+                           data-params-from-query-allowed-value='["query_id", "per_page", "filters", "columns"]'>
+                        <%= content_tag :a,
+                                        helpers.op_icon("icon-hierarchy"),
+                                        href: href_only_when_not_sort_lft,
+                                        class: "spot-link #{deactivate_class_on_lft_sort}",
+                                        title: t(:label_sort_by, value: %("#{t(:label_project_hierarchy)}")) %>
+                      </div>
                     </div>
-                  </div>
-                </th>
-              <% elsif sortable_column?(column) %>
-                <%= build_sort_header column.attribute,
-                                      order_options(column) %>
-              <% else %>
-                <th>
-                  <div class="generic-table--sort-header-outer">
-                    <div class="generic-table--sort-header">
+                  </th>
+                <% elsif sortable_column?(column) %>
+                  <%= build_sort_header column.attribute,
+                                        order_options(column) %>
+                <% else %>
+                  <th>
+                    <div class="generic-table--sort-header-outer">
+                      <div class="generic-table--sort-header">
                       <span>
                         <% if column.attribute == :favored %>
                         <%= render(Primer::Beta::Octicon.new(icon: "star-fill", color: :subtle, ml: 2, "aria-label": I18n.t(:label_favorite))) %>
@@ -70,41 +72,42 @@ See COPYRIGHT and LICENSE files for more details.
                         <%= column.caption %>
                       <% end %>
                       </span>
+                      </div>
                     </div>
-                  </div>
-                </th>
+                  </th>
+                <% end %>
               <% end %>
-            <% end %>
-            <th>
-              <div class="generic-table--empty-header">
-              </div>
-            </th>
-          </tr>
-          </thead>
-          <tbody>
-          <% if rows.empty? %>
-            <tr class="generic-table--empty-row">
-              <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+              <th>
+                <div class="generic-table--empty-header">
+                </div>
+              </th>
             </tr>
+            </thead>
+            <tbody>
+            <% if rows.empty? %>
+              <tr class="generic-table--empty-row">
+                <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+              </tr>
+            <% end %>
+            <%= render_collection rows %>
+            </tbody>
+          </table>
+          <% if inline_create_link && show_inline_create %>
+            <div class="wp-inline-create-button">
+              <%= inline_create_link %>
+            </div>
           <% end %>
-          <%= render_collection rows %>
-          </tbody>
-        </table>
-        <% if inline_create_link && show_inline_create %>
-          <div class="wp-inline-create-button">
-            <%= inline_create_link %>
-          </div>
-        <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<% if paginated? %>
-  <div data-controller="params-from-query"
-       data-application-target="dynamic"
-       data-params-from-query-all-anchors-value="true"
-       data-params-from-query-allowed-value='["query_id", "columns"]'>
-    <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
-  </div>
+  <% if paginated? %>
+    <div data-controller="params-from-query"
+         data-application-target="dynamic"
+         data-params-from-query-all-anchors-value="true"
+         data-params-from-query-allowed-value='["query_id", "columns"]'>
+      <%= helpers.pagination_links_full model, { blocked_url_params: [:query_id, :columns] } %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -30,8 +30,6 @@
 
 module Projects
   class TableComponent < ::TableComponent
-    include OpTurbo::Streamable
-
     options :params # We read collapsed state from params
     options :current_user # adds this option to those of the base class
     options :query

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -30,6 +30,8 @@
 
 module Projects
   class TableComponent < ::TableComponent
+    include OpTurbo::Streamable
+
     options :params # We read collapsed state from params
     options :current_user # adds this option to those of the base class
     options :query
@@ -64,10 +66,11 @@ module Projects
     # We don't return the project row
     # but the [project, level] array from the helper
     def rows
-      @rows ||= begin
-        projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a } # rubocop:disable Lint/ToEnumArguments
-        instance_exec(model, &projects_enumerator)
-      end
+      @rows ||=
+        begin
+          projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
+          instance_exec(model, &projects_enumerator)
+        end
     end
 
     def initialize_sorted_model
@@ -112,14 +115,15 @@ module Projects
     end
 
     def columns
-      @columns ||= begin
-        columns = query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
+      @columns ||=
+        begin
+          columns = query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
 
-        index = columns.index { |column| column.attribute == :name }
-        columns.insert(index, Queries::Projects::Selects::Default.new(:hierarchy)) if index
+          index = columns.index { |column| column.attribute == :name }
+          columns.insert(index, Queries::Projects::Selects::Default.new(:hierarchy)) if index
 
-        columns
-      end
+          columns
+        end
     end
 
     def projects(query)

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.html.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper(tag: "div", data: { turbo: true }) do %>
+  <%= render_parent %>
+<% end %>

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
@@ -30,6 +30,7 @@ module Settings
   module ProjectCustomFields
     module ProjectCustomFieldMapping
       class TableComponent < Projects::TableComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+        include OpTurbo::Streamable
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55123

Once the last project link is removed from the list of project attributes, the empty list text is now rendered.

This was achieved by making the `ProjectTable` a Turbo streamable and respond with it when the mapping table list is empty.