### PR TITLE
[#55193] change permission name

### DIFF
--- a/app/contracts/projects/update_contract.rb
+++ b/app/contracts/projects/update_contract.rb
@@ -31,6 +31,9 @@ module Projects
     private
 
     def manage_permission
+      # Changes on attachment settings are only bound to the manage_files_in_project permission
+      return :manage_files_in_project if work_package_attachment_settings_changed?
+
       if changed_by_user == ["active"]
         :archive_project
       else
@@ -38,6 +41,10 @@ module Projects
         # checked in `Projects::BaseContract#validate_changing_active`
         :edit_project
       end
+    end
+
+    def work_package_attachment_settings_changed?
+      model.settings_change.any? { |setting| setting.key?("deactivate_work_package_attachments") }
     end
   end
 end

--- a/app/contracts/projects/update_contract.rb
+++ b/app/contracts/projects/update_contract.rb
@@ -44,7 +44,9 @@ module Projects
     end
 
     def work_package_attachment_settings_changed?
-      model.settings_change.any? { |setting| setting.key?("deactivate_work_package_attachments") }
+      model.settings_changed? && model.settings_change.any? do |setting|
+        setting.key?("deactivate_work_package_attachments")
+      end
     end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,7 +93,7 @@ class ProjectsController < ApplicationController
 
   def deactivate_work_package_attachments
     call = Projects::UpdateService
-             .new(user: current_user, model: @project)
+             .new(user: current_user, model: @project, contract_class: Projects::SettingsContract)
              .call(deactivate_work_package_attachments: params[:value] != "1")
 
     if call.failure?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -96,7 +96,11 @@ class ProjectsController < ApplicationController
              .new(user: current_user, model: @project)
              .call(deactivate_work_package_attachments: params[:value] != "1")
 
-    render_403 if call.failure?
+    if call.failure?
+      return render_403 if call.errors.map(&:type).include?(:error_unauthorized)
+
+      render_error({ message: call.errors.full_messages.join("\n") })
+    end
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -92,8 +92,11 @@ class ProjectsController < ApplicationController
   end
 
   def deactivate_work_package_attachments
-    @project.deactivate_work_package_attachments = params[:value] != "1"
-    @project.save
+    call = Projects::UpdateService
+             .new(user: current_user, model: @project)
+             .call(deactivate_work_package_attachments: params[:value] != "1")
+
+    render_403 if call.failure?
   end
 
   private

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -95,7 +95,6 @@ Rails.application.reloader.to_prepare do
                      {
                        "projects/settings/general": %i[show],
                        "projects/settings/storage": %i[show],
-                       projects: %i[deactivate_work_package_attachments],
                        "projects/templated": %i[create destroy],
                        "projects/identifier": %i[show update]
                      },

--- a/modules/storages/app/contracts/storages/last_project_folders/delete_contract.rb
+++ b/modules/storages/app/contracts/storages/last_project_folders/delete_contract.rb
@@ -28,6 +28,6 @@
 
 module Storages::LastProjectFolders
   class DeleteContract < ::DeleteContract
-    delete_permission(:manage_storages_in_project)
+    delete_permission(:manage_files_in_project)
   end
 end

--- a/modules/storages/app/contracts/storages/project_storages/concerns/manage_storages_guarded.rb
+++ b/modules/storages/app/contracts/storages/project_storages/concerns/manage_storages_guarded.rb
@@ -42,7 +42,7 @@ module Storages::ProjectStorages
         # Check that the current has the permission on the project.
         # model variable is available because the concern is executed inside a contract.
         def validate_user_allowed_to_manage
-          unless user.allowed_in_project?(:manage_storages_in_project, model.project)
+          unless user.allowed_in_project?(:manage_files_in_project, model.project)
             errors.add :base, :error_unauthorized
           end
         end

--- a/modules/storages/app/contracts/storages/project_storages/delete_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/delete_contract.rb
@@ -28,6 +28,6 @@
 
 module Storages::ProjectStorages
   class DeleteContract < ::DeleteContract
-    delete_permission(:manage_storages_in_project)
+    delete_permission(:manage_files_in_project)
   end
 end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -66,7 +66,7 @@ module Storages
     validates_uniqueness_of :name
 
     scope :visible, ->(user = User.current) do
-      if user.allowed_in_any_project?(:manage_storages_in_project)
+      if user.allowed_in_any_project?(:manage_files_in_project)
         all
       else
         where(

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
   permission_delete_files_explanation: This permission is only available for Nextcloud storages
   permission_header_for_project_module_storages: Automatically managed project folders
   permission_manage_file_links: Manage file links
-  permission_manage_storages_in_project: Manage file storages in project
+  permission_manage_files_in_project: Manage files in project
   permission_read_files: 'Automatically managed project folders: Read files'
   permission_share_files: 'Automatically managed project folders: Share files'
   permission_share_files_explanation: This permission is only available for Nextcloud storages

--- a/modules/storages/db/migrate/20240610130953_rename_manage_storages_in_project_permission.rb
+++ b/modules/storages/db/migrate/20240610130953_rename_manage_storages_in_project_permission.rb
@@ -1,0 +1,5 @@
+class RenameManageStoragesInProjectPermission < ActiveRecord::Migration[7.1]
+  def change
+    RolePermission.where(permission: "manage_storages_in_project").update_all(permission: "manage_files_in_project")
+  end
+end

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -128,7 +128,7 @@ module OpenProject::Storages
       # Permissions documentation: https://www.openproject.org/docs/development/concepts/permissions/#definition-of-permissions
       # Independent of storages module (Disabling storages module does not revoke enabled permissions).
       project_module nil, order: 100 do
-        permission :manage_storages_in_project,
+        permission :manage_files_in_project,
                    { "storages/admin/project_storages": %i[external_file_storages
                                                            attachments
                                                            members
@@ -141,6 +141,7 @@ module OpenProject::Storages
                                                            destroy
                                                            destroy_info
                                                            set_permissions],
+                     projects: %i[deactivate_work_package_attachments],
                      "storages/project_settings/project_storage_members": %i[index] },
                    permissible_on: :project,
                    dependencies: %i[]
@@ -187,7 +188,7 @@ module OpenProject::Storages
       menu :project_menu,
            :settings_project_storages,
            { controller: "/storages/admin/project_storages", action: "external_file_storages" },
-           if: lambda { |project| User.current.allowed_in_project?(:manage_storages_in_project, project) },
+           if: lambda { |project| User.current.allowed_in_project?(:manage_files_in_project, project) },
            caption: :project_module_storages,
            parent: :settings
 

--- a/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Storages::FileLinks::DeleteContract do
   end
 
   # Default test setup should be valid ("happy test setup").
-  # This tests works with manage_storages_in_project permissions for current_user.
+  # This tests works with manage_files_in_project permissions for current_user.
   it_behaves_like "contract is valid"
 
   # Now we remove the permissions from the user by creating a role without special perms.
-  context "without manage_storages_in_project permission for project" do
+  context "without manage_files_in_project permission for project" do
     let(:role) { create(:project_role) }
 
     it_behaves_like "contract is invalid"

--- a/modules/storages/spec/contracts/storages/project_storages/delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/delete_contract_spec.rb
@@ -34,19 +34,19 @@ RSpec.describe Storages::ProjectStorages::DeleteContract do
   include_context "ModelContract shared context"
 
   let(:current_user) { create(:user) }
-  let(:role) { create(:project_role, permissions: [:manage_storages_in_project]) }
+  let(:role) { create(:project_role, permissions: [:manage_files_in_project]) }
   let(:project) { create(:project, members: { current_user => role }) }
   let(:project_storage) { create(:project_storage, project:) }
   let(:contract) { described_class.new(project_storage, current_user) }
 
   # Default test setup should be valid ("happy test setup").
   # The example below was included above from "ModelContract shared context".
-  # This tests works with manage_storages_in_project permissions for current_user.
+  # This tests works with manage_files_in_project permissions for current_user.
   it_behaves_like "contract is valid"
 
   # Now we remove the permissions from the user by creating a role without special perms.
-  context "without manage_storages_in_project permission for project" do
-    # existing_role is a role _without_ the :manage_storages_in_project permission
+  context "without manage_files_in_project permission for project" do
+    # existing_role is a role _without_ the :manage_files_in_project permission
     let(:role) { create(:project_role) }
 
     it_behaves_like "contract is invalid"

--- a/modules/storages/spec/contracts/storages/project_storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/shared_contract_examples.rb
@@ -38,8 +38,7 @@ RSpec.shared_examples_for "ProjectStorages contract" do
   include_context "ModelContract shared context"
 
   let(:current_user) { create(:user) }
-  # The user needs "edit_project" to see the project's settings page
-  let(:role) { create(:project_role, permissions: %i[manage_storages_in_project edit_project]) }
+  let(:role) { create(:project_role, permissions: %i[manage_files_in_project]) }
   # Create a project managed by current user and with Storages enabled.
   let(:project) do
     create(:project,
@@ -50,7 +49,7 @@ RSpec.shared_examples_for "ProjectStorages contract" do
   let(:storage_creator) { current_user }
 
   # This is not 100% precise, as the required permission is not :admin
-  # but :manage_storages_in_project, but let's still include this.
+  # but :manage_files_in_project, but let's still include this.
   it_behaves_like "contract is valid for active admins and invalid for regular users"
 
   describe "validations" do

--- a/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
+++ b/modules/storages/spec/features/delete_project_storage_and_file_links_spec.rb
@@ -35,7 +35,7 @@ require_module_spec_helper
 # objects.
 RSpec.describe "Delete ProjectStorage with FileLinks", :js, :with_cuprite, :webmock do
   let(:user) { create(:user) }
-  let(:role) { create(:project_role, permissions: [:manage_storages_in_project]) }
+  let(:role) { create(:project_role, permissions: [:manage_files_in_project]) }
   let(:project) do
     create(:project,
            name: "Project 1",

--- a/modules/storages/spec/features/hide_attachments_spec.rb
+++ b/modules/storages/spec/features/hide_attachments_spec.rb
@@ -34,7 +34,7 @@ require_module_spec_helper
 RSpec.describe "Hide attachments", :js, :with_cuprite do
   let(:permissions) do
     %i(add_work_packages
-       manage_storages_in_project
+       manage_files_in_project
        edit_project
        view_work_packages
        edit_work_packages

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe("Activation of storages in projects",
   # to provide the user with the edit_project permission in the role.
   let(:role) do
     create(:project_role,
-           permissions: %i[manage_storages_in_project
+           permissions: %i[manage_files_in_project
                            select_project_modules
                            edit_project])
   end

--- a/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
+++ b/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "OAuth Access Grant Nudge upon adding a storage to a project",
   shared_let(:user) { create(:user, preferences: { time_zone: "Etc/UTC" }) }
 
   shared_let(:role) do
-    create(:project_role, permissions: %i[manage_storages_in_project
+    create(:project_role, permissions: %i[manage_files_in_project
                                           oauth_access_grant
                                           select_project_modules
                                           edit_project])

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe "Project storage members connection status view" do
   end
 
   def create_project_with_storage_and_members
-    role_can_read_files = create(:project_role, permissions: %i[manage_storages_in_project read_files])
-    role_cannot_read_files = create(:project_role, permissions: %i[manage_storages_in_project])
+    role_can_read_files = create(:project_role, permissions: %i[manage_files_in_project read_files])
+    role_cannot_read_files = create(:project_role, permissions: %i[manage_files_in_project])
 
     create(:project,
            members: { user => role_can_read_files,

--- a/modules/storages/spec/permissions/manage_storage_in_project_spec.rb
+++ b/modules/storages/spec/permissions/manage_storage_in_project_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Storages::Admin::ProjectStoragesController, "manage_storage_in_pr
   include PermissionSpecs
 
   controller_actions.each do |action|
-    check_permission_required_for("#{described_class.controller_path}##{action}", :manage_storages_in_project)
+    check_permission_required_for("#{described_class.controller_path}##{action}", :manage_files_in_project)
   end
 end
 # rubocop:enable RSpec/EmptyExampleGroup

--- a/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
@@ -210,8 +210,8 @@ RSpec.describe "API v3 storages resource", :webmock, content_type: :json do
       end
     end
 
-    context "if user has :manage_storages_in_project permission in any project" do
-      let(:permissions) { %i(manage_storages_in_project) }
+    context "if user has :manage_files_in_project permission in any project" do
+      let(:permissions) { %i(manage_files_in_project) }
 
       it_behaves_like "successful storage response"
     end

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
   shared_let(:user) { create(:user, preferences: { time_zone: "Etc/UTC" }) }
 
   shared_let(:role) do
-    create(:project_role, permissions: %i[manage_storages_in_project
+    create(:project_role, permissions: %i[manage_files_in_project
                                           oauth_access_grant
                                           select_project_modules
                                           edit_project])

--- a/modules/storages/spec/seeders/seeder_spec.rb
+++ b/modules/storages/spec/seeders/seeder_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe RootSeeder, "Storage module" do
 
     expect(RolePermission.where(permission: :view_file_links).count).to eq 7
     expect(RolePermission.where(permission: :manage_file_links).count).to eq 2
-    expect(RolePermission.where(permission: :manage_storages_in_project).count).to eq 1
+    expect(RolePermission.where(permission: :manage_files_in_project).count).to eq 1
   end
 end

--- a/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/delete_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Storages::ProjectStorages::DeleteService, :webmock, type: :model 
 
   context "with records written to DB" do
     let(:user) { create(:user) }
-    let(:role) { create(:project_role, permissions: [:manage_storages_in_project]) }
+    let(:role) { create(:project_role, permissions: [:manage_files_in_project]) }
     let(:project) { create(:project, members: { user => role }) }
     let(:other_project) { create(:project) }
     let(:storage) { create(:nextcloud_storage) }

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Projects copy", :js, :with_cuprite,
          manage_types
          view_work_packages
          select_custom_fields
-         manage_storages_in_project
+         manage_files_in_project
          manage_file_links
          work_package_assigned)
     end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe(
            permissions: %i[copy_projects
                            view_work_packages
                            work_package_assigned
-                           manage_storages_in_project
+                           manage_files_in_project
                            manage_file_links])
   end
   shared_let(:new_project_role) { create(:project_role, permissions: %i[]) }


### PR DESCRIPTION
[#55193](https://community.openproject.org/work_packages/55193)

also included: [#55194](https://community.openproject.org/wp/55194) | [#55191](https://community.openproject.org/wp/55191)

- manage_storages_in_projects to manage_files_in_projects
- change usage through app
- projects->deactivate_work_package_attachments is now only available
  through manage_files_in_projects
- add migration