### PR TITLE
[55251] Favorite colum margin is too big on project list

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -199,6 +199,8 @@ module Projects
         "project--hierarchy #{project.archived? ? 'archived' : ''}"
       elsif %i[status_explanation description].include?(column.attribute)
         "project-long-text-container"
+      elsif column.attribute == :favored
+        "-w-abs-45"
       elsif custom_field_column?(column)
         cf = column.custom_field
         formattable = cf.field_format == "text" ? " project-long-text-container" : ""

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -56,16 +56,22 @@ See COPYRIGHT and LICENSE files for more details.
               <% elsif sortable_column?(column) %>
                 <%= build_sort_header column.attribute,
                                       order_options(column) %>
+              <% elsif column.attribute == :favored %>
+                <th>
+                  <div class="generic-table--header-outer">
+                    <div class="generic-table--header generic-table--header_centered generic-table--header_no-min-width">
+                      <span>
+                        <%= render(Primer::Beta::Octicon.new(icon: "star-fill", color: :subtle, "aria-label": I18n.t(:label_favorite))) %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
               <% else %>
                 <th>
                   <div class="generic-table--sort-header-outer">
                     <div class="generic-table--sort-header">
                       <span>
-                        <% if column.attribute == :favored %>
-                        <%= render(Primer::Beta::Octicon.new(icon: "star-fill", color: :subtle, ml: 2, "aria-label": I18n.t(:label_favorite))) %>
-                      <% else %>
-                        <%= column.caption %>
-                      <% end %>
+                          <%= column.caption %>
                       </span>
                     </div>
                   </div>

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -220,6 +220,9 @@ table.generic-table
         background-color: var(--body-background)
 
       // fixed column width helpers
+      &.-w-abs-45
+        width: 45px
+
       &.-w-rel-20
         width: 20%
 
@@ -259,7 +262,6 @@ thead.-sticky th
 
 .generic-table--header-outer,
 .generic-table--sort-header-outer
-  padding:      0 12px 0 6px
   line-height:  var(--generic-table--header-height)
   height:  var(--generic-table--header-height)
   z-index:      1
@@ -274,8 +276,14 @@ thead.-sticky th
     &.hover
       background: initial
 
+.generic-table--sort-header-outer
+  padding:      0 12px 0 6px
+
+.generic-table--header-outer,
 .generic-table--empty-header
-  padding:       0 6px
+  padding: 0 6px
+
+.generic-table--empty-header
   height:        var(--generic-table--header-height)
   line-height:   var(--generic-table--header-height)
   border-bottom: 1px solid var(--table-border-color)
@@ -303,6 +311,11 @@ thead.-sticky th
   min-width: 40px
   max-width: 300px
   display: flex
+
+  &_no-min-width
+    min-width: initial
+  &_centered
+    justify-content: center
 
   & > a
     flex: 1 1


### PR DESCRIPTION
Introduce icon-only class for table headers, which do not need the min-width of 40px and should ideally be centered


https://community.openproject.org/projects/openproject/work_packages/55251/activity