### PR TITLE
Get rid of manual html_safe calls in reporting

### DIFF
--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -68,10 +68,6 @@ module ReportingHelper
     end
   end
 
-  def debug_fields(result, prefix = ", ")
-    prefix << result.fields.inspect << ", " << result.important_fields.inspect << ", " << result.key.inspect if params[:debug]
-  end
-
   def month_name(index)
     Date::MONTHNAMES[index].to_s
   end

--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -100,31 +100,50 @@ module ReportingHelper
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def field_representation_map(key, value)
     return I18n.t(:"placeholders.default") if value.blank?
 
     case key.to_sym
-    when :activity_id                           then mapped value, Enumeration, "<i>#{I18n.t(:caption_material_costs)}</i>"
-    when :project_id                            then link_to_project Project.find(value.to_i)
-    when :user_id, :assigned_to_id, :author_id, :logged_by_id then link_to_user(User.find_by(id: value.to_i) || DeletedUser.first)
-    when :tyear, :units                         then h(value.to_s)
-    when :tweek                                 then "#{I18n.t(:label_week)} ##{h value}"
-    when :tmonth                                then month_name(value.to_i)
-    when :category_id                           then h(Category.find(value.to_i).name)
-    when :cost_type_id                          then mapped value, CostType, I18n.t(:caption_labor)
-    when :budget_id                             then budget_link value
-    when :work_package_id                       then link_to_work_package(WorkPackage.find(value.to_i))
-    when :spent_on                              then format_date(value.to_date)
-    when :type_id                               then h(Type.find(value.to_i).name)
-    when :week                                  then "#{I18n.t(:label_week)} #%s" % value.to_i.modulo(100)
-    when :priority_id                           then h(IssuePriority.find(value.to_i).name)
-    when :version_id                            then h(Version.find(value.to_i).name)
-    when :singleton_value                       then ""
-    when :status_id                             then h(Status.find(value.to_i).name)
-    when /custom_field\d+/                      then h(custom_value(key, value))
-    else h(value.to_s)
+    when :activity_id
+      mapped value, Enumeration, "<i>#{I18n.t(:caption_material_costs)}</i>"
+    when :project_id
+      link_to_project Project.find(value.to_i)
+    when :user_id, :assigned_to_id, :author_id, :logged_by_id
+      link_to_user(User.find_by(id: value.to_i) || DeletedUser.first)
+    when :tweek
+      "#{I18n.t(:label_week)} ##{h value}"
+    when :tmonth
+      month_name(value.to_i)
+    when :category_id
+      Category.find(value.to_i).name
+    when :cost_type_id
+      mapped value, CostType, I18n.t(:caption_labor)
+    when :budget_id
+      budget_link value
+    when :work_package_id
+      link_to_work_package(WorkPackage.find(value.to_i))
+    when :spent_on
+      format_date(value.to_date)
+    when :type_id
+      Type.find(value.to_i).name
+    when :week
+      "#{I18n.t(:label_week)} #%s" % value.to_i.modulo(100)
+    when :priority_id
+      IssuePriority.find(value.to_i).name
+    when :version_id
+      Version.find(value.to_i).name
+    when :singleton_value
+      ""
+    when :status_id
+      Status.find(value.to_i).name
+    when /custom_field\d+/
+      custom_value(key, value)
+    else
+      value.to_s
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def custom_value(cf_identifier, value)
     cf_id = cf_identifier.gsub("custom_field", "").to_i
@@ -144,6 +163,13 @@ module ReportingHelper
     when :spent_on                                 then value.to_date.mjd
     else strip_tags(field_representation_map(key, value))
     end
+  end
+
+  def html_safe_gsub(string, *gsub_args, &)
+    html_safe = string.html_safe?
+    string.gsub(*gsub_args, &)
+    # We only mark the string as safe if the previous string was already safe
+    string.html_safe if html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def show_result(row, unit_id = self.unit_id)
@@ -168,33 +194,12 @@ module ReportingHelper
     tabs.map { |cost_type_id| [cost_type_id, cost_type_label(cost_type_id)] }
   end
 
-  def cost_type_label(cost_type_id, cost_type_inst = nil, _plural = true)
+  def cost_type_label(cost_type_id, cost_type_inst = nil)
     case cost_type_id
     when -1 then I18n.t(:caption_labor)
     when 0  then I18n.t(:label_money)
     else (cost_type_inst || CostType.find(cost_type_id)).name
     end
-  end
-
-  def link_to_details(result)
-    return "" # unless result.respond_to? :fields # uncomment to display
-    session_filter = { operators: session[:report][:filters][:operators].dup, values: session[:report][:filters][:values].dup }
-    filters = result.fields.inject session_filter do |struct, (key, value)|
-      key = key.to_sym
-      case key
-      when :week
-        set_filter_options struct, :tweek, value.to_i.modulo(100)
-        set_filter_options struct, :tyear, value.to_i / 100
-      when :month, :year
-        set_filter_options struct, :"t#{key}", value
-      when :count, :units, :costs, :display_costs, :sum, :real_costs
-      else
-        set_filter_options struct, key, value
-      end
-      struct
-    end
-    options = { fields: filters[:operators].keys, set_filter: 1, action: :drill_down }
-    link_to "[+]", filters.merge(options), class: "drill_down", title: I18n.t(:description_drill_down)
   end
 
   ##
@@ -218,8 +223,7 @@ module ReportingHelper
   # For a given row, determine how to render it's contents according to usability and
   # localization rules
   def show_row(row)
-    row_text = link_to_details(row) << row.render { |k, v| show_field(k, v) }
-    row_text.html_safe
+    row.render { |k, v| show_field(k, v) }
   end
 
   def delimit(items, options = {})

--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -65,5 +65,8 @@ See COPYRIGHT and LICENSE files for more details.
 </div>
 <p class="footnote">
   <%= t(:text_costs_are_rounded_note) %>
-  <%= "<br />#{t(:information_restricted_depending_on_permission)}".html_safe unless User.current.admin?%>
+  <% unless User.current.admin? %>
+    <br/>
+    <%= t(:information_restricted_depending_on_permission) %>
+  <% end %>
 </p>

--- a/modules/reporting/lib/report/result.rb
+++ b/modules/reporting/lib/report/result.rb
@@ -35,6 +35,7 @@ class Report::Result
     alias values value
     include Enumerable
     include Report::QueryUtils
+    include ActionView::Helpers::OutputSafetyHelper
 
     def initialize(value)
       @important_fields ||= []
@@ -146,7 +147,8 @@ class Report::Result
     end
 
     def render(keys = important_fields)
-      fields.map { |k, v| yield(k, v) if keys.include? k }.join
+      rendered = fields.map { |k, v| yield(k, v) if keys.include? k }
+      safe_join(rendered)
     end
 
     def set_key(index = [])

--- a/modules/reporting/lib/widget/base.rb
+++ b/modules/reporting/lib/widget/base.rb
@@ -53,15 +53,11 @@ module ::Widget
     end
 
     ##
-    # Write a string to the canvas. The string is marked as html_safe.
-    # This will write twice, if @cache_output is set.
+    # Write a string to the canvas.
     def write(str)
-      str ||= ""
       @output ||= "".html_safe
-      @output = @output + "" if @output.frozen? # Rails 2 freezes tag strings
-      @output.concat str.html_safe
-      @cache_output.concat(str.html_safe) if @cache_output
-      str.html_safe
+      @output << str
+      str
     end
 
     ##
@@ -108,15 +104,13 @@ module ::Widget
         write Rails.cache.fetch(cache_key)
       else
         render(&)
-        Rails.cache.write(cache_key, @cache_output || @output) if cache?
+        Rails.cache.write(cache_key, @output) if cache?
       end
     end
 
     ##
-    # Set the canvas. If the canvas object isn't a string (e.g. cannot be cached easily),
-    # a @cache_output String is created, that will mirror what is being written to the canvas.
+    # Set the canvas.
     def set_canvas(canvas)
-      @cache_output = "".html_safe
       @output = canvas
     end
   end

--- a/modules/reporting/lib/widget/controls/save_as.rb
+++ b/modules/reporting/lib/widget/controls/save_as.rb
@@ -28,14 +28,13 @@
 
 class Widget::Controls::SaveAs < Widget::Controls
   def render
-    if @subject.new_record?
-      link_name = I18n.t(:button_save)
-      icon = "icon-save"
-    else
-      link_name = I18n.t(:button_save_as)
-      icon = "icon-save"
-    end
-    button = link_to(link_name, "#", id: "query-icon-save-as", class: "button icon-context #{icon}")
+    link_name =
+      if @subject.new_record?
+        I18n.t(:button_save)
+      else
+        I18n.t(:button_save_as)
+      end
+    button = link_to(link_name, "#", id: "query-icon-save-as", class: "button icon-context icon-save")
     write(button + render_popup)
   end
 
@@ -43,12 +42,13 @@ class Widget::Controls::SaveAs < Widget::Controls
     "#{super}#{@subject.name}"
   end
 
+  # rubocop:disable Metrics/AbcSize
   def render_popup_form
     name = content_tag :p,
                        class: "form--field -required -wide-label" do
       label_tag(:query_name,
                 class: "form--label -transparent") do
-        Query.human_attribute_name(:name).html_safe
+        Query.human_attribute_name(:name)
       end +
         content_tag(:span,
                     class: "form--field-container") do
@@ -81,6 +81,7 @@ class Widget::Controls::SaveAs < Widget::Controls
       name
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def render_popup_buttons
     save_url_params = { action: "create", set_filter: "1" }

--- a/modules/reporting/lib/widget/cost_types.rb
+++ b/modules/reporting/lib/widget/cost_types.rb
@@ -40,7 +40,7 @@ class Widget::CostTypes < Widget::Base
 
   def contents
     content_tag :div do
-      available_cost_type_tabs(@subject).sort_by { |id, _| id }.map do |id, label|
+      tabs = available_cost_type_tabs(@subject).sort_by { |id, _| id }.map do |id, label|
         content_tag :div, class: "form--field -trailing-label" do
           types = label_tag "unit_#{id}", h(label), class: "form--label"
           types += content_tag :span, class: "form--field-container" do
@@ -49,7 +49,9 @@ class Widget::CostTypes < Widget::Base
             end
           end
         end
-      end.join("").html_safe
+      end
+
+      safe_join(tabs)
     end
   end
 end

--- a/modules/reporting/lib/widget/filters.rb
+++ b/modules/reporting/lib/widget/filters.rb
@@ -26,16 +26,22 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# rubocop:disable Metrics/AbcSize
 class Widget::Filters < Widget::Base
   def render
     spacer = content_tag :li, "", class: "advanced-filters--spacer hide-when-print"
 
     add_filter = content_tag :li, id: "add_filter_block", class: "advanced-filters--add-filter hide-when-print" do
-      add_filter_label = label_tag "add_filter_select", I18n.t(:label_filter_add),
-                                   class: "advanced-filters--add-filter-label"
-      add_filter_label += label_tag "add_filter_select", I18n.t("js.filter.description.text_open_filter") + " " +
-                                                         I18n.t("js.filter.description.text_close_filter"),
-                                    class: "hidden-for-sighted"
+      add_filter_label = label_tag(
+        "add_filter_select",
+        I18n.t(:label_filter_add),
+        class: "advanced-filters--add-filter-label"
+      )
+      add_filter_label += label_tag(
+        "add_filter_select",
+        "#{I18n.t('js.filter.description.text_open_filter')} #{I18n.t('js.filter.description.text_close_filter')}",
+        class: "hidden-for-sighted"
+      )
 
       add_filter_value = content_tag :div, class: "advanced-filters--add-filter-value" do
         select_tag "add_filter_select",
@@ -44,7 +50,7 @@ class Widget::Filters < Widget::Base
                    name: nil
       end
 
-      (add_filter_label + add_filter_value).html_safe
+      add_filter_label + add_filter_value
     end
 
     list = content_tag :ul, id: "filter_table", class: "advanced-filters--filters" do
@@ -63,7 +69,7 @@ class Widget::Filters < Widget::Base
 
   def render_filters
     active_filters = @subject.filters.select(&:display?)
-    engine::Filter.all.select(&:selectable?).map do |filter|
+    filters = engine::Filter.all.select(&:selectable?).map do |filter|
       opts = { id: "filter_#{filter.underscore_name}",
                class: "#{filter.underscore_name} advanced-filters--filter",
                "data-filter-name": filter.underscore_name }
@@ -76,9 +82,12 @@ class Widget::Filters < Widget::Base
       content_tag :li, opts do
         render_filter filter, active_instance
       end
-    end.join.html_safe
+    end
+
+    safe_join(filters)
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def render_filter(f_cls, f_inst)
     f = f_inst || f_cls
     html = "".html_safe
@@ -106,4 +115,7 @@ class Widget::Filters < Widget::Base
     end
     render_widget RemoveButton, f, to: html
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 end
+
+# rubocop:enable Metrics/AbcSize

--- a/modules/reporting/lib/widget/filters/heavy.rb
+++ b/modules/reporting/lib/widget/filters/heavy.rb
@@ -31,6 +31,7 @@
 #        Filter. This is overhead...
 #        But well this is again one of those temporary solutions.
 class Widget::Filters::Heavy < Widget::Filters::Base
+  # rubocop:disable Metrics/AbcSize
   def render
     # TODO: sometimes filter.values is of the form [["3"]] and sometimes ["3"].
     #       (using cost reporting)
@@ -50,9 +51,8 @@ class Widget::Filters::Heavy < Widget::Filters::Base
       end
       box
     end
-    alternate_text = opts.map(&:first).join(", ").html_safe
-    write(div + content_tag(:label) do
-      alternate_text
-    end)
+    alternate_text = safe_join(opts.map(&:first), ", ")
+    write(div + content_tag(:label, alternate_text))
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/modules/reporting/lib/widget/filters/multi_choice.rb
+++ b/modules/reporting/lib/widget/filters/multi_choice.rb
@@ -27,28 +27,30 @@
 #++
 
 class Widget::Filters::MultiChoice < Widget::Filters::Base
+  # rubocop:disable Metrics/AbcSize
   def render
-    filterName = filter_class.underscore_name
-    result = content_tag :div, id: "#{filterName}_arg_1", class: "advanced-filters--filter-value" do
+    filter_name = filter_class.underscore_name
+    result = content_tag :div, id: "#{filter_name}_arg_1", class: "advanced-filters--filter-value" do
       choices = filter_class.available_values.each_with_index.map do |(label, value), i|
         opts = {
           type: "radio",
-          name: "values[#{filterName}][]",
-          id: "#{filterName}_radio_option_#{i}",
+          name: "values[#{filter_name}][]",
+          id: "#{filter_name}_radio_option_#{i}",
           value:
         }
         opts[:checked] = "checked" if filter.values == [value].flatten
         radio_button = tag :input, opts
         content_tag :label, radio_button + translate(label),
-                    for: "#{filterName}_radio_option_#{i}",
+                    for: "#{filter_name}_radio_option_#{i}",
                     "data-filter-name": filter_class.underscore_name,
-                    class: "#{filterName}_radio_option filter_radio_option"
+                    class: "#{filter_name}_radio_option filter_radio_option"
       end
-      content_tag :div, choices.join.html_safe,
+      content_tag :div, safe_join(choices),
                   id: "#{filter_class.underscore_name}_arg_1_val"
     end
     write result
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/modules/reporting/lib/widget/filters/operators.rb
+++ b/modules/reporting/lib/widget/filters/operators.rb
@@ -27,6 +27,7 @@
 #++
 
 class Widget::Filters::Operators < Widget::Filters::Base
+  # rubocop:disable Metrics/AbcSize
   def render
     write(content_tag(:div, class: "advanced-filters--filter-operator") do
       hide_select_box = filter_class.available_operators.count == 1 || filter_class.heavy?
@@ -34,15 +35,16 @@ class Widget::Filters::Operators < Widget::Filters::Base
                   id: "operators[#{filter_class.underscore_name}]",
                   name: "operators[#{filter_class.underscore_name}]",
                   "data-filter-name": filter_class.underscore_name }
-      options.merge! style: "display: none" if hide_select_box
+      options[:style] = "display: none" if hide_select_box
 
       select_box = content_tag :select, options do
-        filter_class.available_operators.map do |o|
+        operators = filter_class.available_operators.map do |o|
           opts = { value: h(o.to_s), "data-arity": o.arity }
           opts.reverse_merge! "data-forced": o.forced if o.forced?
           opts[:selected] = "selected" if filter.operator.to_s == o.to_s
           content_tag(:option, opts) { h(I18n.t(o.label)) }
-        end.join.html_safe
+        end
+        safe_join(operators)
       end
       label1 = content_tag :label,
                            hidden_for_sighted_label,
@@ -56,8 +58,9 @@ class Widget::Filters::Operators < Widget::Filters::Base
       hide_select_box ? label1 + select_box + label : label1 + select_box
     end)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def hidden_for_sighted_label
-    h(filter_class.label) + " " + I18n.t(:label_operator) + " " + I18n.t("js.filter.description.text_open_filter")
+    "#{h(filter_class.label)} #{I18n.t(:label_operator)} #{I18n.t('js.filter.description.text_open_filter')}"
   end
 end

--- a/modules/reporting/lib/widget/filters/option.rb
+++ b/modules/reporting/lib/widget/filters/option.rb
@@ -32,13 +32,19 @@
 # option-tags from the content array instead of the filters available values.
 class Widget::Filters::Option < Widget::Filters::Base
   def render
+    options = content(@options[:content] || filter_class.available_values)
+    write safe_join(options)
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+  def content(values)
     first = true
-    write((@options[:content] || filter_class.available_values).map do |name, id, *args|
+    values.map do |name, id, *args|
       options = args.first || {} # optional configuration for values
       level = options[:level] # nesting_level is optional for values
       name = I18n.t(name) if name.is_a? Symbol
       name = I18n.t(:label_none) if name.empty?
-      name_prefix = (level && level > 0 ? ((" " * 2 * level) + "> ") : "")
+      name_prefix = (level && level > 0 ? "#{' ' * 2 * level}> " : "")
       if options[:optgroup]
         tag :optgroup, label: I18n.t(:label_sector)
       else
@@ -49,6 +55,7 @@ class Widget::Filters::Option < Widget::Filters::Base
         first = false
         content_tag(:option, opts) { name_prefix + name }
       end
-    end.join.html_safe)
+    end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 end

--- a/modules/reporting/lib/widget/reporting_widget.rb
+++ b/modules/reporting/lib/widget/reporting_widget.rb
@@ -31,6 +31,7 @@ class Widget::ReportingWidget < ActionView::Base
   include ActionView::Helpers::AssetTagHelper
   include ActionView::Helpers::FormTagHelper
   include ActionView::Helpers::JavaScriptHelper
+  include ActionView::Helpers::OutputSafetyHelper
   include Rails.application.routes.url_helpers
   include ApplicationHelper
   include ReportingHelper

--- a/modules/reporting/lib/widget/table.rb
+++ b/modules/reporting/lib/widget/table.rb
@@ -47,15 +47,14 @@ class Widget::Table < Widget::Base
   end
 
   def render
-    write("<!-- table start -->")
+    write("<!-- table start -->".html_safe)
     if @subject.result.count <= 0
       write(content_tag(:div, "", class: "generic-table--no-results-container") do
         content_tag(:i, "", class: "icon-info1") +
           content_tag(:span, I18n.t(:no_results_title_text), class: "generic-table--no-results-title")
       end)
     else
-      str = render_widget(resolve_table, @subject, @options.reverse_merge(to: @output))
-      @cache_output.write(str.html_safe) if @cache_output
+      render_widget(resolve_table, @subject, @options.reverse_merge(to: @output))
     end
   end
 end

--- a/modules/reporting/lib/widget/table.rb
+++ b/modules/reporting/lib/widget/table.rb
@@ -30,7 +30,7 @@ class Widget::Table < Widget::Base
   extend Report::InheritedAttribute
   include ReportingHelper
 
-  attr_accessor :debug, :fields, :mapping
+  attr_accessor :fields, :mapping
 
   def initialize(query)
     raise ArgumentError, "Tables only work on CostQuery!" unless query.is_a? CostQuery

--- a/modules/reporting/lib/widget/table/entry_table.rb
+++ b/modules/reporting/lib/widget/table/entry_table.rb
@@ -48,14 +48,15 @@ class ::Widget::Table::EntryTable < Widget::Table
   def colgroup
     content_tag :colgroup do
       FIELDS.each do
-        concat content_tag(:col, "opHighlightCol" => true) {}
+        concat content_tag(:col, "", "opHighlightCol" => true)
       end
-      concat content_tag(:col, "opHighlightCol" => true) {}
-      concat content_tag(:col, "opHighlightCol" => true) {}
-      concat content_tag(:col) {}
+      concat content_tag(:col, "", "opHighlightCol" => true)
+      concat content_tag(:col, "", "opHighlightCol" => true)
+      concat content_tag(:col, "")
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def head
     content_tag :thead do
       content_tag :tr do
@@ -130,17 +131,16 @@ class ::Widget::Table::EntryTable < Widget::Table
       rows = "".html_safe
       @subject.each_direct_result do |result|
         rows << (content_tag(:tr) do
-          "".html_safe
           FIELDS.each do |field|
-            concat content_tag(:td, show_field(field, result.fields[field.to_s]).html_safe,
+            concat content_tag(:td, show_field(field, result.fields[field.to_s]),
                                "raw-data": raw_field(field, result.fields[field.to_s]),
                                class: "left")
           end
-          concat content_tag :td, show_result(result, result.fields["cost_type_id"].to_i).html_safe,
+          concat content_tag :td, show_result(result, result.fields["cost_type_id"].to_i),
                              class: "units right",
                              "raw-data": result.units
           concat content_tag :td,
-                             show_result(result, 0).html_safe,
+                             show_result(result, 0),
                              class: "currency right",
                              "raw-data": result.real_costs
           concat content_tag :td, icons(result)
@@ -176,4 +176,5 @@ class ::Widget::Table::EntryTable < Widget::Table
     end
     icons
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/modules/reporting/lib/widget/table/report_table.rb
+++ b/modules/reporting/lib/widget/table/report_table.rb
@@ -105,7 +105,8 @@ class Widget::Table::ReportTable < Widget::Table
 
   # rubocop:disable Metrics/AbcSize
   def render_thead
-    return if walker.headers && walker.headers_empty?
+    walker.headers
+    return if walker.headers_empty?
 
     write "<thead>".html_safe
     walker.headers do |list, first, first_in_col, last_in_col|

--- a/modules/reporting/lib/widget/table/report_table.rb
+++ b/modules/reporting/lib/widget/table/report_table.rb
@@ -37,117 +37,113 @@ class Widget::Table::ReportTable < Widget::Table
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def configure_walker
     @walker ||= @subject.walker
     @walker.for_final_row do |row, cells|
-      html = "<th scope='row' class='normal inner left -break-word'>#{show_row row}#{debug_fields(row)}</th>"
-      html << cells.join
-      html << "<td class='normal inner right'>#{show_result(row)}#{debug_fields(row)}</th>"
-      html.html_safe
+      content_tag(:th, class: "normal inner left -break-word", scope: "row") do
+        concat show_row(row)
+        concat safe_join(cells)
+        concat content_tag(:td, show_result(row), class: "normal inner right")
+      end
     end
 
     @walker.for_row do |row, subrows|
       subrows.flatten!
       unless row.fields.empty?
-        subrows[0] = %{
-            <th class='top left -break-word' rowspan='#{subrows.size}'>#{show_row row}#{debug_fields(row)}</th>
-              #{subrows[0].gsub("class='normal", "class='top")}
-            <th class='top right' rowspan='#{subrows.size}'>#{show_result(row)}#{debug_fields(row)}</th>
-          }.html_safe
+        subrows[0] = capture do
+          concat content_tag(:th, show_row(row), class: "top left -breakword", rowspan: subrows.size)
+          concat html_safe_gsub(subrows[0], "class='normal", "class='top")
+          concat content_tag(:th, show_result(row), class: "top right", rowspan: subrows.size)
+        end
       end
-      subrows.last.gsub!("class='normal", "class='bottom")
-      subrows.last.gsub!("class='top", "class='bottom top")
+      subrows[-1] = html_safe_gsub(subrows.last, "class='normal", "class='bottom")
+      subrows[-1] = html_safe_gsub(subrows.last, "class='top", "class='bottom top")
+
       subrows
     end
 
     @walker.for_empty_cell { "<td class='normal empty'>&nbsp;</td>".html_safe }
 
     @walker.for_cell do |result|
-      write(" ".html_safe) # XXX: This keeps the Apache from timing out on us. Keep-Alive byte!
-      "<td class='normal right'>#{show_result result}#{debug_fields(result)}</td>".html_safe
+      content_tag(:td, show_result(result), class: "normal right")
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def render
     configure_query
     configure_walker
-    write "<table class='report'>"
+    write "<table class='report'>".html_safe
     render_thead
     render_tfoot
     render_tbody
-    write "</table>"
+    write "</table>".html_safe
   end
 
   def render_tbody
-    write "<tbody>"
+    write "<tbody>".html_safe
     first = true
     odd = true
     walker.body do |line|
       if first
-        line.gsub!("class='normal", "class='top")
+        line = html_safe_gsub(line, "class='normal", "class='top")
         first = false
       end
-      mark_penultimate_column! line
-      write "<tr class='#{odd ? 'odd' : 'even'}'>#{line}</tr>"
+      line = mark_penultimate_column(line)
+      write content_tag(:tr, line, class: odd ? "odd" : "even")
       odd = !odd
     end
-    write "</tbody>"
+    write "</tbody>".html_safe
   end
 
-  def mark_penultimate_column!(line)
-    line.gsub! /(<td class='([^']+)'[^<]+<\/td>)[^<]*<th .+/ do |m|
+  def mark_penultimate_column(line)
+    html_safe_gsub(line, /(<td class='([^']+)'[^<]+<\/td>)[^<]*<th .+/) do |m|
       m.sub /class='([^']+)'/, 'class=\'\1 penultimate\''
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def render_thead
-    return if (walker.headers || true) and walker.headers_empty?
+    return if walker.headers && walker.headers_empty?
 
-    write "<thead>"
+    write "<thead>".html_safe
     walker.headers do |list, first, first_in_col, last_in_col|
-      write "<tr>" if first_in_col
+      write "<tr>".html_safe if first_in_col
       if first
-        write(content_tag(:th, rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)) do
-          ""
-        end)
+        write(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
       end
       list.each do |column|
         opts = { colspan: column.final_number(:column) }
-        opts.merge!(class: "inner") if column.final?(:column)
+        opts[:class] = "inner" if column.final?(:column)
         write(content_tag(:th, opts) do
           show_row column
         end)
       end
       if first
-        write(content_tag(:th, rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)) do
-          ""
-        end)
+        write(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
       end
-      write "</tr>" if last_in_col
+      write "</tr>".html_safe if last_in_col
     end
-    write "</thead>"
+    write "</thead>".html_safe
   end
 
   def render_tfoot
     return if walker.headers_empty?
 
-    write "<tfoot>"
+    write "<tfoot>".html_safe
     walker.reverse_headers do |list, first, first_in_col, last_in_col|
       if first_in_col
-        write "<tr>"
+        write "<tr>".html_safe
         if first
-          write(content_tag(:th, rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row), class: "top") do
-            " "
-          end)
+          write(content_tag(:th, " ", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row), class: "top"))
         end
       end
 
       list.each do |column|
         opts = { colspan: column.final_number(:column) }
-        opts.merge!(class: "inner") if first
-        write(content_tag(:th, opts) do
-          show_result(column) # {debug_fields(column)}
-        end)
+        opts[:class] = "inner" if first
+        write(content_tag(:th, show_result(column), opts))
       end
       if last_in_col
         if first
@@ -158,32 +154,10 @@ class Widget::Table::ReportTable < Widget::Table
                   show_result @subject
                 end)
         end
-        write "</tr>"
+        write "</tr>".html_safe
       end
     end
-    write "</tfoot>"
+    write "</tfoot>".html_safe
   end
-
-  def debug_content
-    content_tag :pre do
-      debug_pre_content = "[ Query ]" +
-                          @subject.chain.each do |child|
-                            "#{h child.class.inspect}, #{h child.type}"
-                          end
-
-      debug_pre_content += "[ RESULT ]"
-      @subject.result.recursive_each_with_level do |level, result|
-        debug_pre_content += ">>> " * (level + 1)
-        debug_pre_content += h(result.inspect)
-        debug_pre_content += "   " * (level + 1)
-        debug_pre_content += h(result.type.inspect)
-        debug_pre_content += "   " * (level + 1)
-        debug_pre_content += h(result.fields.inspect)
-      end
-      debug_pre_content += "[ HEADER STACK ]"
-      debug_pre_content += walker.header_stack.each do |l|
-        ">>> #{l.inspect}"
-      end
-    end
-  end
+  # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
A lot of manual string rendering is done in the reporting engine, resulting in superfluous calls to `.html_safe` on objects that are already SafeBuffers.

https://community.openproject.org/work_packages/55625