### PR TITLE
Maintenance: make more settings runtime writable where possible

### DIFF
--- a/app/contracts/backups/create_contract.rb
+++ b/app/contracts/backups/create_contract.rb
@@ -49,7 +49,7 @@ module Backups
 
     def check_waiting_period(token)
       if token.waiting?
-        valid_at = token.created_at + OpenProject::Configuration.backup_initial_waiting_period
+        valid_at = token.created_at + Setting.backup_initial_waiting_period
         hours = ((valid_at - Time.zone.now) / 60.0 / 60.0).round
 
         errors.add :base, :token_cooldown, message: I18n.t("backup.error.token_cooldown", hours:)
@@ -57,7 +57,7 @@ module Backups
     end
 
     def backup_limit
-      limit = OpenProject::Configuration.backup_daily_limit
+      limit = Setting.backup_daily_limit
       if Backup.where("created_at >= ?", Time.zone.today).count > limit
         errors.add :base, :limit_reached, message: I18n.t("backup.error.limit_reached", limit:)
       end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -146,7 +146,7 @@ class AccountController < ApplicationController
   end
 
   def allow_registration?
-    allow = Setting::SelfRegistration.enabled? && !OpenProject::Configuration.disable_password_login?
+    allow = Setting::SelfRegistration.enabled? && !Setting.disable_password_login?
 
     invited = session[:invitation_token].present?
     get = request.get? && allow
@@ -156,7 +156,7 @@ class AccountController < ApplicationController
   end
 
   def allow_lost_password_recovery?
-    Setting.lost_password? && !OpenProject::Configuration.disable_password_login?
+    Setting.lost_password? && !Setting.disable_password_login?
   end
 
   # Token based account activation
@@ -234,7 +234,7 @@ class AccountController < ApplicationController
   def activate_user(user)
     if omniauth_direct_login?
       direct_login user
-    elsif OpenProject::Configuration.disable_password_login?
+    elsif Setting.disable_password_login?
       flash[:notice] = I18n.t("account.omniauth_login")
 
       redirect_to signin_path
@@ -401,7 +401,7 @@ class AccountController < ApplicationController
   end
 
   def authenticate_user
-    if OpenProject::Configuration.disable_password_login?
+    if Setting.disable_password_login?
       render_404
     else
       password_authentication(params[:username]&.strip, params[:password])

--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -85,7 +85,7 @@ class Admin::BackupsController < ApplicationController
   end
 
   def check_enabled
-    render_404 unless OpenProject::Configuration.backup_enabled?
+    render_404 unless Setting.backup_enabled?
   end
 
   private

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -105,7 +105,7 @@ class AdminController < ApplicationController
   private
 
   def hidden_admin_menu_items
-    OpenProject::Configuration.hidden_menu_items[:admin_menu.to_s] || []
+    Setting.hidden_menu_items[:admin_menu.to_s] || []
   end
 
   def plaintext_extraction_checks

--- a/app/controllers/concerns/accounts/redirect_after_login.rb
+++ b/app/controllers/concerns/accounts/redirect_after_login.rb
@@ -43,7 +43,7 @@ module Accounts::RedirectAfterLogin
   end
 
   def default_redirect
-    if (url = OpenProject::Configuration.after_login_default_redirect_url)
+    if (url = Setting.after_login_default_redirect_url)
       redirect_back_or_default url
     else
       redirect_back_or_default my_page_path
@@ -51,7 +51,7 @@ module Accounts::RedirectAfterLogin
   end
 
   def first_login_redirect
-    if (url = OpenProject::Configuration.after_first_login_redirect_url)
+    if (url = Setting.after_first_login_redirect_url)
       redirect_back_or_default url
     else
       redirect_back_or_default home_url(first_time_user: true)

--- a/app/controllers/concerns/accounts/user_password_change.rb
+++ b/app/controllers/concerns/accounts/user_password_change.rb
@@ -34,7 +34,7 @@ module Accounts::UserPasswordChange
   # to change the password.
   # When making changes here, also check MyController.change_password
   def change_password_flow(user:, params:, update_legacy: true, show_user_name: false)
-    return render_404 if OpenProject::Configuration.disable_password_login?
+    return render_404 if Setting.disable_password_login?
 
     # A JavaScript hides the force_password_change field for external
     # auth sources in the admin UI, so this shouldn't normally happen.

--- a/app/controllers/concerns/password_confirmation.rb
+++ b/app/controllers/concerns/password_confirmation.rb
@@ -45,7 +45,7 @@ module PasswordConfirmation
   # Returns whether password confirmation has been enabled globally
   # AND the current user is internally authenticated.
   def password_confirmation_required?
-    OpenProject::Configuration.internal_password_confirmation? &&
+    Setting.internal_password_confirmation? &&
       !User.current.uses_external_authentication?
   end
 end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -33,7 +33,7 @@ class HelpController < ApplicationController
 
   def text_formatting
     default_link = OpenProject::Static::Links[:text_formatting][:href]
-    help_link = OpenProject::Configuration.force_formatting_help_link.presence || default_link
+    help_link = Setting.force_formatting_help_link.presence || default_link
 
     redirect_to help_link
   end

--- a/app/controllers/ldap_auth_sources_controller.rb
+++ b/app/controllers/ldap_auth_sources_controller.rb
@@ -119,6 +119,6 @@ class LdapAuthSourcesController < ApplicationController
   end
 
   def block_if_password_login_disabled
-    render_404 if OpenProject::Configuration.disable_password_login?
+    render_404 if Setting.disable_password_login?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -295,7 +295,7 @@ class UsersController < ApplicationController
   end
 
   def set_password?(params)
-    params[:user][:password].present? && !OpenProject::Configuration.disable_password_choice?
+    params[:user][:password].present? && !Setting.disable_password_choice?
   end
 
   protected

--- a/app/helpers/backup_helper.rb
+++ b/app/helpers/backup_helper.rb
@@ -49,7 +49,7 @@ module BackupHelper
   end
 
   def instant_backup_threshold_date
-    DateTime.now - OpenProject::Configuration.backup_initial_waiting_period
+    DateTime.now - Setting.backup_initial_waiting_period
   end
 
   def just_installed_openproject?(after: instant_backup_threshold_date)
@@ -71,7 +71,7 @@ module BackupHelper
   end
 
   def notify_user_and_admins(user, backup_token:)
-    waiting_period = backup_token.waiting? && OpenProject::Configuration.backup_initial_waiting_period
+    waiting_period = backup_token.waiting? && Setting.backup_initial_waiting_period
     users = ([user] + User.admin.active).uniq
 
     users.each do |recipient|

--- a/app/helpers/homescreen_helper.rb
+++ b/app/helpers/homescreen_helper.rb
@@ -54,12 +54,12 @@ module HomescreenHelper
   ##
   # Determine whether we should render the links on homescreen?
   def show_homescreen_links?
-    EnterpriseToken.show_banners? || OpenProject::Configuration.show_community_links?
+    EnterpriseToken.show_banners? || Setting.show_community_links?
   end
 
   ##
   # Determine whether we should render the onboarding modal
   def show_onboarding_modal?
-    OpenProject::Configuration.onboarding_enabled? && params[:first_time_user]
+    Setting.onboarding_enabled? && params[:first_time_user]
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -142,6 +142,6 @@ module UsersHelper
   end
 
   def can_users_have_auth_source?
-    LdapAuthSource.any? && !OpenProject::Configuration.disable_password_login?
+    LdapAuthSource.any? && !Setting.disable_password_login?
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -45,7 +45,7 @@ class UserMailer < ApplicationMailer
     send_localized_mail(user) { I18n.t(:mail_subject_backup_ready) }
   end
 
-  def backup_token_reset(recipient, user:, waiting_period: OpenProject::Configuration.backup_initial_waiting_period)
+  def backup_token_reset(recipient, user:, waiting_period: Setting.backup_initial_waiting_period)
     @admin_notification = recipient != user # notification for other admins rather than oneself
     @user_login = user.login
     @waiting_period = waiting_period

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -5,7 +5,7 @@ class Backup < Export
     end
 
     def include_attachments?
-      val = OpenProject::Configuration.backup_include_attachments
+      val = Setting.backup_include_attachments
 
       val.nil? ? true : val.to_s.to_bool # default to true
     end
@@ -14,7 +14,7 @@ class Backup < Export
     # Don't include attachments in archive if they are larger than
     # this value combined.
     def attachment_size_max_sum_mb
-      (OpenProject::Configuration.backup_attachment_size_max_sum_mb.presence || 1024).to_i
+      (Setting.backup_attachment_size_max_sum_mb.presence || 1024).to_i
     end
 
     def attachments_query

--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -235,7 +235,7 @@ class LdapAuthSource < ApplicationRecord
     {
       host:,
       port:,
-      force_no_page: OpenProject::Configuration.ldap_force_no_page,
+      force_no_page: Setting.ldap_force_no_page,
       encryption: ldap_encryption
     }
   end

--- a/app/models/permitted_params/allowed_settings.rb
+++ b/app/models/permitted_params/allowed_settings.rb
@@ -70,7 +70,7 @@ class PermittedParams
 
       add_restriction!(
         keys: password_keys,
-        condition: -> { OpenProject::Configuration.disable_password_login? }
+        condition: -> { Setting.disable_password_login? }
       )
 
       add_restriction!(

--- a/app/models/token/backup.rb
+++ b/app/models/token/backup.rb
@@ -31,7 +31,7 @@ module Token
     def ready?
       return false if created_at.nil?
 
-      created_at.since(OpenProject::Configuration.backup_initial_waiting_period).past?
+      created_at.since(Setting.backup_initial_waiting_period).past?
     end
 
     def waiting?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -213,7 +213,7 @@ class User < Principal
   def self.try_authentication_for_existing_user(user, password, session = nil)
     activate_user! user, session if session
 
-    return nil if !user.active? || OpenProject::Configuration.disable_password_login?
+    return nil if !user.active? || Setting.disable_password_login?
 
     if user.ldap_auth_source
       # user has an external authentication method
@@ -242,7 +242,7 @@ class User < Principal
 
   # Tries to authenticate with available sources and creates user on success
   def self.try_authentication_and_create_user(login, password)
-    return nil if OpenProject::Configuration.disable_password_login?
+    return nil if Setting.disable_password_login?
 
     user = LdapAuthSource.authenticate(login, password)
 
@@ -344,7 +344,7 @@ class User < Principal
   # Does the backend storage allow this user to change their password?
   def change_password_allowed?
     return false if uses_external_authentication? ||
-                    OpenProject::Configuration.disable_password_login?
+                    Setting.disable_password_login?
 
     ldap_auth_source_id.blank?
   end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -79,7 +79,7 @@ class UserPreference < ApplicationRecord
   end
 
   def comments_sorting
-    settings.fetch(:comments_sorting, OpenProject::Configuration.default_comment_sort_order)
+    settings.fetch(:comments_sorting, Setting.default_comment_sort_order)
   end
 
   def comments_in_reverse_order?

--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -72,7 +72,7 @@ module Ldap
     ##
     # Locks the given user if this is what the sync service should do.
     def lock_user!(user)
-      if OpenProject::Configuration.ldap_users_sync_status?
+      if Setting.ldap_users_sync_status?
         Rails.logger.info { "Could not find user #{user.login} in #{ldap.name}. Locking the user." }
         user.update_column(:status, Principal.statuses[:locked])
       else
@@ -85,7 +85,7 @@ module Ldap
     ##
     # Activates the given user if this is what the sync service should do.
     def activate_user!(user)
-      if OpenProject::Configuration.ldap_users_sync_status?
+      if Setting.ldap_users_sync_status?
         Rails.logger.info { "Activating #{user.login} due to it being synced from LDAP #{ldap.name}." }
         user.update_column(:status, Principal.statuses[:active])
       else

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -38,7 +38,7 @@ module Users
     def call!(user)
       OpenProject.logger.info { "Logging out ##{user.id}" }
 
-      if OpenProject::Configuration.drop_old_sessions_on_logout?
+      if Setting.drop_old_sessions_on_logout?
         remove_all_autologin_tokens! user
         remove_all_sessions! user
       else

--- a/app/uploaders/fog_file_uploader.rb
+++ b/app/uploaders/fog_file_uploader.rb
@@ -114,7 +114,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
 
   def set_expires_at!(url_options, options:)
     if options[:expires_in].present?
-      expires = [options[:expires_in], OpenProject::Configuration.fog_download_url_expires_in].min
+      expires = [options[:expires_in], Setting.fog_download_url_expires_in].min
       url_options[:expire_at] = ::Fog::Time.now + expires
     end
 

--- a/app/views/account/_auth_providers.html.erb
+++ b/app/views/account/_auth_providers.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
 # * https://community.openproject.org/work_packages/7192
 # * http://stackoverflow.com/questions/13112430/find-loaded-providers-for-omniauth
 auth_provider_html = call_hook :view_account_login_auth_provider
-no_pwd = OpenProject::Configuration.disable_password_login?
+no_pwd = Setting.disable_password_login?
 pclass = no_pwd ? 'no-pwd' : ''
 wclass = local_assigns[:wide] ? 'wide' : ''
 %>

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
   <h1><%= I18n.t(:label_login) %></h1>
 
   <hr class="form--separator" />
-  <% unless OpenProject::Configuration.disable_password_login? %>
+  <% unless Setting.disable_password_login? %>
     <%= render partial: 'password_login_form' %>
   <% end %>
   <%= render partial: 'auth_providers' %>

--- a/app/views/admin/settings/authentication_settings/show.html.erb
+++ b/app/views/admin/settings/authentication_settings/show.html.erb
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
 
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= I18n.t(:passwords, scope: [:settings]) %></legend>
-      <% if !OpenProject::Configuration.disable_password_login? %>
+      <% if !Setting.disable_password_login? %>
         <div class="form--field -wide-label"><%= setting_text_field :password_min_length, size: 6, container_class: '-xslim' %></div>
         <div class="form--field -wide-label">
           <% rules = OpenProject::Passwords::Evaluator.known_rules.map do |rule|
@@ -91,7 +91,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     </fieldset>
 
-    <% unless OpenProject::Configuration.disable_password_login? %>
+    <% unless Setting.disable_password_login? %>
       <fieldset class="form--fieldset">
         <legend class="form--fieldset-legend"><%= I18n.t(:brute_force_prevention, scope: [:settings]) %></legend>
         <div class="form--field -wide-label"><%= setting_text_field :brute_force_block_after_failed_logins, container_class: '-xslim' %>
@@ -127,7 +127,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="form--field -wide-label"><%= setting_check_box :log_requesting_user %></div>
     </fieldset>
   </section>
-  <% unless OpenProject::Configuration.disable_password_login? %>
+  <% unless Setting.disable_password_login? %>
     <div style="float:right;">
       <%= link_to t(:label_ldap_authentication), {controller: '/ldap_auth_sources', action: 'index'}, class: 'icon icon-server-key' %>
     </div>

--- a/app/views/users/form/authentication/_internal.html.erb
+++ b/app/views/users/form/authentication/_internal.html.erb
@@ -1,4 +1,4 @@
-<% if OpenProject::Configuration.disable_password_login? %>
+<% if Setting.disable_password_login? %>
   <div id="no_password_info">
     <div class="form--field">
       <%= styled_label_tag nil, I18n.t(:warning) %>

--- a/app/views/users/form/authentication/_internal_password.html.erb
+++ b/app/views/users/form/authentication/_internal_password.html.erb
@@ -21,7 +21,7 @@
     </div>
   </div>
 
-  <% unless OpenProject::Configuration.disable_password_choice? %>
+  <% unless Setting.disable_password_choice? %>
     <div class="form--field">
       <%= f.password_field :password,
                            required: @user.new_record?,

--- a/app/workers/attachments/cleanup_uncontainered_job.rb
+++ b/app/workers/attachments/cleanup_uncontainered_job.rb
@@ -47,7 +47,7 @@ class Attachments::CleanupUncontaineredJob < ApplicationJob
     attachment_table = Attachment.arel_table
 
     attachment_table[:created_at]
-      .lteq(Time.zone.now - OpenProject::Configuration.attachments_grace_period.minutes)
+      .lteq(Time.zone.now - Setting.attachments_grace_period.minutes)
       .to_sql
   end
 end

--- a/app/workers/attachments/extract_fulltext_job.rb
+++ b/app/workers/attachments/extract_fulltext_job.rb
@@ -36,7 +36,7 @@ module Attachments
       @text = nil
       @file = nil
       @filename = nil
-      @language = OpenProject::Configuration.main_content_language
+      @language = Setting.main_content_language
 
       return unless OpenProject::Database.allows_tsv?
       return unless @attachment = find_attachment(attachment_id)

--- a/app/workers/exports/cleanup_outdated_job.rb
+++ b/app/workers/exports/cleanup_outdated_job.rb
@@ -30,12 +30,12 @@ class Exports::CleanupOutdatedJob < ApplicationJob
   queue_with_priority :low
 
   def self.perform_after_grace
-    set(wait: OpenProject::Configuration.attachments_grace_period.minutes).perform_later
+    set(wait: Setting.attachments_grace_period.minutes).perform_later
   end
 
   def perform
     Export
-      .where("created_at <= ?", Time.current - OpenProject::Configuration.attachments_grace_period.minutes)
+      .where("created_at <= ?", Time.current - Setting.attachments_grace_period.minutes)
       .destroy_all
   end
 end

--- a/app/workers/ldap/synchronization_job.rb
+++ b/app/workers/ldap/synchronization_job.rb
@@ -35,7 +35,7 @@ module Ldap
     private
 
     def run_user_sync
-      return if OpenProject::Configuration.ldap_users_disable_sync_job?
+      return if Setting.ldap_users_disable_sync_job?
 
       ::LdapAuthSource.find_each do |ldap|
         Rails.logger.info { "[LDAP groups] Synchronizing users for LDAP connection #{ldap.name}" }

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -467,7 +467,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :ldap_authentication,
             { controller: "/ldap_auth_sources", action: "index" },
-            if: Proc.new { User.current.admin? && !OpenProject::Configuration.disable_password_login? },
+            if: Proc.new { User.current.admin? && !Setting.disable_password_login? },
             parent: :authentication,
             caption: :label_ldap_auth_source_plural,
             html: { class: "server_authentication" },
@@ -494,7 +494,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :backups,
             { controller: "/admin/backups", action: "show" },
-            if: Proc.new { OpenProject::Configuration.backup_enabled? && User.current.allowed_globally?(Backup.permission) },
+            if: Proc.new { Setting.backup_enabled? && User.current.allowed_globally?(Backup.permission) },
             caption: :label_backup,
             last: true,
             icon: "save"

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -49,7 +49,7 @@ Rails.application.reloader.to_prepare do
                      },
                      permissible_on: :global,
                      require: :loggedin,
-                     enabled: -> { OpenProject::Configuration.backup_enabled? }
+                     enabled: -> { Setting.backup_enabled? }
 
       map.permission :create_user,
                      {

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -125,7 +125,7 @@ module API
       def fog_cache_seconds
         [
           0,
-          OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+          Setting.fog_download_url_expires_in.to_i - 10
         ].max
       end
 
@@ -140,7 +140,7 @@ module API
       end
 
       def avatar_link_expiry_seconds
-        @avatar_link_expiry_seconds ||= OpenProject::Configuration.avatar_link_expiry_seconds.to_i
+        @avatar_link_expiry_seconds ||= Setting.avatar_link_expiry_seconds.to_i
       end
     end
   end

--- a/lib/api/v3/backups/backups_api.rb
+++ b/lib/api/v3/backups/backups_api.rb
@@ -32,7 +32,7 @@ module API
       class BackupsAPI < ::API::OpenProjectAPI
         resources :backups do
           before do
-            raise API::Errors::NotFound unless OpenProject::Configuration.backup_enabled?
+            raise API::Errors::NotFound unless Setting.backup_enabled?
           end
 
           after_validation do

--- a/lib/open_project/full_text_search.rb
+++ b/lib/open_project/full_text_search.rb
@@ -37,7 +37,7 @@ module OpenProject
         query = tokenize(value, concatenation, normalization)
         return if query.blank?
 
-        language = OpenProject::Configuration.main_content_language
+        language = Setting.main_content_language
 
         ActiveRecord::Base.send(
           :sanitize_sql_array, ["#{column} @@ to_tsquery(?, ?)",

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -153,7 +153,7 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_login_partial
     partial =
-      if OpenProject::Configuration.disable_password_login?
+      if Setting.disable_password_login?
         "account/omniauth_login"
       else
         "account/login"

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -87,7 +87,7 @@ namespace :backup do
 
   desc "Allows user-initiated backups right away, skipping the cooldown period after a new token was created."
   task allow_now: :environment do
-    date = DateTime.now - OpenProject::Configuration.backup_initial_waiting_period
+    date = DateTime.now - Setting.backup_initial_waiting_period
 
     Token::Backup.where("created_at > ?", date).each do |token|
       token.update_column :created_at, date

--- a/lib_static/open_project/authentication/strategies/warden/basic_auth_failure.rb
+++ b/lib_static/open_project/authentication/strategies/warden/basic_auth_failure.rb
@@ -7,7 +7,7 @@ module OpenProject
         # indicate that invalid basic auth credentials were provided.
         class BasicAuthFailure < ::Warden::Strategies::BasicAuth
           def valid?
-            OpenProject::Configuration.apiv3_enable_basic_auth? && super
+            Setting.apiv3_enable_basic_auth? && super
           end
 
           def authenticate_user(_username, _password)

--- a/lib_static/open_project/authentication/strategies/warden/global_basic_auth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/global_basic_auth.rb
@@ -70,7 +70,7 @@ module OpenProject
           ##
           # Only valid if global basic auth is configured and tried.
           def valid?
-            OpenProject::Configuration.apiv3_enable_basic_auth? &&
+            Setting.apiv3_enable_basic_auth? &&
             self.class.configuration? &&
             super &&
             username == self.class.user

--- a/lib_static/open_project/authentication/strategies/warden/user_basic_auth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/user_basic_auth.rb
@@ -17,7 +17,7 @@ module OpenProject
           end
 
           def valid?
-            OpenProject::Configuration.apiv3_enable_basic_auth? &&
+            Setting.apiv3_enable_basic_auth? &&
             super &&
             username == self.class.user
           end

--- a/modules/avatars/app/helpers/avatar_helper.rb
+++ b/modules/avatars/app/helpers/avatar_helper.rb
@@ -125,7 +125,7 @@ module AvatarHelper
   def default_gravatar_options
     {
       secure: OpenProject::Configuration.https?,
-      default: OpenProject::Configuration.gravatar_fallback_image
+      default: Setting.gravatar_fallback_image
     }
   end
 

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "BCF 2.1 viewpoints resource", content_type: :json do
         expect(subject.status).to eq 200
         expect(subject.headers["Content-Type"]).to eq "image/png"
 
-        max_age = OpenProject::Configuration.fog_download_url_expires_in - 10
+        max_age = Setting.fog_download_url_expires_in - 10
 
         expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
         expect(subject.headers["Expires"]).to be_present

--- a/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
+++ b/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
@@ -36,7 +36,7 @@ module LdapGroups
     end
 
     def skipped?
-      OpenProject::Configuration.ldap_groups_disable_sync_job?
+      Setting.ldap_groups_disable_sync_job?
     end
   end
 end

--- a/modules/reporting/app/models/cost_query/cache.rb
+++ b/modules/reporting/app/models/cost_query/cache.rb
@@ -70,7 +70,7 @@ module CostQuery::Cache
     end
 
     def caching_disabled?
-      !OpenProject::Configuration.cost_reporting_cache_filter_classes
+      !Setting.cost_reporting_cache_filter_classes
     end
 
     def reset_required?

--- a/modules/reporting/spec/lib/open_project/configuration_spec.rb
+++ b/modules/reporting/spec/lib/open_project/configuration_spec.rb
@@ -31,11 +31,11 @@ require "spec_helper"
 RSpec.describe "OpenProject::Configuration" do
   describe ".cost_reporting_cache_filter_classes" do
     it "is a true by default via the method" do
-      expect(OpenProject::Configuration.cost_reporting_cache_filter_classes).to be_truthy
+      expect(Setting.cost_reporting_cache_filter_classes).to be_truthy
     end
 
     it "is true by default via the hash" do
-      expect(OpenProject::Configuration["cost_reporting_cache_filter_classes"]).to be_truthy
+      expect(Setting["cost_reporting_cache_filter_classes"]).to be_truthy
     end
   end
 end

--- a/modules/storages/app/workers/storages/cleanup_uncontainered_file_links_job.rb
+++ b/modules/storages/app/workers/storages/cleanup_uncontainered_file_links_job.rb
@@ -32,7 +32,7 @@ class Storages::CleanupUncontaineredFileLinksJob < ApplicationJob
   def perform
     Storages::FileLink
       .where(container: nil)
-      .where("created_at <= ?", Time.current - OpenProject::Configuration.attachments_grace_period.minutes)
+      .where("created_at <= ?", Time.current - Setting.attachments_grace_period.minutes)
       .delete_all
   end
 end

--- a/spec/factories/token_factory.rb
+++ b/spec/factories/token_factory.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     user
 
     after(:build) do |token|
-      token.created_at = DateTime.now - OpenProject::Configuration.backup_initial_waiting_period
+      token.created_at = DateTime.now - Setting.backup_initial_waiting_period
     end
 
     trait :with_waiting_period do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Attachment do
         let(:url_options) { { expires_in: 1.year } }
 
         it "uses the allowed max" do
-          expect(query).to include "X-Amz-Expires=#{OpenProject::Configuration.fog_download_url_expires_in}"
+          expect(query).to include "X-Amz-Expires=#{Setting.fog_download_url_expires_in}"
         end
       end
     end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -456,7 +456,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
           expect(subject.headers["Content-Type"])
             .to eql expected_content_type
 
-          max_age = OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+          max_age = Setting.fog_download_url_expires_in.to_i - 10
 
           expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
           expect(subject.headers["Expires"]).to be_present
@@ -524,7 +524,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
           expect(subject.headers["Location"])
             .to eql external_url
 
-          max_age = OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+          max_age = Setting.fog_download_url_expires_in.to_i - 10
 
           expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
           expect(subject.headers["Expires"]).to be_present


### PR DESCRIPTION
In many places we use `OpenProject::Configuration` instead of `Setting` where there is no need to do so. This only artificially limits the time these options can be changed. For all the calls in this PR it would make sense to allow changing them at runtime, too.

This is mostly relevant in a setup where the environment variables cannot be changed globally, such as our cloud.

Uses in initializers are excluded from this change explicitly because most of the time these will not be changeable at runtime anyway.