### PR TITLE
Fix/replace merge in query

### DIFF
--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -189,7 +189,8 @@ module Queries::BaseQuery
 
   def apply_filters(scope)
     filters.each do |filter|
-      scope = scope.merge(filter.scope)
+      # TODO: rename to filter.apply
+      scope = filter.scope(scope)
     end
 
     scope

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -189,14 +189,13 @@ module Queries::BaseQuery
 
   def apply_filters(query_scope)
     filters.inject(query_scope) do |scope, filter|
-      # TODO: rename to filter.apply
-      filter.scope(scope)
+      filter.apply_to(scope)
     end
   end
 
   def apply_orders(query_scope)
     query_scope = build_orders.inject(query_scope) do |scope, order|
-      order.scope(scope)
+      order.apply_to(scope)
     end
 
     # To get deterministic results, especially when paginating (limit + offset)
@@ -209,7 +208,7 @@ module Queries::BaseQuery
   def apply_group_by(query_scope)
     return query_scope if group_by.nil?
 
-    group_by.scope(query_scope)
+    group_by.apply_to(query_scope)
       .order(group_by.name)
   end
 

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -187,32 +187,29 @@ module Queries::BaseQuery
     self
   end
 
-  def apply_filters(scope)
-    filters.each do |filter|
+  def apply_filters(query_scope)
+    filters.inject(query_scope) do |scope, filter|
       # TODO: rename to filter.apply
-      scope = filter.scope(scope)
+      filter.scope(scope)
     end
-
-    scope
   end
 
-  def apply_orders(scope)
-    build_orders.each do |order|
-      scope = scope.merge(order.scope)
+  def apply_orders(query_scope)
+    query_scope = build_orders.inject(query_scope) do |scope, order|
+      order.scope(scope)
     end
 
     # To get deterministic results, especially when paginating (limit + offset)
     # an order needs to be prepended that is ensured to be
     # different between all elements.
     # Without such a criteria, results can occur on multiple pages.
-    already_ordered_by_id?(scope) ? scope : scope.order(id: :desc)
+    already_ordered_by_id?(query_scope) ? query_scope : query_scope.order(id: :desc)
   end
 
-  def apply_group_by(scope)
-    return scope if group_by.nil?
+  def apply_group_by(query_scope)
+    return query_scope if group_by.nil?
 
-    scope
-      .merge(group_by.scope)
+    group_by.scope(query_scope)
       .order(group_by.name)
   end
 

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -102,9 +102,7 @@ class Queries::Filters::Base
     type_strategy.default_operator_class
   end
 
-  # TODO: rename to apply
-  # remove model ? as it might no longer be needed
-  def scope(query_scope)
+  def apply_to(query_scope)
     query_scope = query_scope.where(where) if where
     query_scope = query_scope.from(from) if from
     query_scope = query_scope.joins(joins) if joins

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -103,7 +103,7 @@ class Queries::Filters::Base
   end
 
   def apply_to(query_scope)
-    query_scope = query_scope.where(where) if where
+    query_scope = query_scope.where(where)
     query_scope = query_scope.from(from) if from
     query_scope = query_scope.joins(joins) if joins
     query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -102,12 +102,14 @@ class Queries::Filters::Base
     type_strategy.default_operator_class
   end
 
-  def scope
-    scope = model.where(where)
-    scope = scope.from(from) if from
-    scope = scope.joins(joins) if joins
-    scope = scope.left_outer_joins(left_outer_joins) if left_outer_joins
-    scope
+  # TODO: rename to apply
+  # remove model ? as it might no longer be needed
+  def scope(query_scope)
+    query_scope = query_scope.where(where) if where
+    query_scope = query_scope.from(from) if from
+    query_scope = query_scope.joins(joins) if joins
+    query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins
+    query_scope
   end
 
   def self.key

--- a/app/models/queries/filters/empty_filter.rb
+++ b/app/models/queries/filters/empty_filter.rb
@@ -48,7 +48,7 @@ module Queries
       # deactivating superclass validation
       def validate_inclusion_of_operator; end
 
-      def scope
+      def scope(_query_scope)
         context.default_scope
       end
 

--- a/app/models/queries/filters/empty_filter.rb
+++ b/app/models/queries/filters/empty_filter.rb
@@ -48,7 +48,7 @@ module Queries
       # deactivating superclass validation
       def validate_inclusion_of_operator; end
 
-      def scope(_query_scope)
+      def apply_to(_query_scope)
         context.default_scope
       end
 

--- a/app/models/queries/filters/not_existing_filter.rb
+++ b/app/models/queries/filters/not_existing_filter.rb
@@ -63,16 +63,9 @@ module Queries
         }
       end
 
-      def scope
-        # TODO: remove switch once the WP query is a
-        # subclass of Queries::Base
-        model = if context.respond_to?(:model)
-                  context.model
-                else
-                  WorkPackage
-                end
-
-        model.unscoped
+      def scope(query_scope)
+        # No change to the query scope whatsoever since the filter does not exist.
+        query_scope
       end
 
       def attributes_hash

--- a/app/models/queries/filters/not_existing_filter.rb
+++ b/app/models/queries/filters/not_existing_filter.rb
@@ -63,7 +63,7 @@ module Queries
         }
       end
 
-      def scope(query_scope)
+      def apply_to(query_scope)
         # No change to the query scope whatsoever since the filter does not exist.
         query_scope
       end

--- a/app/models/queries/group_bys/base.rb
+++ b/app/models/queries/group_bys/base.rb
@@ -50,7 +50,7 @@ module Queries
         nil
       end
 
-      def scope(query_scope)
+      def apply_to(query_scope)
         query_scope = query_scope.joins(joins) if joins
         group_by query_scope
       end

--- a/app/models/queries/group_bys/base.rb
+++ b/app/models/queries/group_bys/base.rb
@@ -50,10 +50,9 @@ module Queries
         nil
       end
 
-      def scope
-        scope = model
-        scope = model.joins(joins) if joins
-        group_by scope
+      def scope(query_scope)
+        query_scope = query_scope.joins(joins) if joins
+        group_by query_scope
       end
 
       def name

--- a/app/models/queries/individual_principals/orders/group_order.rb
+++ b/app/models/queries/individual_principals/orders/group_order.rb
@@ -35,12 +35,12 @@ class Queries::IndividualPrincipals::Orders::GroupOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     order_string = "groups_users.lastname"
 
     order_string += " DESC" if direction == :desc
 
-    model.order(order_string)
+    scope.order(order_string)
   end
 
   def joins

--- a/app/models/queries/individual_principals/orders/name_order.rb
+++ b/app/models/queries/individual_principals/orders/name_order.rb
@@ -35,8 +35,8 @@ class Queries::IndividualPrincipals::Orders::NameOrder < Queries::Orders::Base
 
   private
 
-  def order
-    ordered = model.order_by_name
+  def order(scope)
+    ordered = scope.order_by_name
 
     if direction == :desc
       ordered = ordered.reverse_order

--- a/app/models/queries/members/filters/group_filter.rb
+++ b/app/models/queries/members/filters/group_filter.rb
@@ -30,11 +30,6 @@ class Queries::Members::Filters::GroupFilter < Queries::Members::Filters::Member
   include Queries::Filters::Shared::GroupFilter
 
   def joins
-    nil
-  end
-
-  def scope
-    scope = model.joins(:principal)
-    scope.where(where)
+    :principal
   end
 end

--- a/app/models/queries/members/orders/email_order.rb
+++ b/app/models/queries/members/orders/email_order.rb
@@ -39,13 +39,13 @@ class Queries::Members::Orders::EmailOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     with_raise_on_invalid do
       order_string = "NULLIF(mail, '')"
       order_string += " DESC" if direction == :desc
       order_string += " NULLS LAST"
 
-      model.order(Arel.sql(order_string))
+      scope.order(Arel.sql(order_string))
     end
   end
 end

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -39,7 +39,7 @@ class Queries::Members::Orders::NameOrder < Queries::Orders::Base
 
   protected
 
-  def order
-    model.merge Principal.ordered_by_name(desc: direction == :desc)
+  def order(scope)
+    scope.merge Principal.ordered_by_name(desc: direction == :desc)
   end
 end

--- a/app/models/queries/notifications/orders/project_order.rb
+++ b/app/models/queries/notifications/orders/project_order.rb
@@ -39,10 +39,10 @@ class Queries::Notifications::Orders::ProjectOrder < Queries::Orders::Base
 
   protected
 
-  def order
+  def order(scope)
     order_string = "projects.name"
     order_string += " DESC" if direction == :desc
 
-    model.order(order_string)
+    scope.order(order_string)
   end
 end

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -51,7 +51,7 @@ module Queries
         raise NotImplementedError
       end
 
-      def scope(query_scope)
+      def apply_to(query_scope)
         query_scope = order(query_scope)
         query_scope = query_scope.joins(joins) if joins
         query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -51,11 +51,11 @@ module Queries
         raise NotImplementedError
       end
 
-      def scope
-        scope = order
-        scope = scope.joins(joins) if joins
-        scope = scope.left_outer_joins(left_outer_joins) if left_outer_joins
-        scope
+      def scope(query_scope)
+        query_scope = order(query_scope)
+        query_scope = query_scope.joins(joins) if joins
+        query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins
+        query_scope
       end
 
       def name
@@ -68,8 +68,8 @@ module Queries
 
       private
 
-      def order
-        model.order(name => direction)
+      def order(scope)
+        scope.order(name => direction)
       end
 
       def joins

--- a/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
+++ b/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
@@ -42,7 +42,7 @@ class Queries::Principals::Filters::AccessToAnythingInProjectFilter < Queries::P
     :access_to_anything_in_project
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     case operator
     when "="
       query_scope.visible.in_anything_in_project(values)

--- a/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
+++ b/app/models/queries/principals/filters/access_to_anything_in_project_filter.rb
@@ -42,27 +42,24 @@ class Queries::Principals::Filters::AccessToAnythingInProjectFilter < Queries::P
     :access_to_anything_in_project
   end
 
-  def scope
+  def scope(query_scope)
     case operator
     when "="
-      visible_scope.in_anything_in_project(values)
+      query_scope.visible.in_anything_in_project(values)
     when "!"
-      visible_scope.not_in_anything_in_project(values)
+      query_scope.visible.not_in_anything_in_project(values)
     when "*"
-      member_included_scope.where.not(members: { id: nil })
+      member_included_scope(query_scope).where.not(members: { id: nil })
     when "!*"
-      member_included_scope.where.not(id: Member.distinct(:user_id).select(:user_id))
+      member_included_scope(query_scope).where.not(id: Member.distinct(:user_id).select(:user_id))
     end
   end
 
   private
 
-  def visible_scope
-    Principal.visible(User.current)
-  end
-
-  def member_included_scope
-    visible_scope
+  def member_included_scope(scope)
+    scope
+      .visible
       .includes(:members)
       .merge(Member.where.not(project: nil))
   end

--- a/app/models/queries/principals/filters/member_filter.rb
+++ b/app/models/queries/principals/filters/member_filter.rb
@@ -39,27 +39,24 @@ class Queries::Principals::Filters::MemberFilter < Queries::Principals::Filters:
     :member
   end
 
-  def scope
+  def scope(query_scope)
     case operator
     when "="
-      visible_scope.in_project(values)
+      query_scope.visible.in_project(values)
     when "!"
-      visible_scope.not_in_project(values)
+      query_scope.visible.not_in_project(values)
     when "*"
-      member_included_scope.where.not(members: { id: nil })
+      member_included_scope(query_scope).where.not(members: { id: nil })
     when "!*"
-      member_included_scope.where.not(id: Member.distinct(:user_id).select(:user_id))
+      member_included_scope(query_scope).where.not(id: Member.distinct(:user_id).select(:user_id))
     end
   end
 
   private
 
-  def visible_scope
-    Principal.visible(User.current)
-  end
-
-  def member_included_scope
-    visible_scope
+  def member_included_scope(scope)
+    scope
+      .visible
       .includes(:members)
       .merge(Member.of_any_project)
   end

--- a/app/models/queries/principals/filters/member_filter.rb
+++ b/app/models/queries/principals/filters/member_filter.rb
@@ -39,7 +39,7 @@ class Queries::Principals::Filters::MemberFilter < Queries::Principals::Filters:
     :member
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     case operator
     when "="
       query_scope.visible.in_project(values)

--- a/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
@@ -43,7 +43,7 @@ class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
     :mentionable_on_work_package
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     case operator
     when "="
       query_scope.where(id: principals_with_a_membership)

--- a/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
@@ -43,17 +43,13 @@ class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
     :mentionable_on_work_package
   end
 
-  def scope
+  def scope(query_scope)
     case operator
     when "="
-      principals_with_a_membership
+      query_scope.where(id: principals_with_a_membership)
     when "!"
-      visible_scope.where.not(id: principals_with_a_membership.select(:id))
+      query_scope.where(id: visible_scope.where.not(id: principals_with_a_membership.select(:id)))
     end
-  end
-
-  def where
-    "1=1"
   end
 
   private

--- a/app/models/queries/principals/filters/type_filter.rb
+++ b/app/models/queries/principals/filters/type_filter.rb
@@ -40,11 +40,11 @@ class Queries::Principals::Filters::TypeFilter < Queries::Principals::Filters::P
     :type
   end
 
-  def scope
+  def scope(query_scope)
     if operator == "="
-      Principal.where(type: values)
+      query_scope.where(type: values)
     else
-      Principal.where.not(type: values)
+      query_scope.where.not(type: values)
     end
   end
 end

--- a/app/models/queries/principals/filters/type_filter.rb
+++ b/app/models/queries/principals/filters/type_filter.rb
@@ -40,7 +40,7 @@ class Queries::Principals::Filters::TypeFilter < Queries::Principals::Filters::P
     :type
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     if operator == "="
       query_scope.where(type: values)
     else

--- a/app/models/queries/principals/orders/name_order.rb
+++ b/app/models/queries/principals/orders/name_order.rb
@@ -35,7 +35,7 @@ class Queries::Principals::Orders::NameOrder < Queries::Orders::Base
 
   protected
 
-  def order
-    model.ordered_by_name(desc: direction == :desc)
+  def order(scope)
+    scope.ordered_by_name(desc: direction == :desc)
   end
 end

--- a/app/models/queries/projects/filters/ancestor_filter.rb
+++ b/app/models/queries/projects/filters/ancestor_filter.rb
@@ -30,17 +30,21 @@ module Queries
   module Projects
     module Filters
       class AncestorFilter < ::Queries::Projects::Filters::ProjectFilter
-        def scope
+        def scope(_query_scope)
           case operator
           when "="
-            Project
+            super
               .where(exists_condition.exists)
           when "!"
-            Project
+            super
               .where.not(exists_condition.exists)
           else
             raise "unsupported operator"
           end
+        end
+
+        def where
+          nil
         end
 
         def type

--- a/app/models/queries/projects/filters/ancestor_filter.rb
+++ b/app/models/queries/projects/filters/ancestor_filter.rb
@@ -30,7 +30,7 @@ module Queries
   module Projects
     module Filters
       class AncestorFilter < ::Queries::Projects::Filters::ProjectFilter
-        def scope(_query_scope)
+        def apply_to(_query_scope)
           case operator
           when "="
             super

--- a/app/models/queries/projects/filters/available_project_attributes_filter.rb
+++ b/app/models/queries/projects/filters/available_project_attributes_filter.rb
@@ -49,7 +49,7 @@ class Queries::Projects::Filters::AvailableProjectAttributesFilter < Queries::Pr
     User.current.admin?
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     case operator
     when "="
       super.with_available_custom_fields(values)

--- a/app/models/queries/projects/filters/available_project_attributes_filter.rb
+++ b/app/models/queries/projects/filters/available_project_attributes_filter.rb
@@ -49,15 +49,19 @@ class Queries::Projects::Filters::AvailableProjectAttributesFilter < Queries::Pr
     User.current.admin?
   end
 
-  def scope
+  def scope(_query_scope)
     case operator
     when "="
-      model.with_available_custom_fields(values)
+      super.with_available_custom_fields(values)
     when "!"
-      model.without_available_custom_fields(values)
+      super.without_available_custom_fields(values)
     else
       raise "unsupported operator"
     end
+  end
+
+  def where
+    nil
   end
 
   def human_name

--- a/app/models/queries/projects/filters/favored_filter.rb
+++ b/app/models/queries/projects/filters/favored_filter.rb
@@ -41,7 +41,7 @@ class Queries::Projects::Filters::FavoredFilter < Queries::Projects::Filters::Pr
     User.current.logged?
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     if (values.first == OpenProject::Database::DB_VALUE_TRUE && operator_strategy == Queries::Operators::BooleanEquals) ||
       (values.first == OpenProject::Database::DB_VALUE_FALSE && operator_strategy == Queries::Operators::BooleanNotEquals)
       super.where(id: favored_project_ids)

--- a/app/models/queries/projects/filters/favored_filter.rb
+++ b/app/models/queries/projects/filters/favored_filter.rb
@@ -41,8 +41,9 @@ class Queries::Projects::Filters::FavoredFilter < Queries::Projects::Filters::Pr
     User.current.logged?
   end
 
-  def scope
-    if values.first == OpenProject::Database::DB_VALUE_TRUE
+  def scope(_query_scope)
+    if (values.first == OpenProject::Database::DB_VALUE_TRUE && operator_strategy == Queries::Operators::BooleanEquals) ||
+      (values.first == OpenProject::Database::DB_VALUE_FALSE && operator_strategy == Queries::Operators::BooleanNotEquals)
       super.where(id: favored_project_ids)
     else
       super.where.not(id: favored_project_ids)
@@ -51,7 +52,7 @@ class Queries::Projects::Filters::FavoredFilter < Queries::Projects::Filters::Pr
 
   # Handled by scope
   def where
-    "1=1"
+    nil
   end
 
   def favored_project_ids

--- a/app/models/queries/projects/filters/latest_activity_at_filter.rb
+++ b/app/models/queries/projects/filters/latest_activity_at_filter.rb
@@ -27,8 +27,6 @@
 #++
 
 class Queries::Projects::Filters::LatestActivityAtFilter < Queries::Projects::Filters::ProjectFilter
-  self.model = Project.with_latest_activity
-
   def type
     :datetime_past
   end
@@ -47,6 +45,10 @@ class Queries::Projects::Filters::LatestActivityAtFilter < Queries::Projects::Fi
 
   def human_name
     I18n.t("activerecord.attributes.project.latest_activity_at")
+  end
+
+  def apply_to(query_scope)
+    super.with_latest_activity
   end
 
   def where

--- a/app/models/queries/projects/filters/member_of_filter.rb
+++ b/app/models/queries/projects/filters/member_of_filter.rb
@@ -36,11 +36,11 @@ class Queries::Projects::Filters::MemberOfFilter < Queries::Projects::Filters::P
     :member_of
   end
 
-  def scope
+  def scope(_query_scope)
     if allowed_values.first.intersect?(values)
-      model.visible.with_member
+      super.with_member
     else
-      model.visible.without_member
+      super.without_member
     end
   end
 

--- a/app/models/queries/projects/filters/member_of_filter.rb
+++ b/app/models/queries/projects/filters/member_of_filter.rb
@@ -36,11 +36,11 @@ class Queries::Projects::Filters::MemberOfFilter < Queries::Projects::Filters::P
     :member_of
   end
 
-  def apply_to(_query_scope)
+  def apply_to(query_scope)
     if allowed_values.first.intersect?(values)
-      super.with_member
+      query_scope.with_member
     else
-      super.without_member
+      query_scope.without_member
     end
   end
 

--- a/app/models/queries/projects/filters/member_of_filter.rb
+++ b/app/models/queries/projects/filters/member_of_filter.rb
@@ -36,7 +36,7 @@ class Queries::Projects::Filters::MemberOfFilter < Queries::Projects::Filters::P
     :member_of
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     if allowed_values.first.intersect?(values)
       super.with_member
     else

--- a/app/models/queries/projects/filters/principal_filter.rb
+++ b/app/models/queries/projects/filters/principal_filter.rb
@@ -35,7 +35,7 @@ class Queries::Projects::Filters::PrincipalFilter < Queries::Projects::Filters::
     @allowed_values ||= ::Principal.pluck(:id).map { |id| [id, id.to_s] }
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     if operator_strategy == Queries::Operators::NotEquals
       super
         .where.not(id: member_statement(Queries::Operators::Equals))

--- a/app/models/queries/projects/filters/principal_filter.rb
+++ b/app/models/queries/projects/filters/principal_filter.rb
@@ -35,11 +35,30 @@ class Queries::Projects::Filters::PrincipalFilter < Queries::Projects::Filters::
     @allowed_values ||= ::Principal.pluck(:id).map { |id| [id, id.to_s] }
   end
 
-  def scope
-    super.includes(:memberships).references(:members)
+  def scope(_query_scope)
+    if operator_strategy == Queries::Operators::NotEquals
+      super
+        .where.not(id: member_statement(Queries::Operators::Equals))
+    elsif operator_strategy == Queries::Operators::None
+      super
+        .where.not(id: member_statement(Queries::Operators::All))
+    else
+      super
+        .where(id: member_statement(operator_strategy))
+    end
   end
 
   def where
-    operator_strategy.sql_for_field(values, "members", "user_id")
+    # handled by scope
+    nil
+  end
+
+  private
+
+  def member_statement(used_operator_strategy)
+    Member
+      .of_any_project
+      .where(used_operator_strategy.sql_for_field(values, "members", "user_id"))
+      .select(:project_id)
   end
 end

--- a/app/models/queries/projects/filters/visible_filter.rb
+++ b/app/models/queries/projects/filters/visible_filter.rb
@@ -41,7 +41,7 @@ module Queries
           @allowed_values ||= User.pluck(:id, :id)
         end
 
-        def scope(_query_scope)
+        def apply_to(_query_scope)
           super.where(id: Project.visible(User.find(values.first)))
         end
 

--- a/app/models/queries/projects/filters/visible_filter.rb
+++ b/app/models/queries/projects/filters/visible_filter.rb
@@ -41,13 +41,13 @@ module Queries
           @allowed_values ||= User.pluck(:id, :id)
         end
 
-        def scope
+        def scope(_query_scope)
           super.where(id: Project.visible(User.find(values.first)))
         end
 
         def where
           # Handled by scope
-          "1 = 1"
+          nil
         end
 
         def type

--- a/app/models/queries/projects/orders/custom_field_order.rb
+++ b/app/models/queries/projects/orders/custom_field_order.rb
@@ -53,7 +53,7 @@ class Queries::Projects::Orders::CustomFieldOrder < Queries::Orders::Base
     end
   end
 
-  def scope
+  def scope(_query_scope)
     super.select(custom_field.order_statements)
   end
 

--- a/app/models/queries/projects/orders/custom_field_order.rb
+++ b/app/models/queries/projects/orders/custom_field_order.rb
@@ -63,11 +63,11 @@ class Queries::Projects::Orders::CustomFieldOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     joined_statement = custom_field.order_statements.map do |statement|
       Arel.sql("#{statement} #{direction}")
     end
 
-    model.order(joined_statement)
+    scope.order(joined_statement)
   end
 end

--- a/app/models/queries/projects/orders/custom_field_order.rb
+++ b/app/models/queries/projects/orders/custom_field_order.rb
@@ -53,7 +53,7 @@ class Queries::Projects::Orders::CustomFieldOrder < Queries::Orders::Base
     end
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     super.select(custom_field.order_statements)
   end
 

--- a/app/models/queries/projects/orders/latest_activity_at_order.rb
+++ b/app/models/queries/projects/orders/latest_activity_at_order.rb
@@ -35,9 +35,9 @@ class Queries::Projects::Orders::LatestActivityAtOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     with_raise_on_invalid do
-      model.order(Arel.sql("activity.latest_activity_at").send(direction))
+      scope.order(Arel.sql("activity.latest_activity_at").send(direction))
     end
   end
 end

--- a/app/models/queries/projects/orders/name_order.rb
+++ b/app/models/queries/projects/orders/name_order.rb
@@ -33,7 +33,7 @@ class Queries::Projects::Orders::NameOrder < Queries::Orders::Base
     :name
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     super.select("projects.*", "lower(projects.name)")
   end
 

--- a/app/models/queries/projects/orders/name_order.rb
+++ b/app/models/queries/projects/orders/name_order.rb
@@ -33,13 +33,15 @@ class Queries::Projects::Orders::NameOrder < Queries::Orders::Base
     :name
   end
 
-  def scope
+  def scope(_query_scope)
     super.select("projects.*", "lower(projects.name)")
   end
 
-  def order
+  private
+
+  def order(scope)
     with_raise_on_invalid do
-      model.order(Arel.sql("lower(projects.name)").send(direction))
+      scope.order(Arel.sql("lower(projects.name)").send(direction))
     end
   end
 end

--- a/app/models/queries/projects/orders/project_status_order.rb
+++ b/app/models/queries/projects/orders/project_status_order.rb
@@ -35,9 +35,9 @@ class Queries::Projects::Orders::ProjectStatusOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     with_raise_on_invalid do
-      model.order(Arel.sql("status_code").send(direction))
+      scope.order(Arel.sql("status_code").send(direction))
     end
   end
 end

--- a/app/models/queries/projects/orders/required_disk_space_order.rb
+++ b/app/models/queries/projects/orders/required_disk_space_order.rb
@@ -35,10 +35,10 @@ class Queries::Projects::Orders::RequiredDiskSpaceOrder < Queries::Orders::Base
 
   private
 
-  def order
+  def order(scope)
     with_raise_on_invalid do
       attribute = Project.required_disk_space_sum
-      model.order(Arel.sql(attribute).send(direction))
+      scope.order(Arel.sql(attribute).send(direction))
     end
   end
 end

--- a/app/models/queries/projects/orders/typeahead_order.rb
+++ b/app/models/queries/projects/orders/typeahead_order.rb
@@ -33,7 +33,7 @@ class Queries::Projects::Orders::TypeaheadOrder < Queries::Projects::Orders::Def
     :typeahead
   end
 
-  def order
-    model.order(lft: :asc)
+  def order(scope)
+    scope.order(lft: :asc)
   end
 end

--- a/app/models/queries/versions/orders/semver_name_order.rb
+++ b/app/models/queries/versions/orders/semver_name_order.rb
@@ -35,8 +35,8 @@ class Queries::Versions::Orders::SemverNameOrder < Queries::Orders::Base
 
   private
 
-  def order
-    ordered = Version.order_by_semver_name
+  def order(scope)
+    ordered = scope.order_by_semver_name
 
     if direction == :desc
       ordered = ordered.reverse_order

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -46,14 +46,14 @@ class Queries::WorkPackages::Filter::RelatableFilter < Queries::WorkPackages::Fi
     "(1 = 1)"
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     query_scope.relatable(WorkPackage.find_by(id: values.first), scope_operator)
   end
 
   private
 
   # 'children' used to be supported by the API although 'child' would be more fitting.
-  def scope_operator
+  def apply_to_operator
     if operator == "children"
       Relation::TYPE_CHILD
     else

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -46,8 +46,8 @@ class Queries::WorkPackages::Filter::RelatableFilter < Queries::WorkPackages::Fi
     "(1 = 1)"
   end
 
-  def scope
-    WorkPackage.relatable(WorkPackage.find_by(id: values.first), scope_operator)
+  def scope(query_scope)
+    query_scope.relatable(WorkPackage.find_by(id: values.first), scope_operator)
   end
 
   private

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -53,7 +53,7 @@ class Queries::WorkPackages::Filter::RelatableFilter < Queries::WorkPackages::Fi
   private
 
   # 'children' used to be supported by the API although 'child' would be more fitting.
-  def apply_to_operator
+  def scope_operator
     if operator == "children"
       Relation::TYPE_CHILD
     else

--- a/app/models/queries/work_packages/filter/shared_with_user_filter.rb
+++ b/app/models/queries/work_packages/filter/shared_with_user_filter.rb
@@ -34,7 +34,7 @@ class Queries::WorkPackages::Filter::SharedWithUserFilter <
     super && view_shared_work_packages_allowed?
   end
 
-  def scope
+  def scope(query_scope)
     query = visible_shared_work_packages(scoped_to_visible_projects: !querying_for_self?)
 
     if operator == "="
@@ -43,7 +43,7 @@ class Queries::WorkPackages::Filter::SharedWithUserFilter <
       query = query.where(shared_with_all_of_condition)
     end
 
-    WorkPackage.where(id: query.select("work_packages.id").distinct)
+    query_scope.where(id: query.select("work_packages.id").distinct)
   end
 
   # Conditions handled in +scope+ method

--- a/app/models/queries/work_packages/filter/shared_with_user_filter.rb
+++ b/app/models/queries/work_packages/filter/shared_with_user_filter.rb
@@ -34,7 +34,7 @@ class Queries::WorkPackages::Filter::SharedWithUserFilter <
     super && view_shared_work_packages_allowed?
   end
 
-  def scope(query_scope)
+  def apply_to(query_scope)
     query = visible_shared_work_packages(scoped_to_visible_projects: !querying_for_self?)
 
     if operator == "="

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -41,7 +41,7 @@ class Queries::WorkPackages::Filter::WorkPackageFilter < Queries::Filters::Base
     nil
   end
 
-  def scope
+  def scope(_query_scope)
     # We only return the WorkPackage base scope for now as most of the filters
     # (this one's subclasses) currently do not follow the base filter approach of using the scope.
     # The intend is to have more and more wp filters use the scope method just like the

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -41,7 +41,7 @@ class Queries::WorkPackages::Filter::WorkPackageFilter < Queries::Filters::Base
     nil
   end
 
-  def scope(_query_scope)
+  def apply_to(_query_scope)
     # We only return the WorkPackage base scope for now as most of the filters
     # (this one's subclasses) currently do not follow the base filter approach of using the scope.
     # The intend is to have more and more wp filters use the scope method just like the

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -263,8 +263,7 @@ class ::Query::Results
 
   def filter_merges
     query.filters.inject(::WorkPackage.unscoped) do |scope, filter|
-      scope = scope.merge(filter.scope)
-      scope
+      filter.scope(scope)
     end
   end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -263,7 +263,7 @@ class ::Query::Results
 
   def filter_merges
     query.filters.inject(::WorkPackage.unscoped) do |scope, filter|
-      filter.scope(scope)
+      filter.apply_to(scope)
     end
   end
 

--- a/modules/meeting/app/models/queries/meetings/filters/attended_user_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/attended_user_filter.rb
@@ -43,8 +43,8 @@ class Queries::Meetings::Filters::AttendedUserFilter < Queries::Meetings::Filter
     "meeting_participants.user_id IN (#{values.join(',')}) AND meeting_participants.attended"
   end
 
-  def scope
-    super.joins(:participants)
+  def joins
+    :participants
   end
 
   def self.key

--- a/modules/meeting/app/models/queries/meetings/filters/invited_user_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/invited_user_filter.rb
@@ -43,8 +43,8 @@ class Queries::Meetings::Filters::InvitedUserFilter < Queries::Meetings::Filters
     "meeting_participants.user_id IN (#{values.join(',')}) AND meeting_participants.invited"
   end
 
-  def scope
-    super.joins(:participants)
+  def joins
+    :participants
   end
 
   def self.key

--- a/modules/my_page/spec/queries/grids/filters/scope_filter_spec.rb
+++ b/modules/my_page/spec/queries/grids/filters/scope_filter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Grids::Filters::ScopeFilter, type: :model do
     let(:values) { ["/my/page"] }
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     context 'for "="' do
       let(:operator) { "=" }
 
@@ -53,7 +53,7 @@ RSpec.describe Grids::Filters::ScopeFilter, type: :model do
         it "is the same as handwriting the query" do
           expected = model.where("(grids.type IN ('Grids::MyPage'))")
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
     end

--- a/spec/models/queries/members/filters/also_project_member_filter_spec.rb
+++ b/spec/models/queries/members/filters/also_project_member_filter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Queries::Members::Filters::AlsoProjectMemberFilter do
 
         it "is the same as handwriting the query" do
           expected = expected_base_scope.where("EXISTS (#{exists_query})")
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Queries::Members::Filters::AlsoProjectMemberFilter do
 
         it "is the same as handwriting the query" do
           expected = expected_base_scope.where("NOT EXISTS (#{exists_query})")
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
     end

--- a/spec/models/queries/members/filters/name_filter_spec.rb
+++ b/spec/models/queries/members/filters/name_filter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Queries::Members::Filters::NameFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     before do
       allow(Setting)
         .to receive(:user_format)
@@ -58,7 +58,7 @@ RSpec.describe Queries::Members::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("LOWER(users.firstname) IN ('#{values.first.downcase}') OR unaccent(LOWER(users.firstname)) IN ('#{values.first.downcase}')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Queries::Members::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("LOWER(users.firstname) NOT IN ('a name') AND unaccent(LOWER(users.firstname)) NOT IN ('a name')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Queries::Members::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(LOWER(users.firstname)) LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe Queries::Members::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(LOWER(users.firstname)) NOT LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/members/members_query_integration_spec.rb
+++ b/spec/models/queries/members/members_query_integration_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe Queries::Members::MemberQuery, "Integration" do
       expect(subject.first).to have_attributes(
         project:,
         entity: work_package,
-        user:
+        principal: user
       )
       expect(subject.second).to have_attributes(
         project:,
         entity: nil,
-        user:
+        principal: user
       )
     end
   end

--- a/spec/models/queries/notifications/notification_query_spec.rb
+++ b/spec/models/queries/notifications/notification_query_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = base_scope.merge(Notification.where("notifications.read_ian IN ('t')").order(id: :desc)).to_sql
+        expected = base_scope.where("notifications.read_ian IN ('t')").order(id: :desc).to_sql
 
         expect(instance.results.to_sql).to eql expected
       end
@@ -107,7 +107,7 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = base_scope.merge(Notification.order(id: :asc))
+        expected = base_scope.order(id: :asc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -121,7 +121,7 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = base_scope.merge(Notification.order(read_ian: :desc, id: :desc)).to_sql
+        expected = base_scope.order(read_ian: :desc, id: :desc).to_sql
 
         expect(instance.results.to_sql).to eql expected
       end
@@ -135,7 +135,7 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = base_scope.merge(Notification.order(reason: :desc, id: :desc)).to_sql
+        expected = base_scope.order(reason: :desc, id: :desc).to_sql
 
         expect(instance.results.to_sql).to eql expected
       end
@@ -169,11 +169,11 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        scope = Notification
-          .group(:reason)
-          .order(reason: :asc)
-          .select(:reason, Arel.sql("COUNT(*)"))
-        expected = base_scope.merge(scope).to_sql
+        expected = base_scope
+                     .group(:reason)
+                     .order(reason: :asc)
+                     .select(:reason, Arel.sql("COUNT(*)"))
+                     .to_sql
 
         expect(instance.groups.to_sql).to eql expected
       end
@@ -187,11 +187,11 @@ RSpec.describe Queries::Notifications::NotificationQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        scope = Notification
-          .group(:project_id)
-          .order(project_id: :asc)
-          .select(:project_id, Arel.sql("COUNT(*)"))
-        expected = base_scope.merge(scope).to_sql
+        expected = base_scope
+                     .group(:project_id)
+                     .order(project_id: :asc)
+                     .select(:project_id, Arel.sql("COUNT(*)"))
+                     .to_sql
 
         expect(instance.groups.to_sql).to eql expected
       end

--- a/spec/models/queries/principals/filters/mentionable_on_work_package_filter_spec.rb
+++ b/spec/models/queries/principals/filters/mentionable_on_work_package_filter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Queries::Principals::Filters::MentionableOnWorkPackageFilter do
     let(:type) { :list_optional }
 
     describe "#scope" do
-      subject { instance.scope(Principal) }
+      subject { instance.apply_to(Principal) }
 
       shared_let(:project) { create(:project) }
       shared_let(:other_project) { create(:project) }

--- a/spec/models/queries/principals/filters/mentionable_on_work_package_filter_spec.rb
+++ b/spec/models/queries/principals/filters/mentionable_on_work_package_filter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Queries::Principals::Filters::MentionableOnWorkPackageFilter do
     let(:type) { :list_optional }
 
     describe "#scope" do
-      subject { instance.scope }
+      subject { instance.scope(Principal) }
 
       shared_let(:project) { create(:project) }
       shared_let(:other_project) { create(:project) }

--- a/spec/models/queries/projects/filters/available_project_attributes_filter_spec.rb
+++ b/spec/models/queries/projects/filters/available_project_attributes_filter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Queries::Projects::Filters::AvailableProjectAttributesFilter do
     end
     let(:name) { "Available project attributes" }
 
-    describe "#scope" do
+    describe "#apply_to" do
       let(:values) { valid_values }
 
       let(:project_custom_field_project_mapping_handwritten_sql_subquery) do
@@ -66,7 +66,7 @@ RSpec.describe Queries::Projects::Filters::AvailableProjectAttributesFilter do
               WHERE "projects"."id" IN (#{project_custom_field_project_mapping_handwritten_sql_subquery})
           SQL
 
-          expect(instance.scope.to_sql).to eql handwritten_scope_sql
+          expect(instance.apply_to(Project).to_sql).to eql handwritten_scope_sql
         end
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Queries::Projects::Filters::AvailableProjectAttributesFilter do
               WHERE "projects"."id" NOT IN (#{project_custom_field_project_mapping_handwritten_sql_subquery})
           SQL
 
-          expect(instance.scope.to_sql).to eql handwritten_scope_sql
+          expect(instance.apply_to(Project).to_sql).to eql handwritten_scope_sql
         end
       end
 
@@ -87,7 +87,7 @@ RSpec.describe Queries::Projects::Filters::AvailableProjectAttributesFilter do
         let(:operator) { "!=" }
 
         it "raises an error" do
-          expect { instance.scope }.to raise_error("unsupported operator")
+          expect { instance.apply_to(Project) }.to raise_error("unsupported operator")
         end
       end
     end

--- a/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
+++ b/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Queries::Projects::Filters::LatestActivityAtFilter do
   it_behaves_like "basic query filter" do
     let(:class_key) { :latest_activity_at }
     let(:type) { :datetime_past }
-    let(:model) { Project.with_latest_activity }
+    let(:model) { Project }
     let(:attribute) { :activity }
     let(:values) { ["3"] }
     let(:admin) { build_stubbed(:admin) }

--- a/spec/models/queries/projects/filters/member_of_filter_spec.rb
+++ b/spec/models/queries/projects/filters/member_of_filter_spec.rb
@@ -36,16 +36,16 @@ RSpec.describe Queries::Projects::Filters::MemberOfFilter do
     let(:model) { Project }
     let(:attribute) { :member_of }
 
-    describe "#scope" do
+    describe "#apply_to" do
       let(:operator) { "=" }
 
       context 'for "t"' do
         let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
 
         it "queries for projects where current user is a member" do
-          expected = expected_base_scope.visible.with_member
+          expected = expected_base_scope.with_member
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
 
@@ -53,9 +53,9 @@ RSpec.describe Queries::Projects::Filters::MemberOfFilter do
         let(:values) { [OpenProject::Database::DB_VALUE_FALSE] }
 
         it "queries for projects where current user is not a member" do
-          expected = expected_base_scope.visible.without_member
+          expected = expected_base_scope.without_member
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
     end

--- a/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
+++ b/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe Queries::Projects::Orders::LatestActivityAtOrder do
   end
   let(:direction) { :asc }
 
-  describe "#scope" do
+  describe "#apply_to" do
     context "with a valid direction" do
       it "orders by the disk space" do
-        expect(instance.scope.to_sql)
+        expect(instance.apply_to(Project).to_sql)
           .to eql(Project.order(Arel.sql("activity.latest_activity_at").asc).to_sql)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe Queries::Projects::Orders::LatestActivityAtOrder do
       let(:direction) { "bogus" }
 
       it "raises an error" do
-        expect { instance.scope }
+        expect { instance.apply_to(Project) }
           .to raise_error(ArgumentError)
       end
     end

--- a/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
+++ b/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Queries::Projects::Orders::RequiredDiskSpaceOrder do
   describe "#scope" do
     context "with a valid direction" do
       it "orders by the disk space" do
-        expect(instance.scope.to_sql)
+        expect(instance.apply_to(Project).to_sql)
           .to eql(Project.order(Arel.sql(Project.required_disk_space_sum).asc).to_sql)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe Queries::Projects::Orders::RequiredDiskSpaceOrder do
       let(:direction) { "bogus" }
 
       it "raises an error" do
-        expect { instance.scope }
+        expect { instance.apply_to(Project) }
           .to raise_error(ArgumentError)
       end
     end

--- a/spec/models/queries/relations/filters/from_filter_spec.rb
+++ b/spec/models/queries/relations/filters/from_filter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Queries::Relations::Filters::FromFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     before do
       login_as(current_user)
     end
@@ -66,7 +66,7 @@ RSpec.describe Queries::Relations::Filters::FromFilter do
       it "is the same as handwriting the query" do
         expected = model.where("from_id IN ('1') AND to_id IN (#{visible_sql})")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Queries::Relations::Filters::FromFilter do
       it "is the same as handwriting the query" do
         expected = model.where("from_id NOT IN ('1') AND to_id IN (#{visible_sql})")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/relations/filters/involved_filter_spec.rb
+++ b/spec/models/queries/relations/filters/involved_filter_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Queries::Relations::Filters::InvolvedFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     before do
       login_as(current_user)
     end
@@ -65,7 +65,7 @@ RSpec.describe Queries::Relations::Filters::InvolvedFilter do
         sql = "(from_id IN ('1') AND to_id IN (#{visible_sql})) OR (to_id IN ('1') AND from_id IN (#{visible_sql}))"
         expected = model.where(sql)
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Queries::Relations::Filters::InvolvedFilter do
         sql = "(from_id NOT IN ('1') AND to_id IN (#{visible_sql})) AND (to_id NOT IN ('1') AND from_id IN (#{visible_sql}))"
         expected = model.where(sql)
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/relations/filters/to_filter_spec.rb
+++ b/spec/models/queries/relations/filters/to_filter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Queries::Relations::Filters::ToFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     before do
       login_as(current_user)
     end
@@ -66,7 +66,7 @@ RSpec.describe Queries::Relations::Filters::ToFilter do
       it "is the same as handwriting the query" do
         expected = model.where("to_id IN ('1') AND from_id IN (#{visible_sql})")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Queries::Relations::Filters::ToFilter do
       it "is the same as handwriting the query" do
         expected = model.where("to_id NOT IN ('1') AND from_id IN (#{visible_sql})")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/roles/filters/allows_becoming_assignee_filter_spec.rb
+++ b/spec/models/queries/roles/filters/allows_becoming_assignee_filter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Queries::Roles::Filters::AllowsBecomingAssigneeFilter do
     let(:permission_name) { "work_package_assigned" }
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     shared_let(:assignable_role) do
       create(:project_role,
              name: "assignable_role",
@@ -64,7 +64,7 @@ RSpec.describe Queries::Roles::Filters::AllowsBecomingAssigneeFilter do
       end
     end
 
-    subject { instance.scope.map(&:name) }
+    subject { instance.apply_to(Role).map(&:name) }
 
     context 'with a "=" operator' do
       let(:operator) { "=" }

--- a/spec/models/queries/roles/filters/grantable_filter_spec.rb
+++ b/spec/models/queries/roles/filters/grantable_filter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Queries::Roles::Filters::GrantableFilter do
     let(:model) { Role }
     let(:attribute) { :type }
 
-    describe "#scope" do
+    describe "#apply_to" do
       context "for the true value" do
         let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
 
@@ -50,7 +50,7 @@ RSpec.describe Queries::Roles::Filters::GrantableFilter do
             expected = expected_base_scope
                        .where(["#{expected_table_name}.builtin IN (?)", Role::NON_BUILTIN])
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
 
@@ -61,7 +61,7 @@ RSpec.describe Queries::Roles::Filters::GrantableFilter do
             expected = expected_base_scope
                        .where(["#{expected_table_name}.builtin NOT IN (?)", Role::NON_BUILTIN])
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe Queries::Roles::Filters::GrantableFilter do
             expected = expected_base_scope
                        .where(["#{expected_table_name}.builtin IN (?)", [Role::BUILTIN_ANONYMOUS, Role::BUILTIN_NON_MEMBER]])
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
 
@@ -87,7 +87,7 @@ RSpec.describe Queries::Roles::Filters::GrantableFilter do
             expected = expected_base_scope
                        .where(["#{expected_table_name}.builtin NOT IN (?)", [Role::BUILTIN_ANONYMOUS, Role::BUILTIN_NON_MEMBER]])
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
       end

--- a/spec/models/queries/roles/filters/unit_filter_spec.rb
+++ b/spec/models/queries/roles/filters/unit_filter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Queries::Roles::Filters::UnitFilter do
     let(:model) { Role }
     let(:valid_values) { ["project"] }
 
-    describe "#scope" do
+    describe "#apply_to" do
       context "for the system value" do
         let(:values) { ["system"] }
 
@@ -51,7 +51,7 @@ RSpec.describe Queries::Roles::Filters::UnitFilter do
             expected = model
                        .where(["roles.type = ?", GlobalRole.name]) # rubocop:disable Rails/WhereEquals
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
 
@@ -62,7 +62,7 @@ RSpec.describe Queries::Roles::Filters::UnitFilter do
             expected = model
                        .where(["roles.type != ?", GlobalRole.name]) # rubocop:disable Rails/WhereNot
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
       end
@@ -77,7 +77,7 @@ RSpec.describe Queries::Roles::Filters::UnitFilter do
             expected = model
                        .where(["roles.type = ? AND roles.builtin = ?", ProjectRole.name, Role::NON_BUILTIN])
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
 
@@ -88,7 +88,7 @@ RSpec.describe Queries::Roles::Filters::UnitFilter do
             expected = model
                        .where(["roles.type != ?", ProjectRole.name]) # rubocop:disable Rails/WhereNot
 
-            expect(instance.scope.to_sql).to eql expected.to_sql
+            expect(instance.apply_to(model).to_sql).to eql expected.to_sql
           end
         end
       end

--- a/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
+++ b/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe Queries::Users::Filters::AnyNameAttributeFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     context 'for "~"' do
       let(:operator) { "~" }
 
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(#{filter_str}) LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Queries::Users::Filters::AnyNameAttributeFilter do
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(#{filter_str}) NOT LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/users/filters/name_filter_spec.rb
+++ b/spec/models/queries/users/filters/name_filter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Queries::Users::Filters::NameFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     before do
       allow(Setting)
         .to receive(:user_format)
@@ -58,7 +58,7 @@ RSpec.describe Queries::Users::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("LOWER(users.firstname) IN ('#{values.first.downcase}') OR unaccent(LOWER(users.firstname)) IN ('#{values.first.downcase}')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Queries::Users::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("LOWER(users.firstname) NOT IN ('a name') AND unaccent(LOWER(users.firstname)) NOT IN ('a name')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Queries::Users::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(LOWER(users.firstname)) LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe Queries::Users::Filters::NameFilter do
       it "is the same as handwriting the query" do
         expected = model.where("unaccent(LOWER(users.firstname)) NOT LIKE unaccent('%#{values.first.downcase}%')")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/users/filters/status_filter_spec.rb
+++ b/spec/models/queries/users/filters/status_filter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Queries::Users::Filters::StatusFilter do
     end
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     include_context "filter tests"
     let(:values) { %w[active invited] }
     let(:model) { User.user }
@@ -55,7 +55,7 @@ RSpec.describe Queries::Users::Filters::StatusFilter do
       it "is the same as handwriting the query" do
         expected = model.where("users.status IN (1,4)")
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -48,10 +48,9 @@ RSpec.describe Queries::Users::UserQuery do
     describe "#results" do
       it "is the same as handwriting the query" do
         expected = base_scope
-                   .merge(User
-                          .user
-                          .where(["unaccent(LOWER(CONCAT(users.firstname, ' ', users.lastname))) LIKE unaccent(?)",
-                                  "%a user%"]))
+                     .user
+                     .where(["unaccent(LOWER(CONCAT(users.firstname, ' ', users.lastname))) LIKE unaccent(?)",
+                             "%a user%"])
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -76,7 +75,7 @@ RSpec.describe Queries::Users::UserQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = base_scope.merge(User.user.where("users.status IN (1)"))
+        expected = base_scope.user.where("users.status IN (1)")
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -112,9 +111,8 @@ RSpec.describe Queries::Users::UserQuery do
     describe "#results" do
       it "is the same as handwriting the query" do
         expected = base_scope
-                     .merge(User
-                              .user
-                              .where(["users.id IN (#{User.in_group([group_1.id.to_s]).select(:id).to_sql})"]))
+                   .user
+                   .where(["users.id IN (#{User.in_group([group_1.id.to_s]).select(:id).to_sql})"])
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -165,7 +163,7 @@ RSpec.describe Queries::Users::UserQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = User.user.merge(User.order(id: :asc))
+        expected = User.user.order(id: :asc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -205,7 +203,7 @@ RSpec.describe Queries::Users::UserQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = User.user.merge(User.joins(:groups).order("groups_users.lastname DESC")).order(id: :desc)
+        expected = User.user.joins(:groups).order("groups_users.lastname DESC").order(id: :desc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end

--- a/spec/models/queries/work_packages/filter/shared_with_user_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/shared_with_user_filter_spec.rb
@@ -31,7 +31,7 @@ require "spec_helper"
 RSpec.describe Queries::WorkPackages::Filter::SharedWithUserFilter do
   create_shared_association_defaults_for_work_package_factory
 
-  describe "#scope" do
+  describe "#apply_to" do
     shared_let(:work_package_role) { create(:work_package_role, permissions: %i[blurgh]) }
 
     shared_let(:shared_with_user) { create(:user) }
@@ -73,7 +73,7 @@ RSpec.describe Queries::WorkPackages::Filter::SharedWithUserFilter do
       end
     end
 
-    subject { instance.scope }
+    subject { instance.apply_to(WorkPackage) }
 
     current_user { user }
 

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -117,7 +117,9 @@ RSpec.describe "API v3 Principals resource" do
         [{ type: { operator: "=", values: ["Group"] } }]
       end
 
-      it_behaves_like "API V3 collection response", 1, 1, "Group"
+      it_behaves_like "API V3 collection response", 1, 1, "Group" do
+        let(:elements) { [group] }
+      end
     end
 
     context 'with a filter for type "PlaceholderUser"' do

--- a/spec/requests/api/v3/projects/index_resource_spec.rb
+++ b/spec/requests/api/v3/projects/index_resource_spec.rb
@@ -96,12 +96,8 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
       [{ ancestor: { operator: "=", values: [parent_project.id.to_s] } }]
     end
 
-    it_behaves_like "API V3 collection response", 1, 1, "Project"
-
-    it "returns the child project" do
-      expect(response.body)
-        .to be_json_eql(api_v3_paths.project(project.id).to_json)
-              .at_path("_embedded/elements/0/_links/self/href")
+    it_behaves_like "API V3 collection response", 1, 1, "Project" do
+      let(:elements) { [project] }
     end
   end
 
@@ -118,25 +114,23 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
                                          another_project => another_role })
     end
 
-    let(:get_path) do
-      api_v3_paths.path_for :projects, filters: [{ user_action: { operator:, values: %w[projects/copy work_packages/read] } }]
+    let(:filters) do
+      [{ user_action: { operator:, values: %w[projects/copy work_packages/read] } }]
     end
 
     context "if using the equals operator" do
       let(:operator) { "=" }
 
-      it_behaves_like "API V3 collection response", 2, 2, "Project"
+      it_behaves_like "API V3 collection response", 2, 2, "Project" do
+        let(:elements) { [other_project, project] }
+      end
     end
 
     context "if using the all operator" do
       let(:operator) { "&=" }
 
-      it_behaves_like "API V3 collection response", 1, 1, "Project"
-
-      it "returns the project the current user has the capabilities in" do
-        expect(response.body)
-          .to be_json_eql(api_v3_paths.project(project.id).to_json)
-                .at_path("_embedded/elements/0/_links/self/href")
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project] }
       end
     end
   end
@@ -147,27 +141,32 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
     shared_let(:project_custom_field_mapping1) { create(:project_custom_field_project_mapping, project:) }
     shared_let(:project_custom_field_mapping2) { create(:project_custom_field_project_mapping, project:) }
 
+    let(:current_user) do
+      create(:user, member_with_roles: { project => role,
+                                         other_project => role })
+    end
+
     let(:valid_values) do
       [project_custom_field_mapping1.custom_field_id.to_s, project_custom_field_mapping2.custom_field_id.to_s]
     end
 
-    let(:get_path) do
-      api_v3_paths.path_for :projects, filters: [{ available_project_attributes: { operator:, values: valid_values } }]
+    let(:filters) do
+      [{ available_project_attributes: { operator:, values: valid_values } }]
     end
 
     context "if using the equals operator" do
       let(:operator) { "=" }
 
-      it_behaves_like "API V3 collection response", 1, 1, "Project"
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project] }
+      end
     end
 
     context "if using the not equals operator" do
       let(:operator) { "!" }
 
-      it "returns the projects not matching the value" do
-        expect(last_response.body)
-          .to be_json_eql(other_project.id.to_json)
-                .at_path("_embedded/elements/0/id")
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [other_project] }
       end
     end
   end
@@ -178,41 +177,110 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
       create(:public_project)
     end
     let(:projects) { [project, other_project] }
+    # Just here to make sure that work package members do not interfere
+    let!(:share) do
+      create(:work_package_member,
+             entity: create(:work_package, project: other_project),
+             roles: [create(:work_package_role)])
+    end
 
     context "if filtering for a value" do
-      let(:filter_query) do
+      let(:filters) do
         [{ principal: { operator: "=", values: [current_user.id.to_s] } }]
       end
 
-      let(:get_path) do
-        api_v3_paths.path_for :projects, filters: filter_query
-      end
-
-      it "returns the filtered for value" do
-        expect(response.body)
-          .to be_json_eql(project.id.to_json)
-                .at_path("_embedded/elements/0/id")
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project] }
       end
     end
 
     context "if filtering for a negative value" do
-      let(:filter_query) do
+      let(:filters) do
         [{ principal: { operator: "!", values: [current_user.id.to_s] } }]
       end
 
-      let(:get_path) do
-        api_v3_paths.path_for :projects, filters: filter_query
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [other_project] }
+      end
+    end
+
+    context "if filtering for all" do
+      let(:filters) do
+        [{ principal: { operator: "*", values: [] } }]
       end
 
-      it "returns the projects not matching the value" do
-        expect(last_response.body)
-          .to be_json_eql(other_project.id.to_json)
-                .at_path("_embedded/elements/0/id")
+      # Does not contain the other project as that does not have members
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project] }
+      end
+    end
+
+    context "if filtering for none" do
+      let(:filters) do
+        [{ principal: { operator: "!*", values: [] } }]
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [other_project] }
       end
     end
   end
 
-  context "with filtering by visiblity" do
+  context "when filtering for favored" do
+    let(:favored_project) { create(:project) }
+    let(:unfavored_project) { create(:project) }
+
+    let(:projects) { [favored_project, unfavored_project] }
+
+    current_user do
+      create(:user, member_with_roles: { favored_project => role,
+                                         unfavored_project => role }) do |user|
+        favored_project.set_favored(user)
+      end
+    end
+
+    context "when filtering for favorite projects" do
+      let(:filters) do
+        [{ favored: { operator: "=", values: ["t"] } }]
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [favored_project] }
+      end
+    end
+
+    context "when filtering for nonfavorite projects" do
+      let(:filters) do
+        [{ favored: { operator: "=", values: ["f"] } }]
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [unfavored_project] }
+      end
+    end
+
+    context "when not filtering for favorite projects" do
+      let(:filters) do
+        [{ favored: { operator: "!", values: ["t"] } }]
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [unfavored_project] }
+      end
+    end
+
+    context "when not filtering for nonfavorite projects" do
+      let(:filters) do
+        [{ favored: { operator: "!", values: ["f"] } }]
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [favored_project] }
+      end
+    end
+  end
+
+  context "with filtering by visibility" do
     let(:public_project) do
       # Otherwise, the public project is invisible
       create(:non_member)
@@ -239,16 +307,8 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
 
     current_user { admin }
 
-    it_behaves_like "API V3 collection response", 2, 2, "Project"
-
-    it "contains the expected projects" do
-      expect(last_response.body)
-        .to be_json_eql(public_project.id.to_json)
-              .at_path("_embedded/elements/0/id")
-
-      expect(last_response.body)
-        .to be_json_eql(member_project.id.to_json)
-              .at_path("_embedded/elements/1/id")
+    it_behaves_like "API V3 collection response", 2, 2, "Project" do
+      let(:elements) { [public_project, member_project] }
     end
   end
 
@@ -263,7 +323,9 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
         expect(last_response.status).to eq(200)
       end
 
-      it_behaves_like "API V3 collection response", 1, 1, "Project"
+      it_behaves_like "API V3 collection response", 1, 1, "Project" do
+        let(:elements) { [project] }
+      end
     end
 
     context "with the user being no admin" do

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -78,7 +78,7 @@ RSpec.shared_examples_for "list query filter" do |scope: true|
   let(:type) { :list }
 
   if scope
-    describe "#scope" do
+    describe "#apply_to" do
       context 'for "="' do
         let(:operator) { "=" }
         let(:values) { valid_values }
@@ -86,7 +86,7 @@ RSpec.shared_examples_for "list query filter" do |scope: true|
         it "is the same as handwriting the query" do
           expected = model.where(["#{model.table_name}.#{attribute} IN (?)", values])
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
 
@@ -99,7 +99,7 @@ RSpec.shared_examples_for "list query filter" do |scope: true|
                  OR #{model.table_name}.#{attribute} NOT IN (?))".squish
           expected = model.where([sql, values])
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
     end
@@ -147,7 +147,7 @@ RSpec.shared_examples_for "list_optional query filter" do
     joins || model.table_name
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     let(:values) { valid_values }
     let(:db_values) { defined?(transformed_values) ? transformed_values : valid_values }
 
@@ -158,7 +158,7 @@ RSpec.shared_examples_for "list_optional query filter" do
         expected = expected_base_scope
                    .where(["#{expected_table_name}.#{attribute} IN (?)", db_values])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -170,7 +170,7 @@ RSpec.shared_examples_for "list_optional query filter" do
                OR #{expected_table_name}.#{attribute} NOT IN (?))".squish
         expected = expected_base_scope.where([sql, db_values])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -181,7 +181,7 @@ RSpec.shared_examples_for "list_optional query filter" do
         sql = "#{expected_table_name}.#{attribute} IS NOT NULL"
         expected = expected_base_scope.where([sql])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.shared_examples_for "list_optional query filter" do
       it "is the same as handwriting the query" do
         sql = "#{expected_table_name}.#{attribute} IS NULL"
         expected = expected_base_scope.where([sql])
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end
@@ -224,7 +224,7 @@ end
 
 RSpec.shared_examples_for "list_optional group query filter" do
   include_context "filter tests"
-  describe "#scope" do
+  describe "#apply_to" do
     let(:values) { valid_values }
 
     context 'for "="' do
@@ -232,7 +232,7 @@ RSpec.shared_examples_for "list_optional group query filter" do
 
       it "is the same as handwriting the query" do
         expected = model.where(["users.id IN (#{User.in_group(values).select(:id).to_sql})"])
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -241,7 +241,7 @@ RSpec.shared_examples_for "list_optional group query filter" do
 
       it "is the same as handwriting the query" do
         expected = model.where(["users.id NOT IN (#{User.in_group(values).select(:id).to_sql})"])
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -250,7 +250,7 @@ RSpec.shared_examples_for "list_optional group query filter" do
 
       it "is the same as handwriting the query" do
         expected = model.where(["users.id IN (#{User.within_group([]).select(:id).to_sql})"])
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -259,7 +259,7 @@ RSpec.shared_examples_for "list_optional group query filter" do
 
       it "is the same as handwriting the query" do
         expected = model.where(["users.id NOT IN (#{User.within_group([]).select(:id).to_sql})"])
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end
@@ -306,7 +306,7 @@ RSpec.shared_examples_for "list_all query filter" do
     joins || model.table_name
   end
 
-  describe "#scope" do
+  describe "#apply_to" do
     let(:values) { valid_values }
 
     context 'for "="' do
@@ -316,7 +316,7 @@ RSpec.shared_examples_for "list_all query filter" do
         expected = expected_base_scope
                    .where(["#{expected_table_name}.#{attribute} IN (?)", values])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -328,7 +328,7 @@ RSpec.shared_examples_for "list_all query filter" do
                OR #{expected_table_name}.#{attribute} NOT IN (?))".squish
         expected = expected_base_scope.where([sql, values])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
 
@@ -339,7 +339,7 @@ RSpec.shared_examples_for "list_all query filter" do
         sql = "#{expected_table_name}.#{attribute} IS NOT NULL"
         expected = expected_base_scope.where([sql])
 
-        expect(instance.scope.to_sql).to eql expected.to_sql
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
     end
   end
@@ -397,7 +397,7 @@ RSpec.shared_examples_for "boolean query filter" do |scope: true|
   end
 
   if scope
-    describe "#scope" do
+    describe "#apply_to" do
       let(:values) { valid_values }
 
       context 'for "="' do
@@ -407,7 +407,7 @@ RSpec.shared_examples_for "boolean query filter" do |scope: true|
           expected = expected_base_scope
                      .where(["#{expected_table_name}.#{attribute} IN (?)", values])
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
 
@@ -419,7 +419,7 @@ RSpec.shared_examples_for "boolean query filter" do |scope: true|
                  OR #{expected_table_name}.#{attribute} IN (?)".squish
           expected = expected_base_scope.where([sql, [OpenProject::Database::DB_VALUE_FALSE]])
 
-          expect(instance.scope.to_sql).to eql expected.to_sql
+          expect(instance.apply_to(model).to_sql).to eql expected.to_sql
         end
       end
     end


### PR DESCRIPTION
## Problem

The `ActiveRecord::Scope.merge` method changed it's behaviour between rails 6.1 and 7.0. [Whenever two conditions on the same column that result in the SQL operators `=` or `IN` are merged now, only the later is used](https://www.fastruby.io/blog/rails/upgrades/rails-merge-deprecation.html). Since we use `merge` extensively to fetch scopes from filters, orders or group_bys. That now poses risks in a scenario like the following:

``` 
# Oftentimes defined in the queries to limit visibility
query_scope = SomeModel.visible # where visible is defined as where(id: subselect)
# A filter based on the id
filter_scope = SomeModel.where(id: 5)
# Building the resulting query
query_scope = query_scope.merge(filter_scope)
```
In the Scenario above, the resulting SQL would only be
`SELECT * from some_models where id = 5`
completely omitting the visibility check.

The `Queries::Projects::Filters::AvailableProjectAttributesFilter` is a filter where this problematic combination of merged scopes occurs. This filter has not been released yet.  

## Solution

This PR changes the scope building to no longer rely on fetching a scope from the filters, orders and group_bys but rather the scope of the query (which might already contain scopes like a `visibility` scope) to be passed in and then changed by each of the objects thus amending the query scope.

The alternative, of fetching individual parts from the objects (e.g. filters) and applying them within the query would require to open up the interface of those objects so that the query can access them.

An alternative that was also considered was using the `.and` method of `ActiveRecord::Scope` but it requires the two scope that are involved to be structurally equivalent (i.e. have the same includes and joins) which defeats the purpose.

For most filters, this required little to no change. The only exception, the [principal filter on the project query](https://github.com/opf/openproject/pull/15675/files#diff-eeda7b04e586413810f1c9ed2c094df65a96303fea1c0d005569690891042c85R38-R62), to this cannot really be attributed to the change but rather is a fix so that only actual members of the project are returned. Before, every user having any kind of membership, i.e. a work package share, would be returned as well.

## WP

https://community.openproject.org/wp/55314
