### PR TITLE
[#55196] Wrong menu entry when deactivating a project attribute (not "Delete")

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -227,7 +227,7 @@ module Projects
                          label:,
                          test_selector: "project-list-row--action-menu-item",
                          content_arguments: button_options) do |item|
-            item.with_leading_visual_icon(icon:)
+            item.with_leading_visual_icon(icon:) if icon
           end
         end
       end

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
@@ -45,9 +45,9 @@ module Settings
         def more_menu_detach_project
           if User.current.admin
             {
-              scheme: :danger,
-              icon: :trash,
-              label: I18n.t(:button_delete),
+              scheme: :default,
+              icon: nil,
+              label: I18n.t("projects.settings.project_custom_fields.actions.deactivate_for_project"),
               href: unlink_admin_settings_project_custom_field_path(
                 id: @table.params[:custom_field].id,
                 project_custom_field_project_mapping: { project_id: model.first.id }

--- a/app/views/admin/settings/project_custom_fields/project_mappings.html.erb
+++ b/app/views/admin/settings/project_custom_fields/project_mappings.html.erb
@@ -37,8 +37,17 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <%=
-  render(Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
-    query: @project_custom_field_mappings_query,
-    params: { custom_field: @custom_field })
-  )
+
+  if @custom_field.required?
+    render Primer::Beta::Blankslate.new(border: true) do |component|
+      component.with_visual_icon(icon: :checklist)
+      component.with_heading(tag: :h2).with_content(I18n.t("projects.settings.project_custom_fields.is_required_blank_slate.heading"))
+      component.with_description { I18n.t("projects.settings.project_custom_fields.is_required_blank_slate.description") }
+    end
+  else
+    render(Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
+      query: @project_custom_field_mappings_query,
+      params: { custom_field: @custom_field })
+    )
+  end
 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,9 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
           deactivate_for_project: "Deactivate for this project"
           label_enable_all: "Enable all"
           label_disable_all: "Disable all"
+        is_required_blank_slate:
+          heading: Required in all projects
+          description: This project attribute is activated in all projects since the "Required in all projects" option is checked. It cannot be deactivated for individual projects.
       types:
         no_results_title_text: There are currently no types available.
         form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
         actions:
           label_enable_single: "Active in this project, click to disable"
           label_disable_single: "Inactive in this project, click to enable"
+          deactivate_for_project: "Deactivate for this project"
           label_enable_all: "Enable all"
           label_disable_all: "Disable all"
       types:

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -52,38 +52,34 @@ RSpec.describe "Project Custom Field Mappings", :js do
       visit project_mappings_admin_settings_project_custom_field_path(project_custom_field)
     end
 
-    it "shows a correct breadcrumb menu" do
-      within ".PageHeader-breadcrumbs" do
-        expect(page).to have_link("Administration")
-        expect(page).to have_link("Projects")
-        expect(page).to have_link("Project attributes")
-        expect(page).to have_text(project_custom_field.name)
+    it "renders the project custom field mappings page" do
+      aggregate_failures "shows a correct breadcrumb menu" do
+        within ".PageHeader-breadcrumbs" do
+          expect(page).to have_link("Administration")
+          expect(page).to have_link("Projects")
+          expect(page).to have_link("Project attributes")
+          expect(page).to have_text(project_custom_field.name)
+        end
       end
-    end
 
-    it "shows tab navigation" do
-      within_test_selector("project_attribute_detail_header") do
-        expect(page).to have_link("Details")
-        expect(page).to have_link("Projects")
+      aggregate_failures "shows tab navigation" do
+        within_test_selector("project_attribute_detail_header") do
+          expect(page).to have_link("Details")
+          expect(page).to have_link("Projects")
+        end
       end
-    end
 
-    it "shows the correct project mappings" do
-      within "#project-table" do
-        expect(page).to have_text(project.name)
+      aggregate_failures "shows the correct project mappings" do
+        within "#project-table" do
+          expect(page).to have_text(project.name)
+        end
       end
-    end
 
-    it "renders more menu list item" do
-      project_custom_field_mappings_page.activate_menu_of(project) do |menu|
-        expect(menu).to have_link("Deactivate for this project")
+      aggregate_failures "allows to unlinking a project" do
+        project_custom_field_mappings_page.click_menu_item_of("Deactivate for this project", project)
+
+        expect(page).to have_no_text(project.name)
       end
-    end
-
-    it "allows to unlink a project" do
-      project_custom_field_mappings_page.click_menu_item_of("Deactivate for this project", project)
-
-      expect(page).to have_no_text(project.name)
     end
 
     context "and the project custom field is required" do

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -76,14 +76,22 @@ RSpec.describe "Project Custom Field Mappings", :js do
 
     it "renders more menu list item" do
       project_custom_field_mappings_page.activate_menu_of(project) do |menu|
-        expect(menu).to have_link("Delete")
+        expect(menu).to have_link("Deactivate for this project")
       end
     end
 
     it "allows to unlink a project" do
-      project_custom_field_mappings_page.click_menu_item_of("Delete", project)
+      project_custom_field_mappings_page.click_menu_item_of("Deactivate for this project", project)
 
       expect(page).to have_no_text(project.name)
+    end
+
+    context "and the project custom field is required" do
+      shared_let(:project_custom_field) { create(:project_custom_field, is_required: true) }
+
+      it "renders a blank slate" do
+        expect(page).to have_text("Required in all projects")
+      end
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55196

- [x] Change Project attribute unlink button label to `Deactivate for this project`
- [x] Render an info  blank slate in place of project list for required custom fields

---

![Screenshot 2024-05-27 at 6 01 20 PM](https://github.com/opf/openproject/assets/17295175/8d7bc35c-5eb4-4986-bd7b-b5e66f98016f)
![Screenshot 2024-05-27 at 6 01 01 PM](https://github.com/opf/openproject/assets/17295175/28e78725-6c2f-4134-ba5b-e3f9997aa6b6)
