### PR TITLE
[55339] Missing right margin on setting page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -453,7 +453,9 @@ Rails.application.routes.draw do
       resource :aggregation, controller: "/admin/settings/aggregation_settings", only: %i[show update]
       resource :mail_notifications, controller: "/admin/settings/mail_notifications_settings", only: %i[show update]
       resource :api, controller: "/admin/settings/api_settings", only: %i[show update]
-      resource :work_packages, controller: "/admin/settings/work_packages_settings", only: %i[show update]
+      # It is important to have this named something else than "work_packages".
+      # Otherwise the angular ui-router will also recognize that as a WorkPackage page and apply according classes.
+      resource :work_package_tracking, controller: "/admin/settings/work_packages_settings", only: %i[show update]
       resource :projects, controller: "/admin/settings/projects_settings", only: %i[show update]
       resource :new_project, controller: "/admin/settings/new_project_settings", only: %i[show update]
       resources :project_custom_fields, controller: "/admin/settings/project_custom_fields" do


### PR DESCRIPTION
On the admin work_package settings page (`/admin/settings/work_packages`) there was a space missing on the right side of the page. This was due to the classes `router--work-packages-partitioned-split-view` `router--work-packages-base` being added to the body. That happened because `work_packages` is url that is recognized by the angular uiRouter as a WorkPackage page and thus the according classes are applied. 
So I change the url for the admin settings page to match the current header "Work package tracking".

https://community.openproject.org/projects/openproject/work_packages/55339/activity