### PR TITLE
[#55529] fixed interface of file info query

### DIFF
--- a/frontend/src/app/shared/components/storages/functions/storages.functions.ts
+++ b/frontend/src/app/shared/components/storages/functions/storages.functions.ts
@@ -56,7 +56,7 @@ export function getIconForStorageType(storageType?:string):string {
 }
 
 export function makeFilesCollectionLink(storageLink:IHalResourceLink, location:string):IHalResourceLink {
-  const query = location !== '/' ? `?parent=${encodeURIComponent(location)}` : '';
+  const query = location !== '/' ? `?parent=${location}` : '';
 
   return {
     href: `${storageLink.href}/files${query}`,

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/file_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/file_info_query.rb
@@ -101,7 +101,7 @@ module Storages::Peripherals::StorageInteraction::Nextcloud
           result: ::Storages::StorageFileInfo.new(
             status: data.status,
             status_code: data.statuscode,
-            id: data.id,
+            id: data.id.to_s,
             name: data.name,
             last_modified_at: Time.zone.at(data.mtime),
             created_at: Time.zone.at(data.ctime),

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/file_info_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/file_info_query.rb
@@ -82,7 +82,7 @@ module Storages
 
           def userless_strategy = Registry.resolve("one_drive.authentication.userless").call
 
-          def storage_file_infos(json, status: "ok", status_code: 200)
+          def storage_file_infos(json, status: "ok", status_code: 200) # rubocop:disable Metrics/AbcSize
             StorageFileInfo.new(
               status:,
               status_code:,
@@ -94,7 +94,7 @@ module Storages
               owner_id: json.dig(:createdBy, :user, :id),
               trashed: false,
               permissions: nil,
-              location: Util.extract_location(json[:parentReference], json[:name]),
+              location: Util.escape_path(Util.extract_location(json[:parentReference], json[:name])),
               last_modified_at: Time.zone.parse(json.dig(:fileSystemInfo, :lastModifiedDateTime)),
               created_at: Time.zone.parse(json.dig(:fileSystemInfo, :createdDateTime)),
               last_modified_by_name: json.dig(:lastModifiedBy, :user, :displayName),

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/util.rb
@@ -36,6 +36,12 @@ module Storages
           using ServiceResultRefinements
 
           class << self
+            def escape_path(path)
+              escaped_path = path.split("/").map { |i| CGI.escapeURIComponent(i) }.join("/")
+              escaped_path << "/" if path[-1] == "/"
+              escaped_path
+            end
+
             def mime_type(json)
               json.dig(:file, :mimeType) || (json.key?(:folder) ? "application/x-op-directory" : nil)
             end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/file_info_query_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FileInfoQuer
                    last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
                    permissions: nil,
                    trashed: false,
-                   location: "/Folder/Ümlæûts"
+                   location: "/Folder/%C3%9Cml%C3%A6%C3%BBts"
                  })
       end
     end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_info_query_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesInfoQue
                            last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
                            permissions: nil,
                            trashed: false,
-                           location: "/Folder with spaces"
+                           location: "/Folder%20with%20spaces"
                          },
                          {
                            status: "ok",


### PR DESCRIPTION
[#55529](https://community.openproject.org/work_packages/55529)

- location data is returned escaped
- id data is always a string
- additional encoding in frontend removed