### PR TITLE
[#55186] added settings attribute to project base contract

### DIFF
--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -35,6 +35,7 @@ module Projects
     attribute :identifier
     attribute :description
     attribute :public
+    attribute :settings
     attribute :active do
       validate_active_present
       validate_changing_active
@@ -81,7 +82,7 @@ module Projects
     def validate_parent_assignable
       if model.parent &&
          model.parent_id_changed? &&
-         !assignable_parents.where(id: parent.id).exists?
+         !assignable_parents.exists?(id: parent.id)
         errors.add(:parent, :does_not_exist)
       end
     end

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -82,7 +82,7 @@ module Projects
     def validate_parent_assignable
       if model.parent &&
          model.parent_id_changed? &&
-         !assignable_parents.exists?(id: parent.id)
+         !assignable_parents.where(id: parent.id).exists?
         errors.add(:parent, :does_not_exist)
       end
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,7 +32,7 @@ class ProjectsController < ApplicationController
 
   before_action :find_project, except: %i[index new]
   before_action :load_query_or_deny_access, only: %i[index]
-  before_action :authorize, only: %i[copy]
+  before_action :authorize, only: %i[copy deactivate_work_package_attachments]
   before_action :authorize_global, only: %i[new]
   before_action :require_admin, only: %i[destroy destroy_info]
 


### PR DESCRIPTION
[#55186](https://community.openproject.org/wp/55186)

### WAT?

- if a project setting was set, the missing attribute in the contract prevented the copying of this project, as the contract prevents writing data on it if unset.