### PR TITLE
Display placeholder in case of no time entry activity

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -31,6 +31,7 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
       title: this.i18n.t('js.modals.destroy_time_entry.title'),
     },
     noResults: this.i18n.t('js.grid.widgets.time_entries_list.no_results'),
+    placeholder: this.i18n.t('js.placeholders.default'),
   };
 
   public entries:TimeEntryResource[] = [];
@@ -84,7 +85,7 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
   }
 
   public activityName(entry:TimeEntryResource):string {
-    return entry.activity.name;
+    return entry.activity ? entry.activity.name : this.text.placeholder;
   }
 
   public projectName(entry:TimeEntryResource):string {


### PR DESCRIPTION
Display the placeholder text in case a time entry has no activity when listing it on the project overview page

<img width="1509" alt="image" src="https://github.com/opf/openproject/assets/617519/7f54e209-703b-47b9-b01c-4cc5a32a6e0e">


https://community.openproject.org/wp/53200