### PR TITLE
[#55192] require authorize by default for controller actions

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -36,6 +36,7 @@ class AccountController < ApplicationController
 
   # prevents login action to be filtered by check_if_login_required application scope filter
   skip_before_action :check_if_login_required
+  no_authorization_required!
 
   before_action :apply_csp_appends, only: %i[login]
   before_action :disable_api

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -36,7 +36,19 @@ class AccountController < ApplicationController
 
   # prevents login action to be filtered by check_if_login_required application scope filter
   skip_before_action :check_if_login_required
-  no_authorization_required!
+  no_authorization_required! only: %i[login
+                                      internal_login
+                                      logout
+                                      lost_password
+                                      register
+                                      activate
+                                      consent
+                                      confirm_consent
+                                      decline_consent
+                                      stage_success
+                                      stage_failure
+                                      change_password
+                                      auth_source_sso_failed]
 
   before_action :apply_csp_appends, only: %i[login]
   before_action :disable_api

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -146,20 +146,6 @@ class AccountController < ApplicationController
     end
   end
 
-  def allow_registration?
-    allow = Setting::SelfRegistration.enabled? && !OpenProject::Configuration.disable_password_login?
-
-    invited = session[:invitation_token].present?
-    get = request.get? && allow
-    post = (request.post? || request.patch?) && (session[:auth_source_registration] || allow)
-
-    invited || get || post
-  end
-
-  def allow_lost_password_recovery?
-    Setting.lost_password? && !OpenProject::Configuration.disable_password_login?
-  end
-
   # Token based account activation
   def activate
     token = ::Token::Invitation.find_by_plaintext_value(params[:token])
@@ -176,6 +162,36 @@ class AccountController < ApplicationController
       invalid_token_and_redirect
     end
   end
+
+  # Process a password change form, used when the user is forced
+  # to change the password.
+  # When making changes here, also check MyController.change_password
+  def change_password
+    # Retrieve user_id from session
+    @user = User.find(params[:password_change_user_id])
+
+    change_password_flow(user: @user, params:, show_user_name: true) do
+      password_authentication(@user.login, params[:new_password])
+    end
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.error "Failed to find user for change_password request: #{flash[:_password_change_user_id]}"
+    render_404
+  end
+
+  def auth_source_sso_failed
+    failure = session.delete :auth_source_sso_failure
+    user = auth_source_sso_failure_user(failure)
+
+    if user.try(:new_record?)
+      return onthefly_creation_failed user, login: user.login, ldap_auth_source_id: user.ldap_auth_source_id
+    end
+
+    show_sso_error_for(user, failure)
+
+    render action: "login", back_url: failure[:back_url]
+  end
+
+  private
 
   def handle_expired_token(token)
     send_activation_email! token.user
@@ -255,50 +271,32 @@ class AccountController < ApplicationController
     redirect_to signin_path(username: user.login)
   end
 
-  # Process a password change form, used when the user is forced
-  # to change the password.
-  # When making changes here, also check MyController.change_password
-  def change_password
-    # Retrieve user_id from session
-    @user = User.find(params[:password_change_user_id])
+  def allow_registration?
+    allow = Setting::SelfRegistration.enabled? && !OpenProject::Configuration.disable_password_login?
 
-    change_password_flow(user: @user, params:, show_user_name: true) do
-      password_authentication(@user.login, params[:new_password])
-    end
-  rescue ActiveRecord::RecordNotFound
-    Rails.logger.error "Failed to find user for change_password request: #{flash[:_password_change_user_id]}"
-    render_404
+    invited = session[:invitation_token].present?
+    get = request.get? && allow
+    post = (request.post? || request.patch?) && (session[:auth_source_registration] || allow)
+
+    invited || get || post
   end
 
-  def auth_source_sso_failed
-    failure = session.delete :auth_source_sso_failure
-    login = failure[:login]
-    user = find_user_from_auth_source(login) || build_user_from_auth_source(login)
-
-    if user.try(:new_record?)
-      return onthefly_creation_failed user, login: user.login, ldap_auth_source_id: user.ldap_auth_source_id
-    end
-
-    show_sso_error_for user
-
-    flash.now[:error] = I18n.t(:error_auth_source_sso_failed, value: failure[:login]) +
-                        ": " + String(flash.now[:error])
-
-    render action: "login", back_url: failure[:back_url]
+  def allow_lost_password_recovery?
+    Setting.lost_password? && !OpenProject::Configuration.disable_password_login?
   end
-
-  private
 
   def check_auth_source_sso_failure
     redirect_to home_url unless session[:auth_source_sso_failure].present?
   end
 
-  def show_sso_error_for(user)
+  def show_sso_error_for(user, failure)
     if user.nil?
       flash_and_log_invalid_credentials
     elsif not user.active?
       account_inactive user, flash_now: true
     end
+
+    flash.now[:error] = "#{I18n.t(:error_auth_source_sso_failed, value: failure[:login])}: #{String(flash.now[:error])}"
   end
 
   def registration_through_invitation!
@@ -535,5 +533,11 @@ class AccountController < ApplicationController
 
   def check_internal_login_enabled
     render_404 unless omniauth_direct_login?
+  end
+
+  def auth_source_sso_failure_user(failure)
+    login = failure[:login]
+
+    find_user_from_auth_source(login) || build_user_from_auth_source(login)
   end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -36,19 +36,19 @@ class AccountController < ApplicationController
 
   # prevents login action to be filtered by check_if_login_required application scope filter
   skip_before_action :check_if_login_required
-  no_authorization_required! only: %i[login
-                                      internal_login
-                                      logout
-                                      lost_password
-                                      register
-                                      activate
-                                      consent
-                                      confirm_consent
-                                      decline_consent
-                                      stage_success
-                                      stage_failure
-                                      change_password
-                                      auth_source_sso_failed]
+  no_authorization_required! :login,
+                             :internal_login,
+                             :logout,
+                             :lost_password,
+                             :register,
+                             :activate,
+                             :consent,
+                             :confirm_consent,
+                             :decline_consent,
+                             :stage_success,
+                             :stage_failure,
+                             :change_password,
+                             :auth_source_sso_failed
 
   before_action :apply_csp_appends, only: %i[login]
   before_action :disable_api

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -30,7 +30,7 @@ class ActivitiesController < ApplicationController
   include Layout
 
   menu_item :activity
-  before_action :find_optional_project,
+  before_action :authorize_in_optional_project,
                 :verify_activities_module_activated,
                 :determine_subprojects,
                 :determine_author,

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -30,7 +30,7 @@ class ActivitiesController < ApplicationController
   include Layout
 
   menu_item :activity
-  before_action :authorize_in_optional_project,
+  before_action :load_and_authorize_in_optional_project,
                 :verify_activities_module_activated,
                 :determine_subprojects,
                 :determine_author,

--- a/app/controllers/angular_controller.rb
+++ b/app/controllers/angular_controller.rb
@@ -29,6 +29,8 @@
 class AngularController < ApplicationController
   before_action :require_login
 
+  no_authorization_required!
+
   def empty_layout
     # Frontend will handle rendering
     # but we will need to render with layout

--- a/app/controllers/angular_controller.rb
+++ b/app/controllers/angular_controller.rb
@@ -29,7 +29,7 @@
 class AngularController < ApplicationController
   before_action :require_login
 
-  no_authorization_required! only: %i[empty_layout notifications_layout]
+  no_authorization_required! :empty_layout, :notifications_layout
 
   def empty_layout
     # Frontend will handle rendering

--- a/app/controllers/angular_controller.rb
+++ b/app/controllers/angular_controller.rb
@@ -29,7 +29,7 @@
 class AngularController < ApplicationController
   before_action :require_login
 
-  no_authorization_required!
+  no_authorization_required! only: %i[empty_layout notifications_layout]
 
   def empty_layout
     # Frontend will handle rendering

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -28,7 +28,7 @@
 
 class APIDocsController < ApplicationController
   before_action :require_login
-  no_authorization_required! only: :index
+  no_authorization_required! :index
 
   helper API::APIDocsHelper
 

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -28,6 +28,7 @@
 
 class APIDocsController < ApplicationController
   before_action :require_login
+  no_authorization_required! only: :index
 
   helper API::APIDocsHelper
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -222,8 +222,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_localization
-    # 1. Use completely autheticated user
-    # 2. Use user with some authenticated stages not compelted.
+    # 1. Use completely authenticated user
+    # 2. Use user with some authenticated stages not completed.
     #    In this case user is not considered logged in, but identified.
     #    It covers localization for extra authentication stages(like :consent, for example)
     # 3. Use anonymous instance.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -458,23 +458,6 @@ class ApplicationController < ActionController::Base
     render_404
   end
 
-  # Make sure that the user is a member of the project (or admin) if project is private
-  # used as a before_action for actions that do not require any particular permission
-  # on the project.
-  def check_project_privacy
-    if @project && @project.active?
-      if @project.public? || User.current.member_of?(@project) || User.current.admin?
-        true
-      else
-        User.current.logged? ? render_403 : require_login
-      end
-    else
-      @project = nil
-      render_404
-      false
-    end
-  end
-
   def back_url
     params[:back_url] || request.env["HTTP_REFERER"]
   end

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -28,7 +28,7 @@
 
 class ColorsController < ApplicationController
   before_action :require_admin_unless_readonly_api_request
-  authorization_checked! only: %i[index show new edit create update confirm_destroy destroy]
+  authorization_checked! :index, :show, :new, :edit, :create, :update, :confirm_destroy, :destroy
 
   layout "admin"
 

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -28,6 +28,7 @@
 
 class ColorsController < ApplicationController
   before_action :require_admin_unless_readonly_api_request
+  authorization_checked! only: %i[index show new edit create update confirm_destroy destroy]
 
   layout "admin"
 

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -31,7 +31,7 @@
 module Accounts::Authorization
   extend ActiveSupport::Concern
 
-  METHODS_ENFORCING_AUTHORIZATION = %i[require_admin authorize authorize_global authorize_in_optional_project].freeze
+  METHODS_ENFORCING_AUTHORIZATION = %i[require_admin authorize authorize_global load_and_authorize_in_optional_project].freeze
 
   included do
     class_attribute :authorization_ensured,
@@ -77,7 +77,7 @@ module Accounts::Authorization
   end
 
   # Find a project based on params[:project_id]
-  def authorize_in_optional_project
+  def load_and_authorize_in_optional_project
     @project = Project.find(params[:project_id]) if params[:project_id].present?
 
     do_authorize({ controller: params[:controller], action: params[:action] }, global: params[:project_id].blank?)

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -124,12 +124,28 @@ module Accounts::Authorization
   class_methods do
     # Overriding before_action of rails to check if any authorization method is by now defined.
     def before_action(*names, &)
-      if METHODS_ENFORCING_AUTHORIZATION.intersect?(names)
-        no_authorization_required!(only: names.last.is_a?(Hash) ? Array(names.last[:only]) : [],
-                                   except: names.last.is_a?(Hash) ? Array(names.last[:except]) : [])
-      end
+      set_authorization_checked_if_covered(*names)
 
       super
+    end
+
+    def prepend_before_action(*names, &)
+      set_authorization_checked_if_covered(*names)
+
+      super
+    end
+
+    def append_before_action(*names, &)
+      set_authorization_checked_if_covered(*names)
+
+      super
+    end
+
+    def set_authorization_checked_if_covered(*names)
+      return unless METHODS_ENFORCING_AUTHORIZATION.intersect?(names)
+
+      authorization_checked!(only: names.last.is_a?(Hash) ? Array(names.last[:only]) : [],
+                             except: names.last.is_a?(Hash) ? Array(names.last[:except]) : [])
     end
 
     def no_authorization_required!(only: [], except: [])

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -47,19 +47,15 @@ module Accounts::Authorization
 
   def authorization_check_required
     unless authorization_is_ensured?(params[:action])
-      if Rails.env.development?
-        raise <<-MESSAGE
-          Authorization check required for #{params[:action]} in #{self.class.name}.
+      raise <<-MESSAGE
+        Authorization check required for #{self.class.name}##{params[:action]}.
 
-          Use any method of
-            #{METHODS_ENFORCING_AUTHORIZATION.join(', ')}
-          to ensure authorization. If authorization is checked by any other means,
-          affirm the same by calling 'authorization_checked!' in the controller. If the authorization does
-          not need to be checked for this action, affirm the same by calling 'no_authorization_required!'
-        MESSAGE
-      else
-        render_403
-      end
+        Use any method of
+          #{METHODS_ENFORCING_AUTHORIZATION.join(', ')}
+        to ensure authorization. If authorization is checked by any other means,
+        affirm the same by calling 'authorization_checked!' in the controller. If the authorization does
+        not need to be checked for this action, affirm the same by calling 'no_authorization_required!'
+      MESSAGE
     end
   end
 

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -65,15 +65,14 @@ module Accounts::Authorization
 
   # Authorize the user for the requested controller action.
   # To be used in before_action hooks
-  def authorize(ctrl = params[:controller], action = params[:action])
-    do_authorize({ controller: ctrl, action: }, global: false)
+  def authorize
+    do_authorize({ controller: params[:controller], action: params[:action] }, global: false)
   end
 
   # Authorize the user for the requested controller action outside a project
   # To be used in before_action hooks
   def authorize_global
-    action = { controller: params[:controller], action: params[:action] }
-    do_authorize(action, global: true)
+    do_authorize({ controller: params[:controller], action: params[:action] }, global: true)
   end
 
   # Find a project based on params[:project_id]

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -1,0 +1,139 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+##
+# Intended to be used by the ApplicationController to provide authorization helpers
+module Accounts::Authorization
+  extend ActiveSupport::Concern
+
+  METHODS_ENFORCING_AUTHORIZATION = %i[require_admin authorize authorize_global authorize_in_optional_project].freeze
+
+  included do
+    class_attribute :authorization_ensured,
+                    default: {
+                      only: [],
+                      except: [],
+                      generally_allowed: false,
+                      controller: self
+                    }
+  end
+
+  def require_admin
+    return unless require_login
+
+    render_403 unless current_user.admin?
+  end
+
+  def authorization_check_required
+    unless authorization_is_ensured?(params[:action])
+      if Rails.env.development?
+        raise <<-MESSAGE
+          Authorization check required for #{params[:action]} in #{self.class.name}.
+
+          Use any method of 'authorize', 'authorize_global', 'authorize_in_optional_project'
+          or 'require_admin' to ensure authorization. If authorization is checked by any other means,
+          affirm the same by calling 'authorization_checked!' in the controller. If the authorization does
+          not need to be checked for this action, affirm the same by calling 'no_authorization_required!'
+        MESSAGE
+      else
+        render_403
+      end
+    end
+  end
+
+  private
+
+  def authorization_is_ensured?(action)
+    return false if authorization_ensured.nil?
+
+    (authorization_ensured[:generally_allowed] == true || authorization_ensured[:only].include?(action.to_sym)) &&
+      authorization_ensured[:except].exclude?(action.to_sym)
+  end
+
+  class_methods do
+    # Overriding before_action of rails to check if any authorization method is by now defined.
+    def before_action(*names, &)
+      if METHODS_ENFORCING_AUTHORIZATION.intersect?(names)
+        no_authorization_required!(only: names.last.is_a?(Hash) ? Array(names.last[:only]) : [],
+                                   except: names.last.is_a?(Hash) ? Array(names.last[:except]) : [])
+      end
+
+      super
+    end
+
+    def no_authorization_required!(only: [], except: [])
+      only = Array(only)
+      except = Array(except)
+
+      # A class_attribute is used so that inheritance works also for defined only/except actions.
+      # But since the only/accept arrays are only modified in place, the same object would be used from the
+      # ApplicationController downwards. So whenever it is detected that the controller the authorization_ensured
+      # object is defined for changes, we clone it so that henceforth all changes are local.
+      clone_authorization_ensured unless self == authorization_ensured[:controller]
+
+      if only.any? || except.any?
+        update_authorization_ensured_on_actions(only:, except:)
+      else
+        update_authorization_ensured_on_all
+      end
+    end
+
+    alias :authorization_checked! :no_authorization_required!
+
+    def update_authorization_ensured_on_actions(only: [], except: [])
+      update_authorization_ensured_on_action_only(only)
+      update_authorization_ensured_on_action_except(only, except)
+    end
+
+    def update_authorization_ensured_on_action_only(only)
+      authorization_ensured[:generally_allowed] = true if only.empty?
+
+      if only.any?
+        authorization_ensured[:only] += only
+        authorization_ensured[:only].uniq!
+      end
+    end
+
+    def update_authorization_ensured_on_action_except(only, except)
+      authorization_ensured[:except] += except - authorization_ensured[:only] if except.any?
+      authorization_ensured[:except] -= only if only.any?
+      authorization_ensured[:except].uniq!
+    end
+
+    def update_authorization_ensured_on_all
+      authorization_ensured[:generally_allowed] = true
+    end
+
+    def clone_authorization_ensured
+      self.authorization_ensured = { only: authorization_ensured[:only].dup,
+                                     except: authorization_ensured[:except].dup,
+                                     generally_allowed: authorization_ensured[:generally_allowed],
+                                     controller: self }
+    end
+  end
+end

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -51,8 +51,9 @@ module Accounts::Authorization
         raise <<-MESSAGE
           Authorization check required for #{params[:action]} in #{self.class.name}.
 
-          Use any method of 'authorize', 'authorize_global', 'authorize_in_optional_project'
-          or 'require_admin' to ensure authorization. If authorization is checked by any other means,
+          Use any method of
+            #{METHODS_ENFORCING_AUTHORIZATION.join(', ')}
+          to ensure authorization. If authorization is checked by any other means,
           affirm the same by calling 'authorization_checked!' in the controller. If the authorization does
           not need to be checked for this action, affirm the same by calling 'no_authorization_required!'
         MESSAGE

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -44,7 +44,7 @@ module Accounts::OmniauthLogin
       check_session_lifetime
     ]
       .each { |key| skip_before_action key, only: [:omniauth_login] }
-    no_authorization_required! only: %i[omniauth_login omniauth_failure]
+    no_authorization_required! :omniauth_login, :omniauth_failure
 
     helper :omniauth
   end

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -38,10 +38,13 @@ module Accounts::OmniauthLogin
     # the other filters are not applicable either since OmniAuth is doing authentication
     # itself
     %i[
-      verify_authenticity_token user_setup
-      check_if_login_required check_session_lifetime
+      verify_authenticity_token
+      user_setup
+      check_if_login_required
+      check_session_lifetime
     ]
       .each { |key| skip_before_action key, only: [:omniauth_login] }
+    no_authorization_required! only: %i[omniauth_login omniauth_failure]
 
     helper :omniauth
   end

--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -30,12 +30,19 @@ class CustomStylesController < ApplicationController
   layout "admin"
   menu_item :custom_style
 
+  UNGUARDED_ACTIONS = %i[logo_download
+                         export_logo_download
+                         export_cover_download
+                         favicon_download
+                         touch_icon_download].freeze
+
   before_action :require_admin,
-                except: %i[logo_download export_logo_download export_cover_download favicon_download touch_icon_download]
+                except: UNGUARDED_ACTIONS
   before_action :require_ee_token,
-                except: %i[upsale logo_download export_logo_download export_cover_download favicon_download touch_icon_download]
+                except: UNGUARDED_ACTIONS + %i[upsale]
   skip_before_action :check_if_login_required,
-                     only: %i[logo_download export_logo_download export_cover_download favicon_download touch_icon_download]
+                     only: UNGUARDED_ACTIONS
+  no_authorization_required! only: UNGUARDED_ACTIONS
 
   def show
     @custom_style = CustomStyle.current || CustomStyle.new

--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -42,7 +42,7 @@ class CustomStylesController < ApplicationController
                 except: UNGUARDED_ACTIONS + %i[upsale]
   skip_before_action :check_if_login_required,
                      only: UNGUARDED_ACTIONS
-  no_authorization_required! only: UNGUARDED_ACTIONS
+  no_authorization_required! *UNGUARDED_ACTIONS
 
   def show
     @custom_style = CustomStyle.current || CustomStyle.new

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -29,6 +29,7 @@
 class FavoritesController < ApplicationController
   before_action :find_favored_by_object
   before_action :require_login
+  no_authorization_required! only: %i[favorite unfavorite]
 
   def favorite
     if @favored.visible?(User.current)

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -29,7 +29,7 @@
 class FavoritesController < ApplicationController
   before_action :find_favored_by_object
   before_action :require_login
-  no_authorization_required! only: %i[favorite unfavorite]
+  no_authorization_required! :favorite, :unfavorite
 
   def favorite
     if @favored.visible?(User.current)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,7 +31,7 @@ class GroupsController < ApplicationController
   layout "admin"
 
   before_action :require_admin, except: %i[show]
-  no_authorization_required! only: %i[show]
+  no_authorization_required! :show
 
   before_action :find_group, only: %i[destroy update show create_memberships destroy_membership
                                       edit_membership add_users]

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,6 +31,8 @@ class GroupsController < ApplicationController
   layout "admin"
 
   before_action :require_admin, except: %i[show]
+  no_authorization_required! only: %i[show]
+
   before_action :find_group, only: %i[destroy update show create_memberships destroy_membership
                                       edit_membership add_users]
 

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -27,7 +27,7 @@
 #++
 
 class HelpController < ApplicationController
-  no_authorization_required! only: %i[keyboard_shortcuts text_formatting]
+  no_authorization_required! :keyboard_shortcuts, :text_formatting
 
   def keyboard_shortcuts
     redirect_to OpenProject::Static::Links[:shortcuts][:href]

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -27,6 +27,8 @@
 #++
 
 class HelpController < ApplicationController
+  no_authorization_required! only: %i[keyboard_shortcuts text_formatting]
+
   def keyboard_shortcuts
     redirect_to OpenProject::Static::Links[:shortcuts][:href]
   end

--- a/app/controllers/highlighting_controller.rb
+++ b/app/controllers/highlighting_controller.rb
@@ -29,6 +29,7 @@
 class HighlightingController < ApplicationController
   before_action :determine_freshness
   skip_before_action :check_if_login_required, only: [:styles]
+  no_authorization_required! only: [:styles]
 
   def styles
     response.content_type = Mime[:css]

--- a/app/controllers/highlighting_controller.rb
+++ b/app/controllers/highlighting_controller.rb
@@ -29,7 +29,7 @@
 class HighlightingController < ApplicationController
   before_action :determine_freshness
   skip_before_action :check_if_login_required, only: [:styles]
-  no_authorization_required! only: [:styles]
+  no_authorization_required! :styles
 
   def styles
     response.content_type = Mime[:css]

--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -28,6 +28,7 @@
 
 class HomescreenController < ApplicationController
   skip_before_action :check_if_login_required, only: [:robots]
+  no_authorization_required! only: %i[index robots]
 
   layout "global"
 

--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -28,7 +28,7 @@
 
 class HomescreenController < ApplicationController
   skip_before_action :check_if_login_required, only: [:robots]
-  no_authorization_required! only: %i[index robots]
+  no_authorization_required! :index, :robots
 
   layout "global"
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -29,7 +29,7 @@
 #++
 
 class JournalsController < ApplicationController
-  before_action :authorize_in_optional_project, only: [:index]
+  before_action :load_and_authorize_in_optional_project, only: [:index]
   before_action :find_journal,
                 :ensure_permitted,
                 only: [:diff]

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -29,9 +29,12 @@
 #++
 
 class JournalsController < ApplicationController
-  before_action :find_optional_project, only: [:index]
-  before_action :find_journal, only: [:diff]
-  before_action :ensure_permitted, only: [:diff]
+  before_action :authorize_in_optional_project, only: [:index]
+  before_action :find_journal,
+                :ensure_permitted,
+                only: [:diff]
+  authorization_checked! only: %i[diff]
+
   accept_key_auth :index
   menu_item :issues
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -33,7 +33,7 @@ class JournalsController < ApplicationController
   before_action :find_journal,
                 :ensure_permitted,
                 only: [:diff]
-  authorization_checked! only: %i[diff]
+  authorization_checked! :diff
 
   accept_key_auth :index
   menu_item :issues

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,6 +32,8 @@ class MessagesController < ApplicationController
   model_object Message, scope: Forum
   before_action :find_object_and_scope
   before_action :authorize, except: %i[edit update destroy]
+  # Checked inside the method.
+  no_authorization_required! only: %i[edit update destroy]
 
   include AttachmentsHelper
   include PaginationHelper

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -33,7 +33,7 @@ class MessagesController < ApplicationController
   before_action :find_object_and_scope
   before_action :authorize, except: %i[edit update destroy]
   # Checked inside the method.
-  no_authorization_required! only: %i[edit update destroy]
+  no_authorization_required! :edit, :update, :destroy
 
   include AttachmentsHelper
   include PaginationHelper

--- a/app/controllers/my/auto_login_tokens_controller.rb
+++ b/app/controllers/my/auto_login_tokens_controller.rb
@@ -1,5 +1,8 @@
 module My
   class AutoLoginTokensController < ::ApplicationController
+    before_action :require_login
+    no_authorization_required! only: %i(destroy)
+
     before_action :find_token, only: %i(destroy)
 
     layout "my"

--- a/app/controllers/my/auto_login_tokens_controller.rb
+++ b/app/controllers/my/auto_login_tokens_controller.rb
@@ -1,7 +1,7 @@
 module My
   class AutoLoginTokensController < ::ApplicationController
     before_action :require_login
-    no_authorization_required! only: %i(destroy)
+    no_authorization_required! :destroy
 
     before_action :find_token, only: %i(destroy)
 

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -1,6 +1,8 @@
 module My
   class SessionsController < ::ApplicationController
     before_action :require_login
+    no_authorization_required! only: %i(index show destroy)
+
     self._model_object = ::Sessions::UserSession
 
     before_action :find_model_object, only: %i(show destroy)

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -1,7 +1,9 @@
 module My
   class SessionsController < ::ApplicationController
     before_action :require_login
-    no_authorization_required! only: %i(index show destroy)
+    no_authorization_required! :index,
+                               :show,
+                               :destroy
 
     self._model_object = ::Sessions::UserSession
 

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -39,6 +39,22 @@ class MyController < ApplicationController
   before_action :set_grouped_ical_tokens, only: %i[access_token]
   before_action :set_ical_token, only: %i[revoke_ical_token]
 
+  no_authorization_required! only: %i[account
+                                      update_account
+                                      settings
+                                      update_settings
+                                      password
+                                      change_password
+                                      access_token
+                                      delete_storage_token
+                                      notifications
+                                      reminders
+                                      generate_rss_key
+                                      revoke_rss_key
+                                      generate_api_key
+                                      revoke_api_key
+                                      revoke_ical_token]
+
   menu_item :account,             only: [:account]
   menu_item :settings,            only: [:settings]
   menu_item :password,            only: [:password]
@@ -177,6 +193,8 @@ class MyController < ApplicationController
     redirect_to action: 'access_token'
   end
 
+  private
+
   def default_breadcrumb
     I18n.t(:label_my_account)
   end
@@ -184,8 +202,6 @@ class MyController < ApplicationController
   def show_local_breadcrumb
     false
   end
-
-  private
 
   def redirect_if_password_change_not_allowed_for(user)
     unless user.change_password_allowed?

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -39,21 +39,21 @@ class MyController < ApplicationController
   before_action :set_grouped_ical_tokens, only: %i[access_token]
   before_action :set_ical_token, only: %i[revoke_ical_token]
 
-  no_authorization_required! only: %i[account
-                                      update_account
-                                      settings
-                                      update_settings
-                                      password
-                                      change_password
-                                      access_token
-                                      delete_storage_token
-                                      notifications
-                                      reminders
-                                      generate_rss_key
-                                      revoke_rss_key
-                                      generate_api_key
-                                      revoke_api_key
-                                      revoke_ical_token]
+  no_authorization_required! :account,
+                             :update_account,
+                             :settings,
+                             :update_settings,
+                             :password,
+                             :change_password,
+                             :access_token,
+                             :delete_storage_token,
+                             :notifications,
+                             :reminders,
+                             :generate_rss_key,
+                             :revoke_rss_key,
+                             :generate_api_key,
+                             :revoke_api_key,
+                             :revoke_ical_token
 
   menu_item :account,             only: [:account]
   menu_item :settings,            only: [:settings]

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -36,7 +36,7 @@ class NewsController < ApplicationController
   before_action :find_project_from_association, except: %i[new create index]
   before_action :find_project, only: %i[new create]
   before_action :authorize, except: [:index]
-  before_action :authorize_in_optional_project, only: [:index]
+  before_action :load_and_authorize_in_optional_project, only: [:index]
   accept_key_auth :index
 
   def index

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -112,13 +112,4 @@ class NewsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render_404
   end
-
-  def find_optional_project
-    return true unless params[:project_id]
-
-    @project = Project.find(params[:project_id])
-    authorize
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
 end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -36,7 +36,7 @@ class NewsController < ApplicationController
   before_action :find_project_from_association, except: %i[new create index]
   before_action :find_project, only: %i[new create]
   before_action :authorize, except: [:index]
-  before_action :find_optional_project, only: [:index]
+  before_action :authorize_in_optional_project, only: [:index]
   accept_key_auth :index
 
   def index

--- a/app/controllers/oauth/auth_base_controller.rb
+++ b/app/controllers/oauth/auth_base_controller.rb
@@ -37,7 +37,9 @@ module OAuth
     prepend_before_action :extend_content_security_policy
 
     skip_before_action :check_if_login_required
-    no_authorization_required!
+    no_authorization_required! only: %i[new
+                                        create
+                                        show]
 
     layout "only_logo"
 

--- a/app/controllers/oauth/auth_base_controller.rb
+++ b/app/controllers/oauth/auth_base_controller.rb
@@ -37,6 +37,8 @@ module OAuth
     prepend_before_action :extend_content_security_policy
 
     skip_before_action :check_if_login_required
+    no_authorization_required!
+
     layout "only_logo"
 
     def extend_content_security_policy

--- a/app/controllers/oauth/auth_base_controller.rb
+++ b/app/controllers/oauth/auth_base_controller.rb
@@ -37,9 +37,9 @@ module OAuth
     prepend_before_action :extend_content_security_policy
 
     skip_before_action :check_if_login_required
-    no_authorization_required! only: %i[new
-                                        create
-                                        show]
+    no_authorization_required! :new,
+                               :create,
+                               :show
 
     layout "only_logo"
 

--- a/app/controllers/oauth/grants_controller.rb
+++ b/app/controllers/oauth/grants_controller.rb
@@ -29,6 +29,7 @@
 module OAuth
   class GrantsController < ::ApplicationController
     before_action :require_login
+    authorization_checked! only: %i[index revoke_application]
 
     layout "my"
     menu_item :access_token
@@ -57,6 +58,7 @@ module OAuth
 
     def find_application
       ::Doorkeeper::Application
+        .authorized_for(current_user)
         .where(id: params[:application_id])
         .select(:name, :id)
         .take

--- a/app/controllers/oauth/grants_controller.rb
+++ b/app/controllers/oauth/grants_controller.rb
@@ -29,7 +29,7 @@
 module OAuth
   class GrantsController < ::ApplicationController
     before_action :require_login
-    authorization_checked! only: %i[index revoke_application]
+    authorization_checked! :index, :revoke_application
 
     layout "my"
     menu_item :access_token

--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -38,6 +38,8 @@ class OAuthClientsController < ApplicationController
   before_action :set_code, only: [:callback]
   before_action :set_connection_manager, only: [:callback]
 
+  no_authorization_required! only: %i[callback ensure_connection]
+
   after_action :clear_oauth_state_cookie, only: [:callback]
 
   # Provide the OAuth2 "callback" endpoint.

--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -38,7 +38,7 @@ class OAuthClientsController < ApplicationController
   before_action :set_code, only: [:callback]
   before_action :set_connection_manager, only: [:callback]
 
-  no_authorization_required! only: %i[callback ensure_connection]
+  no_authorization_required! :callback, :ensure_connection
 
   after_action :clear_oauth_state_cookie, only: [:callback]
 

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -27,7 +27,7 @@
 #++
 
 class OnboardingController < ApplicationController
-  no_authorization_required! only: %i[user_settings]
+  no_authorization_required! :user_settings
 
   def user_settings
     @user = User.current

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -27,6 +27,8 @@
 #++
 
 class OnboardingController < ApplicationController
+  no_authorization_required! only: %i[user_settings]
+
   def user_settings
     @user = User.current
 

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -30,6 +30,7 @@ class PlaceholderUsersController < ApplicationController
   include EnterpriseTrialHelper
   layout "admin"
   before_action :authorize_global, except: %i[show]
+  no_authorization_required! only: %i[show]
 
   before_action :find_placeholder_user, only: %i[show
                                                  edit

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -30,7 +30,7 @@ class PlaceholderUsersController < ApplicationController
   include EnterpriseTrialHelper
   layout "admin"
   before_action :authorize_global, except: %i[show]
-  no_authorization_required! only: %i[show]
+  no_authorization_required! :show
 
   before_action :find_placeholder_user, only: %i[show
                                                  edit

--- a/app/controllers/projects/menus_controller.rb
+++ b/app/controllers/projects/menus_controller.rb
@@ -29,6 +29,7 @@ module Projects
   class MenusController < ApplicationController
     # No authorize as every user (or logged in user)
     # is allowed to see the menu.
+    no_authorization_required! only: :show
 
     def show
       projects_menu = Menus::Projects.new(controller_path: params[:controller_path], params:, current_user:)

--- a/app/controllers/projects/menus_controller.rb
+++ b/app/controllers/projects/menus_controller.rb
@@ -29,7 +29,7 @@ module Projects
   class MenusController < ApplicationController
     # No authorize as every user (or logged in user)
     # is allowed to see the menu.
-    no_authorization_required! only: :show
+    no_authorization_required! :show
 
     def show
       projects_menu = Menus::Projects.new(controller_path: params[:controller_path], params:, current_user:)

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -30,6 +30,7 @@ class Projects::QueriesController < ApplicationController
   include Projects::QueryLoading
 
   # No need for a more specific authorization check. That is carried out in the contracts.
+  no_authorization_required! only: %i[show new create rename update publish unpublish destroy]
   before_action :require_login
   before_action :find_query, only: %i[show rename update destroy publish unpublish]
   before_action :build_query_or_deny_access, only: %i[new create]

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -30,7 +30,7 @@ class Projects::QueriesController < ApplicationController
   include Projects::QueryLoading
 
   # No need for a more specific authorization check. That is carried out in the contracts.
-  no_authorization_required! only: %i[show new create rename update publish unpublish destroy]
+  no_authorization_required! :show, :new, :create, :rename, :update, :publish, :unpublish, :destroy
   before_action :require_login
   before_action :find_query, only: %i[show rename update destroy publish unpublish]
   before_action :build_query_or_deny_access, only: %i[new create]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,6 +36,8 @@ class ProjectsController < ApplicationController
   before_action :authorize_global, only: %i[new]
   before_action :require_admin, only: %i[destroy destroy_info]
 
+  no_authorization_required! only: %i[index]
+
   include SortHelper
   include PaginationHelper
   include QueriesHelper

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -104,15 +104,6 @@ class ProjectsController < ApplicationController
     project.project_storages.any?(&:project_folder_automatic?)
   end
 
-  def find_optional_project
-    return true unless params[:id]
-
-    @project = Project.find(params[:id])
-    authorize
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
-
   def hide_project_in_layout
     @project = nil
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,7 +36,7 @@ class ProjectsController < ApplicationController
   before_action :authorize_global, only: %i[new]
   before_action :require_admin, only: %i[destroy destroy_info]
 
-  no_authorization_required! only: %i[index]
+  no_authorization_required! :index
 
   include SortHelper
   include PaginationHelper

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -29,7 +29,7 @@
 class SearchController < ApplicationController
   include Layout
 
-  before_action :find_optional_project,
+  before_action :authorize_in_optional_project,
                 :prepare_tokens
 
   LIMIT = 10

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -29,7 +29,7 @@
 class SearchController < ApplicationController
   include Layout
 
-  before_action :authorize_in_optional_project,
+  before_action :load_and_authorize_in_optional_project,
                 :prepare_tokens
 
   LIMIT = 10

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -62,15 +62,6 @@ class SearchController < ApplicationController
     end
   end
 
-  def find_optional_project
-    return true unless params[:project_id]
-
-    @project = Project.find(params[:project_id])
-    check_project_privacy
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
-
   def limit_results_first_page
     @pagination_previous_date = @results[0].event_datetime if offset && @results[0]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,6 +44,9 @@ class UsersController < ApplicationController
   before_action :authorize_for_user, only: [:destroy]
   before_action :check_if_deletion_allowed, only: %i[deletion_info
                                                      destroy]
+  no_authorization_required! only: %i[show]
+  authorization_checked! only: %i[destroy deletion_info]
+
   before_action :set_current_activity_page, only: [:show]
 
   # Password confirmation helpers and actions

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,8 +44,8 @@ class UsersController < ApplicationController
   before_action :authorize_for_user, only: [:destroy]
   before_action :check_if_deletion_allowed, only: %i[deletion_info
                                                      destroy]
-  no_authorization_required! only: %i[show]
-  authorization_checked! only: %i[destroy deletion_info]
+  no_authorization_required! :show
+  authorization_checked! :destroy, :deletion_info
 
   before_action :set_current_activity_page, only: [:show]
 

--- a/app/controllers/watchers_controller.rb
+++ b/app/controllers/watchers_controller.rb
@@ -32,7 +32,8 @@ class WatchersController < ApplicationController
                 :require_login,
                 :deny_access_unless_visible
 
-  authorization_checked! only: %i[watch unwatch]
+  authorization_checked! :watch,
+                         :unwatch
 
   def watch
     set_watcher(User.current, true)

--- a/app/controllers/watchers_controller.rb
+++ b/app/controllers/watchers_controller.rb
@@ -27,16 +27,15 @@
 #++
 
 class WatchersController < ApplicationController
-  before_action :find_watched_by_object
-  before_action :find_project
-  before_action :require_login, :check_project_privacy, only: %i[watch unwatch]
+  before_action :find_watched_by_object,
+                :find_project,
+                :require_login,
+                :deny_access_unless_visible
+
+  authorization_checked! only: %i[watch unwatch]
 
   def watch
-    if @watched.respond_to?(:visible?) && !@watched.visible?(User.current)
-      render_403
-    else
-      set_watcher(User.current, true)
-    end
+    set_watcher(User.current, true)
   end
 
   def unwatch
@@ -59,5 +58,9 @@ class WatchersController < ApplicationController
   def set_watcher(user, watching)
     @watched.set_watcher(user, watching)
     redirect_back(fallback_location: home_url)
+  end
+
+  def deny_access_unless_visible
+    deny_access unless @watched.visible?(User.current)
   end
 end

--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -30,7 +30,7 @@ require "rack/utils"
 
 class WorkPackages::AutoCompletesController < ApplicationController
   # Authorization is checked by the query.
-  no_authorization_required! only: :index
+  no_authorization_required! :index
 
   def index
     @work_packages = work_packages_matching_query_prop

--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -29,6 +29,9 @@
 require "rack/utils"
 
 class WorkPackages::AutoCompletesController < ApplicationController
+  # Authorization is checked by the query.
+  no_authorization_required! only: :index
+
   def index
     @work_packages = work_packages_matching_query_prop
 

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -37,6 +37,7 @@ class WorkPackages::ProgressController < ApplicationController
   layout false
   before_action :set_work_package
   before_action :extract_persisted_progress_attributes, only: %i[edit create update]
+  authorization_checked! only: %i[new edit create update]
 
   helper_method :modal_class
 

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -37,7 +37,7 @@ class WorkPackages::ProgressController < ApplicationController
   layout false
   before_action :set_work_package
   before_action :extract_persisted_progress_attributes, only: %i[edit create update]
-  authorization_checked! only: %i[new edit create update]
+  authorization_checked! :new, :edit, :create, :update
 
   helper_method :modal_class
 

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -36,9 +36,10 @@ class WorkPackagesController < ApplicationController
 
   before_action :authorize_on_work_package,
                 :project, only: :show
-  before_action :find_optional_project,
+  before_action :authorize_in_optional_project,
                 :check_allowed_export,
                 :protect_from_unauthorized_export, only: :index
+  authorization_checked! only: %i[index show]
 
   before_action :load_and_validate_query, only: :index, unless: -> { request.format.html? }
   before_action :load_work_packages, only: :index, if: -> { request.format.atom? }

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -36,7 +36,7 @@ class WorkPackagesController < ApplicationController
 
   before_action :authorize_on_work_package,
                 :project, only: :show
-  before_action :authorize_in_optional_project,
+  before_action :load_and_authorize_in_optional_project,
                 :check_allowed_export,
                 :protect_from_unauthorized_export, only: :index
   authorization_checked! only: %i[index show]

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -39,7 +39,7 @@ class WorkPackagesController < ApplicationController
   before_action :load_and_authorize_in_optional_project,
                 :check_allowed_export,
                 :protect_from_unauthorized_export, only: :index
-  authorization_checked! only: %i[index show]
+  authorization_checked! :index, :show
 
   before_action :load_and_validate_query, only: :index, unless: -> { request.format.html? }
   before_action :load_work_packages, only: :index, if: -> { request.format.atom? }

--- a/modules/avatars/app/controllers/avatars/avatar_controller.rb
+++ b/modules/avatars/app/controllers/avatars/avatar_controller.rb
@@ -3,7 +3,7 @@ module ::Avatars
     before_action :ensure_enabled
     before_action :find_avatar
 
-    no_authorization_required!
+    no_authorization_required! only: %i[show]
 
     def show
       send_file @avatar.diskfile,

--- a/modules/avatars/app/controllers/avatars/avatar_controller.rb
+++ b/modules/avatars/app/controllers/avatars/avatar_controller.rb
@@ -3,7 +3,7 @@ module ::Avatars
     before_action :ensure_enabled
     before_action :find_avatar
 
-    no_authorization_required! only: %i[show]
+    no_authorization_required! :show
 
     def show
       send_file @avatar.diskfile,

--- a/modules/avatars/app/controllers/avatars/avatar_controller.rb
+++ b/modules/avatars/app/controllers/avatars/avatar_controller.rb
@@ -3,6 +3,8 @@ module ::Avatars
     before_action :ensure_enabled
     before_action :find_avatar
 
+    no_authorization_required!
+
     def show
       send_file @avatar.diskfile,
                 filename: filename_for_content_disposition(@avatar.filename),

--- a/modules/avatars/app/controllers/avatars/my_avatar_controller.rb
+++ b/modules/avatars/app/controllers/avatars/my_avatar_controller.rb
@@ -3,6 +3,8 @@ module ::Avatars
     before_action :require_login
     before_action :set_user
 
+    no_authorization_required! only: %i[show update destroy]
+
     layout "my"
     menu_item :avatar
 

--- a/modules/avatars/app/controllers/avatars/my_avatar_controller.rb
+++ b/modules/avatars/app/controllers/avatars/my_avatar_controller.rb
@@ -3,7 +3,9 @@ module ::Avatars
     before_action :require_login
     before_action :set_user
 
-    no_authorization_required! only: %i[show update destroy]
+    no_authorization_required! :show,
+                               :update,
+                               :destroy
 
     layout "my"
     menu_item :avatar

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -39,6 +39,7 @@ module Bim
       before_action :authorize, except: %i[direct_upload_finished set_direct_upload_file_name]
       before_action :require_login, only: [:set_direct_upload_file_name]
       skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name] # AJAX request in page, so skip authenticity token
+      no_authorization_required! only: %i[set_direct_upload_file_name direct_upload_finished]
 
       menu_item :ifc_models
 

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -39,7 +39,8 @@ module Bim
       before_action :authorize, except: %i[direct_upload_finished set_direct_upload_file_name]
       before_action :require_login, only: [:set_direct_upload_file_name]
       skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name] # AJAX request in page, so skip authenticity token
-      no_authorization_required! only: %i[set_direct_upload_file_name direct_upload_finished]
+      no_authorization_required! :set_direct_upload_file_name,
+                                 :direct_upload_finished
 
       menu_item :ifc_models
 

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -2,10 +2,7 @@ module ::Boards
   class BoardsController < BaseController
     include Layout
 
-    before_action :find_optional_project
-
-    before_action :authorize_global, if: -> { @project.nil? }
-    before_action :authorize, if: -> { @project.present? }
+    before_action :authorize_in_optional_project
 
     # The boards permission alone does not suffice
     # to view work packages

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -2,7 +2,7 @@ module ::Boards
   class BoardsController < BaseController
     include Layout
 
-    before_action :authorize_in_optional_project
+    before_action :load_and_authorize_in_optional_project
 
     # The boards permission alone does not suffice
     # to view work packages

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -32,16 +32,17 @@ class BudgetsController < ApplicationController
   before_action :find_budget, only: %i[show edit update copy destroy_info]
   before_action :find_budgets, only: :destroy
   before_action :check_and_update_belonging_work_packages, only: :destroy
-  before_action :find_project, only: %i[new create update_material_budget_item update_labor_budget_item]
+  before_action :find_project_by_project_id, only: %i[new create update_material_budget_item update_labor_budget_item]
   before_action :find_optional_project, only: :index
 
   before_action :authorize_global, only: :index
   before_action :authorize, except: [
-    # unrestricted actions
     :index,
+    # unrestricted actions
     :update_material_budget_item,
     :update_labor_budget_item
   ]
+  no_authorization_required! only: %i[update_material_budget_item update_labor_budget_item]
 
   helper :sort
   include SortHelper

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -219,12 +219,6 @@ class BudgetsController < ApplicationController
     render_404
   end
 
-  def find_project
-    @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
-
   def find_optional_project
     @project = Project.find(params[:project_id]) if params[:project_id].present?
   rescue ActiveRecord::RecordNotFound

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -42,7 +42,8 @@ class BudgetsController < ApplicationController
     :update_material_budget_item,
     :update_labor_budget_item
   ]
-  no_authorization_required! only: %i[update_material_budget_item update_labor_budget_item]
+  no_authorization_required! :update_material_budget_item,
+                             :update_labor_budget_item
 
   helper :sort
   include SortHelper

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -28,7 +28,7 @@
 
 module ::Calendar
   class CalendarsController < ApplicationController
-    before_action :authorize_in_optional_project
+    before_action :load_and_authorize_in_optional_project
     before_action :build_calendar_view, only: %i[new]
     before_action :authorize, except: %i[index new create]
     before_action :authorize_global, only: %i[index new create]

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -28,7 +28,7 @@
 
 module ::Calendar
   class CalendarsController < ApplicationController
-    before_action :find_optional_project
+    before_action :authorize_in_optional_project
     before_action :build_calendar_view, only: %i[new]
     before_action :authorize, except: %i[index new create]
     before_action :authorize_global, only: %i[index new create]

--- a/modules/calendar/app/controllers/calendar/ical_controller.rb
+++ b/modules/calendar/app/controllers/calendar/ical_controller.rb
@@ -30,6 +30,7 @@ module ::Calendar
   class ICalController < ApplicationController
     # Authentication and authorization is handled within the service.
     skip_before_action :check_if_login_required
+    no_authorization_required! only: :show
 
     def show
       begin

--- a/modules/calendar/app/controllers/calendar/ical_controller.rb
+++ b/modules/calendar/app/controllers/calendar/ical_controller.rb
@@ -30,7 +30,7 @@ module ::Calendar
   class ICalController < ApplicationController
     # Authentication and authorization is handled within the service.
     skip_before_action :check_if_login_required
-    no_authorization_required! only: :show
+    no_authorization_required! :show
 
     def show
       begin

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -115,22 +115,6 @@ class CostlogController < ApplicationController
     render_404
   end
 
-  def find_optional_project
-    if params[:work_package_id].present?
-      @work_package = WorkPackage.find(params[:work_package_id])
-      @project = @work_package.project
-    elsif params[:work_package_id].present?
-      @work_package = WorkPackage.find(params[:work_package_id])
-      @project = @work_package.project
-    elsif params[:project_id].present?
-      @project = Project.find(params[:project_id])
-    end
-
-    if params[:cost_type_id].present?
-      @cost_type = CostType.find(params[:cost_type_id])
-    end
-  end
-
   def find_associated_objects
     user_id = cost_entry_params.delete(:user_id)
     @user = if @cost_entry.present? && @cost_entry.user_id == user_id

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -38,8 +38,9 @@ class HourlyRatesController < ApplicationController
   before_action :find_optional_project, only: %i[show edit update]
   before_action :find_project, only: [:set_rate]
 
-  # #show, #edit have their own authorization
+  # #show, #edit and #update have their own authorization
   before_action :authorize, except: %i[show edit update]
+  no_authorization_required! only: %i[show edit update]
 
   # TODO: this should be an index
   def show

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -40,7 +40,9 @@ class HourlyRatesController < ApplicationController
 
   # #show, #edit and #update have their own authorization
   before_action :authorize, except: %i[show edit update]
-  no_authorization_required! only: %i[show edit update]
+  no_authorization_required! :show,
+                             :edit,
+                             :update
 
   # TODO: this should be an index
   def show

--- a/modules/gantt/app/controllers/gantt/gantt_controller.rb
+++ b/modules/gantt/app/controllers/gantt/gantt_controller.rb
@@ -6,7 +6,7 @@ module ::Gantt
 
     accept_key_auth :index
 
-    before_action :find_optional_project, :protect_from_unauthorized_export, only: :index
+    before_action :authorize_in_optional_project, :protect_from_unauthorized_export, only: :index
 
     before_action :load_and_validate_query, only: :index, unless: -> { request.format.html? }
 

--- a/modules/gantt/app/controllers/gantt/gantt_controller.rb
+++ b/modules/gantt/app/controllers/gantt/gantt_controller.rb
@@ -6,7 +6,7 @@ module ::Gantt
 
     accept_key_auth :index
 
-    before_action :authorize_in_optional_project, :protect_from_unauthorized_export, only: :index
+    before_action :load_and_authorize_in_optional_project, :protect_from_unauthorized_export, only: :index
 
     before_action :load_and_validate_query, only: :index, unless: -> { request.format.html? }
 

--- a/modules/gantt/app/controllers/gantt/menus_controller.rb
+++ b/modules/gantt/app/controllers/gantt/menus_controller.rb
@@ -27,7 +27,7 @@
 # ++
 module Gantt
   class MenusController < ApplicationController
-    before_action :find_optional_project
+    before_action :authorize_in_optional_project
 
     def show
       @sidebar_menu_items = menu_items

--- a/modules/gantt/app/controllers/gantt/menus_controller.rb
+++ b/modules/gantt/app/controllers/gantt/menus_controller.rb
@@ -27,7 +27,7 @@
 # ++
 module Gantt
   class MenusController < ApplicationController
-    before_action :authorize_in_optional_project
+    before_action :load_and_authorize_in_optional_project
 
     def show
       @sidebar_menu_items = menu_items

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -28,7 +28,7 @@
 
 class MeetingsController < ApplicationController
   around_action :set_time_zone
-  before_action :find_optional_project, only: %i[index new show create history]
+  before_action :authorize_in_optional_project, only: %i[index new show create history]
   before_action :verify_activities_module_activated, only: %i[history]
   before_action :determine_date_range, only: %i[history]
   before_action :determine_author, only: %i[history]

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -28,7 +28,7 @@
 
 class MeetingsController < ApplicationController
   around_action :set_time_zone
-  before_action :authorize_in_optional_project, only: %i[index new show create history]
+  before_action :load_and_authorize_in_optional_project, only: %i[index new show create history]
   before_action :verify_activities_module_activated, only: %i[history]
   before_action :determine_date_range, only: %i[history]
   before_action :determine_author, only: %i[history]

--- a/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
+++ b/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
@@ -7,6 +7,7 @@ module ::Recaptcha
 
     # User is not yet logged in, so skip login required check
     skip_before_action :check_if_login_required
+    no_authorization_required! only: %i[perform verify]
 
     # Skip if recaptcha was disabled
     before_action :skip_if_disabled

--- a/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
+++ b/modules/recaptcha/app/controllers/recaptcha/request_controller.rb
@@ -7,7 +7,8 @@ module ::Recaptcha
 
     # User is not yet logged in, so skip login required check
     skip_before_action :check_if_login_required
-    no_authorization_required! only: %i[perform verify]
+    no_authorization_required! :perform,
+                               :verify
 
     # Skip if recaptcha was disabled
     before_action :skip_if_disabled

--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -40,7 +40,7 @@ class CostReportsController < ApplicationController
 
   before_action :check_cache
   before_action :load_all
-  before_action :find_optional_project
+  before_action :authorize_in_optional_project
   before_action :find_optional_user
 
   include Layout

--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -40,7 +40,7 @@ class CostReportsController < ApplicationController
 
   before_action :check_cache
   before_action :load_all
-  before_action :authorize_in_optional_project
+  before_action :load_and_authorize_in_optional_project
   before_action :find_optional_user
 
   include Layout

--- a/modules/storages/app/controllers/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/project_storages_controller.rb
@@ -36,6 +36,7 @@ class Storages::ProjectStoragesController < ApplicationController
   before_action :find_model_object
   before_action :find_project_by_project_id
   before_action :render_403, unless: -> { User.current.allowed_in_project?(:view_file_links, @project) }
+  no_authorization_required! only: %i[open]
 
   # rubocop:disable Metrics/AbcSize
   def open

--- a/modules/storages/app/controllers/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/project_storages_controller.rb
@@ -36,7 +36,7 @@ class Storages::ProjectStoragesController < ApplicationController
   before_action :find_model_object
   before_action :find_project_by_project_id
   before_action :render_403, unless: -> { User.current.allowed_in_project?(:view_file_links, @project) }
-  no_authorization_required! only: %i[open]
+  no_authorization_required! :open
 
   # rubocop:disable Metrics/AbcSize
   def open

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -2,10 +2,8 @@ module ::TeamPlanner
   class TeamPlannerController < BaseController
     include EnterpriseTrialHelper
     include Layout
-    before_action :find_optional_project
+    before_action :authorize_in_optional_project
     before_action :build_plan_view, only: %i[new]
-    before_action :authorize, except: %i[overview new create upsale]
-    before_action :authorize_global, only: %i[overview new create]
     before_action :require_ee_token, except: %i[upsale]
     before_action :find_plan_view, only: %i[destroy]
 

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -2,7 +2,7 @@ module ::TeamPlanner
   class TeamPlannerController < BaseController
     include EnterpriseTrialHelper
     include Layout
-    before_action :authorize_in_optional_project
+    before_action :load_and_authorize_in_optional_project
     before_action :build_plan_view, only: %i[new]
     before_action :require_ee_token, except: %i[upsale]
     before_action :find_plan_view, only: %i[destroy]

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -11,7 +11,12 @@ module ::TwoFactorAuthentication
 
     # User is not yet logged in, so skip login required check
     skip_before_action :check_if_login_required
-    no_authorization_required!
+    no_authorization_required! only: %i[request_otp
+                                        confirm_otp
+                                        enter_backup_code
+                                        verify_backup_code
+                                        retry
+                                        webauthn_challenge]
 
     # Avoid catch-all from core resulting in methods
     before_action :only_post, only: :confirm_otp

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -11,6 +11,7 @@ module ::TwoFactorAuthentication
 
     # User is not yet logged in, so skip login required check
     skip_before_action :check_if_login_required
+    no_authorization_required!
 
     # Avoid catch-all from core resulting in methods
     before_action :only_post, only: :confirm_otp

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -11,12 +11,12 @@ module ::TwoFactorAuthentication
 
     # User is not yet logged in, so skip login required check
     skip_before_action :check_if_login_required
-    no_authorization_required! only: %i[request_otp
-                                        confirm_otp
-                                        enter_backup_code
-                                        verify_backup_code
-                                        retry
-                                        webauthn_challenge]
+    no_authorization_required! :request_otp,
+                               :confirm_otp,
+                               :enter_backup_code,
+                               :verify_backup_code,
+                               :retry,
+                               :webauthn_challenge
 
     # Avoid catch-all from core resulting in methods
     before_action :only_post, only: :confirm_otp

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
@@ -6,12 +6,12 @@ module ::TwoFactorAuthentication
 
       # Skip default login
       skip_before_action :check_if_login_required
-      no_authorization_required! only: %i[register
-                                          new
-                                          confirm
-                                          web_authn
-                                          make_default
-                                          destroy]
+      no_authorization_required! :register,
+                                 :new,
+                                 :confirm,
+                                 :web_authn,
+                                 :make_default,
+                                 :destroy
 
       before_action :find_device, only: [:confirm]
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
@@ -6,6 +6,12 @@ module ::TwoFactorAuthentication
 
       # Skip default login
       skip_before_action :check_if_login_required
+      no_authorization_required! only: %i[register
+                                          new
+                                          confirm
+                                          web_authn
+                                          make_default
+                                          destroy]
 
       before_action :find_device, only: [:confirm]
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
@@ -3,6 +3,7 @@ module ::TwoFactorAuthentication
     class BackupCodesController < ::ApplicationController
       # Ensure user is logged in
       before_action :require_login
+      no_authorization_required! only: %i[show create]
 
       # Password confirmation helpers and actions
       include PasswordConfirmation
@@ -22,6 +23,8 @@ module ::TwoFactorAuthentication
       def show
         render
       end
+
+      private
 
       def check_regenerate_done
         @backup_codes = flash[:_backup_codes]

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
@@ -3,7 +3,7 @@ module ::TwoFactorAuthentication
     class BackupCodesController < ::ApplicationController
       # Ensure user is logged in
       before_action :require_login
-      no_authorization_required! only: %i[show create]
+      no_authorization_required! :show, :create
 
       # Password confirmation helpers and actions
       include PasswordConfirmation

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
@@ -6,7 +6,7 @@ module ::TwoFactorAuthentication
 
       # Ensure user is logged in
       before_action :require_login
-      no_authorization_required! only: :destroy
+      no_authorization_required! :destroy
 
       layout "my"
       menu_item :two_factor_authentication

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
@@ -6,7 +6,7 @@ module ::TwoFactorAuthentication
 
       # Ensure user is logged in
       before_action :require_login
-      no_authorization_required!
+      no_authorization_required! only: :destroy
 
       layout "my"
       menu_item :two_factor_authentication

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
@@ -6,6 +6,7 @@ module ::TwoFactorAuthentication
 
       # Ensure user is logged in
       before_action :require_login
+      no_authorization_required!
 
       layout "my"
       menu_item :two_factor_authentication

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -4,9 +4,16 @@ module ::TwoFactorAuthentication
       # Ensure user is logged in
       before_action :require_login
       before_action :set_user_variables
-      # Authorization is not handled explictly but as the user on which changes can be done is only the current user
+      # Authorization is not handled explicitly but as the user on which changes can be done is only the current user
       # (and that user needs to be logged in), no action harmful to other users can be done.
-      no_authorization_required!
+      no_authorization_required! only: %i[new
+                                          index
+                                          create
+                                          register
+                                          confirm
+                                          destroy
+                                          make_default
+                                          webauthn_challenge]
 
       before_action :find_device, except: %i[new index register webauthn_challenge]
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -3,8 +3,10 @@ module ::TwoFactorAuthentication
     class TwoFactorDevicesController < ::TwoFactorAuthentication::BaseController
       # Ensure user is logged in
       before_action :require_login
-
       before_action :set_user_variables
+      # Authorization is not handled explictly but as the user on which changes can be done is only the current user
+      # (and that user needs to be logged in), no action harmful to other users can be done.
+      no_authorization_required!
 
       before_action :find_device, except: %i[new index register webauthn_challenge]
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -6,14 +6,14 @@ module ::TwoFactorAuthentication
       before_action :set_user_variables
       # Authorization is not handled explicitly but as the user on which changes can be done is only the current user
       # (and that user needs to be logged in), no action harmful to other users can be done.
-      no_authorization_required! only: %i[new
-                                          index
-                                          create
-                                          register
-                                          confirm
-                                          destroy
-                                          make_default
-                                          webauthn_challenge]
+      no_authorization_required! :new,
+                                 :index,
+                                 :create,
+                                 :register,
+                                 :confirm,
+                                 :destroy,
+                                 :make_default,
+                                 :webauthn_challenge
 
       before_action :find_device, except: %i[new index register webauthn_challenge]
 

--- a/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
@@ -35,6 +35,9 @@ module Webhooks
 
       # Disable CSRF detection since we openly welcome POSTs here!
       skip_before_action :verify_authenticity_token
+      # Authorization cannot be applied since authentication is skipped.
+      # It is then to be ensured when handling the hook.
+      no_authorization_required! only: [:handle_hook]
 
       # Wrap the JSON body as 'payload' param
       # making it available as params[:payload]

--- a/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
@@ -37,7 +37,7 @@ module Webhooks
       skip_before_action :verify_authenticity_token
       # Authorization cannot be applied since authentication is skipped.
       # It is then to be ensured when handling the hook.
-      no_authorization_required! only: [:handle_hook]
+      no_authorization_required! :handle_hook
 
       # Wrap the JSON body as 'payload' param
       # making it available as params[:payload]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe ApplicationController do
 
   # Fake controller to test calling an action
   controller do
+    no_authorization_required!
+
     def index
       # just do anything that doesn't require an extra template
       redirect_to root_path
@@ -151,6 +153,8 @@ RSpec.describe ApplicationController do
   describe "rack timeout duplicate error suppression", with_settings: { login_required: false } do
     controller do
       include OpenProjectErrorHelper
+
+      no_authorization_required!
 
       def index
         op_handle_error "fail"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ApplicationController do
 
   # Fake controller to test calling an action
   controller do
-    no_authorization_required!
+    no_authorization_required! :index
 
     def index
       # just do anything that doesn't require an extra template
@@ -154,7 +154,7 @@ RSpec.describe ApplicationController do
     controller do
       include OpenProjectErrorHelper
 
-      no_authorization_required!
+      no_authorization_required! :index
 
       def index
         op_handle_error "fail"

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
 
       def authorize; end
 
-      def authorize_in_optional_project; end
+      def load_and_authorize_in_optional_project; end
 
       def other_before_action; end
     end
@@ -110,9 +110,9 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "succeeds"
   end
 
-  context "with authorization checked with authorize_in_optional_project" do
+  context "with authorization checked with load_and_authorize_in_optional_project" do
     controller do
-      before_action :authorize_in_optional_project
+      before_action :load_and_authorize_in_optional_project
 
       include controller_setup
     end

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -1,0 +1,302 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe ApplicationController, "enforcement of authorization" do # rubocop:disable RSpec/FilePath, RSpec/SpecFilePathFormat
+  shared_let(:user) { create(:user) }
+
+  controller_setup = Module.new do
+    extend ActiveSupport::Concern
+
+    included do
+      def index
+        render plain: "OK"
+      end
+
+      private
+
+      def require_admin; end
+      def authorize_global; end
+
+      def authorize; end
+
+      def authorize_in_optional_project; end
+
+      def other_before_action; end
+    end
+  end
+
+  current_user { user }
+
+  shared_examples "succeeds" do
+    it "succeeds" do
+      get :index
+
+      expect(response)
+        .to have_http_status :ok
+    end
+  end
+
+  shared_examples "is prevented" do
+    it "fails with a 403" do
+      get :index
+
+      expect(response)
+        .to have_http_status :forbidden
+    end
+  end
+
+  context "without authorization or authorization forfeiting" do
+    controller do
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "with authorization checked with require_admin" do
+    controller do
+      before_action :require_admin
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked with authorize_global" do
+    controller do
+      before_action :authorize_global
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked with authorize" do
+    controller do
+      before_action :authorize
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked with authorize_in_optional_project" do
+    controller do
+      before_action :authorize_in_optional_project
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with another before action specified" do
+    controller do
+      before_action :other_before_action
+
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "when forfeiting authorization checks" do
+    controller do
+      no_authorization_required!
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when stating that authorization has been checked" do
+    controller do
+      authorization_checked!
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization check in the superclass" do
+    controller(described_class) do
+      before_action :require_admin
+    end
+
+    controller(controller_class) do
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when stating that authorization has been checked in the superclass" do
+    controller(described_class) do
+      authorization_checked!
+    end
+
+    controller(controller_class) do
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when forfeiting authorization checks in the superclass" do
+    controller(described_class) do
+      no_authorization_required!
+    end
+
+    controller(controller_class) do
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when forfeiting authorization checks on this specific action with only" do
+    controller do
+      no_authorization_required! only: %i[index]
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when forfeiting authorization checks on another action with only" do
+    controller do
+      no_authorization_required! only: %i[some_other_action]
+
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "when forfeiting authorization checks on all but another action with except" do
+    controller do
+      no_authorization_required! except: %i[some_other_action]
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "when forfeiting authorization on all other actions with except" do
+    controller do
+      no_authorization_required! except: %i[index]
+
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "with authorization checked on another action with only" do
+    controller do
+      before_action :require_admin, only: %i[some_other_action]
+
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "with authorization checked on the action with only" do
+    controller do
+      before_action :require_admin, only: %i[index]
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked on all but this action with except" do
+    controller do
+      before_action :require_admin, except: %i[index]
+
+      include controller_setup
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "with authorization checked on all but another action with except" do
+    controller do
+      before_action :require_admin, except: %i[another_action]
+
+      def another_action; end
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked in a sibling class" do
+    # Superclass
+    controller do
+      include controller_setup
+    end
+
+    anonymous_superclass = controller_class
+
+    # Sibling class
+    controller(anonymous_superclass) do
+      before_action :require_admin
+    end
+
+    # actually tested class
+    controller(anonymous_superclass) do
+      # Nothing extra
+    end
+
+    it_behaves_like "is prevented"
+  end
+
+  context "with authorization checked by a number of different actions" do
+    controller do
+      before_action :require_admin, except: %i[index]
+      before_action :authorize, only: %i[index]
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+end

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -150,26 +150,6 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "is prevented"
   end
 
-  context "when forfeiting authorization checks" do
-    controller do
-      no_authorization_required!
-
-      include controller_setup
-    end
-
-    it_behaves_like "succeeds"
-  end
-
-  context "when stating that authorization has been checked" do
-    controller do
-      authorization_checked!
-
-      include controller_setup
-    end
-
-    it_behaves_like "succeeds"
-  end
-
   context "with authorization check in the superclass" do
     controller(described_class) do
       before_action :require_admin
@@ -182,9 +162,19 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "succeeds"
   end
 
+  context "when forfeiting authorization checks on this specific action" do
+    controller do
+      no_authorization_required! :index
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
   context "when stating that authorization has been checked in the superclass" do
     controller(described_class) do
-      authorization_checked!
+      authorization_checked! :index
     end
 
     controller(controller_class) do
@@ -196,7 +186,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
 
   context "when forfeiting authorization checks in the superclass" do
     controller(described_class) do
-      no_authorization_required!
+      no_authorization_required! :index
     end
 
     controller(controller_class) do
@@ -206,39 +196,9 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "succeeds"
   end
 
-  context "when forfeiting authorization checks on this specific action with only" do
+  context "when forfeiting authorization checks on another action" do
     controller do
-      no_authorization_required! only: %i[index]
-
-      include controller_setup
-    end
-
-    it_behaves_like "succeeds"
-  end
-
-  context "when forfeiting authorization checks on another action with only" do
-    controller do
-      no_authorization_required! only: %i[some_other_action]
-
-      include controller_setup
-    end
-
-    it_behaves_like "is prevented"
-  end
-
-  context "when forfeiting authorization checks on all but another action with except" do
-    controller do
-      no_authorization_required! except: %i[some_other_action]
-
-      include controller_setup
-    end
-
-    it_behaves_like "succeeds"
-  end
-
-  context "when forfeiting authorization on all other actions with except" do
-    controller do
-      no_authorization_required! except: %i[index]
+      no_authorization_required! :some_other_action
 
       include controller_setup
     end

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "succeeds"
   end
 
+  context "with authorization checked via prepend_before_action" do
+    controller do
+      prepend_before_action :authorize
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked via append_before_action" do
+    controller do
+      append_before_action :authorize
+
+      include controller_setup
+    end
+
+    it_behaves_like "succeeds"
+  end
+
   context "with another before action specified" do
     controller do
       before_action :other_before_action

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -64,11 +64,9 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
   end
 
   shared_examples "is prevented" do
-    it "fails with a 403" do
-      get :index
-
-      expect(response)
-        .to have_http_status :forbidden
+    it "fails with a RuntimeError" do
+      expect { get :index }
+        .to raise_error RuntimeError
     end
   end
 

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Login" do
     end
 
     it "prevents login for a blocked user" do
-      user.lock!
+      user.locked!
 
       login_with(user.login, user.password)
 

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -52,15 +52,19 @@ module PermissionSpecs
         controller_name, action_name = controller_action.split("#")
 
         it "allows calling #{controller_action} when having the permission #{permission}" do
+          controller.params = { controller: controller_name, action: action_name }
+
           become_member_with_permissions(project, current_user, permission)
 
-          expect(controller.send(:authorize, controller_name, action_name)).to be_truthy
+          expect(controller.send(:authorize)).to be_truthy
         end
 
         it "prevents calling #{controller_action} when not having the permission #{permission}" do
+          controller.params = { controller: controller_name, action: action_name }
+
           become_member(project, current_user)
 
-          expect(controller.send(:authorize, controller_name, action_name)).to be_falsey
+          expect(controller.send(:authorize)).to be_falsey
         end
       end
 


### PR DESCRIPTION
### Goal

The PR adds a `before_action` that enforces developers to add any of the standard authorization methods as a before_action:

* `authorize`
* `authorize_global`
* `require_admin`
* `load_and_authorize_in_optional_project` (renamed from find_by_optional_project)

When failing to do so an error is raised in the `dev` environment and a 403 is returned in the others. 

Developers can choose to explicitly allow an action to skip authorization by calling:

* `no_authrization_required! only: :some_action`
* `no_authrization_required! except: :some_other_action`

If authorization is in fact checked but not by any of the default actions, the developer can instruct the system of this by stating:

* `authorization_checked! only: :some_action`
* `authorization_checked! except: :some_other_action`

### Other changes

* centralizes authorization controller code in a concern. 
* removes code (i.e. unused authorization methods)

### WP

https://community.openproject.org/wp/55192