### PR TITLE
[55230] Transform remove action from share modals to an IconButton

### DIFF
--- a/app/components/work_packages/share/modal_body_component.html.erb
+++ b/app/components/work_packages/share/modal_body_component.html.erb
@@ -79,7 +79,11 @@
                     form_with(url: work_package_shares_bulk_path(@work_package),
                               method: :delete,
                               data: { 'work-packages--share--bulk-selection-target': 'bulkForm' }) do
-                      render(Primer::Beta::Button.new(type: :submit, scheme: :invisible)) { I18n.t('work_package.sharing.remove') }
+                      render(Primer::Beta::IconButton.new(icon: "trash",
+                                                          type: :submit,
+                                                          scheme: :danger,
+                                                          "aria-label": I18n.t('work_package.sharing.remove'),
+                                                          test_selector: 'op-share-wp--bulk-remove'))
                     end
                   )
                 end

--- a/app/components/work_packages/share/share_row_component.html.erb
+++ b/app/components/work_packages/share/share_row_component.html.erb
@@ -28,7 +28,11 @@
 
         user_row_grid.with_area(:remove, tag: :div) do
           form_with url: work_packages_share_path(share), method: :delete do
-            render(Primer::Beta::Button.new(type: :submit, scheme: :link)) { I18n.t('work_package.sharing.remove') }
+            render(Primer::Beta::IconButton.new(icon: "trash",
+                                                type: :submit,
+                                                scheme: :danger,
+                                                "aria-label": I18n.t('work_package.sharing.remove'),
+                                                test_selector: 'op-share-wp--remove'))
           end
         end
       end

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -129,21 +129,21 @@ module Components
 
       def expect_bulk_actions_available
         within shares_header do
-          expect(page).to have_button "Remove"
+          expect(page).to have_test_selector("op-share-wp--bulk-remove")
           expect(page).to have_test_selector("op-share-wp-bulk-update-role")
         end
       end
 
       def expect_bulk_actions_not_available
         within shares_header do
-          expect(page).to have_no_button("Remove", wait: 0)
+          expect(page).not_to have_test_selector("op-share-wp--bulk-remove", wait: 0)
           expect(page).not_to have_test_selector("op-share-wp-bulk-update-role", wait: 0)
         end
       end
 
       def bulk_remove
         within shares_header do
-          click_button "Remove"
+          page.find_test_selector("op-share-wp--bulk-remove").click
         end
       end
 
@@ -238,7 +238,7 @@ module Components
 
       def remove_user(user)
         within user_row(user) do
-          click_button "Remove"
+          page.find_test_selector("op-share-wp--remove").click
         end
       end
 


### PR DESCRIPTION
**Before**
<img width="949" alt="Bildschirmfoto 2024-05-29 um 11 13 42" src="https://github.com/opf/openproject/assets/7457313/bec68a51-23a6-43a1-ae29-e3cbb68a5efc">

**After**
<img width="953" alt="Bildschirmfoto 2024-05-29 um 11 12 54" src="https://github.com/opf/openproject/assets/7457313/8ce6ec98-4feb-4feb-89ef-5e2904ff62bd">


https://community.openproject.org/projects/openproject/work_packages/55230/activity