### PR TITLE
Possible provided_params already symbolized.

### DIFF
--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -78,7 +78,7 @@ module API
 
       def calculate_resulting_params(provided_params)
         calculate_default_params
-          .merge(provided_params.slice("offset", "pageSize").symbolize_keys)
+          .merge(provided_params.symbolize_keys.slice(:offset, :pageSize))
           .tap do |params|
           if query.manually_sorted?
             params[:query_id] = query.id

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -77,22 +77,11 @@ module API
       end
 
       def calculate_resulting_params(provided_params)
-        calculate_default_params
-          .merge(provided_params.symbolize_keys.slice(:offset, :pageSize))
-          .tap do |params|
-          if query.manually_sorted?
-            params[:query_id] = query.id
-            params[:offset] = 1
-            # Force the setting value in all cases except when 0 is requested explicitly. Fetching with pageSize = 0
-            # is done for performance reasons to simply get the query without the results.
-            params[:pageSize] = pageSizeParam(params) == 0 ? pageSizeParam(params) : Setting.forced_single_page_size
-          else
-            params[:offset] = to_i_or_nil(params[:offset])
-            params[:pageSize] = pageSizeParam(params)
-          end
-
-          params[:select] = nested_from_csv(provided_params["select"]) if provided_params["select"]
-        end
+        params = calculate_default_params
+                 .merge(provided_params.symbolize_keys.slice(:offset, :pageSize))
+        handle_offset_paging_params(params)
+        handle_select_params(params, provided_params)
+        params
       end
 
       def calculate_default_params
@@ -172,6 +161,23 @@ module API
             query:
           )
         end
+      end
+
+      def handle_offset_paging_params(params)
+        if query.manually_sorted?
+          params[:query_id] = query.id
+          params[:offset] = 1
+          # Force the setting value in all cases except when 0 is requested explicitly. Fetching with pageSize = 0
+          # is done for performance reasons to simply get the query without the results.
+          params[:pageSize] = pageSizeParam(params) == 0 ? pageSizeParam(params) : Setting.forced_single_page_size
+        else
+          params[:offset] = to_i_or_nil(params[:offset])
+          params[:pageSize] = pageSizeParam(params)
+        end
+      end
+
+      def handle_select_params(params, provided_params)
+        params[:select] = nested_from_csv(provided_params["select"]) if provided_params["select"]
       end
 
       def to_i_or_nil(value)


### PR DESCRIPTION
Which will lead pageSize lost.

Seems in 2019, it already [there](https://github.com/opf/openproject/commit/4ba8cf0ad48d712068a1711c0e2f7af0b79c63e9#diff-b649e6d17c252d0cef9e27b110f8a9d9b6d9d7f571e67eee48088689c4db801bR72).