### PR TITLE
Stop interrupting the sync process on error.

### DIFF
--- a/modules/storages/app/common/storages/errors.rb
+++ b/modules/storages/app/common/storages/errors.rb
@@ -48,25 +48,17 @@ module Storages
       end
     end
 
-    class IntegrationJobError < BaseError
-      attr_reader :errors, :storage
-
-      def initialize(storage:, errors:)
-        super(errors.log_message)
-        @storage = storage
-        @errors = errors
-      end
-    end
+    class IntegrationJobError < BaseError; end
 
     def self.registry_error_for(key)
-      case key.split('.')
-      in [storage, 'contracts', model]
+      case key.split(".")
+      in [storage, "contracts", model]
         MissingContract.new("No #{model} contract defined for provider: #{storage.camelize}")
-      in [storage, 'commands' | 'queries' => type, operation]
+      in [storage, "commands" | "queries" => type, operation]
         OperationNotSupported.new(
           "#{type.singularize.capitalize} #{operation} not supported by provider: #{storage.camelize}"
         )
-      in [storage, 'models', object]
+      in [storage, "models", object]
         MissingModel.new("Model #{object} not registered for provider: #{storage.camelize}")
       else
         ResolverStandardError.new("Cannot resolve key #{key}.")


### PR DESCRIPTION
#### Related WP: [OP#55767](https://community.openproject.org/projects/openproject/work_packages/55767)

## What?

When an error during the sync process happened, we were raising an exception and that was stopping the other storages from completing their own sync processes

## How?

I moved the exception raising to outside of the processing block and the unhealthy event emission to the the `#perform` method.

Also added a test to verify the behaviour.

## And now?

This is a hacky fix. We need to make the sync job work over a specific storage / project as a more long term solution, but this will take sometime and will be addressed in a following PR.