### PR TITLE
[55786] Main menu resizer handle icon change on hover not working for Safari

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -348,6 +348,8 @@ a.main-menu--parent-node
 
   .main-menu--navigation-toggler
     position: relative
+    // Needed for Safari due to the fixed position of the parent element
+    -webkit-transform: translateZ(0)
     cursor: pointer
     margin-left: -0.75rem
     color: var(--main-menu-font-color)


### PR DESCRIPTION
I don't know exactly what happened here. For whatever reason the hover is effect on the main menu toggler is swallowed in Safari. It is shortly recognized but then immedeatly lost. I assume, that when toggling the visibility of the icons, the element is shortly either very small or positioned somewhere else due to the parent element being `position: fixed`. Thus, it looses the hover effect and does not change the icon. 

In the end, I got the hint [here](https://stackoverflow.com/a/55023181/8900797).


https://community.openproject.org/projects/openproject/work_packages/55786/activity