### PR TITLE
Fix typo in migration

### DIFF
--- a/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
+++ b/db/migrate/20230731153909_add_file_link_journals_to_existing_containers.rb
@@ -37,7 +37,7 @@ class AddFileLinkJournalsToExistingContainers < ActiveRecord::Migration[7.0]
       next unless container.class.journaled?
 
       Journals::CreateService.new(container, system_user)
-                             .call(cause: Jounal::CausedBySystemUpdate.new(feature: "file_links_journal"))
+                             .call(cause: Journal::CausedBySystemUpdate.new(feature: "file_links_journal"))
     end
   end
 


### PR DESCRIPTION
As commented [here](https://github.com/opf/openproject/commit/349d43500aaa7186fc25bbf65a1df599f50bae27#commitcomment-142533205), there's a typo in the migration that causes migrations from older states to fail. 

We'll figure out what versions this needs to be backported to