### PR TITLE
[50724] Show notifications button correctly on mobile

### DIFF
--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -60,7 +60,7 @@
 
   .form--field-inline-buttons-container,
   .form--field-inline-button
-    width: auto
+    width: auto !important
 
   .-browser-safari,
   .-browser-chrome


### PR DESCRIPTION
Enforce correct width for inline buttons on mobile, otherwise the notification buttons are not correctly shown

### Before
<img width="365" alt="Bildschirmfoto 2024-06-03 um 11 41 42" src="https://github.com/opf/openproject/assets/7457313/cd51745d-9227-4826-a828-3a695c366d6a">

### After
<img width="377" alt="Bildschirmfoto 2024-06-03 um 11 41 20" src="https://github.com/opf/openproject/assets/7457313/347ef6f6-3c5c-4cee-ae68-3d24dd4adc7b">


https://community.openproject.org/projects/openproject/work_packages/50724/activity