### PR TITLE
Merge table helpers and schedule helpers together

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -111,10 +111,6 @@ Rails.application.configure do
 
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}")
 
-  # Spring reloads, and therefore needs the application to not cache classes so
-  # that relaoding can work.
-  config.cache_classes = false
-
   # Use in-memory store for testing
   Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  config.public_file_server.headers = { "Cache-Control" => "public, max-age=3600" }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
@@ -75,11 +75,11 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Silence deprecations early on for testing on CI
-  deprecators.silenced = ENV['CI'].present?
+  deprecators.silenced = ENV["CI"].present?
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation =
-    if ENV['CI']
+    if ENV["CI"]
       :silence
     else
       :stderr
@@ -111,10 +111,14 @@ Rails.application.configure do
 
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}")
 
+  # Spring reloads, and therefore needs the application to not cache classes so
+  # that relaoding can work.
+  config.cache_classes = false
+
   # Use in-memory store for testing
   Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
-  if ENV['TEST_ENV_NUMBER']
+  if ENV["TEST_ENV_NUMBER"]
     assets_cache_path = Rails.root.join("tmp/cache/assets/paralleltests#{ENV['TEST_ENV_NUMBER']}")
     config.assets.cache = Sprockets::Cache::FileStore.new(assets_cache_path)
   end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe StatusesController do
 
           perform_enqueued_jobs
 
-          expect_work_packages([parent, child, other_child], <<~TABLE)
+          expect_work_packages_after_reload([parent, child, other_child], <<~TABLE)
             subject       | status   | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
             parent        | New      |      |                |            |    10h |              10h |           0%
               child       | Rejected |  10h |             5h |        50% |        |                  |
@@ -245,7 +245,7 @@ RSpec.describe StatusesController do
 
           perform_enqueued_jobs
 
-          expect_work_packages([parent, child, other_child], <<~TABLE)
+          expect_work_packages_after_reload([parent, child, other_child], <<~TABLE)
             subject       | status   | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
             parent        | New      |      |                |         0% |    10h |              10h |           0%
               child       | Rejected |  10h |             3h |        70% |        |                  |
@@ -271,7 +271,7 @@ RSpec.describe StatusesController do
 
             perform_enqueued_jobs
 
-            expect_work_packages([parent, child, other_child], <<~TABLE)
+            expect_work_packages_after_reload([parent, child, other_child], <<~TABLE)
               subject       | status   | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
               parent        | New      |      |                |         0% |    10h |              10h |           0%
                 child       | Rejected |  10h |             6h |        40% |        |                  |

--- a/spec/migrations/remove_totals_from_childless_work_packages_spec.rb
+++ b/spec/migrations/remove_totals_from_childless_work_packages_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RemoveTotalsFromChildlessWorkPackages, type: :model do
       end
 
       it "removes totals from childless work packages" do
-        expect_work_packages(table_work_packages.map(&:reload), <<~TABLE)
+        expect_work_packages_after_reload(table_work_packages, <<~TABLE)
           hierarchy               | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
           wp totals set           |   5h |             3h |        40% |        |                  |
           wp only pc set          |      |                |        60% |        |                  |

--- a/spec/migrations/update_progress_calculation_spec.rb
+++ b/spec/migrations/update_progress_calculation_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
 
     run_migration
 
-    table.work_packages.map(&:reload)
-    expect_work_packages(table.work_packages, to)
+    expect_work_packages_after_reload(table.work_packages, to)
 
     table.work_packages
   end
@@ -829,7 +828,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
       end
 
       it "fixes the total values and sets ∑ % complete to nil (not 0) and keeps % complete (unless wrong)" do
-        expect_work_packages(table_work_packages.map(&:reload), <<~TABLE)
+        expect_work_packages_after_reload(table_work_packages, <<~TABLE)
           subject            | work  | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete |
           wp zero            |       |                |          0 |        |                  |              |
           wp correct         |  100h |            50h |         50 |   100h |              50h |           50 |

--- a/spec/services/work_packages/set_schedule_service_working_days_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_working_days_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe WorkPackages::SetScheduleService, "working days" do
 
   context "with a single successor" do
     context "when moving successor will cover non-working days" do
-      let_schedule(<<~CHART)
-        days          | MTWTFSS |
+      let_work_packages(<<~CHART)
+        subject       | MTWTFSS | properties
         work_package  | XX      |
         follower      |   XXX   | follows work_package
       CHART
@@ -56,8 +56,8 @@ RSpec.describe WorkPackages::SetScheduleService, "working days" do
       end
 
       it "extends to a later due date to keep the same duration" do
-        expect_schedule(subject.all_results, <<~CHART)
-          days          | MTWTFSS   |
+        expect_work_packages(subject.all_results, <<~CHART)
+          subject       | MTWTFSS   |
           work_package  | XXXX      |
           follower      |     X..XX |
         CHART

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
                 set_attributes_on(child, field => value)
                 call_update_ancestors_service(child)
 
-                expect_work_packages([parent, child], <<~TABLE)
+                expect_work_packages_after_reload([parent, child], <<~TABLE)
                   | subject | status | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete |
                   | parent  | Open   |  10h |    15h |            10h |              10h |         0% |          33% |
                   |   child | Closed |   5h |        |             0h |                  |       100% |              |
@@ -95,7 +95,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
           end
 
           it "still recomputes child remaining work and updates ancestors total % complete excluding it" do
-            expect_work_packages([parent, child], <<~TABLE)
+            expect_work_packages_after_reload([parent, child], <<~TABLE)
               | subject | status   | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete |
               | parent  | Open     |  10h |    10h |            10h |              10h |         0% |           0% |
               |   child | Rejected |   5h |        |             4h |                  |        20% |              |
@@ -119,7 +119,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
           end
 
           it "sets parent total % complete to 100% and its total remaining work to 0h" do
-            expect_work_packages(table_work_packages, <<~TABLE)
+            expect_work_packages_after_reload(table_work_packages, <<~TABLE)
               hierarchy | status | work | ∑ work | remaining work | ∑ remaining work | % complete | ∑ % complete
               parent    | Open   |      |    15h |                |               0h |         0% |         100%
                 child1  | Closed |  10h |        |             0h |                  |       100% |
@@ -386,7 +386,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
 
       it "updates the totals of the ancestors" do
         subject
-        expect_work_packages([grandparent, parent, sibling, work_package], <<~TABLE)
+        expect_work_packages_after_reload([grandparent, parent, sibling, work_package], <<~TABLE)
           hierarchy        | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
           grandparent      |   3h |           1.5h |        50% |    13h |               5h |          62%
             parent         |   3h |             0h |       100% |    10h |             3.5h |          65%
@@ -447,7 +447,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
 
         it "updates the totals of the ancestors" do
           subject
-          expect_work_packages([grandparent, parent, work_package], <<~TABLE)
+          expect_work_packages_after_reload([grandparent, parent, work_package], <<~TABLE)
             hierarchy        | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
             grandparent      |      |                |            |    10h |               5h |          50%
               parent         |   3h |           1.5h |        50% |    10h |               5h |          50%
@@ -494,7 +494,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
 
       it "updates the totals of the new parent and the former parent" do
         subject
-        expect_work_packages([grandparent, old_parent, new_parent, work_package], <<~TABLE)
+        expect_work_packages_after_reload([grandparent, old_parent, new_parent, work_package], <<~TABLE)
           hierarchy        | work | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete
           grandparent      |      |                |            |    10h |               2h |          80%
             old parent     |      |                |            |        |                  |
@@ -597,7 +597,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
         it "does not update the parent total work" do
           expect(call_result).to be_success
           expect(call_result.dependent_results).to be_empty
-          expect_work_packages([parent.reload], <<~TABLE)
+          expect_work_packages_after_reload([parent], <<~TABLE)
             subject | total work |
             parent  |            |
           TABLE
@@ -693,7 +693,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
         it "does not update the parent total remaining work" do
           expect(call_result).to be_success
           expect(call_result.dependent_results).to be_empty
-          expect_work_packages([parent.reload], <<~TABLE)
+          expect_work_packages_after_reload([parent], <<~TABLE)
             subject | total remaining work
             parent  |
           TABLE

--- a/spec/support/table_helpers/column.rb
+++ b/spec/support/table_helpers/column.rb
@@ -34,6 +34,8 @@ require_relative "column_type/with_identifier_metadata"
 require_relative "column_type/duration"
 require_relative "column_type/hierarchy"
 require_relative "column_type/percentage"
+require_relative "column_type/properties"
+require_relative "column_type/schedule"
 require_relative "column_type/status"
 require_relative "column_type/subject"
 
@@ -49,6 +51,8 @@ module TableHelpers
       done_ratio: ColumnType::Percentage,
       derived_done_ratio: ColumnType::Percentage,
       hierarchy: ColumnType::Hierarchy,
+      properties: ColumnType::Properties,
+      schedule: ColumnType::Schedule,
       status: ColumnType::Status,
       subject: ColumnType::Subject,
       __fallback__: ColumnType::Generic
@@ -82,6 +86,10 @@ module TableHelpers
         :derived_done_ratio
       when /end date/i
         :due_date
+      when /.*MTWTFSS.*/
+        :schedule
+      when /\s*properties\s*/
+        :properties
       when /status/, /hierarchy/
         to_identifier(header)
       else
@@ -103,7 +111,7 @@ module TableHelpers
       @column_type ||= COLUMN_TYPES.fetch(attribute, COLUMN_TYPES[:__fallback__]).new
     end
 
-    delegate :format, :cell_format, to: :column_type
+    delegate :format, :align, to: :column_type
 
     def attributes_for_work_package(work_package)
       column_type.attributes_for_work_package(attribute, work_package)

--- a/spec/support/table_helpers/column_type/duration.rb
+++ b/spec/support/table_helpers/column_type/duration.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Column type used for values that represent a duration like work and
+    # remaining work.
+    #
+    # Parse hours or plain floats, for instance "2", "2h", or "3.5".
+    # Format to hours, for instance "2h" or "3.5h".
+    class Duration < Generic
+      def text_align
+        :rjust
+      end
+
+      def format(value)
+        if value.nil?
+          ""
+        elsif value == value.truncate
+          "%sh" % value.to_i
+        else
+          "%sh" % value
+        end
+      end
+
+      def parse(raw_value)
+        raw_value.blank? ? nil : raw_value.to_f
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/generic.rb
+++ b/spec/support/table_helpers/column_type/generic.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    class Generic
+      def text_align
+        :ljust
+      end
+
+      def format(value)
+        value.to_s
+      end
+
+      def cell_format(value, size)
+        format(value).send(text_align, size)
+      end
+
+      def parse(raw_value)
+        raw_value.strip
+      end
+
+      # Extracts attributes data and metadata from the work package data read
+      # from a table.
+      def extract_data(attribute, raw_header, work_package_data, work_packages_data)
+        raw_value = work_package_data.dig(:row, raw_header)
+
+        {
+          attributes: attributes_for_raw_value(attribute, raw_value, work_package_data, work_packages_data),
+          **metadata_for_raw_value(raw_value)
+        }
+      end
+
+      # Extracts attribute values data from a work package.
+      #
+      # The values are to be displayed in the table.
+      #
+      # Override if:
+      # - multiple attributes are extracted from a work package for a column
+      #   type (for instance `Hierarchy` column type extracts both `subject` and
+      #   `parent` attributes)
+      # - or if the value is not read from a work package attribute, but from
+      #   one of its relations (for instance, `Status` column type reads
+      #   `work_package.status.name` to have a string value, because
+      #   `work_package.status` alone is not a string).
+      def attributes_for_work_package(attribute, work_package)
+        { attribute => work_package.read_attribute(attribute) }
+      end
+
+      # Extracts attribute values data from the raw value read from a cell.
+      #
+      # Override if:
+      # - multiple attributes are extracted from a single cell raw value for a
+      #   column type (for instance `Hierarchy` column type extracts both
+      #   `subject` and `parent` attributes)
+      def attributes_for_raw_value(attribute, raw_value, _data, _work_packages_data)
+        { attribute => parse(raw_value) }
+      end
+
+      # Extracts metadata from the raw value read from a cell.
+      #
+      # The metadata is useful to store additional information about the row.
+      #
+      # Override when needing to store additional metadata. For instance the
+      # `Subject` column type stores the work package identifier as metadata.
+      def metadata_for_raw_value(_raw_value)
+        {}
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/generic.rb
+++ b/spec/support/table_helpers/column_type/generic.rb
@@ -39,8 +39,8 @@ module TableHelpers
         value.to_s
       end
 
-      def cell_format(value, size)
-        format(value).send(text_align, size)
+      def align(text, size)
+        text.send(text_align, size)
       end
 
       def parse(raw_value)

--- a/spec/support/table_helpers/column_type/hierarchy.rb
+++ b/spec/support/table_helpers/column_type/hierarchy.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Adds the `:identifier` metadata to the row.
+    #
+    # The `:identifier` value is the key being used to identify a work package
+    # by its variable name. It's also the variable name to be used when using
+    # the work packages in the tests.
+    class Hierarchy < Generic
+      include WithIdentifierMetadata
+
+      def attributes_for_work_package(_attribute, work_package)
+        {
+          parent: to_identifier(work_package.parent&.subject),
+          subject: work_package.subject
+        }
+      end
+
+      def attributes_for_raw_value(_attribute, raw_value, data, work_packages_data)
+        {
+          parent: find_parent(raw_value, data, work_packages_data),
+          subject: parse(raw_value)
+        }
+      end
+
+      def metadata_for_raw_value(raw_value)
+        super.merge(hierarchy_indent: hierarchy_indent(raw_value))
+      end
+
+      private
+
+      def hierarchy_indent(raw_value)
+        raw_value[/\A */].size
+      end
+
+      def find_parent(raw_value, data, work_packages_data)
+        hierarchy_indent = hierarchy_indent(raw_value)
+        return if hierarchy_indent == 0
+
+        work_packages_data
+            .slice(0, data[:index])
+            .reverse
+            .find { _1[:hierarchy_indent] < hierarchy_indent }
+            .then { _1&.fetch(:identifier) }
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/percentage.rb
+++ b/spec/support/table_helpers/column_type/percentage.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module TableHelpers
+  module ColumnType
+    # Column type used for values that represent a percentage like % complete.
+    #
+    # Parse percentage or plain integers, for instance "10", "20%", or "100%".
+    # Format to percentage, for instance "2%" or "35%".
+    class Percentage < Generic
+      def text_align
+        :rjust
+      end
+
+      def format(value)
+        if value.nil?
+          ""
+        else
+          "%s%%" % value.to_i
+        end
+      end
+
+      def parse(raw_value)
+        raw_value.blank? ? nil : raw_value.to_i
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/properties.rb
+++ b/spec/support/table_helpers/column_type/properties.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Column to add properties to work packages like "follows wp1 with lag 2".
+    #
+    # Supported properties:
+    #   - follows :wp
+    #   - follows :wp with lag :int
+    #
+    # Example:
+    #
+    #   | subject   | properties              |
+    #   | main      |                         |
+    #   | follower  | follows main with lag 2 |
+    #   | follower2 | follows follower        |
+    #
+    # Adapted from original implementation in `spec/support/schedule_helpers/chart_builder.rb`.
+    class Properties < Generic
+      def attributes_for_work_package(_attribute, _work_package)
+        {}
+      end
+
+      def extract_data(_attribute, raw_header, work_package_data, _work_packages_data)
+        properties = work_package_data.dig(:row, raw_header)
+        properties = properties.split(",").map(&:strip).compact_blank
+        parse_properties(properties)
+      end
+
+      def parse_properties(properties)
+        properties.reduce({}) do |data, property|
+          case parse_property(property)
+          in {relations: relation}
+            data[:relations] ||= []
+            data[:relations] << relation
+          end
+          data
+        end
+      end
+
+      def relations_for_raw_value(raw_value)
+        raw_value.split
+        {}
+      end
+
+      def parse_property(property)
+        case property
+        when /^follows (\w+)(?: with lag (\d+))?/
+          {
+            relations: {
+              raw: property,
+              type: :follows,
+              predecessor: $1,
+              lag: $2.to_i
+            }
+          }
+        else
+          spell_checker = DidYouMean::SpellChecker.new(
+            dictionary: [
+              "follows :wp",
+              "follows :wp with lag :int"
+            ]
+          )
+          suggestions = spell_checker.correct(property).map(&:inspect).join(" ")
+          did_you_mean = " Did you mean #{suggestions} instead?" if suggestions.present?
+          raise "unable to parse property #{property.inspect}.#{did_you_mean}"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/schedule.rb
+++ b/spec/support/table_helpers/column_type/schedule.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Column to specify start date and due date using an ascii calendar.
+    #
+    # The title of the column is "MTWTFSS" to represent the days of the week.
+    #
+    # The Monday is the next occuring Monday meaning the dates can be different
+    # from one test run to another. To always use the same dates please use
+    # `travel_to` with a fixed date.
+    #
+    # Use 'X' to mark the days from start to due date. Only the first and last
+    # 'X' are considered as start and due dates.
+    # Use '[' to mark the start date only and ']' for the due date only.
+    # Any other character is ignored
+    #
+    # Example:
+    #
+    #   | subject                   | MTWTFSS   |
+    #   | main                      | XXX       |
+    #   | crossing non working days |  XXXX..XX |
+    #   | start date only           | [         |
+    #   | due date only             |     ]     |
+    #   | no dates                  |           |
+    #
+    # Adapted from original implementation in `spec/support/schedule_helpers/chart_builder.rb`.
+    class Schedule < Generic
+      def attributes_for_work_package(_attribute, work_package)
+        {
+          start_date: work_package.start_date,
+          due_date: work_package.due_date
+        }
+      end
+
+      def extract_data(_attribute, raw_header, work_package_data, _work_packages_data)
+        raw_value = work_package_data.dig(:row, raw_header)
+
+        {
+          attributes: scheduling_attributes(raw_header, raw_value),
+          **metadata_for_raw_value(raw_value)
+        }
+      end
+
+      private
+
+      def scheduling_attributes(reference, timespan)
+        nb_days_from_origin_monday = reference.index("M")
+
+        start_pos = timespan.index("[") || timespan.index("X")
+        due_pos = timespan.rindex("]") || timespan.rindex("X")
+        {
+          start_date: start_pos && (current_monday - nb_days_from_origin_monday + start_pos),
+          due_date: due_pos && (current_monday - nb_days_from_origin_monday + due_pos)
+        }
+      end
+
+      def current_monday
+        Date.current.next_occurring(:monday)
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/status.rb
+++ b/spec/support/table_helpers/column_type/status.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    class Status < Generic
+      def attributes_for_work_package(_attribute, work_package)
+        { status: work_package.status.name }
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/subject.rb
+++ b/spec/support/table_helpers/column_type/subject.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    class Subject < Generic
+      include WithIdentifierMetadata
+    end
+  end
+end

--- a/spec/support/table_helpers/column_type/with_identifier_metadata.rb
+++ b/spec/support/table_helpers/column_type/with_identifier_metadata.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Adds the `:identifier` metadata to the row.
+    #
+    # The `:identifier` value is the key being used to identify a work package
+    # by its variable name. It's also the variable name to be used when using
+    # the work packages in the tests.
+    module WithIdentifierMetadata
+      include Identifier
+
+      def metadata_for_raw_value(raw_value, *)
+        super.merge(identifier: to_identifier(raw_value))
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/example_methods.rb
+++ b/spec/support/table_helpers/example_methods.rb
@@ -51,13 +51,42 @@ module TableHelpers
 
     # Expect the given work packages to match a visual table representation.
     #
+    # It uses +match_table+ internally. It does not reload the work packages
+    # before comparing. To reload, use `expect_work_packages_after_reload`
+    #
+    # For instance:
+    #
+    #   it 'is scheduled' do
+    #     expect_work_packages(work_packages, <<~TABLE)
+    #       subject | work | derived work |
+    #       parent  |   1h |           3h |
+    #       child   |   2h |           2h |
+    #     TABLE
+    #   end
+    #
+    # is equivalent to:
+    #
+    #   it 'is scheduled' do
+    #     expect(work_packages).to match_table(<<~TABLE)
+    #       subject | work | derived work |
+    #       parent  |   1h |           3h |
+    #       child   |   2h |           2h |
+    #     TABLE
+    #   end
+    def expect_work_packages(work_packages, table_representation)
+      expect(work_packages).to match_table(table_representation)
+    end
+
+    # Expect the given work packages to match a visual table representation
+    # after being reloaded.
+    #
     # It uses +match_table+ internally and reloads the work packages from
     # database before comparing.
     #
     # For instance:
     #
     #   it 'is scheduled' do
-    #     expect_work_packages(work_packages, <<~TABLE)
+    #     expect_work_packages_after_reload(work_packages, <<~TABLE)
     #       subject | work | derived work |
     #       parent  |   1h |           3h |
     #       child   |   2h |           2h |
@@ -74,9 +103,9 @@ module TableHelpers
     #       child   |   2h |           2h |
     #     TABLE
     #   end
-    def expect_work_packages(work_packages, table_representation)
+    def expect_work_packages_after_reload(work_packages, table_representation)
       work_packages.each(&:reload)
-      expect(work_packages).to match_table(table_representation)
+      expect_work_packages(work_packages, table_representation)
     end
   end
 end

--- a/spec/support_spec/table_helpers/column_type/duration_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/duration_spec.rb
@@ -30,57 +30,35 @@
 
 require "spec_helper"
 
-module TableHelpers::Column
-  RSpec.describe Generic do
-    subject(:column) { described_class.new(header: "Some header") }
-
-    describe "#format" do
-      it "renders the value as string" do
-        expect(column.format("hello")).to eq "hello"
-        expect(column.format(42)).to eq "42"
-        expect(column.format(3.5)).to eq "3.5"
-        expect(column.format(nil)).to eq ""
-        expect(column.format(true)).to eq "true"
-      end
-    end
-
-    describe "#cell_format" do
-      it "renders the value on the left side of the cell" do
-        expect(column.cell_format("hello", 0)).to eq "hello"
-        expect(column.cell_format("hello", 10)).to eq "hello     "
-        expect(column.cell_format("hello", 20)).to eq "hello               "
-      end
-    end
-  end
-
+module TableHelpers::ColumnType
   RSpec.describe Duration do
-    subject(:column) { described_class.new(header: "Duration in hours") }
+    subject(:column_type) { described_class.new }
 
     describe "#parse" do
       it "parses empty string as nil" do
-        expect(column.parse("")).to be_nil
+        expect(column_type.parse("")).to be_nil
       end
     end
 
     describe "#format" do
       it 'renders the duration with a "h" suffix' do
-        expect(column.format(3.5)).to eq "3.5h"
+        expect(column_type.format(3.5)).to eq "3.5h"
       end
 
       it "renders the duration without the decimal part if the decimal part is 0" do
-        expect(column.format(3.0)).to eq "3h"
+        expect(column_type.format(3.0)).to eq "3h"
       end
 
       it "renders nothing if nil" do
-        expect(column.format(nil)).to eq ""
+        expect(column_type.format(nil)).to eq ""
       end
     end
 
     describe "#cell_format" do
       it "renders the duration on the right side of the cell" do
-        expect(column.cell_format(3.5, 0)).to eq "3.5h"
-        expect(column.cell_format(3.5, 10)).to eq "      3.5h"
-        expect(column.cell_format(3.5, 20)).to eq "                3.5h"
+        expect(column_type.cell_format(3.5, 0)).to eq "3.5h"
+        expect(column_type.cell_format(3.5, 10)).to eq "      3.5h"
+        expect(column_type.cell_format(3.5, 20)).to eq "                3.5h"
       end
     end
   end

--- a/spec/support_spec/table_helpers/column_type/duration_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/duration_spec.rb
@@ -54,11 +54,11 @@ module TableHelpers::ColumnType
       end
     end
 
-    describe "#cell_format" do
+    describe "#align" do
       it "renders the duration on the right side of the cell" do
-        expect(column_type.cell_format(3.5, 0)).to eq "3.5h"
-        expect(column_type.cell_format(3.5, 10)).to eq "      3.5h"
-        expect(column_type.cell_format(3.5, 20)).to eq "                3.5h"
+        expect(column_type.align("3.5h", 0)).to eq "3.5h"
+        expect(column_type.align("3.5h", 10)).to eq "      3.5h"
+        expect(column_type.align("3.5h", 20)).to eq "                3.5h"
       end
     end
   end

--- a/spec/support_spec/table_helpers/column_type/generic_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/generic_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Generic do
+    subject(:column_type) { described_class.new }
+
+    describe "#format" do
+      it "renders the value as string" do
+        expect(column_type.format("hello")).to eq "hello"
+        expect(column_type.format(42)).to eq "42"
+        expect(column_type.format(3.5)).to eq "3.5"
+        expect(column_type.format(nil)).to eq ""
+        expect(column_type.format(true)).to eq "true"
+      end
+    end
+
+    describe "#cell_format" do
+      it "renders the value on the left side of the cell" do
+        expect(column_type.cell_format("hello", 0)).to eq "hello"
+        expect(column_type.cell_format("hello", 10)).to eq "hello     "
+        expect(column_type.cell_format("hello", 20)).to eq "hello               "
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/generic_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/generic_spec.rb
@@ -44,11 +44,11 @@ module TableHelpers::ColumnType
       end
     end
 
-    describe "#cell_format" do
+    describe "#align" do
       it "renders the value on the left side of the cell" do
-        expect(column_type.cell_format("hello", 0)).to eq "hello"
-        expect(column_type.cell_format("hello", 10)).to eq "hello     "
-        expect(column_type.cell_format("hello", 20)).to eq "hello               "
+        expect(column_type.align("hello", 0)).to eq "hello"
+        expect(column_type.align("hello", 10)).to eq "hello     "
+        expect(column_type.align("hello", 20)).to eq "hello               "
       end
     end
   end

--- a/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Hierarchy do
+    subject(:column_type) { described_class.new }
+
+    describe "#extract_data" do
+      let(:attribute) { :hierarchy }
+      let(:subject_raw_header) { "Hierarchy    " }
+      let(:work_packages_data) do
+        [
+          {
+            index: 0,
+            row: { subject_raw_header => "Parent        " }
+          },
+          {
+            index: 1,
+            row: { subject_raw_header => "  Child1      " }
+          },
+          {
+            index: 2,
+            row: { subject_raw_header => "  Child2      " }
+          },
+          {
+            index: 3,
+            row: { subject_raw_header => "     Grand Child" }
+          }
+        ]
+      end
+
+      it "extracts the identifier metadata along with the :subject attribute value" do
+        # check first row only
+        expect(column_type.extract_data(attribute, subject_raw_header, work_packages_data.first, work_packages_data))
+          .to include({ attributes: a_hash_including(subject: "Parent"),
+                        identifier: :parent })
+      end
+
+      it "extracts the hierarchy_indent metadata as the number of spaces before the name, " \
+         "and the :parent attribute value holding the identifier of the parent from previous rows" do
+        # first row
+        work_package_data = work_packages_data.first
+        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        expect(row_extract).to include({ attributes: a_hash_including(parent: nil),
+                                         hierarchy_indent: 0 })
+
+        # second row
+        work_package_data.deep_merge!(row_extract)
+        work_package_data = work_packages_data.second
+        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        expect(row_extract).to include({ attributes: a_hash_including(parent: :parent),
+                                         hierarchy_indent: 2,
+                                         identifier: :child1 })
+
+        # third row
+        work_package_data.deep_merge!(row_extract)
+        work_package_data = work_packages_data.third
+        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        expect(row_extract).to include({ attributes: a_hash_including(parent: :parent),
+                                         hierarchy_indent: 2,
+                                         identifier: :child2 })
+
+        # fourth row
+        work_package_data.deep_merge!(row_extract)
+        work_package_data = work_packages_data.fourth
+        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        expect(row_extract).to include({ attributes: a_hash_including(parent: :child2),
+                                         hierarchy_indent: 5,
+                                         identifier: :grand_child })
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/percentage_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/percentage_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Percentage do
+    subject(:column_type) { described_class.new }
+
+    describe "#parse" do
+      it "parses empty string as nil" do
+        expect(column_type.parse("")).to be_nil
+      end
+    end
+
+    describe "#format" do
+      it 'renders the percentage with a "%" suffix' do
+        expect(column_type.format(30)).to eq "30%"
+        expect(column_type.format(30.9)).to eq "30%"
+      end
+
+      it "renders nothing if nil" do
+        expect(column_type.format(nil)).to eq ""
+      end
+    end
+
+    describe "#cell_format" do
+      it "renders the percentage on the right side of the cell" do
+        expect(column_type.cell_format(20, 0)).to eq "20%"
+        expect(column_type.cell_format(35, 10)).to eq "       35%"
+        expect(column_type.cell_format(57, 20)).to eq "                 57%"
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/percentage_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/percentage_spec.rb
@@ -51,11 +51,11 @@ module TableHelpers::ColumnType
       end
     end
 
-    describe "#cell_format" do
+    describe "#align" do
       it "renders the percentage on the right side of the cell" do
-        expect(column_type.cell_format(20, 0)).to eq "20%"
-        expect(column_type.cell_format(35, 10)).to eq "       35%"
-        expect(column_type.cell_format(57, 20)).to eq "                 57%"
+        expect(column_type.align("20%", 0)).to eq "20%"
+        expect(column_type.align("35%", 10)).to eq "       35%"
+        expect(column_type.align("57%", 20)).to eq "                 57%"
       end
     end
   end

--- a/spec/support_spec/table_helpers/column_type/properties_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/properties_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Properties do
+    subject(:column_type) { described_class.new }
+
+    def parsed_data(table)
+      TableHelpers::TableParser.new.parse(table)
+    end
+
+    describe "empty" do
+      it "stores nothing when empty" do
+        work_package_data = parsed_data(<<~TABLE).first
+          | properties |
+          |            |
+        TABLE
+        expect(work_package_data[:relations]).to be_nil
+        expect(work_package_data[:attributes]).to be_empty
+
+        work_package_data = parsed_data(<<~TABLE).first
+          | properties
+          |
+        TABLE
+        expect(work_package_data[:relations]).to be_nil
+        expect(work_package_data[:attributes]).to be_empty
+      end
+    end
+
+    describe "follows <predecessor> [with lag <nb_days>]" do
+      it "stores follows relations in work_package_data" do
+        work_package_data = parsed_data(<<~TABLE).first
+          | properties              |
+          | follows main with lag 3 |
+        TABLE
+        expect(work_package_data[:relations])
+          .to eq([{ raw: "follows main with lag 3", type: :follows, predecessor: "main", lag: 3 }])
+      end
+
+      it "has a default lag of 0 days when not specified" do
+        work_package_data = parsed_data(<<~TABLE).first
+          | properties   |
+          | follows main |
+        TABLE
+        expect(work_package_data[:relations])
+          .to eq([{ raw: "follows main", type: :follows, predecessor: "main", lag: 0 }])
+      end
+
+      it "can store multiple relations" do
+        work_package_data = parsed_data(<<~TABLE).first
+          | properties               |
+          | follows wp1, follows wp2 |
+        TABLE
+        expect(work_package_data[:relations])
+          .to eq([
+                   { raw: "follows wp1", type: :follows, predecessor: "wp1", lag: 0 },
+                   { raw: "follows wp2", type: :follows, predecessor: "wp2", lag: 0 }
+                 ])
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/schedule_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/schedule_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Schedule do
+    let(:fake_today) { Date.new(2022, 6, 16) } # Thursday 16 June 2022
+    let(:monday) { Date.new(2022, 6, 20) } # Monday 20 June
+    let(:tuesday) { Date.new(2022, 6, 21) }
+    let(:wednesday) { Date.new(2022, 6, 22) }
+    let(:thursday) { Date.new(2022, 6, 23) }
+    let(:friday) { Date.new(2022, 6, 24) }
+    let(:saturday) { Date.new(2022, 6, 25) }
+    let(:sunday) { Date.new(2022, 6, 26) }
+
+    def parsed_attributes(table)
+      work_packages_data = TableHelpers::TableParser.new.parse(table)
+      work_packages_data.pluck(:attributes)
+    end
+
+    before do
+      travel_to(fake_today)
+    end
+
+    describe "origin day" do
+      it "is identified by the 'M' in 'MTWTFSS' in the header and corresponds to the next monday" do
+        expect(parsed_attributes(<<~TABLE))
+          |   MTWTFSS |
+          |   X       |
+        TABLE
+          .to eq([{ start_date: monday, due_date: monday }])
+      end
+
+      it "is not identified by mtwtfss which can be used as documentation instead" do
+        expect(parsed_attributes(<<~TABLE))
+          | mtwtfssMTWTFSSmtwtfss |
+          |        X              |
+        TABLE
+          .to eq([{ start_date: monday, due_date: monday }])
+      end
+    end
+
+    describe "work package dates extraction" do
+      def parsed_attributes(table)
+        work_packages_data = TableHelpers::TableParser.new.parse(table)
+        work_packages_data.pluck(:attributes)
+      end
+
+      it "recognizes multiple 'X' as the duration spanning from start date and end date" do
+        expect(parsed_attributes(<<~TABLE))
+          | MTWTFSS |
+          | XX      |
+        TABLE
+          .to eq([{ start_date: monday, due_date: tuesday }])
+      end
+
+      it "recognizes start date and end date outside of the reference week" do
+        expect(parsed_attributes(<<~TABLE))
+          |     MTWTFSS   |
+          |        XXXXXX |
+          | XXXXXX        |
+        TABLE
+          .to eq([
+                   { start_date: thursday, due_date: tuesday + 7.days },
+                   { start_date: thursday - 7.days, due_date: tuesday }
+                 ])
+      end
+
+      it "recognizes '[' as start date, making the due date nil if there are no 'X' or ']' after it" do
+        expect(parsed_attributes(<<~TABLE))
+          | MTWTFSS |
+          |  [      |
+        TABLE
+          .to eq([{ start_date: tuesday, due_date: nil }])
+      end
+
+      it "recognizes ']' as end date, making the start date nil if there are no 'X' or '[' before it" do
+        expect(parsed_attributes(<<~TABLE))
+          | MTWTFSS |
+          |    ]    |
+        TABLE
+          .to eq([{ start_date: nil, due_date: thursday }])
+      end
+
+      it "sets start date and due date to nil if there are no 'X', '[', or ']' at all" do
+        expect(parsed_attributes(<<~TABLE))
+          | MTWTFSS |
+          |         |
+        TABLE
+          .to eq([{ start_date: nil, due_date: nil }])
+      end
+
+      it "ignores characters other than 'X', '[', or ']', allowing to use other characters to " \
+         "represent other things (like '.' for non-working days)" do
+        expect(parsed_attributes(<<~TABLE))
+          | MTWTFSS   |
+          |    XX..XX |
+        TABLE
+          .to include(start_date: thursday, due_date: tuesday + 7.days)
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/status_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/status_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Status do
+    subject(:column_type) { described_class.new }
+
+    describe "#attributes_for_work_package" do
+      let(:status) { build(:status, name: "New") }
+      let(:work_package) { build(:work_package, status:) }
+
+      it "uses the status name as the value for status attribute" do
+        expect(column_type.attributes_for_work_package(:status, work_package))
+          .to eq(status: "New")
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/column_type/subject_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/subject_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe Subject do
+    subject(:column_type) { described_class.new }
+
+    describe "#extract_data" do
+      it "extracts the identifier metadata along with the :subject attribute value" do
+        attribute = :subject
+        subject_raw_header = "subject   "
+        work_packages_data =
+          [
+            {
+              index: 0,
+              row: { subject_raw_header => "  Work package 2  " }
+            }
+          ]
+        work_package_data = work_packages_data.first
+
+        expect(column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data))
+          .to eq({ attributes: { subject: "Work package 2" },
+                   identifier: :work_package2 })
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/table_data_spec.rb
+++ b/spec/support_spec/table_helpers/table_data_spec.rb
@@ -71,6 +71,31 @@ module TableHelpers
         expect(table_data.values_for_attribute(:remaining_hours)).to eq([3.0, nil])
         expect(table_data.work_package_identifiers).to eq(%i[work_package another_one])
       end
+
+      it "can read schedule column data from work packages" do
+        expected_table = <<~TABLE
+          | subject        |   MTWTFSS |
+          | work package 1 | XXX       |
+          | work package 2 |       ]   |
+        TABLE
+
+        columns = described_class.for(expected_table).columns
+        monday = Date.current.next_occurring(:monday)
+        work_package1 = build(:work_package, subject: "work package 1",
+                                             start_date: monday - 2, due_date: monday)
+        work_package2 = build(:work_package, subject: "work package 2",
+                                             start_date: nil, due_date: monday + 4)
+
+        table_data = described_class.from_work_packages([work_package1, work_package2], columns)
+        expect(table_data.work_packages_data.size).to eq(2)
+        expect(table_data.columns.size).to eq(2)
+        expect(table_data.headers).to eq(["subject", "MTWTFSS"])
+        expect(table_data.values_for_attribute(:start_date))
+          .to eq([monday - 2, nil])
+        expect(table_data.values_for_attribute(:due_date))
+          .to eq([monday, monday + 4])
+        expect(table_data.work_package_identifiers).to eq(%i[work_package1 work_package2])
+      end
     end
 
     describe "#headers" do
@@ -112,18 +137,43 @@ module TableHelpers
     end
 
     describe "#create_work_packages" do
+      let(:monday) { Date.current.next_occurring(:monday) }
+
       it "creates work packages out of the table data" do
         status = create(:status, name: "To do")
         table_representation = <<~TABLE
-          subject | status | work |
-          My wp   | To do  |   5h |
+          subject | status | work | MTWTFSS |
+          My wp   | To do  |   5h | XXX     |
         TABLE
 
         table_data = described_class.for(table_representation)
         table = table_data.create_work_packages
         expect(table.work_packages.count).to eq(1)
         expect(table.work_package(:my_wp))
-          .to have_attributes(subject: "My wp", status:, estimated_hours: 5.0)
+          .to have_attributes(
+            subject: "My wp",
+            status:,
+            estimated_hours: 5.0,
+            start_date: monday,
+            due_date: monday + 2.days
+          )
+      end
+
+      it "creates relations between work packages out of the table data" do
+        table_representation = <<~TABLE
+          subject  | properties
+          main     |
+          follower | follows main with lag 2
+        TABLE
+
+        table_data = described_class.for(table_representation)
+        table = table_data.create_work_packages
+        expect(table.work_packages.count).to eq(2)
+        main = table.work_package(:main)
+        follower = table.work_package(:follower)
+        expect(follower.follows_relations.count).to eq(1)
+        expect(follower.follows_relations.first.to).to eq(main)
+        expect(follower.follows_relations.first.lag).to eq(2)
       end
 
       it "raises an error if a given status name does not exist" do

--- a/spec/support_spec/table_helpers/table_parser_spec.rb
+++ b/spec/support_spec/table_helpers/table_parser_spec.rb
@@ -82,13 +82,15 @@ RSpec.describe TableHelpers::TableParser do
       .to raise_error(ArgumentError, "Too many cells in row 1, have you forgotten some headers?")
   end
 
-  it "is ok to have more headers than cells (value of missing cells will be nil)" do
+  it "is ok to have more headers than cells (raw values of missing cells will be empty strings)" do
     table = <<~TABLE
       subject | work | remaining work
       wp      |   4h
     TABLE
     parsed_data = described_class.new.parse(table)
+    expect(parsed_data.dig(0, :row, " work ")).to eq("   4h")
     expect(parsed_data.dig(0, :attributes, :estimated_hours)).to eq(4.0)
+    expect(parsed_data.dig(0, :row, " remaining work")).to eq("")
     expect(parsed_data.dig(0, :attributes, :remaining_hours)).to be_nil
   end
 

--- a/spec/support_spec/table_helpers/table_representer_spec.rb
+++ b/spec/support_spec/table_helpers/table_representer_spec.rb
@@ -100,5 +100,68 @@ module TableHelpers
         TABLE
       end
     end
+
+    describe "schedule column" do
+      let(:table) do
+        <<~TABLE
+          | subject |   MTWTFSS   |
+          | wp1     |   X         |
+          | wp2     |     [       |
+          | wp3     |       ]     |
+          | wp4     |             |
+          | wp5     |    XXX      |
+          | wp6     | X           |
+          | wp7     |           X |
+          | wp8     |           X |
+        TABLE
+      end
+      let(:columns) { [Column.for("MTWTFSS")] }
+
+      it "is rendered as a schedule" do
+        expect(representer.render(table_data)).to eq <<~TABLE
+          |   MTWTFSS   |
+          |   X         |
+          |     [       |
+          |       ]     |
+          |             |
+          |    XXX      |
+          | X           |
+          |           X |
+          |           X |
+        TABLE
+      end
+
+      context "when using a second table for the size" do
+        let(:twin_table) do
+          <<~TABLE
+            | subject | MTWTFSS          |
+            | wp5     |  XXX             |
+            | wp9     |               XX |
+          TABLE
+        end
+        let(:twin_table_data) { TableData.for(twin_table) }
+
+        let(:tables_data) { [table_data, twin_table_data] }
+
+        it "adapts the column size to the largest of both tables so they are diffable" do
+          expect(representer.render(table_data)).to eq <<~TABLE
+            |   MTWTFSS          |
+            |   X                |
+            |     [              |
+            |       ]            |
+            |                    |
+            |    XXX             |
+            | X                  |
+            |           X        |
+            |           X        |
+          TABLE
+          expect(representer.render(twin_table_data)).to eq <<~TABLE
+            |   MTWTFSS          |
+            |    XXX             |
+            |                 XX |
+          TABLE
+        end
+      end
+    end
   end
 end

--- a/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
+++ b/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob do
 
     job.perform_now(cause_type:, status_name:, status_id:, changes:)
 
-    table.work_packages.map(&:reload)
-    expect_work_packages(table.work_packages, to)
+    expect_work_packages_after_reload(table.work_packages, to)
 
     table.work_packages
   end

--- a/spec/workers/work_packages/progress/apply_total_percent_complete_mode_change_job_spec.rb
+++ b/spec/workers/work_packages/progress/apply_total_percent_complete_mode_change_job_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe WorkPackages::Progress::ApplyTotalPercentCompleteModeChangeJob do
 
     job.perform_now(cause_type:, mode:)
 
-    table.work_packages.map(&:reload)
-    expect_work_packages(table.work_packages, to)
+    expect_work_packages_after_reload(table.work_packages, to)
 
     table.work_packages
   end

--- a/spec/workers/work_packages/progress/migrate_remove_totals_from_childless_work_packages_job_spec.rb
+++ b/spec/workers/work_packages/progress/migrate_remove_totals_from_childless_work_packages_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe WorkPackages::Progress::MigrateRemoveTotalsFromChildlessWorkPacka
   def expect_performing_job_changes(from:, to:)
     table = create_table(from)
     job.perform_now
-    expect_work_packages(table.work_packages.map(&:reload), to)
+    expect_work_packages_after_reload(table.work_packages, to)
     table.work_packages
   end
 


### PR DESCRIPTION
They both take table as input to create work packages, and have similarities in how they work. It would be easier to maintain them together rather than have them in two separate places.

This is still a work in progress.