### PR TITLE
Bug/55505 Reinstate listing archived projects in project attributes "enabled in projects" page, just disable the "Deactivate in project" option

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
@@ -43,14 +43,15 @@ module Settings
         private
 
         def more_menu_detach_project
-          if User.current.admin
+          project = model.first
+          if User.current.admin && project.active?
             {
               scheme: :default,
               icon: nil,
               label: I18n.t("projects.settings.project_custom_fields.actions.deactivate_for_project"),
               href: unlink_admin_settings_project_custom_field_path(
                 id: @table.params[:custom_field].id,
-                project_custom_field_project_mapping: { project_id: model.first.id }
+                project_custom_field_project_mapping: { project_id: project.id }
               ),
               data: { turbo_method: :delete }
             }

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -167,7 +167,6 @@ module Admin::Settings
         name: "project-custom-field-mappings-#{@custom_field.id}"
       ) do |query|
         query.where(:available_project_attributes, "=", [@custom_field.id])
-        query.where("active", "=", OpenProject::Database::DB_VALUE_TRUE)
         query.select(:name)
         query.order("lft" => "asc")
       end

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -77,7 +77,11 @@ RSpec.describe "Project Custom Field Mappings", :js do
       aggregate_failures "shows the correct project mappings" do
         within "#project-table" do
           expect(page).to have_text(project.name)
-          expect(page).to have_no_text(archived_project.name)
+          expect(page).to have_text(archived_project.name)
+
+          within("tr#settings-project-custom-fields-project-custom-field-mapping-row-component-project-#{archived_project.id}") do
+            expect(page.find(".buttons")).not_to have_test_selector("project-list-row--action-menu")
+          end
         end
       end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/55505

_This is a revert of https://github.com/opf/openproject/pull/15845_ It's better UX to inform the user that the archived project is in deed mapped but the linking cannot be amended on an archived project.

----

![Screenshot 2024-06-14 at 6 06 37 PM](https://github.com/opf/openproject/assets/17295175/ec75e004-4aab-42a9-9193-efad02e1fb62)
