### PR TITLE
[52555] Add searchbar to Submenu component

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -3,6 +3,5 @@
 @import "work_packages/progress/modal_body_component"
 @import "open_project/common/attribute_component"
 @import "filter/filters_component"
-@import "projects/settings/project_custom_field_sections/index_component"
 @import "projects/row_component"
 @import "settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component"

--- a/app/components/filter/filter_button_component.html.erb
+++ b/app/components/filter/filter_button_component.html.erb
@@ -1,7 +1,7 @@
 <%= render(Primer::Beta::Button.new(scheme: :secondary,
                                     disabled:,
-                                    data: { "filters-target": "filterFormToggle",
-                                            action: "filters#toggleDisplayFilters" },
+                                    data: { "filter--filters-form-target": "filterFormToggle",
+                                            action: "filter--filters-form#toggleDisplayFilters" },
                                     test_selector: "filter-component-toggle")) do |button| %>
   <% button.with_trailing_visual_counter(count: filters_count, test_selector: "filters-button-counter") %>
   <%= t(:label_filter) %>

--- a/app/components/filter/filter_component.html.erb
+++ b/app/components/filter/filter_component.html.erb
@@ -2,14 +2,14 @@
              method: :get,
              class: "op-filters-form op-filters-form_top-margin #{show_filters_section? ? "-expanded" : ""}",
              data: {
-               'filters-target': 'filterForm',
-               action: 'submit->filters#sendForm:prevent'
+               'filter--filters-form-target': 'filterForm',
+               action: 'submit->filter--filters-form#sendForm:prevent'
              }) do %>
   <% operators_without_values = %w[* !* t w] %>
   <fieldset class="advanced-filters--container">
     <a title="<%= t('js.close_form_title') %>"
        class="advanced-filters--close icon-context icon-close"
-       data-action="filters#toggleDisplayFilters"></a>
+       data-action="filter--filters-form#toggleDisplayFilters"></a>
     <legend><%= t(:label_filter_plural) %></legend>
     <ul class="advanced-filters--filters">
       <% each_filter do |filter, filter_active, additional_options| %>
@@ -19,7 +19,7 @@
         <li class="advanced-filters--filter <%= filter_active ? '' : 'hidden' %>"
             filter-name="<%= filter.name %>"
             filter-type="<%= filter.type %>"
-            data-filters-target="filter">
+            data-filter--filters-form-target="filter">
           <label class='advanced-filters--filter-name' for="<%= filter.name %>">
             <%= filter.human_name %>
           </label>
@@ -33,9 +33,9 @@
                              selected_operator),
                            class: 'advanced-filters--select',
                            data: {
-                             action: 'change->filters#setValueVisibility',
-                             'filters-filter-name-param': filter.name,
-                             'filters-target': 'operator',
+                             action: 'change->filter--filters-form#setValueVisibility',
+                             'filter--filters-form-filter-name-param': filter.name,
+                             'filter--filters-form-target': 'operator',
                              'filter-name': filter.name
                            } %>
           <% end %>
@@ -68,8 +68,8 @@
           <div class="advanced-filters--remove-filter">
             <a href="#"
                class="filter_rem"
-               data-action="click->filters#removeFilter"
-               data-filters-filter-name-param="<%= filter.name %>">
+               data-action="click->filter--filters-form#removeFilter"
+               data-filter--filters-form-filter-name-param="<%= filter.name %>">
               <%= helpers.op_icon("icon-close advanced-filters--remove-filter-icon", title: I18n.t('js.button_delete')) %>
             </a>
           </div>
@@ -77,7 +77,7 @@
       <% end %>
 
       <li class="advanced-filters--spacer <%= query.filters.blank? ? 'hidden' : '' %>"
-          data-filters-target="spacer"></li>
+          data-filter--filters-form-target="spacer"></li>
 
       <li class="advanced-filters--add-filter">
         <!-- Add filters -->
@@ -104,8 +104,8 @@
                          focus: "false",
                          'aria-invalid': "false",
                          data: {
-                           'filters-target': 'addFilterSelect',
-                           action: 'change->filters#addFilter:prevent'
+                           'filter--filters-form-target': 'addFilterSelect',
+                           action: 'change->filter--filters-form#addFilter:prevent'
                          } %>
         </div>
       </li>

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -1,10 +1,28 @@
-<div class="op-sidebar">
+<div class="op-sidebar" data-controller="filter--filter-list" data-application-target="dynamic">
+  <% if @searchable %>
+    <div class="op-sidebar--search">
+      <%= render Primer::Alpha::TextField.new(name: "search",
+                                              label: I18n.t("label_search"),
+                                              leading_visual: { icon: :search },
+                                              visually_hide_label: true,
+                                              classes: "op-sidebar--search-input",
+                                              data: {
+                                                action: "input->filter--filter-list#filterLists",
+                                                "filter--filter-list-target": "filter"
+                                              })  %>
+
+      <%= render Primer::Beta::Text.new(display: :none, classes: "op-sidebar--search-no-results-container") do
+        I18n.t("js.autocompleter.notFoundText")
+      end %>
+    </div>
+  <% end %>
+
   <div class="op-sidebar--body">
     <% if top_level_sidebar_menu_items.any? %>
       <div class="op-sidemenu">
         <ul class="op-sidemenu--items">
           <% top_level_sidebar_menu_items.first.children.each do |menu_item| %>
-            <li class="op-sidemenu--item">
+            <li class="op-sidemenu--item" data-filter--filter-list-target="searchItem">
               <% selected = menu_item.selected ? 'selected' : '' %>
               <a class="op-sidemenu--item-action <%= selected %>" href="<%= menu_item.href %>">
                 <span class="op-sidemenu--item-title"><%= menu_item.title %></span>
@@ -33,7 +51,7 @@
         <ul class="op-sidemenu--items"
             data-menus--expandable-sidemenu-target="container">
           <% menu_item.children.each do |child_item| %>
-            <li class="op-sidemenu--item">
+            <li class="op-sidemenu--item" data-filter--filter-list-target="searchItem">
               <% selected = child_item.selected ? 'selected' : '' %>
               <a class="op-sidemenu--item-action <%= selected %>" href="<%= child_item.href %>">
                 <span class="op-sidemenu--item-title"><%= child_item.title %></span>

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -8,10 +8,16 @@
                                               classes: "op-sidebar--search-input",
                                               data: {
                                                 action: "input->filter--filter-list#filterLists",
-                                                "filter--filter-list-target": "filter"
-                                              })  %>
+                                                "filter--filter-list-target": "filter",
+                                                "test-selector": "op-sidebar--search-input"
+                                              },)  %>
 
-      <%= render Primer::Beta::Text.new(display: :none, classes: "op-sidebar--search-no-results-container") do
+      <%= render Primer::Beta::Text.new(display: :none,
+                                        classes: "op-sidebar--search-no-results-container",
+                                        data: {
+                                          "test-selector": "op-sidebar--search-no-results",
+                                          "filter--filter-list-target": "noResultsText",
+                                        }) do
         I18n.t("js.autocompleter.notFoundText")
       end %>
     </div>

--- a/app/components/open_project/common/submenu_component.rb
+++ b/app/components/open_project/common/submenu_component.rb
@@ -31,9 +31,10 @@
 module OpenProject
   module Common
     class SubmenuComponent < ApplicationComponent
-      def initialize(sidebar_menu_items: nil)
+      def initialize(sidebar_menu_items: nil, searchable: false)
         super()
         @sidebar_menu_items = sidebar_menu_items
+        @searchable = searchable
       end
 
       def render?

--- a/app/components/projects/index_sub_header_component.html.erb
+++ b/app/components/projects/index_sub_header_component.html.erb
@@ -1,5 +1,5 @@
 <%= render(Primer::OpenProject::SubHeader.new(data: {
-    controller: "filters",
+    controller: "filter--filters-form",
     "application-target": "dynamic",
   })) do |subheader|
     subheader.with_filter_component do

--- a/app/components/projects/settings/project_custom_field_sections/index_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/index_component.html.erb
@@ -12,7 +12,7 @@
                                         size: :small
                                       },
                                       show_clear_button: true,
-                                      clear_button_id: "project-custom-fields-mapping-filter-clear-button",
+                                      clear_button_id: clear_button_id,
                                       data: {
                                         action: "input->projects--settings--project-custom-fields-mapping-filter#filterLists",
                                         "projects--settings--project-custom-fields-mapping-filter-target": "filter"

--- a/app/components/projects/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/projects/settings/project_custom_field_sections/index_component.rb
@@ -46,8 +46,13 @@ module Projects
         def wrapper_data_attributes
           {
             controller: "projects--settings--project-custom-fields-mapping-filter",
-            "application-target": "dynamic"
+            "application-target": "dynamic",
+            "projects--settings--project-custom-fields-mapping-filter-clear-button-id-value": clear_button_id
           }
+        end
+
+        def clear_button_id
+          "project-custom-fields-mapping-filter-clear-button"
         end
       end
     end

--- a/app/components/projects/settings/project_custom_field_sections/index_component.sass
+++ b/app/components/projects/settings/project_custom_field_sections/index_component.sass
@@ -1,3 +1,0 @@
-.Box
-  .hidden-by-filter
-    display: none

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -9,7 +9,7 @@
                             class: 'form--field',
                             data: {
                               'filter-autocomplete': true,
-                              'filters-target': 'filterValueContainer',
+                              'filter--filters-form-target': 'filterValueContainer',
                               'filter-name': filter.name
                             }
   %>

--- a/app/views/filters/_boolean.html.erb
+++ b/app/views/filters/_boolean.html.erb
@@ -1,5 +1,5 @@
 <label class="advanced-filters--filter-value"
-       data-filters-target="filterValueContainer"
+       data-filter--filters-form-target="filterValueContainer"
        data-filter-name="<%= filter.name %>">
   <%= angular_component_tag 'spot-switch',
                             inputs: {

--- a/app/views/filters/_text.html.erb
+++ b/app/views/filters/_text.html.erb
@@ -1,5 +1,5 @@
 <div class="advanced-filters--filter-value <%= value_visibility %>"
-     data-filters-target="filterValueContainer"
+     data-filter--filters-form-target="filterValueContainer"
      data-filter-name="<%= filter.name %>">
   <% if filter.type == :string %>
       <div>
@@ -7,7 +7,7 @@
                            filter.values.first,
                            class: 'advanced-filters--text-field -slim',
                            data: {
-                             'filters-target': 'simpleValue',
+                             'filter--filters-form-target': 'simpleValue',
                              'filter-name': filter.name
                            } %>
       </div>
@@ -17,7 +17,7 @@
                            filter.values.first,
                            class: 'advanced-filters--text-field -slim',
                            data: {
-                             'filters-target': 'simpleValue',
+                             'filter--filters-form-target': 'simpleValue',
                              'filter-name': filter.name
                            } %>
       </div>
@@ -28,7 +28,7 @@
                              class: 'advanced-filters--text-field -slim',
                              step: 'any',
                              data: {
-                               'filters-target': 'simpleValue',
+                               'filter--filters-form-target': 'simpleValue',
                                'filter-name': filter.name
                              }%>
       </div>
@@ -39,7 +39,7 @@
                              class: 'advanced-filters--text-field -slim',
                              step: 'any',
                              data: {
-                               'filters-target': 'simpleValue',
+                               'filter--filters-form-target': 'simpleValue',
                                'filter-name': filter.name
                              }%>
       </div>

--- a/app/views/filters/date/_days.html.erb
+++ b/app/views/filters/date/_days.html.erb
@@ -5,7 +5,7 @@
           <%= number_field_tag :value,
                                value,
                                class: 'advanced-filters--text-field -slim',
-                               'data-filters-target': 'days',
+                               'data-filter--filters-form-target': 'days',
                                'data-filter-name': filter.name %>
           <label for="value" class="form-label -transparent">days</label>
          </span>

--- a/app/views/filters/date/_input_options.html.erb
+++ b/app/views/filters/date/_input_options.html.erb
@@ -9,7 +9,7 @@
   end
 %>
 <div class="advanced-filters--filter-value <%= value_visibility %> <%= value_format %>"
-     data-filters-target="filterValueContainer"
+     data-filter--filters-form-target="filterValueContainer"
      data-filter-name="<%= filter.name %>">
   <%= render partial: 'filters/date/days',
              locals: { filter: filter,

--- a/app/views/filters/list/_input_options.html.erb
+++ b/app/views/filters/list/_input_options.html.erb
@@ -1,7 +1,7 @@
 <% filter_values = filter.values || [] %>
 
 <div class="advanced-filters--filter-value <%= value_visibility %> <%= filter_values.size > 1 ? 'multi-value' : '' %>"
-     data-filters-target="filterValueContainer"
+     data-filter--filters-form-target="filterValueContainer"
      data-filter-name="<%= filter.name %>">
   <%= render partial: 'filters/list/select', locals: { filter: filter, selected_values: filter_values.first, multi_value: false } %>
   <%= render partial: 'filters/list/select', locals: { filter: filter, selected_values: filter_values, multi_value: true } %>

--- a/app/views/filters/list/_select.html.erb
+++ b/app/views/filters/list/_select.html.erb
@@ -8,7 +8,7 @@
                               selected_values),
                           {
                             class: 'form--select -slim',
-                            'data-filters-target': 'filterValueSelect',
+                            'data-filter--filters-form-target': 'filterValueSelect',
                             'data-filter-name': filter.name
                           }]
        if multi_value
@@ -18,8 +18,8 @@
     <a href=""
        class="form-label no-decoration-on-hover -transparent multi-select-toggle"
        tabindex="0"
-       data-action="click->filters#toggleMultiSelect"
-       data-filters-filter-name-param="<%= filter.name %>">
+       data-action="click->filter--filters-form#toggleMultiSelect"
+       data-filter--filters-form-filter-name-param="<%= filter.name %>">
       <span class="icon-context icon-button <%= multi_value ? 'icon-minus2' : 'icon-add' %> icon4" title="<%= t(:label_enable_multi_select) %>">
         <span class="hidden-for-sighted"><%= t(:label_enable_multi_select) %></span>
       </span>

--- a/app/views/projects/menus/show.html.erb
+++ b/app/views/projects/menus/show.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "projects_sidemenu" do %>
-  <%= render OpenProject::Common::SubmenuComponent.new(sidebar_menu_items: @sidebar_menu_items) %>
+  <%= render OpenProject::Common::SubmenuComponent.new(sidebar_menu_items: @sidebar_menu_items, searchable: true) %>
 <% end %>

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
@@ -3,7 +3,7 @@
   #input
   type="text"
   class="spot-input"
-  data-filters-target="singleDay"
+  data-filter--filters-form-target="singleDay"
   [ngClass]="inputClassNames"
   [attr.data-value]="value"
   [id]="id"
@@ -20,7 +20,7 @@
   <input
     type="date"
     class="spot-input"
-    data-filters-target="singleDay"
+    data-filter--filters-form-target="singleDay"
     [ngClass]="inputClassNames"
     [attr.data-value]="value"
     [id]="id"

--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -7,6 +7,9 @@
   &--search
     margin: 12px
     color: var(--main-menu-font-color)
+    display: flex
+    flex-direction: column
+    row-gap: 16px
 
   &--search-input
     // Overriding the defult input styles, because of the default dark background of the sidebar

--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -4,6 +4,15 @@
   flex-direction: column
   overflow: hidden
 
+  &--search
+    margin: 12px
+    color: var(--main-menu-font-color)
+
+  &--search-input
+    // Overriding the defult input styles, because of the default dark background of the sidebar
+    color: var(--main-menu-font-color) !important
+    border-color: var(--borderColor-muted) !important
+
   &--body
     flex-grow: 1
     overflow: auto

--- a/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
@@ -28,41 +28,50 @@
  * ++
  */
 
-import FilterListController from '../../filter/filter-list.controller';
+import { Controller } from '@hotwired/stimulus';
 
-export default class extends FilterListController {
+export default class FilterListController extends Controller {
   static targets = [
-    'bulkActionContainer',
+    'filter',
+    'searchItem',
   ];
 
-  declare readonly bulkActionContainerTargets:HTMLInputElement[];
+  static values = {
+    clearButtonId: String,
+  };
+
+  declare readonly filterTarget:HTMLInputElement;
+  declare readonly searchItemTargets:HTMLInputElement[];
+  declare readonly clearButtonIdValue:string;
+
+  connect():void {
+   document.getElementById(this.clearButtonIdValue)?.addEventListener('click', () => {
+      this.resetFilterViaClearButton();
+    });
+  }
+
+  disconnect():void {
+    document.getElementById(this.clearButtonIdValue)?.removeEventListener('click', () => {
+      this.resetFilterViaClearButton();
+    });
+  }
 
   filterLists() {
     const query = this.filterTarget.value.toLowerCase();
 
-    if (query.length > 0) {
-      this.hideBulkActionContainers();
-    } else {
-      this.showBulkActionContainers();
-    }
+    this.searchItemTargets.forEach((item) => {
+      const text = item.textContent?.toLowerCase();
 
-    super.filterLists();
-  }
-
-  resetFilterViaClearButton() {
-    this.showBulkActionContainers();
-
-    super.resetFilterViaClearButton();
-  }
-
-  hideBulkActionContainers() {
-    this.bulkActionContainerTargets.forEach((item) => {
-      (item as HTMLElement).classList.add('d-none');
+      if (text?.includes(query)) {
+        (item as HTMLElement).classList.remove('d-none');
+      } else {
+        (item as HTMLElement).classList.add('d-none');
+      }
     });
   }
 
-  showBulkActionContainers() {
-    this.bulkActionContainerTargets.forEach((item) => {
+  resetFilterViaClearButton() {
+    this.searchItemTargets.forEach((item) => {
       (item as HTMLElement).classList.remove('d-none');
     });
   }

--- a/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
@@ -34,6 +34,7 @@ export default class FilterListController extends Controller {
   static targets = [
     'filter',
     'searchItem',
+    'noResultsText',
   ];
 
   static values = {
@@ -41,6 +42,7 @@ export default class FilterListController extends Controller {
   };
 
   declare readonly filterTarget:HTMLInputElement;
+  declare readonly noResultsTextTarget:HTMLInputElement;
   declare readonly searchItemTargets:HTMLInputElement[];
   declare readonly clearButtonIdValue:string;
 
@@ -58,16 +60,24 @@ export default class FilterListController extends Controller {
 
   filterLists() {
     const query = this.filterTarget.value.toLowerCase();
+    let showNoResultsText = true;
 
     this.searchItemTargets.forEach((item) => {
       const text = item.textContent?.toLowerCase();
 
       if (text?.includes(query)) {
         (item as HTMLElement).classList.remove('d-none');
+        showNoResultsText = false;
       } else {
         (item as HTMLElement).classList.add('d-none');
       }
     });
+
+    if (showNoResultsText) {
+      this.noResultsTextTarget?.classList.remove('d-none');
+    } else {
+      this.noResultsTextTarget?.classList.add('d-none');
+    }
   }
 
   resetFilterViaClearButton() {

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -37,7 +37,7 @@ interface InternalFilterValue {
   value:string[];
 }
 
-export default class FiltersController extends Controller {
+export default class FiltersFormController extends Controller {
   static paramsToCopy = ['sortBy', 'columns', 'query_id', 'per_page'];
 
   static targets = [
@@ -207,7 +207,7 @@ export default class FiltersController extends Controller {
     params.append('filters', this.buildFiltersParam(this.parseFilters()));
 
     const currentParams = new URLSearchParams(window.location.search);
-    FiltersController.paramsToCopy.forEach((name) => {
+    FiltersFormController.paramsToCopy.forEach((name) => {
       if (currentParams.has(name)) {
         params.append(name, currentParams.get(name) as string);
       }

--- a/lookbook/previews/open_project/common/submenu_component_preview.rb
+++ b/lookbook/previews/open_project/common/submenu_component_preview.rb
@@ -2,32 +2,48 @@ module OpenProject
   module Common
     # @logical_path OpenProject/Common
     class SubmenuComponentPreview < Lookbook::Preview
+      # @label Default
       def default
-        # Meant to be rendered inside the left-handed sidebar
-        render OpenProject::Common::SubmenuComponent.new(
-          sidebar_menu_items: [
-            OpenProject::Menu::MenuGroup.new(
-              header: nil,
-              children: [
-                OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.all"), href: "", selected: true),
-                OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.locked"), href: "", selected: false),
-                OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.invited"), href: "", selected: false)
-              ]
-            ),
-            OpenProject::Menu::MenuGroup.new(
-              header: I18n.t("members.menu.project_roles"),
-              children: [
-                OpenProject::Menu::MenuItem.new(title: "ROLE X", href: "", selected: false)
-              ]
-            ),
-            OpenProject::Menu::MenuGroup.new(
-              header: I18n.t("members.menu.groups"),
-              children: [
-                OpenProject::Menu::MenuItem.new(title: "GROUP X", href: "", selected: false)
-              ]
-            )
-          ]
-        )
+        render_with_template(template: "open_project/common/submenu_preview/playground",
+                             locals: { sidebar_menu_items: menu_items, searchable: false })
+      end
+
+      # @label Searchable
+      # Searching is currently not working in the lookbook because stimulus controllers are not loaded correctly.
+      # It will be fine in production.
+      def searchable
+        render_with_template(template: "open_project/common/submenu_preview/playground",
+                             locals: { sidebar_menu_items: menu_items, searchable: true })
+      end
+
+      private
+
+      def menu_items
+        [
+          OpenProject::Menu::MenuGroup.new(
+            header: nil,
+            children: [
+              OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.all"), href: "", selected: true),
+              OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.locked"), href: "", selected: false),
+              OpenProject::Menu::MenuItem.new(title: I18n.t("members.menu.invited"), href: "", selected: false)
+            ]
+          ),
+          OpenProject::Menu::MenuGroup.new(
+            header: I18n.t("members.menu.project_roles"),
+            children: [
+              OpenProject::Menu::MenuItem.new(title: "Developer", href: "", selected: false),
+              OpenProject::Menu::MenuItem.new(title: "Manager", href: "", selected: true)
+            ]
+          ),
+          OpenProject::Menu::MenuGroup.new(
+            header: I18n.t("members.menu.groups"),
+            children: [
+              OpenProject::Menu::MenuItem.new(title: "UX", href: "", selected: false),
+              OpenProject::Menu::MenuItem.new(title: "Customer success", href: "", selected: false),
+              OpenProject::Menu::MenuItem.new(title: "Core dev team", href: "", selected: false)
+            ]
+          )
+        ]
       end
     end
   end

--- a/lookbook/previews/open_project/common/submenu_preview/playground.html.erb
+++ b/lookbook/previews/open_project/common/submenu_preview/playground.html.erb
@@ -1,0 +1,6 @@
+<div class="main-menu"> <!-- Meant to be rendered inside the left-handed sidebar and is currently depending on that -->
+  <%= render OpenProject::Common::SubmenuComponent.new(
+    sidebar_menu_items: sidebar_menu_items,
+    searchable: searchable)
+  %>
+</div>

--- a/lookbook/previews/open_project/filter/filter_button_component_preview/filter_section_toggle.html.erb
+++ b/lookbook/previews/open_project/filter/filter_button_component_preview/filter_section_toggle.html.erb
@@ -1,7 +1,7 @@
-<div data-controller="filters"
+<div data-controller="filter--filters-form"
      data-application-target="dynamic"
-     data-filters-display-filters-value="false"
-     data-filters-output-format-value="params">
+     data-filter--filters-form-display-filters-value="false"
+     data-filter--filters-form-output-format-value="params">
   <%= render ::Filter::FilterButtonComponent.new(query: query) %>
   <%= render Projects::ProjectsFiltersComponent.new(query: query) %>
 </div>

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -1,7 +1,7 @@
 <%= render(Primer::OpenProject::SubHeader.new(data: {
-  controller: "filters",
+  controller: "filter--filters-form",
   "application-target": "dynamic",
-  "filters-output-format-value": "json",
+  "filter--filters-form-output-format-value": "json",
 })) do |subheader|
   subheader.with_filter_component do
     render(Meetings::MeetingFilterButtonComponent.new(query: @query, project: @project))

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -73,9 +73,7 @@ module Pages::Meetings
     end
 
     def set_sidebar_filter(filter_name)
-      within "#main-menu" do
-        click_on text: filter_name
-      end
+      submenu.click_item(filter_name)
     end
 
     def expect_no_meetings_listed
@@ -174,6 +172,10 @@ module Pages::Meetings
 
     def row_for(meeting)
       find("td.title", text: meeting.title).ancestor("tr")
+    end
+
+    def submenu
+      Components::Submenu.new
     end
   end
 end

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -507,6 +507,32 @@ RSpec.describe "Persisted lists on projects index page",
       expect(page)
         .to have_text("You are not authorized to access this page.")
     end
+
+    it "can search for a query in the sidebar" do
+      # Go to the persisted query
+      visit projects_path(query_id: my_projects_list.id)
+      projects_page.expect_sidebar_filter("My projects list", selected: true)
+
+      # In the sidebar, search for a substring
+      projects_page.search_for_sidebar_filter("My proj")
+
+      # Only matches are still shown and the selection state is kept
+      projects_page.expect_sidebar_filter("My projects list", selected: true, visible: true)
+      projects_page.expect_sidebar_filter("My projects", selected: false, visible: true)
+
+      projects_page.expect_sidebar_filter("Active projects", selected: false, visible: false)
+      projects_page.expect_sidebar_filter("Archived projects", selected: false, visible: false)
+
+      # In the sidebar, search for another substring
+      projects_page.search_for_sidebar_filter("DO NOT MATCH")
+
+      projects_page.expect_sidebar_filter("My projects list", selected: true, visible: false)
+      projects_page.expect_sidebar_filter("My projects", selected: false, visible: false)
+      projects_page.expect_sidebar_filter("Active projects", selected: false, visible: false)
+      projects_page.expect_sidebar_filter("Archived projects", selected: false, visible: false)
+
+      projects_page.expect_no_search_results_in_sidebar
+    end
   end
 
   describe "persisted query access on invalid query" do

--- a/spec/support/components/common/submenu.rb
+++ b/spec/support/components/common/submenu.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Components
+  class Submenu
+    include Capybara::DSL
+    include Capybara::RSpecMatchers
+    include RSpec::Matchers
+
+    def expect_item(name, selected: false, visible: true)
+      within "#main-menu" do
+        selected_specifier = selected ? ".selected" : ":not(.selected)"
+
+        expect(page).to have_css(".op-sidemenu--item-action#{selected_specifier}", text: name, visible:)
+      end
+    end
+
+    def expect_no_item(name)
+      within "#main-menu" do
+        expect(page).to have_no_css(".op-sidemenu--item-action", text: name)
+      end
+    end
+
+    def click_item(name)
+      within "#main-menu" do
+        click_on text: name
+      end
+    end
+
+    def search_for_item(name)
+      within "#main-menu" do
+        page.find_test_selector("op-sidebar--search-input").set(name)
+      end
+    end
+
+    def expect_no_results_text
+      within "#main-menu" do
+        expect(page).to have_test_selector("op-sidebar--search-no-results", text: "No items found")
+      end
+    end
+  end
+end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -75,18 +75,24 @@ module Pages
         expect(page).to have_css('[data-test-selector="project-query-name"]', text: name)
       end
 
-      def expect_sidebar_filter(filter_name, selected: false)
-        within "#main-menu" do
-          selected_specifier = selected ? ".selected" : ":not(.selected)"
-
-          expect(page).to have_css(".op-sidemenu--item-action#{selected_specifier}", text: filter_name)
-        end
+      def expect_sidebar_filter(filter_name, selected: false, visible: true)
+        submenu.expect_item(filter_name, selected:, visible:)
       end
 
       def expect_no_sidebar_filter(filter_name)
-        within "#main-menu" do
-          expect(page).to have_no_css(".op-sidemenu--item-action", text: filter_name)
-        end
+        submenu.expect_no_item(filter_name)
+      end
+
+      def search_for_sidebar_filter(filter_name)
+        submenu.search_for_item(filter_name)
+      end
+
+      def expect_no_search_results_in_sidebar
+        submenu.expect_no_results_text
+      end
+
+      def set_sidebar_filter(filter_name)
+        submenu.click_item(filter_name)
       end
 
       def expect_current_page_number(number)
@@ -99,12 +105,6 @@ module Pages
         within ".op-pagination--pages" do
           expect(page).to have_css(".op-pagination--item", text: number)
           expect(page).to have_no_css(".op-pagination--item", text: number + 1)
-        end
-      end
-
-      def set_sidebar_filter(filter_name)
-        within "#main-menu" do
-          click_on text: filter_name
         end
       end
 
@@ -442,6 +442,10 @@ module Pages
 
       def boolean_filter?(filter)
         %w[active member_of favored public templated].include?(filter.to_s)
+      end
+
+      def submenu
+        Components::Submenu.new
       end
     end
   end


### PR DESCRIPTION
### ToDo

- [x] Add an option to display a "search" input the SubMenu component
  - [x] Extract logic of filtering used for projectAttribute list (in the project settings) into a reusable controller
  - [x] Use that generic controller inside the SubMenu component
  - [x] When there are no results, show a generic info text
- [x] Enable the search functionality on the project list page

**cleanup**

* [x] I moved the existing `filters.controller` to a separate `filter` folder and renamed it to `filters-form.controller`

https://community.openproject.org/projects/openproject/work_packages/52555/activity