### PR TITLE
[55622] Fix label for status default percent complete in admin

### DIFF
--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="form--field">
     <%= f.select :default_done_ratio,
                  (0..100).step(10).map { |r| ["#{r} %", r] },
-                 { container_class: "-xslim" },
+                 container_class: "-xslim",
                  label: WorkPackage.human_attribute_name(:done_ratio) %>
   </div>
   <div class="form--field"><%= f.check_box "is_closed" %></div>


### PR DESCRIPTION
https://community.openproject.org/wp/55622

It was showing "Default done ratio" because the `:label` argument is not in the options hash. The regression was introduced in 4b5292de3f3 when the `:container_class` was added.