### PR TITLE
Allow smtp_timeout to be set to anything != 5 seconds

### DIFF
--- a/app/models/setting/mail_settings.rb
+++ b/app/models/setting/mail_settings.rb
@@ -76,6 +76,8 @@ class Setting
 
       ActionMailer::Base.smtp_settings[:enable_starttls_auto] = Setting.smtp_enable_starttls_auto?
       ActionMailer::Base.smtp_settings[:ssl] = Setting.smtp_ssl?
+      ActionMailer::Base.smtp_settings[:open_timeout] = Setting.smtp_timeout
+      ActionMailer::Base.smtp_settings[:read_timeout] = Setting.smtp_timeout
 
       Setting.smtp_openssl_verify_mode.tap do |mode|
         ActionMailer::Base.smtp_settings[:openssl_verify_mode] = mode unless mode.nil?

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1030,6 +1030,10 @@ module Settings
         default: "",
         env_alias: "SMTP_PASSWORD"
       },
+      smtp_timeout: {
+        format: :integer,
+        default: 5,
+      },
       software_name: {
         description: "Override software application name",
         default: "OpenProject"

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -478,7 +478,8 @@ RSpec.describe Setting do
            smtp_port: 25,
            smtp_user_name: "username",
            smtp_enable_starttls_auto: 1,
-           smtp_ssl: 0
+           smtp_ssl: 0,
+           smtp_timeout: 1234
          } do
         described_class.reload_mailer_settings!
         expect(ActionMailer::Base).to have_received(:perform_deliveries=).with(true)
@@ -489,6 +490,8 @@ RSpec.describe Setting do
                                                        domain: "example.com",
                                                        enable_starttls_auto: true,
                                                        openssl_verify_mode: "peer",
+                                                       read_timeout: 1234,
+                                                       open_timeout: 1234,
                                                        ssl: false)
       end
     end
@@ -515,6 +518,8 @@ RSpec.describe Setting do
                                                        domain: "example.com",
                                                        enable_starttls_auto: false,
                                                        openssl_verify_mode: "peer",
+                                                       open_timeout: 5,
+                                                       read_timeout: 5,
                                                        ssl: true)
       end
     end
@@ -543,6 +548,8 @@ RSpec.describe Setting do
                                                        password: "p4ssw0rd",
                                                        enable_starttls_auto: true,
                                                        openssl_verify_mode: "peer",
+                                                       open_timeout: 5,
+                                                       read_timeout: 5,
                                                        ssl: false)
       end
     end
@@ -571,6 +578,8 @@ RSpec.describe Setting do
                                                        password: "p4ssw0rd",
                                                        enable_starttls_auto: false,
                                                        openssl_verify_mode: "peer",
+                                                       open_timeout: 5,
+                                                       read_timeout: 5,
                                                        ssl: true)
       end
     end


### PR DESCRIPTION
Rails 7.0 started setting smtp_timeout=5, which should be configurable https://guides.rubyonrails.org/configuring.html#config-action-mailer-smtp-timeout

https://community.openproject.org/work_packages/55879/activity