### PR TITLE
[55919] Gantt elements overlap the header

### DIFF
--- a/frontend/src/global_styles/content/work_packages/timelines/_timelines_header.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_timelines_header.sass
@@ -9,6 +9,7 @@ wp-timeline-header
   z-index: 2
 
 .wp-timeline--header-element
+  background: var(--body-background)
   position: absolute
   height: 10px
   width: 10px


### PR DESCRIPTION
Set background to timeline header. Otherwise the elements will be visible behind them when scrolling. This was accidentally removed in the scope of introducing the dark mode.


https://community.openproject.org/projects/openproject/work_packages/55919/github?query_id=5092