### PR TITLE
[#55176] Cleanup Rails's tmp/pid/server.pid file for docker based development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,11 +46,14 @@ x-op-backend: &backend
     OPENPROJECT_WEB_MAX__THREADS: 1
     OPENPROJECT_WEB_MIN__THREADS: 1
     OPENPROJECT_WEB_WORKERS: 0
+    PIDFILE: /home/dev/openproject/tmpfs/pids/server.pid
   volumes:
     - ".:/home/dev/openproject"
     - "opdata:/var/openproject/assets"
     - "bundle:/usr/local/bundle"
     - "tmp:/home/dev/openproject/tmp"
+  tmpfs:
+    - /home/dev/openproject/tmpfs/pids:uid=$DEV_UID,gid=$DEV_GID
   networks:
     - network
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/55176

When developing with Rails it happens frequently that a PID file does not get cleaned up. Debugging why a local dev environment did not boot slows down development and increases developer frustration. 

This PR aims to ensure that all former PID files are gone when calling `docker compose up -d backend` next time. 

Implementation details:

There are multiple approaches on how to make that happen.

-  @oliverguenther for example chose a solution that removes such files from within the `docker/prod/web` file. That was inspired by an existing solution in [`docker/prod/entrypoint.sh`](https://github.com/opf/openproject/blob/dev/docker/prod/entrypoint.sh#L40)
- At least for development I prefer the solution promoted [in this blog post](https://ieftimov.com/posts/docker-compose-stray-pids-rails-beyond/), as it hands over the complexity of having temporary files to specialized volumes (tmpfs, which lives in memory only), makes it transparent in the `docker-compose.yml` file and also allows individual developers to easily override it at need. 