### PR TITLE
Update Rubocop gems and properly load them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ require:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
-  - rubocop-inflector
   - ./config/initializers/inflections.rb
 
 <% if File.exist?('.rubocop-local.yml') %>

--- a/Gemfile
+++ b/Gemfile
@@ -330,10 +330,12 @@ group :development, :test do
 
   # ruby linting
   gem "rubocop", require: false
-  gem "rubocop-inflector", require: false
+  gem "rubocop-capybara", require: false
+  gem "rubocop-factory_bot", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
+  gem "rubocop-rspec_rails", require: false
 
   # erb linting
   gem "erb_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -940,7 +940,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
-    rexml (3.2.9)
+    rexml (3.3.0)
       strscan
     rinku (2.0.6)
     roar (1.2.0)
@@ -985,12 +985,8 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.26.0)
-      rubocop (~> 1.41)
-    rubocop-inflector (0.2.1)
-      activesupport
-      rubocop
-      rubocop-rspec
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -999,13 +995,11 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (2.31.0)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.29.0)
-      rubocop (~> 1.40)
+    rubocop-rspec (3.0.1)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-duration (3.2.3)
       activesupport (>= 3.0.0)
       i18n
@@ -1316,10 +1310,12 @@ DEPENDENCIES
   rspec-rails (~> 6.1.0)
   rspec-retry (~> 0.6.1)
   rubocop
-  rubocop-inflector
+  rubocop-capybara
+  rubocop-factory_bot
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   ruby-duration (~> 3.2.0)
   ruby-prof
   ruby-progressbar (~> 1.13.0)


### PR DESCRIPTION
Rubocop-rspec 3 has put the cops for rails specific stuff, capybara and factorybot into their own gems. This replaces the dependabot update because there is an incompatability with the `rubocop-inflector` package that monkey patches a now removed cop. A [PR on that repo](https://github.com/aeroastro/rubocop-inflector/pull/5) has been open for a while and not merged yet. Also, I am not sure if the `rubocop-inflectors` stuff is still needed, as `rubocop-rspec` has been aware of Inflections since this PR: https://github.com/rubocop/rubocop-rspec/pull/1266

---

Replaces #15826, #15829

