### PR TITLE
Use strict-dynamic CSP and nonces for all include tags

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -43,7 +43,7 @@ module FrontendAssetHelper
   def include_frontend_assets
     capture do
       %w(vendor.js polyfills.js runtime.js main.js).each do |file|
-        concat javascript_include_tag variable_asset_path(file), skip_pipeline: true
+        concat nonced_javascript_include_tag variable_asset_path(file), skip_pipeline: true
       end
 
       concat stylesheet_link_tag variable_asset_path("styles.css"), media: :all, skip_pipeline: true
@@ -54,6 +54,10 @@ module FrontendAssetHelper
     capture do
       concat stylesheet_link_tag variable_asset_path("spot.css"), media: :all, skip_pipeline: true
     end
+  end
+
+  def nonced_javascript_include_tag(path, **)
+    javascript_include_tag(path, nonce: content_security_policy_script_nonce, **)
   end
 
   private

--- a/app/views/api_docs/index.html.erb
+++ b/app/views/api_docs/index.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag "openapi-explorer.min.js" %>
+<%= nonced_javascript_include_tag "openapi-explorer.min.js" %>
 
 <%= content_tag('openapi-explorer',
                 '',

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -16,7 +16,7 @@ Rails.application.config.after_initialize do
     config.referrer_policy = "origin-when-cross-origin"
 
     # Valid for assets
-    assets_src = ["'self'"]
+    assets_src = []
     asset_host = OpenProject::Configuration.rails_asset_host
     assets_src << asset_host if asset_host.present?
 
@@ -70,7 +70,7 @@ Rails.application.config.after_initialize do
       base_uri: %w('self'),
 
       # Allow fonts from self, asset host, or DATA uri
-      font_src: assets_src + %w(data:),
+      font_src: assets_src + %w(data: 'self'),
       # Form targets can only be self
       form_action: default_src,
       # Allow iframe from vimeo (welcome video)
@@ -79,9 +79,9 @@ Rails.application.config.after_initialize do
       # Allow images from anywhere including data urls and blobs (used in resizing)
       img_src: %w(* data: blob:),
       # Allow scripts from self
-      script_src:,
+      script_src: script_src + %w('strict-dynamic'),
       # Allow unsafe-inline styles
-      style_src: assets_src + %w('unsafe-inline'),
+      style_src: assets_src + %w('unsafe-inline' 'self'),
       # Allow object-src from Release API
       object_src: [OpenProject::Configuration[:security_badge_url]],
 


### PR DESCRIPTION
If we allow `self` as a script-src in CSP, we also theoretically allow execution of all user provided attachments. To prevent this, use CSP [strict-dynamic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) and nonces on all javascript tags we render.

Note that the asset host is still marked as a valid source, as that will only be a CDN caching assets.

https://community.openproject.org/work_packages/55203