### PR TITLE
Add a dedicated time matcher and use it instead of `be_within.of`

### DIFF
--- a/modules/bim/spec/requests/api/bcf/v2_1/shared_responses.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/shared_responses.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples_for "bcf api successful response" do
       expected_modified_date = expected_item.delete("modified_date")&.to_time
 
       if expected_modified_date
-        expect(subject_modified_date).to be_within(10.seconds).of(expected_modified_date)
+        expect(subject_modified_date).to equal_time_without_usec(expected_modified_date)
       else
         expect(subject_modified_date).to eql(expected_modified_date)
       end
@@ -50,7 +50,7 @@ RSpec.shared_examples_for "bcf api successful response" do
       expected_created_date = expected_item.delete("date")&.to_time
 
       if expected_created_date
-        expect(subject_created_date).to be_within(10.seconds).of(expected_created_date)
+        expect(subject_created_date).to equal_time_without_usec(expected_created_date)
       else
         expect(subject_created_date).to eql(expected_created_date)
       end

--- a/modules/bim/spec/requests/api/bcf/v2_1/shared_responses.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/shared_responses.rb
@@ -27,7 +27,7 @@
 #++
 
 RSpec.shared_examples_for "bcf api successful response" do
-  def expect_identical_without_time(subject, expected_body)
+  def expect_identical_without_time(subject, expected_body) # rubocop:disable Metrics/PerceivedComplexity
     body = Array.wrap(JSON.parse(subject.body))
     expected = Array.wrap(expected_body)
     expect(body.size).to eql(expected.size)
@@ -43,7 +43,7 @@ RSpec.shared_examples_for "bcf api successful response" do
       if expected_modified_date
         expect(subject_modified_date).to equal_time_without_usec(expected_modified_date)
       else
-        expect(subject_modified_date).to eql(expected_modified_date)
+        expect(subject_modified_date).to be_nil
       end
 
       subject_created_date = subject_body.delete("date")&.to_time
@@ -52,7 +52,7 @@ RSpec.shared_examples_for "bcf api successful response" do
       if expected_created_date
         expect(subject_created_date).to equal_time_without_usec(expected_created_date)
       else
-        expect(subject_created_date).to eql(expected_created_date)
+        expect(subject_created_date).to be_nil
       end
 
       expect(subject_body.to_json).to be_json_eql(expected_item.to_json)

--- a/modules/costs/spec/models/project/activity_spec.rb
+++ b/modules/costs/spec/models/project/activity_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Projects::Activity, "costs" do
       budget2.update(updated_at: initial_time - 20.seconds)
 
       # there is a loss of precision for timestamps stored in database
-      expect(latest_activity).to be_within(0.00001).of(budget.updated_at)
+      expect(latest_activity).to equal_time_without_usec(budget.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
@@ -71,7 +71,7 @@ RSpec.describe Projects::Activity, "costs" do
       # work_package
       # budget
 
-      expect(latest_activity).to be_within(0.00001).of(work_package.updated_at)
+      expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
       work_package.update(updated_at: budget.updated_at - 10.seconds)
 
@@ -79,7 +79,7 @@ RSpec.describe Projects::Activity, "costs" do
       # budget
       # work_package
 
-      expect(latest_activity).to be_within(0.00001).of(budget.updated_at)
+      expect(latest_activity).to equal_time_without_usec(budget.updated_at)
     end
   end
 end

--- a/modules/meeting/spec/models/project/activity_spec.rb
+++ b/modules/meeting/spec/models/project/activity_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Projects::Activity, "meeting" do
       meeting2.update(updated_at: initial_time - 20.seconds)
 
       # there is a loss of precision for timestamps stored in database
-      expect(latest_activity).to be_within(0.00001).of(meeting.updated_at)
+      expect(latest_activity).to equal_time_without_usec(meeting.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
@@ -71,7 +71,7 @@ RSpec.describe Projects::Activity, "meeting" do
       # work_package
       # meeting
 
-      expect(latest_activity).to be_within(0.00001).of(work_package.updated_at)
+      expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
       work_package.update(updated_at: meeting.updated_at - 10.seconds)
 
@@ -79,7 +79,7 @@ RSpec.describe Projects::Activity, "meeting" do
       # meeting
       # work_package
 
-      expect(latest_activity).to be_within(0.00001).of(meeting.updated_at)
+      expect(latest_activity).to equal_time_without_usec(meeting.updated_at)
     end
   end
 end

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe MyController, :skip_2fa_stage do
   shared_examples "should log in the user" do
     it "logs in given user" do
       expect(response).to redirect_to my_account_path
-      expect(user.reload.last_login_on).to be_within(10.seconds).of(Time.current)
+      expect(user.reload.last_login_on).to equal_time_without_usec(Time.current)
       expect(session[:user_id]).to eq user.id
     end
   end
@@ -194,7 +194,7 @@ RSpec.describe MyController, :skip_2fa_stage do
       expect(session[:updated_at]).to be > session_update_time
 
       # User not is not relogged
-      expect(user.reload.last_login_on).to be_within(1.second).of(last_login)
+      expect(user.reload.last_login_on).to equal_time_without_usec(last_login)
 
       # Session values are kept
       expect(session[:should_be_kept]).to be true

--- a/spec/models/projects/activity_spec.rb
+++ b/spec/models/projects/activity_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Projects::Activity, "core" do
       work_package2.reload
 
       # there is a loss of precision for timestamps stored in database
-      expect(latest_activity).to be_within(0.00001).of(work_package.updated_at)
+      expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
     end
 
     it "is the latest wiki_pages update" do
@@ -132,7 +132,7 @@ RSpec.describe Projects::Activity, "core" do
       wiki_page.reload
       wiki_page2.reload
 
-      expect(latest_activity).to be_within(0.00001).of(wiki_page.updated_at)
+      expect(latest_activity).to equal_time_without_usec(wiki_page.updated_at)
     end
 
     it "is the latest news update" do
@@ -141,7 +141,7 @@ RSpec.describe Projects::Activity, "core" do
       news.reload
       news2.reload
 
-      expect(latest_activity).to be_within(0.00001).of(news.updated_at)
+      expect(latest_activity).to equal_time_without_usec(news.updated_at)
     end
 
     it "is the latest changeset update" do
@@ -150,7 +150,7 @@ RSpec.describe Projects::Activity, "core" do
       changeset.reload
       changeset2.reload
 
-      expect(latest_activity).to be_within(0.00001).of(changeset.committed_on)
+      expect(latest_activity).to equal_time_without_usec(changeset.committed_on)
     end
 
     it "is the latest message update" do
@@ -159,7 +159,7 @@ RSpec.describe Projects::Activity, "core" do
       message.reload
       message2.reload
 
-      expect(latest_activity).to be_within(0.00001).of(message.updated_at)
+      expect(latest_activity).to equal_time_without_usec(message.updated_at)
     end
 
     it "is the latest time_entry update" do
@@ -169,14 +169,14 @@ RSpec.describe Projects::Activity, "core" do
       time_entry.reload
       time_entry2.reload
 
-      expect(latest_activity).to be_within(0.00001).of(time_entry.updated_at)
+      expect(latest_activity).to equal_time_without_usec(time_entry.updated_at)
     end
 
     it "is the latest project update" do
       work_package.update(updated_at: initial_time - 60.seconds)
       project.update(updated_at: initial_time - 10.seconds)
 
-      expect(latest_activity).to be_within(0.00001).of(project.updated_at)
+      expect(latest_activity).to equal_time_without_usec(project.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
@@ -201,7 +201,7 @@ RSpec.describe Projects::Activity, "core" do
       # message
       # project
 
-      expect(latest_activity).to be_within(0.00001).of(work_package.updated_at)
+      expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
       work_package.update(updated_at: project.updated_at - 10.seconds)
 
@@ -213,7 +213,7 @@ RSpec.describe Projects::Activity, "core" do
       # project
       # work_package
 
-      expect(latest_activity).to be_within(0.00001).of(wiki_page.updated_at)
+      expect(latest_activity).to equal_time_without_usec(wiki_page.updated_at)
 
       wiki_page.update(updated_at: work_package.updated_at - 10.seconds)
 
@@ -225,7 +225,7 @@ RSpec.describe Projects::Activity, "core" do
       # work_package
       # wiki_page
 
-      expect(latest_activity).to be_within(0.00001).of(news.updated_at)
+      expect(latest_activity).to equal_time_without_usec(news.updated_at)
 
       news.update(updated_at: wiki_page.updated_at - 10.seconds)
 
@@ -237,7 +237,7 @@ RSpec.describe Projects::Activity, "core" do
       # wiki_page
       # news
 
-      expect(latest_activity).to be_within(0.00001).of(changeset.committed_on)
+      expect(latest_activity).to equal_time_without_usec(changeset.committed_on)
 
       changeset.update(committed_on: news.updated_at - 10.seconds)
 
@@ -249,7 +249,7 @@ RSpec.describe Projects::Activity, "core" do
       # news
       # changeset
 
-      expect(latest_activity).to be_within(0.00001).of(message.updated_at)
+      expect(latest_activity).to equal_time_without_usec(message.updated_at)
 
       message.update(updated_at: changeset.committed_on - 10.seconds)
 
@@ -261,7 +261,7 @@ RSpec.describe Projects::Activity, "core" do
       # changeset
       # message
 
-      expect(latest_activity).to be_within(0.00001).of(project.updated_at)
+      expect(latest_activity).to equal_time_without_usec(project.updated_at)
     end
   end
 end

--- a/spec/services/projects/create_service_integration_spec.rb
+++ b/spec/services/projects/create_service_integration_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Projects::CreateService, "integration", type: :model do
           .to be_success
 
         new_project.reload
-        expect(new_project.created_at).to bequal_time_without_usec(created_at)
+        expect(new_project.created_at).to equal_time_without_usec(created_at)
       end
     end
 

--- a/spec/services/work_packages/create_service_integration_spec.rb
+++ b/spec/services/work_packages/create_service_integration_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe WorkPackages::CreateService, "integration", type: :model do
           expect(service_result)
             .to be_success
 
-          expect(new_work_package.created_at).to be_within(1.second).of(created_at)
+          expect(new_work_package.created_at).to equal_time_without_usec(created_at)
         end
       end
 

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -25,48 +25,10 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+RSpec::Matchers.define :equal_time_without_usec do |expected|
+  failure_message { "expected: #{expected.iso8601}, actual: #{actual.iso8601}, difference: #{actual - expected}s" }
 
-require "spec_helper"
-
-RSpec.describe Projects::CreateService, "integration", type: :model do
-  let(:instance) { described_class.new(user:) }
-  let(:new_project) { service_result.result }
-  let(:service_result) { instance.call(**attributes) }
-
-  before do
-    login_as(user)
-  end
-
-  describe "writing created_at timestamp" do
-    shared_let(:user) { create(:admin) }
-
-    let(:created_at) { 11.days.ago }
-
-    let(:attributes) do
-      {
-        name: "test",
-        created_at:
-      }
-    end
-
-    context "when enabled", with_settings: { apiv3_write_readonly_attributes: true } do
-      it "updates the timestamps correctly" do
-        expect(service_result)
-          .to be_success
-
-        new_project.reload
-        expect(new_project.created_at).to bequal_time_without_usec(created_at)
-      end
-    end
-
-    context "when disabled", with_settings: { apiv3_write_readonly_attributes: false } do
-      it "rejects the creation" do
-        expect(service_result)
-          .not_to be_success
-
-        expect(new_project.errors.symbols_for(:created_at))
-          .to contain_exactly(:error_readonly)
-      end
-    end
+  match do |actual|
+    actual.change(usec: 0) == expected.change(usec: 0)
   end
 end


### PR DESCRIPTION
Especially when storing stuff in the database, the micro- and nanoseconds are usually truncated. So when comparing something like `Time.now` with a value stored in the DB, this will never be equal. We "solved" that issue by testing something like `be_within(1.second).of(time)`. That's probably not what we want to test. 

This PR adds a new matcher that truncates the microseconds from a time object and then compares them.