### PR TITLE
Reserve project queries identifier

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,7 +41,7 @@ class Project < ApplicationRecord
   IDENTIFIER_MAX_LENGTH = 100
 
   # reserved identifiers
-  RESERVED_IDENTIFIERS = %w(new menu).freeze
+  RESERVED_IDENTIFIERS = %w[new menu queries].freeze
 
   has_many :members, -> {
     # TODO: check whether this should

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -411,4 +411,33 @@ RSpec.describe Project do
     let(:model_instance) { project }
     let(:custom_field) { create(:string_project_custom_field) }
   end
+
+  describe "url identifier" do
+    let(:reserved) do
+      Rails.application.routes.routes
+        .map { |route| route.path.spec.to_s }
+        .filter_map { |path| path[%r{^/projects/(\w+)\(\.:format\)$}, 1] }
+        .uniq
+    end
+
+    it "is set from name" do
+      project = described_class.new(name: "foo")
+
+      project.validate
+
+      expect(project.identifier).to eq("foo")
+    end
+
+    it "is not allowed to clash with projects routing" do
+      expect(reserved).not_to be_empty
+
+      reserved.each do |word|
+        project = described_class.new(name: word)
+
+        project.validate
+
+        expect(project.identifier).not_to eq(word)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a test to warn us about urls nester under projects that are not reserved for project url identifiers and add `queries` to the reserved list.