### PR TITLE
Fix colspan length bug in Favorite projects empty case

### DIFF
--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -85,7 +85,7 @@ See COPYRIGHT and LICENSE files for more details.
           <tbody>
           <% if rows.empty? %>
             <tr class="generic-table--empty-row">
-              <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+              <td colspan="<%= columns.length + 1 %>"><%= empty_row_message %></td>
             </tr>
           <% end %>
           <%= render_collection rows %>


### PR DESCRIPTION
<img width="962" alt="image" src="https://github.com/opf/openproject/assets/1131536/67ed3d9b-40a0-45fa-9ff3-296fb74be593">

Introduced at [#15619](https://github.com/opf/openproject/pull/15619/files#diff-27b9e041d73c197675e741e4ba64cc20aa5c6ed04449127a9e424c5d5e1319d2L87)