### PR TITLE
rack wait_timeout only in production

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1087,7 +1087,7 @@ module Settings
         description: "Web worker count and threads configuration",
         default: {
           "workers" => 2,
-          "timeout" => 120,
+          "timeout" => Rails.env.production? ? 120 : 0,
           "wait_timeout" => 10,
           "min_threads" => 4,
           "max_threads" => 16


### PR DESCRIPTION
According to the rack timeout documentation
https://github.com/zombocom/rack-timeout/blob/main/doc/settings.md#service-timeout

"Service timeout can be disabled entirely by setting the property to 0 or false."

Limiting the service timeout to be active only in production enables debugging in dev and test env without fearing for the timeout to take oneself out of context.