### PR TITLE
[#55158] Add complete attribute to storage representer

### DIFF
--- a/docs/api/apiv3/components/examples/storage-nextcloud-response-for-creation.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-response-for-creation.yml
@@ -1,0 +1,55 @@
+# Example: Nextcloud storage on creation (includes client secret)
+---
+value:
+  _type: Storage
+  id: 1337
+  name: My New DeathStar
+  hasApplicationPassword: false
+  createdAt: '2024-05-21T09:11:53.880Z'
+  updatedAt: '2024-05-21T09:11:53.880Z'
+  complete: false
+  _embedded:
+    oauthApplication:
+      id: 42
+      _type: OAuthApplication
+      name: My New DeathStar (Nextcloud)
+      clientId: gNQ-gi3VX59ruoft5B9aRmukEYbZOhKIsxXE9iT1tcQ
+      confidential: true
+      clientSecret: 79hIlb1Ezj5kPx8LgE6LI9L1-mb8g7jX1-u_a08RJlI
+      createdAt: '2024-05-21T09:11:53.908Z'
+      updatedAt: '2024-05-21T09:11:53.908Z'
+      scopes:
+        - api_v3
+      _links:
+        self:
+          href: '/api/v3/oauth_applications/42'
+        owner:
+          href: '/api/v3/users/13'
+          title: Darth Vader
+        integration:
+          href: '/api/v3/storages/1337'
+          title: My New DeathStar
+        redirectUri:
+          - href: 'https://nextcloud.deathstar.rocks/index.php/apps/integration_openproject/oauth-redirect'
+  _links:
+    self:
+      href: /api/v3/storages/1337
+      title: My New DeathStar
+    type:
+      href: urn:openproject-org:api:v3:storages:Nextcloud
+      title: Nextcloud
+    origin:
+      href: https://nextcloud.deathstar.rocks/
+    open:
+      href: /api/v3/storages/1337/open
+    prepareUpload: []
+    authorizationState:
+      href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
+      title: Authorization failed
+    projectStrages:
+      href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
+    oauthApplication:
+      href: /api/v3/oauth_application/42
+      title: My New DeathStar (Nextcloud)
+    oauthClientCredentials:
+      href: null

--- a/docs/api/apiv3/components/examples/storage-nextcloud-response.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-response.yml
@@ -1,0 +1,86 @@
+# Example: Nextcloud storage
+---
+value:
+  _type: Storage
+  id: 1337
+  name: It's no moon
+  hasApplicationPassword: true
+  createdAt: '2021-12-20T13:37:00.211Z'
+  updatedAt: '2021-12-20T13:37:00.211Z'
+  complete: true
+  _embedded:
+    oauthApplication:
+      id: 42
+      _type: OAuthApplication
+      name: It's no moon (Nextcloud)
+      clientId: O5h6WObhMg1Z8IcLHRE3_LMh4jJYmmca2V6OTFSv8DA
+      confidential: true
+      createdAt: '2022-12-07T12:56:42.626Z'
+      updatedAt: '2022-12-07T12:56:42.626Z'
+      scopes:
+        - api_v3
+      _links:
+        self:
+          href: '/api/v3/oauth_applications/42'
+        owner:
+          href: '/api/v3/users/13'
+          title: Darth Vader
+        integration:
+          href: '/api/v3/storages/1337'
+          title: It's no moon
+        redirectUri:
+          - href: 'https://nextcloud.deathstar.rocks/index.php/apps/integration_openproject/oauth-redirect'
+    oauthClientCredentials:
+      _type: OAuthClientCredentials
+      id: 42
+      clientId: fGEFWxIpROrpci25TW6qWCZozDFEAKSkonMBkrf3LYvBXRljBbLajBf2vD2fjePm
+      confidential: true
+      createdAt: '2023-12-08T09:49:24.397Z'
+      updatedAt: '2023-12-08T09:49:24.397Z'
+      _links:
+        self:
+          href: /api/v3/oauth_client_credentials/42
+        integration:
+          href: /api/v3/storages/1337
+          title: It's no moon
+  _links:
+    self:
+      href: /api/v3/storages/1337
+      title: It's no moon
+    type:
+      href: urn:openproject-org:api:v3:storages:Nextcloud
+      title: Nextcloud
+    origin:
+      href: https://nextcloud.deathstar.rocks/
+    prepareUpload:
+      - href: /api/v3/storages/1337/files/prepare_upload
+        method: post
+        title: Upload file
+        payload:
+          projectId: 21
+          fileName: '{fileName}'
+          parent: '{parent}'
+        templated: true
+      - href: /api/v3/storages/95/files/prepare_upload
+        method: post
+        title: Upload file
+        payload:
+          projectId: 11
+          fileName: '{fileName}'
+          parent: '{parent}'
+        templated: true
+    open:
+      href: /api/v3/storages/1337/open
+    authorizationState:
+      href: urn:openproject-org:api:v3:storages:authorization:Connected
+      title: Connected
+    #    authorize:
+    #      href: https://nextcloud.deathstar.rocks/authorize/
+    #      title: Authorize
+    projectStrages:
+      href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
+    oauthApplication:
+      href: /api/v3/oauth_application/42
+      title: It's no moon (Nextcloud)
+    oauthClientCredentials:
+      href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/examples/storage-nextcloud-unauthorized-response.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-unauthorized-response.yml
@@ -1,0 +1,70 @@
+# Example: Nextcloud storage
+---
+value:
+  _type: Storage
+  id: 1337
+  name: It's no moon
+  hasApplicationPassword: false
+  createdAt: '2021-12-20T13:37:00.211Z'
+  updatedAt: '2021-12-20T13:37:00.211Z'
+  complete: true
+  _embedded:
+    oauthApplication:
+      id: 42
+      _type: OAuthApplication
+      name: It's no moon (Nextcloud)
+      clientId: O5h6WObhMg1Z8IcLHRE3_LMh4jJYmmca2V6OTFSv8DA
+      confidential: true
+      createdAt: '2022-12-07T12:56:42.626Z'
+      updatedAt: '2022-12-07T12:56:42.626Z'
+      scopes:
+        - api_v3
+      _links:
+        self:
+          href: '/api/v3/oauth_applications/42'
+        owner:
+          href: '/api/v3/users/13'
+          title: Darth Vader
+        integration:
+          href: '/api/v3/storages/1337'
+          title: It's no moon
+        redirectUri:
+          - href: 'https://nextcloud.deathstar.rocks/index.php/apps/integration_openproject/oauth-redirect'
+    oauthClientCredentials:
+      _type: OAuthClientCredentials
+      id: 42
+      clientId: fGEFWxIpROrpci25TW6qWCZozDFEAKSkonMBkrf3LYvBXRljBbLajBf2vD2fjePm
+      confidential: true
+      createdAt: '2023-12-08T09:49:24.397Z'
+      updatedAt: '2023-12-08T09:49:24.397Z'
+      _links:
+        self:
+          href: /api/v3/oauth_client_credentials/42
+        integration:
+          href: /api/v3/storages/1337
+          title: It's no moon
+  _links:
+    self:
+      href: /api/v3/storages/1337
+      title: It's no moon
+    type:
+      href: urn:openproject-org:api:v3:storages:Nextcloud
+      title: Nextcloud
+    origin:
+      href: https://nextcloud.deathstar.rocks/
+    prepareUpload: []
+    open:
+      href: /api/v3/storages/1337/open
+    authorizationState:
+      href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
+      title: Authorization failed
+    authorize:
+      href: https://nextcloud25.local/index.php/apps/oauth2/authorize?client_id=fnrIeJZqqAKGQlejuDaGhSQfCAVtoayHLACWCYcPJ0w17Pp6daPPUktkM9QaGxca&redirect_uri=https://openproject.local/oauth_clients/fnrIeJZqqAKGQlejuDaGhSQfCAVtoayHLACWCYcPJ0w17Pp6daPPUktkM9QaGxca/callback&response_type=code
+      title: Authorize
+    projectStrages:
+      href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
+    oauthApplication:
+      href: /api/v3/oauth_application/42
+      title: It's no moon (Nextcloud)
+    oauthClientCredentials:
+      href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
+++ b/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
@@ -8,7 +8,7 @@ value:
   driveId: null
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
-  complete: true
+  complete: false
   _links:
     self:
       href: /api/v3/storages/1337

--- a/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
+++ b/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
@@ -1,0 +1,28 @@
+# Example: OneDrive storage
+---
+value:
+  _type: Storage
+  id: 1337
+  name: It's no moon
+  tenantId: e36f1dbc-fdae-427e-b61b-0d96ddfb81a4
+  driveId: null
+  createdAt: '2021-12-20T13:37:00.211Z'
+  updatedAt: '2021-12-20T13:37:00.211Z'
+  complete: true
+  _links:
+    self:
+      href: /api/v3/storages/1337
+      title: It's no moon
+    type:
+      href: urn:openproject-org:api:v3:storages:OneDrive
+      title: OneDrive/SharePoint
+    prepareUpload: []
+    open:
+      href: /api/v3/storages/1337/open
+    authorizationState:
+      href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
+      title: Authorization failed
+    projectStrages:
+      href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
+    oauthClientCredentials:
+      href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/examples/storage-one-drive-response.yml
+++ b/docs/api/apiv3/components/examples/storage-one-drive-response.yml
@@ -1,0 +1,50 @@
+# Example: OneDrive storage
+---
+value:
+  _type: Storage
+  id: 1337
+  name: It's no moon
+  tenantId: e36f1dbc-fdae-427e-b61b-0d96ddfb81a4
+  driveId: b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK
+  createdAt: '2021-12-20T13:37:00.211Z'
+  updatedAt: '2021-12-20T13:37:00.211Z'
+  complete: true
+  _embedded:
+    oauthClientCredentials:
+      _type: OAuthClientCredentials
+      id: 42
+      clientId: b8a5bb54-5fb2-4e0e-9427-9d24dbac32ff
+      confidential: true
+      createdAt: '2023-12-08T09:49:24.397Z'
+      updatedAt: '2023-12-08T09:49:24.397Z'
+      _links:
+        self:
+          href: /api/v3/oauth_client_credentials/42
+        integration:
+          href: /api/v3/storages/1337
+          title: It's no moon
+  _links:
+    self:
+      href: /api/v3/storages/1337
+      title: It's no moon
+    type:
+      href: urn:openproject-org:api:v3:storages:OneDrive
+      title: OneDrive/SharePoint
+    prepareUpload:
+      - href: /api/v3/storages/1337/files/prepare_upload
+        method: post
+        title: Upload file
+        payload:
+          projectId: 33
+          fileName: '{fileName}'
+          parent: '{parent}'
+        templated: true
+    open:
+      href: /api/v3/storages/1337/open
+    authorizationState:
+      href: urn:openproject-org:api:v3:storages:authorization:Connected
+      title: Connected
+    projectStrages:
+      href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
+    oauthClientCredentials:
+      href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
+++ b/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
@@ -71,16 +71,18 @@ properties:
 
               **Resource**: Storage
       redirectUri:
-        allOf:
-          - $ref: './link.yml'
-          - description: |-
-              The redirect URI of the OAuth application
-
-              **Resource**: N/A
+        type: array
+        items:
+          allOf:
+            - $ref: './link.yml'
+            - description: |-
+                A redirect URI of the OAuth application
+  
+                **Resource**: N/A
 
 example:
   id: 1337
-  _type: OauthClientCredentials
+  _type: OAuthApplication
   name: Vader's secure OAuth app
   clientId: O5h6WObhMg1Z8IcLHRE3_LMh4jJYmmca2V6OTFSv8DA
   confidential: true
@@ -98,4 +100,4 @@ example:
       href: '/api/v3/storages/42'
       title: Death Star Cloud
     redirectUri:
-      href: 'https://death-star.cloud.tools/index.php/apps/integration_openproject/oauth-redirect'
+      - href: 'https://death-star.cloud.tools/index.php/apps/integration_openproject/oauth-redirect'

--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -17,12 +17,24 @@ properties:
   name:
     type: string
     description: Storage name
+  tenantId:
+    type: string
+    description: |-
+      The tenant id of a file storage of type OneDrive/SharePoint.
+
+      Ignored if the provider type is not OneDrive/SharePoint.
+  driveId:
+    type: string
+    description: |-
+      The drive id of a file storage of type OneDrive/SharePoint.
+
+      Ignored if the provider type is not OneDrive/SharePoint.
   hasApplicationPassword:
     type: boolean
     description: |-
       Whether the storage has the application password to use for the Nextcloud storage.
 
-      Ignored if the provider type is not Nextcloud
+      Ignored if the provider type is not Nextcloud.
   createdAt:
     type: string
     format: date-time
@@ -31,11 +43,11 @@ properties:
     type: string
     format: date-time
     description: Time of the most recent change to the storage
+  complete:
+    type: boolean
+    description: Indication, if the storage is fully configured
   _embedded:
     type: object
-    required:
-      - oauthApplication
-      - oauthClientCredentials
     properties:
       oauthApplication:
         $ref: './oauth_application_read_model.yml'
@@ -46,7 +58,6 @@ properties:
     required:
       - self
       - type
-      - origin
       - open
       - authorizationState
     properties:
@@ -68,7 +79,8 @@ properties:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              Web URI of the storage instance.
+              Web URI of the storage instance. This link is ignored, if the storage is hosted in a cloud and has no own
+              URL, like file storages of type OneDrive/SharePoint.
 
               **Resource**: N/A
       open:
@@ -124,32 +136,3 @@ properties:
               - User has role `admin`
 
               **Resource**: OAuthClientCredentials
-example:
-  id: 1337
-  _type: Storage
-  name: It's no moon
-  hasApplicationPassword: true
-  createdAt: '2021-12-20T13:37:00.211Z'
-  updatedAt: '2021-12-20T13:37:00.211Z'
-  _links:
-    self:
-      href: /api/v3/storages/1337
-      title: It's no moon
-    type:
-      href: urn:openproject-org:api:v3:storages:nextcloud
-      title: Nextcloud
-    origin:
-      href: https://nextcloud.deathstar.rocks/
-    open:
-      href: https://nextcloud.deathstar.rocks/apps/files
-    authorizationState:
-      href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
-      title: Failed Authorization
-    authorize:
-      href: https://nextcloud.deathstar.rocks/authorize/
-      title: Authorize
-    oauthApplication:
-      href: /api/v3/oauth_application/42
-      title: It's no moon (Nextcloud)
-    oauthClientCredentials:
-      href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -513,6 +513,16 @@ components:
       $ref: "./components/examples/project_body.yml"
     ProjectCollection:
       $ref: "./components/examples/project_collection.yml"
+    StorageNextcloudResponse:
+      $ref: "./components/examples/storage-nextcloud-response.yml"
+    StorageNextcloudResponseForCreation:
+      $ref: "./components/examples/storage-nextcloud-response-for-creation.yml"
+    StorageNextcloudUnauthorizedResponse:
+      $ref: "./components/examples/storage-nextcloud-unauthorized-response.yml"
+    StorageOneDriveIncompleteResponse:
+      $ref: "./components/examples/storage-one-drive-incomplete-response.yml"
+    StorageOneDriveResponse:
+      $ref: "./components/examples/storage-one-drive-response.yml"
     QueriesModel:
       $ref: "./components/examples/queries.yml"
     QueryModel:

--- a/docs/api/apiv3/paths/storage.yml
+++ b/docs/api/apiv3/paths/storage.yml
@@ -23,6 +23,17 @@ get:
         application/hal+json:
           schema:
             $ref: '../components/schemas/storage_read_model.yml'
+          examples:
+            'Nextcloud storage':
+              $ref: '../components/examples/storage-nextcloud-response.yml'
+            'Freshly created Nextcloud storage':
+              $ref: '../components/examples/storage-nextcloud-response-for-creation.yml'
+            'OneDrive storage':
+              $ref: '../components/examples/storage-one-drive-response.yml'
+            'Incomplete OneDrive storage':
+              $ref: '../components/examples/storage-one-drive-incomplete-response.yml'
+            'Unauthorized Nextcloud storage':
+              $ref: '../components/examples/storage-nextcloud-unauthorized-response.yml'
     '404':
       content:
         application/hal+json:

--- a/lib/api/v3/oauth/oauth_applications_representer.rb
+++ b/lib/api/v3/oauth/oauth_applications_representer.rb
@@ -76,10 +76,8 @@ module API::V3::OAuth
       }
     end
 
-    link :redirectUri do
-      {
-        href: represented.redirect_uri
-      }
+    links :redirectUri do
+      represented.redirect_uri.split(/[\r\n]+/).map { |href| { href: } }
     end
 
     def _type

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -102,7 +102,7 @@ module API::V3::Storages
              getter: ->(represented:, **) { represented.drive_id if represented.provider_type_one_drive? },
              setter: ->(fragment:, represented:, **) { represented.drive_id = fragment }
 
-    property :complete,
+    property :configured,
              skip_parse: true,
              getter: ->(represented:, **) { represented.configured? }
 

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -90,14 +90,28 @@ module API::V3::Storages
                end
              }
 
+    property :tenant_id,
+             skip_render: ->(represented:, **) { !represented.provider_type_one_drive? },
+             render_nil: true,
+             getter: ->(represented:, **) { represented.tenant_id if represented.provider_type_one_drive? },
+             setter: ->(fragment:, represented:, **) { represented.tenant_id = fragment }
+
+    property :drive_id,
+             skip_render: ->(represented:, **) { !represented.provider_type_one_drive? },
+             render_nil: true,
+             getter: ->(represented:, **) { represented.drive_id if represented.provider_type_one_drive? },
+             setter: ->(fragment:, represented:, **) { represented.drive_id = fragment }
+
+    property :complete,
+             skip_parse: true,
+             getter: ->(represented:, **) { represented.configured? }
+
     property :hasApplicationPassword,
              skip_parse: true,
              skip_render: ->(represented:, **) { !represented.provider_type_nextcloud? },
-             getter: ->(represented:, **) {
-               break unless represented.provider_type_nextcloud?
-
-               represented.automatic_management_enabled?
-             },
+             getter: ->(represented:, **) do
+               represented.automatic_management_enabled? if represented.provider_type_nextcloud?
+             end,
              setter: ->(*) {}
 
     date_time_property :created_at
@@ -120,7 +134,7 @@ module API::V3::Storages
                           }
 
     link_without_resource :origin,
-                          getter: ->(*) { { href: represented.host } },
+                          getter: ->(*) { { href: represented.host } if represented.host.present? },
                           setter: ->(fragment:, **) {
                             break if fragment["href"].blank?
 

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -163,6 +163,7 @@ FactoryBot.define do
     host { nil }
     tenant_id { SecureRandom.uuid }
     drive_id { SecureRandom.uuid }
+    automatically_managed { false }
 
     trait :as_automatically_managed do
       automatically_managed { true }

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
       let(:value) { storage.name }
     end
 
-    it_behaves_like "property", :complete do
+    it_behaves_like "property", :configured do
       let(:value) { true }
     end
 
@@ -218,11 +218,15 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
 
     it_behaves_like "common file storage properties"
 
-    describe "properties (Nextcloud only)" do
-      it_behaves_like "property", :hasApplicationPassword do
+    context "if file storage is not completely configured" do
+      let(:storage) { build_stubbed(:nextcloud_storage, oauth_client: nil) }
+
+      it_behaves_like "property", :configured do
         let(:value) { false }
       end
+    end
 
+    describe "properties (Nextcloud only)" do
       describe "hasApplicationPassword" do
         it_behaves_like "property", :hasApplicationPassword do
           let(:value) { false }
@@ -295,6 +299,14 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
     let(:storage) { build_stubbed(:one_drive_storage, oauth_client: oauth_client_credentials) }
 
     it_behaves_like "common file storage properties"
+
+    context "if file storage is not completely configured" do
+      let(:storage) { build_stubbed(:one_drive_storage, drive_id: nil, oauth_client: oauth_client_credentials) }
+
+      it_behaves_like "property", :configured do
+        let(:value) { false }
+      end
+    end
 
     describe "properties (OneDrive/SharePoint only)" do
       it_behaves_like "property", :tenantId do

--- a/spec/lib/api/v3/oauth/oauth_applications_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/oauth/oauth_applications_representer_rendering_spec.rb
@@ -1,0 +1,133 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::OAuth::OAuthApplicationsRepresenter, "rendering" do
+  let(:user) { build_stubbed(:user) }
+  let(:oauth_application) { build_stubbed(:oauth_application) }
+  let(:representer) { described_class.new(oauth_application, current_user: user, embed_links: true) }
+
+  subject(:generated) { representer.to_json }
+
+  describe "properties" do
+    it_behaves_like "property", :_type do
+      let(:value) { "OAuthApplication" }
+    end
+
+    it_behaves_like "property", :id do
+      let(:value) { oauth_application.id }
+    end
+
+    it_behaves_like "property", :name do
+      let(:value) { oauth_application.name }
+    end
+
+    it_behaves_like "property", :clientId do
+      let(:value) { oauth_application.uid }
+    end
+
+    it_behaves_like "datetime property", :createdAt do
+      let(:value) { oauth_application.created_at }
+    end
+
+    it_behaves_like "datetime property", :updatedAt do
+      let(:value) { oauth_application.updated_at }
+    end
+
+    it_behaves_like "property", :scopes do
+      let(:value) { ["api_v3"] }
+    end
+
+    describe "confidential" do
+      context "if the oauth application is confidential" do
+        it_behaves_like "property", :confidential do
+          let(:value) { true }
+        end
+      end
+
+      context "if the oauth application is not confidential" do
+        let(:oauth_application) { build_stubbed(:oauth_application, confidential: false) }
+
+        it_behaves_like "property", :confidential do
+          let(:value) { false }
+        end
+      end
+    end
+
+    describe "clientSecret" do
+      context "if the oauth application is not confidential" do
+        let(:oauth_application) { build_stubbed(:oauth_application, confidential: false) }
+
+        it_behaves_like "no property", :clientSecret
+      end
+
+      context "if the oauth application is confidential, but not just created" do
+        it_behaves_like "no property", :clientSecret
+      end
+
+      context "if the oauth application is confidential and just created" do
+        before do
+          allow(oauth_application).to receive_messages(plaintext_secret: "my-secret")
+        end
+
+        it_behaves_like "property", :clientSecret do
+          let(:value) { "my-secret" }
+        end
+      end
+    end
+  end
+
+  describe "_links" do
+    describe "self" do
+      it_behaves_like "has a titled link" do
+        let(:link) { "self" }
+        let(:href) { "/api/v3/oauth_applications/#{oauth_application.id}" }
+        let(:title) { oauth_application.name }
+      end
+    end
+
+    describe "redirectUri" do
+      it_behaves_like "has a link collection" do
+        let(:link) { "redirectUri" }
+        let(:hrefs) { [{ href: oauth_application.redirect_uri }] }
+      end
+
+      context "if multiple redirect uris are defined" do
+        let(:oauth_application) do
+          build_stubbed(:oauth_application, redirect_uri: "https://my.deathstar.com\nhttps://starkiller.base.fo")
+        end
+
+        it_behaves_like "has a link collection" do
+          let(:link) { "redirectUri" }
+          let(:hrefs) { [{ href: "https://my.deathstar.com" }, { href: "https://starkiller.base.fo" }] }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[#55158](https://community.openproject.org/work_packages/55158)

### WAT?

- complete attribute for every storage type
- fix API to be able to create one drive storages
- fix API to show tenant id and drive id for one drive storages