### PR TITLE
Fix/limit on reminder and date alert interval

### DIFF
--- a/app/workers/cron/quarter_hour_schedule_job.rb
+++ b/app/workers/cron/quarter_hour_schedule_job.rb
@@ -69,7 +69,11 @@ module Cron::QuarterHourScheduleJob
                       .first
 
       if predecessor
-        predecessor.cron_at + 15.minutes
+        # To ovoid the jobs spanning a very long time e.g after a longer downtime, the interval
+        # is limited to a somewhat arbitrary 24 hours.
+        # On the other hand the two jobs currently making use of this module have a time reference where
+        # it would not make sense to send very old data (i.e. reminders or date alerts)
+        [upper_boundary - 24.hours, predecessor.cron_at + 15.minutes].max
       else
         upper_boundary
       end

--- a/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Notifications::CreateDateAlertsNotificationsJob, type: :job, with
     timezone.now.change(time_hash(time))
   end
 
-  def run_job(scheduled_at: "1:00", local_time: "1:04", timezone: timezone_paris)
+  def run_job(local_time: "1:04", timezone: timezone_paris)
     travel_to(timezone_time(local_time, timezone)) do
       job.perform_now(user)
 

--- a/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
+++ b/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
@@ -116,5 +116,18 @@ RSpec.describe Notifications::ScheduleReminderMailsJob, type: :job do
         let(:expected_upper_boundary) { job_cron_at }
       end
     end
+
+    context "when there is a predecessor job with a cron_at more than 24 hours before" do
+      let(:previous_job_cron_at) { job_cron_at - 25.hours }
+
+      before do
+        previous_job
+      end
+
+      it_behaves_like "schedules reminder mails" do
+        let(:expected_lower_boundary) { job_cron_at - 24.hours }
+        let(:expected_upper_boundary) { job_cron_at }
+      end
+    end
   end
 end


### PR DESCRIPTION
In case the date alert or reminder mail scheduling jobs haven't run successfully for more than a day, subsequent runs will continuously fail as the last successful job's cron_at value is taken. As a result, the interval handed over to `User.having_reminder_mail_to_send` would be larger than 24 hours which the interval prohibits as a safe guard. 

That somewhat arbitrary 24 hour limit is now also placed on the boundary calculation to avoid running into an error. 

----

https://community.openproject.org/wp/55223