### PR TITLE
Fix/saas safe good job predecessor finding

### DIFF
--- a/app/models/users/scopes/having_reminder_mail_to_send.rb
+++ b/app/models/users/scopes/having_reminder_mail_to_send.rb
@@ -175,7 +175,8 @@ module Users::Scopes
       end
 
       def quarters_between_earliest_and_latest(earliest_time, latest_time) # rubocop:disable Metrics/AbcSize
-        raise ArgumentError if latest_time < earliest_time || (latest_time - earliest_time) > 1.day
+        raise ArgumentError, "#{latest_time} < #{earliest_time}" if latest_time < earliest_time
+        raise ArgumentError, "#{latest_time} - #{earliest_time} > 1 day" if (latest_time - earliest_time) > 1.day
 
         # The first quarter is equal or greater to the earliest time
         first_quarter = earliest_time.change(min: (earliest_time.min.to_f / 15).ceil * 15)


### PR DESCRIPTION
On SaaS the query for `GoodJob::Job.where(job_class: self.class.name)` will return jobs also from other tenants. Therefore, the `cron_key` needs to be used which is prepended with the tenant schema key.