### PR TITLE
Bug/53772 the label for spent time is still visible after deactiving the module time and costs active modules

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -155,7 +155,8 @@ class GroupsController < ApplicationController
   end
 
   def visible_group_members?
-    current_user.allowed_in_any_project?(:manage_members) ||
+    current_user.admin? ||
+      current_user.allowed_in_any_project?(:manage_members) ||
       Group.in_project(Project.allowed_to(current_user, :view_members)).exists?
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -252,6 +252,13 @@ class Project < ApplicationRecord
     enabled_modules.map(&:name)
   end
 
+  def reload(*)
+    @allowed_permissions = nil
+    @allowed_actions = nil
+
+    super
+  end
+
   def allowed_permissions
     @allowed_permissions ||=
       begin

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -9,7 +9,6 @@ module Authorization
     def allowed_globally?(permission)
       perms = contextual_permissions(permission, :global)
       return false unless authorizable_user?
-      return true if admin_and_all_granted_to_admin?(perms)
 
       cached_permissions(nil).intersect?(perms.map(&:name))
     end
@@ -19,9 +18,7 @@ module Authorization
       return false if projects_to_check.blank?
       return false unless authorizable_user?
 
-      projects = Array(projects_to_check)
-
-      projects.all? do |project|
+      Array(projects_to_check).all? do |project|
         allowed_in_single_project?(perms, project)
       end
     end
@@ -29,7 +26,6 @@ module Authorization
     def allowed_in_any_project?(permission)
       perms = contextual_permissions(permission, :project)
       return false unless authorizable_user?
-      return true if admin_and_all_granted_to_admin?(perms)
 
       cached_in_any_project?(perms)
     end
@@ -51,7 +47,6 @@ module Authorization
       perms = contextual_permissions(permission, context_name(entity_class))
       return false unless authorizable_user?
       return false if in_project && !(in_project.active? || in_project.being_archived?)
-      return true if admin_and_all_granted_to_admin?(perms)
 
       if entity_is_project_scoped?(entity_class)
         allowed_in_any_project_scoped_entity?(perms, entity_class, in_project:)
@@ -64,7 +59,25 @@ module Authorization
 
     def cached_permissions(context)
       @cached_permissions ||= Hash.new do |hash, context_key|
-        hash[context_key] = user.all_permissions_for(context_key)
+        hash[context_key] = if user.admin?
+                              permissible_key = case context_key
+                                                when WorkPackage
+                                                  :work_package
+                                                when Project
+                                                  :project
+                                                when nil
+                                                  :global
+                                                else
+                                                  raise "Unknown context key: #{context_key}"
+                                                end
+
+                              OpenProject::AccessControl
+                                .permissions
+                                .select { |p| p.permissible_on?(permissible_key) && p.grant_to_admin? }
+                                .map(&:name)
+                            else
+                              user.all_permissions_for(context_key)
+                            end
       end
 
       @cached_permissions[context]
@@ -85,7 +98,6 @@ module Authorization
       permissions_filtered_for_project = permissions_by_enabled_project_modules(project, permissions)
 
       return false if permissions_filtered_for_project.empty?
-      return true if admin_and_all_granted_to_admin?(permissions)
 
       cached_permissions(project).intersect?(permissions_filtered_for_project)
     end
@@ -106,7 +118,6 @@ module Authorization
       permissions_filtered_for_project = permissions_by_enabled_project_modules(entity.project, permissions)
 
       return false if permissions_filtered_for_project.empty?
-      return true if admin_and_all_granted_to_admin?(permissions)
 
       # The combination of this is better then doing
       # EntityClass.allowed_to(user, permission).exists?.

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -59,25 +59,7 @@ module Authorization
 
     def cached_permissions(context)
       @cached_permissions ||= Hash.new do |hash, context_key|
-        hash[context_key] = if user.admin?
-                              permissible_key = case context_key
-                                                when WorkPackage
-                                                  :work_package
-                                                when Project
-                                                  :project
-                                                when nil
-                                                  :global
-                                                else
-                                                  raise "Unknown context key: #{context_key}"
-                                                end
-
-                              OpenProject::AccessControl
-                                .permissions
-                                .select { |p| p.permissible_on?(permissible_key) && p.grant_to_admin? }
-                                .map(&:name)
-                            else
-                              user.all_permissions_for(context_key)
-                            end
+        hash[context_key] = user.all_permissions_for(context_key)
       end
 
       @cached_permissions[context]

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -89,7 +89,28 @@ module OpenProject
       end
 
       def permissible_on?(context_type)
-        @permissible_on.include?(context_type)
+        # Sometimes the context_type passed in is a decorated object.
+        # Most of the times, this would then be an 'EagerLoadingWrapper' instance.
+        # We need to unwrap the object to get the actual object.
+        # Checking for `context_type.is_a?(SimpleDelegator)` fails for unknown reasons.
+        context_type = context_type.__getobj__ if context_type.class.ancestors.include?(SimpleDelegator)
+
+        context_symbol = case context_type
+                         when WorkPackage
+                           :work_package
+                         when Project
+                           :project
+                         when ::Queries::Projects::ProjectQuery
+                           :project_query
+                         when Symbol
+                           context_type
+                         when nil
+                           :global
+                         else
+                           raise "Unknown context: #{context_type}"
+                         end
+
+        @permissible_on.include?(context_symbol)
       end
 
       def grant_to_admin?

--- a/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/global_menu_item_spec.rb
@@ -32,6 +32,7 @@
 require "spec_helper"
 
 RSpec.describe "Global menu item for boards", :js, :with_cuprite do
+  shared_let(:project) { create(:project) }
   let(:boards_label) { I18n.t("boards.label_boards") }
 
   before do

--- a/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
@@ -29,14 +29,11 @@
 require "spec_helper"
 
 RSpec.describe "Top menu item for boards", :js, :with_cuprite do
-  let(:user) { create(:admin) }
+  current_user { create(:admin) }
+  shared_let(:project) { create(:project) }
 
   let(:menu) { find(".op-app-menu a[title='#{I18n.t('label_modules')}']") }
   let(:boards) { I18n.t("boards.label_boards") }
-
-  before do
-    allow(User).to receive(:current).and_return user
-  end
 
   shared_examples_for "the boards menu item" do
     it "sends the user to the boards overview when clicked" do
@@ -52,8 +49,6 @@ RSpec.describe "Top menu item for boards", :js, :with_cuprite do
   end
 
   context "when in the project settings" do
-    let!(:project) { create(:project) }
-
     before do
       visit "/projects/#{project.identifier}/settings/general"
     end

--- a/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
@@ -29,11 +29,14 @@
 require "spec_helper"
 
 RSpec.describe "Top menu item for boards", :js, :with_cuprite do
-  current_user { create(:admin) }
+  shared_let(:admin) { create(:admin) }
+  shared_let(:user) { create(:user) }
   shared_let(:project) { create(:project) }
 
   let(:menu) { find(".op-app-menu a[title='#{I18n.t('label_modules')}']") }
   let(:boards) { I18n.t("boards.label_boards") }
+
+  current_user { admin }
 
   shared_examples_for "the boards menu item" do
     it "sends the user to the boards overview when clicked" do
@@ -64,7 +67,7 @@ RSpec.describe "Top menu item for boards", :js, :with_cuprite do
     it_behaves_like "the boards menu item"
 
     context "with missing permissions" do
-      let(:user) { create(:user) }
+      current_user { user }
 
       it "does not display the menu item" do
         within "#more-menu", visible: false do

--- a/modules/meeting/spec/controllers/meetings_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meetings_controller_spec.rb
@@ -29,19 +29,11 @@
 require "#{File.dirname(__FILE__)}/../spec_helper"
 
 RSpec.describe MeetingsController do
-  let(:user) { create(:admin) }
-  let(:project) { create(:project) }
-  let(:other_project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project) }
+  shared_let(:other_project) { create(:project) }
 
-  before do
-    allow(User).to receive(:current).and_return user
-
-    allow(Project).to receive(:find).and_return(project)
-
-    allow(controller).to receive(:authorize)
-    allow(controller).to receive(:authorize_global)
-    allow(controller).to receive(:check_if_login_required)
-  end
+  current_user { user }
 
   describe "GET" do
     describe "index" do
@@ -161,8 +153,6 @@ RSpec.describe MeetingsController do
       let(:meeting_params) { base_meeting_params }
 
       before do
-        allow(Project).to receive(:find).and_return(project)
-
         post :create,
              params:
       end

--- a/modules/meeting/spec/features/meetings_global_menu_item_spec.rb
+++ b/modules/meeting/spec/features/meetings_global_menu_item_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Meetings global menu item",
                :with_cuprite do
   shared_let(:user_without_permissions) { create(:user) }
   shared_let(:admin) { create(:admin) }
+  shared_let(:project) { create(:project) }
   shared_let(:meetings_label) { I18n.t(:label_meeting_plural) }
 
   let(:meetings_page) { Pages::Meetings::Index.new(project: nil) }

--- a/modules/reporting/spec/features/top_menu_item_spec.rb
+++ b/modules/reporting/spec/features/top_menu_item_spec.rb
@@ -29,6 +29,8 @@
 require "spec_helper"
 
 RSpec.describe "Top menu items", :js do
+  shared_let(:project) { create(:project) }
+
   let(:user) { create(:user) }
   let(:open_menu) { true }
 

--- a/modules/reporting/spec/workers/cost_query/export_job_spec.rb
+++ b/modules/reporting/spec/workers/cost_query/export_job_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe CostQuery::ExportJob do
-  let(:user) { build_stubbed(:admin) }
+  let(:user) { build_stubbed(:user) }
   let(:project) { build_stubbed(:project) }
 
   let(:initial_filter_params) do
@@ -44,6 +44,10 @@ RSpec.describe CostQuery::ExportJob do
         user_id: ["me"], spent_on: ["2024-03-30", ""], project_id: [project.id.to_s]
       }
     }
+  end
+
+  before do
+    mock_permissions_for(user, &:allow_everything)
   end
 
   # Performs a cost export with the given extra filters.

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -30,6 +30,8 @@ require "spec_helper"
 
 RSpec.describe ActivitiesController do
   shared_let(:admin) { create(:admin) }
+  shared_let(:project) { create(:project) }
+
   current_user { admin }
 
   before do

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe NewsController do
   let(:news) { create(:news) }
 
   shared_let(:project) { create(:project) }
-  current_user { create(:admin) }
+  shared_current_user { create(:admin) }
 
   describe "#index" do
     it "renders index" do

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -33,15 +33,10 @@ RSpec.describe NewsController do
 
   include BecomeMember
 
-  let(:user) do
-    create(:admin)
-  end
-  let(:project) { create(:project) }
   let(:news) { create(:news) }
 
-  before do
-    allow(User).to receive(:current).and_return user
-  end
+  shared_let(:project) { create(:project) }
+  current_user { create(:admin) }
 
   describe "#index" do
     it "renders index" do
@@ -101,7 +96,7 @@ RSpec.describe NewsController do
   describe "#create" do
     context "with news_added notifications" do
       it "persists a news item" do
-        become_member(project, user)
+        become_member(project, current_user)
 
         post :create,
              params: {
@@ -117,7 +112,7 @@ RSpec.describe NewsController do
         news = News.find_by!(title: "NewsControllerTest")
         expect(news).not_to be_nil
         expect(news.description).to eq "This is the description"
-        expect(news.author).to eq user
+        expect(news.author).to eq current_user
         expect(news.project).to eq project
       end
     end

--- a/spec/features/custom_fields/create_long_text_spec.rb
+++ b/spec/features/custom_fields/create_long_text_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "custom fields", :js do
   let(:cf_page) { Pages::CustomFields.new }
   let(:editor) { Components::WysiwygEditor.new "#custom_field_form" }
   let(:type) { create(:type_task) }
-  let(:project) { create(:project, enabled_module_names: %i[work_package_tracking], types: [type]) }
+  let!(:project) { create(:project, enabled_module_names: %i[work_package_tracking], types: [type]) }
 
   let(:wp_page) { Pages::FullWorkPackageCreate.new project: }
 

--- a/spec/features/news/global_menu_item_spec.rb
+++ b/spec/features/news/global_menu_item_spec.rb
@@ -34,6 +34,7 @@ require "spec_helper"
 RSpec.describe "News global menu item spec", :js, :with_cuprite do
   shared_let(:admin) { create(:admin) }
   shared_let(:user_without_permissions) { create(:user) }
+  shared_let(:project) { create(:project) }
 
   before do
     login_as current_user

--- a/spec/features/projects/global_menu_item_spec.rb
+++ b/spec/features/projects/global_menu_item_spec.rb
@@ -32,7 +32,10 @@
 require "spec_helper"
 
 RSpec.describe "Projects global menu item", :js, :with_cuprite do
-  current_user { create(:user) }
+  shared_let(:user) { create(:user) }
+  shared_let(:admin) { create(:admin) }
+
+  current_user { user }
 
   before do
     visit root_path
@@ -64,7 +67,7 @@ RSpec.describe "Projects global menu item", :js, :with_cuprite do
     end
 
     context "with an admin user" do
-      current_user { create(:admin) }
+      current_user { admin }
 
       it "renders the archived filter as well" do
         within "#main-menu" do

--- a/spec/features/projects/global_menu_item_spec.rb
+++ b/spec/features/projects/global_menu_item_spec.rb
@@ -32,10 +32,9 @@
 require "spec_helper"
 
 RSpec.describe "Projects global menu item", :js, :with_cuprite do
-  let(:user) { create(:user) }
+  current_user { create(:user) }
 
   before do
-    login_as user
     visit root_path
   end
 
@@ -65,7 +64,7 @@ RSpec.describe "Projects global menu item", :js, :with_cuprite do
     end
 
     context "with an admin user" do
-      let(:user) { create(:admin) }
+      current_user { create(:admin) }
 
       it "renders the archived filter as well" do
         within "#main-menu" do

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "form configuration", :js do
   shared_let(:admin) { create(:admin) }
   let(:type) { create(:type) }
 
-  let(:project) { create(:project, types: [type]) }
+  let!(:project) { create(:project, types: [type]) }
   let(:category) { create(:category, project:) }
   let(:work_package) do
     create(:work_package,

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -29,13 +29,12 @@
 require "spec_helper"
 
 RSpec.describe "Work Packages", "index view", :js, :with_cuprite do
-  let(:user) { create(:admin) }
-  let(:project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
+
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
 
-  before do
-    login_as(user)
-  end
+  current_user { user }
 
   context "within a global context" do
     before do

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -79,6 +79,68 @@ RSpec.describe OpenProject::AccessControl::Permission do
     end
   end
 
+  describe "#permissible_on?" do
+    context "when marked as permissible on work package roles" do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :work_package)
+      end
+
+      it { expect(permission).to be_permissible_on(WorkPackage.new) }
+      it { expect(permission).not_to be_permissible_on(Project.new) }
+      it { expect(permission).not_to be_permissible_on(nil) }
+      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).to be_permissible_on(:work_package) }
+      it { expect(permission).not_to be_permissible_on(:project) }
+      it { expect(permission).not_to be_permissible_on(:global) }
+      it { expect(permission).not_to be_permissible_on(:project_query) }
+    end
+
+    context "when marked as permissible on project roles" do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :project)
+      end
+
+      it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
+      it { expect(permission).to be_permissible_on(Project.new) }
+      it { expect(permission).not_to be_permissible_on(nil) }
+      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(:work_package) }
+      it { expect(permission).to be_permissible_on(:project) }
+      it { expect(permission).not_to be_permissible_on(:global) }
+      it { expect(permission).not_to be_permissible_on(:project_query) }
+    end
+
+    context "when marked as permissible on global roles" do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :global)
+      end
+
+      it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
+      it { expect(permission).not_to be_permissible_on(Project.new) }
+      it { expect(permission).to be_permissible_on(nil) }
+      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(:work_package) }
+      it { expect(permission).not_to be_permissible_on(:project) }
+      it { expect(permission).to be_permissible_on(:global) }
+      it { expect(permission).not_to be_permissible_on(:project_query) }
+    end
+
+    context "when marked as permissible on project queries" do
+      subject(:permission) do
+        described_class.new(:perm, { cont: [:action] }, permissible_on: :project_query)
+      end
+
+      it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
+      it { expect(permission).not_to be_permissible_on(Project.new) }
+      it { expect(permission).not_to be_permissible_on(nil) }
+      it { expect(permission).to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(:work_package) }
+      it { expect(permission).not_to be_permissible_on(:project) }
+      it { expect(permission).not_to be_permissible_on(:global) }
+      it { expect(permission).to be_permissible_on(:project_query) }
+    end
+  end
+
   describe "marking it as permissible on multiple role types" do
     subject(:permission) do
       described_class.new(:perm, { cont: [:action] }, permissible_on: %i[work_package project])

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe WorkPackage, ".allowed_to" do
         expect(subject).to be_empty
       end
     end
+
+    context "when the module the permission belongs to is disabled" do
+      before do
+        private_project.enabled_module_names = private_project.enabled_module_names - ["work_package_tracking"]
+      end
+
+      it "excludes work packages where the module is disabled in" do
+        expect(subject).to contain_exactly(work_package_in_public_project)
+      end
+    end
   end
 
   context "when the user has the permission directly on the work package" do

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -29,15 +29,14 @@
 require "spec_helper"
 
 RSpec.describe WorkPackage, ".allowed_to" do
-  let(:user) { create(:user) }
+  shared_let(:user) { create(:user) }
+  shared_let(:project_status) { true }
+  shared_let(:private_project) { create(:project, public: false, active: project_status) }
+  shared_let(:public_project) { create(:project, public: true, active: project_status) }
 
-  let!(:private_project) { create(:project, public: false, active: project_status) }
-  let!(:public_project) { create(:project, public: true, active: project_status) }
-  let(:project_status) { true }
-
-  let!(:work_package_in_public_project) { create(:work_package, project: public_project) }
-  let!(:work_package_in_private_project) { create(:work_package, project: private_project) }
-  let!(:other_work_package_in_private_project) { create(:work_package, project: private_project) }
+  shared_let(:work_package_in_public_project) { create(:work_package, project: public_project) }
+  shared_let(:work_package_in_private_project) { create(:work_package, project: private_project) }
+  shared_let(:other_work_package_in_private_project) { create(:work_package, project: private_project) }
 
   let(:project_permissions) { [] }
   let(:project_role) { create(:project_role, permissions: project_permissions) }

--- a/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Rate limiting APIv3",
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 
+  shared_let(:project) { create(:project) }
   current_user { create(:admin) }
 
   context "when enabled", with_config: { rate_limiting: { api_v3: true } } do


### PR DESCRIPTION
### Goal

For admin users, permissions were granted regardless of whether the module a permission belongs to is active or not. Now, this is always checked. 

This comes with the caveat that for some scenarios, e.g. displaying the menu items "Boards" and "Meetings", a project needs to exist to have the menu items show up. Since the permission check is against `allowed_in_any_project?` this seems to be correct however. In most real live scenarios, there should always be a project anyway. In tests, this might not always be the case which is why some needed to be amended in the scope of this PR.

### WP

https://community.openproject.org/wp/53772