### PR TITLE
Do not trigger development seeders if installation is obviously old

### DIFF
--- a/app/seeders/development_data/projects_seeder.rb
+++ b/app/seeders/development_data/projects_seeder.rb
@@ -47,7 +47,13 @@ module DevelopmentData
     end
 
     def applicable?
-      Project.where(identifier: project_identifiers).count == 0
+      recent_installation? && Project.where(identifier: project_identifiers).count == 0
+    end
+
+    # returns true if no projects have been created more than 1 hour ago,
+    # meaning this is a recent installation
+    def recent_installation?
+      Project.where(created_at: ..1.hour.ago).none?
     end
 
     def project_identifiers


### PR DESCRIPTION
`DevelopmentData::ProjectsSeeder` creates 4 projects trying to be useful for development, but it's possible that we do not need them and delete them. If that's the case, we do not want
`DevelopmentData::ProjectsSeeder` to try to create them again.

This commit adds an additional check: if there are no projects older than 1 hour, that means that the instance is recent and the dev projects should be seeded. Otherwise, they should not.

It should prevent us from having errors in the future when we delete the projects and the seeder tries to create them again.