### PR TITLE
[Bug #55901] 403 when entering the overview page of a project in which a work package is shared with the current user

### DIFF
--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -60,7 +60,10 @@ module Overviews
 
         OpenProject::AccessControl.permission(:view_work_packages)
           .controller_actions
-          .push("overviews/overviews/show")
+          .push(
+            "overviews/overviews/show",
+            "overviews/overviews/project_custom_fields_sidebar"
+          )
 
         OpenProject::AccessControl.map do |ac_map|
           ac_map.project_module nil do |map|

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Shared Work Package Access",
                :js, :with_cuprite,
                with_ee: %i[work_package_sharing] do
   shared_let(:project) { create(:project_with_types) }
+  shared_let(:int_project_custom_field) { create(:integer_project_custom_field, projects: [project]) }
   shared_let(:work_package) { create(:work_package, project:, journal_notes: "Hello!") }
   shared_let(:sharer) { create(:admin) }
   shared_let(:shared_with_user) { create(:user, firstname: "Mean", lastname: "Turkey") }
@@ -86,6 +87,12 @@ RSpec.describe "Shared Work Package Access",
 
       # 3. Visiting the Project's URL directly
       project_page.visit!
+
+      # The project overview page is loaded and e.g. custom fields can be seen
+      # This ensures that the page is loaded.
+      project_page.within_async_loaded_sidebar do
+        expect(page).to have_content(int_project_custom_field.name)
+      end
 
       #
       # Work Package is now visible
@@ -160,6 +167,12 @@ RSpec.describe "Shared Work Package Access",
 
       # 3. Visiting the Project's URL directly
       project_page.visit!
+
+      # The project overview page is loaded and e.g. custom fields can be seen
+      # This ensures that the page is loaded.
+      project_page.within_async_loaded_sidebar do
+        expect(page).to have_content(int_project_custom_field.name)
+      end
 
       #
       # Work Package is now visible
@@ -239,6 +252,12 @@ RSpec.describe "Shared Work Package Access",
 
       # 3. Visiting the Project's URL directly
       project_page.visit!
+
+      # The project overview page is loaded and e.g. custom fields can be seen
+      # This ensures that the page is loaded.
+      project_page.within_async_loaded_sidebar do
+        expect(page).to have_content(int_project_custom_field.name)
+      end
 
       #
       # Work Package is now visible


### PR DESCRIPTION
Without the permission, the project overview page of a work package shared with the user displays a 403.

### WP

https://community.openproject.org/wp/55901