### PR TITLE
[Bug] Autocompleter height does not grow with the items

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete_primerized.sass
+++ b/frontend/src/global_styles/content/_autocomplete_primerized.sass
@@ -30,5 +30,4 @@
   &.ng-select--primerized
     .ng-select-container
       border-radius: 6px
-      height: 32px !important
       min-height: 32px !important


### PR DESCRIPTION
Remove fixed height value of ngSelect, as the input will otherwise not grow when there are many entries

### Before
<img width="959" alt="Bildschirmfoto 2024-06-07 um 13 21 22" src="https://github.com/opf/openproject/assets/7457313/9d95a465-6eba-4510-b640-bee6df4466c1">


### After
<img width="958" alt="Bildschirmfoto 2024-06-07 um 13 20 47" src="https://github.com/opf/openproject/assets/7457313/4203ea57-beac-4e6f-b47f-be384b968b68">

