### PR TITLE
Revert "[#54749] Vertically center the include sub-projects checkbox (  #15770)"

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
@@ -6,8 +6,3 @@
     &:before
       @include icon-font-common
       margin-right: 10px
-
-.FormControl-horizontalGroup
-    display: flex
-    align-items: center
-    justify-content: space-between


### PR DESCRIPTION
https://community.openproject.org/work_packages/55583

Revert https://github.com/opf/openproject/pull/15770 will followup with a better fix

Vertical alignment fix was global and broke other pages like the progress popover fields alignement when an error is displayed.