### PR TITLE
Only cache the client credential token if requests where successful

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,6 +236,10 @@ RSpec/DescribeMethod:
 RSpec/SpecFilePathFormat:
   IgnoreMethods: true
 
+# Disable deprecated cop
+RSpec/FilePath:
+  Enabled: false
+
 # Prevent  "fit" or similar to be committed
 RSpec/Focus:
   Enabled: true

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -187,6 +189,24 @@ class ServiceResult
       [result]
     else
       []
+    end
+  end
+
+  def deconstruct_keys(keys)
+    if keys
+      value = {}
+      keys.each do |key|
+        case key
+        when :success then value[key] = success?
+        when :failure then value[key] = failure?
+        when :result then value[key] = result
+        when :errors then value[key] = errors
+        end
+      end
+
+      value
+    else
+      { success: success?, failure: failure?, result:, errors: }
     end
   end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
@@ -64,6 +64,8 @@ module Storages
             if access_token.nil? && operation_result.success?
               token = http.instance_variable_get(:@options).oauth_session.access_token
               Rails.cache.write("storage.#{storage.id}.httpx_access_token", token, expires_in: 50.minutes)
+            elsif operation_result.failure? && operation_result.result == :forbidden
+              Rails.cache.delete("storage.#{storage.id}.httpx_access_token")
             end
 
             operation_result

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
@@ -59,12 +59,14 @@ module Storages
 
             http = http_result.result
 
-            if access_token.nil?
+            operation_result = yield http
+
+            if access_token.nil? && operation_result.success?
               token = http.instance_variable_get(:@options).oauth_session.access_token
               Rails.cache.write("storage.#{storage.id}.httpx_access_token", token, expires_in: 50.minutes)
             end
 
-            yield http
+            operation_result
           end
 
           # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_configuration.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_configuration.rb
@@ -48,6 +48,10 @@ module Storages
             @issuer = issuer
             @scope = scope
           end
+
+          def to_h
+            { issuer:, client_id:, client_secret:, scope: }
+          end
         end
       end
     end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/o_auth_client_credentials_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/o_auth_client_credentials_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthClientCredentials, :webmock do
+  let(:storage) { create(:sharepoint_dev_drive_storage) }
+
+  subject(:strategy) { described_class.new }
+
+  context "when the attempted request fails with a 403" do
+    before do
+      stub_request(:post, "https://login.microsoftonline.com/4d44bf36-9b56-45c0-8807-bbf386dd047f/oauth2/v2.0/token")
+        .and_return(status: 200, body: token_json, headers: { content_type: "application/json" })
+
+      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root")
+        .and_return(status: 403)
+    end
+
+    it "does not cache the result" do
+      expect(Rails.cache.fetch("storage.#{storage.id}.httpx_access_token")).to be_nil
+
+      strategy.call(storage:) do |http|
+        http.get("https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root").raise_for_status
+      rescue HTTPX::Error
+        ServiceResult.failure
+      end
+
+      expect(Rails.cache.fetch("storage.#{storage.id}.httpx_access_token")).to be_nil
+    end
+
+    it "returns the result of the operation" do
+      result = strategy.call(storage:) do |http|
+        http.get("https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root").raise_for_status
+      rescue HTTPX::Error
+        ServiceResult.failure(result: "It failed")
+      end
+
+      expect(result).to be_failure
+      expect(result.result).to eq("It failed")
+    end
+  end
+
+  context "when the attempted request works" do
+    before do
+      Rails.cache.clear
+
+      stub_request(:post, "https://login.microsoftonline.com/4d44bf36-9b56-45c0-8807-bbf386dd047f/oauth2/v2.0/token")
+        .and_return(status: 200, body: token_json, headers: { content_type: "application/json" })
+
+      stub_request(:get, "https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root")
+        .and_return(status: 200, body: { data: "bunch of data" }.to_json, headers: { content_type: "application/json" })
+    end
+
+    it "caches the generated token" do
+      expect(Rails.cache.fetch("storage.#{storage.id}.httpx_access_token")).to be_nil
+
+      strategy.call(storage:) do |http|
+        http.get("https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root").raise_for_status
+        ServiceResult.success
+      end
+
+      expect(Rails.cache.fetch("storage.#{storage.id}.httpx_access_token")).to eq("TOTALLY_VALID_TOKEN")
+    end
+
+    it "returns the result of the operation" do
+      result = strategy.call(storage:) do |http|
+        http.get("https://graph.microsoft.com/v1.0/drives/#{storage.drive_id}/root").raise_for_status
+        ServiceResult.success(result: "It works")
+      end
+
+      expect(result).to be_success
+      expect(result.result).to eq("It works")
+    end
+  end
+
+  private
+
+  def token_json
+    '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"TOTALLY_VALID_TOKEN"}'
+  end
+end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/rename_file_command_spec.rb
@@ -31,13 +31,14 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::RenameFileCommand, :webmock,
-               skip: "TODO: disabled because it's flaky on dev currently. Needs to be reenabled before merging" do
+RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::RenameFileCommand, :webmock do
   let(:storage) { create(:sharepoint_dev_drive_storage) }
+  let(:userless_strategy) { Storages::Peripherals::Registry.resolve("one_drive.authentication.userless").call }
   let(:folder) do
     Storages::Peripherals::Registry
                    .resolve("one_drive.commands.create_folder")
-                   .call(storage:, folder_path: "Wrong Name")
+                   .call(auth_strategy: userless_strategy, storage:, folder_name: "Wrong Name",
+                         parent_location: Storages::Peripherals::ParentFolder.new("/"))
   end
 
   subject(:command) { described_class.new(storage) }
@@ -72,6 +73,6 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::RenameFileCo
   def delete_folder(folder_id)
     Storages::Peripherals::Registry
       .resolve("one_drive.commands.delete_folder")
-      .call(storage:, location: folder_id)
+      .call(auth_strategy: userless_strategy, storage:, location: folder_id)
   end
 end

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/rename_folder_success.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/one_drive/rename_folder_success.yml
@@ -4,6 +4,119 @@ http_interactions:
     method: post
     uri: https://login.microsoftonline.com/4d44bf36-9b56-45c0-8807-bbf386dd047f/oauth2/v2.0/token
     body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=4262df2b-77bb-49c2-a5df-28355da676d2&client_secret=Vwk8Q%7EJTuPh.pAjvPiWBQBdTFMDK%7EAIwxbj9_axB
+    headers:
+      User-Agent:
+      - httpx.rb/1.2.5
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '201'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 5d94463c-89b2-4148-8afa-47d6d7686900
+      X-Ms-Ests-Server:
+      - 2.1.18216.5 - SEC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=ApsGOKKY9c5MtcLEnQSVmSqkbDoXAQAAAJkC-d0OAAAA; expires=Wed, 10-Jul-2024
+        14:20:10 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 10 Jun 2024 14:20:09 GMT
+      Content-Length:
+      - '1735'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 10 Jun 2024 14:20:10 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"Wrong Name","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - httpx.rb/1.2.5
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '76'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{B880A739-43EF-4363-9134-BD49CFE7C910},1"'
+      Location:
+      - https://finn.sharepoint.com/_api/v2.0/drives('b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs')/items('root')/children('01AZJL5PJZU6ALR32DMNBZCNF5JHH6PSIQ')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - cd98c895-8ec4-45b7-8f07-eca6799a38c2
+      Client-Request-Id:
+      - cd98c895-8ec4-45b7-8f07-eca6799a38c2
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000005B8"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 10 Jun 2024 14:20:10 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children/$entity","@odata.etag":"\"{B880A739-43EF-4363-9134-BD49CFE7C910},1\"","createdDateTime":"2024-06-10T14:20:11Z","eTag":"\"{B880A739-43EF-4363-9134-BD49CFE7C910},1\"","id":"01AZJL5PJZU6ALR32DMNBZCNF5JHH6PSIQ","lastModifiedDateTime":"2024-06-10T14:20:11Z","name":"Wrong
+        Name","size":0,"webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Wrong%20Name","cTag":"\"c:{B880A739-43EF-4363-9134-BD49CFE7C910},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OpenProject
+        Dev App","id":"4262df2b-77bb-49c2-a5df-28355da676d2"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OpenProject Dev App","id":"4262df2b-77bb-49c2-a5df-28355da676d2"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","driveType":"documentLibrary","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","sharepointIds":{"listId":"f3baf95b-362b-4740-80d8-4f593d28f5ec","listItemUniqueId":"049e81d0-52fb-4624-af6d-96611c29a9cc","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50","siteUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests","tenantId":"4d44bf36-9b56-45c0-8807-bbf386dd047f","webId":"7ef259e8-8eed-4645-920a-8b367bb0d8e0"}},"fileSystemInfo":{"createdDateTime":"2024-06-10T14:20:11Z","lastModifiedDateTime":"2024-06-10T14:20:11Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 10 Jun 2024 14:20:11 GMT
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/4d44bf36-9b56-45c0-8807-bbf386dd047f/oauth2/v2.0/token
+    body:
       encoding: UTF-8
       string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
     headers:
@@ -37,85 +150,29 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - 5cad9093-3a22-406e-bb6e-91a1a8067200
+      - bb546166-785b-453c-81bc-cb8c93af6e00
       X-Ms-Ests-Server:
-      - 2.1.17122.3 - FRC ProdSlices
+      - 2.1.18216.5 - SEC ProdSlices
+      X-Ms-Srs:
+      - 1.P
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AtJoMauZWOBDo0kxnN79HDmkbDoXAQAAAMfaSt0OAAAA; expires=Thu, 29-Feb-2024
-        11:55:52 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhKGA6Jv29JLr32JHmFcFrukbDoXAQAAAJoC-d0OAAAA; expires=Wed, 10-Jul-2024
+        14:20:11 GMT; path=/; secure; HttpOnly; SameSite=None
       - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
       - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
       Date:
-      - Tue, 30 Jan 2024 11:55:51 GMT
+      - Mon, 10 Jun 2024 14:20:11 GMT
       Content-Length:
       - '1708'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Tue, 30 Jan 2024 11:55:52 GMT
-- request:
-    method: post
-    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root/children
-    body:
-      encoding: UTF-8
-      string: '{"name":"Wrong Name","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
-    headers:
-      Authorization:
-      - Bearer <BEARER TOKEN>
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - httpx.rb/1.2.1
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '76'
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-store, no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
-      Content-Encoding:
-      - gzip
-      Etag:
-      - '"{2CA620AC-3D42-437A-94B0-7DE8295827B8},1"'
-      Location:
-      - https://finn.sharepoint.com/_api/v2.0/drives('b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs')/items('root')/children('01AZJL5PNMECTCYQR5PJBZJMD55AUVQJ5Y')
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000
-      Request-Id:
-      - 736fc399-438a-40ca-93fd-75a21903b009
-      Client-Request-Id:
-      - 736fc399-438a-40ca-93fd-75a21903b009
-      X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF00000318"}}'
-      Odata-Version:
-      - '4.0'
-      Date:
-      - Tue, 30 Jan 2024 11:55:51 GMT
-    body:
-      encoding: UTF-8
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/root/children/$entity","@odata.etag":"\"{2CA620AC-3D42-437A-94B0-7DE8295827B8},1\"","createdDateTime":"2024-01-30T11:55:52Z","eTag":"\"{2CA620AC-3D42-437A-94B0-7DE8295827B8},1\"","id":"01AZJL5PNMECTCYQR5PJBZJMD55AUVQJ5Y","lastModifiedDateTime":"2024-01-30T11:55:52Z","name":"Wrong
-        Name","size":0,"webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/Wrong%20Name","cTag":"\"c:{2CA620AC-3D42-437A-94B0-7DE8295827B8},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OpenProject
-        Dev App","id":"4262df2b-77bb-49c2-a5df-28355da676d2"},"user":{"displayName":"SharePoint
-        App"}},"lastModifiedBy":{"application":{"displayName":"OpenProject Dev App","id":"4262df2b-77bb-49c2-a5df-28355da676d2"},"user":{"displayName":"SharePoint
-        App"}},"parentReference":{"driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","driveType":"documentLibrary","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","sharepointIds":{"listId":"f3baf95b-362b-4740-80d8-4f593d28f5ec","listItemUniqueId":"049e81d0-52fb-4624-af6d-96611c29a9cc","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50","siteUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests","tenantId":"4d44bf36-9b56-45c0-8807-bbf386dd047f","webId":"7ef259e8-8eed-4645-920a-8b367bb0d8e0"}},"fileSystemInfo":{"createdDateTime":"2024-01-30T11:55:52Z","lastModifiedDateTime":"2024-01-30T11:55:52Z"},"folder":{"childCount":0}}'
-  recorded_at: Tue, 30 Jan 2024 11:55:52 GMT
+  recorded_at: Mon, 10 Jun 2024 14:20:11 GMT
 - request:
     method: patch
-    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PNMECTCYQR5PJBZJMD55AUVQJ5Y
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PJZU6ALR32DMNBZCNF5JHH6PSIQ
     body:
       encoding: UTF-8
       string: '{"name":"My Project No. 1 (19)"}'
@@ -127,7 +184,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - httpx.rb/1.2.1
+      - httpx.rb/1.2.5
       Accept-Encoding:
       - gzip, deflate
       Content-Length:
@@ -139,8 +196,6 @@ http_interactions:
     headers:
       Cache-Control:
       - no-store, no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Content-Encoding:
@@ -150,37 +205,35 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 1e9e401d-cacf-41f9-ac60-91ebb154f9fc
+      - 6ec63b53-7694-4127-91f2-6c9cc9741bd5
       Client-Request-Id:
-      - 1e9e401d-cacf-41f9-ac60-91ebb154f9fc
+      - 6ec63b53-7694-4127-91f2-6c9cc9741bd5
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF000002DC"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002E4"}}'
       Odata-Version:
       - '4.0'
       Date:
-      - Tue, 30 Jan 2024 11:55:52 GMT
+      - Mon, 10 Jun 2024 14:20:11 GMT
     body:
       encoding: UTF-8
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/items/$entity","createdDateTime":"2024-01-30T11:55:52Z","eTag":"\"{2CA620AC-3D42-437A-94B0-7DE8295827B8},2\"","id":"01AZJL5PNMECTCYQR5PJBZJMD55AUVQJ5Y","lastModifiedDateTime":"2024-01-30T11:55:53Z","name":"My
-        Project No. 1 (19)","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/My%20Project%20No.%201%20(19)","cTag":"\"c:{2CA620AC-3D42-437A-94B0-7DE8295827B8},0\"","size":0,"createdBy":{"application":{"id":"4262df2b-77bb-49c2-a5df-28355da676d2","displayName":"OpenProject
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs'')/items/$entity","createdDateTime":"2024-06-10T14:20:11Z","eTag":"\"{B880A739-43EF-4363-9134-BD49CFE7C910},3\"","id":"01AZJL5PJZU6ALR32DMNBZCNF5JHH6PSIQ","lastModifiedDateTime":"2024-06-10T14:20:12Z","name":"My
+        Project No. 1 (19)","webUrl":"https://finn.sharepoint.com/sites/openprojectfilestoragetests/VCR/My%20Project%20No.%201%20(19)","cTag":"\"c:{B880A739-43EF-4363-9134-BD49CFE7C910},0\"","size":0,"createdBy":{"application":{"id":"4262df2b-77bb-49c2-a5df-28355da676d2","displayName":"OpenProject
         Dev App"},"user":{"displayName":"SharePoint App"}},"lastModifiedBy":{"application":{"id":"4262df2b-77bb-49c2-a5df-28355da676d2","displayName":"OpenProject
-        Dev App"},"user":{"displayName":"SharePoint App"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","name":"VCR","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"fileSystemInfo":{"createdDateTime":"2024-01-30T11:55:52Z","lastModifiedDateTime":"2024-01-30T11:55:53Z"},"folder":{"childCount":0},"shared":{"scope":"users"}}'
-  recorded_at: Tue, 30 Jan 2024 11:55:52 GMT
+        Dev App"},"user":{"displayName":"SharePoint App"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs","id":"01AZJL5PN6Y2GOVW7725BZO354PWSELRRZ","name":"VCR","path":"/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/root:","siteId":"1b4b6576-906d-4d94-8f49-6d00a9507b50"},"fileSystemInfo":{"createdDateTime":"2024-06-10T14:20:11Z","lastModifiedDateTime":"2024-06-10T14:20:12Z"},"folder":{"childCount":0},"shared":{"scope":"users"}}'
+  recorded_at: Mon, 10 Jun 2024 14:20:12 GMT
 - request:
     method: delete
-    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PNMECTCYQR5PJBZJMD55AUVQJ5Y
+    uri: https://graph.microsoft.com/v1.0/drives/b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2OBb-brzKzZAR4DYT1k9KPXs/items/01AZJL5PJZU6ALR32DMNBZCNF5JHH6PSIQ
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Authorization:
       - Bearer <BEARER TOKEN>
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
       User-Agent:
-      - httpx.rb/1.2.1
+      - httpx.rb/1.2.5
+      Accept:
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
   response:
@@ -193,15 +246,15 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 2a31e02e-a29a-443c-9da3-f2e3767198c2
+      - b6c9de3e-fb1a-428a-bac3-158a753dae5d
       Client-Request-Id:
-      - 2a31e02e-a29a-443c-9da3-f2e3767198c2
+      - b6c9de3e-fb1a-428a-bac3-158a753dae5d
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"5","ScaleUnit":"005","RoleInstance":"FR3PEPF00000366"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000553"}}'
       Date:
-      - Tue, 30 Jan 2024 11:55:52 GMT
+      - Mon, 10 Jun 2024 14:20:11 GMT
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Tue, 30 Jan 2024 11:55:52 GMT
+  recorded_at: Mon, 10 Jun 2024 14:20:12 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
### ⚠️ Related WP: [OP#55620](https://community.openproject.org/projects/openproject/work_packages/55620/)

## What?

We cache the client credential token for most of its duration, which is fine unless the storage is miss-configured and we get a failure. Then the possibly broken token will potentially continue failing until the cache expires.

This PR intends to avoid that, by only caching tokens after a successful response.

## How?

The caching of the token was moved to after the yielding of the HTTP client. There's also a check for a `:forbidden` result (from a 403) that evicts an existing token from the cache.

Not all Commands/Queries return 403s but introducing this was left out of this PR