### PR TITLE
Bug/55504 changing page sizepage after removing a project from an project attribute leads to page not found

### DIFF
--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -104,5 +104,5 @@ See COPYRIGHT and LICENSE files for more details.
 </div>
 
 <% if paginated? %>
-  <%= helpers.pagination_links_full model, allowed_params: %i[query_id filters columns sortBy] %>
+  <%= helpers.pagination_links_full model, pagination_options %>
 <% end %>

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -34,8 +34,8 @@ module Projects
     options :current_user # adds this option to those of the base class
     options :query
 
-    def initialize(**options)
-      super(rows: [], **options)
+    def initialize(**)
+      super(rows: [], **)
     end
 
     def before_render
@@ -80,6 +80,18 @@ module Projects
 
     def paginated?
       true
+    end
+
+    def pagination_options
+      default_pagination_options.merge(optional_pagination_options)
+    end
+
+    def default_pagination_options
+      { allowed_params: %i[query_id filters columns sortBy] }
+    end
+
+    def optional_pagination_options
+      {}
     end
 
     def deactivate_class_on_lft_sort

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/table_component.rb
@@ -39,6 +39,23 @@ module Settings
         def sortable?
           false
         end
+
+        # @override optional_pagination_options are passed to the pagination_options
+        # which are passed to #pagination_links_full in pagination_helper.rb
+        #
+        # In Turbo streamable components, we need to be able to specify the url_for(action:) so that links are
+        # generated in the context of the component index action, instead of any turbo stream actions performing
+        # partial updates on the page.
+        #
+        # params[:url_for_action] is passed to the pagination_options making it's way down to any pagination links
+        # that are generated via link_to which calls url_for which uses the params[:url_for_action] to specify
+        # the controller action that link_to should use.
+        #
+        def optional_pagination_options
+          return super unless params[:url_for_action]
+
+          super.merge(params: { action: params[:url_for_action] })
+        end
       end
     end
   end

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -79,7 +79,7 @@ module Admin::Settings
                               include_sub_projects: include_sub_projects?)
                          .call
 
-      create_service.on_success { render_project_list }
+      create_service.on_success { render_project_list(url_for_action: :project_mappings) }
 
       create_service.on_failure do
         update_flash_message_via_turbo_stream(
@@ -96,7 +96,7 @@ module Admin::Settings
                          .new(user: current_user, model: @project_custom_field_mapping)
                          .call
 
-      delete_service.on_success { render_project_list }
+      delete_service.on_success { render_project_list(url_for_action: :project_mappings) }
 
       delete_service.on_failure do
         update_flash_message_via_turbo_stream(
@@ -147,7 +147,7 @@ module Admin::Settings
 
     private
 
-    def render_project_list
+    def render_project_list(url_for_action: action_name)
       update_via_turbo_stream(
         component: Settings::ProjectCustomFields::ProjectCustomFieldMapping::NewProjectMappingComponent.new(
           project_mapping: ProjectCustomFieldProjectMapping.new(project_custom_field: @custom_field),
@@ -157,7 +157,7 @@ module Admin::Settings
       update_via_turbo_stream(
         component: Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
           query: project_custom_field_mappings_query,
-          params: { custom_field: @custom_field }
+          params: { custom_field: @custom_field, url_for_action: }
         )
       )
     end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55504

### WAT?

On turbo updates, the _ProjectCustomFieldMapping::TableComponent_ was rendered with the originating controller actions _#link_ and _#unlink_ which meant _link_to_ generated links would default to non-existent urls: `/admin/settings/project_custom_fields/:id/{link,unlink}` causing the 404 errors on click

### HOW

_Allow pagination options to be passed in `Projects::TableComponent` that are propagated down [`PaginationHelper#pagination_links_full`](https://github.com/opf/openproject/blob/dev/app/helpers/pagination_helper.rb#L32-L48) to [`PaginationHelper#per_page_links`](https://github.com/opf/openproject/blob/dev/app/helpers/pagination_helper.rb#L91-L103)_

In Turbo streamable components, we need to be able to specify the [`url_for(action:)`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html) so that [`link_to`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html) generated links are in the context of the component index action, instead of any turbo stream actions performing partial updates on the page.

-----


https://github.com/opf/openproject/assets/17295175/5c0cd62b-fdb7-42d7-bb99-954c31cda050

