### PR TITLE
translate deploy comment, allow to be made by manually set github user

### DIFF
--- a/modules/github_integration/config/locales/en.yml
+++ b/modules/github_integration/config/locales/en.yml
@@ -46,3 +46,4 @@ en:
   text_deploy_target_api_key_info: >
     An OpenProject [API key](docs_url)
     belonging to a user who has the global introspection permission.
+  text_pull_request_deployed_to: "%{pr_link} deployed to %{deploy_target_link}"

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -35,6 +35,14 @@ module OpenProject::GithubIntegration
 
     include OpenProject::Plugins::ActsAsOpEngine
 
+    def self.settings
+      {
+        default: {
+          "github_user_id" => nil
+        }
+      }
+    end
+
     initializer "github.feature_decisions" do
       OpenProject::FeatureDecisions.add :deploy_targets
     end
@@ -42,7 +50,8 @@ module OpenProject::GithubIntegration
     register(
       "openproject-github_integration",
       author_url: "https://www.openproject.org/",
-      bundled: true
+      bundled: true,
+      settings:
     ) do
       ::Redmine::MenuManager.map(:admin_menu) do |menu|
         menu.push :admin_github_integration,


### PR DESCRIPTION
A bug in the deploy target feature was noticed. The comment made is not translated.
This PR fixes it and while we're at it, it also allows the github user to be configured (for now) by hand so that the comments can come from is rather than the system user.