### PR TITLE
[#55381] The available_projects api endpoint displays custom fields incorrectly

### DIFF
--- a/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
+++ b/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
@@ -1,0 +1,64 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::Projects::ProjectEagerLoadingWrapper do
+  shared_let(:projects) { create_list(:project, 3) }
+
+  describe ".wrap" do
+    subject(:loaded_projects) { described_class.wrap(projects) }
+
+    it "returns wrapped projects with relations eager loaded" do
+      expect(loaded_projects.size).to eq(projects.size)
+      association_names = %i[@available_custom_fields @ancestors_from_root]
+      loaded_projects.each do |loaded_project|
+        association_names.each do |association|
+          expect(loaded_project.__getobj__.instance_variables).to include(association)
+        end
+      end
+    end
+
+    context "with available custom fields" do
+      let!(:text_project_custom_field) do
+        create :text_project_custom_field, projects: [projects.second, projects.third]
+      end
+
+      let!(:string_project_custom_field) do
+        create :string_project_custom_field, projects: [projects.third]
+      end
+
+      it "returns available custom fields for each project separately" do
+        expect(loaded_projects.first.available_custom_fields).to eq([])
+        expect(loaded_projects.second.available_custom_fields).to eq([text_project_custom_field])
+        expect(loaded_projects.third.available_custom_fields)
+          .to eq([text_project_custom_field, string_project_custom_field])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/versions/available_projects_resource_spec.rb
+++ b/spec/requests/api/v3/versions/available_projects_resource_spec.rb
@@ -29,7 +29,7 @@
 require "spec_helper"
 require "rack/test"
 
-RSpec.describe "API v3 members available projects resource" do
+RSpec.describe "API v3 versions available projects resource" do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 
@@ -78,7 +78,7 @@ RSpec.describe "API v3 members available projects resource" do
 
   subject(:response) { last_response }
 
-  describe "GET api/v3/members/available_projects" do
+  describe "GET api/v3/versions/available_projects" do
     let(:projects) { [manage_project, view_project, unauthorized_project] }
     let(:path) { api_v3_paths.versions_available_projects }
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/55381

Previously if the first project didn't had any custom fields enabled the ProjectEagerLoadingWrapper returned an empty available_custom_fields section for all the projects. The fix consists of returning the available custom fields for each project apart.