### PR TITLE
Feature/50140 avoid redundant emails in case of mentions and email reminder

### DIFF
--- a/app/models/notifications/scopes/unsent_reminders_before.rb
+++ b/app/models/notifications/scopes/unsent_reminders_before.rb
@@ -36,7 +36,7 @@ module Notifications::Scopes
       def unsent_reminders_before(recipient:, time:)
         where(Notification.arel_table[:created_at].lteq(time))
           .where(recipient:)
-          .where("read_ian IS NULL OR read_ian IS FALSE")
+          .where(read_ian: [false, nil])
           .where(mail_reminder_sent: false)
       end
     end

--- a/app/models/notifications/scopes/unsent_reminders_before.rb
+++ b/app/models/notifications/scopes/unsent_reminders_before.rb
@@ -38,6 +38,7 @@ module Notifications::Scopes
           .where(recipient:)
           .where(read_ian: [false, nil])
           .where(mail_reminder_sent: false)
+          .where(mail_alert_sent: [false, nil])
       end
     end
   end

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -111,9 +111,9 @@ class Notifications::CreateFromModelService
       journal:,
       actor: user_with_fallback,
       reason:,
-      read_ian: strategy.supports_ian? ? false : nil,
-      mail_reminder_sent: strategy.supports_mail_digest? ? false : nil,
-      mail_alert_sent: strategy.supports_mail? ? false : nil
+      read_ian: strategy.supports_ian?(reason) ? false : nil,
+      mail_reminder_sent: strategy.supports_mail_digest?(reason) ? false : nil,
+      mail_alert_sent: strategy.supports_mail?(reason) ? false : nil
     }
 
     Notifications::CreateService
@@ -129,7 +129,7 @@ class Notifications::CreateFromModelService
 
     Notifications::UpdateService
       .new(model: existing_notification, user:, contract_class: EmptyContract)
-      .call(read_ian: strategy.supports_ian? ? false : nil,
+      .call(read_ian: strategy.supports_ian?(reason) ? false : nil,
             reason:)
   end
 

--- a/app/services/notifications/create_from_model_service/comment_strategy.rb
+++ b/app/services/notifications/create_from_model_service/comment_strategy.rb
@@ -35,15 +35,15 @@ module Notifications::CreateFromModelService::CommentStrategy
     :view_news
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     false
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     false
   end
 
-  def self.supports_mail?
+  def self.supports_mail?(_reason)
     true
   end
 

--- a/app/services/notifications/create_from_model_service/message_strategy.rb
+++ b/app/services/notifications/create_from_model_service/message_strategy.rb
@@ -35,15 +35,15 @@ module Notifications::CreateFromModelService::MessageStrategy
     :view_messages
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     false
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     false
   end
 
-  def self.supports_mail?
+  def self.supports_mail?(_reason)
     true
   end
 

--- a/app/services/notifications/create_from_model_service/news_strategy.rb
+++ b/app/services/notifications/create_from_model_service/news_strategy.rb
@@ -35,15 +35,15 @@ module Notifications::CreateFromModelService::NewsStrategy
     :view_news
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     false
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     false
   end
 
-  def self.supports_mail?
+  def self.supports_mail?(_reason)
     true
   end
 

--- a/app/services/notifications/create_from_model_service/wiki_page_strategy.rb
+++ b/app/services/notifications/create_from_model_service/wiki_page_strategy.rb
@@ -35,15 +35,15 @@ module Notifications::CreateFromModelService::WikiPageStrategy
     :view_wiki_pages
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     false
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     false
   end
 
-  def self.supports_mail?
+  def self.supports_mail?(_reason)
     true
   end
 

--- a/app/services/notifications/create_from_model_service/work_package_strategy.rb
+++ b/app/services/notifications/create_from_model_service/work_package_strategy.rb
@@ -35,16 +35,16 @@ module Notifications::CreateFromModelService::WorkPackageStrategy
     :view_work_packages
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     true
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     true
   end
 
-  def self.supports_mail?
-    true
+  def self.supports_mail?(reason)
+    reason == :mentioned
   end
 
   def self.watcher_users(journal)

--- a/app/workers/notifications/with_marked_notifications.rb
+++ b/app/workers/notifications/with_marked_notifications.rb
@@ -37,16 +37,21 @@ module Notifications
 
       def with_marked_notifications(notification_ids)
         Notification.transaction do
-          mark_notifications_sent(notification_ids)
+          # It might be decided by the callers that the notifications should not be sent after all which
+          # is signaled by `nil`. This happens e.g. for work packages where users might have disabled the
+          # immediate_reminders for mentioned.
+          was_sent = yield
 
-          yield
+          mark_notifications_sent(notification_ids, was_sent.present? ? !!was_sent : nil)
+
+          was_sent
         end
       end
 
-      def mark_notifications_sent(notification_ids)
+      def mark_notifications_sent(notification_ids, was_sent)
         Notification
           .where(id: Array(notification_ids))
-          .update_all(notification_marked_attribute => true, updated_at: Time.current)
+          .update_all(notification_marked_attribute => was_sent, updated_at: Time.current)
       end
     end
   end

--- a/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
+++ b/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
@@ -35,15 +35,15 @@ module Notifications::CreateFromModelService::DocumentStrategy
     :view_documents
   end
 
-  def self.supports_ian?
+  def self.supports_ian?(_reason)
     false
   end
 
-  def self.supports_mail_digest?
+  def self.supports_mail_digest?(_reason)
     false
   end
 
-  def self.supports_mail?
+  def self.supports_mail?(_reason)
     true
   end
 

--- a/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
+++ b/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
@@ -44,14 +44,16 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
              recipient: notification_recipient,
              read_ian: notification_read_ian,
              mail_reminder_sent: notification_mail_reminder_sent,
+             mail_alert_sent: notification_mail_alert_sent,
              created_at: notification_created_at)
     end
     let(:notification_mail_reminder_sent) { false }
+    let(:notification_mail_alert_sent) { false }
     let(:notification_read_ian) { false }
     let(:notification_created_at) { 10.minutes.ago }
     let(:notification_recipient) { recipient }
 
-    context "with an unread and not reminded notification that was created before the time and for the user" do
+    context "with an unread, not alerted about and not reminded notification that was created before the time and for the user" do
       it "returns the notification" do
         expect(scope).to contain_exactly(notification)
       end
@@ -91,6 +93,20 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
 
     context "with a read notification" do
       let(:notification_read_ian) { true }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "with a notification alert mark set to nil" do
+      let(:notification_mail_alert_sent) { nil }
+
+      it "returns the notification" do
+        expect(scope).to contain_exactly(notification)
+      end
+    end
+
+    context "with a notification about which user was already alerted" do
+      let(:notification_mail_alert_sent) { true }
 
       it { is_expected.to be_empty }
     end

--- a/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
+++ b/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
       it { is_expected.to be_empty }
     end
 
+    context "with a notification read mark set to nil" do
+      let(:notification_read_ian) { nil }
+
+      it "returns the notification" do
+        expect(scope).to contain_exactly(notification)
+      end
+    end
+
     context "with a read notification" do
       let(:notification_read_ian) { true }
 

--- a/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
+++ b/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
       Time.current
     end
 
-    let(:notification) do
+    let!(:notification) do
       create(:notification,
              recipient: notification_recipient,
              read_ian: notification_read_ian,
@@ -51,50 +51,40 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
     let(:notification_created_at) { 10.minutes.ago }
     let(:notification_recipient) { recipient }
 
-    let!(:notifications) { notification }
-
-    shared_examples_for "is empty" do
-      it "is empty" do
-        expect(scope)
-          .to be_empty
-      end
-    end
-
     context "with a unread and not reminded notification that was created before the time and for the user" do
       it "returns the notification" do
-        expect(scope)
-          .to contain_exactly(notification)
+        expect(scope).to contain_exactly(notification)
       end
     end
 
     context "with a unread and not reminded notification that was created after the time and for the user" do
       let(:notification_created_at) { 10.minutes.from_now }
 
-      it_behaves_like "is empty"
+      it { is_expected.to be_empty }
     end
 
     context "with a unread and not reminded notification that was created before the time and for different user" do
       let(:notification_recipient) { create(:user) }
 
-      it_behaves_like "is empty"
+      it { is_expected.to be_empty }
     end
 
     context "with a unread and not reminded notification created before the time and for the user" do
       let(:notification_mail_reminder_sent) { nil }
 
-      it_behaves_like "is empty"
+      it { is_expected.to be_empty }
     end
 
     context "with a unread but reminded notification created before the time and for the user" do
       let(:notification_mail_reminder_sent) { true }
 
-      it_behaves_like "is empty"
+      it { is_expected.to be_empty }
     end
 
     context "with a read notification that was created before the time" do
       let(:notification_read_ian) { true }
 
-      it_behaves_like "is empty"
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
+++ b/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
@@ -51,37 +51,37 @@ RSpec.describe Notifications::Scopes::UnsentRemindersBefore do
     let(:notification_created_at) { 10.minutes.ago }
     let(:notification_recipient) { recipient }
 
-    context "with a unread and not reminded notification that was created before the time and for the user" do
+    context "with an unread and not reminded notification that was created before the time and for the user" do
       it "returns the notification" do
         expect(scope).to contain_exactly(notification)
       end
     end
 
-    context "with a unread and not reminded notification that was created after the time and for the user" do
+    context "with a notification that was created after the time" do
       let(:notification_created_at) { 10.minutes.from_now }
 
       it { is_expected.to be_empty }
     end
 
-    context "with a unread and not reminded notification that was created before the time and for different user" do
+    context "with a notification that was created for different user" do
       let(:notification_recipient) { create(:user) }
 
       it { is_expected.to be_empty }
     end
 
-    context "with a unread and not reminded notification created before the time and for the user" do
+    context "with a notification reminded mark set to nil" do
       let(:notification_mail_reminder_sent) { nil }
 
       it { is_expected.to be_empty }
     end
 
-    context "with a unread but reminded notification created before the time and for the user" do
+    context "with a reminded notification" do
       let(:notification_mail_reminder_sent) { true }
 
       it { is_expected.to be_empty }
     end
 
-    context "with a read notification that was created before the time" do
+    context "with a read notification" do
       let(:notification_read_ian) { true }
 
       it { is_expected.to be_empty }

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :assigned,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end
@@ -139,7 +139,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :assigned,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -168,7 +168,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :assigned,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -212,7 +212,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :responsible,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end
@@ -265,7 +265,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :watched,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end
@@ -283,7 +283,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :watched,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -332,7 +332,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :created,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end
@@ -350,7 +350,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :created,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -380,7 +380,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :created,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -429,7 +429,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :shared,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end
@@ -477,7 +477,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :created,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -533,7 +533,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :commented,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -582,7 +582,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :processed,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -631,7 +631,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :prioritized,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -680,7 +680,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :scheduled,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -729,7 +729,7 @@ RSpec.describe Notifications::CreateFromModelService,
           {
             read_ian: false,
             reason: :scheduled,
-            mail_alert_sent: false,
+            mail_alert_sent: nil,
             mail_reminder_sent: false
           }
         end
@@ -762,7 +762,7 @@ RSpec.describe Notifications::CreateFromModelService,
         {
           read_ian: false,
           reason: :assigned,
-          mail_alert_sent: false,
+          mail_alert_sent: nil,
           mail_reminder_sent: false
         }
       end

--- a/spec/services/notifications/mail_service_mentioned_integration_spec.rb
+++ b/spec/services/notifications/mail_service_mentioned_integration_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Notifications::MailService, "Mentioned integration", type: :model
     expect(assigned_notification).to be_present
     expect(assigned_notification.recipient).to eq assignee
     expect(assigned_notification.read_ian).to be false
-    expect(assigned_notification.mail_alert_sent).to be false
+    expect(assigned_notification.mail_alert_sent).to be_nil
   end
 
   it "triggers only one mention notification mail when editing attributes afterwards" do


### PR DESCRIPTION
[OP#50140](https://community.openproject.org/projects/openproject/work_packages/50140)

This scope is used only to find notifications to send and to filter recipients before that.

Ticket mentions filtering by reason (mention), but it looks like it doesn't make sense overall to send a mail later if there was an instant/alert email sent right after event.

The `mail_alert_sent` for Notification created in spec/features/notifications/reminder_mail_spec.rb is unexpectedly `true` without sending alert email and despite the setting to not send alert email, so it should be investigated to finish this.