### PR TITLE
Fix for 500 of /projects URL which sorted by latest_activity_at

### DIFF
--- a/app/services/queries/projects/project_queries/set_attributes_service.rb
+++ b/app/services/queries/projects/project_queries/set_attributes_service.rb
@@ -81,6 +81,9 @@ class Queries::Projects::ProjectQueries::SetAttributesService < BaseServices::Se
     return unless orders
 
     model.orders.clear
+    if has_latest_activity_at?(orders)
+      model.set_model(Project.with_latest_activity)
+    end
     model.order(orders.to_h { |o| [o[:attribute], o[:direction]] })
   end
 
@@ -93,5 +96,9 @@ class Queries::Projects::ProjectQueries::SetAttributesService < BaseServices::Se
 
   def default_columns
     (["favored", "name"] + Setting.enabled_projects_columns).uniq
+  end
+
+  def has_latest_activity_at?(orders)
+    orders.any? { |order| order[:attribute] == "latest_activity_at" }
   end
 end

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -1142,6 +1142,12 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
                                child_project_z,
                                public_project)
     end
+
+    it "sorts projects by latest_activity_at" do
+      click_link_or_button('Sort by "Latest activity at"')
+
+      expect_project_at_place(project, 1)
+    end
   end
 
   describe "blocked filter" do


### PR DESCRIPTION
I'm not sure this fix is right or not in implementation, but at least it resolve the 500 error at [THAPE staging server](https://plm-ppp.thape.com.cn/projects?query_id=my&sortBy=%5B%5B%22latest_activity_at%22%2C%22asc%22%5D%5D)

<img width="1228" alt="image" src="https://github.com/opf/openproject/assets/1131536/7ba62145-7484-427a-a4e6-54d55237e7df">


