### PR TITLE
Chore: avoid misleading "Unpermitted parameters: xxx" message log

### DIFF
--- a/app/controllers/admin/settings/api_settings_controller.rb
+++ b/app/controllers/admin/settings/api_settings_controller.rb
@@ -39,5 +39,11 @@ module Admin::Settings
         settings["apiv3_cors_origins"] = settings["apiv3_cors_origins"].split(/\r?\n/)
       end
     end
+
+    def extra_permitted_filters
+      # attachment_whitelist is normally permitted as an array parameter.
+      # Explicitly permit it as a string here.
+      [:apiv3_cors_origins]
+    end
   end
 end

--- a/app/controllers/admin/settings/attachments_settings_controller.rb
+++ b/app/controllers/admin/settings/attachments_settings_controller.rb
@@ -41,5 +41,11 @@ module Admin::Settings
         settings["attachment_whitelist"] = settings["attachment_whitelist"].split(/\r?\n/)
       end
     end
+
+    def extra_permitted_filters
+      # attachment_whitelist is normally permitted as an array parameter.
+      # Explicitly permit it as a string here.
+      [:attachment_whitelist]
+    end
   end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -90,7 +90,17 @@ module Admin
     end
 
     def settings_params
-      permitted_params.settings.to_h
+      permitted_params.settings(*extra_permitted_filters).to_h
+    end
+
+    # Override to allow additional permitted parameters.
+    #
+    # Useful when the format of the setting in the parameters is different from
+    # the expected format in the setting definition, for instance a setting is
+    # an array in the definition but is passed as a string to be split in the
+    # parameters.
+    def extra_permitted_filters
+      nil
     end
 
     def update_service

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -179,8 +179,8 @@ class PermittedParams
     params.require(:status).permit(*self.class.permitted_attributes[:status])
   end
 
-  def settings
-    params.require(:settings).permit(*AllowedSettings.filters)
+  def settings(extra_permitted_filters = nil)
+    params.require(:settings).permit(*AllowedSettings.filters, *extra_permitted_filters)
   end
 
   def user(additional_params = [])

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -180,10 +180,8 @@ class PermittedParams
   end
 
   def settings
-    permitted_params = params.require(:settings).permit
-    all_valid_keys = AllowedSettings.all
-
-    permitted_params.merge(params[:settings].to_unsafe_hash.slice(*all_valid_keys))
+    scalar_filters, complex_filters = AllowedSettings.scalar_and_complex_filters
+    params.require(:settings).permit(*scalar_filters, **complex_filters)
   end
 
   def user(additional_params = [])

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -180,8 +180,7 @@ class PermittedParams
   end
 
   def settings
-    scalar_filters, complex_filters = AllowedSettings.scalar_and_complex_filters
-    params.require(:settings).permit(*scalar_filters, **complex_filters)
+    params.require(:settings).permit(*AllowedSettings.filters)
   end
 
   def user(additional_params = [])

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'permitted_params/allowed_settings'
+require "permitted_params/allowed_settings"
 
 class PermittedParams
   # This class intends to provide a method for all params hashes coming from the
@@ -162,7 +162,7 @@ class PermittedParams
     p = params.require(:query).permit(*self.class.permitted_attributes[:query])
     p[:sort_criteria] = params
       .require(:query)
-      .permit(sort_criteria: { '0' => [], '1' => [], '2' => [] })
+      .permit(sort_criteria: { "0" => [], "1" => [], "2" => [] })
     p[:sort_criteria].delete :sort_criteria
     p
   end
@@ -340,7 +340,7 @@ class PermittedParams
   end
 
   def attachments
-    params.permit(attachments: %i[file description id])['attachments']
+    params.permit(attachments: %i[file description id])["attachments"]
   end
 
   def enumerations
@@ -407,7 +407,7 @@ class PermittedParams
     # Reject blank values from include_hidden select fields
     values.each { |_, v| v.compact_blank! if v.is_a?(Array) }
 
-    values.empty? ? {} : { 'custom_field_values' => values.permit! }
+    values.empty? ? {} : { "custom_field_values" => values.permit! }
   end
 
   def permitted_attributes(key, additions = {})
@@ -529,7 +529,7 @@ class PermittedParams
           :subject,
           Proc.new do |args|
             # avoid costly allowed_in_project? if the param is not there at all
-            if args[:params]['work_package']&.has_key?('watcher_user_ids') &&
+            if args[:params]["work_package"]&.has_key?("watcher_user_ids") &&
                args[:current_user].allowed_in_project?(:add_work_package_watchers, args[:project])
 
               { watcher_user_ids: [] }

--- a/app/models/permitted_params/allowed_settings.rb
+++ b/app/models/permitted_params/allowed_settings.rb
@@ -29,24 +29,20 @@ class PermittedParams
       keys
     end
 
-    def scalar_and_complex_filters
+    def filters
       restricted_keys = Set.new(self.restricted_keys)
-      scalar_filters = []
-      complex_filters = {}
-      Settings::Definition.all.each do |key, definition| # rubocop:disable Rails/FindEach
+      Settings::Definition.all.flat_map do |key, definition|
         next if restricted_keys.include?(key)
 
         case definition.format
         when :hash
-          complex_filters[key] = {}
+          { key => {} }
         when :array
-          complex_filters[key] = []
+          { key => [] }
         else
-          scalar_filters << key
+          key
         end
       end
-
-      [scalar_filters, complex_filters]
     end
 
     def restricted_keys

--- a/app/models/permitted_params/allowed_settings.rb
+++ b/app/models/permitted_params/allowed_settings.rb
@@ -29,6 +29,31 @@ class PermittedParams
       keys
     end
 
+    def scalar_and_complex_filters
+      restricted_keys = Set.new(self.restricted_keys)
+      scalar_filters = []
+      complex_filters = {}
+      Settings::Definition.all.each do |key, definition| # rubocop:disable Rails/FindEach
+        next if restricted_keys.include?(key)
+
+        case definition.format
+        when :hash
+          complex_filters[key] = {}
+        when :array
+          complex_filters[key] = []
+        else
+          scalar_filters << key
+        end
+      end
+
+      [scalar_filters, complex_filters]
+    end
+
+    def restricted_keys
+      restrictions.select(&:applicable?)
+                  .flat_map(&:restricted_keys)
+    end
+
     def add_restriction!(keys:, condition:)
       restrictions << Restriction.new(keys, condition)
     end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -26,13 +26,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe PermittedParams do
   let(:user) { build_stubbed(:user) }
   let(:admin) { build_stubbed(:admin) }
 
-  shared_context 'prepare params comparison' do
+  shared_context "with prepare params comparison" do
     let(:params_key) { defined?(hash_key) ? hash_key : attribute }
     let(:params) do
       nested_params =
@@ -52,182 +52,181 @@ RSpec.describe PermittedParams do
       ActionController::Parameters.new(ac_params)
     end
 
-    subject { PermittedParams.new(params, user).send(attribute).to_h }
+    subject { described_class.new(params, user).send(attribute).to_h }
   end
 
-  shared_examples_for 'allows params' do
-    include_context 'prepare params comparison'
+  shared_examples_for "allows params" do
+    include_context "with prepare params comparison"
 
     it do
-      expected = defined?(allowed_params) ? allowed_params : hash
+      expected = defined?(expected_allowed_params) ? expected_allowed_params : hash
       expect(subject).to eq(expected)
     end
   end
 
-  shared_examples_for 'allows nested params' do
-    include_context 'prepare params comparison'
+  shared_examples_for "allows nested params" do
+    include_context "with prepare params comparison"
 
     it { expect(subject).to eq(hash) }
   end
 
-  shared_examples_for 'forbids params' do
-    include_context 'prepare params comparison'
+  shared_examples_for "forbids params" do
+    include_context "with prepare params comparison"
 
     it { expect(subject).not_to eq(hash) }
   end
 
-  describe '#permit' do
-    it 'adds an attribute to be permitted later' do
+  describe "#permit" do
+    it "adds an attribute to be permitted later" do
       # just taking project_type here as an example, could be anything
 
       # taking the originally whitelisted params to be restored later
-      original_whitelisted = PermittedParams.instance_variable_get(:@whitelisted_params)
+      original_whitelisted = described_class.instance_variable_get(:@whitelisted_params)
 
-      params = ActionController::Parameters.new(project_type: { 'blubs1' => 'blubs' })
+      ActionController::Parameters.new(project_type: { "blubs1" => "blubs" })
 
-      PermittedParams.instance_variable_set(:@whitelisted_params, original_whitelisted)
+      described_class.instance_variable_set(:@whitelisted_params, original_whitelisted)
     end
 
-    it 'raises an argument error if key does not exist' do
-      expect { PermittedParams.permit(:bogus_key) }.to raise_error ArgumentError
+    it "raises an argument error if key does not exist" do
+      expect { described_class.permit(:bogus_key) }.to raise_error ArgumentError
     end
   end
 
-  describe '#pref' do
+  describe "#pref" do
     let(:attribute) { :pref }
 
     let(:hash) do
       acceptable_params = %w(hide_mail time_zone
                              comments_sorting warn_on_leaving_unsaved)
 
-      acceptable_params.index_with { |_x| 'value' }
+      acceptable_params.index_with { |_x| "value" }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#news' do
+  describe "#news" do
     let(:attribute) { :news }
     let(:hash) do
-      %w(title summary description).index_with { |_x| 'value' }.to_h
+      %w(title summary description).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#comment' do
+  describe "#comment" do
     let(:attribute) { :comment }
     let(:hash) do
-      %w(commented author comments).index_with { |_x| 'value' }.to_h
+      %w(commented author comments).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#watcher' do
+  describe "#watcher" do
     let(:attribute) { :watcher }
     let(:hash) do
-      %w(watchable user user_id).index_with { |_x| 'value' }.to_h
+      %w(watchable user user_id).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#reply' do
+  describe "#reply" do
     let(:attribute) { :reply }
     let(:hash) do
-      %w(content subject).index_with { |_x| 'value' }.to_h
+      %w(content subject).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#wiki' do
+  describe "#wiki" do
     let(:attribute) { :wiki }
     let(:hash) do
-      %w(start_page).index_with { |_x| 'value' }.to_h
+      %w(start_page).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#membership' do
+  describe "#membership" do
     let(:attribute) { :membership }
     let(:hash) do
-      { 'project_id' => '1', 'role_ids' => ['1', '2', '4'] }
+      { "project_id" => "1", "role_ids" => ["1", "2", "4"] }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#category' do
+  describe "#category" do
     let(:attribute) { :category }
     let(:hash) do
-      %w(name assigned_to_id).index_with { |_x| 'value' }.to_h
+      %w(name assigned_to_id).index_with { |_x| "value" }.to_h
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#version' do
+  describe "#version" do
     let(:attribute) { :version }
 
-    context 'whitelisted params' do
+    context "with whitelisted params" do
       let(:hash) do
         %w(name description effective_date due_date
-           start_date wiki_page_title status sharing).index_with { |_x| 'value' }.to_h
+           start_date wiki_page_title status sharing).index_with { |_x| "value" }.to_h
       end
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'empty' do
+    context "when empty" do
       let(:hash) { {} }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'custom field values' do
-      let(:hash) { { 'custom_field_values' => { '1' => '5' } } }
+    context "for custom field values" do
+      let(:hash) { { "custom_field_values" => { "1" => "5" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
   end
 
-  describe '#message' do
+  describe "#message" do
     let(:attribute) { :message }
 
-    context 'no instance passed' do
-      let(:allowed_params) do
-        %w(subject content forum_id).index_with { |_x| 'value' }.to_h
+    context "with no instance passed" do
+      let(:expected_allowed_params) do
+        %w(subject content forum_id).index_with { |_x| "value" }.to_h
       end
 
       let(:hash) do
-        allowed_params.merge(evil: 'true', sticky: 'true', locked: 'true')
+        expected_allowed_params.merge(evil: "true", sticky: "true", locked: "true")
       end
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'empty' do
+    context "when empty" do
       let(:hash) { {} }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'with instance passed' do
-      let(:instance) { double('message', project: double('project')) }
-      let(:project) { double('project') }
-      let(:allowed_params) do
-        { 'subject' => 'value',
-          'content' => 'value',
-          'forum_id' => 'value',
-          'sticky' => 'true',
-          'locked' => 'true' }
+    context "with project instance passed" do
+      let(:project) { instance_double(Project) }
+      let(:expected_allowed_params) do
+        { "subject" => "value",
+          "content" => "value",
+          "forum_id" => "value",
+          "sticky" => "true",
+          "locked" => "true" }
       end
 
       let(:hash) do
-        ActionController::Parameters.new('message' => allowed_params.merge(evil: 'true'))
+        ActionController::Parameters.new("message" => expected_allowed_params.merge(evil: "true"))
       end
 
       before do
@@ -236,215 +235,209 @@ RSpec.describe PermittedParams do
         end
       end
 
-      subject { PermittedParams.new(hash, user).message(project).to_h }
+      subject { described_class.new(hash, user).message(project).to_h }
 
       it do
-        expect(subject).to eq(allowed_params)
+        expect(subject).to eq(expected_allowed_params)
       end
     end
   end
 
-  describe '#attachments' do
+  describe "#attachments" do
     let(:attribute) { :attachments }
 
     let(:hash) do
-      { 'file' => 'myfile',
-        'description' => 'mydescription' }
+      { "file" => "myfile",
+        "description" => "mydescription" }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#projects_type_ids' do
+  describe "#projects_type_ids" do
     let(:attribute) { :projects_type_ids }
-    let(:hash_key) { 'project' }
+    let(:hash_key) { "project" }
 
     let(:hash) do
-      { 'type_ids' => ['1', '', '2'] }
+      { "type_ids" => ["1", "", "2"] }
     end
 
-    let(:allowed_params) do
+    let(:expected_allowed_params) do
       [1, 2]
     end
 
-    include_context 'prepare params comparison'
+    include_context "with prepare params comparison"
 
     it do
-      actual = PermittedParams.new(params, user).send(attribute)
+      actual = described_class.new(params, user).send(attribute)
 
-      expect(actual).to eq(allowed_params)
+      expect(actual).to eq(expected_allowed_params)
     end
   end
 
-  describe '#color' do
+  describe "#color" do
     let(:attribute) { :color }
 
     let(:hash) do
-      { 'name' => 'blubs',
-        'hexcode' => '#fff' }
+      { "name" => "blubs",
+        "hexcode" => "#fff" }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#color_move' do
+  describe "#color_move" do
     let(:attribute) { :color_move }
-    let(:hash_key) { 'color' }
+    let(:hash_key) { "color" }
 
     let(:hash) do
-      { 'move_to' => '1' }
+      { "move_to" => "1" }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#custom_field' do
+  describe "#custom_field" do
     let(:attribute) { :custom_field }
 
     let(:hash) do
-      { 'editable' => '0', 'visible' => '0' }
+      { "editable" => "0", "visible" => "0" }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
-  describe '#custom_action' do
+  describe "#custom_action" do
     let(:attribute) { :custom_action }
     let(:hash) do
       {
-        'name' => 'blubs',
-        'description' => 'blubs blubs',
-        'actions' => { 'assigned_to' => '1' },
-        'conditions' => { 'status' => '42' },
-        'move_to' => 'lower'
+        "name" => "blubs",
+        "description" => "blubs blubs",
+        "actions" => { "assigned_to" => "1" },
+        "conditions" => { "status" => "42" },
+        "move_to" => "lower"
       }
     end
 
-    it_behaves_like 'allows params'
+    it_behaves_like "allows params"
   end
 
   describe "#update_work_package" do
     let(:attribute) { :update_work_package }
-    let(:hash_key) { 'work_package' }
+    let(:hash_key) { "work_package" }
 
-    context 'subject' do
-      let(:hash) { { 'subject' => 'blubs' } }
+    describe "subject" do
+      let(:hash) { { "subject" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'description' do
-      let(:hash) { { 'description' => 'blubs' } }
+    describe "description" do
+      let(:hash) { { "description" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'start_date' do
-      let(:hash) { { 'start_date' => '2013-07-08' } }
+    describe "start_date" do
+      let(:hash) { { "start_date" => "2013-07-08" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'due_date' do
-      let(:hash) { { 'due_date' => '2013-07-08' } }
+    describe "due_date" do
+      let(:hash) { { "due_date" => "2013-07-08" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'assigned_to_id' do
-      let(:hash) { { 'assigned_to_id' => '1' } }
+    describe "assigned_to_id" do
+      let(:hash) { { "assigned_to_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'responsible_id' do
-      let(:hash) { { 'responsible_id' => '1' } }
+    describe "responsible_id" do
+      let(:hash) { { "responsible_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'type_id' do
-      let(:hash) { { 'type_id' => '1' } }
+    describe "type_id" do
+      let(:hash) { { "type_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'priority_id' do
-      let(:hash) { { 'priority_id' => '1' } }
+    describe "priority_id" do
+      let(:hash) { { "priority_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'parent_id' do
-      let(:hash) { { 'parent_id' => '1' } }
+    describe "parent_id" do
+      let(:hash) { { "parent_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'parent_id' do
-      let(:hash) { { 'parent_id' => '1' } }
+    describe "version_id" do
+      let(:hash) { { "version_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'version_id' do
-      let(:hash) { { 'version_id' => '1' } }
+    describe "estimated_hours" do
+      let(:hash) { { "estimated_hours" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'estimated_hours' do
-      let(:hash) { { 'estimated_hours' => '1' } }
+    describe "done_ratio" do
+      let(:hash) { { "done_ratio" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'done_ratio' do
-      let(:hash) { { 'done_ratio' => '1' } }
+    describe "lock_version" do
+      let(:hash) { { "lock_version" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'lock_version' do
-      let(:hash) { { 'lock_version' => '1' } }
+    describe "status_id" do
+      let(:hash) { { "status_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'status_id' do
-      let(:hash) { { 'status_id' => '1' } }
+    describe "category_id" do
+      let(:hash) { { "category_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'category_id' do
-      let(:hash) { { 'category_id' => '1' } }
+    describe "budget_id" do
+      let(:hash) { { "budget_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'budget_id' do
-      let(:hash) { { 'budget_id' => '1' } }
+    describe "notes" do
+      let(:hash) { { "journal_notes" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'notes' do
-      let(:hash) { { 'journal_notes' => 'blubs' } }
+    describe "attachments" do
+      let(:hash) { { "attachments" => [{ "file" => "djskfj", "description" => "desc" }] } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'attachments' do
-      let(:hash) { { 'attachments' => [{ 'file' => 'djskfj', 'description' => 'desc' }] } }
-
-      it_behaves_like 'allows params'
-    end
-
-    context 'watcher_user_ids' do
-      include_context 'prepare params comparison'
-      let(:hash) { { 'watcher_user_ids' => ['1', '2'] } }
-      let(:project) { double('project') }
+    describe "watcher_user_ids" do
+      include_context "with prepare params comparison"
+      let(:hash) { { "watcher_user_ids" => ["1", "2"] } }
+      let(:project) { instance_double(Project) }
 
       before do
         mock_permissions_for(user) do |mock|
@@ -452,9 +445,9 @@ RSpec.describe PermittedParams do
         end
       end
 
-      subject { PermittedParams.new(params, user).update_work_package(project:).to_h }
+      subject { described_class.new(params, user).update_work_package(project:).to_h }
 
-      context 'user is allowed to add watchers' do
+      context "when user is allowed to add watchers" do
         before do
           mock_permissions_for(user) do |mock|
             mock.allow_in_project :add_work_package_watchers, project:
@@ -466,7 +459,7 @@ RSpec.describe PermittedParams do
         end
       end
 
-      context 'user is not allowed to add watchers' do
+      context "when user is not allowed to add watchers" do
         before do
           mock_permissions_for(user, &:forbid_everything)
         end
@@ -477,20 +470,20 @@ RSpec.describe PermittedParams do
       end
     end
 
-    context 'custom field values' do
-      let(:hash) { { 'custom_field_values' => { '1' => '5' } } }
+    context "for custom field values" do
+      let(:hash) { { "custom_field_values" => { "1" => "5" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context "removes custom field values that do not follow the schema 'id as string' => 'value as string'" do
-      let(:hash) { { 'custom_field_values' => { 'blubs' => '5', '5' => { '1' => '2' } } } }
+    describe "removes custom field values that do not follow the schema 'id as string' => 'value as string'" do
+      let(:hash) { { "custom_field_values" => { "blubs" => "5", "5" => { "1" => "2" } } } }
 
-      it_behaves_like 'forbids params'
+      it_behaves_like "forbids params"
     end
   end
 
-  describe '#time_entry_activities_project' do
+  describe "#time_entry_activities_project" do
     let(:attribute) { :time_entry_activities_project }
     let(:hash) do
       [
@@ -498,98 +491,101 @@ RSpec.describe PermittedParams do
         { "activity_id" => "6", "active" => "1" }
       ]
     end
-    let(:allowed_params) do
-      [{ "activity_id" => "5", "active" => "0" }, { "activity_id" => "6", "active" => "1" }]
+    let(:expected_allowed_params) do
+      [
+        ActionController::Parameters.new("activity_id" => "5", "active" => "0").permit!,
+        ActionController::Parameters.new("activity_id" => "6", "active" => "1").permit!
+      ]
     end
 
-    it_behaves_like 'allows params' do
-      subject { PermittedParams.new(params, user).send(attribute) }
+    it_behaves_like "allows params" do
+      subject { described_class.new(params, user).send(attribute) }
     end
   end
 
-  describe '#user' do
-    include_context 'prepare params comparison'
+  describe "#user" do
+    include_context "with prepare params comparison"
 
-    let(:hash_key) { 'user' }
+    let(:hash_key) { "user" }
     let(:external_authentication) { false }
     let(:change_password_allowed) { true }
 
-    subject { PermittedParams.new(params, user).send(attribute, external_authentication, change_password_allowed).to_h }
+    subject { described_class.new(params, user).send(attribute, external_authentication, change_password_allowed).to_h }
 
-    all_permissions = ['admin',
-                       'login',
-                       'firstname',
-                       'lastname',
-                       'mail',
-                       'language',
-                       'custom_fields',
-                       'ldap_auth_source_id',
-                       'force_password_change']
+    all_permissions = ["admin",
+                       "login",
+                       "firstname",
+                       "lastname",
+                       "mail",
+                       "language",
+                       "custom_fields",
+                       "ldap_auth_source_id",
+                       "force_password_change"]
 
-    describe :user_create_as_admin do
+    describe "#user_create_as_admin" do
       let(:attribute) { :user_create_as_admin }
       let(:default_permissions) { %w[custom_fields firstname lastname language mail ldap_auth_source_id] }
 
-      context 'for a non-admin' do
+      context "for a non-admin" do
         let(:hash) { all_permissions.zip(all_permissions).to_h }
 
-        it 'permits default permissions' do
+        it "permits default permissions" do
           expect(subject.keys).to match_array(default_permissions)
         end
       end
 
-      context 'for a non-admin with global :create_user permission' do
+      context "for a non-admin with global :create_user permission" do
         let(:user) { create(:user, global_permissions: [:create_user]) }
         let(:hash) { all_permissions.zip(all_permissions).to_h }
 
         it 'permits default permissions and "login"' do
-          expect(subject.keys).to match_array(default_permissions + ['login'])
+          expect(subject.keys).to match_array(default_permissions + ["login"])
         end
       end
 
-      context 'for an admin' do
+      context "for an admin" do
         let(:user) { admin }
 
         all_permissions.each do |field|
           context field do
-            let(:hash) { { field => 'test' } }
+            let(:hash) { { field => "test" } }
 
             it "permits #{field}" do
-              expect(subject).to eq(field => 'test')
+              expect(subject).to eq(field => "test")
             end
           end
         end
 
-        context 'with no password change allowed' do
-          let(:hash) { { 'force_password_change' => 'true' } }
+        context "with no password change allowed" do
+          let(:hash) { { "force_password_change" => "true" } }
           let(:change_password_allowed) { false }
 
-          it 'does not permit force_password_change' do
+          it "does not permit force_password_change" do
             expect(subject).to eq({})
           end
         end
 
-        context 'with external authentication' do
-          let(:hash) { { 'ldap_auth_source_id' => 'true' } }
+        context "with external authentication" do
+          let(:hash) { { "ldap_auth_source_id" => "true" } }
           let(:external_authentication) { true }
 
-          it 'does not permit ldap_auth_source_id' do
+          it "does not permit ldap_auth_source_id" do
             expect(subject).to eq({})
           end
         end
 
-        context 'custom field values' do
-          let(:hash) { { 'custom_field_values' => { '1' => '5' } } }
+        context "for custom field values" do
+          let(:hash) { { "custom_field_values" => { "1" => "5" } } }
 
-          it 'permits custom_field_values' do
+          it "permits custom_field_values" do
             expect(subject).to eq(hash)
           end
         end
 
-        context "custom field values that do not follow the schema 'id as string' => 'value as string'" do
-          let(:hash) { { 'custom_field_values' => { 'blubs' => '5', '5' => { '1' => '2' } } } }
+        context "for custom field values that do not follow the schema 'id as string' => 'value as string'" do
+          let(:hash) { { "custom_field_values" => { "blubs" => "5", "5" => { "1" => "2" } } } }
 
-          it 'are removed' do
+          it "are removed" do
             expect(subject).to eq({})
           end
         end
@@ -597,134 +593,134 @@ RSpec.describe PermittedParams do
     end
 
     user_permissions = [
-      'firstname',
-      'lastname',
-      'mail',
-      'language',
-      'custom_fields'
+      "firstname",
+      "lastname",
+      "mail",
+      "language",
+      "custom_fields"
     ]
 
-    describe '#user' do
+    describe "#user" do
       let(:attribute) { :user }
       let(:user) { admin }
 
       user_permissions.each do |field|
         context field do
-          let(:hash) { { field => 'test' } }
+          let(:hash) { { field => "test" } }
 
-          it_behaves_like 'allows params'
+          it_behaves_like "allows params"
         end
       end
 
       (all_permissions - user_permissions).each do |field|
-        context "#{field} (admin-only)" do
-          let(:hash) { { field => 'test' } }
+        context "for #{field} (admin-only)" do
+          let(:hash) { { field => "test" } }
 
-          it_behaves_like 'forbids params'
+          it_behaves_like "forbids params"
         end
       end
 
-      context 'custom field values' do
-        let(:hash) { { 'custom_field_values' => { '1' => '5' } } }
+      context "for custom field values" do
+        let(:hash) { { "custom_field_values" => { "1" => "5" } } }
 
-        it_behaves_like 'allows params'
+        it_behaves_like "allows params"
       end
 
-      context "custom field values that do not follow the schema 'id as string' => 'value as string'" do
-        let(:hash) { { 'custom_field_values' => { 'blubs' => '5', '5' => { '1' => '2' } } } }
+      context "for custom field values that do not follow the schema 'id as string' => 'value as string'" do
+        let(:hash) { { "custom_field_values" => { "blubs" => "5", "5" => { "1" => "2" } } } }
 
-        it_behaves_like 'forbids params'
+        it_behaves_like "forbids params"
       end
 
-      context 'identity_url' do
-        let(:hash) { { 'identity_url' => 'test_identity_url' } }
+      context "for identity_url" do
+        let(:hash) { { "identity_url" => "test_identity_url" } }
 
-        it_behaves_like 'forbids params'
+        it_behaves_like "forbids params"
       end
     end
   end
 
-  describe '#user_register_via_omniauth' do
+  describe "#user_register_via_omniauth" do
     let(:attribute) { :user_register_via_omniauth }
-    let(:hash_key) { 'user' }
+    let(:hash_key) { "user" }
 
     user_permissions = %w(login firstname lastname mail language)
 
     user_permissions.each do |field|
-      let(:hash) { { field => 'test' } }
+      let(:hash) { { field => "test" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    context 'identity_url' do
-      let(:hash) { { 'identity_url' => 'test_identity_url' } }
+    context "for identity_url" do
+      let(:hash) { { "identity_url" => "test_identity_url" } }
 
-      it_behaves_like 'forbids params'
-    end
-  end
-
-  shared_examples_for 'allows enumeration move params' do
-    let(:hash) { { '2' => { 'move_to' => 'lower' } } }
-
-    it_behaves_like 'allows params'
-  end
-
-  shared_examples_for 'allows move params' do
-    let(:hash) { { 'move_to' => 'lower' } }
-
-    it_behaves_like 'allows params'
-  end
-
-  shared_examples_for 'allows custom fields' do
-    describe 'valid custom fields' do
-      let(:hash) { { '1' => { 'custom_field_values' => { '1' => '5' } } } }
-
-      it_behaves_like 'allows params'
-    end
-
-    describe 'invalid custom fields' do
-      let(:hash) { { 'custom_field_values' => { 'blubs' => '5', '5' => { '1' => '2' } } } }
-
-      it_behaves_like 'forbids params'
+      it_behaves_like "forbids params"
     end
   end
 
-  describe '#status' do
+  shared_examples_for "allows enumeration move params" do
+    let(:hash) { { "2" => { "move_to" => "lower" } } }
+
+    it_behaves_like "allows params"
+  end
+
+  shared_examples_for "allows move params" do
+    let(:hash) { { "move_to" => "lower" } }
+
+    it_behaves_like "allows params"
+  end
+
+  shared_examples_for "allows custom fields" do
+    describe "valid custom fields" do
+      let(:hash) { { "1" => { "custom_field_values" => { "1" => "5" } } } }
+
+      it_behaves_like "allows params"
+    end
+
+    describe "invalid custom fields" do
+      let(:hash) { { "custom_field_values" => { "blubs" => "5", "5" => { "1" => "2" } } } }
+
+      it_behaves_like "forbids params"
+    end
+  end
+
+  describe "#status" do
     let (:attribute) { :status }
 
-    describe 'name' do
-      let(:hash) { { 'name' => 'blubs' } }
+    describe "name" do
+      let(:hash) { { "name" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'default_done_ratio' do
-      let(:hash) { { 'default_done_ratio' => '10' } }
+    describe "default_done_ratio" do
+      let(:hash) { { "default_done_ratio" => "10" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'is_closed' do
-      let(:hash) { { 'is_closed' => 'true' } }
+    describe "is_closed" do
+      let(:hash) { { "is_closed" => "true" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'is_default' do
-      let(:hash) { { 'is_default' => 'true' } }
+    describe "is_default" do
+      let(:hash) { { "is_default" => "true" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'move_to' do
-      it_behaves_like 'allows move params'
+    describe "move_to" do
+      it_behaves_like "allows move params"
     end
   end
 
-  describe '#settings' do
+  describe "#settings" do
     let (:attribute) { :settings }
 
-    describe 'with password login enabled' do
+    describe "with password login enabled" do
       before do
         allow(OpenProject::Configuration)
           .to receive(:disable_password_login?)
@@ -733,19 +729,19 @@ RSpec.describe PermittedParams do
 
       let(:hash) do
         {
-          'sendmail_arguments' => 'value',
-          'brute_force_block_after_failed_logins' => 'value',
-          'password_active_rules' => ['value'],
-          'default_projects_modules' => ['value', 'value'],
-          'emails_footer' => { 'en' => 'value' }
+          "sendmail_arguments" => "value",
+          "brute_force_block_after_failed_logins" => "value",
+          "password_active_rules" => ["value"],
+          "default_projects_modules" => ["value", "value"],
+          "emails_footer" => { "en" => "value" }
         }
       end
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'with password login disabled' do
-      include_context 'prepare params comparison'
+    describe "with password login disabled" do
+      include_context "with prepare params comparison"
 
       before do
         allow(OpenProject::Configuration)
@@ -755,27 +751,27 @@ RSpec.describe PermittedParams do
 
       let(:hash) do
         {
-          'sendmail_arguments' => 'value',
-          'brute_force_block_after_failed_logins' => 'value',
-          'password_active_rules' => ['value'],
-          'default_projects_modules' => ['value', 'value'],
-          'emails_footer' => { 'en' => 'value' }
+          "sendmail_arguments" => "value",
+          "brute_force_block_after_failed_logins" => "value",
+          "password_active_rules" => ["value"],
+          "default_projects_modules" => ["value", "value"],
+          "emails_footer" => { "en" => "value" }
         }
       end
 
       let(:permitted_hash) do
         {
-          'sendmail_arguments' => 'value',
-          'brute_force_block_after_failed_logins' => 'value',
-          'default_projects_modules' => ['value', 'value'],
-          'emails_footer' => { 'en' => 'value' }
+          "sendmail_arguments" => "value",
+          "brute_force_block_after_failed_logins" => "value",
+          "default_projects_modules" => ["value", "value"],
+          "emails_footer" => { "en" => "value" }
         }
       end
 
       it { expect(subject).to eq(permitted_hash) }
     end
 
-    describe 'with writable registration footer' do
+    describe "with writable registration footer" do
       before do
         allow(Setting)
           .to receive(:registration_footer_writable?)
@@ -784,17 +780,17 @@ RSpec.describe PermittedParams do
 
       let(:hash) do
         {
-          'registration_footer' => {
-            'en' => 'some footer'
+          "registration_footer" => {
+            "en" => "some footer"
           }
         }
       end
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'with a non-writable registration footer (set via env var or config file)' do
-      include_context 'prepare params comparison'
+    describe "with a non-writable registration footer (set via env var or config file)" do
+      include_context "with prepare params comparison"
 
       before do
         allow(Setting)
@@ -804,8 +800,8 @@ RSpec.describe PermittedParams do
 
       let(:hash) do
         {
-          'registration_footer' => {
-            'en' => 'some footer'
+          "registration_footer" => {
+            "en" => "some footer"
           }
         }
       end
@@ -818,173 +814,178 @@ RSpec.describe PermittedParams do
     end
   end
 
-  describe '#enumerations' do
+  describe "#enumerations" do
     let (:attribute) { :enumerations }
 
-    describe 'name' do
-      let(:hash) { { '1' => { 'name' => 'blubs' } } }
+    describe "name" do
+      let(:hash) { { "1" => { "name" => "blubs" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'active' do
-      let(:hash) { { '1' => { 'active' => 'true' } } }
+    describe "active" do
+      let(:hash) { { "1" => { "active" => "true" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'is_default' do
-      let(:hash) { { '1' => { 'is_default' => 'true' } } }
+    describe "is_default" do
+      let(:hash) { { "1" => { "is_default" => "true" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'reassign_to_id' do
-      let(:hash) { { '1' => { 'reassign_to_id' => '1' } } }
+    describe "reassign_to_id" do
+      let(:hash) { { "1" => { "reassign_to_id" => "1" } } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'move_to' do
-      it_behaves_like 'allows enumeration move params'
+    describe "move_to" do
+      it_behaves_like "allows enumeration move params"
     end
 
-    describe 'custom fields' do
-      it_behaves_like 'allows custom fields'
+    describe "custom fields" do
+      it_behaves_like "allows custom fields"
     end
   end
 
-  describe '#wiki_page_rename' do
+  describe "#wiki_page_rename" do
     let(:hash_key) { :page }
     let (:attribute) { :wiki_page_rename }
 
-    describe 'title' do
-      let(:hash) { { 'title' => 'blubs' } }
+    describe "title" do
+      let(:hash) { { "title" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'redirect_existing_links' do
-      let(:hash) { { 'redirect_existing_links' => '1' } }
+    describe "redirect_existing_links" do
+      let(:hash) { { "redirect_existing_links" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
   end
 
-  describe '#wiki_page' do
+  describe "#wiki_page" do
     let(:hash_key) { :page }
     let (:attribute) { :wiki_page }
 
-    describe 'title' do
-      let(:hash) { { 'title' => 'blubs' } }
+    describe "title" do
+      let(:hash) { { "title" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'parent_id' do
-      let(:hash) { { 'parent_id' => '1' } }
+    describe "parent_id" do
+      let(:hash) { { "parent_id" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'redirect_existing_links' do
-      let(:hash) { { 'redirect_existing_links' => '1' } }
+    describe "redirect_existing_links" do
+      let(:hash) { { "redirect_existing_links" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'journal_notes' do
-      let(:hash) { { 'journal_notes' => 'blubs' } }
+    describe "journal_notes" do
+      let(:hash) { { "journal_notes" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'text' do
-      let(:hash) { { 'text' => 'blubs' } }
+    describe "text" do
+      let(:hash) { { "text" => "blubs" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'lock_version' do
-      let(:hash) { { 'lock_version' => '1' } }
+    describe "lock_version" do
+      let(:hash) { { "lock_version" => "1" } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
   end
 
-  describe 'member' do
+  describe "member" do
     let (:attribute) { :member }
 
-    describe 'role_ids' do
-      let(:hash) { { 'role_ids' => [] } }
+    describe "role_ids" do
+      let(:hash) { { "role_ids" => [] } }
 
-      it_behaves_like 'allows params'
+      it_behaves_like "allows params"
     end
 
-    describe 'user_id' do
-      let(:hash) { { 'user_id' => 'blubs' } }
+    describe "user_id" do
+      let(:hash) { { "user_id" => "blubs" } }
 
-      it_behaves_like 'forbids params'
+      it_behaves_like "forbids params"
     end
 
-    describe 'project_id' do
-      let(:hash) { { 'project_id' => 'blubs' } }
+    describe "project_id" do
+      let(:hash) { { "project_id" => "blubs" } }
 
-      it_behaves_like 'forbids params'
+      it_behaves_like "forbids params"
     end
 
-    describe 'created_at' do
-      let(:hash) { { 'created_at' => 'blubs' } }
+    describe "created_at" do
+      let(:hash) { { "created_at" => "blubs" } }
 
-      it_behaves_like 'forbids params'
+      it_behaves_like "forbids params"
     end
   end
 
-  describe '.add_permitted_attributes' do
+  describe ".add_permitted_attributes" do
     before do
-      @original_permitted_attributes = PermittedParams.permitted_attributes.clone
+      @original_permitted_attributes = described_class.permitted_attributes.clone
     end
 
     after do
       # Class variable is not accessible within class_eval
       original_permitted_attributes = @original_permitted_attributes
 
-      PermittedParams.class_eval do
+      described_class.class_eval do
         @whitelisted_params = original_permitted_attributes
       end
     end
 
-    describe 'with a known key' do
+    describe "with a known key" do
       let(:attribute) { :user }
 
       before do
-        PermittedParams.send(:add_permitted_attributes, user: [:a_test_field])
+        described_class.send(:add_permitted_attributes, user: [:a_test_field])
       end
 
-      context 'with an allowed parameter' do
-        let(:hash) { { 'a_test_field' => 'a test value' } }
+      context "with an allowed parameter" do
+        let(:hash) { { "a_test_field" => "a test value" } }
 
-        it_behaves_like 'allows params'
+        it_behaves_like "allows params"
       end
 
-      context 'with a disallowed parameter' do
-        let(:hash) { { 'a_not_allowed_field' => 'a test value' } }
+      context "with a disallowed parameter" do
+        let(:hash) { { "a_not_allowed_field" => "a test value" } }
 
-        it_behaves_like 'forbids params'
+        it_behaves_like "forbids params"
       end
     end
 
-    describe 'with an unknown key' do
+    describe "with an unknown key" do
       let(:attribute) { :unknown_key }
-      let(:hash) { { 'a_test_field' => 'a test value' } }
+      let(:hash) { { "a_test_field" => "a test value" } }
 
       before do
-        expect(Rails.logger).not_to receive(:warn)
-        PermittedParams.send(:add_permitted_attributes, unknown_key: [:a_test_field])
+        allow(Rails.logger).to receive(:warn)
+        described_class.send(:add_permitted_attributes, unknown_key: [:a_test_field])
       end
 
-      it 'permitted attributes should include the key' do
-        expect(PermittedParams.permitted_attributes.keys).to include(:unknown_key)
+      it "permitted attributes should include the key" do
+        expect(described_class.permitted_attributes.keys).to include(:unknown_key)
+      end
+
+      it "does not log any warnings" do
+        described_class.permitted_attributes.keys
+        expect(Rails.logger).not_to have_received(:warn)
       end
     end
   end


### PR DESCRIPTION
When `PermittedParams#settings` was called, it was not permitting any params, which lead to "Unpermitted parameters: ..." messages being logged, and then merged the resulting empty params with the controller params after having filtered them manually. It was ok-ish but the logged error message was misleading.

The `#settings` method was refactored to permit params that are allowed in a single step and avoid the misleading log messages.

The rubocop linting has been put in a separate commit for easier reviewing.