### PR TITLE
[fix] api spec replace complete with configured

### DIFF
--- a/docs/api/apiv3/components/examples/storage-nextcloud-response-for-creation.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-response-for-creation.yml
@@ -7,7 +7,7 @@ value:
   hasApplicationPassword: false
   createdAt: '2024-05-21T09:11:53.880Z'
   updatedAt: '2024-05-21T09:11:53.880Z'
-  complete: false
+  configured: false
   _embedded:
     oauthApplication:
       id: 42
@@ -46,7 +46,7 @@ value:
     authorizationState:
       href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
       title: Authorization failed
-    projectStrages:
+    projectStorages:
       href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
     oauthApplication:
       href: /api/v3/oauth_application/42

--- a/docs/api/apiv3/components/examples/storage-nextcloud-response.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-response.yml
@@ -7,7 +7,7 @@ value:
   hasApplicationPassword: true
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
-  complete: true
+  configured: true
   _embedded:
     oauthApplication:
       id: 42
@@ -74,10 +74,7 @@ value:
     authorizationState:
       href: urn:openproject-org:api:v3:storages:authorization:Connected
       title: Connected
-    #    authorize:
-    #      href: https://nextcloud.deathstar.rocks/authorize/
-    #      title: Authorize
-    projectStrages:
+    projectStorages:
       href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
     oauthApplication:
       href: /api/v3/oauth_application/42

--- a/docs/api/apiv3/components/examples/storage-nextcloud-unauthorized-response.yml
+++ b/docs/api/apiv3/components/examples/storage-nextcloud-unauthorized-response.yml
@@ -7,7 +7,7 @@ value:
   hasApplicationPassword: false
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
-  complete: true
+  configured: true
   _embedded:
     oauthApplication:
       id: 42
@@ -61,7 +61,7 @@ value:
     authorize:
       href: https://nextcloud25.local/index.php/apps/oauth2/authorize?client_id=fnrIeJZqqAKGQlejuDaGhSQfCAVtoayHLACWCYcPJ0w17Pp6daPPUktkM9QaGxca&redirect_uri=https://openproject.local/oauth_clients/fnrIeJZqqAKGQlejuDaGhSQfCAVtoayHLACWCYcPJ0w17Pp6daPPUktkM9QaGxca/callback&response_type=code
       title: Authorize
-    projectStrages:
+    projectStorages:
       href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
     oauthApplication:
       href: /api/v3/oauth_application/42

--- a/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
+++ b/docs/api/apiv3/components/examples/storage-one-drive-incomplete-response.yml
@@ -8,7 +8,7 @@ value:
   driveId: null
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
-  complete: false
+  configured: false
   _links:
     self:
       href: /api/v3/storages/1337
@@ -22,7 +22,7 @@ value:
     authorizationState:
       href: urn:openproject-org:api:v3:storages:authorization:FailedAuthorization
       title: Authorization failed
-    projectStrages:
+    projectStorages:
       href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
     oauthClientCredentials:
       href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/examples/storage-one-drive-response.yml
+++ b/docs/api/apiv3/components/examples/storage-one-drive-response.yml
@@ -8,7 +8,7 @@ value:
   driveId: b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
-  complete: true
+  configured: true
   _embedded:
     oauthClientCredentials:
       _type: OAuthClientCredentials
@@ -44,7 +44,7 @@ value:
     authorizationState:
       href: urn:openproject-org:api:v3:storages:authorization:Connected
       title: Connected
-    projectStrages:
+    projectStorages:
       href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
     oauthClientCredentials:
       href: /api/v3/oauth_client_credentials/42

--- a/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
@@ -12,6 +12,7 @@ value:
         _type: Storage
         name: It's no moon
         hasApplicationPassword: true
+        configured: true
         createdAt: '2021-12-20T13:37:00.211Z'
         updatedAt: '2021-12-20T13:37:00.211Z'
         _links:
@@ -31,6 +32,8 @@ value:
           authorize:
             href: https://nextcloud.deathstar.rocks/authorize/
             title: Authorize
+          projectStorages:
+            href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1337"]}}]
           oauthApplication:
             href: /api/v3/oauth_application/42
             title: It's no moon (Nextcloud)
@@ -39,8 +42,11 @@ value:
       - id: 1338
         _type: Storage
         name: EmpireSharepoint
-        createdAt: '2022-12-21T13:37:00.296Z'
-        updatedAt: '2022-12-21T13:37:00.296Z'
+        tenantId: e36f1dbc-fdae-427e-b61b-0d96ddfb81a4
+        driveId: b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK
+        createdAt: '2021-12-20T13:37:00.211Z'
+        updatedAt: '2021-12-20T13:37:00.211Z'
+        configured: true
         _links:
           self:
             href: /api/v3/storages/1338
@@ -53,5 +59,7 @@ value:
           authorizationState:
             href: urn:openproject-org:api:v3:storages:authorization:Connected
             title: Connected
+          projectStorages:
+            href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1338"]}}]
           oauthClientCredentials:
             href: /api/v3/oauth_client_credentials/44

--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -43,7 +43,7 @@ properties:
     type: string
     format: date-time
     description: Time of the most recent change to the storage
-  complete:
+  configured:
     type: boolean
     description: Indication, if the storage is fully configured
   _embedded:


### PR DESCRIPTION
- API spec is not correct after changing implementation to use configured as represented attribute
- some other example improvements on the storages responses
