### PR TITLE
[#55268] PDF report: multi column table with pictures not included

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem "structured_warnings", "~> 0.4.0"
 gem "airbrake", "~> 13.0.0", require: false
 
 gem "markly", "~> 0.10" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "8f14736a88ad0064d2a97be108fe7061ffbcee91"
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "8772c791a21819751c0d111be903b3b44ef7d862"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 8f14736a88ad0064d2a97be108fe7061ffbcee91
-  ref: 8f14736a88ad0064d2a97be108fe7061ffbcee91
+  revision: 8772c791a21819751c0d111be903b3b44ef7d862
+  ref: 8772c791a21819751c0d111be903b3b44ef7d862
   specs:
-    md_to_pdf (0.0.26)
+    md_to_pdf (0.0.27)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
-      json-schema (~> 4.1)
+      json-schema (~> 4.3)
       markly (~> 0.10)
       matrix (~> 0.4)
       nokogiri (~> 1.1)


### PR DESCRIPTION
Table layouting bug deep in md-to-pdf. Fixed there with [tests](https://github.com/opf/md-to-pdf/blob/main/spec/fixtures/image/large_in_table.md?plain=1)

* [x] fix bug in md-to-pdf
* [x] update md-to-pdf gem in OP

https://community.openproject.org/work_packages/55268

Nothing much to review here as  changes are in the dependency. Find a test case for the previous non-working combination of table + image size + image position: https://pr-15812-55268-pdf-r-ip-3-73-130-232.my.pullpreview.com/projects/demo-project/work_packages/2/activity