### PR TITLE
Fix meeting type label selection on the new meeting form.

### DIFF
--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -71,7 +71,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="form--field-container">
         <div class="op-tile-block">
           <label class="op-tile-block--tile form--radio-button-container -wide"
-                 for="meeting_type_dynamic"
+                 for="meeting_type_StructuredMeeting"
                  data-test-selector="op-tile-block">
             <div class="op-tile-block--content">
               <%= styled_radio_button_tag 'meeting[type]',
@@ -94,7 +94,7 @@ See COPYRIGHT and LICENSE files for more details.
             </div>
           </label>
           <label class="op-tile-block--tile form--radio-button-container -wide"
-                 for="meeting_type_classic"
+                 for="meeting_type_Meeting"
                  data-test-selector="op-tile-block">
             <div class="op-tile-block--content">
               <%= styled_radio_button_tag 'meeting[type]',

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -306,6 +306,13 @@ RSpec.describe "Meetings new", :js, with_cuprite: false do
         new_page.set_type "Classic"
         new_page.set_title "Some title"
 
+        # Ensure we have the correct type labels set up (Regression #15625)
+        dynamic_button = find_field "Dynamic"
+        classic_button = find_field "Classic"
+
+        expect(page).to have_css("label[for='#{dynamic_button[:id]}']")
+        expect(page).to have_css("label[for='#{classic_button[:id]}']")
+
         show_page = new_page.click_create
 
         show_page.expect_toast(message: "Successful creation")


### PR DESCRIPTION
The labels for selecting the meeting type has been broken due to renaming of the radio buttons.
![May-21-2024 16-31-29](https://github.com/opf/openproject/assets/83396/e83f7106-2652-495d-9a5a-28b95439d3e7)
