### PR TITLE
[55231] User icon appearing on the share work packages modal in the empty state

### DIFF
--- a/app/components/work_packages/share/share_counter_component.html.erb
+++ b/app/components/work_packages/share/share_counter_component.html.erb
@@ -1,5 +1,3 @@
 <%
-  concat(render(Primer::Beta::Octicon.new(icon: 'person')))
-
-  concat(render(Primer::Beta::Text.new(ml: 2)) { I18n.t('work_package.sharing.count', count:) })
+  concat(render(Primer::Beta::Text.new) { I18n.t('work_package.sharing.count', count:) })
 %>


### PR DESCRIPTION
Remove user icon from share modal box header


https://community.openproject.org/projects/openproject/work_packages/55231/activity