### PR TITLE
[#54966] Saturday missing in "My spent time" widget in "My page"

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/services/configuration-modal/configuration-modal.service.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/services/configuration-modal/configuration-modal.service.ts
@@ -25,8 +25,9 @@ export class TimeEntriesCurrentUserConfigurationModalService {
     // offsetToApply = -1, so we need to pass the last daysCheckedValues to the start of the array to match the localeWeekDays order
     // In order save the result, we will have to reorder it with offset 1 (getCheckedValuesInOriginalOrder)
     const offsetToApply = localeOffset - 1;
-    const offsetCheckedValues = offsetToApply >= 0 ? daysCheckedValues.splice(0, offsetToApply) : daysCheckedValues.splice(offsetToApply);
-    const orderedDaysCheckedValues = offsetToApply >= 0 ? [...daysCheckedValues, ...offsetCheckedValues] : [...offsetCheckedValues, ...daysCheckedValues];
+    const checkedValues = Array.from(daysCheckedValues);
+    const offsetCheckedValues = offsetToApply >= 0 ? checkedValues.splice(0, offsetToApply) : checkedValues.splice(offsetToApply);
+    const orderedDaysCheckedValues = offsetToApply >= 0 ? [...checkedValues, ...offsetCheckedValues] : [...offsetCheckedValues, ...checkedValues];
     const weekDaysWithCheckedValue = orderedDaysCheckedValues
       .map(
         (dayCheckedValue, index) => ({
@@ -61,7 +62,7 @@ export class TimeEntriesCurrentUserConfigurationModalService {
 
   private validDays(days:DisplayedDays) {
     if (days.every((value) => !value)) {
-      return Array.apply(null, Array(7)).map(() => true);
+      return Array.from({ length: 7 }, () => true);
     }
     return days;
   }

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -277,6 +277,16 @@ RSpec.describe "My page time entries current user widget spec", :js do
     expect(page)
       .to have_content "Total: 13 h"
 
+    ## Opening the configuration modal multiple times (Regression#54966)
+    entries_area.click_menu_item I18n.t("js.grid.configure")
+    click_on "Cancel"
+    entries_area.click_menu_item I18n.t("js.grid.configure")
+
+    ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].each do |day_name|
+      expect(page).to have_field(day_name, checked: true)
+    end
+    click_on "Cancel"
+
     ## Hiding weekdays
     entries_area.click_menu_item I18n.t("js.grid.configure")
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/54966

The actual bug was that every time the day selector modal was opened, one day has disappeared from the list, starting with Saturday.