### PR TITLE
Makes sure Commands/Queries handle 403 responses

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/auth_check_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/auth_check_query.rb
@@ -59,6 +59,8 @@ module Storages
               ServiceResult.success
             in { status: 401 }
               ServiceResult.failure(result: :unauthorized, errors: ::Storages::StorageError.new(code: :unauthorized))
+            in { status: 403 }
+              ServiceResult.failure(result: :forbidden, errors: ::Storages::StorageError.new(code: :forbidden))
             else
               data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
               ServiceResult.failure(result: :error, errors: ::Storages::StorageError.new(code: :error, data:))

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/create_folder_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/create_folder_command.rb
@@ -62,24 +62,22 @@ module Storages
           end
 
           def handle_response(response)
-            data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
-
             case response
             in { status: 200..299 }
               ServiceResult.success(result: file_info_for(MultiJson.load(response.body, symbolize_keys: true)),
                                     message: "Folder was successfully created.")
             in { status: 404 }
               ServiceResult.failure(result: :not_found,
-                                    errors: ::Storages::StorageError.new(code: :not_found, data:))
+                                    errors: Util.storage_error(code: :not_found, response:, source: self.class))
             in { status: 401 }
               ServiceResult.failure(result: :unauthorized,
-                                    errors: ::Storages::StorageError.new(code: :unauthorized, data:))
+                                    errors: Util.storage_error(code: :unauthorized, response:, source: self.class))
             in { status: 409 }
               ServiceResult.failure(result: :already_exists,
-                                    errors: ::Storages::StorageError.new(code: :conflict, data:))
+                                    errors: Util.storage_error(code: :conflict, response:, source: self.class))
             else
               ServiceResult.failure(result: :error,
-                                    errors: ::Storages::StorageError.new(code: :error, data:))
+                                    errors: Util.storage_error(code: :error, response:, source: self.class))
             end
           end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/files_query.rb
@@ -68,10 +68,13 @@ module Storages
               ServiceResult.success(result: response.json(symbolize_keys: true).fetch(map_value))
             in { status: 404 }
               ServiceResult.failure(result: :not_found,
-                                    errors: Util.storage_error(response:, code: :not_found, source: self))
+                                    errors: Util.storage_error(response:, code: :not_found, source: self.class))
+            in { status: 403 }
+              ServiceResult.failure(result: :forbidden,
+                                    errors: Util.storage_error(response:, code: :forbidden, source: self.class))
             in { status: 401 }
               ServiceResult.failure(result: :unauthorized,
-                                    errors: Util.storage_error(response:, code: :unauthorized, source: self))
+                                    errors: Util.storage_error(response:, code: :unauthorized, source: self.class))
             else
               data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
               ServiceResult.failure(result: :error, errors: ::Storages::StorageError.new(code: :error, data:))

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/open_storage_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/open_storage_query.rb
@@ -69,8 +69,8 @@ module Storages
               ServiceResult.failure(result: :unauthorized,
                                     errors: Util.storage_error(response:, code: :unauthorized, source: self.class))
             else
-              data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
-              ServiceResult.failure(result: :error, errors: ::Storages::StorageError.new(code: :error, data:))
+              ServiceResult.failure(result: :error,
+                                    errors: Util.storage_error(response:, code: :error, source: self.class))
             end
           end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/rename_file_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/rename_file_command.rb
@@ -53,23 +53,24 @@ module Storages
           private
 
           def handle_response(response)
-            data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
-
             case response
             in { status: 200..299 }
               ServiceResult.success(result: storage_file(response.json(symbolize_keys: true)))
             in { status: 401 }
               ServiceResult.failure(result: :unauthorized,
-                                    errors: ::Storages::StorageError.new(code: :unauthorized, data:))
+                                    errors: Util.storage_error(response:, code: :unauthorized, source: self.class))
+            in { status: 403 }
+              ServiceResult.failure(result: :forbidden,
+                                    errors: Util.storage_error(response:, code: :forbidden, source: self.class))
             in { status: 404 }
               ServiceResult.failure(result: :not_found,
-                                    errors: ::Storages::StorageError.new(code: :not_found, data:))
+                                    errors: Util.storage_error(response:, code: :not_found, source: self.class))
             in { status: 409 }
               ServiceResult.failure(result: :conflict,
-                                    errors: ::Storages::StorageError.new(code: :conflict, data:))
+                                    errors: Util.storage_error(response:, code: :conflict, source: self.class))
             else
               ServiceResult.failure(result: :error,
-                                    errors: ::Storages::StorageError.new(code: :error, data:))
+                                    errors: Util.storage_error(response:, code: :error, source: self.class))
             end
           end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/set_permissions_command.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/set_permissions_command.rb
@@ -131,23 +131,26 @@ module Storages
           end
 
           def handle_response(response)
-            data = ::Storages::StorageErrorData.new(source: self.class, payload: response)
-
             case response
             in { status: 200 }
               ServiceResult.success(result: response.json(symbolize_keys: true))
             in { status: 204 }
               ServiceResult.success(result: response)
             in { status: 400 }
-              ServiceResult.failure(result: :bad_request, errors: ::Storages::StorageError.new(code: :bad_request, data:))
+              ServiceResult.failure(result: :bad_request,
+                                    errors: Util.storage_error(response:, code: :bad_request, source: self.class))
             in { status: 401 }
-              ServiceResult.failure(result: :unauthorized, errors: ::Storages::StorageError.new(code: :unauthorized, data:))
+              ServiceResult.failure(result: :unauthorized,
+                                    errors: Util.storage_error(response:, code: :unauthorized, source: self.class))
             in { status: 403 }
-              ServiceResult.failure(result: :forbidden, errors: ::Storages::StorageError.new(code: :forbidden, data:))
+              ServiceResult.failure(result: :forbidden,
+                                    errors: Util.storage_error(response:, code: :forbidden, source: self.class))
             in { status: 404 }
-              ServiceResult.failure(result: :not_found, errors: ::Storages::StorageError.new(code: :not_found, data:))
+              ServiceResult.failure(result: :not_found,
+                                    errors: Util.storage_error(response:, code: :not_found, source: self.class))
             else
-              ServiceResult.failure(result: :error, errors: ::Storages::StorageError.new(code: :error, data:))
+              ServiceResult.failure(result: :error,
+                                    errors: Util.storage_error(response:, code: :error, source: self.class))
             end
           end
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/one_drive/util.rb
@@ -69,10 +69,12 @@ module Storages
                 )
             end
 
-            def storage_error(response:, code:, source:)
-              data = StorageErrorData.new(source:, payload: response.json(symbolize_keys: true))
+            def storage_error(response:, code:, source:, log_message: nil)
+              # Some errors, like timeouts, aren't json responses so we need to adapt
+              payload = response.respond_to?(:json) ? response.json(symbolize_keys: true) : response.to_s
+              data = StorageErrorData.new(source:, payload:)
 
-              StorageError.new(code:, data:)
+              StorageError.new(code:, data:, log_message:)
             end
 
             def join_uri_path(uri, *)

--- a/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
@@ -198,16 +198,9 @@ module Storages
     end
 
     def format_and_log_error(error, context = {})
-      payload = error.data.payload
-      data =
-        case payload
-        in { status: Integer }
-          { status: payload.status, body: payload.body.to_s }
-        else
-          payload.error.to_s
-        end
-
-      error_message = context.merge({ command: error.data.source, message: error.log_message, data: })
+      error_message = context.merge({ command: error.data.source,
+                                      message: error.log_message,
+                                      data: { status: error.code, body: error.data.payload.to_s } })
       OpenProject.logger.warn error_message
     end
   end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/files_query_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::FilesQuery, 
       it "must return not found" do
         result = described_class.call(storage:, auth_strategy:, folder:)
         expect(result).to be_failure
-        expect(result.error_source).to be_a(described_class)
+        expect(result.error_source).to eq(described_class)
 
         result.match(
           on_failure: ->(error) { expect(error.code).to eq(:not_found) },

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/open_file_link_query_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenFileLink
   let(:storage) { create(:sharepoint_dev_drive_storage, oauth_client_token_user: user) }
   let(:file_id) { "01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU" }
   let(:auth_strategy) do
-    Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken.strategy.with_user(user)
+    Storages::Peripherals::Registry.resolve("one_drive.authentication.userbound").call(user:)
   end
 
   subject { described_class.new(storage) }
@@ -79,11 +79,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::OpenFileLink
         result = subject.call(auth_strategy:, file_id:)
         expect(result).to be_failure
         expect(result.error_source).to be(Storages::Peripherals::StorageInteraction::OneDrive::Internal::DriveItemQuery)
-
-        result.match(
-          on_failure: ->(error) { expect(error.code).to eq(:not_found) },
-          on_success: ->(file_infos) { fail "Expected failure, got #{file_infos}" }
-        )
+        expect(result.result).to eq(:not_found)
       end
     end
   end

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
             .to have_received(:warn)
                   .with(command: described_class,
                         message: nil,
-                        data: "timed out while waiting on select")
+                        data: { body: /timed out while waiting on select/, status: nil })
         end
       end
 
@@ -288,7 +288,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
                   .with(folder_path: "[Sample] Project Name _ Ehuu (#{project.id})",
                         command: Storages::Peripherals::StorageInteraction::OneDrive::CreateFolderCommand,
                         message: nil,
-                        data: { status: 409, body: /nameAlreadyExists/ })
+                        data: { status: :conflict, body: /nameAlreadyExists/ })
         ensure
           delete_folder(already_existing_folder.id)
         end
@@ -308,7 +308,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
                         target: "[Sample] Project Name _ Ehuu (#{project.id})",
                         command: Storages::Peripherals::StorageInteraction::OneDrive::RenameFileCommand,
                         message: nil,
-                        data: { status: 409, body: /nameAlreadyExists/ })
+                        data: { status: :conflict, body: /nameAlreadyExists/ })
         ensure
           delete_folder(already_existing_folder.result.id)
         end
@@ -323,7 +323,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
             .to have_received(:warn)
                   .with(command: Storages::Peripherals::StorageInteraction::OneDrive::SetPermissionsCommand,
                         message: nil,
-                        data: { body: /noResolvedUsers/, status: 400 }).twice
+                        data: { body: /noResolvedUsers/, status: nil }).twice
         end
       end
     end


### PR DESCRIPTION
#### ⚠️ Related WP: [OP#55683](https://community.openproject.org/projects/openproject/work_packages/55683)

## What?

This tries to make sure that all commands handle 403s correctly. 

## How?

By handling 403s! Surprising, huh? But in all seriousness there are some standardization of the way we treat the errors across different commands as well as some code cleanup where needed.