### PR TITLE
[#55523] make add projects dialog mobile friendly

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
@@ -27,7 +27,7 @@
       ) do |form|
         concat(render(Primer::Alpha::Dialog::Body.new(
           id: dialog_body_id, test_selector: dialog_body_id, aria: { label: title },
-          classes: "FormControl-horizontalGroup--sm-vertical",
+          classes: "FormControl-horizontalGroup--sm-vertical FormControl-horizontalGroup--center-aligned",
           style: "min-height: 300px"
         )) do
           render(Projects::CustomFields::CustomFieldMappingForm.new(form, project_custom_field: @project_custom_field))

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
@@ -27,6 +27,7 @@
       ) do |form|
         concat(render(Primer::Alpha::Dialog::Body.new(
           id: dialog_body_id, test_selector: dialog_body_id, aria: { label: title },
+          classes: "FormControl-horizontalGroup--sm-vertical",
           style: "min-height: 300px"
         )) do
           render(Projects::CustomFields::CustomFieldMappingForm.new(form, project_custom_field: @project_custom_field))

--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -47,8 +47,8 @@ module Projects::CustomFields
           name: :include_sub_projects,
           label: I18n.t("projects.settings.project_custom_fields.new_project_mapping_form.include_sub_projects"),
           checked: false,
-          class: "my-sm-2",
-          label_arguments: { class: "no-wrap my-sm-2" }
+          my: [0, 2],
+          label_arguments: { class: "no-wrap", my: [0, 2] }
         )
       end
     end

--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -47,8 +47,7 @@ module Projects::CustomFields
           name: :include_sub_projects,
           label: I18n.t("projects.settings.project_custom_fields.new_project_mapping_form.include_sub_projects"),
           checked: false,
-          my: [0, 2],
-          label_arguments: { class: "no-wrap", my: [0, 2] }
+          label_arguments: { class: "no-wrap" }
         )
       end
     end

--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -28,9 +28,9 @@
 
 module Projects::CustomFields
   class CustomFieldMappingForm < ApplicationForm
-    form do |f|
-      f.group(layout: :horizontal) do |f_group|
-        f_group.project_autocompleter(
+    form do |form|
+      form.group(layout: :horizontal) do |group|
+        group.project_autocompleter(
           name: :id,
           label: Project.model_name.human,
           visually_hide_label: true,
@@ -43,11 +43,12 @@ module Projects::CustomFields
           }
         )
 
-        f_group.check_box(
+        group.check_box(
           name: :include_sub_projects,
           label: I18n.t("projects.settings.project_custom_fields.new_project_mapping_form.include_sub_projects"),
           checked: false,
-          label_arguments: { class: "no-wrap" }
+          class: "my-sm-2",
+          label_arguments: { class: "no-wrap my-sm-2" }
         )
       end
     end

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -73,3 +73,7 @@ page-header
     .FormControl-horizontalGroup
       flex-direction: column
       row-gap: 1rem
+
+.FormControl-horizontalGroup--center-aligned
+  .FormControl-horizontalGroup
+    align-items: center


### PR DESCRIPTION
https://community.openproject.org/work_packages/55523

I also tried centering the checkbox and its label on desktop with flexbox / flex grid, but then the actual checkbox and its label did no longer align (even though they both were more centered than before). If anyone knows a better solution, please let me know :)