### PR TITLE
[55874][55812] Page width is too large if the content is wide

### DIFF
--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -115,6 +115,8 @@ $left-space: 20px
   grid-area: body
   padding-bottom: $bottom-space
   padding-left: $left-space
+  // Limit the width of the body to the container around it
+  overflow-x: hidden
 
   // Special rules for pages that still follow the old layout and render everything inside the content-body
   .accessibility-helper ~ &


### PR DESCRIPTION
Limit the width of content-body. Elements that overflow, need to take care of the scrolling themeselves (e.g. tables). Otherwise, other elements of the page are out of view as well (e.g. pagination)

https://community.openproject.org/projects/openproject/work_packages/55874/activity
https://community.openproject.org/projects/openproject/work_packages/55812/activity