### PR TITLE
[#55523] Add Dialog not mobile friendly: don't center align on mobile

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
@@ -27,7 +27,7 @@
       ) do |form|
         concat(render(Primer::Alpha::Dialog::Body.new(
           id: dialog_body_id, test_selector: dialog_body_id, aria: { label: title },
-          classes: "FormControl-horizontalGroup--sm-vertical FormControl-horizontalGroup--non-mobile-center-aligned",
+          classes: "FormControl-horizontalGroup--sm-vertical FormControl-horizontalGroup--center-aligned",
           style: "min-height: 300px"
         )) do
           render(Projects::CustomFields::CustomFieldMappingForm.new(form, project_custom_field: @project_custom_field))

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
@@ -27,7 +27,7 @@
       ) do |form|
         concat(render(Primer::Alpha::Dialog::Body.new(
           id: dialog_body_id, test_selector: dialog_body_id, aria: { label: title },
-          classes: "FormControl-horizontalGroup--sm-vertical FormControl-horizontalGroup--center-aligned",
+          classes: "FormControl-horizontalGroup--sm-vertical FormControl-horizontalGroup--non-mobile-center-aligned",
           style: "min-height: 300px"
         )) do
           render(Projects::CustomFields::CustomFieldMappingForm.new(form, project_custom_field: @project_custom_field))

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -67,14 +67,16 @@ page-header
 
 // For some specific cases like progress form in small screens,
 // we need to change the direction of elements to column,
-// therefore elements are placed below each other
-.FormControl-horizontalGroup--sm-vertical
+// therefore elements are placed below each other.
+//
+// body needed for higher specificity compared to .FormControl-horizontalGroup--center-aligned
+body .FormControl-horizontalGroup--sm-vertical
   @media screen and (max-width: $breakpoint-sm)
     .FormControl-horizontalGroup
       flex-direction: column
       row-gap: 1rem
+      align-items: normal
 
-.FormControl-horizontalGroup--non-mobile-center-aligned
+.FormControl-horizontalGroup--center-aligned
   .FormControl-horizontalGroup
-    @media screen and (min-width: $breakpoint-sm)
-      align-items: center
+    align-items: center

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -74,6 +74,7 @@ page-header
       flex-direction: column
       row-gap: 1rem
 
-.FormControl-horizontalGroup--center-aligned
+.FormControl-horizontalGroup--non-mobile-center-aligned
   .FormControl-horizontalGroup
-    align-items: center
+    @media screen and (min-width: $breakpoint-sm)
+      align-items: center


### PR DESCRIPTION
Before (mobile / desktop):
![Screenshot from 2024-06-13 17-18-57](https://github.com/opf/openproject/assets/9654673/b18e3287-9dd6-4f8f-bc30-88640b20564d)
![Screenshot from 2024-06-13 17-19-18](https://github.com/opf/openproject/assets/9654673/ec9a2a62-41f2-4bae-9235-f69e66763629)

After (mobile / desktop):
![Screenshot from 2024-06-13 17-18-33](https://github.com/opf/openproject/assets/9654673/f194691c-142f-454c-8991-dea1fbd56b9b)
![Screenshot from 2024-06-13 17-21-36](https://github.com/opf/openproject/assets/9654673/8b121f43-4035-480c-86f5-6573abdbd02e)
