### PR TITLE
Bug/54109 mobile scrolling within a modal scrolls the content underneath

### DIFF
--- a/frontend/src/app/shared/components/modal/modal.service.ts
+++ b/frontend/src/app/shared/components/modal/modal.service.ts
@@ -82,6 +82,7 @@ export class OpModalService {
    * @param notFullscreen
    * @param mobileTopPosition
    * @param target An optional target override for the modal portal outlet
+   * @param anchor An optional HTML element that is fixed on opening the modal
    */
   public show<T extends OpModalComponent>(
     modal:ComponentType<T>,
@@ -90,6 +91,7 @@ export class OpModalService {
     notFullscreen = false,
     mobileTopPosition = false,
     target = PortalOutletTarget.Default,
+    anchor:HTMLElement|null = null,
   ):Observable<T> {
     this.close();
 
@@ -106,7 +108,7 @@ export class OpModalService {
       target,
     });
 
-    this.fixBodyPosition();
+    this.fixElementPosition(anchor);
 
     return this.activeModalInstance$
       .pipe(
@@ -118,23 +120,35 @@ export class OpModalService {
   /**
    * Closes currently open modal window
    */
-  public close():void {
-    this.unfixBodyPosition();
+  public close(anchor:HTMLElement|null = null):void {
+    this.unfixElementPosition(anchor);
 
     this.activeModalData$.next(null);
   }
 
-  private fixBodyPosition():void {
+  private fixElementPosition(element:HTMLElement|null):void {
+    let anchor = document.body;
+
+    if (element !== null) {
+      anchor = element;
+    }
+
     const scrollY:string = document.documentElement.style.getPropertyValue('--scroll-y');
-    this.bodyRenderer.setStyle(document.body, 'position', 'fixed');
-    this.bodyRenderer.setStyle(document.body, 'top', `-${scrollY}`);
+    this.bodyRenderer.setStyle(anchor, 'position', 'fixed');
+    this.bodyRenderer.setStyle(anchor, 'top', `-${scrollY}`);
   }
 
-  private unfixBodyPosition():void {
-    const scrollY:string = document.body.style.top;
+  private unfixElementPosition(element:HTMLElement|null):void {
+    let anchor = document.body;
 
-    this.bodyRenderer.setStyle(document.body, 'position', '');
-    this.bodyRenderer.setStyle(document.body, 'top', '');
+    if (element !== null) {
+      anchor = element;
+    }
+
+    const scrollY:string = anchor.style.top;
+
+    this.bodyRenderer.setStyle(anchor, 'position', '');
+    this.bodyRenderer.setStyle(anchor, 'top', '');
 
     window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
   }

--- a/frontend/src/app/shared/components/modal/modal.service.ts
+++ b/frontend/src/app/shared/components/modal/modal.service.ts
@@ -134,9 +134,9 @@ export class OpModalService {
     const scrollY:string = document.body.style.top;
 
     this.bodyRenderer.setStyle(document.body, 'position', '');
-    this.bodyRenderer.setStyle(document.body, 'top', ``);
+    this.bodyRenderer.setStyle(document.body, 'top', '');
 
-    window.scrollTo(0, parseInt(scrollY || '0') * -1);
+    window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
   }
 
   /**

--- a/frontend/src/app/shared/components/modal/modal.service.ts
+++ b/frontend/src/app/shared/components/modal/modal.service.ts
@@ -58,7 +58,7 @@ export class OpModalService {
 
   constructor(
     private readonly injector:Injector,
-    private readonly rendererFactory:RendererFactory2,
+    readonly rendererFactory:RendererFactory2,
   ) {
     // Listen to keystrokes on window to close context menus
     window.addEventListener('keydown', (evt:KeyboardEvent) => {
@@ -127,23 +127,16 @@ export class OpModalService {
   }
 
   private fixElementPosition(element:HTMLElement|null):void {
-    let anchor = document.body;
-
-    if (element !== null) {
-      anchor = element;
-    }
+    const anchor = element || document.body;
 
     const scrollY:string = document.documentElement.style.getPropertyValue('--scroll-y');
+
     this.bodyRenderer.setStyle(anchor, 'position', 'fixed');
     this.bodyRenderer.setStyle(anchor, 'top', `-${scrollY}`);
   }
 
   private unfixElementPosition(element:HTMLElement|null):void {
-    let anchor = document.body;
-
-    if (element !== null) {
-      anchor = element;
-    }
+    const anchor = element || document.body;
 
     const scrollY:string = anchor.style.top;
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/54109

This fixes the scrolling background when a modal is open. This is achieved by adding and removing an attribute to the body respecting when a modal is open or not.