### PR TITLE
[55318] Convert pt to pt-BR in packaged installations

### DIFF
--- a/packaging/addons/openproject/bin/postinstall
+++ b/packaging/addons/openproject/bin/postinstall
@@ -10,6 +10,11 @@ CLI="${APP_NAME}"
 ${CLI} config:set OPENPROJECT_SEED_ADMIN_USER_MAIL="$(wiz_get "openproject/admin_email" || wiz_get "smtp/admin_email")"
 ${CLI} config:set RECOMPILE_RAILS_ASSETS="true"
 
+# Convert language pt to pt-BR (work packages #53374 and #55318)
+if [ "$(wiz_get "openproject/default_language")" = "pt" ]; then
+        wiz_set "openproject/default_language" "pt-BR"
+fi
+
 # Set the configured default language
 # Will be unset at installation postinstall before restart to ensure the setting is writable
 ${CLI} config:set OPENPROJECT_DEFAULT_LANGUAGE="$(wiz_get "openproject/default_language" || echo "en")"


### PR DESCRIPTION
https://community.openproject.org/wp/55318

If the value "pt" (Portuguese) was selected in the installation wizard, the value is saved in `/etc/openproject/installer.dat`. This value is then used in the postinstall script to set `OPENPROJECT_DEFAULT_LANGUAGE`. But since work package #53374, pt has been split into pt-BR and pt-PT and the app will refuse to start with value pt.

Changing the saved value to pt-BR when it's pt fixes the issue.