### PR TITLE
allow changing of direct login provider at runtime

### DIFF
--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -42,6 +42,6 @@ module OmniauthHelper
   # If this option is active /login will lead directly to the configured omniauth provider
   # and so will a click on 'Sign in' (as opposed to opening the drop down menu).
   def direct_login_provider
-    OpenProject::Configuration["omniauth_direct_login_provider"]
+    Setting.omniauth_direct_login_provider
   end
 end

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -121,8 +121,7 @@ RSpec.describe "Omniauth authentication" do
   end
 
   describe "sign out a user with direct login and login required",
-           with_config: { omniauth_direct_login_provider: "developer" },
-           with_settings: { login_required?: true } do
+           with_config: { omniauth_direct_login_provider: "developer", login_required: true } do
     it "shows a notice that the user has been logged out" do
       visit signout_path
 

--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -70,6 +70,11 @@ class WithConfig
       .to receive(:[])
       .with(key.to_sym)
       .and_return(value)
+
+    # if a configuration value was set then it automatically pins
+    # the respective setting as well which is why we stub this here too
+    allow(Setting).to receive(:[]).with(key.to_s).and_return(value)
+    allow(Setting).to receive(:[]).with(key.to_sym).and_return(value)
   end
 
   def aggregate_mocked_configuration(example, config)
@@ -90,6 +95,7 @@ class WithConfig
     return if @call_original_implementation_done
 
     allow(OpenProject::Configuration).to receive(:[]).and_call_original
+    allow(Setting).to receive(:[]).and_call_original
     @call_original_implementation_done = true
   end
 end


### PR DESCRIPTION
because why would you not?

Also fixes the `with_config` spec helper to also stub Settings to pin their values just like they are outside of tests.