### PR TITLE
Rework membership on global entities and implement ProjectQueryRole

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -33,10 +33,13 @@ module Roles
     validate :check_permission_prerequisites
 
     def assignable_permissions(keep_public: false)
-      if model.is_a?(GlobalRole)
+      case model
+      when GlobalRole
         assignable_global_permissions
-      elsif model.is_a?(WorkPackageRole)
+      when WorkPackageRole
         assignable_work_package_permissions
+      when ProjectQueryRole
+        assignable_project_query_permissions
       else
         assignable_member_permissions
       end.reject do |permission|
@@ -52,6 +55,10 @@ module Roles
 
     def assignable_work_package_permissions
       OpenProject::AccessControl.work_package_permissions
+    end
+
+    def assignable_project_query_permissions
+      OpenProject::AccessControl.project_query_permissions
     end
 
     def assignable_member_permissions

--- a/app/models/concerns/has_members.rb
+++ b/app/models/concerns/has_members.rb
@@ -1,0 +1,36 @@
+# --copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module HasMembers
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :members, as: :entity, dependent: :destroy
+    has_many :member_principals, through: :members, class_name: "Principal", source: :principal
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -86,7 +86,7 @@ class Member < ApplicationRecord
   end
 
   def project_role?
-    entity_id.nil?
+    entity_id.nil? && project_id.present?
   end
 
   def deletable_role?(role)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,7 +30,8 @@ class Member < ApplicationRecord
   include ::Scopes::Scoped
 
   ALLOWED_ENTITIES = [
-    "WorkPackage"
+    "WorkPackage",
+    "Queries::Projects::ProjectQuery"
   ].freeze
 
   extend DeprecatedAlias

--- a/app/models/project_query_role.rb
+++ b/app/models/project_query_role.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ProjectQueryRole < Role
+  def self.givable
+    super
+      .where(type: "ProjectQueryRole")
+  end
+
+  def member?
+    true
+  end
+end

--- a/app/models/projects/activity.rb
+++ b/app/models/projects/activity.rb
@@ -33,13 +33,12 @@ module Projects::Activity
 
   module ActivityScopes
     def latest_project_activity
-      @latest_project_activity ||=
-        OpenProject::ProjectLatestActivity.registered.map do |params|
-          build_latest_project_activity_for(on: params[:on].constantize,
-                                            chain: Array(params[:chain]).map(&:constantize),
-                                            attribute: params[:attribute],
-                                            project_id_attribute: params[:project_id_attribute])
-        end
+      OpenProject::ProjectLatestActivity.registered.map do |params|
+        build_latest_project_activity_for(on: params[:on].constantize,
+                                          chain: Array(params[:chain]).map(&:constantize),
+                                          attribute: params[:attribute],
+                                          project_id_attribute: params[:project_id_attribute])
+      end
     end
 
     def with_latest_activity
@@ -50,7 +49,7 @@ module Projects::Activity
     end
 
     def latest_activity_sql
-      <<-SQL
+      <<-SQL.squish
         SELECT project_id, MAX(updated_at) latest_activity_at
         FROM (#{all_activity_provider_union_sql}) activity
         GROUP BY project_id
@@ -67,7 +66,7 @@ module Projects::Activity
 
       joins = build_joins_from_chain(join_chain)
 
-      <<-SQL
+      <<-SQL.squish
         SELECT #{project_id_attribute} project_id, MAX(#{on.table_name}.#{attribute}) updated_at
         FROM #{from.table_name}
         #{joins.join(' ')}
@@ -77,21 +76,17 @@ module Projects::Activity
     end
 
     def build_joins_from_chain(join_chain)
-      joins = []
-
-      (0..join_chain.length - 2).each do |i|
-        joins << build_join(join_chain[i + 1],
-                            join_chain[i])
+      (0..join_chain.length - 2).map do |i|
+        build_join(join_chain[i + 1],
+                   join_chain[i])
       end
-
-      joins
     end
 
     def build_join(right, left)
       associations = right.reflect_on_all_associations
       association = associations.detect { |a| a.class_name == left.to_s }
 
-      <<-SQL
+      <<-SQL.squish
         LEFT OUTER JOIN #{right.table_name}
         ON #{left.table_name}.id =
            #{right.table_name}.#{association.foreign_key}

--- a/app/models/projects/activity.rb
+++ b/app/models/projects/activity.rb
@@ -33,7 +33,7 @@ module Projects::Activity
 
   module ActivityScopes
     def latest_project_activity
-      OpenProject::ProjectLatestActivity.registered.map do |params|
+      @latest_project_activity ||= OpenProject::ProjectLatestActivity.registered.map do |params|
         build_latest_project_activity_for(on: params[:on].constantize,
                                           chain: Array(params[:chain]).map(&:constantize),
                                           attribute: params[:attribute],

--- a/app/models/queries/projects/project_queries/scopes/allowed_to.rb
+++ b/app/models/queries/projects/project_queries/scopes/allowed_to.rb
@@ -52,7 +52,15 @@ module Queries::Projects::ProjectQueries::Scopes
             public_queries:,
             user_owned_queries:,
             allowed_queries: allowed_via_membership
-          ).where("project_queries.id IN (SELECT id FROM public_queries UNION SELECT id FROM user_owned_queries UNION SELECT id FROM allowed_queries)")
+          ).where(<<~SQL.squish)
+            project_queries.id IN (
+              SELECT id FROM public_queries
+              UNION
+              SELECT id FROM user_owned_queries
+              UNION
+              SELECT id FROM allowed_queries
+            )
+          SQL
         end
       end
 

--- a/app/models/queries/projects/project_queries/scopes/allowed_to.rb
+++ b/app/models/queries/projects/project_queries/scopes/allowed_to.rb
@@ -1,0 +1,102 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2023 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Queries::Projects::ProjectQueries::Scopes
+  module AllowedTo
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns an ActiveRecord::Relation to find all project queries for which
+      # the +user+ either has the given +permission+ directly on the project query
+      # or if the project query is owned by the +user+
+      def allowed_to(user, permission) # rubocop:disable Metrics/AbcSize
+        permissions = Authorization.contextual_permissions(permission, :project_query, raise_on_unknown: true)
+
+        return none if user.locked?
+        return none if permissions.empty?
+
+        if user.anonymous?
+          # TODO: Possible chance to also allow access to public queries here
+          none
+        else
+          public_queries = where(public: true).select(:id).arel
+          user_owned_queries = where(user_id: user.id).select(:id).arel
+          allowed_via_membership = allowed_to_member_relation(user, permissions).select(arel_table[:id]).arel
+
+          with(
+            public_queries:,
+            user_owned_queries:,
+            allowed_queries: allowed_via_membership
+          ).where("project_queries.id IN (SELECT id FROM public_queries UNION SELECT id FROM user_owned_queries UNION SELECT id FROM allowed_queries)")
+        end
+      end
+
+      private
+
+      def allowed_to_member_relation(user, permissions)
+        Member
+          .joins(allowed_to_member_in_query_join)
+          .joins(member_roles: :role)
+          .joins(allowed_to_role_permission_join(permissions))
+          .where(member_conditions(user))
+          .select(arel_table[:id])
+      end
+
+      def allowed_to_role_permission_join(permissions) # rubocop:disable Metrics/AbcSize
+        return if permissions.all?(&:public?)
+
+        role_permissions_table = RolePermission.arel_table
+        roles_table = Role.arel_table
+
+        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
+          permission_condition = role_permissions_table[:permission].eq(permission.name)
+
+          or_condition.or(permission_condition)
+        end
+
+        arel_table
+          .join(role_permissions_table, Arel::Nodes::InnerJoin)
+          .on(roles_table[:id].eq(role_permissions_table[:role_id])
+                              .and(condition))
+          .join_sources
+      end
+
+      def allowed_to_member_in_query_join
+        members_table = Member.arel_table
+        arel_table.join(arel_table)
+        .on(members_table[:entity_id].eq(arel_table[:id]))
+        .join_sources
+      end
+
+      def member_conditions(user)
+        Member.arel_table[:user_id].eq(user.id)
+        .and(Member.arel_table[:entity_type].eq(model_name.name))
+      end
+    end
+  end
+end

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -30,6 +30,7 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   include Queries::BaseQuery
   include Queries::Serialization::Hash
   include HasMembers
+  include ::Scopes::Scoped
 
   belongs_to :user
 
@@ -41,8 +42,10 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   scope :private_lists, ->(user: User.current) { where(public: false, user:) }
 
   scope :visible, ->(user = User.current) {
-                    public_lists.or(private_lists(user:))
+                    allowed_to(user, :view_project_query)
                   }
+
+  scopes :allowed_to
 
   def visible?(user = User.current)
     public? || user == self.user

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -51,6 +51,15 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
     public? || user == self.user
   end
 
+  def can_edit?(user = User.current)
+    # non public queries can only be edited by the owner
+    (!public? && user == self.user) ||
+    # public queries can be edited by users with the global permission (regardless of ownership)
+    (public? && user.allowed_globally?(:manage_public_project_queries)) ||
+    # or by users with the edit permission on the query
+    user.allowed_to?(:edit_project_query, self)
+  end
+
   def self.model
     Project
   end

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -48,16 +48,18 @@ class Queries::Projects::ProjectQuery < ApplicationRecord
   scopes :allowed_to
 
   def visible?(user = User.current)
-    public? || user == self.user
+    public? ||
+    user == self.user ||
+    user.allowed_in_project_query?(:view_project_query, self)
   end
 
-  def can_edit?(user = User.current)
+  def editable?(user = User.current)
     # non public queries can only be edited by the owner
     (!public? && user == self.user) ||
     # public queries can be edited by users with the global permission (regardless of ownership)
     (public? && user.allowed_globally?(:manage_public_project_queries)) ||
     # or by users with the edit permission on the query
-    user.allowed_to?(:edit_project_query, self)
+    user.allowed_in_project_query?(:edit_project_query, self)
   end
 
   def self.model

--- a/app/models/queries/projects/project_query.rb
+++ b/app/models/queries/projects/project_query.rb
@@ -29,6 +29,7 @@
 class Queries::Projects::ProjectQuery < ApplicationRecord
   include Queries::BaseQuery
   include Queries::Serialization::Hash
+  include HasMembers
 
   belongs_to :user
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -40,7 +40,7 @@ class Role < ApplicationRecord
   HIDDEN_ROLE_TYPES = [
     "WorkPackageRole",
     "ProjectQueryRole"
-  ]
+  ].freeze
 
   scope :builtin, ->(*args) {
     compare = "not" if args.first == true

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -34,6 +34,13 @@ class Role < ApplicationRecord
   BUILTIN_WORK_PACKAGE_VIEWER = 3
   BUILTIN_WORK_PACKAGE_COMMENTER = 4
   BUILTIN_WORK_PACKAGE_EDITOR = 5
+  BUILTIN_PROJECT_QUERY_VIEW = 6
+  BUILTIN_PROJECT_QUERY_EDIT = 7
+
+  HIDDEN_ROLE_TYPES = [
+    "WorkPackageRole",
+    "ProjectQueryRole"
+  ]
 
   scope :builtin, ->(*args) {
     compare = "not" if args.first == true
@@ -41,7 +48,7 @@ class Role < ApplicationRecord
   }
 
   # Work Package Roles are intentionally visually hidden from users temporarily
-  scope :visible, -> { where.not(type: "WorkPackageRole") }
+  scope :visible, -> { where.not(type: HIDDEN_ROLE_TYPES) }
   scope :ordered_by_builtin_and_position, -> { order(Arel.sql("builtin, position")) }
 
   before_destroy(prepend: true) do
@@ -84,7 +91,9 @@ class Role < ApplicationRecord
           Role::BUILTIN_ANONYMOUS,
           Role::BUILTIN_WORK_PACKAGE_VIEWER,
           Role::BUILTIN_WORK_PACKAGE_COMMENTER,
-          Role::BUILTIN_WORK_PACKAGE_EDITOR
+          Role::BUILTIN_WORK_PACKAGE_EDITOR,
+          Role::BUILTIN_PROJECT_QUERY_VIEW,
+          Role::BUILTIN_PROJECT_QUERY_EDIT
         ]
       )
       .order(Arel.sql("position"))

--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -33,8 +33,8 @@ module Users::PermissionChecks
     # Some Ruby magic. Create methods for each entity we can have memberships on automatically
     # i.e. allowed_in_work_package? and allowed_in_any_work_package?
     Member::ALLOWED_ENTITIES.each do |entity_model_name|
-      entity_name_underscored = entity_model_name.underscore
       entity_class = entity_model_name.constantize
+      entity_name_underscored = entity_class.model_name.element
 
       define_method :"allowed_in_#{entity_name_underscored}?" do |permission, entity|
         allowed_in_entity?(permission, entity, entity_class)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -40,6 +40,7 @@ class WorkPackage < ApplicationRecord
   include WorkPackages::Costs
   include WorkPackages::Relations
   include ::Scopes::Scoped
+  include HasMembers
 
   include OpenProject::Journal::AttachmentHelper
 
@@ -66,9 +67,6 @@ class WorkPackage < ApplicationRecord
   }
 
   has_and_belongs_to_many :github_pull_requests # rubocop:disable Rails/HasAndBelongsToMany
-
-  has_many :members, as: :entity, dependent: :destroy
-  has_many :member_principals, through: :members, class_name: "Principal", source: :principal
 
   has_many :meeting_agenda_items, dependent: :nullify
   # The MeetingAgendaItem has a default order, but the ordered field is not part of the select

--- a/app/seeders/basic_data/base_role_seeder.rb
+++ b/app/seeders/basic_data/base_role_seeder.rb
@@ -52,6 +52,8 @@ module BasicData
       when :work_package_editor then Role::BUILTIN_WORK_PACKAGE_EDITOR
       when :work_package_commenter then Role::BUILTIN_WORK_PACKAGE_COMMENTER
       when :work_package_viewer then Role::BUILTIN_WORK_PACKAGE_VIEWER
+      when :project_query_view then Role::BUILTIN_PROJECT_QUERY_VIEW
+      when :project_query_edit then Role::BUILTIN_PROJECT_QUERY_EDIT
       else Role::NON_BUILTIN
       end
     end

--- a/app/seeders/basic_data/project_query_role_seeder.rb
+++ b/app/seeders/basic_data/project_query_role_seeder.rb
@@ -25,22 +25,10 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module Standard
-  class BasicDataSeeder < ::BasicDataSeeder
-    def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::WorkPackageRoleSeeder,
-        ::BasicData::ProjectQueryRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::BasicData::SettingSeeder
-      ]
-    end
+module BasicData
+  class ProjectQueryRoleSeeder < BaseRoleSeeder
+    self.model_class = ProjectQueryRole
+    self.seed_data_model_key = "project_query_roles"
+    self.attribute_names_for_lookups = %i[builtin]
   end
 end

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -239,6 +239,22 @@ open_color_palette:
       - "#e8590c"
       - "#d9480f"
 
+project_query_roles:
+  - reference: :default_role_project_query_view
+    t_name: Project query viewer
+    position: 10
+    builtin: :project_query_view
+    permissions:
+      - :view_project_query
+
+  - reference: :default_role_project_query_edit
+    t_name: Project query editor
+    position: 11
+    builtin: :project_query_edit
+    permissions:
+      - :view_project_query
+      - :edit_project_query
+
 work_package_roles:
   - reference: :default_role_work_package_editor
     t_name: Work package editor

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -43,7 +43,7 @@ module Authorization
       entities = Array(entities_to_check)
 
       entities.all? do |entity|
-        allowed_in_single_entity?(perms, entity)
+        allowed_in_single_entity?(perms, entity, entity_class)
       end
     end
 
@@ -96,8 +96,8 @@ module Authorization
       cached_permissions(project).intersect?(permissions_filtered_for_project)
     end
 
-    def allowed_in_single_entity?(permissions, entity)
-      if entity_is_project_scoped?(entity.class)
+    def allowed_in_single_entity?(permissions, entity, entity_class)
+      if entity_is_project_scoped?(entity_class)
         allowed_in_single_project_scoped_entity?(permissions, entity)
       else
         allowed_in_single_standalone_entity?(permissions, entity)

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -57,6 +57,8 @@ module Authorization
       # ^-- still a problem in some cases
       allowed_scope = entity_class.allowed_to(user, perms)
 
+      # TODO: Also refactor to allow for checking non-project scoped entities
+
       if in_project
         allowed_in_single_project?(perms, in_project) || allowed_scope.exists?(project: in_project)
       else

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -185,6 +185,16 @@ Rails.application.reloader.to_prepare do
                      permissible_on: :global,
                      require: :loggedin,
                      grant_to_admin: true
+
+      map.permission :view_project_query,
+                     {},
+                     permissible_on: :project_query,
+                     require: :loggedin
+
+      map.permission :edit_project_query,
+                     {},
+                     permissible_on: :project_query,
+                     require: :loggedin
     end
 
     map.project_module :work_package_tracking, order: 90 do |wpt|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2863,6 +2863,8 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   permission_manage_public_bcf_queries: "Manage public BCF queries"
   permission_edit_attribute_help_texts: "Edit attribute help texts"
   permission_manage_public_project_queries: "Manage public project lists"
+  permission_view_project_query: "View project query"
+  permission_edit_project_query: "Edit project query"
 
   placeholders:
     default: "-"

--- a/db/migrate/20240527070439_add_project_query_roles.rb
+++ b/db/migrate/20240527070439_add_project_query_roles.rb
@@ -1,0 +1,21 @@
+class AddProjectQueryRoles < ActiveRecord::Migration[7.1]
+  def up
+    view_role ||= ProjectQueryRole.find_or_initialize_by(builtin: Role::BUILTIN_PROJECT_QUERY_VIEW)
+
+    view_role.update!(
+      name: I18n.t("seeds.common.project_query_roles.item_0.name", default: "Project query viewer"),
+      permissions: %i[
+        view_project_query
+      ]
+    )
+
+    edit_role ||= ProjectQueryRole.find_or_initialize_by(builtin: Role::BUILTIN_PROJECT_QUERY_EDIT)
+    edit_role.update!(
+      name: I18n.t("seeds.common.project_query_roles.item_1.name", default: "Project query editor"),
+      permissions: %i[
+        view_project_query
+        edit_project_query
+      ]
+    )
+  end
+end

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -114,6 +114,10 @@ module OpenProject
         @work_package_permissions ||= permissions.select(&:work_package?)
       end
 
+      def project_query_permissions
+        @project_query_permissions ||= permissions.select(&:project_query?)
+      end
+
       def project_permissions
         @project_permissions ||= permissions.select(&:project?)
       end

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -84,6 +84,10 @@ module OpenProject
         permissible_on? :global
       end
 
+      def project_query?
+        permissible_on? :project_query
+      end
+
       def permissible_on?(context_type)
         @permissible_on.include?(context_type)
       end

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -33,6 +33,7 @@ module Bim
         ::BasicData::ProjectRoleSeeder,
         ::BasicData::WorkPackageRoleSeeder,
         ::BasicData::GlobalRoleSeeder,
+        ::BasicData::ProjectQueryRoleSeeder,
         ::BasicData::TimeEntryActivitySeeder,
         ::BasicData::ColorSeeder,
         ::BasicData::ColorSchemeSeeder,

--- a/spec/factories/principal_factory.rb
+++ b/spec/factories/principal_factory.rb
@@ -76,16 +76,22 @@ FactoryBot.define do
           role = create(:project_role, permissions:)
           create(:member, principal:, project: object, roles: [role])
         elsif Member.can_be_member_of?(object)
-          role = create(:work_package_role, permissions:)
-          create(:member, principal:, entity: object, project: object.project, roles: [role])
+          project = object.respond_to?(:project) ? object.project : nil
+          role_factory = :"#{object.model_name.element}_role"
+
+          role = create(role_factory, permissions:)
+          create(:member, principal:, entity: object, project:, roles: [role])
         end
       end
 
       evaluator.member_with_roles.each do |object, role_or_roles|
-        if object.is_a? Project
+        case object
+        when Project
           create(:member, principal:, project: object, roles: Array(role_or_roles))
-        elsif object.is_a?(WorkPackage)
+        when WorkPackage
           create(:member, principal:, entity: object, project: object.project, roles: Array(role_or_roles))
+        when Queries::Projects::ProjectQuery
+          create(:member, principal:, entity: object, project: nil, roles: Array(role_or_roles))
         end
       end
 

--- a/spec/factories/project_query_role_factory.rb
+++ b/spec/factories/project_query_role_factory.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :project_query_role do
+    sequence(:name) { |n| "ProjectQuery Role #{n}" }
+  end
+
+  factory :view_project_query_role, parent: :project_query_role do
+    name { "Project Query view" }
+    builtin { Role::BUILTIN_PROJECT_QUERY_VIEW }
+    permissions do
+      %i(view_project_query)
+    end
+  end
+
+  factory :edit_project_query_role, parent: :project_query_role do
+    name { "Project Query edit" }
+    builtin { Role::BUILTIN_PROJECT_QUERY_EDIT }
+    permissions do
+      %i(view_project_query edit_project_query)
+    end
+  end
+end

--- a/spec/models/queries/projects/project_queries/scopes/allowed_to_spec.rb
+++ b/spec/models/queries/projects/project_queries/scopes/allowed_to_spec.rb
@@ -1,0 +1,127 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Projects::ProjectQuery, "#allowed to" do # rubocop:disable RSpec/FilePath,RSpec/SpecFilePathFormat
+  shared_let(:user) { create(:user) }
+  shared_let(:other_user) { create(:user) }
+
+  let(:checked_user) { user }
+  let(:permission) { :view_project_query }
+
+  subject { described_class.allowed_to(checked_user, permission) }
+
+  shared_let(:view_role) { create(:view_project_query_role) }
+  shared_let(:edit_role) { create(:edit_project_query_role) }
+
+  shared_let(:owned_query) { create(:project_query, user:) }
+  shared_let(:owned_public_query) { create(:project_query, user:, public: true) }
+  shared_let(:public_other_query) { create(:project_query, user: other_user, public: true) }
+  shared_let(:private_other_query) { create(:project_query, user: other_user) }
+  shared_let(:private_other_query_with_view) do
+    create(:project_query, user: other_user, members: [
+             create(:member, user:, roles: [view_role])
+           ])
+  end
+  shared_let(:private_other_query_with_edit) do
+    create(:project_query, user: other_user, members: [
+             create(:member, user:, roles: [edit_role])
+           ])
+  end
+
+  context "when the user is locked" do
+    let(:checked_user) { create(:locked_user) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "when no permission is checked" do
+    let(:permission) { nil }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "when the user is anonymous" do
+    let(:checked_user) { create(:anonymous) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "for the view permission" do
+    let(:permission) { :view_project_query }
+
+    it do
+      expect(subject).to contain_exactly(
+        # public queries
+        public_other_query,
+        owned_public_query,
+        # user owned queries
+        owned_query,
+        # view membership queries
+        private_other_query_with_view,
+        private_other_query_with_edit
+      )
+    end
+  end
+
+  context "for the edit permission" do
+    let(:permission) { :edit_project_query }
+
+    context "when the user can manage global queries" do
+      before do
+        mock_permissions_for(user) do |mock|
+          mock.allow_globally(:manage_public_project_queries)
+        end
+      end
+
+      it do
+        expect(subject).to contain_exactly(
+          # public queries
+          public_other_query,
+          owned_public_query,
+          # user owned queries
+          owned_query,
+          # view membership queries
+          private_other_query_with_edit
+        )
+      end
+    end
+
+    context "when the user cannot manage global queries" do
+      it do
+        expect(subject).to contain_exactly(
+          # user owned queries
+          owned_query,
+          # edit membership queries
+          private_other_query_with_edit
+        )
+      end
+    end
+  end
+end

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -442,6 +442,92 @@ RSpec.describe Queries::Projects::ProjectQuery do
 
         it { is_expected.not_to be_visible(user) }
       end
+
+      context "and the query has been shared with the user" do
+        before do
+          mock_permissions_for(user) do |mock|
+            mock.allow_in_project_query(:view_project_query, project_query: subject)
+          end
+        end
+
+        it { is_expected.to be_visible(user) }
+      end
+    end
+  end
+
+  describe "#editable?" do
+    subject { build(:project_query, user: owner, public:) }
+
+    context "when the query is private" do
+      let(:public) { false }
+
+      context "and the user is the owner" do
+        let(:owner) { user }
+
+        it { is_expected.to be_editable(user) }
+      end
+
+      context "and the user is not the owner" do
+        let(:owner) { build(:user) }
+
+        it { is_expected.not_to be_editable(user) }
+
+        context "and the query has been shared with the user" do
+          before do
+            mock_permissions_for(user) do |mock|
+              mock.allow_in_project_query(:edit_project_query, project_query: subject)
+            end
+          end
+
+          it { is_expected.to be_editable(user) }
+        end
+      end
+    end
+
+    context "when the query is public" do
+      let(:public) { true }
+
+      context "and the user is the owner" do
+        let(:owner) { user }
+
+        it { is_expected.not_to be_editable(user) }
+
+        context "and the user has the global permission" do
+          before do
+            mock_permissions_for(user) do |mock|
+              mock.allow_globally(:manage_public_project_queries)
+            end
+          end
+
+          it { is_expected.to be_editable(user) }
+        end
+      end
+
+      context "and the user is not the owner" do
+        let(:owner) { build(:user) }
+
+        it { is_expected.not_to be_editable(user) }
+
+        context "and the user has the global permission" do
+          before do
+            mock_permissions_for(user) do |mock|
+              mock.allow_globally(:manage_public_project_queries)
+            end
+          end
+
+          it { is_expected.to be_editable(user) }
+        end
+
+        context "and the query has been shared with the user" do
+          before do
+            mock_permissions_for(user) do |mock|
+              mock.allow_in_project_query(:edit_project_query, project_query: subject)
+            end
+          end
+
+          it { is_expected.to be_editable(user) }
+        end
+      end
     end
   end
 end

--- a/spec/models/users/permission_checks_spec.rb
+++ b/spec/models/users/permission_checks_spec.rb
@@ -48,12 +48,14 @@ RSpec.describe User, "permission check methods" do
 
   Member::ALLOWED_ENTITIES.each do |entity_model_name|
     context "for #{entity_model_name}" do
+      let(:model_name_part) { entity_model_name.constantize.model_name.element }
+
       it "defines allowed_in_#{entity_model_name.underscore}?" do
-        expect(subject).to respond_to("allowed_in_#{entity_model_name.underscore}?")
+        expect(subject).to respond_to("allowed_in_#{model_name_part}?")
       end
 
       it "defines allowed_in_any_#{entity_model_name.underscore}?" do
-        expect(subject).to respond_to("allowed_in_any_#{entity_model_name.underscore}?")
+        expect(subject).to respond_to("allowed_in_any_#{model_name_part}?")
       end
     end
   end

--- a/spec/seeders/basic_data/project_query_role_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_query_role_seeder_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe BasicData::ProjectQueryRoleSeeder do
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { Source::SeedData.new(data_hash) }
+
+  before do
+    seeder.seed!
+  end
+
+  context "with some project query roles defined" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        project_query_roles:
+          - reference: :default_role_project_query_view
+            name: Project query viewer
+            position: 10
+            builtin: :project_query_view
+            permissions:
+              - :view_project_query
+
+          - reference: :default_role_project_query_edit
+            name: Project query editor
+            position: 11
+            builtin: :project_query_edit
+            permissions:
+              - :view_project_query
+              - :edit_project_query
+      SEEDING_DATA_YAML
+    end
+
+    it "creates the corresponding project query roles with the given attributes", :aggregate_failures do
+      expect(ProjectQueryRole.count).to eq(2)
+      expect(ProjectQueryRole.find_by(builtin: Role::BUILTIN_PROJECT_QUERY_VIEW)).to have_attributes(
+        permissions: %i[view_project_query]
+      )
+      expect(ProjectQueryRole.find_by(builtin: Role::BUILTIN_PROJECT_QUERY_EDIT)).to have_attributes(
+        permissions: %i[view_project_query edit_project_query]
+      )
+    end
+
+    it "references the role in the seed data" do
+      role = ProjectQueryRole.find_by(builtin: Role::BUILTIN_PROJECT_QUERY_VIEW)
+      expect(seed_data.find_reference(:default_role_project_query_view)).to eq(role)
+    end
+  end
+
+  context "with permissions: :all_assignable_permissions" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        project_query_roles:
+            - name: All Project Query Permissions
+              permissions: :all_assignable_permissions
+      SEEDING_DATA_YAML
+    end
+
+    it "gives all assignable permissions to the role" do
+      role = ProjectQueryRole.find_by(name: "All Project Query Permissions")
+      expected_roles = Roles::CreateContract.new(ProjectQueryRole.new, nil).assignable_permissions.map { _1.name.to_sym }
+      expect(role.permissions).to match_array(expected_roles)
+    end
+  end
+end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe RootSeeder,
     include_examples "it creates records", model: DocumentCategory, expected_count: 3
     include_examples "it creates records", model: GlobalRole, expected_count: 1
     include_examples "it creates records", model: WorkPackageRole, expected_count: 3
-    include_examples "it creates records", model: Role, expected_count: 9
+    include_examples "it creates records", model: ProjectRole, expected_count: 5
+    include_examples "it creates records", model: ProjectQueryRole, expected_count: 2
     include_examples "it creates records", model: IssuePriority, expected_count: 4
     include_examples "it creates records", model: Status, expected_count: 14
     include_examples "it creates records", model: TimeEntryActivity, expected_count: 6

--- a/spec/support/mocked_permission_helper.rb
+++ b/spec/support/mocked_permission_helper.rb
@@ -68,6 +68,15 @@ class PermissionMock
     permitted_entities[work_package] += permissions
   end
 
+  def allow_in_project_query(*permissions, project_query:)
+    raise ArgumentError, NIL_ERROR if project_query.nil?
+
+    permissions.each do |permission|
+      Authorization.contextual_permissions(permission, :project_query, raise_on_unknown: true)
+    end
+    permitted_entities[project_query] += permissions
+  end
+
   def allow_globally(*permissions)
     permissions.each do |permission|
       Authorization.contextual_permissions(permission, :global, raise_on_unknown: true)

--- a/spec/support_spec/mocked_permission_helper_spec.rb
+++ b/spec/support_spec/mocked_permission_helper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe MockedPermissionHelper do
   let(:work_package_in_project) { build(:work_package, project:) }
   let(:other_work_package_in_project) { build(:work_package, project:) }
   let(:other_work_package) { build(:work_package) }
+  let(:project_query) { build(:project_query) }
 
   context "when trying to mock a permission that does not exist" do
     it "raises UnknownPermissionError exception" do
@@ -76,6 +77,16 @@ RSpec.describe MockedPermissionHelper do
     end
   end
 
+  context "when trying to mock a permission on nil as the project query" do
+    it "raises an ArgumentError exception" do
+      expect do
+        mock_permissions_for(user) do |mock|
+          mock.allow_in_project_query :view_project_query, project_query: nil
+        end
+      end.to raise_error(ArgumentError, /tried to mock a permission on nil/)
+    end
+  end
+
   context "when not providing a block" do
     it "does not allow anything" do
       expect do
@@ -90,6 +101,7 @@ RSpec.describe MockedPermissionHelper do
         mock.allow_everything
         mock.allow_globally :add_project
         mock.allow_in_project(:add_work_packages, project:)
+        mock.allow_in_project_query(:view_project_query, project_query:)
 
         # this removes all permissions previously set
         mock.forbid_everything
@@ -102,6 +114,8 @@ RSpec.describe MockedPermissionHelper do
       expect(user).not_to be_allowed_in_any_project(:add_work_packages)
       expect(user).not_to be_allowed_in_work_package(:add_work_packages, work_package_in_project)
       expect(user).not_to be_allowed_in_any_work_package(:add_work_packages)
+      expect(user).not_to be_allowed_in_project_query(:view_project_query, project_query)
+      expect(user).not_to be_allowed_in_any_project_query(:view_project_query)
     end
   end
 
@@ -116,6 +130,8 @@ RSpec.describe MockedPermissionHelper do
       expect(user).to be_allowed_in_any_project(:add_work_packages)
       expect(user).to be_allowed_in_work_package(:add_work_packages, work_package_in_project)
       expect(user).to be_allowed_in_any_work_package(:add_work_packages)
+      expect(user).to be_allowed_in_project_query(:view_project_query, project_query)
+      expect(user).to be_allowed_in_any_project_query(:view_project_query)
     end
   end
 


### PR DESCRIPTION
- [x] Change the Membership model so that it explicitly supports `entity present` + `project nil`
- [x] Add a `ProjectQueryRole` and the permissions
- [x] Add an `allowed_to` scope for `ProjectQuery`
- [x] Change `visible` and add `editable` method to `ProjectQuery`
- [x] Add tests 

---

Implements https://community.openproject.org/work_packages/55160
Implements https://community.openproject.org/work_packages/55161