### PR TITLE
[#55502] Sorting suggested to be possible when it isn't

### DIFF
--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -104,7 +104,7 @@ module Projects
     end
 
     def sortable_column?(select)
-      query.known_order?(select.attribute)
+      sortable? && query.known_order?(select.attribute)
     end
 
     def columns

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
@@ -35,6 +35,10 @@ module Settings
         def columns
           @columns ||= query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
         end
+
+        def sortable?
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
Only marking the table component as not sortable was not sufficient since then it would raise in ProjectsHelper#projects_sort_header_tag, which is used when rendering the component.