### PR TITLE
Fix global menu item too height in Safari 17

### DIFF
--- a/frontend/src/global_styles/common/menu/menu.sass
+++ b/frontend/src/global_styles/common/menu/menu.sass
@@ -13,8 +13,7 @@
       align-items: center
 
     &-action
-      display: flex
-      align-items: center
+      display: block
       height: 32px
       line-height: 32px
       text-decoration: none


### PR DESCRIPTION
Before:

<img width="1549" alt="iShot_2024-06-11_22 56 17" src="https://github.com/opf/openproject/assets/1131536/f0c6e02e-572d-4c63-8de2-4341d332b379">

After:

<img width="1295" alt="iShot_2024-06-12_10 48 17" src="https://github.com/opf/openproject/assets/1131536/bc2be724-db5b-425c-a862-387644d7a510">
