### PR TITLE
Bump appsignal to fix logging exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,7 +215,7 @@ gem "dry-container"
 gem "store_attribute", "~> 1.0"
 
 # Appsignal integration
-gem "appsignal", "~> 3.0", require: false
+gem "appsignal", "~> 3.8.1", require: false
 
 gem "view_component"
 # Lookbook

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
     airbrake-ruby (6.2.2)
       rbtree3 (~> 0.6)
     android_key_attestation (0.3.0)
-    appsignal (3.7.5)
+    appsignal (3.8.1)
       rack
     ast (2.4.2)
     attr_required (1.0.2)
@@ -1165,7 +1165,7 @@ DEPENDENCIES
   acts_as_tree (~> 2.9.0)
   addressable (~> 2.8.0)
   airbrake (~> 13.0.0)
-  appsignal (~> 3.0)
+  appsignal (~> 3.8.1)
   auto_strip_attributes (~> 2.5)
   awesome_nested_set (~> 3.6.0)
   aws-sdk-core (~> 3.107)


### PR DESCRIPTION
https://community.openproject.org/work_packages/https://github.com/appsignal/appsignal-ruby/commit/37fbae5a0f1a4e964baceb21837e5d5f0cf903c0

Fixes the logger problem:

```
17-06-2024 15:35:10.052[application][ERROR][olemtoo][rails]3, [2024-06-17T15:35:10.052015 #75910] 3 -- rails: ArgumentError: test!

17-06-2024 15:35:49.627[application][ERROR][olemtoo][rails]3, [2024-06-17T15:35:49.627253 #75910] 3 -- rails: error | Internal error: Called refresh_token without a previously existing token.



```