### PR TITLE
Rubocop corrections

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,8 +5,9 @@
 21a696ef9b170e14ad2daf53364a4c2113822c2f
 # Update copyright information for 2024
 c795874f7f281297bbd3bad2fdb58b24cb4ce624
-# switch to double quotes
+# rubocop autocorrections
 f3c99ee5dded81ad55f2b6f3706216d5fa765677
 5c72ea0046a6b5230bf456f55a296ed6fd579535
 9e4934cd0a468f46d8f0fc0f11ebc2d4216f789c
 6678cab48d443b5782fa93b171d62093819ee4fc
+fa5d03eae00bc8931f99598a74ffd76e0cbca3da

--- a/app/components/members/table_component.rb
+++ b/app/components/members/table_component.rb
@@ -43,7 +43,7 @@ module Members
     sortable_columns :name, :mail, :status
 
     def apply_sort(model)
-      apply_member_scopes super(model)
+      apply_member_scopes super
     end
 
     def apply_member_scopes(model)

--- a/app/components/members/user_filter_component.rb
+++ b/app/components/members/user_filter_component.rb
@@ -128,7 +128,7 @@ module Members
       end
 
       def apply_filters(params, query)
-        super(params, query)
+        super
         filter_shares(query, params[:shared_role_id]) if params.key?(:shared_role_id)
 
         query

--- a/app/components/row_component.rb
+++ b/app/components/row_component.rb
@@ -33,8 +33,8 @@
 class RowComponent < ApplicationComponent
   attr_reader :table
 
-  def initialize(row:, table:, **options)
-    super(row, **options)
+  def initialize(row:, table:, **)
+    super(row, **)
     @table = table
   end
 

--- a/app/components/settings/project_custom_fields/new_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/new_form_header_component.rb
@@ -32,7 +32,7 @@ module Settings
       def breadcrumb_items
         [{ href: admin_index_path, text: t("label_administration") },
          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
-         { href: admin_settings_project_custom_fields_path, text:  t("settings.project_attributes.heading") },
+         { href: admin_settings_project_custom_fields_path, text: t("settings.project_attributes.heading") },
          t("settings.project_attributes.new.heading")]
       end
     end

--- a/app/components/user_filter_component.rb
+++ b/app/components/user_filter_component.rb
@@ -59,7 +59,7 @@ class UserFilterComponent < IndividualPrincipalBaseFilterComponent
     protected
 
     def apply_filters(params, query)
-      super(params, query)
+      super
       filter_status query, status_param(params)
 
       query

--- a/app/contracts/custom_actions/cu_contract.rb
+++ b/app/contracts/custom_actions/cu_contract.rb
@@ -36,7 +36,7 @@ module CustomActions
     end
 
     def initialize(model, user = nil)
-      super(model, user)
+      super
     end
 
     attribute :name

--- a/app/contracts/versions/base_contract.rb
+++ b/app/contracts/versions/base_contract.rb
@@ -63,10 +63,10 @@ module Versions
           true
         else
           case s
-          when 'system'
+          when "system"
             # Only admin users can set a systemwide sharing
             user.admin?
-          when 'hierarchy', 'tree'
+          when "hierarchy", "tree"
             # Only users allowed to manage versions of the root project can
             # set sharing to hierarchy or tree
             model.project.nil? || user.allowed_in_project?(:manage_versions, model.project.root)
@@ -83,7 +83,7 @@ module Versions
       if wiki
         wiki.pages
       else
-        WikiPage.where('1=0')
+        WikiPage.where("1=0")
       end
     end
 

--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -31,7 +31,7 @@ class Admin::BackupsController < ApplicationController
   include ActionView::Helpers::TagHelper
   include BackupHelper
 
-  layout 'admin'
+  layout "admin"
 
   before_action :check_enabled
   before_action :authorize_global
@@ -65,7 +65,7 @@ class Admin::BackupsController < ApplicationController
   rescue StandardError => e
     token_reset_failed! e
   ensure
-    redirect_to action: 'show'
+    redirect_to action: "show"
   end
 
   def delete_token
@@ -73,7 +73,7 @@ class Admin::BackupsController < ApplicationController
 
     flash[:info] = t("backup.text_token_deleted")
 
-    redirect_to action: 'show'
+    redirect_to action: "show"
   end
 
   def default_breadcrumb
@@ -105,16 +105,16 @@ class Admin::BackupsController < ApplicationController
 
   def token_reset_flash_message(token)
     [
-      t('my.access_token.notice_reset_token', type: 'Backup'),
+      t("my.access_token.notice_reset_token", type: "Backup"),
       content_tag(:strong, token.plain_value),
-      t('my.access_token.token_value_warning')
+      t("my.access_token.token_value_warning")
     ]
   end
 
   def token_reset_failed!(error)
     Rails.logger.error "Failed to reset user ##{current_user.id}'s Backup token: #{error}"
 
-    flash[:error] = t('my.access_token.failed_to_reset_token', error: error.message)
+    flash[:error] = t("my.access_token.failed_to_reset_token", error: error.message)
   end
 
   def may_include_attachments?

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -89,7 +89,7 @@ module Accounts::CurrentUser
   def current_autologin_user
     return unless Setting::Autologin.enabled?
 
-    autologin_cookie_name = OpenProject::Configuration['autologin_cookie_name']
+    autologin_cookie_name = OpenProject::Configuration["autologin_cookie_name"]
     autologin_token = cookies[autologin_cookie_name]
     return unless autologin_token
 
@@ -105,7 +105,7 @@ module Accounts::CurrentUser
   end
 
   def current_rss_key_user
-    if params[:format] == 'atom' && params[:key] && accept_key_auth_actions.include?(params[:action])
+    if params[:format] == "atom" && params[:key] && accept_key_auth_actions.include?(params[:action])
       # RSS key authentication does not start a session
       User.find_by_rss_key(params[:key])
     end
@@ -183,8 +183,8 @@ module Accounts::CurrentUser
 
         format.any(:xml, :js, :json) do
           head :unauthorized,
-               'X-Reason' => 'login needed',
-               'WWW-Authenticate' => auth_header
+               "X-Reason" => "login needed",
+               "WWW-Authenticate" => auth_header
         end
 
         format.all { head :not_acceptable }

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -48,7 +48,7 @@ class WorkPackages::BulkController < ApplicationController
 
     if @call.success?
       flash[:notice] = t(:notice_successful_update)
-      redirect_back_or_default(controller: '/work_packages', action: :index, project_id: @project)
+      redirect_back_or_default(controller: "/work_packages", action: :index, project_id: @project)
     else
       flash[:error] = bulk_error_message(@work_packages, @call)
       setup_edit
@@ -75,7 +75,7 @@ class WorkPackages::BulkController < ApplicationController
                            associated: WorkPackage.associated_classes_to_address_before_destruction_of(@work_packages) }
         end
         format.json do
-          render json: { error_message: 'Clean up of associated objects required' }, status: 420
+          render json: { error_message: "Clean up of associated objects required" }, status: 420
         end
       end
     end
@@ -125,6 +125,6 @@ class WorkPackages::BulkController < ApplicationController
   def transform_attributes(attributes)
     Hash(attributes)
       .compact_blank
-      .transform_values { |v| Array(v).include?('none') ? '' : v }
+      .transform_values { |v| Array(v).include?("none") ? "" : v }
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -32,11 +32,11 @@ module SearchHelper
 
     return nil unless split_text.length > 1 || text_on_not_found
 
-    result = ''
+    result = ""
     split_text.each_with_index do |words, i|
       if result.length > 1200
         # maximum length of the preview reached
-        result << '...'
+        result << "..."
         break
       end
 
@@ -83,7 +83,7 @@ module SearchHelper
   def notes_anchor(event)
     version = event.version.to_i
 
-    version > 1 ? "note-#{version - 1}" : ''
+    version > 1 ? "note-#{version - 1}" : ""
   end
 
   def with_notes_anchor(event, tokens)
@@ -100,8 +100,8 @@ module SearchHelper
 
   def current_scope
     params[:scope] ||
-      ('subprojects' unless @project.nil? || @project.descendants.active.empty?) ||
-      ('current_project' unless @project.nil?)
+      ("subprojects" unless @project.nil? || @project.descendants.active.empty?) ||
+      ("current_project" unless @project.nil?)
   end
 
   def link_to_previous_search_page(pagination_previous_date)
@@ -109,7 +109,7 @@ module SearchHelper
                            @search_params.merge(previous: 1,
                                                 project_id: @project.try(:identifier),
                                                 offset: pagination_previous_date.to_r.to_s),
-                           class: 'navigate-left')
+                           class: "navigate-left")
   end
 
   def link_to_next_search_page(pagination_next_date)
@@ -117,20 +117,20 @@ module SearchHelper
                            @search_params.merge(previous: nil,
                                                 project_id: @project.try(:identifier),
                                                 offset: pagination_next_date.to_r.to_s),
-                           class: 'navigate-right')
+                           class: "navigate-right")
   end
 
   private
 
   def attachment_fulltexts(event)
     only_if_tsv_supported(event) do
-      Attachment.where(id: event.attachment_ids).pluck(:fulltext).join(' ')
+      Attachment.where(id: event.attachment_ids).pluck(:fulltext).join(" ")
     end
   end
 
   def attachment_filenames(event)
     only_if_tsv_supported(event) do
-      event.attachments&.map(&:filename)&.join(' ')
+      event.attachments&.map(&:filename)&.join(" ")
     end
   end
 
@@ -142,7 +142,7 @@ module SearchHelper
 
   def token_span(tokens, words)
     t = (tokens.index(words.downcase) || 0) % 4
-    content_tag('span', h(words), class: "search-highlight token-#{t}")
+    content_tag("span", h(words), class: "search-highlight token-#{t}")
   end
 
   def abbreviated_text(words)
@@ -154,11 +154,11 @@ module SearchHelper
                           formatted_words
                         end
 
-    if words[0] == ' '
+    if words[0] == " "
       abbreviated_words = " #{abbreviated_words}"
     end
 
-    if words[-1] == ' ' && words.length > 1
+    if words[-1] == " " && words.length > 1
       abbreviated_words = "#{abbreviated_words} "
     end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -115,7 +115,6 @@ module UsersHelper
   end
 
   def change_user_status_links(user)
-
     build_change_user_status_action(user) do |title, name|
       link_to title,
               change_status_user_path(user,

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -85,7 +85,7 @@ module WorkPackagesHelper
     if package.closed? && !options[:no_hidden]
       parts[:hidden_link] << content_tag(:span,
                                          I18n.t(:label_closed_work_packages),
-                                         class: 'hidden-for-sighted')
+                                         class: "hidden-for-sighted")
     end
 
     # Suffix part
@@ -109,12 +109,12 @@ module WorkPackagesHelper
 
     # combining
 
-    prefix = parts[:prefix].join(' ')
-    suffix = parts[:suffix].join(' ')
-    link = parts[:link].join(' ').strip
+    prefix = parts[:prefix].join(" ")
+    suffix = parts[:suffix].join(" ")
+    link = parts[:link].join(" ").strip
     hidden_link = parts[:hidden_link].join
-    title = parts[:title].join(' ')
-    css_class = parts[:css_class].join(' ')
+    title = parts[:title].join(" ")
+    css_class = parts[:css_class].join(" ")
 
     # Determine path or url
     work_package_link =
@@ -125,8 +125,8 @@ module WorkPackagesHelper
       end
 
     if options[:all_link]
-      link_text = [prefix, link].reject(&:empty?).join(' - ')
-      link_text = [link_text, suffix].reject(&:empty?).join(': ')
+      link_text = [prefix, link].reject(&:empty?).join(" - ")
+      link_text = [link_text, suffix].reject(&:empty?).join(": ")
       link_text = [hidden_link, link_text].reject(&:empty?).join
 
       link_to(link_text.html_safe,
@@ -141,8 +141,8 @@ module WorkPackagesHelper
                           title:,
                           class: css_class)
 
-      [[prefix, html_link].reject(&:empty?).join(' - '),
-       suffix].reject(&:empty?).join(': ')
+      [[prefix, html_link].reject(&:empty?).join(" - "),
+       suffix].reject(&:empty?).join(": ")
     end.html_safe
   end
 
@@ -158,41 +158,41 @@ module WorkPackagesHelper
   end
 
   def send_notification_option(checked = false)
-    content_tag(:label, for: 'send_notification', class: 'form--label-with-check-box') do
-      (content_tag 'span', class: 'form--check-box-container' do
-        boxes = hidden_field_tag('send_notification', '0', id: nil)
+    content_tag(:label, for: "send_notification", class: "form--label-with-check-box") do
+      (content_tag "span", class: "form--check-box-container" do
+        boxes = hidden_field_tag("send_notification", "0", id: nil)
 
-        boxes += check_box_tag('send_notification',
-                               '1',
+        boxes += check_box_tag("send_notification",
+                               "1",
                                checked,
-                               class: 'form--check-box')
+                               class: "form--check-box")
         boxes
-      end) + I18n.t('notifications.send_notifications')
+      end) + I18n.t("notifications.send_notifications")
     end
   end
 
   # Returns a string of css classes that apply to the issue
   def work_package_css_classes(work_package)
-    s = 'work_package preview-trigger'.html_safe
+    s = "work_package preview-trigger".html_safe
     s << " status-#{work_package.status.position}" if work_package.status
     s << " priority-#{work_package.priority.position}" if work_package.priority
-    s << ' closed' if work_package.closed?
-    s << ' overdue' if work_package.overdue?
-    s << ' child' if work_package.child?
-    s << ' parent' unless work_package.leaf?
-    s << ' created-by-me' if User.current.logged? && work_package.author_id == User.current.id
-    s << ' assigned-to-me' if User.current.logged? && work_package.assigned_to_id == User.current.id
+    s << " closed" if work_package.closed?
+    s << " overdue" if work_package.overdue?
+    s << " child" if work_package.child?
+    s << " parent" unless work_package.leaf?
+    s << " created-by-me" if User.current.logged? && work_package.author_id == User.current.id
+    s << " assigned-to-me" if User.current.logged? && work_package.assigned_to_id == User.current.id
     s
   end
 
   def work_package_associations_to_address(associated)
-    ret = ''.html_safe
+    ret = "".html_safe
 
-    ret += content_tag(:p, I18n.t(:text_destroy_with_associated), class: 'bold')
+    ret += content_tag(:p, I18n.t(:text_destroy_with_associated), class: "bold")
 
     ret += content_tag(:ul) do
-      associated.inject(''.html_safe) do |list, associated_class|
-        list += content_tag(:li, associated_class.model_name.human, class: 'decorated')
+      associated.inject("".html_safe) do |list, associated_class|
+        list += content_tag(:li, associated_class.model_name.human, class: "decorated")
 
         list
       end
@@ -202,8 +202,8 @@ module WorkPackagesHelper
   end
 
   def back_url_is_wp_show?
-    route = Rails.application.routes.recognize_path(params[:back_url] || request.env['HTTP_REFERER'])
-    route[:controller] == 'work_packages' && route[:action] == 'index' && route[:state]&.match?(/^\d+/)
+    route = Rails.application.routes.recognize_path(params[:back_url] || request.env["HTTP_REFERER"])
+    route[:controller] == "work_packages" && route[:action] == "index" && route[:state]&.match?(/^\d+/)
   end
 
   def last_work_package_note(work_package)
@@ -228,7 +228,7 @@ module WorkPackagesHelper
 
   def protected_work_packages_columns_options
     work_packages_columns_options
-      .select { |column| column[:id] == 'id' || column[:id] == 'subject' }
+      .select { |column| column[:id] == "id" || column[:id] == "subject" }
   end
 
   private
@@ -239,8 +239,8 @@ module WorkPackagesHelper
     if description_lines[lines - 1] && work_package.description.to_s.lines.to_a.size > lines
       description_lines[lines - 1].strip!
 
-      while !description_lines[lines - 1].end_with?('...')
-        description_lines[lines - 1] = description_lines[lines - 1] + '.'
+      while !description_lines[lines - 1].end_with?("...")
+        description_lines[lines - 1] = description_lines[lines - 1] + "."
       end
     end
 
@@ -248,7 +248,7 @@ module WorkPackagesHelper
       empty_element_tag
     else
       ::OpenProject::TextFormatting::Renderer.format_text(
-        description_lines.join(''),
+        description_lines.join(""),
         object: work_package,
         attribute: :description,
         no_nesting: true
@@ -267,12 +267,12 @@ module WorkPackagesHelper
                    h(work_package.assigned_to.name).to_s
                end
 
-    [responsible, assignee].compact.join('<br>').html_safe
+    [responsible, assignee].compact.join("<br>").html_safe
   end
 
   def link_to_work_package_css_classes(package, options)
-    classes = ['work_package']
-    classes << 'closed' if package.closed?
+    classes = ["work_package"]
+    classes << "closed" if package.closed?
     classes << options[:class].to_s
 
     classes

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -248,7 +248,7 @@ module WorkPackagesHelper
       empty_element_tag
     else
       ::OpenProject::TextFormatting::Renderer.format_text(
-        description_lines.join(""),
+        description_lines.join,
         object: work_package,
         attribute: :description,
         no_nesting: true

--- a/app/mailers/work_package_mailer.rb
+++ b/app/mailers/work_package_mailer.rb
@@ -43,7 +43,7 @@ class WorkPackageMailer < ApplicationMailer
       references journal
 
       send_localized_mail(recipient) do
-        I18n.t(:'mail.mention.subject',
+        I18n.t(:"mail.mention.subject",
                user_name: author.name,
                id: @work_package.id,
                subject: @work_package.subject)
@@ -75,13 +75,13 @@ class WorkPackageMailer < ApplicationMailer
   end
 
   def set_work_package_headers(work_package)
-    open_project_headers 'Project' => work_package.project.identifier,
-                         'WorkPackage-Id' => work_package.id,
-                         'WorkPackage-Author' => work_package.author.login,
-                         'Type' => 'WorkPackage'
+    open_project_headers "Project" => work_package.project.identifier,
+                         "WorkPackage-Id" => work_package.id,
+                         "WorkPackage-Author" => work_package.author.login,
+                         "Type" => "WorkPackage"
 
     if work_package.assigned_to
-      open_project_headers 'WorkPackage-Assignee' => work_package.assigned_to.login
+      open_project_headers "WorkPackage-Assignee" => work_package.assigned_to.login
     end
   end
 end

--- a/app/models/activities/base_activity_provider.rb
+++ b/app/models/activities/base_activity_provider.rb
@@ -108,7 +108,7 @@ class Activities::BaseActivityProvider
   end
 
   def event_datetime(event)
-    event['event_datetime'].is_a?(String) ? DateTime.parse(event['event_datetime']) : event['event_datetime']
+    event["event_datetime"].is_a?(String) ? DateTime.parse(event["event_datetime"]) : event["event_datetime"]
   end
 
   def event_type(_event_data)
@@ -128,12 +128,12 @@ class Activities::BaseActivityProvider
   # reference table is different from 'project_id'                            #
   #############################################################################
   def project_id_reference_field
-    'project_id'
+    "project_id"
   end
 
   def activitied_type
     class_name = self.class.name.demodulize
-    class_name.gsub('ActivityProvider', '').constantize
+    class_name.gsub("ActivityProvider", "").constantize
   end
 
   protected
@@ -174,11 +174,11 @@ class Activities::BaseActivityProvider
 
   def event_params(event_data)
     params = { provider: self,
-               event_id: event_data['event_id'],
-               event_description: event_data['event_description'],
-               author_id: event_data['author_id'].to_i,
-               journable_id: event_data['journable_id'],
-               project_id: event_data['project_id'].to_i }
+               event_id: event_data["event_id"],
+               event_description: event_data["event_description"],
+               author_id: event_data["author_id"].to_i,
+               journable_id: event_data["journable_id"],
+               project_id: event_data["project_id"].to_i }
 
     %i[event_name event_title event_type event_description event_datetime event_path event_url].each do |a|
       params[a] = send(a, event_data) if self.class.method_defined? a
@@ -190,12 +190,12 @@ class Activities::BaseActivityProvider
   end
 
   def event_projection
-    [[:id, 'event_id'],
-     [:created_at, 'event_datetime'],
-     [:user_id, 'author_id'],
-     [:notes, 'event_description'],
-     [:version, 'version'],
-     [:journable_id, 'journable_id']].map do |column, alias_name|
+    [[:id, "event_id"],
+     [:created_at, "event_datetime"],
+     [:user_id, "author_id"],
+     [:notes, "event_description"],
+     [:version, "version"],
+     [:journable_id, "journable_id"]].map do |column, alias_name|
       journals_table[column].as(alias_name)
     end
   end
@@ -281,7 +281,7 @@ class Activities::BaseActivityProvider
 
   def event_name(event)
     @event_names ||= {}
-    @event_names[event_type(event)] ||= I18n.t(event_type(event).underscore, scope: 'events')
+    @event_names[event_type(event)] ||= I18n.t(event_type(event).underscore, scope: "events")
   end
 
   def url_helpers

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,3 @@
-
 class ApplicationRecord < ActiveRecord::Base
   include ::OpenProject::Acts::Watchable
   include ::OpenProject::Acts::Favorable

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'digest/md5'
+require "digest/md5"
 
 class Attachment < ApplicationRecord
   enum status: {
@@ -38,7 +38,7 @@ class Attachment < ApplicationRecord
   }.freeze, _prefix: true
 
   belongs_to :container, polymorphic: true
-  belongs_to :author, class_name: 'User'
+  belongs_to :author, class_name: "User"
 
   validates :author, :content_type, :filesize, :status, presence: true
   validates :description, length: { maximum: 255 }
@@ -65,7 +65,7 @@ class Attachment < ApplicationRecord
   acts_as_journalized
   acts_as_event title: -> { file.name },
                 url: (Proc.new do |o|
-                  { controller: '/attachments', action: 'download', id: o.id, filename: o.filename }
+                  { controller: "/attachments", action: "download", id: o.id, filename: o.filename }
                 end)
 
   mount_uploader :file, OpenProject::Configuration.file_uploader
@@ -108,7 +108,7 @@ class Attachment < ApplicationRecord
   end
 
   def content_disposition(include_filename: true)
-    disposition = inlineable? ? 'inline' : 'attachment'
+    disposition = inlineable? ? "inline" : "attachment"
 
     if include_filename
       "#{disposition}; filename=#{filename}"
@@ -160,7 +160,7 @@ class Attachment < ApplicationRecord
   alias :image? :is_image?
 
   def is_pdf?
-    content_type == 'application/pdf'
+    content_type == "application/pdf"
   end
 
   def is_text?
@@ -194,7 +194,7 @@ class Attachment < ApplicationRecord
   end
 
   def filename
-    attributes['file'] || super
+    attributes["file"] || super
   end
 
   ##

--- a/app/models/queries/days/day_query.rb
+++ b/app/models/queries/days/day_query.rb
@@ -43,7 +43,7 @@ class Queries::Days::DayQuery
   # If there are multiple filters with custom from clause (currently not possible),
   # the first one is applied and the rest is ignored.
   def apply_filters(scope)
-    scope = super
+    scope = super(scope) # rubocop:disable Style/SuperArguments
     from_clause_filter = filters.find(&:from)
     scope = scope.from(from_clause_filter.from) if from_clause_filter
     scope

--- a/app/models/queries/days/day_query.rb
+++ b/app/models/queries/days/day_query.rb
@@ -43,7 +43,7 @@ class Queries::Days::DayQuery
   # If there are multiple filters with custom from clause (currently not possible),
   # the first one is applied and the rest is ignored.
   def apply_filters(scope)
-    scope = super(scope)
+    scope = super
     from_clause_filter = filters.find(&:from)
     scope = scope.from(from_clause_filter.from) if from_clause_filter
     scope

--- a/app/models/queries/work_packages/selects/work_package_select.rb
+++ b/app/models/queries/work_packages/selects/work_package_select.rb
@@ -27,18 +27,17 @@
 #++
 
 class Queries::WorkPackages::Selects::WorkPackageSelect
-  attr_accessor :highlightable
+  attr_accessor :highlightable,
+                :name,
+                :sortable_join,
+                :summable,
+                :default_order,
+                :association
   alias_method :highlightable?, :highlightable
 
   attr_reader :groupable,
               :sortable,
               :displayable
-
-  attr_accessor :name,
-                :sortable_join,
-                :summable,
-                :default_order,
-                :association
 
   attr_writer :null_handling,
               :summable_select,

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -190,7 +190,7 @@ class Query < ApplicationRecord
   end
 
   def filter_for(field)
-    filter = (filters || []).detect { |f| f.field.to_s == field.to_s } || super(field)
+    filter = (filters || []).detect { |f| f.field.to_s == field.to_s } || super
 
     filter.context = self
 

--- a/app/models/query/highlighting.rb
+++ b/app/models/query/highlighting.rb
@@ -100,7 +100,7 @@ module Query::Highlighting
       if difference.any?
         errors.add(:highlighted_attributes,
                    I18n.t(:error_attribute_not_highlightable,
-                          attributes: difference.map(&:to_s).map(&:capitalize).join(", ")))
+                          attributes: difference.map { |attribute| attribute.to_s.capitalize }.join(", ")))
       end
     end
 

--- a/app/models/query/highlighting.rb
+++ b/app/models/query/highlighting.rb
@@ -100,7 +100,7 @@ module Query::Highlighting
       if difference.any?
         errors.add(:highlighted_attributes,
                    I18n.t(:error_attribute_not_highlightable,
-                          attributes: difference.map(&:to_s).map(&:capitalize).join(', ')))
+                          attributes: difference.map(&:to_s).map(&:capitalize).join(", ")))
       end
     end
 

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -50,7 +50,7 @@ class Repository::Git < Repository
   end
 
   def self.permitted_params(params)
-    super(params).merge(params.permit(:path_encoding))
+    super.merge(params.permit(:path_encoding))
   end
 
   def self.supported_types

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -54,7 +54,7 @@ class Repository::Subversion < Repository
   end
 
   def self.permitted_params(params)
-    super(params).merge(params.permit(:login, :password))
+    super.merge(params.permit(:login, :password))
   end
 
   def self.supported_types

--- a/app/models/work_package/pdf_export/gantt.rb
+++ b/app/models/work_package/pdf_export/gantt.rb
@@ -96,7 +96,7 @@ module WorkPackage::PDFExport::Gantt
 
   GanttDataPageGroup = Struct.new(:index, :entry_ids, :pages) do
     def initialize(*args)
-      super(*args)
+      super
       pages.each { |page| page.group = self }
     end
   end
@@ -104,7 +104,7 @@ module WorkPackage::PDFExport::Gantt
   GanttDataPage = Struct.new(:index, :entry_ids, :header_cells, :rows, :columns,
                              :text_column, :width, :height, :header_row_height, :group, :lines) do
     def initialize(*args)
-      super(*args)
+      super
       rows.each { |row| row.page = self }
       columns.each { |column| column.page = self }
       self.lines = []

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -82,7 +82,7 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
   def title
     # <project>_<type>_<ID>_<subject><YYYY-MM-DD>_<HH-MM>.pdf
     build_pdf_filename([work_package.project, work_package.type,
-                        "##{work_package.id}", work_package.subject].join('_'))
+                        "##{work_package.id}", work_package.subject].join("_"))
   end
 
   def with_images?

--- a/app/seeders/basic_data/project_role_seeder.rb
+++ b/app/seeders/basic_data/project_role_seeder.rb
@@ -31,7 +31,7 @@ module BasicData
     self.seed_data_model_key = "project_roles"
 
     def update_permissions_with_modules_data(role_data)
-      super(role_data)
+      super
 
       role_data["permissions"] += OpenProject::AccessControl.public_permissions.map(&:name)
     end

--- a/app/services/base_services/delete.rb
+++ b/app/services/base_services/delete.rb
@@ -34,7 +34,7 @@ module BaseServices
     end
 
     def persist(service_result)
-      service_result = super(service_result)
+      service_result = super
 
       unless destroy(service_result.result)
         service_result.errors = service_result.result.errors

--- a/app/services/base_services/delete.rb
+++ b/app/services/base_services/delete.rb
@@ -34,7 +34,7 @@ module BaseServices
     end
 
     def persist(service_result)
-      service_result = super
+      service_result = super(service_result) # rubocop:disable Style/SuperArguments
 
       unless destroy(service_result.result)
         service_result.errors = service_result.result.errors

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -31,7 +31,7 @@ module BaseServices
     protected
 
     def persist(service_result)
-      service_result = super(service_result)
+      service_result = super
 
       unless service_result.result.save
         service_result.errors = service_result.result.errors

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -31,7 +31,7 @@ module BaseServices
     protected
 
     def persist(service_result)
-      service_result = super
+      service_result = super(service_result) # rubocop:disable Style/SuperArguments
 
       unless service_result.result.save
         service_result.errors = service_result.result.errors

--- a/app/services/custom_actions/update_service.rb
+++ b/app/services/custom_actions/update_service.rb
@@ -35,7 +35,7 @@ class CustomActions::UpdateService < CustomActions::BaseService
     self.user = user
   end
 
-  def call(attributes:, &block)
-    super(attributes:, action:, &block)
+  def call(attributes:, &)
+    super(attributes:, action:, &)
   end
 end

--- a/app/services/grids/copy_service.rb
+++ b/app/services/grids/copy_service.rb
@@ -46,7 +46,7 @@ module Grids
     end
 
     def initialize(user:, source:, contract_class: ::EmptyContract)
-      super(user:, source:, contract_class:)
+      super
     end
 
     protected

--- a/app/services/members/delete_service.rb
+++ b/app/services/members/delete_service.rb
@@ -40,7 +40,7 @@ class Members::DeleteService < BaseServices::Delete
   protected
 
   def after_perform(service_call)
-    super(service_call).tap do |call|
+    super.tap do |call|
       member = call.result
 
       cleanup_for_group(member)

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -48,7 +48,7 @@ class Notifications::CreateFromModelService
      MENTION_GROUP_TAG_ID_PATTERN,
      MENTION_GROUP_HASH_ID_PATTERN]
       .map { |pattern| "(?:#{pattern})" }
-      .join('|').freeze
+      .join("|").freeze
 
   # Skip looking for mentions in quoted lines completely.
   # We need to allow an optional single white space before the ">", because the `#text_for_mentions`
@@ -264,7 +264,7 @@ class Notifications::CreateFromModelService
       end
     end
 
-    potential_text.gsub(QUOTED_LINES_PATTERN, '')
+    potential_text.gsub(QUOTED_LINES_PATTERN, "")
   end
 
   def mentioned_ids

--- a/app/services/oauth_clients/create_service.rb
+++ b/app/services/oauth_clients/create_service.rb
@@ -38,7 +38,7 @@ module OAuthClients
 
     def after_validate(params, contract_call)
       OAuthClient.where(integration: params[:integration]).delete_all
-      super(params, contract_call)
+      super
     end
   end
 end

--- a/app/services/roles/delete_service.rb
+++ b/app/services/roles/delete_service.rb
@@ -30,13 +30,13 @@ class Roles::DeleteService < BaseServices::Delete
   def persist(service_result)
     # after destroy permissions can not be reached
     @permissions = model.permissions
-    super(service_result)
+    super
   end
 
   protected
 
   def after_perform(service_call)
-    super(service_call).tap do |_call|
+    super.tap do |_call|
       ::OpenProject::Notifications.send(
         ::OpenProject::Events::ROLE_DESTROYED,
         permissions: @permissions

--- a/app/services/roles/set_attributes_service.rb
+++ b/app/services/roles/set_attributes_service.rb
@@ -29,7 +29,7 @@
 module Roles
   class SetAttributesService < ::BaseServices::SetAttributes
     def set_attributes(params)
-      super(params)
+      super
 
       if model.is_a?(ProjectRole)
         model.permissions += OpenProject::AccessControl.public_permissions.map(&:name)

--- a/app/services/users/create_service.rb
+++ b/app/services/users/create_service.rb
@@ -36,7 +36,7 @@ module Users
     def persist(call)
       new_user = call.result
 
-      return super(call) unless new_user.invited?
+      return super unless new_user.invited?
 
       # As we're basing on the user's mail, this parameter is required
       # before we're able to validate the contract or user

--- a/app/services/users/set_attributes_service.rb
+++ b/app/services/users/set_attributes_service.rb
@@ -37,7 +37,7 @@ module Users
     def set_attributes(params)
       self.pref = params.delete(:pref)
 
-      super(params)
+      super
     end
 
     def validate_and_result

--- a/app/services/users/update_service.rb
+++ b/app/services/users/update_service.rb
@@ -41,7 +41,7 @@ module Users
     end
 
     def persist(service_result)
-      service_result = super
+      service_result = super(service_result) # rubocop:disable Style/SuperArguments
 
       if service_result.success?
         service_result.success = model.pref.save

--- a/app/services/users/update_service.rb
+++ b/app/services/users/update_service.rb
@@ -41,7 +41,7 @@ module Users
     end
 
     def persist(service_result)
-      service_result = super(service_result)
+      service_result = super
 
       if service_result.success?
         service_result.success = model.pref.save

--- a/app/services/work_package_members/delete_service.rb
+++ b/app/services/work_package_members/delete_service.rb
@@ -40,7 +40,7 @@ class WorkPackageMembers::DeleteService < BaseServices::Delete
   protected
 
   def after_perform(service_call)
-    super(service_call).tap do |call|
+    super.tap do |call|
       work_package_member = call.result
 
       cleanup_for_group(work_package_member)

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -29,9 +29,9 @@
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.title   title
-  xml.link    "rel" => "self", "href" => url_for(format: 'atom', key: User.current.rss_key, only_path: false)
+  xml.link    "rel" => "self", "href" => url_for(format: "atom", key: User.current.rss_key, only_path: false)
   xml.link    "rel" => "alternate", "href" => home_url(only_path: false)
-  xml.id      url_for(controller: '/homescreen', action: :index, only_path: false)
+  xml.id      url_for(controller: "/homescreen", action: :index, only_path: false)
   xml.updated((journals.first ? journals.first.created_at : Time.now).xmlschema)
   xml.author { xml.name Setting.app_title.to_s }
   journals.each do |change|
@@ -39,7 +39,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
     xml.entry do
       xml.title   "#{work_package.project.name} - #{work_package.type.name} ##{work_package.id}: #{work_package.subject}"
       xml.link    "rel" => "alternate", "href" => work_package_url(work_package)
-      xml.id      url_for(controller: '/work_packages', action: 'show', id: work_package, journal_id: change,
+      xml.id      url_for(controller: "/work_packages", action: "show", id: work_package, journal_id: change,
                           only_path: false)
       xml.updated change.created_at.xmlschema
       xml.author do
@@ -47,12 +47,12 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
         xml.email(change.user.mail) if change.user.is_a?(User) && change.user.mail.present? && change.user.pref.can_expose_mail?
       end
       xml.content "type" => "html" do
-        xml.text! '<ul>'
+        xml.text! "<ul>"
         change.details.each do |detail|
           change_content = change.render_detail(detail, html: true)
           xml.text!(content_tag(:li, change_content)) if change_content.present?
         end
-        xml.text! '</ul>'
+        xml.text! "</ul>"
         xml.text! format_text(change, :notes, only_path: false) if change.notes.present?
       end
     end

--- a/app/workers/application_job.rb
+++ b/app/workers/application_job.rb
@@ -61,7 +61,7 @@ class ApplicationJob < ActiveJob::Base
     if value.is_a?(Symbol)
       super(priority_number(value))
     else
-      super(value)
+      super
     end
   end
 

--- a/app/workers/backup_job.rb
+++ b/app/workers/backup_job.rb
@@ -26,8 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'tempfile'
-require 'zip'
+require "tempfile"
+require "zip"
 
 class BackupJob < ApplicationJob
   include OpenProject::PostgresEnvironment
@@ -135,21 +135,21 @@ class BackupJob < ApplicationJob
     File.open(file_name) do |file|
       call = Attachments::CreateService
         .bypass_whitelist(user:)
-        .call(container: backup, filename: file_name, file:, description: 'OpenProject backup')
+        .call(container: backup, filename: file_name, file:, description: "OpenProject backup")
 
       call.on_success do
         download_url = ::API::V3::Utilities::PathHelper::ApiV3Path.attachment_content(call.result.id)
 
         upsert_status(
           status: :success,
-          message: I18n.t('export.succeeded'),
+          message: I18n.t("export.succeeded"),
           payload: download_payload(download_url)
         )
       end
 
       call.on_failure do
         upsert_status status: :failure,
-                      message: I18n.t('export.failed', message: call.message)
+                      message: I18n.t("export.failed", message: call.message)
       end
     end
   end
@@ -253,7 +253,7 @@ class BackupJob < ApplicationJob
   end
 
   def failure!(error: nil)
-    msg = I18n.t 'backup.failed'
+    msg = I18n.t "backup.failed"
 
     upsert_status(
       status: :failure,

--- a/app/workers/scm/create_remote_repository_job.rb
+++ b/app/workers/scm/create_remote_repository_job.rb
@@ -36,7 +36,7 @@
 # Until then, a synchronous process is more failsafe.
 class SCM::CreateRemoteRepositoryJob < SCM::RemoteRepositoryJob
   def perform(repository)
-    super(repository)
+    super
 
     response = send_request(repository_request.merge(action: :create))
     repository.root_url = response["path"]

--- a/app/workers/scm/relocate_repository_job.rb
+++ b/app/workers/scm/relocate_repository_job.rb
@@ -32,7 +32,7 @@ class SCM::RelocateRepositoryJob < SCM::RemoteRepositoryJob
   queue_with_priority :below_normal
 
   def perform(repository)
-    super(repository)
+    super
 
     if repository.class.manages_remote?
       relocate_remote

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,12 +26,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
-require 'active_support'
-require 'active_support/dependencies'
-require 'core_extensions'
+require "rails/all"
+require "active_support"
+require "active_support/dependencies"
+require "core_extensions"
 require "view_component"
 require "primer/view_components/engine"
 
@@ -39,7 +39,7 @@ require "primer/view_components/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups(:opf_plugins))
 
-require_relative '../lib_static/open_project/configuration'
+require_relative "../lib_static/open_project/configuration"
 
 module OpenProject
   class Application < Rails::Application
@@ -104,8 +104,8 @@ module OpenProject
                                     if: lambda { |_env, _code, headers, _body|
                                       # Firefox fails to properly decode gzip attachments
                                       # We thus avoid deflating if sending gzip already.
-                                      content_type = headers['Content-Type']
-                                      content_type != 'application/x-gzip'
+                                      content_type = headers["Content-Type"]
+                                      content_type != "application/x-gzip"
                                     }
 
     config.middleware.use Rack::Attack
@@ -115,14 +115,14 @@ module OpenProject
 
     # Add lookbook preview paths when enabled
     if OpenProject::Configuration.lookbook_enabled?
-      config.paths.add Primer::ViewComponents::Engine.root.join('app/components').to_s, eager_load: true
+      config.paths.add Primer::ViewComponents::Engine.root.join("app/components").to_s, eager_load: true
       config.paths.add Rails.root.join("lookbook/previews").to_s, eager_load: true
-      config.paths.add Primer::ViewComponents::Engine.root.join('previews').to_s, eager_load: true
+      config.paths.add Primer::ViewComponents::Engine.root.join("previews").to_s, eager_load: true
     end
 
     # Constants in lib_static should only be loaded once and never be unloaded.
     # That directory contains configurations and patches to rails core functionality.
-    config.autoload_once_paths << Rails.root.join('lib_static').to_s
+    config.autoload_once_paths << Rails.root.join("lib_static").to_s
 
     # Configure the relative url root to be whatever the configuration is set to.
     # This allows for setting the root either via config file or via environment variable.
@@ -130,7 +130,7 @@ module OpenProject
     # than `config.exceptions_app = routes`. Otherwise Rails.application.routes.url_helpers
     # will not have configured prefix.
     # Read https://github.com/rails/rails/issues/42243 for some details.
-    config.relative_url_root = OpenProject::Configuration['rails_relative_url_root']
+    config.relative_url_root = OpenProject::Configuration["rails_relative_url_root"]
 
     # Use our own error rendering for prettier error pages
     config.exceptions_app = routes
@@ -167,7 +167,7 @@ module OpenProject
     I18n.backend.class.send(:include, I18n::Backend::Cascade)
 
     # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = 'utf-8'
+    config.encoding = "utf-8"
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
@@ -208,13 +208,12 @@ module OpenProject
 
     # Load any local configuration that is kept out of source control
     # (e.g. patches).
-    if File.exist?(File.join(File.dirname(__FILE__), 'additional_environment.rb'))
-      instance_eval File.read(File.join(File.dirname(__FILE__), 'additional_environment.rb'))
+    if File.exist?(File.join(File.dirname(__FILE__), "additional_environment.rb"))
+      instance_eval File.read(File.join(File.dirname(__FILE__), "additional_environment.rb"))
     end
 
     # initialize variable for register plugin tests
     config.plugins_to_test_paths = []
-
 
     config.active_job.queue_adapter = :good_job
 
@@ -236,7 +235,7 @@ module OpenProject
     # Return false instead of self when enqueuing is aborted from a callback.
     # Rails.application.config.active_job.return_false_on_aborted_enqueue = true
 
-    config.log_level = OpenProject::Configuration['log_level'].to_sym
+    config.log_level = OpenProject::Configuration["log_level"].to_sym
 
     # Enable the Rails 7 cache format
     config.active_support.cache_format_version = 7.0

--- a/config/initializers/acts_as_watchable.rb
+++ b/config/initializers/acts_as_watchable.rb
@@ -3,6 +3,6 @@
 # In development and non-eager loaded mode, we need to register the acts_as_watchable models manually
 # as no eager loading takes place
 Rails.application.config.after_initialize do
-    OpenProject::Acts::Watchable::Registry
-      .add(WorkPackage, Message, Forum, News, Meeting, Wiki, WikiPage)
+  OpenProject::Acts::Watchable::Registry
+    .add(WorkPackage, Message, Forum, News, Meeting, Wiki, WikiPage)
 end

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -79,5 +79,4 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      label: nil,
                                                      order: 11,
                                                      formatter: "CustomValue::EmptyStrategy")
-
 end

--- a/db/migrate/20240123151246_create_good_jobs.rb
+++ b/db/migrate/20240123151246_create_good_jobs.rb
@@ -29,12 +29,15 @@ class CreateGoodJobs < ActiveRecord::Migration[7.0]
     end
 
     add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
-    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
-    add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
-    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
-    add_index :good_jobs, [:cron_key, :created_at], name: :index_good_jobs_on_cron_key_and_created_at
-    add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
+    add_index :good_jobs, %i[queue_name scheduled_at], where: "(finished_at IS NULL)",
+                                                       name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, %i[active_job_id created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)",
+                                            name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, %i[cron_key created_at], name: :index_good_jobs_on_cron_key_and_created_at
+    add_index :good_jobs, %i[cron_key cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
     add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
-    add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
+    add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL",
+                                          name: :index_good_jobs_jobs_on_finished_at
   end
 end

--- a/db/migrate/20240123151248_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/db/migrate/20240123151248_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -12,8 +12,9 @@ class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::M
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
-      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
-      algorithm: :concurrently
+    add_index :good_jobs, %i[priority created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+                                                   where: "finished_at IS NULL",
+                                                   name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+                                                   algorithm: :concurrently
   end
 end

--- a/db/migrate/20240123151250_create_good_job_executions.rb
+++ b/db/migrate/20240123151250_create_good_job_executions.rb
@@ -21,7 +21,7 @@ class CreateGoodJobExecutions < ActiveRecord::Migration[7.0]
       t.datetime :finished_at
       t.text :error
 
-      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+      t.index %i[active_job_id created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
     end
 
     change_table :good_jobs do |t|

--- a/db/migrate/20240123151252_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/migrate/20240123151252_recreate_good_job_cron_indexes_with_conditional.rb
@@ -7,12 +7,15 @@ class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.0]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
-          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
-                    name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key created_at], where: "(cron_key IS NOT NULL)",
+                                                         name: :index_good_jobs_on_cron_key_and_created_at_cond,
+                                                         algorithm: :concurrently
         end
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
-          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
-                    name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key cron_at], where: "(cron_key IS NOT NULL)",
+                                                      unique: true,
+                                                      name: :index_good_jobs_on_cron_key_and_cron_at_cond,
+                                                      algorithm: :concurrently
         end
 
         if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
@@ -25,12 +28,13 @@ class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.0]
 
       dir.down do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
-          add_index :good_jobs, [:cron_key, :created_at],
-                    name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key created_at], name: :index_good_jobs_on_cron_key_and_created_at,
+                                                         algorithm: :concurrently
         end
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
-          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
-                    name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+          add_index :good_jobs, %i[cron_key cron_at], unique: true,
+                                                      name: :index_good_jobs_on_cron_key_and_cron_at,
+                                                      algorithm: :concurrently
         end
 
         if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)

--- a/db/migrate/20240208100316_enable_required_project_custom_fields_in_all_projects.rb
+++ b/db/migrate/20240208100316_enable_required_project_custom_fields_in_all_projects.rb
@@ -12,13 +12,12 @@ class EnableRequiredProjectCustomFieldsInAllProjects < ActiveRecord::Migration[7
         .group_by(&:first)
         .transform_values { |values| values.map(&:last) }
         .reduce([]) do |acc, (project_id, custom_field_ids)|
+          missing_custom_field_ids = required_custom_field_ids - custom_field_ids
 
-        missing_custom_field_ids = required_custom_field_ids - custom_field_ids
-
-        acc + missing_custom_field_ids.map do |custom_field_id|
-          { project_id: , custom_field_id: }
+          acc + missing_custom_field_ids.map do |custom_field_id|
+            { project_id:, custom_field_id: }
+          end
         end
-      end
 
     ProjectCustomFieldProjectMapping.insert_all!(missing_custom_field_attributes)
   end

--- a/db/migrate/20240306154735_create_good_job_labels_index.rb
+++ b/db/migrate/20240306154735_create_good_job_labels_index.rb
@@ -35,8 +35,10 @@ class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
-          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
-            name: :index_good_jobs_on_labels, algorithm: :concurrently
+          add_index :good_jobs, :labels, using: :gin,
+                                         where: "(labels IS NOT NULL)",
+                                         name: :index_good_jobs_on_labels,
+                                         algorithm: :concurrently
         end
       end
 

--- a/db/migrate/20240306154737_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/migrate/20240306154737_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -40,8 +40,9 @@ class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
-      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
-      algorithm: :concurrently
+    add_index :good_jobs, %i[priority created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+                                                   where: "finished_at IS NULL",
+                                                   name: :index_good_job_jobs_for_candidate_lookup,
+                                                   algorithm: :concurrently
   end
 end

--- a/db/migrate/20240311111957_enable_unaccent_extension.rb
+++ b/db/migrate/20240311111957_enable_unaccent_extension.rb
@@ -1,47 +1,47 @@
-  #-- copyright
-  # OpenProject is an open source project management software.
-  # Copyright (C) 2012-2024 the OpenProject GmbH
-  #
-  # This program is free software; you can redistribute it and/or
-  # modify it under the terms of the GNU General Public License version 3.
-  #
-  # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-  # Copyright (C) 2006-2013 Jean-Philippe Lang
-  # Copyright (C) 2010-2013 the ChiliProject Team
-  #
-  # This program is free software; you can redistribute it and/or
-  # modify it under the terms of the GNU General Public License
-  # as published by the Free Software Foundation; either version 2
-  # of the License, or (at your option) any later version.
-  #
-  # This program is distributed in the hope that it will be useful,
-  # but WITHOUT ANY WARRANTY; without even the implied warranty of
-  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  # GNU General Public License for more details.
-  #
-  # You should have received a copy of the GNU General Public License
-  # along with this program; if not, write to the Free Software
-  # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-  #
-  # See COPYRIGHT and LICENSE files for more details.
-  #++
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
 
-  class EnableUnaccentExtension < ActiveRecord::Migration[7.1]
-    def up
-      ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA pg_catalog;")
-    rescue StandardError => e
-      raise unless e.message.include?("unaccent")
+class EnableUnaccentExtension < ActiveRecord::Migration[7.1]
+  def up
+    ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA pg_catalog;")
+  rescue StandardError => e
+    raise unless e.message.include?("unaccent")
 
-      raise <<~MESSAGE
-        \e[33mWARNING:\e[0m Could not find or enable the `unaccent` extension for PostgreSQL.
-        This is needed for filtering users with accents, please install the postgresql-contrib module
-        for your PostgreSQL installation and re-run this migration.
+    raise <<~MESSAGE
+      \e[33mWARNING:\e[0m Could not find or enable the `unaccent` extension for PostgreSQL.
+      This is needed for filtering users with accents, please install the postgresql-contrib module
+      for your PostgreSQL installation and re-run this migration.
 
-        Read more about the contrib module at `https://www.postgresql.org/docs/current/contrib.html`.
-      MESSAGE
-    end
-
-    def down
-      ActiveRecord::Base.connection.execute("DROP EXTENSION IF EXISTS unaccent CASCADE;")
-    end
+      Read more about the contrib module at `https://www.postgresql.org/docs/current/contrib.html`.
+    MESSAGE
   end
+
+  def down
+    ActiveRecord::Base.connection.execute("DROP EXTENSION IF EXISTS unaccent CASCADE;")
+  end
+end

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -37,7 +37,7 @@ module API
         base.extend ClassMethods
       end
 
-      def from_hash(hash, *args)
+      def from_hash(hash, *)
         return super unless hash && hash["_links"]
 
         copied_hash = hash.deep_dup
@@ -52,7 +52,7 @@ module API
           copied_hash[name] = fragment
         end
 
-        super(copied_hash, *args)
+        super(copied_hash, *)
       end
 
       module ClassMethods

--- a/lib/api/errors/unauthenticated.rb
+++ b/lib/api/errors/unauthenticated.rb
@@ -33,7 +33,7 @@ module API
       code 401
 
       def initialize(message = I18n.t("api_v3.errors.code_401"))
-        super(message)
+        super
       end
     end
   end

--- a/lib/api/errors/unsupported_media_type.rb
+++ b/lib/api/errors/unsupported_media_type.rb
@@ -33,7 +33,7 @@ module API
       code 415
 
       def initialize(message)
-        super(message)
+        super
       end
     end
   end

--- a/lib/api/errors/unsupported_media_type.rb
+++ b/lib/api/errors/unsupported_media_type.rb
@@ -31,10 +31,6 @@ module API
     class UnsupportedMediaType < ErrorBase
       identifier "TypeNotSupported"
       code 415
-
-      def initialize(message)
-        super
-      end
     end
   end
 end

--- a/lib/api/utilities/meta_property.rb
+++ b/lib/api/utilities/meta_property.rb
@@ -47,7 +47,7 @@ module API
         def create(model, **args)
           meta = args.delete(:meta)
 
-          super(model, **args).tap do |instance|
+          super.tap do |instance|
             instance.meta = meta
           end
         end

--- a/lib/api/utilities/payload_representer.rb
+++ b/lib/api/utilities/payload_representer.rb
@@ -95,13 +95,13 @@ module API
         property.merge!(render_filter: filter)
       end
 
-      def from_hash(hash, *args)
+      def from_hash(hash, *)
         # Prevent entries in _embedded from overriding anything in the _links section
         copied_hash = hash.deep_dup
 
         copied_hash.delete("_embedded")
 
-        super(copied_hash, *args)
+        super(copied_hash, *)
       end
 
       def contract?(represented)
@@ -126,8 +126,8 @@ module API
       end
 
       module ClassMethods
-        def create_class(*args)
-          new_class = super(*args)
+        def create_class(*)
+          new_class = super
 
           new_class.send(:include, ::API::Utilities::PayloadRepresenter)
 

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -31,7 +31,7 @@ module API
     module Activities
       class ActivitiesAPI < ::API::OpenProjectAPI
         resources :activities do
-          route_param :id, type: Integer, desc: 'Activity ID' do
+          route_param :id, type: Integer, desc: "Activity ID" do
             after_validation do
               @activity = Journal.find(declared_params[:id])
 
@@ -41,7 +41,7 @@ module API
             end
 
             get &::API::V3::Utilities::Endpoints::Show.new(model: ::Journal,
-                                                           api_name: 'Activity',
+                                                           api_name: "Activity",
                                                            instance_generator: ->(*) { @activity })
                                                       .mount
 
@@ -50,7 +50,7 @@ module API
             end
 
             patch &::API::V3::Utilities::Endpoints::Update.new(model: ::Journal,
-                                                               api_name: 'Activity',
+                                                               api_name: "Activity",
                                                                instance_generator: ->(*) { @activity },
                                                                params_modifier: ->(*) {
                                                                  { notes: declared_params[:comment] }

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/activities/activity_representer'
+require "api/v3/activities/activity_representer"
 
 module API
   module V3
@@ -58,7 +58,7 @@ module API
                        .new(user: current_user,
                             work_package: @work_package)
                        .call(params[:comment][:raw],
-                             send_notifications: !(params.has_key?(:notify) && params[:notify] == 'false'))
+                             send_notifications: !(params.has_key?(:notify) && params[:notify] == "false"))
 
             if call.success?
               Activities::ActivityRepresenter.new(call.result, current_user:)

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -79,9 +79,9 @@ module API
 
         def _type
           if represented.noop? || represented.notes.present?
-            'Activity::Comment'
+            "Activity::Comment"
           else
-            'Activity'
+            "Activity"
           end
         end
 

--- a/lib/api/v3/backups/backups_api.rb
+++ b/lib/api/v3/backups/backups_api.rb
@@ -46,7 +46,7 @@ module API
               :attachments,
               type: Boolean,
               default: true,
-              desc: 'Whether or not to include attachments (default: true)'
+              desc: "Whether or not to include attachments (default: true)"
             )
           end
           post do

--- a/lib/api/v3/memberships/schemas/membership_schema_representer.rb
+++ b/lib/api/v3/memberships/schemas/membership_schema_representer.rb
@@ -32,10 +32,7 @@ module API
       module Schemas
         class MembershipSchemaRepresenter < ::API::Decorators::SchemaRepresenter
           def initialize(represented, self_link: nil, current_user: nil, form_embedded: false)
-            super(represented,
-                  self_link:,
-                  current_user:,
-                  form_embedded:)
+            super
           end
 
           schema :id,

--- a/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
@@ -32,10 +32,6 @@ module API
       module Filters
         class QueryFilterInstancePayloadRepresenter < QueryFilterInstanceRepresenter
           include ::API::Utilities::PayloadRepresenter
-
-          def initialize(model)
-            super
-          end
         end
       end
     end

--- a/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
@@ -34,7 +34,7 @@ module API
           include ::API::Utilities::PayloadRepresenter
 
           def initialize(model)
-            super(model)
+            super
           end
         end
       end

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_collection_representer.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_collection_representer.rb
@@ -34,7 +34,7 @@ module API
           def initialize(filters, ...)
             filters = filters.reject { ::Queries::Register.excluded_filters.include?(_1.class) }
 
-            super(filters, ...)
+            super
           end
 
           def model_self_link(model)

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -35,10 +35,7 @@ module API
       module Schemas
         class QuerySchemaRepresenter < ::API::Decorators::SchemaRepresenter
           def initialize(represented, self_link: nil, current_user: nil, form_embedded: false)
-            super(represented,
-                  self_link:,
-                  current_user:,
-                  form_embedded:)
+            super
           end
 
           def self.filters_schema

--- a/lib/api/v3/versions/schemas/version_schema_representer.rb
+++ b/lib/api/v3/versions/schemas/version_schema_representer.rb
@@ -36,10 +36,7 @@ module API
           custom_field_injector type: :schema_representer
 
           def initialize(represented, self_link: nil, current_user: nil, form_embedded: false)
-            super(represented,
-                  self_link:,
-                  current_user:,
-                  form_embedded:)
+            super
           end
 
           schema :id,

--- a/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
+++ b/lib/api/v3/work_packages/work_package_at_timestamp_representer.rb
@@ -77,9 +77,9 @@ module API
           Representable::Binding::Map.new(super.select { |bind| rendered_properties.include?(bind.name) })
         end
 
-        def compile_links_for(configs, *args)
+        def compile_links_for(configs, *)
           super(configs.select { |config| rendered_properties_for_links.include?(config.first[:rel]) },
-                *args)
+                *)
         end
 
         def rendered_properties

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -293,9 +293,9 @@ module OpenProject::Plugins
         OpenProject::Activity.register(event_type, options)
       end
 
-      def add_cron_jobs(&block)
+      def add_cron_jobs
         config.to_prepare do
-          Rails.application.config.good_job.cron.merge!(block.call)
+          Rails.application.config.good_job.cron.merge!(yield)
         end
       end
 

--- a/lib/open_project/text_formatting/filters/autolink_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_filter.rb
@@ -42,7 +42,8 @@ module OpenProject::TextFormatting
         autolink_context = default_autolink_options.merge context.fetch(:autolink, {})
         return doc if autolink_context[:enabled] == false
 
-        ::Rinku.auto_link(html, :all, "class=\"#{autolink_context[:classes]}\" rel=\"noopener noreferrer\"", nil, Rinku::AUTOLINK_SHORT_DOMAINS)
+        ::Rinku.auto_link(html, :all, "class=\"#{autolink_context[:classes]}\" rel=\"noopener noreferrer\"", nil,
+                          Rinku::AUTOLINK_SHORT_DOMAINS)
       end
 
       def default_autolink_options

--- a/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
+++ b/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
@@ -29,8 +29,8 @@
 module OpenProject::TextFormatting
   module Filters
     class SyntaxHighlightFilter < HTML::Pipeline::SyntaxHighlightFilter
-      def initialize(*args)
-        super(*args)
+      def initialize(*)
+        super
 
         @formatter = highlighter_class
       end

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -35,7 +35,7 @@ module OpenProject::TextFormatting
       attr_reader :headings, :ids
 
       def initialize(doc, context = nil, result = nil)
-        super(doc, context, result)
+        super
         @headings ||= doc.css("h1, h2, h3, h4, h5, h6")
         @ids = Set.new
       end

--- a/lib/primer/open_project/forms/dsl/work_package_autocompleter_input.rb
+++ b/lib/primer/open_project/forms/dsl/work_package_autocompleter_input.rb
@@ -9,7 +9,7 @@ module Primer
             options.reverse_merge(
               component: "opce-autocompleter",
               resource: "work_packages",
-              searchKey: "subjectOrId",
+              searchKey: "subjectOrId"
             )
           end
         end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -123,7 +123,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     (label + container_wrap_field(input, :date_picker, options))
   end
 
-  def radio_button(field, value, options = {}, *args)
+  def radio_button(field, value, options = {}, *)
     options[:class] = Array(options[:class]) + %w(form--radio-button)
 
     input_options, label_options = extract_from options
@@ -134,7 +134,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     end
 
     label = label_for_field(field, label_options)
-    input = super(field, value, input_options, *args)
+    input = super(field, value, input_options, *)
 
     (label + container_wrap_field(input, "radio-button", options))
   end

--- a/lib_static/open_project/acts/favorable.rb
+++ b/lib_static/open_project/acts/favorable.rb
@@ -47,6 +47,7 @@ module OpenProject
         # as it's used to identify whether a user can actually favorite the object.
         def acts_as_favorable
           return if included_modules.include?(::OpenProject::Acts::Favorable::InstanceMethods)
+
           OpenProject::Acts::Favorable::Registry.add(self)
 
           class_eval do

--- a/lib_static/open_project/acts/watchable.rb
+++ b/lib_static/open_project/acts/watchable.rb
@@ -114,10 +114,10 @@ module OpenProject
           active_scope = Principal.not_locked.user
 
           allowed_scope = if project.public?
-            User.allowed(self.class.acts_as_watchable_permission, project)
-          else
-            User.allowed_members_on_work_package(self.class.acts_as_watchable_permission, self)
-          end
+                            User.allowed(self.class.acts_as_watchable_permission, project)
+                          else
+                            User.allowed_members_on_work_package(self.class.acts_as_watchable_permission, self)
+                          end
 
           active_scope.where(id: allowed_scope)
         end

--- a/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journalized.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts/journalized/journalized.rb
@@ -77,8 +77,8 @@ module Acts::Journalized
     module ClassMethods
       # Overrides the +journaled+ method to first define the +journaled?+ class method before
       # deferring to the original +journaled+.
-      def acts_as_journalized(*args)
-        super(*args)
+      def acts_as_journalized(*)
+        super
 
         class << self
           def journaled?

--- a/lookbook/previews/open_project/common/autocomplete_preview.rb
+++ b/lookbook/previews/open_project/common/autocomplete_preview.rb
@@ -30,7 +30,6 @@ module OpenProject
   module Common
     # @logical_path OpenProject/Common
     class AutocompletePreview < Lookbook::Preview
-
       # @display min_height 250px
       def decorated
         render_with_template

--- a/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
@@ -28,9 +28,9 @@
 
 module OmniAuth
   class FlexibleBuilder < Builder
-    def use(middleware, *args, &)
+    def use(middleware, *, &)
       middleware.extend FlexibleStrategyClass
-      super(middleware, *args, &)
+      super
     end
   end
 end

--- a/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
@@ -91,7 +91,7 @@ module OmniAuth
 
   module FlexibleStrategyClass
     def new(app, *args, &)
-      super(app, *args, &).tap do |strategy|
+      super.tap do |strategy|
         strategy.extend FlexibleStrategy
       end
     end

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -1,4 +1,4 @@
-require 'omniauth-saml'
+require "omniauth-saml"
 module OpenProject
   module AuthSaml
     def self.configuration
@@ -26,10 +26,10 @@ module OpenProject
     end
 
     def self.settings_from_config
-      if OpenProject::Configuration['saml'].present?
+      if OpenProject::Configuration["saml"].present?
         Rails.logger.info("[auth_saml] Registering saml integration from configuration.yml")
 
-        OpenProject::Configuration['saml']
+        OpenProject::Configuration["saml"]
       end
     end
 
@@ -47,8 +47,8 @@ module OpenProject
       include OpenProject::Plugins::ActsAsOpEngine
       extend OpenProject::Plugins::AuthPlugin
 
-      register 'openproject-auth_saml',
-               author_url: 'https://github.com/finnlabs/openproject-auth_saml',
+      register "openproject-auth_saml",
+               author_url: "https://github.com/finnlabs/openproject-auth_saml",
                bundled: true,
                settings: { default: { "providers" => nil } }
 
@@ -78,8 +78,8 @@ module OpenProject
         end
       end
 
-      initializer 'auth_saml.configuration' do
-        ::Settings::Definition.add 'saml',
+      initializer "auth_saml.configuration" do
+        ::Settings::Definition.add "saml",
                                    default: nil,
                                    format: :hash,
                                    writable: false

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series.rb
@@ -35,7 +35,7 @@ module OpenProject::Backlogs::Burndown
 
       raise "Unsupported unit '#{@unit}'" unless %i[points hours].include? @unit
 
-      super(*args)
+      super
     end
 
     attr_reader :unit, :name

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -32,7 +32,7 @@ module OpenProject::Backlogs::Burndown
       @collect = args.pop
       @sprint = args.pop
       @project = args.pop
-      super(*args)
+      super
     end
 
     attr_reader :collect, :sprint, :project

--- a/modules/backlogs/lib/open_project/backlogs/mixins/prevent_issue_sti.rb
+++ b/modules/backlogs/lib/open_project/backlogs/mixins/prevent_issue_sti.rb
@@ -39,7 +39,7 @@ module OpenProject::Backlogs::Mixins
     def find_sti_class(type_name)
       type_name = to_s if type_name == "WorkPackage"
 
-      super(type_name)
+      super
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
@@ -33,7 +33,7 @@ module OpenProject::Backlogs::Patches::PermittedParamsPatch
 
   module InstanceMethods
     def update_work_package(args = {})
-      permitted_params = super(args)
+      permitted_params = super
 
       backlogs_params = params.require(:work_package).permit(:story_points)
       permitted_params.merge!(backlogs_params)

--- a/modules/bim/app/services/bim/bcf/viewpoints/create_service.rb
+++ b/modules/bim/app/services/bim/bcf/viewpoints/create_service.rb
@@ -35,7 +35,7 @@ module Bim::Bcf
         # snapshot base64 data must not get stored
         service_result.result.json_viewpoint["snapshot"]&.delete("snapshot_data")
 
-        super(service_result)
+        super
       end
     end
   end

--- a/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
@@ -4,7 +4,7 @@ module OpenProject::Bim::BcfXml
   class Exporter < ::WorkPackage::Exports::QueryExporter
     def initialize(object, options = {})
       object.add_filter("bcf_issue_associated", "=", ["t"])
-      super(object, options)
+      super
     end
 
     def current_user

--- a/modules/bim/lib/open_project/bim/patches/type_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/type_patch.rb
@@ -42,7 +42,7 @@ module OpenProject::Bim::Patches::TypePatch
     private
 
     def default_attribute?(active_cfs, key)
-      super(active_cfs, key) && key != "bcf_thumbnail"
+      super && key != "bcf_thumbnail"
     end
   end
 end

--- a/modules/boards/app/services/boards/base_create_service.rb
+++ b/modules/boards/app/services/boards/base_create_service.rb
@@ -14,7 +14,7 @@ module Boards
     end
 
     def before_perform(params, _service_result)
-      return super(params, _service_result) if no_widgets_initially?
+      return super if no_widgets_initially?
 
       create_query_result = create_query(params)
 

--- a/modules/costs/app/models/time_entries/scopes/ongoing.rb
+++ b/modules/costs/app/models/time_entries/scopes/ongoing.rb
@@ -42,7 +42,8 @@ module TimeEntries::Scopes
 
       def visible_work_packages(user)
         WorkPackage.allowed_to(user, :log_own_time).or(
-          WorkPackage.where(project_id: Project.allowed_to(User.current, :log_time)))
+          WorkPackage.where(project_id: Project.allowed_to(User.current, :log_time))
+        )
       end
 
       def not_ongoing

--- a/modules/gantt/app/controllers/gantt/menus_controller.rb
+++ b/modules/gantt/app/controllers/gantt/menus_controller.rb
@@ -60,7 +60,7 @@ module Gantt
 
         menu_item(
           params,
-          I18n.t("js.queries.#{query_key.to_s}"),
+          I18n.t("js.queries.#{query_key}")
         )
       end
     end

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_github_user_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_github_user_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe OpenProject::GithubIntegration::Services::UpsertGithubUser do
     end
 
     it "updates the github user" do
-      expect { upsert }.to change { github_user.reload.github_avatar_url }.from("https://github.com/test_user/old_avatar.jpg").to("https://github.com/test_user/avatar.jpg")
+      expect { upsert }.to change { github_user.reload.github_avatar_url }
+                             .from("https://github.com/test_user/old_avatar.jpg")
+                             .to("https://github.com/test_user/avatar.jpg")
     end
   end
 end

--- a/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
@@ -32,10 +32,7 @@ module API
       module Schemas
         class GridSchemaRepresenter < ::API::Decorators::SchemaRepresenter
           def initialize(represented, self_link: nil, current_user: nil, form_embedded: false)
-            super(represented,
-                  self_link:,
-                  current_user:,
-                  form_embedded:)
+            super
           end
 
           schema :id,

--- a/modules/grids/app/services/grids/set_attributes_service.rb
+++ b/modules/grids/app/services/grids/set_attributes_service.rb
@@ -34,7 +34,7 @@ class Grids::SetAttributesService < BaseServices::SetAttributes
   def set_attributes(attributes)
     widget_attributes = attributes.delete(:widgets)
 
-    ret = super(attributes)
+    ret = super
 
     update_widgets(widget_attributes)
 

--- a/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
@@ -45,7 +45,7 @@ module LdapGroups
     def map_to_users(sync_group, entries)
       create_missing!(entries) if sync_group.sync_users
 
-      User.where('LOWER(login) IN (?)', entries.keys.map(&:downcase))
+      User.where("LOWER(login) IN (?)", entries.keys.map(&:downcase))
     end
 
     ##
@@ -129,7 +129,7 @@ module LdapGroups
     # Get the memberof filter to use for querying members
     def memberof_filter(group)
       # memberOf filter to identify member entries of the group
-      filter = Net::LDAP::Filter.eq('memberOf', group.dn)
+      filter = Net::LDAP::Filter.eq("memberOf", group.dn)
 
       # Add the LDAP auth source own filter if present
       if ldap.filter_string.present?

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -60,7 +60,7 @@ module Meetings
           }
         }
       else
-        super(filter)
+        super
       end
     end
 

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -47,11 +47,14 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
         .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.zone.now)
         .includes(:project)
         .find_each do |meeting|
-        select.option(
-          label: "#{meeting.project.name}: #{meeting.title} #{format_date(meeting.start_time)} #{format_time(meeting.start_time, false)}",
-          value: meeting.id
-        )
-      end
+          select.option(
+            label: "#{meeting.project.name}: " \
+                   "#{meeting.title} " \
+                   "#{format_date(meeting.start_time)} " \
+                   "#{format_time(meeting.start_time, false)}",
+            value: meeting.id
+          )
+        end
     end
   end
 

--- a/modules/meeting/app/services/meetings/create_service.rb
+++ b/modules/meeting/app/services/meetings/create_service.rb
@@ -31,7 +31,6 @@ module Meetings
     protected
 
     def instance(params)
-
       # Setting the #type as attributes will not work
       # as the STI instance is not changed without using e.g., +becomes!+
       case params.delete(:type)

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_position.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_position.rb
@@ -27,7 +27,7 @@
 #++
 
 class OpenProject::JournalFormatter::AgendaItemPosition < JournalFormatter::Base
-  def render(_key, values, options = { html: true })
+  def render(_key, _values, options = { html: true })
     label_text = I18n.t(:label_agenda_items)
     label_text = content_tag(:strong, label_text) if options[:html]
 

--- a/modules/meeting/spec/controllers/meetings_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meetings_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe MeetingsController do
           before do
             get "index"
           end
+
           it { expect(response).to be_successful }
           it { expect(assigns(:meetings)).to match_array meetings[1..2] }
         end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe "Structured meetings CRUD",
     perform_enqueued_jobs
     expect(ActionMailer::Base.deliveries.size).to eq 0
   end
-    
+
   context "with sections" do
     let!(:meeting) { create(:structured_meeting, project:, author: current_user) }
     let(:show_page) { Pages::StructuredMeeting::Show.new(meeting) }

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Meeting do
 
   describe "acts_as_watchable" do
     it "is watchable" do
-      expect(described_class).to include(::OpenProject::Acts::Watchable::InstanceMethods)
+      expect(described_class).to include(OpenProject::Acts::Watchable::InstanceMethods)
     end
 
     it "uses the :view_meetings permission" do

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -1,4 +1,4 @@
-require 'open_project/plugins'
+require "open_project/plugins"
 
 module OpenProject::OpenIDConnect
   class Engine < ::Rails::Engine
@@ -7,16 +7,16 @@ module OpenProject::OpenIDConnect
     include OpenProject::Plugins::ActsAsOpEngine
     extend OpenProject::Plugins::AuthPlugin
 
-    register 'openproject-openid_connect',
-             author_url: 'https://www.openproject.org',
+    register "openproject-openid_connect",
+             author_url: "https://www.openproject.org",
              bundled: true,
-             settings: { 'default' => { 'providers' => {} } } do
+             settings: { "default" => { "providers" => {} } } do
       menu :admin_menu,
            :plugin_openid_connect,
            :openid_connect_providers_path,
            parent: :authentication,
-           caption: ->(*) { I18n.t('openid_connect.menu_title') },
-           enterprise_feature: 'openid_providers'
+           caption: ->(*) { I18n.t("openid_connect.menu_title") },
+           enterprise_feature: "openid_providers"
     end
 
     assets %w(
@@ -25,7 +25,7 @@ module OpenProject::OpenIDConnect
       openid_connect/auth_provider-heroku.png
     )
 
-    class_inflection_override('openid_connect' => 'OpenIDConnect')
+    class_inflection_override("openid_connect" => "OpenIDConnect")
 
     register_auth_providers do
       OmniAuth::OpenIDConnect::Providers.configure custom_options: %i[
@@ -60,11 +60,11 @@ module OpenProject::OpenIDConnect
       )
     end
 
-    initializer 'openid_connect.form_post_method' do
+    initializer "openid_connect.form_post_method" do
       # If response_mode 'form_post' is chosen,
       # the IP sends a POST to the callback. Only if
       # the sameSite flag is not set on the session cookie, is the cookie send along with the request.
-      if OpenProject::Configuration['openid_connect']&.any? { |_, v| v['response_mode']&.to_s == 'form_post' }
+      if OpenProject::Configuration["openid_connect"]&.any? { |_, v| v["response_mode"]&.to_s == "form_post" }
         SecureHeaders::Configuration.default.cookies[:samesite][:lax] = false
         # Need to reload the secure_headers config to
         # avoid having set defaults (e.g. https) when changing the cookie values

--- a/modules/overviews/app/components/project_custom_fields/sidebar_component.rb
+++ b/modules/overviews/app/components/project_custom_fields/sidebar_component.rb
@@ -39,6 +39,7 @@ module ProjectCustomFields
     end
 
     private
+
     def available_project_custom_fields_grouped_by_section
       @available_project_custom_fields_grouped_by_section ||=
         @project.available_custom_fields.group_by(&:project_custom_field_section)

--- a/modules/overviews/config/routes.rb
+++ b/modules/overviews/config/routes.rb
@@ -3,9 +3,11 @@ Rails.application.routes.draw do
     get "projects/:project_id",
         to: "overviews/overviews#show",
         as: :project_overview
-    get "projects/:project_id/project_custom_fields_sidebar", to: "overviews/overviews#project_custom_fields_sidebar", as: :project_custom_fields_sidebar
+    get "projects/:project_id/project_custom_fields_sidebar", to: "overviews/overviews#project_custom_fields_sidebar",
+                                                              as: :project_custom_fields_sidebar
     get "projects/:project_id/project_custom_field_section_dialog/:section_id", to: "overviews/overviews#project_custom_field_section_dialog",
                                                                                 as: :project_custom_field_section_dialog
-    put "projects/:project_id/update_project_custom_values/:section_id", to: "overviews/overviews#update_project_custom_values", as: :update_project_custom_values
+    put "projects/:project_id/update_project_custom_values/:section_id", to: "overviews/overviews#update_project_custom_values",
+                                                                         as: :update_project_custom_values
   end
 end

--- a/modules/reporting/app/models/cost_query/sql_statement.rb
+++ b/modules/reporting/app/models/cost_query/sql_statement.rb
@@ -37,7 +37,7 @@ class CostQuery::SqlStatement < Report::SqlStatement
   attr_accessor :entry_union
 
   def initialize(table, desc = "")
-    super(table, desc)
+    super
     @entry_union = false
   end
 

--- a/modules/reporting/lib/widget/settings.rb
+++ b/modules/reporting/lib/widget/settings.rb
@@ -87,7 +87,7 @@ class Widget::Settings < Widget::Base
     @cost_types = options.delete(:cost_types)
     @selected_type_id = options.delete(:selected_type_id)
 
-    super(options, &)
+    super
   end
 
   def settings_to_render

--- a/modules/reporting/lib/widget/settings/fieldset.rb
+++ b/modules/reporting/lib/widget/settings/fieldset.rb
@@ -33,7 +33,7 @@ class Widget::Settings::Fieldset < Widget::Base
     @type = options.delete(:type) || "filter"
     @id = @type.to_s
     @label = :"label_#{@type}"
-    super(options, &)
+    super
   end
 
   def render

--- a/modules/storages/app/components/storages/admin/forms/oauth_client_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/oauth_client_form_component.rb
@@ -35,8 +35,8 @@ module Storages::Admin::Forms
     attr_reader :storage
     alias_method :oauth_client, :model
 
-    def initialize(oauth_client:, storage:, **options)
-      super(oauth_client, **options)
+    def initialize(oauth_client:, storage:, **)
+      super(oauth_client, **)
       @storage = storage
     end
 

--- a/modules/storages/app/components/storages/admin/forms/redirect_uri_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/redirect_uri_form_component.rb
@@ -35,8 +35,8 @@ module Storages::Admin::Forms
     attr_reader :storage
     alias_method :oauth_client, :model
 
-    def initialize(oauth_client:, storage:, **options)
-      super(oauth_client, **options)
+    def initialize(oauth_client:, storage:, **)
+      super(oauth_client, **)
       @storage = storage
     end
 

--- a/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_access_grant_nudge_modal_component.rb
@@ -36,9 +36,9 @@ module Storages::Admin
 
     attr_reader :project_storage
 
-    def initialize(project_storage:, **options)
+    def initialize(project_storage:, **)
       @project_storage = find_project_storage(project_storage)
-      super(@project_storage, **options)
+      super(@project_storage, **)
     end
 
     def render?

--- a/modules/storages/app/components/storages/admin/oauth_application_info_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_component.rb
@@ -36,8 +36,8 @@ module Storages::Admin
     attr_reader :storage
     alias_method :oauth_application, :model
 
-    def initialize(oauth_application:, storage:, **options)
-      super(oauth_application, **options)
+    def initialize(oauth_application:, storage:, **)
+      super(oauth_application, **)
       @storage = storage
     end
   end

--- a/modules/storages/app/components/storages/admin/oauth_application_info_copy_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_application_info_copy_component.rb
@@ -35,8 +35,8 @@ module Storages::Admin
     attr_reader :storage
     alias_method :oauth_application, :model
 
-    def initialize(oauth_application:, storage:, **options)
-      super(oauth_application, **options)
+    def initialize(oauth_application:, storage:, **)
+      super(oauth_application, **)
       @storage = storage
     end
 

--- a/modules/storages/app/components/storages/admin/oauth_client_info_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_client_info_component.rb
@@ -36,8 +36,8 @@ module Storages::Admin
     attr_reader :storage
     alias_method :oauth_client, :model
 
-    def initialize(oauth_client:, storage:, **options)
-      super(oauth_client, **options)
+    def initialize(oauth_client:, storage:, **)
+      super(oauth_client, **)
       @storage = storage
     end
 

--- a/modules/storages/app/components/storages/admin/redirect_uri_component.rb
+++ b/modules/storages/app/components/storages/admin/redirect_uri_component.rb
@@ -36,8 +36,8 @@ module Storages::Admin
     attr_reader :storage
     alias_method :oauth_client, :model
 
-    def initialize(oauth_client:, storage:, **options)
-      super(oauth_client, **options)
+    def initialize(oauth_client:, storage:, **)
+      super(oauth_client, **)
       @storage = storage
     end
 

--- a/modules/storages/app/components/storages/open_project_storage_modal_component/body.rb
+++ b/modules/storages/app/components/storages/open_project_storage_modal_component/body.rb
@@ -30,8 +30,8 @@ class Storages::OpenProjectStorageModalComponent::Body < ApplicationComponent # 
           waiting_title: I18n.t("storages.open_project_storage_modal.waiting.title"),
           waiting_subtitle: I18n.t("storages.open_project_storage_modal.waiting.subtitle")
 
-  def initialize(state, **options)
+  def initialize(state, **)
     @state = state
-    super(nil, **options)
+    super(nil, **)
   end
 end

--- a/modules/storages/app/controllers/storages/admin/access_management_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/access_management_controller.rb
@@ -97,7 +97,7 @@ class Storages::Admin::AccessManagementController < ApplicationController
   private
 
   def find_model_object(object_id = :storage_id)
-    super(object_id)
+    super
     @storage = @object
   end
 

--- a/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/automatically_managed_project_folders_controller.rb
@@ -129,7 +129,7 @@ class Storages::Admin::AutomaticallyManagedProjectFoldersController < Applicatio
   # GET    /admin/settings/storages/:storage_id/automatically_managed_project_folders/new
   # POST   /admin/settings/storages/:storage_id/automatically_managed_project_folders
   def find_model_object(object_id = :storage_id)
-    super(object_id)
+    super
     @storage = @object
   end
 

--- a/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
+++ b/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
@@ -58,7 +58,7 @@ class Storages::ProjectSettings::ProjectStorageMembersController < Projects::Set
   private
 
   def find_model_object(object_id = :project_storage_id)
-    super(object_id)
+    super
     @project_storage = @object
     @storage = @project_storage.storage
   end

--- a/modules/storages/app/models/storages/storage_file.rb
+++ b/modules/storages/app/models/storages/storage_file.rb
@@ -53,18 +53,7 @@ module Storages
       location: nil,
       permissions: nil
     )
-      super(
-        id:,
-        name:,
-        size:,
-        mime_type:,
-        created_at:,
-        last_modified_at:,
-        created_by_name:,
-        last_modified_by_name:,
-        location:,
-        permissions:
-      )
+      super
     end
   end
 end

--- a/modules/storages/app/services/storages/file_links/create_service.rb
+++ b/modules/storages/app/services/storages/file_links/create_service.rb
@@ -33,7 +33,7 @@ class Storages::FileLinks::CreateService < BaseServices::Create
       service_result
     else
       # create
-      super(service_result)
+      super
     end
   end
 

--- a/modules/storages/app/services/storages/project_storages/create_service.rb
+++ b/modules/storages/app/services/storages/project_storages/create_service.rb
@@ -32,7 +32,7 @@ module Storages::ProjectStorages
     protected
 
     def after_perform(service_call)
-      super(service_call)
+      super
 
       project_storage = service_call.result
       project_folder_mode = project_storage.project_folder_mode.to_sym

--- a/modules/storages/app/services/storages/project_storages/delete_service.rb
+++ b/modules/storages/app/services/storages/project_storages/delete_service.rb
@@ -45,7 +45,7 @@ module Storages::ProjectStorages
     # by ::BaseServices::Delete
     def persist(service_result)
       # Perform the @object.destroy etc. in the super-class
-      super(service_result).tap do |deletion_result|
+      super.tap do |deletion_result|
         if deletion_result.success?
           delete_associated_file_links
           OpenProject::Notifications.send(

--- a/modules/storages/app/services/storages/project_storages/update_service.rb
+++ b/modules/storages/app/services/storages/project_storages/update_service.rb
@@ -33,7 +33,7 @@ module Storages::ProjectStorages
     protected
 
     def after_perform(service_call)
-      super(service_call)
+      super
 
       project_storage = service_call.result
       project_folder_mode = project_storage.project_folder_mode.to_sym

--- a/modules/storages/app/services/storages/storages/create_service.rb
+++ b/modules/storages/app/services/storages/storages/create_service.rb
@@ -37,7 +37,7 @@ module Storages::Storages
     protected
 
     def after_perform(service_call)
-      super(service_call)
+      super
 
       storage = service_call.result
       # Automatically create an OAuthApplication object for the Nextcloud storage

--- a/modules/storages/app/services/storages/storages/set_provider_fields_attributes_service.rb
+++ b/modules/storages/app/services/storages/storages/set_provider_fields_attributes_service.rb
@@ -40,7 +40,7 @@ module Storages::Storages
     private
 
     def set_attributes(params)
-      super(params)
+      super
       set_default_provider_fields(params)
     end
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -36,7 +36,7 @@ module Pages
     attr_reader :filters
 
     def initialize(project)
-      super(project)
+      super
 
       @filters = ::Components::WorkPackages::Filters.new
     end

--- a/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
+++ b/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
@@ -57,13 +57,13 @@ module TwoFactorAuthentication
 
     ##
     # Validate a token that was input by the user
-    def verify(input, **options)
+    def verify(input, **)
       # Validate that we can request the token for this user
       # and get the matching strategy we will use
       verify_device_and_strategy
 
       # Produce the token with the given strategy (e.g., sending an sms)
-      result = strategy.verify(input, **options)
+      result = strategy.verify(input, **)
 
       ServiceResult.new(success: result)
     rescue StandardError => e

--- a/modules/xls_export/lib/open_project/xls_export/xls_views.rb
+++ b/modules/xls_export/lib/open_project/xls_export/xls_views.rb
@@ -16,7 +16,7 @@ class OpenProject::XlsExport::XlsViews
     when :project_id                then project_representation(value)
     when :user_id, :assigned_to_id  then user_representation(value)
     when :work_package_id           then work_package_representation(value)
-    else super(key, value)
+    else super
     end
   end
 

--- a/spec/contracts/backups/create_contract_spec.rb
+++ b/spec/contracts/backups/create_contract_spec.rb
@@ -26,19 +26,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
-require 'contracts/shared/model_contract_shared_context'
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
 
 RSpec.describe Backups::CreateContract do
   let(:backup) { Backup.new }
   let(:contract) { described_class.new backup, current_user, options: { backup_token: backup_token.plain_value } }
   let(:backup_token) { create(:backup_token, user: current_user) }
 
-  include_context 'ModelContract shared context'
+  include_context "ModelContract shared context"
 
-  context 'with regular user who has the :create_backup permission' do
+  context "with regular user who has the :create_backup permission" do
     let(:current_user) { create(:user, global_permissions: [:create_backup]) }
 
-    it_behaves_like 'contract is valid'
+    it_behaves_like "contract is valid"
   end
 end

--- a/spec/factories/backup_factory.rb
+++ b/spec/factories/backup_factory.rb
@@ -27,6 +27,5 @@
 #++
 
 FactoryBot.define do
-  factory :backup, class: "Backup" do
-  end
+  factory :backup, class: "Backup"
 end

--- a/spec/factories/backup_factory.rb
+++ b/spec/factories/backup_factory.rb
@@ -27,6 +27,6 @@
 #++
 
 FactoryBot.define do
-  factory :backup, class: 'Backup' do
+  factory :backup, class: "Backup" do
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -27,22 +27,22 @@
 #++
 
 FactoryBot.define do
-  factory :user, parent: :principal, class: 'User' do
-    firstname { 'Bob' }
-    lastname { 'Bobbit' }
+  factory :user, parent: :principal, class: "User" do
+    firstname { "Bob" }
+    lastname { "Bobbit" }
     sequence(:login) { |n| "bob#{n}" }
     sequence(:mail) { |n| "bobmail#{n}.bobbit@bob.com" }
-    password { 'adminADMIN!' }
-    password_confirmation { 'adminADMIN!' }
+    password { "adminADMIN!" }
+    password_confirmation { "adminADMIN!" }
 
     transient do
       preferences { {} }
     end
 
-    language { 'en' }
+    language { "en" }
     status { User.statuses[:active] }
     admin { false }
-    first_login { false if User.table_exists? and User.columns.map(&:name).include? 'first_login' }
+    first_login { false if User.table_exists? and User.columns.map(&:name).include? "first_login" }
 
     callback(:after_build) do |user, evaluator|
       evaluator.preferences&.each do |key, val|
@@ -71,23 +71,23 @@ FactoryBot.define do
     end
 
     factory :admin do
-      firstname { 'OpenProject' }
+      firstname { "OpenProject" }
       sequence(:lastname) { |n| "Admin#{n}" }
       sequence(:login) { |n| "admin#{n}" }
       sequence(:mail) { |n| "admin#{n}@example.com" }
       admin { true }
-      first_login { false if User.table_exists? and User.columns.map(&:name).include? 'first_login' }
+      first_login { false if User.table_exists? and User.columns.map(&:name).include? "first_login" }
     end
 
-    factory :deleted_user, class: 'DeletedUser'
+    factory :deleted_user, class: "DeletedUser"
 
     factory :locked_user do
-      firstname { 'Locked' }
-      lastname { 'User' }
+      firstname { "Locked" }
+      lastname { "User" }
       sequence(:login) { |n| "locked#{n}" }
       sequence(:mail) { |n| "locked#{n}@bob.com" }
-      password { 'adminADMIN!' }
-      password_confirmation { 'adminADMIN!' }
+      password { "adminADMIN!" }
+      password_confirmation { "adminADMIN!" }
       status { User.statuses[:locked] }
     end
 
@@ -96,11 +96,11 @@ FactoryBot.define do
     end
   end
 
-  factory :anonymous, class: 'AnonymousUser' do
+  factory :anonymous, class: "AnonymousUser" do
     initialize_with { User.anonymous }
   end
 
-  factory :system, class: 'SystemUser' do
+  factory :system, class: "SystemUser" do
     initialize_with { User.system }
   end
 end

--- a/spec/features/activities/project_attributes_activity_spec.rb
+++ b/spec/features/activities/project_attributes_activity_spec.rb
@@ -31,9 +31,9 @@ require "spec_helper"
 RSpec.describe "Project attributes activity", :js, :with_cuprite do
   let(:user) do
     create(:user, member_with_permissions: {
-        project => %i[view_work_packages edit_work_packages],
-        project2 => %i[view_work_packages edit_work_packages]
-      })
+             project => %i[view_work_packages edit_work_packages],
+             project2 => %i[view_work_packages edit_work_packages]
+           })
   end
   let(:parent_project) { create(:project, name: "parent") }
   let(:project) { create(:project, parent: parent_project, active: false) }

--- a/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
@@ -83,7 +83,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   let!(:section_for_multi_select_fields) { create(:project_custom_field_section, name: "Multi select fields") }
 
   let!(:boolean_project_custom_field) do
-    field = create(:boolean_project_custom_field, projects: [project], name: "Boolean field",
+    field = create(:boolean_project_custom_field, projects: [project],
+                                                  name: "Boolean field",
                                                   project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: true)
@@ -92,7 +93,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:string_project_custom_field) do
-    field = create(:string_project_custom_field, projects: [project], name: "String field",
+    field = create(:string_project_custom_field, projects: [project],
+                                                 name: "String field",
                                                  project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: "Foo")
@@ -101,7 +103,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:integer_project_custom_field) do
-    field = create(:integer_project_custom_field, projects: [project], name: "Integer field",
+    field = create(:integer_project_custom_field, projects: [project],
+                                                  name: "Integer field",
                                                   project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: 123)
@@ -110,7 +113,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:float_project_custom_field) do
-    field = create(:float_project_custom_field, projects: [project], name: "Float field",
+    field = create(:float_project_custom_field, projects: [project],
+                                                name: "Float field",
                                                 project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: 123.456)
@@ -119,7 +123,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:date_project_custom_field) do
-    field = create(:date_project_custom_field, projects: [project], name: "Date field",
+    field = create(:date_project_custom_field, projects: [project],
+                                               name: "Date field",
                                                project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: Date.new(2024, 1, 1))
@@ -128,8 +133,9 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:link_project_custom_field) do
-    field = create(:link_project_custom_field, projects: [project], name: "Link field",
-                   project_custom_field_section: section_for_input_fields)
+    field = create(:link_project_custom_field, projects: [project],
+                                               name: "Link field",
+                                               project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: "https://www.openproject.org")
 
@@ -137,7 +143,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:text_project_custom_field) do
-    field = create(:text_project_custom_field, projects: [project], name: "Text field",
+    field = create(:text_project_custom_field, projects: [project],
+                                               name: "Text field",
                                                project_custom_field_section: section_for_input_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: "Lorem\n\nipsum")
@@ -146,7 +153,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:list_project_custom_field) do
-    field = create(:list_project_custom_field, projects: [project], name: "List field",
+    field = create(:list_project_custom_field, projects: [project],
+                                               name: "List field",
                                                project_custom_field_section: section_for_select_fields,
                                                possible_values: ["Option 1", "Option 2", "Option 3"])
 
@@ -156,7 +164,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:version_project_custom_field) do
-    field = create(:version_project_custom_field, projects: [project], name: "Version field",
+    field = create(:version_project_custom_field, projects: [project],
+                                                  name: "Version field",
                                                   project_custom_field_section: section_for_select_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: first_version.id)
@@ -165,7 +174,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:user_project_custom_field) do
-    field = create(:user_project_custom_field, projects: [project], name: "User field",
+    field = create(:user_project_custom_field, projects: [project],
+                                               name: "User field",
                                                project_custom_field_section: section_for_select_fields)
 
     create(:custom_value, customized: project, custom_field: field, value: member_in_project.id)
@@ -174,7 +184,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:multi_list_project_custom_field) do
-    field = create(:list_project_custom_field, projects: [project], name: "Multi list field",
+    field = create(:list_project_custom_field, projects: [project],
+                                               name: "Multi list field",
                                                project_custom_field_section: section_for_multi_select_fields,
                                                possible_values: ["Option 1", "Option 2", "Option 3"],
                                                multi_value: true)
@@ -186,7 +197,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:multi_version_project_custom_field) do
-    field = create(:version_project_custom_field, projects: [project], name: "Multi version field",
+    field = create(:version_project_custom_field, projects: [project],
+                                                  name: "Multi version field",
                                                   project_custom_field_section: section_for_multi_select_fields,
                                                   multi_value: true)
 
@@ -197,7 +209,8 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   end
 
   let!(:multi_user_project_custom_field) do
-    field = create(:user_project_custom_field, projects: [project], name: "Multi user field",
+    field = create(:user_project_custom_field, projects: [project],
+                                               name: "Multi user field",
                                                project_custom_field_section: section_for_multi_select_fields,
                                                multi_value: true)
 

--- a/spec/lib/acts_as_watchable/lib/acts_as_watchable/routes_spec.rb
+++ b/spec/lib/acts_as_watchable/lib/acts_as_watchable/routes_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe ::OpenProject::Acts::Watchable::Routes do
+RSpec.describe OpenProject::Acts::Watchable::Routes do
   let(:request) do
     Struct.new(:type, :id) do
       def path_parameters
@@ -43,7 +43,7 @@ RSpec.describe ::OpenProject::Acts::Watchable::Routes do
         let(:id) { "1" }
 
         it "is true" do
-          expect(::OpenProject::Acts::Watchable::Routes.matches?(request)).to be_truthy
+          expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_truthy
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe ::OpenProject::Acts::Watchable::Routes do
         let(:id) { "schmu" }
 
         it "is false" do
-          expect(::OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
+          expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe ::OpenProject::Acts::Watchable::Routes do
       let(:id) { "4" }
 
       it "is false" do
-        expect(::OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
+        expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
       end
     end
   end

--- a/spec/lib/acts_as_watchable/lib/acts_as_watchable/routes_spec.rb
+++ b/spec/lib/acts_as_watchable/lib/acts_as_watchable/routes_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OpenProject::Acts::Watchable::Routes do
         let(:id) { "1" }
 
         it "is true" do
-          expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_truthy
+          expect(described_class).to be_matches(request)
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe OpenProject::Acts::Watchable::Routes do
         let(:id) { "schmu" }
 
         it "is false" do
-          expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
+          expect(described_class).not_to be_matches(request)
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe OpenProject::Acts::Watchable::Routes do
       let(:id) { "4" }
 
       it "is false" do
-        expect(OpenProject::Acts::Watchable::Routes.matches?(request)).to be_falsey
+        expect(described_class).not_to be_matches(request)
       end
     end
   end

--- a/spec/mailers/announcement_mailer_spec.rb
+++ b/spec/mailers/announcement_mailer_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe AnnouncementMailer do
       let(:recipient) { build_stubbed(:user, status: Principal.statuses[:locked]) }
 
       it "does not send an email" do
-        expect(mail.subject).to be nil
-        expect(mail.to).to be nil
+        expect(mail.subject).to be_nil
+        expect(mail.to).to be_nil
       end
     end
   end

--- a/spec/migrations/reduce_configurable_design_variables_spec.rb
+++ b/spec/migrations/reduce_configurable_design_variables_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe ReduceConfigurableDesignVariables, type: :model do
       expect(DesignColor.find_by(variable: "primary-color-dark")).not_to be_nil
       expect(DesignColor.find_by(variable: "alternative-color")).not_to be_nil
       expect(DesignColor.find_by(variable: "content-link-color")).not_to be_nil
-
     end
   end
 end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe ApplicationRecord do
-  describe '#most_recently_changed' do
+  describe "#most_recently_changed" do
     let!(:work_package) do
       create(:work_package).tap do |wp|
         wp.update_column(:updated_at, 5.days.from_now)
@@ -24,7 +24,7 @@ RSpec.describe ApplicationRecord do
       expect(postgres_utc_iso8601).to eq(rails_utc_iso8601)
     end
 
-    it 'returns the most recently changed timestamp of the given resource classes' do
+    it "returns the most recently changed timestamp of the given resource classes" do
       expect_matched_date described_class.most_recently_changed(WorkPackage, Type, Status),
                           work_package.updated_at
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -26,90 +26,90 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Version do
-  subject(:version) { build(:version, name: 'Test Version') }
+  subject(:version) { build(:version, name: "Test Version") }
 
   it { is_expected.to be_valid }
 
-  describe 'default values' do
+  describe "default values" do
     let(:version) { described_class.new }
 
-    it 'sets the status to be open' do
+    it "sets the status to be open" do
       expect(version.status)
-        .to eq 'open'
+        .to eq "open"
     end
   end
 
-  describe 'validations' do
-    context 'with finish date that is smaller than the start date' do
+  describe "validations" do
+    context "with finish date that is smaller than the start date" do
       before do
-        version.start_date = '2013-05-01'
-        version.effective_date = '2012-01-01'
+        version.start_date = "2013-05-01"
+        version.effective_date = "2012-01-01"
       end
 
-      it 'is invalid' do
+      it "is invalid" do
         expect(version).not_to be_valid
         expect(version.errors[:effective_date])
-          .to eq [I18n.t('activerecord.errors.messages.greater_than_start_date')]
+          .to eq [I18n.t("activerecord.errors.messages.greater_than_start_date")]
       end
     end
 
-    context 'with an invalid date' do
+    context "with an invalid date" do
       before do
-        version.start_date = '2013-05-01'
-        version.effective_date = '99999-01-01'
+        version.start_date = "2013-05-01"
+        version.effective_date = "99999-01-01"
       end
 
-      it 'is invalid' do
+      it "is invalid" do
         expect(version).not_to be_valid
         expect(version.errors[:effective_date])
-          .to eq [I18n.t('activerecord.errors.messages.not_a_date')]
+          .to eq [I18n.t("activerecord.errors.messages.not_a_date")]
       end
     end
   end
 
-  describe '#to_s_for_project' do
+  describe "#to_s_for_project" do
     let(:other_project) { build(:project) }
 
-    it 'returns only the version for the same project' do
+    it "returns only the version for the same project" do
       expect(version.to_s_for_project(version.project)).to eq(version.name.to_s)
     end
 
-    it 'returns the project name and the version name for a different project' do
+    it "returns the project name and the version name for a different project" do
       expect(version.to_s_for_project(other_project)).to eq("#{version.project.name} - #{version.name}")
     end
   end
 
-  describe '#systemwide' do
-    it 'contains the version if it is shared with all projects' do
-      version.sharing = 'system'
+  describe "#systemwide" do
+    it "contains the version if it is shared with all projects" do
+      version.sharing = "system"
       version.save!
 
       expect(described_class.systemwide).to contain_exactly(version)
     end
 
-    it 'is empty if the version is not shared' do
-      version.sharing = 'none'
+    it "is empty if the version is not shared" do
+      version.sharing = "none"
       version.save!
 
       expect(described_class.systemwide).to be_empty
     end
 
-    it 'is empty if the version is shared with the project hierarchy' do
-      version.sharing = 'hierarchy'
+    it "is empty if the version is shared with the project hierarchy" do
+      version.sharing = "hierarchy"
       version.save!
 
       expect(described_class.systemwide).to be_empty
     end
   end
 
-  describe '#<=>' do
+  describe "#<=>" do
     let(:version1) { build_stubbed(:version) }
     let(:version2) { build_stubbed(:version) }
 
-    it 'is 0 if name and project are equal' do
+    it "is 0 if name and project are equal" do
       version1.project = version2.project
       version1.name = version2.name
 
@@ -117,19 +117,19 @@ RSpec.describe Version do
     end
 
     it "is -1 if the project name is alphabetically before the other's project name" do
-      version1.name = 'BBBB'
-      version1.project.name = 'AAAA'
-      version2.name = 'AAAA'
-      version2.project.name = 'BBBB'
+      version1.name = "BBBB"
+      version1.project.name = "AAAA"
+      version2.name = "AAAA"
+      version2.project.name = "BBBB"
 
       expect(version1 <=> version2).to be -1
     end
 
     it "is 1 if the project name is alphabetically after the other's project name" do
-      version1.name = 'AAAA'
-      version1.project.name = 'BBBB'
-      version2.name = 'BBBB'
-      version2.project.name = 'AAAA'
+      version1.name = "AAAA"
+      version1.project.name = "BBBB"
+      version2.name = "BBBB"
+      version2.project.name = "AAAA"
 
       expect(version1 <=> version2).to be 1
     end
@@ -137,8 +137,8 @@ RSpec.describe Version do
     it "is -1 if the project name is equal
         and the version's name is alphabetically before the other's name" do
       version1.project.name = version2.project.name
-      version1.name = 'AAAA'
-      version2.name = 'BBBB'
+      version1.name = "AAAA"
+      version2.name = "BBBB"
 
       expect(version1 <=> version2).to be -1
     end
@@ -146,13 +146,13 @@ RSpec.describe Version do
     it "is 1 if the project name is equal
         and the version's name is alphabetically after the other's name" do
       version1.project.name = version2.project.name
-      version1.name = 'BBBB'
-      version2.name = 'AAAA'
+      version1.name = "BBBB"
+      version2.name = "AAAA"
 
       expect(version1 <=> version2).to be 1
     end
 
-    it 'is 0 if name and project are equal except for case' do
+    it "is 0 if name and project are equal except for case" do
       version1.project.name = version2.project.name.upcase
       version1.name = version2.name.upcase
 
@@ -160,19 +160,19 @@ RSpec.describe Version do
     end
 
     it "is -1 if the project name is alphabetically before the other's project name ignoring case" do
-      version1.name = 'BBBB'
-      version1.project.name = 'aaaa'
-      version2.name = 'AAAA'
-      version2.project.name = 'BBBB'
+      version1.name = "BBBB"
+      version1.project.name = "aaaa"
+      version2.name = "AAAA"
+      version2.project.name = "BBBB"
 
       expect(version1 <=> version2).to be -1
     end
 
     it "is 1 if the project name is alphabetically after the other's project name ignoring case" do
-      version1.name = 'AAAA'
-      version1.project.name = 'BBBB'
-      version2.name = 'BBBB'
-      version2.project.name = 'aaaa'
+      version1.name = "AAAA"
+      version1.project.name = "BBBB"
+      version2.name = "BBBB"
+      version2.project.name = "aaaa"
 
       expect(version1 <=> version2).to be 1
     end
@@ -180,8 +180,8 @@ RSpec.describe Version do
     it "is -1 if the project name is equal
         and the version's name is alphabetically before the other's name ignoring case" do
       version1.project.name = version2.project.name
-      version1.name = 'aaaa'
-      version2.name = 'BBBB'
+      version1.name = "aaaa"
+      version2.name = "BBBB"
 
       expect(version1 <=> version2).to be -1
     end
@@ -189,47 +189,47 @@ RSpec.describe Version do
     it "is 1 if the project name is equal
         and the version's name is alphabetically after the other's name ignoring case" do
       version1.project.name = version2.project.name
-      version1.name = 'BBBB'
-      version2.name = 'aaaa'
+      version1.name = "BBBB"
+      version2.name = "aaaa"
 
       expect(version1 <=> version2).to be 1
     end
   end
 
-  describe '#projects' do
+  describe "#projects" do
     let(:grand_parent_project) do
-      build(:project, name: 'grand_parent_project')
+      build(:project, name: "grand_parent_project")
     end
     let(:parent_project) do
-      build(:project, parent: grand_parent_project, name: 'parent_project')
+      build(:project, parent: grand_parent_project, name: "parent_project")
     end
     let(:sibling_parent_project) do
-      build(:project, parent: grand_parent_project, name: 'sibling_parent_project')
+      build(:project, parent: grand_parent_project, name: "sibling_parent_project")
     end
     let(:child_project) do
-      build(:project, parent: parent_project, name: 'child_project')
+      build(:project, parent: parent_project, name: "child_project")
     end
     let(:sibling_project) do
-      build(:project, parent: parent_project, name: 'sibling_project')
+      build(:project, parent: parent_project, name: "sibling_project")
     end
     let(:unrelated_project) do
-      build(:project, name: 'unrelated_project')
+      build(:project, name: "unrelated_project")
     end
 
     let(:unshared_version) do
-      build(:version, project: parent_project, sharing: 'none')
+      build(:version, project: parent_project, sharing: "none")
     end
     let(:hierarchy_shared_version) do
-      build(:version, project: parent_project, sharing: 'hierarchy')
+      build(:version, project: parent_project, sharing: "hierarchy")
     end
     let(:descendants_shared_version) do
-      build(:version, project: parent_project, sharing: 'descendants')
+      build(:version, project: parent_project, sharing: "descendants")
     end
     let(:system_shared_version) do
-      build(:version, project: parent_project, sharing: 'system')
+      build(:version, project: parent_project, sharing: "system")
     end
     let(:tree_shared_version) do
-      build(:version, project: parent_project, sharing: 'tree')
+      build(:version, project: parent_project, sharing: "tree")
     end
 
     def save_all_projects
@@ -245,50 +245,50 @@ RSpec.describe Version do
       save_all_projects
     end
 
-    it 'returns a scope' do
+    it "returns a scope" do
       unshared_version.save
 
       expect(unshared_version.projects).to be_a(ActiveRecord::Relation)
     end
 
-    it 'is empty for a new version' do
+    it "is empty for a new version" do
       expect(described_class.new.projects).to be_empty
     end
 
-    it 'returns project the version is defined in for unshared' do
+    it "returns project the version is defined in for unshared" do
       unshared_version.save
 
       expect(unshared_version.projects).to contain_exactly(parent_project)
     end
 
-    it 'returns all projects the version is shared with (hierarchy)' do
+    it "returns all projects the version is shared with (hierarchy)" do
       hierarchy_shared_version.save!
 
       expect(hierarchy_shared_version.projects).to contain_exactly(grand_parent_project, parent_project, child_project,
                                                                    sibling_project)
     end
 
-    it 'returns all projects the version is shared with (descendants)' do
+    it "returns all projects the version is shared with (descendants)" do
       descendants_shared_version.save!
 
       expect(descendants_shared_version.projects).to contain_exactly(parent_project, child_project, sibling_project)
     end
 
-    it 'returns all projects the version is shared with (tree)' do
+    it "returns all projects the version is shared with (tree)" do
       tree_shared_version.save!
 
       expect(tree_shared_version.projects).to contain_exactly(grand_parent_project, parent_project, sibling_parent_project,
                                                               child_project, sibling_project)
     end
 
-    it 'returns all projects the version is shared with (system)' do
+    it "returns all projects the version is shared with (system)" do
       system_shared_version.save!
 
       expect(system_shared_version.projects).to contain_exactly(grand_parent_project, parent_project, sibling_parent_project,
                                                                 child_project, sibling_project, unrelated_project)
     end
 
-    it 'returns only the projects for the version although there is a system shared version' do
+    it "returns only the projects for the version although there is a system shared version" do
       unshared_version.save
       system_shared_version.save!
 
@@ -296,108 +296,108 @@ RSpec.describe Version do
     end
   end
 
-  describe '#estimated_hours' do
+  describe "#estimated_hours" do
     before do
       version.save
     end
 
-    context 'without assigned work packages' do
-      it 'returns 0.0' do
+    context "without assigned work packages" do
+      it "returns 0.0" do
         expect(version.estimated_hours)
           .to eq 0.0
       end
     end
 
-    context 'with assigned work packages without estimated hours' do
+    context "with assigned work packages without estimated hours" do
       let!(:work_package) { create(:work_package, version:) }
 
-      it 'returns 0.0' do
+      it "returns 0.0" do
         expect(version.estimated_hours)
           .to eq 0.0
       end
     end
 
-    context 'with two assigned work packages with estimated hours' do
+    context "with two assigned work packages with estimated hours" do
       let!(:work_package1) { create(:work_package, version:, estimated_hours: 2.5) }
       let!(:work_package2) { create(:work_package, version:, estimated_hours: 5) }
 
-      it 'returns the sum of estimated hours' do
+      it "returns the sum of estimated hours" do
         expect(version.estimated_hours)
           .to eq 7.5
       end
     end
 
-    context 'with assigned work packages with estimated hours in the leaves' do
+    context "with assigned work packages with estimated hours in the leaves" do
       let!(:parent) { create(:work_package, version:) }
       let!(:work_package1) { create(:work_package, parent:, version:, estimated_hours: 2.5) }
       let!(:work_package2) { create(:work_package, parent:, version:, estimated_hours: 5) }
 
-      it 'returns the sum of estimated hours' do
+      it "returns the sum of estimated hours" do
         expect(version.estimated_hours)
           .to eq 7.5
       end
     end
   end
 
-  describe '#start_date' do
-    context 'with a value saved and a work package with its own start_date' do
-      let(:version) { create(:version, start_date: '2010-01-05') }
-      let!(:work_package) { create(:work_package, version:, start_date: '2010-03-01') }
+  describe "#start_date" do
+    context "with a value saved and a work package with its own start_date" do
+      let(:version) { create(:version, start_date: "2010-01-05") }
+      let!(:work_package) { create(:work_package, version:, start_date: "2010-03-01") }
 
-      it 'is the value' do
+      it "is the value" do
         expect(version.start_date)
-          .to eq Date.parse('2010-01-05')
+          .to eq Date.parse("2010-01-05")
       end
     end
 
-    context 'without a value saved and a work package with its own start_date' do
+    context "without a value saved and a work package with its own start_date" do
       let(:version) { create(:version) }
-      let!(:work_package) { create(:work_package, version:, start_date: '2010-03-01') }
+      let!(:work_package) { create(:work_package, version:, start_date: "2010-03-01") }
 
-      it 'is nil' do
+      it "is nil" do
         expect(version.start_date)
           .to be_nil
       end
     end
   end
 
-  describe '#completed_percent and #closed_percent' do
+  describe "#completed_percent and #closed_percent" do
     create_shared_association_defaults_for_work_package_factory
 
     let(:project) { create(:project) }
     let(:version) { create(:version, project:) }
     let(:closed_status) { create(:status, is_closed: true) }
 
-    context 'without a work package' do
-      it 'is 0 for completed_percent' do
+    context "without a work package" do
+      it "is 0 for completed_percent" do
         expect(version.completed_percent)
           .to eq 0
       end
 
-      it 'is 0 for closed_percent' do
+      it "is 0 for closed_percent" do
         expect(version.closed_percent)
           .to eq 0
       end
     end
 
-    context 'with assigned work packages that are not begun' do
+    context "with assigned work packages that are not begun" do
       before do
         create(:work_package, version:)
         create(:work_package, version:, done_ratio: 0)
       end
 
-      it 'is 0 for completed_percent' do
+      it "is 0 for completed_percent" do
         expect(version.completed_percent)
           .to eq 0
       end
 
-      it 'is 0 for closed_percent' do
+      it "is 0 for closed_percent" do
         expect(version.closed_percent)
           .to eq 0
       end
     end
 
-    context 'with assigned work packages that are closed' do
+    context "with assigned work packages that are closed" do
       before do
         create(:work_package, status: closed_status, version:)
         create(:work_package, status: closed_status, version:, done_ratio: 20)
@@ -405,54 +405,54 @@ RSpec.describe Version do
         create(:work_package, status: closed_status, version:, estimated_hours: 15)
       end
 
-      it 'is 100 for completed_percent' do
+      it "is 100 for completed_percent" do
         expect(version.completed_percent)
           .to eq 100
       end
 
-      it 'is 100 for closed_percent' do
+      it "is 100 for closed_percent" do
         expect(version.closed_percent)
           .to eq 100
       end
     end
 
-    context 'with assigned work packages that have only done ratio' do
+    context "with assigned work packages that have only done ratio" do
       before do
         create(:work_package, version:)
         create(:work_package, version:, done_ratio: 20)
         create(:work_package, version:, done_ratio: 70)
       end
 
-      it 'considers the done ratio of open work packages' do
+      it "considers the done ratio of open work packages" do
         expect(version.completed_percent)
           .to eq (0.0 + 20.0 + 70.0) / 3
       end
 
-      it 'is 0 for closed_percent' do
+      it "is 0 for closed_percent" do
         expect(version.closed_percent)
           .to eq 0
       end
     end
 
-    context 'with assigned work packages that have only done ratio with one being closed' do
+    context "with assigned work packages that have only done ratio with one being closed" do
       before do
         create(:work_package, version:)
         create(:work_package, version:, done_ratio: 20)
         create(:work_package, status: closed_status, version:)
       end
 
-      it 'considers the done ratio of open work packages' do
+      it "considers the done ratio of open work packages" do
         expect(version.completed_percent)
           .to eq (0.0 + 20.0 + 100.0) / 3
       end
 
-      it 'is 33 for closed_percent' do
+      it "is 33 for closed_percent" do
         expect(version.closed_percent)
           .to eq 100.0 / 3
       end
     end
 
-    context 'with assigned work packages that have weighted done ratio' do
+    context "with assigned work packages that have weighted done ratio" do
       before do
         create(:work_package, version:, estimated_hours: 10)
         create(:work_package, version:, done_ratio: 30, estimated_hours: 20)
@@ -460,18 +460,18 @@ RSpec.describe Version do
         create(:work_package, status: closed_status, version:, estimated_hours: 25)
       end
 
-      it 'considers the weighted done ratio of open work packages' do
+      it "considers the weighted done ratio of open work packages" do
         expect(version.completed_percent)
           .to eq ((10.0 * 0) + (20.0 * 0.3) + (40 * 0.1) + (25.0 * 1)) / 95.0 * 100
       end
 
-      it 'is considers the weighted closed_percent' do
+      it "is considers the weighted closed_percent" do
         expect(version.closed_percent)
           .to eq 25.0 / 95.0 * 100
       end
     end
 
-    context 'with assigned work packages that have partly weighted done ratio' do
+    context "with assigned work packages that have partly weighted done ratio" do
       before do
         create(:work_package, version:, done_ratio: 20)
         create(:work_package, version:, done_ratio: 30, estimated_hours: 10)
@@ -479,19 +479,19 @@ RSpec.describe Version do
         create(:work_package, status: closed_status, version:)
       end
 
-      it 'considers the weighted done ratio of open work packages and uses default weighting if unset' do
+      it "considers the weighted done ratio of open work packages and uses default weighting if unset" do
         expect(version.completed_percent)
           .to eq ((25.0 * 0.2) + (25.0 * 1) + (10.0 * 0.3) + (40.0 * 0.1)) / 100.0 * 100
       end
 
-      it 'is considers the weighted closed_percent using average for the estimated hours' do
+      it "is considers the weighted closed_percent using average for the estimated hours" do
         expect(version.closed_percent)
           .to eq 25.0 / 100.0 * 100
       end
     end
   end
 
-  it_behaves_like 'acts_as_customizable included' do
+  it_behaves_like "acts_as_customizable included" do
     let(:model_instance) { version }
     let(:custom_field) { create(:version_custom_field) }
   end

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -154,12 +154,12 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
   describe "with a request for a PDF table" do
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  query.name,
-                                  *column_titles,
-                                  *work_package_columns(work_package_parent),
-                                  *work_package_columns(work_package_child),
-                                  "1/1", export_time_formatted, query.name
-                                ].join(" ")
+        query.name,
+        *column_titles,
+        *work_package_columns(work_package_parent),
+        *work_package_columns(work_package_child),
+        "1/1", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -168,15 +168,15 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  query.name,
-                                  work_package_parent.type.name,
-                                  *column_titles,
-                                  *work_package_columns(work_package_parent),
-                                  work_package_child.type.name,
-                                  *column_titles,
-                                  *work_package_columns(work_package_child),
-                                  "1/1", export_time_formatted, query.name
-                                ].join(" ")
+        query.name,
+        work_package_parent.type.name,
+        *column_titles,
+        *work_package_columns(work_package_parent),
+        work_package_child.type.name,
+        *column_titles,
+        *work_package_columns(work_package_child),
+        "1/1", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -185,17 +185,17 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  query.name,
-                                  work_package_parent.type.name,
-                                  *column_titles,
-                                  *work_package_columns(work_package_parent),
-                                  I18n.t("js.label_sum"), work_package_parent.story_points.to_s,
-                                  work_package_child.type.name,
-                                  *column_titles,
-                                  *work_package_columns(work_package_child),
-                                  I18n.t("js.label_sum"), work_package_child.story_points.to_s,
-                                  "1/1", export_time_formatted, query.name
-                                ].join(" ")
+        query.name,
+        work_package_parent.type.name,
+        *column_titles,
+        *work_package_columns(work_package_parent),
+        I18n.t("js.label_sum"), work_package_parent.story_points.to_s,
+        work_package_child.type.name,
+        *column_titles,
+        *work_package_columns(work_package_child),
+        I18n.t("js.label_sum"), work_package_child.story_points.to_s,
+        "1/1", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -204,17 +204,17 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  query.name,
-                                  "Foo",
-                                  *column_titles,
-                                  *work_package_columns(work_package_child),
-                                  I18n.t("js.label_sum"), work_package_child.story_points.to_s,
-                                  "Foo, Bar",
-                                  *column_titles,
-                                  *work_package_columns(work_package_parent),
-                                  I18n.t("js.label_sum"), work_package_parent.story_points.to_s,
-                                  "1/1", export_time_formatted, query.name
-                                ].join(" ")
+        query.name,
+        "Foo",
+        *column_titles,
+        *work_package_columns(work_package_child),
+        I18n.t("js.label_sum"), work_package_child.story_points.to_s,
+        "Foo, Bar",
+        *column_titles,
+        *work_package_columns(work_package_parent),
+        I18n.t("js.label_sum"), work_package_parent.story_points.to_s,
+        "1/1", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -223,15 +223,15 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  *cover_page_content,
-                                  query.name,
-                                  "1.", "2", work_package_parent.subject,
-                                  "2.", "2", work_package_child.subject,
-                                  "1/2", export_time_formatted, query.name,
-                                  *work_package_details(work_package_parent, "1"),
-                                  *work_package_details(work_package_child, "2"),
-                                  "2/2", export_time_formatted, query.name
-                                ].join(" ")
+        *cover_page_content,
+        query.name,
+        "1.", "2", work_package_parent.subject,
+        "2.", "2", work_package_child.subject,
+        "1/2", export_time_formatted, query.name,
+        *work_package_details(work_package_parent, "1"),
+        *work_package_details(work_package_child, "2"),
+        "2/2", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -241,15 +241,15 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  *cover_page_content,
-                                  query.name,
-                                  "1.", "2", work_package_parent.subject,
-                                  "1.1.", "2", work_package_child.subject,
-                                  "1/2", export_time_formatted, query.name,
-                                  *work_package_details(work_package_parent, "1"),
-                                  *work_package_details(work_package_child, "1.1"),
-                                  "2/2", export_time_formatted, query.name
-                                ].join(" ")
+        *cover_page_content,
+        query.name,
+        "1.", "2", work_package_parent.subject,
+        "1.1.", "2", work_package_child.subject,
+        "1/2", export_time_formatted, query.name,
+        *work_package_details(work_package_parent, "1"),
+        *work_package_details(work_package_child, "1.1"),
+        "2/2", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -259,18 +259,18 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  *cover_page_content,
-                                  query.name,
-                                  "1.", "2", work_package_parent.subject,
-                                  "2.", "2", work_package_child.subject,
-                                  "1/2", export_time_formatted, query.name,
-                                  I18n.t("js.work_packages.tabs.overview"),
-                                  column_title(:story_points),
-                                  I18n.t("js.label_sum"), work_packages_sum.to_s,
-                                  *work_package_details(work_package_parent, "1"),
-                                  *work_package_details(work_package_child, "2"),
-                                  "2/2", export_time_formatted, query.name
-                                ].join(" ")
+        *cover_page_content,
+        query.name,
+        "1.", "2", work_package_parent.subject,
+        "2.", "2", work_package_child.subject,
+        "1/2", export_time_formatted, query.name,
+        I18n.t("js.work_packages.tabs.overview"),
+        column_title(:story_points),
+        I18n.t("js.label_sum"), work_packages_sum.to_s,
+        *work_package_details(work_package_parent, "1"),
+        *work_package_details(work_package_child, "2"),
+        "2/2", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -280,20 +280,20 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  *cover_page_content,
-                                  query.name,
-                                  "1.", "2", work_package_parent.subject,
-                                  "2.", "2", work_package_child.subject,
-                                  "1/2", export_time_formatted, query.name,
-                                  I18n.t("js.work_packages.tabs.overview"),
-                                  column_title(:type), column_title(:story_points),
-                                  work_package_parent.type.name, work_package_parent.story_points.to_s,
-                                  work_package_child.type.name, work_package_child.story_points.to_s,
-                                  I18n.t("js.label_sum"), work_packages_sum.to_s,
-                                  *work_package_details(work_package_parent, "1"),
-                                  *work_package_details(work_package_child, "2"),
-                                  "2/2", export_time_formatted, query.name
-                                ].join(" ")
+        *cover_page_content,
+        query.name,
+        "1.", "2", work_package_parent.subject,
+        "2.", "2", work_package_child.subject,
+        "1/2", export_time_formatted, query.name,
+        I18n.t("js.work_packages.tabs.overview"),
+        column_title(:type), column_title(:story_points),
+        work_package_parent.type.name, work_package_parent.story_points.to_s,
+        work_package_child.type.name, work_package_child.story_points.to_s,
+        I18n.t("js.label_sum"), work_packages_sum.to_s,
+        *work_package_details(work_package_parent, "1"),
+        *work_package_details(work_package_child, "2"),
+        "2/2", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 
@@ -303,22 +303,22 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
 
     it "contains correct data" do
       expect(pdf_strings).to eq [
-                                  *cover_page_content,
-                                  query.name,
-                                  "1.", "2", work_package_child.subject,
-                                  "2.", "2", work_package_parent.subject,
-                                  "1/2", export_time_formatted, query.name,
-                                  I18n.t("js.work_packages.tabs.overview"),
-                                  list_custom_field.name.upcase, column_title(:story_points),
+        *cover_page_content,
+        query.name,
+        "1.", "2", work_package_child.subject,
+        "2.", "2", work_package_parent.subject,
+        "1/2", export_time_formatted, query.name,
+        I18n.t("js.work_packages.tabs.overview"),
+        list_custom_field.name.upcase, column_title(:story_points),
 
-                                  "Foo", work_package_child.story_points.to_s,
-                                  "Foo, Bar", work_package_parent.story_points.to_s,
-                                  I18n.t("js.label_sum"), work_packages_sum.to_s,
+        "Foo", work_package_child.story_points.to_s,
+        "Foo, Bar", work_package_parent.story_points.to_s,
+        I18n.t("js.label_sum"), work_packages_sum.to_s,
 
-                                  *work_package_details(work_package_child, "1"),
-                                  *work_package_details(work_package_parent, "2"),
-                                  "2/2", export_time_formatted, query.name
-                                ].join(" ")
+        *work_package_details(work_package_child, "1"),
+        *work_package_details(work_package_parent, "2"),
+        "2/2", export_time_formatted, query.name
+      ].join(" ")
     end
   end
 end

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -26,16 +26,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
-require 'rack/test'
+require "spec_helper"
+require "rack/test"
 
 RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
   include API::V3::Utilities::PathHelper
 
-  describe 'activities' do
+  describe "activities" do
     let(:project) { work_package.project }
     let(:work_package) { create(:work_package) }
-    let(:comment) { 'This is a test comment!' }
+    let(:comment) { "This is a test comment!" }
     let(:current_user) do
       create(:user, member_with_roles: { project => role })
     end
@@ -46,28 +46,28 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
       allow(User).to receive(:current).and_return(current_user)
     end
 
-    describe 'GET /api/v3/work_packages/:id/activities' do
+    describe "GET /api/v3/work_packages/:id/activities" do
       before do
         get api_v3_paths.work_package_activities work_package.id
       end
 
-      it 'succeeds' do
+      it "succeeds" do
         expect(last_response.status).to be 200
       end
 
-      context 'not allowed to see work package' do
+      context "not allowed to see work package" do
         let(:current_user) { create(:user) }
 
-        it 'fails with HTTP Not Found' do
+        it "fails with HTTP Not Found" do
           expect(last_response.status).to be 404
         end
       end
     end
 
-    describe 'POST /api/v3/work_packages/:id/activities' do
+    describe "POST /api/v3/work_packages/:id/activities" do
       let(:work_package) { create(:work_package) }
 
-      shared_context 'create activity' do
+      shared_context "create activity" do
         before do
           header "Content-Type", "application/json"
           post api_v3_paths.work_package_activities(work_package.id),
@@ -75,34 +75,34 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
         end
       end
 
-      it_behaves_like 'safeguarded API' do
+      it_behaves_like "safeguarded API" do
         let(:permissions) { %i(view_work_packages) }
 
-        include_context 'create activity'
+        include_context "create activity"
       end
 
-      it_behaves_like 'valid activity request' do
+      it_behaves_like "valid activity request" do
         let(:status_code) { 201 }
 
-        include_context 'create activity'
+        include_context "create activity"
       end
 
-      context 'with an erroneous work package' do
+      context "with an erroneous work package" do
         before do
-          work_package.subject = ''
+          work_package.subject = ""
           work_package.save!(validate: false)
         end
 
-        include_context 'create activity'
+        include_context "create activity"
 
-        it 'responds with error' do
+        it "responds with error" do
           expect(last_response.status).to be 422
         end
 
-        it 'notes the error' do
+        it "notes the error" do
           expect(last_response.body)
             .to be_json_eql("Subject can't be blank.".to_json)
-            .at_path('message')
+            .at_path("message")
         end
       end
     end

--- a/spec/routing/watchers_spec.rb
+++ b/spec/routing/watchers_spec.rb
@@ -31,7 +31,7 @@ require "spec_helper"
 RSpec.describe WatchersController do
   shared_examples_for "watched model routes" do
     before do
-      expect(::OpenProject::Acts::Watchable::Routes).to receive(:matches?).and_return(true)
+      expect(OpenProject::Acts::Watchable::Routes).to receive(:matches?).and_return(true)
     end
 
     it "connects POST /:object_type/:object_id/watch to watchers#watch" do

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -166,8 +166,9 @@ RSpec.describe WorkPackages::Shared::AllDays do
       end
 
       context "with lag" do
-        include_examples "soonest working day with lag", date: Date.new(2022, 12, 24), lag: 7,
-                                                           expected: Date.new(2022, 12, 31)
+        include_examples "soonest working day with lag", date: Date.new(2022, 12, 24),
+                                                         lag: 7,
+                                                         expected: Date.new(2022, 12, 31)
       end
     end
   end

--- a/spec/services/work_packages/shared/working_days_spec.rb
+++ b/spec/services/work_packages/shared/working_days_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
     end
 
     context "with lag" do
-      it "returns the soonest working day from the given day, after a configurable  lag of working days" do
+      it "returns the soonest working day from the given day, after a configurable lag of working days" do
         expect(subject.soonest_working_day(sunday_2022_07_31, lag: nil)).to eq(sunday_2022_07_31)
         expect(subject.soonest_working_day(sunday_2022_07_31, lag: 0)).to eq(sunday_2022_07_31)
         expect(subject.soonest_working_day(sunday_2022_07_31, lag: 1)).to eq(monday_2022_08_01)

--- a/spec/support/components/common/modal.rb
+++ b/spec/support/components/common/modal.rb
@@ -57,8 +57,8 @@ module Components
         end
       end
 
-      def within_modal(name = nil, **options, &)
-        super(name, **options, &)
+      def within_modal(name = nil, **, &)
+        super
       end
 
       def modal_element

--- a/spec/support/pages/notifications/split_screen.rb
+++ b/spec/support/pages/notifications/split_screen.rb
@@ -35,7 +35,7 @@ module Pages
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 
       def initialize(work_package, project = nil)
-        super(work_package, project)
+        super
         @selector = ".work-packages--details"
       end
     end

--- a/spec/support/pages/work_packages/split_work_package.rb
+++ b/spec/support/pages/work_packages/split_work_package.rb
@@ -34,7 +34,7 @@ module Pages
     attr_reader :selector
 
     def initialize(work_package, project = nil)
-      super(work_package, project)
+      super
       @selector = ".work-packages--details"
     end
 

--- a/spec/support/pages/work_packages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages/work_packages_timeline.rb
@@ -50,7 +50,7 @@ module Pages
     end
 
     def expect_work_package_listed(*work_packages)
-      super(*work_packages)
+      super
 
       within(timeline_container) do
         work_packages.each do |wp|

--- a/spec/support/wait/handler.rb
+++ b/spec/support/wait/handler.rb
@@ -4,12 +4,12 @@
 module RSpec
   module Wait
     module Handler
-      def handle_matcher(target, *args, &)
+      def handle_matcher(target, *, &)
         t = Time.current
 
         begin
           actual = target.respond_to?(:call) ? target.call : target
-          super(actual, *args, &)
+          super(actual, *, &)
         rescue RSpec::Expectations::ExpectationNotMetError => e
           elapsed = Time.current - t
           if elapsed < RSpec.configuration.wait_timeout

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -50,7 +50,8 @@ RSpec.configure do |config|
         "chromedriver.storage.googleapis.com",
         "openproject-ci-public-logs.s3.eu-west-1.amazonaws.com",
         "cuprite-chrome"
-      ])
+      ]
+    )
     WebMock.enable!
     example.run
   ensure

--- a/spec/workers/backup_job_spec.rb
+++ b/spec/workers/backup_job_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe BackupJob, type: :model do
   shared_examples "it creates a backup" do |opts = {}|
@@ -85,16 +85,16 @@ RSpec.describe BackupJob, type: :model do
       job.perform **arguments.first
     end
 
-    describe 'environment variables' do
+    describe "environment variables" do
       let(:hash_config) do
-        ActiveRecord::DatabaseConfigurations::HashConfig.new('test', 'primary', config_double)
+        ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config_double)
       end
 
       before do
         allow(ActiveRecord::Base).to receive(:connection_db_config).and_return(hash_config)
       end
 
-      context 'when config has username' do
+      context "when config has username" do
         let(:config_double) do
           {
             adapter: :postgresql,
@@ -104,16 +104,16 @@ RSpec.describe BackupJob, type: :model do
           }
         end
 
-        it 'sets PGUSER and other variables' do
+        it "sets PGUSER and other variables" do
           perform
 
           expect(Open3).to have_received(:capture3) do |*args|
-            expect(args[0]).to include('PGUSER' => 'foobar', 'PGPASSWORD' => 'blabla', 'PGDATABASE' => 'test')
+            expect(args[0]).to include("PGUSER" => "foobar", "PGPASSWORD" => "blabla", "PGDATABASE" => "test")
           end
         end
       end
 
-      context 'when config has user reference, not username (regression #44251)' do
+      context "when config has user reference, not username (regression #44251)" do
         let(:config_double) do
           {
             adapter: :postgresql,
@@ -123,11 +123,11 @@ RSpec.describe BackupJob, type: :model do
           }
         end
 
-        it 'still sets PGUSER and other variables' do
+        it "still sets PGUSER and other variables" do
           perform
 
           expect(Open3).to have_received(:capture3) do |*args|
-            expect(args[0]).to include('PGUSER' => 'foobar', 'PGPASSWORD' => 'blabla', 'PGDATABASE' => 'test')
+            expect(args[0]).to include("PGUSER" => "foobar", "PGPASSWORD" => "blabla", "PGDATABASE" => "test")
           end
         end
       end
@@ -218,7 +218,7 @@ RSpec.describe BackupJob, type: :model do
 
     before do
       FileUtils.mkdir_p Pathname(dummy_path).parent.to_s
-      File.open(dummy_path, "w") { |f| f.puts 'dummy' }
+      File.open(dummy_path, "w") { |f| f.puts "dummy" }
 
       allow_any_instance_of(LocalFileUploader).to receive(:cached?).and_return(true)
       allow_any_instance_of(LocalFileUploader)


### PR DESCRIPTION
Continue #15055

Excluding `Rails/WhereRange`, as it may in the end not be safe when used with `merge` method.

I also corrected manually some violations reported on the diff, but not all, as it will be better to look at them when working on specific code.

```ruby
#!/usr/bin/env ruby

require 'json'
require 'set'
require 'time'

# there are less than 100, no need to go through pages
data = `curl --silent -H "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/opf/openproject/pulls?state=open&per_page=100'`

threshold = Date.today - 100 # only updated during last 100 days
pr_ids = JSON.parse(data)
  .filter{ Time.iso8601(_1['updated_at']).to_date >= threshold }
  .map{ _1['number'] }

system *%W[git fetch origin dev], *pr_ids.map{ "+refs/pull/#{_1}/head:refs/remotes/origin/pr/#{_1}" }

refs = pr_ids.map{ |pr_id| "origin/pr/#{pr_id}" }
refs += `git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*'`.split("\n")

pr_touched_paths = Set.new

refs.each do |ref|
  pr_touched_paths.merge IO.popen(%W[git diff --name-only ...#{ref}], &:read).split("\n")
end

rubocop_target_paths = IO.popen(%W[rubocop --list-target-files], &:read).split("\n")

paths = rubocop_target_paths - pr_touched_paths.to_a

system *%w[rubocop --format offenses] + paths

system *%w[rubocop --autocorrect --except Rails/WhereRange -o /dev/null] + paths
```