### PR TITLE
[#55506] Adjust modal header sizes to match mockup

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.html.erb
@@ -15,7 +15,8 @@
 
       dialog.with_header(
         show_divider: false,
-        visually_hide_title: false
+        visually_hide_title: false,
+        variant: :large
       )
 
       primer_form_with(

--- a/modules/meeting/app/components/meetings/sidebar/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/sidebar/details_component.html.erb
@@ -13,6 +13,7 @@
                 id: "edit-meeting-details-dialog", title: t("label_meeting_details"),
                 size: :medium_portrait
               )) do |dialog|
+                dialog.with_header(variant: :large)
                 dialog.with_show_button(icon: :pencil, 'aria-label': t("label_meeting_details_edit"), scheme: :invisible)
                 render(Meetings::Sidebar::DetailsFormComponent.new(meeting: @meeting))
               end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55506

Mockup:
https://www.figma.com/design/6RzNWrc8jpqhE7jpaCXsGB/Multi-project-selector?node-id=600-3768&t=jXHV1ohltYn4whIF-0

In a discussion we decided to also adapt the meeting details modal header to stay consistent in the application.