### PR TITLE
[#54749] Vertically center the `include sub-projects` checkbox

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
@@ -6,3 +6,8 @@
     &:before
       @include icon-font-common
       margin-right: 10px
+
+.FormControl-horizontalGroup
+    display: flex
+    align-items: center
+    justify-content: space-between


### PR DESCRIPTION
https://community.openproject.org/work_packages/54749

Arises From: https://github.com/opf/openproject/pull/15700#pullrequestreview-2099241778

It would be ideal to add a primer sys arg to the form group but unfortunately it does not currently propagate system arguments: _@HDinger is aware of this issue._

See: 
* https://github.com/opf/primer_view_components/blob/main/lib/primer/forms/group.html.erb#L1
* https://github.com/opf/primer_view_components/blob/main/lib/primer/forms/group.rb#L14

![Screenshot 2024-06-06 at 3 44 03 PM](https://github.com/opf/openproject/assets/17295175/bdb656b2-8e8c-4fe4-81b7-36caa1dc5f8e)

---

🚧  _The autocompleter is also slightly off as you can tell but I wasn't able to fix it as it's already within the flexbox container. AFAICT, it could be related to the angular node taking up some room._