### PR TITLE
[55431] Fix error message when duration input is invalid

### DIFF
--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -130,17 +130,7 @@ class WorkPackages::ProgressController < ApplicationController
 
   def work_package_params
     params.require(:work_package)
-          .permit(allowed_params).tap do |wp_params|
-      %w[estimated_hours remaining_hours].each do |attr|
-        if wp_params[attr].present?
-          begin
-            wp_params[attr] = DurationConverter.parse(wp_params[attr])
-          rescue ChronicDuration::DurationParseError
-            @work_package.errors.add(attr.to_sym, :invalid)
-          end
-        end
-      end
-    end
+          .permit(allowed_params)
   end
 
   def allowed_params

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -315,13 +315,11 @@ class WorkPackage < ApplicationRecord
   end
 
   def estimated_hours=(hours)
-    converted_hours = (hours.is_a?(String) ? hours.to_hours : hours)
-    write_attribute :estimated_hours, !!converted_hours ? converted_hours : hours
+    write_attribute :estimated_hours, convert_duration_to_hours(hours)
   end
 
   def remaining_hours=(hours)
-    converted_hours = (hours.is_a?(String) ? hours.to_hours : hours)
-    write_attribute :remaining_hours, !!converted_hours ? converted_hours : hours
+    write_attribute :remaining_hours, convert_duration_to_hours(hours)
   end
 
   def duration_in_hours
@@ -544,6 +542,17 @@ class WorkPackage < ApplicationRecord
                               spent_on: Time.zone.today)
 
     time_entries.build(attributes)
+  end
+
+  def convert_duration_to_hours(value)
+    if value.is_a?(String)
+      begin
+        value = value.blank? ? nil : DurationConverter.parse(value)
+      rescue ChronicDuration::DurationParseError
+        # keep invalid value, error shall be caught by numericality validator
+      end
+    end
+    value
   end
 
   ##

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1111,6 +1111,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
               only_same_project_categories_allowed: "The category of a work package must be within the same project as the work package."
               does_not_exist: "The specified category does not exist."
             estimated_hours:
+              not_a_number: "is not a valid duration."
               cant_be_inferior_to_remaining_work: "Cannot be lower than Remaining work."
               must_be_set_when_remaining_work_is_set: "Required when Remaining work is set."
               only_values_greater_or_equal_zeroes_allowed: "Must be >= 0."

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe WorkPackage do
                        priority:,
                        subject: "test_create",
                        description: "WorkPackage#create",
-                       estimated_hours: "1:30" }
+                       estimated_hours: "1h30" }
     end
   end
 
@@ -746,9 +746,22 @@ RSpec.describe WorkPackage do
   end
 
   describe "#remaining_hours" do
-    it "allows empty values" do
-      expect(work_package.remaining_hours).to be_nil
+    it "allows empty value" do
+      work_package.remaining_hours = ""
       expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to be_nil
+    end
+
+    it "allows blank values" do
+      work_package.remaining_hours = "  "
+      expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to be_nil
+    end
+
+    it "allows nil value" do
+      work_package.remaining_hours = nil
+      expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to be_nil
     end
 
     it "allows values greater than or equal to 0" do
@@ -772,6 +785,24 @@ RSpec.describe WorkPackage do
     it "allows non-integers" do
       work_package.remaining_hours = "1.3"
       expect(work_package).to be_valid
+    end
+
+    it "allows hours like '1h06'" do
+      work_package.remaining_hours = "1h06"
+      expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to eq(1.1)
+    end
+
+    it "allows hours like '1h 24m'" do
+      work_package.remaining_hours = "1h 24m"
+      expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to eq(1.4)
+    end
+
+    it "allows hours like '3d 1h 30m'" do
+      work_package.remaining_hours = "3d 1h 30m"
+      expect(work_package).to be_valid
+      expect(work_package.remaining_hours).to eq((3 * 8) + 1.5)
     end
   end
 end


### PR DESCRIPTION
[Bug: Display an error when duration input is invalid (#55431)](https://community.openproject.org/projects/openproject/work_packages/55431)

Passing invalid input like "abcdef" will now display the error as "is not a valid duration." instead of "is not a number.".