### PR TITLE
[55169] Meetings participants toggle has the wrong color

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -9,6 +9,7 @@
      configured design outside of high contrast mode  */
   [data-color-mode]:not([data-light-theme=light_high_contrast]) {
     --fgColor-accent: var(--accent-color) !important;
+    --fgColor-link: var(--accent-color) !important;
     --control-checked-bgColor-rest: var(--control-checked-color) !important;
     --control-checked-bgColor-active: var(--control-checked-color) !important;
     --control-checked-bgColor-hover: var(--control-checked-color--major1) !important;


### PR DESCRIPTION
Set `button-link` color to our accent color

https://community.openproject.org/projects/openproject/work_packages/55169/activity