### PR TITLE
Fetch enough

### DIFF
--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -9,14 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Fetch all commits for PR branch plus head commit of base branch
-        run: |
-          # fetch all commits of the PR branch
-          git fetch --shallow-exclude "${{ github.base_ref }}" origin "${{ github.ref }}"
-          # fix for "fatal: error in object: unshallow"
-          git repack -d
-          # fetch head commit of base branch
-          git fetch --deepen 1 origin "${{ github.ref }}"
+        with:
+          fetch-depth: 2 # we are comparing PR merge head with base
       - uses: ruby/setup-ruby@v1
       - uses: opf/action-rubocop@master
         with:


### PR DESCRIPTION
Fix fetching enough commits of branch upto base.

This probably will fetch more than needed if there are a lot of merges, but much less then whole repository and will not fail if base branch has something merged in it.