### PR TITLE
Conform with RSpecRails/HaveHttpStatus cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,10 +236,6 @@ RSpec/DescribeMethod:
 RSpec/SpecFilePathFormat:
   IgnoreMethods: true
 
-# Disable deprecated cop
-RSpec/FilePath:
-  Enabled: false
-
 # Prevent  "fit" or similar to be committed
 RSpec/Focus:
   Enabled: true

--- a/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Avatars::AvatarController do
           let(:target_user) { user_with_avatar }
 
           it "renders the send file" do
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
           end
         end
 
@@ -41,7 +41,7 @@ RSpec.describe Avatars::AvatarController do
           let(:target_user) { user_without_avatar }
 
           it "renders 404" do
-            expect(response.status).to eq 404
+            expect(response).to have_http_status :not_found
           end
         end
       end
@@ -51,7 +51,7 @@ RSpec.describe Avatars::AvatarController do
         let(:target_user) { user_with_avatar }
 
         it "renders a 404" do
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe Avatars::MyAvatarController do
 
       it "renders 404" do
         post :update
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
     it "returns invalid method for post request" do
       post :update
       expect(response).not_to be_successful
-      expect(response.status).to eq 405
+      expect(response).to have_http_status :method_not_allowed
     end
 
     it "calls the service for put" do
@@ -54,7 +54,7 @@ RSpec.describe Avatars::MyAvatarController do
 
       put :update
       expect(response).to be_successful
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
     end
 
     it "calls the service for put" do
@@ -64,7 +64,7 @@ RSpec.describe Avatars::MyAvatarController do
 
       put :update
       expect(response).not_to be_successful
-      expect(response.status).to eq 400
+      expect(response).to have_http_status :bad_request
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Avatars::MyAvatarController do
     it "returns invalid method for post request" do
       post :destroy
       expect(response).not_to be_successful
-      expect(response.status).to eq 405
+      expect(response).to have_http_status :method_not_allowed
     end
 
     it "calls the service for delete" do

--- a/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Avatars::UsersController do
       end
 
       it "renders 403" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
   end
@@ -55,14 +55,14 @@ RSpec.describe Avatars::UsersController do
 
       it "renders 404" do
         put :update, params: { id: target_user.id }
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
     it "returns invalid method for post request" do
       post :update, params: { id: target_user.id }
       expect(response).not_to be_successful
-      expect(response.status).to eq 405
+      expect(response).to have_http_status :method_not_allowed
     end
 
     it "calls the service for put" do
@@ -72,7 +72,7 @@ RSpec.describe Avatars::UsersController do
 
       put :update, params: { id: target_user.id }
       expect(response).to be_successful
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
     end
 
     it "calls the service for put" do
@@ -82,7 +82,7 @@ RSpec.describe Avatars::UsersController do
 
       put :update, params: { id: target_user.id }
       expect(response).not_to be_successful
-      expect(response.status).to eq 400
+      expect(response).to have_http_status :bad_request
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe Avatars::UsersController do
     it "returns invalid method for post request" do
       post :destroy, params: { id: target_user.id }
       expect(response).not_to be_successful
-      expect(response.status).to eq 405
+      expect(response).to have_http_status :method_not_allowed
     end
 
     it "calls the service for delete" do

--- a/modules/avatars/spec/requests/user_avatar_api_spec.rb
+++ b/modules/avatars/spec/requests/user_avatar_api_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "API v3 User avatar resource", content_type: :json do
       let(:local_avatars) { false }
 
       it "renders a 404" do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe "API v3 User avatar resource", content_type: :json do
       let(:local_avatars) { false }
 
       it "redirects to gravatar" do
-        expect(response.status).to eq 302
+        expect(response).to have_http_status :found
         expect(response.location).to match /gravatar\.com/
       end
 
@@ -98,7 +98,7 @@ RSpec.describe "API v3 User avatar resource", content_type: :json do
       end
 
       it "serves the attachment file" do
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
 
       it_behaves_like "cache headers set to 24 hours"
@@ -117,7 +117,7 @@ RSpec.describe "API v3 User avatar resource", content_type: :json do
         # so here we just make sue it's called accordingly when the external
         # storage is configured
         it "redirects to temporary external URL" do
-          expect(response.status).to eq 302
+          expect(response).to have_http_status :found
           expect(response.location).to eq "external URL"
         end
       end

--- a/modules/backlogs/spec/api/work_package_resource_spec.rb
+++ b/modules/backlogs/spec/api/work_package_resource_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "API v3 Work package resource" do
 
       include_context "query work package"
 
-      it { expect(last_response.status).to be 200 }
+      it { expect(last_response).to have_http_status :ok }
 
       it { is_expected.not_to have_json_path("storyPoints") }
     end

--- a/modules/backlogs/spec/api/work_packages/form_resource_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/form_resource_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "API v3 Work package form resource" do
     shared_examples_for "valid payload" do
       subject { response.body }
 
-      it { expect(response.status).to eq(200) }
+      it { expect(response).to have_http_status(:ok) }
 
       it { is_expected.to have_json_path("_embedded/payload") }
 

--- a/modules/backlogs/spec/controllers/backlogs_settings_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs_settings_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe BacklogsSettingsController do
 
       it "fails" do
         get :show
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
   end
@@ -102,7 +102,7 @@ RSpec.describe BacklogsSettingsController do
           subject
 
           expect(response).not_to be_successful
-          expect(response.status).to eq 403
+          expect(response).to have_http_status :forbidden
         end
       end
     end

--- a/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -689,7 +689,7 @@ RSpec.describe "BCF 2.1 topics resource", content_type: :json do
         end
 
         it "responds with a not authorized error" do
-          expect(response.status).to eq 403
+          expect(response).to have_http_status :forbidden
           expect(response.body).to include "You are not authorized to access this resource."
         end
       end
@@ -707,7 +707,7 @@ RSpec.describe "BCF 2.1 topics resource", content_type: :json do
         end
 
         it "responds with a not authorized error" do
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
           expect(response.body).to include "The requested resource could not be found."
         end
       end

--- a/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
+++ b/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "POST /projects/:project_id/ifc_models/set_direct_upload_file_nam
   context "when user is not logged in" do
     it "requires login" do
       post set_direct_upload_file_name_bcf_project_ifc_models_path(project_id: project.id)
-      expect(last_response.status).to eq(406) # rubocop:disable RSpecRails/HaveHttpStatus
+      expect(last_response).to have_http_status(:not_acceptable)
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe "POST /projects/:project_id/ifc_models/set_direct_upload_file_nam
       it "returns a 422" do
         post set_direct_upload_file_name_bcf_project_ifc_models_path(project_id: project.id),
              { title: "Test.ifc", isDefault: "0", filesize: "113328073" }
-        expect(last_response.status).to eq(422) # rubocop:disable RSpecRails/HaveHttpStatus
+        expect(last_response).to have_http_status(:unprocessable_entity)
         expect(parse_json(last_response.body)).to eq({ "error" => "is too large (maximum size is 1024 Bytes)." })
       end
     end

--- a/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe API::V3::TimeEntries::CreateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/time_entries/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -190,7 +190,7 @@ RSpec.describe API::V3::TimeEntries::CreateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/time_entries/:id/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -205,13 +205,13 @@ RSpec.describe API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
         end
 
         it "returns 200 OK" do
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(:ok)
         end
       end
 
       context "with the time_entry being of a different user" do
         it "returns 403 Not Authorized" do
-          expect(response.status).to eq(403)
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
       let(:permissions) { %i[view_time_entries] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/modules/github_integration/spec/requests/extended_root_resource_spec.rb
+++ b/modules/github_integration/spec/requests/extended_root_resource_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "API v3 Root resource with the github integration extension", wit
       end
 
       it "responds with 200" do
-        expect(response.status).to eq(200) # rubocop:disable RSpecRails/HaveHttpStatus
+        expect(response).to have_http_status(:ok)
       end
 
       it "does not include the core SHA in the res" do
@@ -79,7 +79,7 @@ RSpec.describe "API v3 Root resource with the github integration extension", wit
       end
 
       it "responds with 200" do
-        expect(response.status).to eq(200) # rubocop:disable RSpecRails/HaveHttpStatus
+        expect(response).to have_http_status(:ok)
       end
 
       it "does includes the core SHA in the response" do

--- a/modules/ldap_groups/spec/controllers/synchronized_groups_controller_spec.rb
+++ b/modules/ldap_groups/spec/controllers/synchronized_groups_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
       let(:logged_in_user) { user }
 
       it "does not give access" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
       it "does not give access" do
         get :show, params: { ldap_group_id: id }
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
         it "renders 404" do
           get :show, params: { ldap_group_id: id }
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -78,7 +78,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
       it "does not give access" do
         get :new
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
       let(:params) { {} }
 
       it "does not give access" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
         let(:params) { {} }
 
         it "renders 400" do
-          expect(response.status).to eq(400)
+          expect(response).to have_http_status(:bad_request)
         end
       end
 
@@ -135,7 +135,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
         context "and saving fails" do
           it "renders new page" do
-            expect(response.status).to eq(200)
+            expect(response).to have_http_status(:ok)
             expect(response).to render_template :new
           end
         end
@@ -150,7 +150,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
       it "does not give access" do
         get :destroy_info, params: { ldap_group_id: id }
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -162,7 +162,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
         it "renders 404" do
           get :destroy_info, params: { ldap_group_id: id }
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -191,7 +191,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
       it "does not give access" do
         delete :destroy, params: { ldap_group_id: id }
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -203,7 +203,7 @@ RSpec.describe LdapGroups::SynchronizedGroupsController, with_ee: %i[ldap_groups
 
         it "renders 404" do
           delete :destroy, params: { ldap_group_id: id }
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
 

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "API v3 Meeting resource" do
 
       context "when valid id" do
         it "returns HTTP 200" do
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_http_status :ok
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe "API v3 Meeting resource" do
         let(:permissions) { [:view_work_packages] }
 
         it "returns HTTP 404" do
-          expect(last_response.status).to eq 404
+          expect(last_response).to have_http_status :not_found
         end
       end
 

--- a/modules/recaptcha/spec/controllers/admin_controller_spec.rb
+++ b/modules/recaptcha/spec/controllers/admin_controller_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Recaptcha::AdminController do
 
     it "does not allow access" do
       get :show
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
 
       post :update
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
   end
 

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe "API v3 file links resource" do
       let(:path) { "#{api_v3_paths.file_links(work_package.id)}?filters=#{CGI.escape(filters.to_json)}" }
 
       it "return a 400 HTTP error" do
-        expect(last_response.status).to be 400
+        expect(last_response).to have_http_status :bad_request
       end
     end
   end
@@ -636,7 +636,7 @@ RSpec.describe "API v3 file links resource" do
         let(:error) { :not_found }
 
         it "fails with outbound request failure" do
-          expect(last_response.status).to be(500)
+          expect(last_response).to have_http_status(:internal_server_error)
 
           body = JSON.parse(last_response.body)
           expect(body["message"]).to eq(I18n.t("api_v3.errors.code_500_outbound_request_failure", status_code: 404))

--- a/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
@@ -31,7 +31,6 @@
 require "spec_helper"
 require_module_spec_helper
 
-# rubocop:disable RSpecRails/HaveHttpStatus
 RSpec.describe "API v3 storage files", :webmock, content_type: :json do
   include API::V3::Utilities::PathHelper
   include StorageServerHelpers
@@ -137,20 +136,20 @@ RSpec.describe "API v3 storage files", :webmock, content_type: :json do
       context "with authorization failure" do
         let(:error) { :unauthorized }
 
-        it { expect(last_response.status).to be(500) }
+        it { expect(last_response).to have_http_status(:internal_server_error) }
       end
 
       context "with internal error" do
         let(:error) { :error }
 
-        it { expect(last_response.status).to be(500) }
+        it { expect(last_response).to have_http_status(:internal_server_error) }
       end
 
       context "with not found" do
         let(:error) { :not_found }
 
         it "fails with outbound request failure" do
-          expect(last_response.status).to be(500)
+          expect(last_response).to have_http_status(:internal_server_error)
 
           body = JSON.parse(last_response.body)
           expect(body["message"]).to eq(I18n.t("api_v3.errors.code_500_outbound_request_failure", status_code: 404))
@@ -218,7 +217,7 @@ RSpec.describe "API v3 storage files", :webmock, content_type: :json do
         let(:error) { :forbidden }
 
         it "fails with outbound request failure" do
-          expect(last_response.status).to be(500)
+          expect(last_response).to have_http_status(:internal_server_error)
 
           body = JSON.parse(last_response.body)
           expect(body["message"]).to eq(I18n.t("api_v3.errors.code_500_outbound_request_failure", status_code: 403))
@@ -229,14 +228,14 @@ RSpec.describe "API v3 storage files", :webmock, content_type: :json do
       context "with internal error" do
         let(:error) { :error }
 
-        it { expect(last_response.status).to be(500) }
+        it { expect(last_response).to have_http_status(:internal_server_error) }
       end
 
       context "with not found" do
         let(:error) { :not_found }
 
         it "fails with outbound request failure" do
-          expect(last_response.status).to be(500)
+          expect(last_response).to have_http_status(:internal_server_error)
 
           body = JSON.parse(last_response.body)
           expect(body["message"]).to eq(I18n.t("api_v3.errors.code_500_outbound_request_failure", status_code: 404))
@@ -288,20 +287,20 @@ RSpec.describe "API v3 storage files", :webmock, content_type: :json do
       describe "due to authorization failure" do
         let(:error) { :unauthorized }
 
-        it { expect(last_response.status).to be(500) }
+        it { expect(last_response).to have_http_status(:internal_server_error) }
       end
 
       describe "due to internal error" do
         let(:error) { :error }
 
-        it { expect(last_response.status).to be(500) }
+        it { expect(last_response).to have_http_status(:internal_server_error) }
       end
 
       describe "due to not found" do
         let(:error) { :not_found }
 
         it "fails with outbound request failure" do
-          expect(last_response.status).to be(500)
+          expect(last_response).to have_http_status(:internal_server_error)
 
           body = JSON.parse(last_response.body)
           expect(body["message"]).to eq(I18n.t("api_v3.errors.code_500_outbound_request_failure", status_code: 404))
@@ -313,15 +312,13 @@ RSpec.describe "API v3 storage files", :webmock, content_type: :json do
     context "with invalid request body" do
       let(:body) { { fileNam_: "ape.png", parent: "/Pictures", projectId: project.id }.to_json }
 
-      it { expect(last_response.status).to be(400) }
+      it { expect(last_response).to have_http_status(:bad_request) }
     end
 
     context "without ee token", with_ee: false do
       let(:storage) { create(:one_drive_storage, creator: current_user) }
 
-      it { expect(last_response.status).to be(500) }
+      it { expect(last_response).to have_http_status(:internal_server_error) }
     end
   end
 end
-
-# rubocop:enable RSpecRails/HaveHttpStatus

--- a/modules/storages/spec/requests/project_storages_open_spec.rb
+++ b/modules/storages/spec/requests/project_storages_open_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
               it "redirects to api_v3_projects_storage_open_url" do
                 get route, {}, { "HTTP_ACCEPT" => "text/html" }
 
-                expect(last_response.status).to eq (302)
+                expect(last_response).to have_http_status(:found)
                 expect(last_response.headers["Location"]).to eq(expected_redirect_url)
               end
             end
@@ -74,7 +74,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
               it "renders an appropirate turbo_stream" do
                 get route, {}, { "HTTP_ACCEPT" => "text/vnd.turbo-stream.html" }
 
-                expect(last_response.status).to eq (200)
+                expect(last_response).to have_http_status(:ok)
                 expect(last_response.body).to eq ("<turbo-stream action=\"update\" target=\"open-project-storage-modal-body-component\">\n    <template>\n        <div data-view-component=\"true\" class=\"flex-items-center p-4 d-flex flex-column\">\n      <div data-view-component=\"true\">      <svg aria-hidden=\"true\" height=\"24\" viewBox=\"0 0 24 24\" version=\"1.1\" width=\"24\" data-view-component=\"true\" class=\"octicon octicon-check-circle color-fg-success\">\n    <path d=\"M17.28 9.28a.75.75 0 0 0-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l6.5-6.5Z\"></path><path d=\"M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Z\"></path>\n</svg>\n</div>\n      <div data-view-component=\"true\">      <h2 data-view-component=\"true\" class=\"text-center\">Integration setup completed</h2>\n</div>\n      <div data-view-component=\"true\">      <span data-view-component=\"true\" class=\"text-center color-fg-muted\">You are being redirected</span>\n</div>\n</div>\n\n\n    </template>\n</turbo-stream>\n\n")
               end
             end
@@ -99,7 +99,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
                 it "redirects to ensure_connection url with current request url as a destination_url" do
                   get route, {}, { "HTTP_ACCEPT" => "text/html" }
 
-                  expect(last_response.status).to eq (302)
+                  expect(last_response).to have_http_status(:found)
                   expect(last_response.headers["Location"]).to eq (
                     "http://example.org/oauth_clients/#{storage.oauth_client.client_id}/ensure_connection?destination_url=http%3A%2F%2Fexample.org%2Fprojects%2F#{project.identifier}%2Fproject_storages%2F#{project_storage.id}%2Fopen&storage_id=#{storage.id}"
                   )
@@ -110,7 +110,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
                 it "redirects to project overview page with modal flash set up" do
                   get route, {}, { "HTTP_ACCEPT" => "text/html" }
 
-                  expect(last_response.status).to eq (302)
+                  expect(last_response).to have_http_status(:found)
                   expect(last_response.headers["Location"]).to eq ("http://example.org/projects/#{project.identifier}")
                   expect(last_request.session["flash"]["flashes"])
                     .to eq({
@@ -129,7 +129,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
               it "responds with 204 no content" do
                 get route, {}, { "HTTP_ACCEPT" => "text/vnd.turbo-stream.html" }
 
-                expect(last_response.status).to eq (204)
+                expect(last_response).to have_http_status(:no_content)
                 expect(last_response.body).to eq ("")
               end
             end
@@ -141,7 +141,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
             it "redirects to project overview page with modal flash set up" do
               get route, {}, { "HTTP_ACCEPT" => "text/html" }
 
-              expect(last_response.status).to eq (302)
+              expect(last_response).to have_http_status(:found)
               expect(last_response.headers["Location"]).to eq ("http://example.org/projects/#{project.identifier}")
               expect(last_request.session["flash"]["flashes"])
                 .to eq({
@@ -159,7 +159,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
             it "responds with 204 no content" do
               get route, {}, { "HTTP_ACCEPT" => "text/vnd.turbo-stream.html" }
 
-              expect(last_response.status).to eq (204)
+              expect(last_response).to have_http_status(:no_content)
               expect(last_response.body).to eq ("")
             end
           end
@@ -170,7 +170,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
         it "redirects to storage_open_url" do
           get route, {}, { "HTTP_ACCEPT" => "text/html" }
 
-          expect(last_response.status).to eq (302)
+          expect(last_response).to have_http_status(:found)
           expect(last_response.headers["Location"]).to eq (expected_redirect_url)
         end
       end
@@ -181,7 +181,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
 
       it "responds with 403" do
         get route, {}, { "HTTP_ACCEPT" => "text/html" }
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_http_status(:forbidden)
       end
     end
   end
@@ -189,7 +189,7 @@ RSpec.describe "projects/:project_id/project_storages/:id/open" do
   context "when user is not logged in" do
     it "responds with 401" do
       get route
-      expect(last_response.status).to eq(401)
+      expect(last_response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
         project_id: project_storage.project.id,
         id: project_storage
       )
-      expect(last_response.status).to eq(401)
+      expect(last_response).to have_http_status(:unauthorized)
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
           project_id: project_storage.project.id,
           id: project_storage
         )
-        expect(last_response.status).to eq(302)
+        expect(last_response).to have_http_status(:found)
         expect(last_response.location).to eq(
           "#{storage.host}/index.php/apps/oauth2/authorize?client_id=#{storage.oauth_client.client_id}&" \
           "redirect_uri=#{redirect_uri}&response_type=code&state=#{nonce}"
@@ -104,7 +104,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
         )
 
         storage.oauth_client
-        expect(last_response.status).to eq(302)
+        expect(last_response).to have_http_status(:found)
         expect(last_response.location).to eq("http://example.org/projects/#{project.id}/settings/project_storages/external_file_storages")
         expect(last_response.cookies.keys).to eq(["_open_project_session"])
       end

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe TwoFactorAuthentication::AuthenticationController, with_settings:
     end
 
     it "returns a 500" do
-      expect(response.status).to eq 500
+      expect(response).to have_http_status :internal_server_error
     end
   end
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesCont
 
     context "when logged in, but not enabled" do
       it "does not give access" do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesCont
       describe "#get" do
         it "croaks on missing id" do
           get :confirm, params: { device_id: 1234 }
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
 
         describe "and registered totp device" do
@@ -162,7 +162,7 @@ RSpec.describe TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesCont
       describe "#post" do
         it "croaks on missing id" do
           get :confirm, params: { device_id: 1234 }
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
 
         describe "and registered totp device" do

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TwoFactorAuthentication::My::TwoFactorDevicesController do
 
     context "when logged in, but not enabled" do
       it "does not give access" do
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe TwoFactorAuthentication::My::TwoFactorDevicesController do
       describe "#get" do
         it "croaks on missing id" do
           get :confirm, params: { device_id: 1234 }
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
 
         describe "and registered totp device" do
@@ -156,7 +156,7 @@ RSpec.describe TwoFactorAuthentication::My::TwoFactorDevicesController do
       describe "#post" do
         it "croaks on missing id" do
           get :confirm, params: { device_id: 1234 }
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
 
         describe "and registered totp device" do
@@ -226,7 +226,7 @@ RSpec.describe TwoFactorAuthentication::My::TwoFactorDevicesController do
     describe "#destroy" do
       it "croaks on missing id" do
         delete :destroy, params: { device_id: "1234" }
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
 
       context "assuming password check is valid" do

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
       let(:logged_in_user) { other_user }
 
       it "does not give access" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
       let(:logged_in_user) { user }
 
       it "does not give access" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
         let(:active_strategies) { [] }
 
         it "renders a 404 because no strategies enabled" do
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
       end
     end
@@ -182,7 +182,7 @@ RSpec.describe TwoFactorAuthentication::Users::TwoFactorDevicesController do
     describe "#destroy" do
       it "croaks on missing id" do
         delete :destroy, params: { id: user.id, device_id: "1234" }
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
 
       context "with existing non-default device" do

--- a/modules/webhooks/spec/controllers/outgoing/admin_controller_spec.rb
+++ b/modules/webhooks/spec/controllers/outgoing/admin_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Webhooks::Outgoing::AdminController do
 
     it "renders 403" do
       get :index
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe Webhooks::Outgoing::AdminController do
       it "renders 404" do
         get :edit, params: { webhook_id: "1234" }
         expect(response).not_to be_successful
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -157,7 +157,7 @@ RSpec.describe Webhooks::Outgoing::AdminController do
       it "renders an error" do
         put :update, params: { webhook_id: "bar" }
         expect(response).not_to be_successful
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe EnterprisesController do
         end
 
         it "renders 404" do
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end
@@ -195,7 +195,7 @@ RSpec.describe EnterprisesController do
     end
 
     it "is forbidden" do
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
   end
 end

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ForumsController do
     context "when not login_required", with_settings: { login_required: false } do
       it "renders 404 for not found" do
         get :index, params: { project_id: "not found" }
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe GroupsController do
     it "forbids index" do
       get :index
       expect(response).not_to be_successful
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
 
     it "shows" do
@@ -191,7 +191,7 @@ RSpec.describe GroupsController do
     it "forbids new" do
       get :new
       expect(response).not_to be_successful
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
 
     it "forbids create" do
@@ -200,14 +200,14 @@ RSpec.describe GroupsController do
       end.not_to(change(Group, :count))
 
       expect(response).not_to be_successful
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
 
     it "forbids edit" do
       get :edit, params: { id: group.id }
 
       expect(response).not_to be_successful
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
   end
 end

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe HomescreenController do
 
   shared_examples "renders blocks" do
     it "renders a response" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     describe "with rendered views" do

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe MyController do
     let!(:user_session) { Sessions::UserSession.find_by(session_id: "internal_foobar") }
 
     let(:params) do
-      { user: { mail: "foo@example.org"} }
+      { user: { mail: "foo@example.org" } }
     end
 
     it "clears other sessions and removes tokens" do

--- a/spec/controllers/placeholder_users/memberships_controller_spec.rb
+++ b/spec/controllers/placeholder_users/memberships_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
           }
         }
 
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
           id: 1234
         }
 
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
           id: 1234
         }
 
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -126,7 +126,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
           }
         }
 
-        expect(response.status).to eq 302
+        expect(response).to have_http_status :found
         expect(placeholder_user.reload.memberships).to be_empty
       end
     end
@@ -142,7 +142,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
             id: membership.id
           }
 
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
       end
 
@@ -153,7 +153,7 @@ RSpec.describe PlaceholderUsers::MembershipsController do
             id: membership.id
           }
 
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/spec/controllers/placeholder_users_controller_spec.rb
+++ b/spec/controllers/placeholder_users_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PlaceholderUsersController do
   shared_examples "do not allow non-admins" do
     it "responds with unauthorized status" do
       expect(response).not_to be_successful
-      expect(response.status).to eq 403
+      expect(response).to have_http_status :forbidden
     end
   end
 
@@ -348,7 +348,7 @@ RSpec.describe PlaceholderUsersController do
 
       it "responds with unauthorized status" do
         expect(response).not_to be_successful
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -359,7 +359,7 @@ RSpec.describe PlaceholderUsersController do
 
       it "responds with unauthorized status" do
         expect(response).not_to be_successful
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ProjectsController do
 
       it "shows an error" do
         get "copy", params: { id: project.id }
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
   end

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { get "index" }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { get "new" }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { get "edit", params: { id: "123" } }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { post "create" }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { delete "destroy", params: { id: "123" } }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { post "update", params: { id: "123" } }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe TypesController do
       describe "the access should be restricted" do
         before { post "move", params: { id: "123" } }
 
-        it { expect(response.status).to eq(403) }
+        it { expect(response).to have_http_status(:forbidden) }
       end
     end
   end
@@ -161,7 +161,7 @@ RSpec.describe TypesController do
           post :create, params:
         end
 
-        it { expect(response.status).to eq(200) }
+        it { expect(response).to have_http_status(:ok) }
 
         it "shows an error message" do
           expect(response.body).to have_content("Name can't be blank")

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe UsersController do
       end
 
       it "returns 403 forbidden" do
-        expect(response.status).to eq 403
+        expect(response).to have_http_status :forbidden
       end
     end
 
@@ -401,7 +401,7 @@ RSpec.describe UsersController do
       let(:change_action) { :wtf }
 
       it "renders 400" do
-        expect(response.status).to eq(400)
+        expect(response).to have_http_status(:bad_request)
         expect(response).not_to render_template "users/change_status_info"
       end
     end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe VersionsController do
     it "renders correctly" do
       login_as(user)
       get :new, params: { project_id: project.id }
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe WikiController do
       it "renders 404 if used with an unknown page title" do
         get "new_child", params: { project_id: project, id: "foobar" }
 
-        expect(response.status).to eq(404) # not found
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/controllers/wiki_menu_authentication_spec.rb
+++ b/spec/controllers/wiki_menu_authentication_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WikiMenuItemsController do
 
       get "edit", params: @params
 
-      expect(response.status).to eq(403) # forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
       end
 
       it "succeeds" do
-        expect(last_response.status).to be 200
+        expect(last_response).to have_http_status :ok
       end
 
       context "not allowed to see work package" do
         let(:current_user) { create(:user) }
 
         it "fails with HTTP Not Found" do
-          expect(last_response.status).to be 404
+          expect(last_response).to have_http_status :not_found
         end
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do
         include_context "create activity"
 
         it "responds with error" do
-          expect(last_response.status).to be 422
+          expect(last_response).to have_http_status :unprocessable_entity
         end
 
         it "notes the error" do

--- a/spec/requests/api/v3/attachments_spec.rb
+++ b/spec/requests/api/v3/attachments_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
       let(:permissions) { [] }
 
       it "forbids to prepare attachments" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
     end
 
@@ -63,7 +63,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
       let(:permissions) { [:edit_work_packages] }
 
       it "can prepare attachments" do
-        expect(last_response.status).to eq 201
+        expect(last_response).to have_http_status :created
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
       let(:permissions) { [:add_work_package_attachments] }
 
       it "can prepare attachments" do
-        expect(last_response.status).to eq 201
+        expect(last_response).to have_http_status :created
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
         let(:status) { :uploaded }
 
         it "returns 404" do
-          expect(last_response.status).to eq 404
+          expect(last_response).to have_http_status :not_found
         end
       end
 
@@ -104,7 +104,7 @@ RSpec.describe API::V3::Attachments::AttachmentsAPI do
         end
 
         it "responds with HTTP OK" do
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_http_status :ok
         end
 
         it "returns the attachment representation" do

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V3 do
       let(:oauth_access_token) { token.plaintext_token }
 
       it "authenticates successfully" do
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_http_status :ok
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe API::V3 do
       let(:oauth_access_token) { "1337" }
 
       it "returns unauthorized" do
-        expect(last_response.status).to eq 401
+        expect(last_response).to have_http_status :unauthorized
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe API::V3 do
       let(:oauth_access_token) { token.plaintext_token }
 
       it "returns unauthorized" do
-        expect(last_response.status).to eq 401
+        expect(last_response).to have_http_status :unauthorized
       end
     end
   end
@@ -97,7 +97,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 401 unauthorized" do
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_http_status :unauthorized
           end
         end
       end
@@ -109,7 +109,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 401 unauthorized" do
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_http_status :unauthorized
           end
 
           it "returns the correct JSON response" do
@@ -131,7 +131,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 401 unauthorized" do
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_http_status :unauthorized
           end
 
           it "returns the correct JSON response" do
@@ -156,7 +156,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 401 unauthorized" do
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_http_status :unauthorized
           end
 
           it "returns the correct JSON response" do
@@ -183,7 +183,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 401 unauthorized" do
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_http_status :unauthorized
           end
 
           it "returns the correct JSON response" do
@@ -207,7 +207,7 @@ RSpec.describe API::V3 do
           end
 
           it "returns 200 OK" do
-            expect(last_response.status).to eq 200
+            expect(last_response).to have_http_status :ok
           end
         end
       end
@@ -276,7 +276,7 @@ RSpec.describe API::V3 do
             end
 
             it "returns 200 OK" do
-              expect(last_response.status).to eq 200
+              expect(last_response).to have_http_status :ok
             end
 
             it '"login"s the anonymous user' do
@@ -291,7 +291,7 @@ RSpec.describe API::V3 do
             end
 
             it "returns 401 unauthorized" do
-              expect(last_response.status).to eq 401
+              expect(last_response).to have_http_status :unauthorized
             end
           end
 
@@ -302,7 +302,7 @@ RSpec.describe API::V3 do
             end
 
             it "returns 200 OK" do
-              expect(last_response.status).to eq 200
+              expect(last_response).to have_http_status :ok
             end
           end
 
@@ -313,7 +313,7 @@ RSpec.describe API::V3 do
             end
 
             it "returns 200 OK" do
-              expect(last_response.status).to eq 200
+              expect(last_response).to have_http_status :ok
             end
           end
         end

--- a/spec/requests/api/v3/backups/backups_api_spec.rb
+++ b/spec/requests/api/v3/backups/backups_api_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
         include_context "request"
 
         it "results in a bad request error" do
-          expect(last_response.status).to eq 400
+          expect(last_response).to have_http_status :bad_request
         end
       end
 
@@ -74,7 +74,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
         end
 
         it "enqueues the backup including attachments" do
-          expect(last_response.status).to eq 202
+          expect(last_response).to have_http_status :accepted
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
         end
 
         it "enqueues a backup not including attachments" do
-          expect(last_response.status).to eq 202
+          expect(last_response).to have_http_status :accepted
         end
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
       include_context "request"
 
       it "results in a conflict" do
-        expect(last_response.status).to eq 409
+        expect(last_response).to have_http_status :conflict
       end
     end
 
@@ -113,7 +113,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
       include_context "request"
 
       it "is forbidden" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
       include_context "request"
 
       it "is forbidden" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
       include_context "request"
 
       it "is rate limited" do
-        expect(last_response.status).to eq 429
+        expect(last_response).to have_http_status :too_many_requests
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe API::V3::Backups::BackupsAPI, with_config: { backup_enabled: true
       include_context "request"
 
       it "is forbidden" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
 
       it "shows the remaining hours until the token is valid" do

--- a/spec/requests/api/v3/content_type_header_spec.rb
+++ b/spec/requests/api/v3/content_type_header_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "API v3 Content-Type header" do
     context "on a GET request" do
       it "is successful" do
         get api_v3_paths.work_package(work_package.id)
-        expect(last_response.status).not_to eq(406)
+        expect(last_response.status).not_to have_http_status(:not_acceptable)
         expect(last_response).to be_ok
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe "API v3 Content-Type header" do
     context "on a DELETE request" do
       it "is successful" do
         delete api_v3_paths.work_package(work_package.id)
-        expect(last_response.status).not_to eq(406)
+        expect(last_response.status).not_to have_http_status(:not_acceptable)
         expect(last_response).to be_no_content
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe "API v3 Content-Type header" do
     context "on any other HTTP method" do
       it "responds with a 406 status and a missing Content-Type header message" do
         patch api_v3_paths.work_package(work_package.id), {}
-        expect(last_response.status).to eq(406)
+        expect(last_response).to have_http_status(:not_acceptable)
         expect(last_response.body).to include("Missing content-type header")
       end
     end

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
       current_user { create(:admin) }
 
       it "responds with 201" do
-        expect(last_response.status).to eq(201)
+        expect(last_response).to have_http_status(:created)
       end
 
       it "creates the group and sets the members" do
@@ -155,7 +155,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
       end
 
       it "responds with 422 and explains the error" do
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("Name can't be blank.".to_json)
@@ -221,7 +221,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
       current_user { admin }
 
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "updates the group" do

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "API v3 Help texts resource" do
         end
 
         context "valid type id" do
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
         end
 
         context "invalid type id" do

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       let(:role) { defined?(expected_role) ? expected_role : other_role }
 
       it "responds with 201" do
-        expect(last_response.status).to eq(201)
+        expect(last_response).to have_http_status(:created)
       end
 
       it "creates the member" do
@@ -675,7 +675,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
 
       context "as a non admin" do
         it "responds with 422 and explains the error" do
-          expect(last_response.status).to eq(422)
+          expect(last_response).to have_http_status(:unprocessable_entity)
 
           expect(last_response.body)
             .to be_json_eql("Project can't be blank.".to_json)
@@ -705,7 +705,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       end
 
       it "responds with 422 and explains the error" do
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("User has already been taken.".to_json)
@@ -734,7 +734,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       end
 
       it "responds with 422 and explains the error" do
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         error_message = "For property 'user' a link like '/api/v3/groups/:id' or " +
                         "'/api/v3/users/:id' or '/api/v3/placeholder_users/:id' is expected, " +
@@ -762,7 +762,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       end
 
       it "responds with 422 and explains the error" do
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("Roles need to be assigned.".to_json)
@@ -862,7 +862,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
 
     context "for a user" do
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "updates the member" do
@@ -955,7 +955,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
       let(:last_user_member_updated_at) { Member.find_by(principal: users.last).updated_at }
 
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "updates the member and all inherited members but does not update memberships users have already had" do
@@ -1038,7 +1038,7 @@ RSpec.describe "API v3 memberships resource", content_type: :json do
         let(:another_role) { create(:global_role) }
 
         it "responds with 200" do
-          expect(last_response.status).to eq(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "updates the member and all inherited members but does not update memberships users have already had" do

--- a/spec/requests/api/v3/memberships/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/create_form_resource_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe API::V3::Memberships::CreateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/memberships/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -157,7 +157,7 @@ RSpec.describe API::V3::Memberships::CreateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/v3/memberships/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/update_form_resource_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe API::V3::Memberships::UpdateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/memberships/:id/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -217,7 +217,7 @@ RSpec.describe API::V3::Memberships::UpdateFormAPI, content_type: :json do
       let(:permissions) { [:view_members] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe API::V3::Memberships::UpdateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 404 Not Found" do
-        expect(response.status).to eq(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v3/notifications/details_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/details_resource_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
 
       it "returns a 404 response" do
         send_request
-        expect(last_response.status).to eq(404)
+        expect(last_response).to have_http_status(:not_found)
       end
     end
 
@@ -151,7 +151,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
     end
 
     it "returns a 404 response" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 
@@ -163,7 +163,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
     end
 
     it "returns a 404 response" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
 
     it "can read and unread" do
       send_read
-      expect(last_response.status).to eq(204)
+      expect(last_response).to have_http_status(:no_content)
       expect(notification.reload.read_ian).to be_truthy
 
       send_unread
-      expect(last_response.status).to eq(204)
+      expect(last_response).to have_http_status(:no_content)
       expect(notification.reload.read_ian).to be_falsey
     end
   end
@@ -78,10 +78,10 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
 
     it "returns a 404 response" do
       send_read
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
 
       send_unread
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v3/notifications/show_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/show_resource_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
     end
 
     it "returns a 404 response" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
     end
 
     it "returns a 404 response" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples "create placeholder user request flow" do
       it "returns an erroneous response" do
         send_request
 
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
         expect(last_response.body)
           .to be_json_eql("urn:openproject-org:api:v3:errors:PropertyConstraintViolation".to_json)
                 .at_path("errorIdentifier")
@@ -63,7 +63,7 @@ RSpec.shared_examples "create placeholder user request flow" do
     it "creates the placeholder when valid" do
       send_request
 
-      expect(last_response.status).to eq(201)
+      expect(last_response).to have_http_status(:created)
       placeholder = PlaceholderUser.find_by(name: parameters[:name])
       expect(placeholder).to be_present
     end
@@ -74,7 +74,7 @@ RSpec.shared_examples "create placeholder user request flow" do
       it "returns an error" do
         send_request
 
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
         expect(last_response.body)
           .to be_json_eql("urn:openproject-org:api:v3:errors:PropertyConstraintViolation".to_json)
                 .at_path("errorIdentifier")
@@ -92,7 +92,7 @@ RSpec.shared_examples "create placeholder user request flow" do
     it "adds an error that its only available in EE" do
       send_request
 
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
       expect(parsed_response["message"])
         .to eq("Placeholder Users is only available in the OpenProject Enterprise edition")
 

--- a/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
@@ -27,7 +27,7 @@
 
 RSpec.shared_examples "deletion allowed" do
   it "responds with 202" do
-    expect(last_response.status).to eq 202
+    expect(last_response).to have_http_status :accepted
   end
 
   it "locks the account and mark for deletion" do
@@ -47,7 +47,7 @@ end
 
 RSpec.shared_examples "deletion is not allowed" do
   it "responds with 403" do
-    expect(last_response.status).to eq 403
+    expect(last_response).to have_http_status :forbidden
   end
 
   it "does not delete the user" do

--- a/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
@@ -27,7 +27,7 @@
 
 RSpec.shared_examples "represents the placeholder" do
   it do
-    expect(last_response.status).to eq(200)
+    expect(last_response).to have_http_status(:ok)
     expect(last_response.body)
       .to(be_json_eql("PlaceholderUser".to_json).at_path("_type"))
 

--- a/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
     let(:user) { build(:user) }
 
     it "returns a 403 response" do
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
@@ -32,7 +32,7 @@ RSpec.shared_examples "updates the placeholder" do
     end
 
     it "returns an error" do
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
       expect(last_response.body)
         .to be_json_eql("urn:openproject-org:api:v3:errors:PropertyConstraintViolation".to_json)
               .at_path("errorIdentifier")
@@ -51,7 +51,7 @@ RSpec.shared_examples "updates the placeholder" do
     end
 
     it "updates the placeholder" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
 
       placeholder.reload
 

--- a/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
     let(:user) { build(:user) }
 
     it "returns a 403 response" do
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
   subject(:response) { last_response }
 
   it "returns 200 FORM response", :aggregate_failures do
-    expect(response.status).to eq(200)
+    expect(response).to have_http_status(:ok)
 
     expect(response.body)
       .to be_json_eql("Form".to_json)
@@ -240,7 +240,7 @@ RSpec.describe API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
     end
 
     it "returns 403 Not Authorized" do
-      expect(response.status).to eq(403)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -71,12 +71,11 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
   subject(:response) { last_response }
 
-  # rubocop:disable RSpecRails/HaveHttpStatus
   # those are mock responses that don't deal well with the rails helpers
   describe "#POST /api/v3/projects/:id/copy" do
     describe "with empty params" do
       it "returns 422", :aggregate_failures do
-        expect(response.status).to eq(422)
+        expect(response).to have_http_status(:unprocessable_entity)
 
         expect(response.body)
           .to be_json_eql("Error".to_json)
@@ -99,7 +98,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
       it "returns with a redirect to job" do
         aggregate_failures do
-          expect(response.status).to eq(302)
+          expect(response).to have_http_status(:found)
 
           expect(response).to be_redirect
 
@@ -108,7 +107,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
         get response.location
 
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
 
         expect(last_response.body)
           .to be_json_eql("in_queue".to_json)
@@ -118,7 +117,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
 
         get response.location
 
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
 
         expect(last_response.body)
           .to be_json_eql("success".to_json)
@@ -199,9 +198,8 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
       end
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
-  # rubocop:enable RSpecRails/HaveHttpStatus
 end

--- a/spec/requests/api/v3/projects/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_form_resource_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe API::V3::Projects::CreateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/projects/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -195,7 +195,7 @@ RSpec.describe API::V3::Projects::CreateFormAPI, content_type: :json do
       end
 
       it "returns 200 OK" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
       end
 
       it "returns the schema with a required parent field" do
@@ -209,7 +209,7 @@ RSpec.describe API::V3::Projects::CreateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
   end
 
   it "responds with 201 CREATED" do
-    expect(last_response.status).to eq(201)
+    expect(last_response).to have_http_status(:created)
   end
 
   it "creates a project" do
@@ -182,7 +182,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
     let(:permissions) { [] }
 
     it "responds with 403" do
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
 
     it "creates no project" do
@@ -199,7 +199,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
     end
 
     it "responds with 422" do
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
     end
 
     it "creates no project" do
@@ -233,7 +233,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
     end
 
     it "responds with 422" do
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
     end
 
     it "creates no project" do

--- a/spec/requests/api/v3/projects/index_resource_spec.rb
+++ b/spec/requests/api/v3/projects/index_resource_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
       current_user { admin }
 
       it "responds with 200 OK" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it_behaves_like "API V3 collection response", 1, 1, "Project" do
@@ -332,7 +332,7 @@ RSpec.describe "API v3 Project resource index", content_type: :json do
       it_behaves_like "API V3 collection response", 0, 0, "Project"
 
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe API::V3::Projects::UpdateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/projects/:id/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -262,7 +262,7 @@ RSpec.describe API::V3::Projects::UpdateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -270,7 +270,7 @@ RSpec.describe API::V3::Projects::UpdateFormAPI, content_type: :json do
       let(:path) { api_v3_paths.project_form(1) }
 
       it "returns 404 Not found" do
-        expect(response.status).to eq(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
   end
 
   it "responds with 200 OK" do
-    expect(last_response.status).to eq(200)
+    expect(last_response).to have_http_status(:ok)
   end
 
   it "alters the project" do
@@ -97,7 +97,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     end
 
     it "responds with 200 OK" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
     end
 
     it "sets the cf value" do
@@ -124,7 +124,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
       let(:current_user) { create(:admin) }
 
       it "responds with 200 OK" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "sets the cf value" do
@@ -141,7 +141,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     context "with non-admin permissions" do
       it "responds with 200 OK" do
         # TBD: trying to set a not accessible custom field is silently ignored
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "does not set the cf value" do
@@ -171,7 +171,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     let(:permissions) { [] }
 
     it "responds with 403" do
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
 
     it "does not change the project" do
@@ -266,7 +266,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     end
 
     it "responds with 422" do
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
     end
 
     it "does not change the project" do
@@ -299,7 +299,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     end
 
     it "responds with 422" do
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
     end
 
     it "does not change the project status" do

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "POST /api/v3/queries/form",
   end
 
   it "returns 200(OK)" do
-    expect(last_response.status).to eq(200)
+    expect(last_response).to have_http_status(:ok)
   end
 
   it "is of type form" do

--- a/spec/requests/api/v3/queries/create_query_spec.rb
+++ b/spec/requests/api/v3/queries/create_query_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "POST /api/v3/queries",
     end
 
     it "returns 201 (created)" do
-      expect(last_response.status).to eq(201)
+      expect(last_response).to have_http_status(:created)
     end
 
     it "renders the created query" do
@@ -139,7 +139,7 @@ RSpec.describe "POST /api/v3/queries",
 
     context "without EE", with_ee: false do
       it "yields a 422 error given a timestamp older than 1 day" do
-        expect(last_response.status).to eq 422
+        expect(last_response).to have_http_status :unprocessable_entity
         expect(json["message"]).to eq "Timestamps contain forbidden values: #{timestamps.first}"
       end
 
@@ -147,7 +147,7 @@ RSpec.describe "POST /api/v3/queries",
         let(:timestamps) { ["oneDayAgo@12:00+00:00"] }
 
         it "returns 201 (created)" do
-          expect(last_response.status).to eq(201)
+          expect(last_response).to have_http_status(:created)
         end
 
         it "updates the query timestamps" do
@@ -168,7 +168,7 @@ RSpec.describe "POST /api/v3/queries",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Project not found"
     end
 
@@ -177,7 +177,7 @@ RSpec.describe "POST /api/v3/queries",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Status Operator is not set to one of the allowed values."
     end
 
@@ -186,7 +186,7 @@ RSpec.describe "POST /api/v3/queries",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Statuz filter does not exist."
     end
   end

--- a/spec/requests/api/v3/queries/order/query_order_api_spec.rb
+++ b/spec/requests/api/v3/queries/order/query_order_api_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "/api/v3/queries/:id/order" do
     it "returns the order" do
       get path
 
-      expect(last_response.status).to eq 200
+      expect(last_response).to have_http_status :ok
       expect(body).to be_a Hash
       expect(body).to eq({ wp1.id => 0, wp2.id => 8192 }.stringify_keys)
     end
@@ -70,7 +70,7 @@ RSpec.describe "/api/v3/queries/:id/order" do
 
     it "allows inserting a delta" do
       patch path, { delta: { wp2.id.to_s => 1234 } }.to_json
-      expect(last_response.status).to eq 200
+      expect(last_response).to have_http_status :ok
 
       query.reload
       expect(body).to eq("t" => timestamp)
@@ -79,7 +79,7 @@ RSpec.describe "/api/v3/queries/:id/order" do
 
     it "allows removing an item" do
       patch path, { delta: { wp1.id.to_s => -1 } }.to_json
-      expect(last_response.status).to eq 200
+      expect(last_response).to have_http_status :ok
 
       query.reload
       expect(body).to eq("t" => timestamp)

--- a/spec/requests/api/v3/queries/query_resource_spec.rb
+++ b/spec/requests/api/v3/queries/query_resource_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "API v3 Query resource",
 
     context "user has view_work_packages in a project" do
       it "succeeds" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe "API v3 Query resource",
       let(:permissions) { [:manage_public_queries] }
 
       it "succeeds" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe "API v3 Query resource",
       include_context "with non-member permissions from non_member_permissions"
 
       it "succeeds" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       context "that is not allowed to see queries anywhere" do
@@ -247,7 +247,7 @@ RSpec.describe "API v3 Query resource",
     end
 
     it "responds with HTTP No Content" do
-      expect(last_response.status).to eq 204
+      expect(last_response).to have_http_status :no_content
     end
 
     it "deletes the Query" do
@@ -279,7 +279,7 @@ RSpec.describe "API v3 Query resource",
     end
 
     it "succeeds" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
     end
 
     it "returns a Collection of projects for which the user has view work packages permission" do
@@ -317,7 +317,7 @@ RSpec.describe "API v3 Query resource",
 
         context "when starring an unstarred query" do
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to true' do
@@ -327,7 +327,7 @@ RSpec.describe "API v3 Query resource",
 
         context "when starring already starred query" do
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to true' do
@@ -356,7 +356,7 @@ RSpec.describe "API v3 Query resource",
 
         context "starring his own query" do
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to true' do
@@ -398,7 +398,7 @@ RSpec.describe "API v3 Query resource",
           end
 
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to false' do
@@ -412,7 +412,7 @@ RSpec.describe "API v3 Query resource",
           end
 
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to false' do
@@ -453,7 +453,7 @@ RSpec.describe "API v3 Query resource",
 
         context "unstarring his own query" do
           it "responds with 200" do
-            expect(last_response.status).to eq(200)
+            expect(last_response).to have_http_status(:ok)
           end
 
           it 'returns the query with "starred" property set to true' do
@@ -490,7 +490,7 @@ RSpec.describe "API v3 Query resource",
     end
 
     it "succeeds" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
     end
 
     it "returns the form" do

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "POST /api/v3/queries/form",
   end
 
   it "returns 200(OK)" do
-    expect(last_response.status).to eq(200)
+    expect(last_response).to have_http_status(:ok)
   end
 
   it "is of type form" do

--- a/spec/requests/api/v3/queries/update_query_spec.rb
+++ b/spec/requests/api/v3/queries/update_query_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
     end
 
     it "returns 200 (ok)" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
     end
 
     it "renders the updated query" do
@@ -159,7 +159,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
 
     context "without EE", with_ee: false do
       it "yields a 422 error given a timestamp older than 1 day" do
-        expect(last_response.status).to eq 422
+        expect(last_response).to have_http_status :unprocessable_entity
         expect(json["message"]).to eq "Timestamps contain forbidden values: #{timestamps.first}"
       end
 
@@ -167,7 +167,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
         let(:timestamps) { ["oneDayAgo@12:00+00:00"] }
 
         it "returns 200 (ok)" do
-          expect(last_response.status).to eq(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "updates the query timestamps" do
@@ -188,7 +188,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Project not found"
     end
 
@@ -197,7 +197,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Status Operator is not set to one of the allowed values."
     end
 
@@ -206,7 +206,7 @@ RSpec.describe "PATCH /api/v3/queries/:id",
 
       post!
 
-      expect(last_response.status).to eq 422
+      expect(last_response).to have_http_status :unprocessable_entity
       expect(json["message"]).to eq "Statuz filter does not exist."
     end
   end

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     end
 
     it "returns 201 (created)" do
-      expect(last_response.status).to eq(201)
+      expect(last_response).to have_http_status(:created)
     end
 
     it "has created a new relation" do
@@ -121,7 +121,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       end
 
       it "responds with error" do
-        expect(last_response.status).to be 422
+        expect(last_response).to have_http_status :unprocessable_entity
       end
 
       it "states the reason for the error" do
@@ -242,7 +242,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     end
 
     it "returns 200 (ok)" do
-      expect(last_response.status).to eq 200
+      expect(last_response).to have_http_status :ok
     end
 
     it "updates the relation's description" do
@@ -267,7 +267,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       end
 
       it "returns 422" do
-        expect(last_response.status).to eq 422
+        expect(last_response).to have_http_status :unprocessable_entity
       end
 
       it "indicates an error with the type attribute" do
@@ -291,7 +291,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       end
 
       it "returns 422" do
-        expect(last_response.status).to eq 422
+        expect(last_response).to have_http_status :unprocessable_entity
       end
 
       it "indicates an error with the `from` attribute" do
@@ -329,7 +329,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
 
     context "with the required permissions" do
       it "works" do
-        expect(last_response.status).to eq 201
+        expect(last_response).to have_http_status :created
       end
     end
 
@@ -337,7 +337,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       let(:permissions) { [:view_work_packages] }
 
       it "is forbidden" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
     end
 
@@ -349,7 +349,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       let!(:to) { create(:work_package) }
 
       it "returns 422" do
-        expect(last_response.status).to eq 422
+        expect(last_response).to have_http_status :unprocessable_entity
       end
 
       it "indicates an error with the `to` attribute" do
@@ -392,7 +392,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     end
 
     it "returns 204 and destroy the relation" do
-      expect(last_response.status).to eq 204
+      expect(last_response).to have_http_status :no_content
       expect(Relation.exists?(relation.id)).to be_falsey
     end
 
@@ -400,7 +400,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       let(:permissions) { %i[view_work_packages] }
 
       it "returns 403" do
-        expect(last_response.status).to eq 403
+        expect(last_response).to have_http_status :forbidden
       end
 
       it "leaves the relation" do
@@ -458,7 +458,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     end
 
     it "returns 200" do
-      expect(last_response.status).to be 200
+      expect(last_response).to have_http_status :ok
     end
 
     it "returns the visible relation (and only the visible one) satisfying the filter" do
@@ -502,7 +502,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
 
     context "for a relation with visible work packages" do
       it "returns 200" do
-        expect(last_response.status).to be 200
+        expect(last_response).to have_http_status :ok
       end
 
       it "returns the relation" do
@@ -534,7 +534,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       end
 
       it "returns 404 NOT FOUND" do
-        expect(last_response.status).to be 404
+        expect(last_response).to have_http_status :not_found
       end
     end
   end

--- a/spec/requests/api/v3/repositories/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_resource_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "API v3 Revisions resource" do
       end
 
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       describe "response body" do

--- a/spec/requests/api/v3/root_resource_spec.rb
+++ b/spec/requests/api/v3/root_resource_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "API v3 Root resource" do
 
       context "when not login_required", with_settings: { login_required: false } do
         it "responds with 200", :aggregate_failures do
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(:ok)
           expect(subject).to have_json_path("instanceName")
         end
       end
@@ -73,7 +73,7 @@ RSpec.describe "API v3 Root resource" do
       end
 
       it "responds with 200" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
       end
 
       it "responds with a root representer" do
@@ -82,7 +82,7 @@ RSpec.describe "API v3 Root resource" do
 
       context "without the X-requested-with header", :skip_xhr_header do
         it "returns OK because GET requests are allowed" do
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(:ok)
           expect(subject).to have_json_path("instanceName")
         end
       end

--- a/spec/requests/api/v3/status_resource_spec.rb
+++ b/spec/requests/api/v3/status_resource_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "API v3 Status resource" do
         end
 
         context "valid status id" do
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
         end
 
         context "invalid status id" do

--- a/spec/requests/api/v3/support/api_helper.rb
+++ b/spec/requests/api/v3/support/api_helper.rb
@@ -27,7 +27,7 @@
 #++
 
 RSpec.shared_examples_for "safeguarded API" do
-  it { expect(last_response.status).to eq(404) }
+  it { expect(last_response).to have_http_status(:not_found) }
 end
 
 RSpec.shared_examples_for "valid activity request" do
@@ -38,7 +38,7 @@ RSpec.shared_examples_for "valid activity request" do
     allow(User).to receive(:current).and_return(admin)
   end
 
-  it { expect(last_response.status).to eq(status_code) }
+  it { expect(last_response).to have_http_status(status_code) }
 
   describe "response body" do
     subject { last_response.body }
@@ -56,5 +56,5 @@ RSpec.shared_examples_for "invalid activity request" do
     allow(User).to receive(:current).and_return(admin)
   end
 
-  it { expect(last_response.status).to eq(422) }
+  it { expect(last_response).to have_http_status(:unprocessable_entity) }
 end

--- a/spec/requests/api/v3/support/api_v3_collection_response.rb
+++ b/spec/requests/api/v3/support/api_v3_collection_response.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples_for "API V3 collection response" do |total, count, element
 
   it "returns a collection successfully" do
     aggregate_failures do
-      expect(last_response.status).to eq(expected_status_code)
+      expect(last_response).to have_http_status(expected_status_code)
       errors = JSON.parse(subject).dig("_embedded", "errors")&.map { _1["message"] }
       expect(errors).to eq([]) if errors # make errors visible in console if any
     end

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 
 RSpec.shared_examples_for "successful response" do |code = 200|
   it "has the status code #{code}" do
-    expect(last_response.status).to eq(code)
+    expect(last_response).to have_http_status(code)
   end
 
   it "has a HAL+JSON Content-Type" do
@@ -42,7 +42,7 @@ end
 
 RSpec.shared_examples_for "successful no content response" do |code = 204|
   it "has the status code #{code}" do
-    expect(last_response.status).to eq(code)
+    expect(last_response).to have_http_status(code)
   end
 end
 
@@ -50,7 +50,7 @@ RSpec.shared_examples_for "redirect response" do |code = 303|
   let(:location) { "" }
 
   it "has the status code #{code}" do
-    expect(last_response.status).to eq(code)
+    expect(last_response).to have_http_status(code)
   end
 
   it "redirects to expected location" do
@@ -64,7 +64,7 @@ RSpec.shared_examples_for "error response" do |code, id, provided_message = nil|
   end
 
   it "has the status code #{code}" do
-    expect(last_response.status).to eq(code)
+    expect(last_response).to have_http_status(code)
   end
 
   it "has a HAL+JSON Content-Type" do
@@ -182,7 +182,7 @@ RSpec.shared_examples_for "param validation error" do
   subject { JSON.parse(last_response.body) }
 
   it "results in a validation error" do
-    expect(last_response.status).to eq(400)
+    expect(last_response).to have_http_status(:bad_request)
     expect(subject["errorIdentifier"]).to eq("urn:openproject-org:api:v3:errors:BadRequest")
     expect(subject["message"]).to match /Bad request: .+? is invalid/
   end

--- a/spec/requests/api/v3/types/type_resource_spec.rb
+++ b/spec/requests/api/v3/types/type_resource_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "API v3 Type resource" do
         end
 
         context "valid type id" do
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
         end
 
         context "invalid type id" do

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe API::V3::Users::CreateFormAPI, content_type: :json do
       it "returns a payload with validation errors",
          :aggregate_failures,
          with_settings: { default_language: :es } do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
@@ -101,7 +101,7 @@ RSpec.describe API::V3::Users::CreateFormAPI, content_type: :json do
       end
 
       it "returns a valid payload", :aggregate_failures do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
@@ -149,7 +149,7 @@ RSpec.describe API::V3::Users::CreateFormAPI, content_type: :json do
       end
 
       it "returns a valid form response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)

--- a/spec/requests/api/v3/user/create_user_common_examples.rb
+++ b/spec/requests/api/v3/user/create_user_common_examples.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "represents the created user" do |expected_attributes|
   it "returns the represented user" do
     send_request
 
-    expect(last_response.status).to eq(201)
+    expect(last_response).to have_http_status(:created)
     expect(last_response.body).to have_json_type(Object).at_path("_links")
     expect(last_response.body)
       .to be_json_eql("User".to_json)
@@ -50,7 +50,7 @@ RSpec.shared_examples "property is not writable" do |attribute_name|
 
     attr = JSON.parse(last_response.body).dig "_embedded", "details", "attribute"
 
-    expect(last_response.status).to eq 422
+    expect(last_response).to have_http_status :unprocessable_entity
     expect(attr).to eq attribute_name
   end
 end
@@ -64,7 +64,7 @@ RSpec.shared_examples "create user request flow" do
     it "returns an erroneous response" do
       send_request
 
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
 
       expect(errors.count).to eq(5)
       expect(errors.collect { |el| el["_embedded"]["details"]["attribute"] })
@@ -140,7 +140,7 @@ RSpec.shared_examples "create user request flow" do
     it "returns an erroneous response" do
       send_request
 
-      expect(last_response.status).to eq(422)
+      expect(last_response).to have_http_status(:unprocessable_entity)
 
       expect(errors).not_to be_empty
       expect(last_response.body)

--- a/spec/requests/api/v3/user/create_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_user_resource_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe API::V3::Users::UsersAPI do
         it "returns an error on that attribute" do
           send_request
 
-          expect(last_response.status).to eq(422)
+          expect(last_response).to have_http_status(:unprocessable_entity)
 
           expect(last_response.body)
             .to be_json_eql("authSource".to_json)
@@ -247,7 +247,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
     it "returns an erroneous response" do
       send_request
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
 
     describe "empty payload" do
       it "returns a valid form", :aggregate_failures do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
@@ -96,7 +96,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
       end
 
       it "returns a valid response", :aggregate_failures do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(subject.body)
@@ -121,7 +121,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
       end
 
       it "returns an invalid form", :aggregate_failures do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
@@ -156,7 +156,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
       let(:path) { api_v3_paths.user_form(12345) }
 
       it "returns 404 Not found" do
-        expect(response.status).to eq(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V3::Users::UsersAPI do
     it "responds with the represented updated user" do
       send_request
 
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
       expect(last_response.body).to have_json_type(Object).at_path("_links")
       expect(last_response.body)
         .to be_json_eql("User".to_json)
@@ -83,7 +83,7 @@ RSpec.describe API::V3::Users::UsersAPI do
       it "returns an erroneous response" do
         send_request
 
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("email".to_json)
@@ -107,7 +107,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
       it "updates the users password correctly" do
         send_request
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
 
         updated_user = User.find(user.id)
         matches = updated_user.check_password?(password)
@@ -121,7 +121,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
       it "responds with 404" do
         send_request
-        expect(last_response.status).to be(404)
+        expect(last_response).to have_http_status(:not_found)
       end
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
       it "rejects the users password update" do
         send_request
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("password".to_json)
@@ -157,7 +157,7 @@ RSpec.describe API::V3::Users::UsersAPI do
 
     it "returns an erroneous response" do
       send_request
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "API v3 Version resource", content_type: :json do
 
     shared_examples_for "successful response" do
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       it "returns the version" do
@@ -157,7 +157,7 @@ RSpec.describe "API v3 Version resource", content_type: :json do
     end
 
     it "responds with 200" do
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_http_status(:ok)
     end
 
     it "updates the version" do
@@ -297,7 +297,7 @@ RSpec.describe "API v3 Version resource", content_type: :json do
     end
 
     it "responds with 201" do
-      expect(last_response.status).to eq(201)
+      expect(last_response).to have_http_status(:created)
     end
 
     it "creates the version" do

--- a/spec/requests/api/v3/versions/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/create_form_resource_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe API::V3::Versions::CreateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/versions/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -186,7 +186,7 @@ RSpec.describe API::V3::Versions::CreateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/v3/versions/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/update_form_resource_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe API::V3::Versions::UpdateFormAPI, content_type: :json do
 
   describe "#POST /api/v3/versions/:id/form" do
     it "returns 200 OK" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns a form" do
@@ -215,7 +215,7 @@ RSpec.describe API::V3::Versions::UpdateFormAPI, content_type: :json do
       let(:permissions) { [:view_work_packages] }
 
       it "returns 403 Not Authorized" do
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe API::V3::Versions::UpdateFormAPI, content_type: :json do
       let(:permissions) { [] }
 
       it "returns 404 Not Found" do
-        expect(response.status).to eq(404)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v3/views/create_resource_spec.rb
+++ b/spec/requests/api/v3/views/create_resource_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe API::V3::Views::ViewsAPI,
       end
 
       it "responds with 422 and explains the error" do
-        expect(last_response.status).to eq(422)
+        expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
           .to be_json_eql("Query does not exist.".to_json)

--- a/spec/requests/api/v3/views/show_resource_spec.rb
+++ b/spec/requests/api/v3/views/show_resource_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe API::V3::Views::ViewsAPI,
     end
 
     it "returns a 404 response" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackagesByProjectAPI, content_type: :j
   end
 
   it "returns Created(201)" do
-    expect(last_response.status).to eq(201)
+    expect(last_response).to have_http_status(:created)
   end
 
   it "creates a work package" do
@@ -114,7 +114,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackagesByProjectAPI, content_type: :j
     let(:current_user) { create(:user) }
 
     it "hides the endpoint" do
-      expect(last_response.status).to eq(404)
+      expect(last_response).to have_http_status(:not_found)
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackagesByProjectAPI, content_type: :j
     let(:permissions) { [:view_project] }
 
     it "points out the missing permission" do
-      expect(last_response.status).to eq(403)
+      expect(last_response).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V3::WorkPackages::CreateProjectFormAPI do
   subject(:response) { last_response }
 
   it "returns 200(OK)" do
-    expect(response.status).to eq(200)
+    expect(response).to have_http_status(:ok)
   end
 
   it "is of type form" do

--- a/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe API::V3::WorkPackages::CreateProjectFormAPI, content_type: :json 
   subject(:response) { last_response }
 
   it "returns 200(OK)" do
-    expect(response.status).to eq(200)
+    expect(response).to have_http_status(:ok)
   end
 
   it "is of type form" do

--- a/spec/requests/api/v3/work_packages/create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_resource_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "API v3 Work package resource",
     end
 
     it "returns Created(201)" do
-      expect(last_response.status).to eq(201)
+      expect(last_response).to have_http_status(:created)
     end
 
     it "creates a work package" do
@@ -132,7 +132,7 @@ RSpec.describe "API v3 Work package resource",
       let(:current_user) { create(:user) }
 
       it "hides the endpoint" do
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_http_status(:forbidden)
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe "API v3 Work package resource",
       let(:permissions) { [:view_project] }
 
       it "points out the missing permission" do
-        expect(last_response.status).to eq(403)
+        expect(last_response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "API v3 Work package form resource" do
         shared_examples_for "valid payload" do
           subject { last_response.body }
 
-          it { expect(last_response.status).to eq(200) }
+          it { expect(last_response).to have_http_status(:ok) }
 
           it { is_expected.to have_json_path("_embedded/payload") }
 
@@ -232,7 +232,7 @@ RSpec.describe "API v3 Work package form resource" do
 
                 include_context "with post request"
 
-                it { expect(last_response.status).to eq(409) }
+                it { expect(last_response).to have_http_status(:conflict) }
 
                 it_behaves_like "update conflict"
               end
@@ -803,7 +803,7 @@ RSpec.describe "API v3 Work package form resource" do
               end
 
               it "responds with a valid body (Regression OP#37510)" do
-                expect(last_response.status).to eq(200)
+                expect(last_response).to have_http_status(:ok)
               end
             end
           end
@@ -825,7 +825,7 @@ RSpec.describe "API v3 Work package form resource" do
       subject { last_response.body }
 
       shared_examples_for "valid payload" do
-        it { expect(last_response.status).to eq(200) }
+        it { expect(last_response).to have_http_status(:ok) }
 
         it { is_expected.to have_json_path("_embedded/payload") }
 

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "API v3 Work package resource",
       end
 
       it "responds with 200" do
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_http_status(:ok)
       end
 
       describe "response body" do
@@ -248,7 +248,7 @@ RSpec.describe "API v3 Work package resource",
 
         context "with EE", with_ee: %i[baseline_comparison] do
           it "responds with 200" do
-            expect(subject && last_response.status).to eq(200)
+            expect(subject && last_response).to have_http_status(:ok)
           end
 
           it "has the current attributes as attributes" do
@@ -502,13 +502,13 @@ RSpec.describe "API v3 Work package resource",
         context "without EE" do
           shared_examples "success" do
             it "responds with 200" do
-              expect(subject && last_response.status).to eq(200)
+              expect(subject && last_response).to have_http_status(:ok)
             end
           end
 
           shared_examples "error" do
             it "responds with 400" do
-              expect(subject && last_response.status).to eq(400)
+              expect(subject && last_response).to have_http_status(:bad_request)
             end
 
             it "has the invalid timestamps message" do

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) }
+        it { expect(response).to have_http_status(:ok) }
 
         it "responds with updated work package subject" do
           expect(subject.body).to be_json_eql("Updated subject".to_json).at_path("subject")
@@ -172,7 +172,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(422) }
+          it { expect(response).to have_http_status(:unprocessable_entity) }
 
           it "has a readonly error" do
             expect(response.body)
@@ -200,7 +200,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it_behaves_like "description updated"
         end
@@ -214,7 +214,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it_behaves_like "description updated"
         end
@@ -226,7 +226,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) }
+        it { expect(response).to have_http_status(:ok) }
 
         it "updates the scheduling mode" do
           expect(subject.body).to be_json_eql(schedule_manually.to_json).at_path("scheduleManually")
@@ -239,7 +239,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) }
+        it { expect(response).to have_http_status(:ok) }
 
         it "responds with updated start date" do
           expect(subject.body).to be_json_eql(date_string.to_json).at_path("startDate")
@@ -254,7 +254,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) }
+        it { expect(response).to have_http_status(:ok) }
 
         it "responds with updated finish date" do
           expect(subject.body).to be_json_eql(date_string.to_json).at_path("dueDate")
@@ -269,7 +269,7 @@ RSpec.describe "API v3 Work package resource",
 
         include_context "patch request"
 
-        it { expect(response.status).to eq(200) } # rubocop:disable RSpecRails/HaveHttpStatus
+        it { expect(response).to have_http_status(:ok) }
 
         it "responds with updated finish date" do
           expect(subject.body).to be_json_eql(duration.to_json).at_path("remainingTime")
@@ -297,7 +297,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with updated work package status" do
             expect(subject.body).to be_json_eql(target_status.name.to_json)
@@ -349,7 +349,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with updated work package type" do
             expect(subject.body).to be_json_eql(target_type.name.to_json)
@@ -425,7 +425,7 @@ RSpec.describe "API v3 Work package resource",
           include_context "patch request"
 
           it "is successful" do
-            expect(response.status).to eq(200)
+            expect(response).to have_http_status(:ok)
           end
 
           it_behaves_like "lock version updated"
@@ -496,7 +496,7 @@ RSpec.describe "API v3 Work package resource",
 
             include_context "patch request"
 
-            it { expect(response.status).to eq(200) }
+            it { expect(response).to have_http_status(:ok) }
 
             it { expect(response.body).to be_json_eql(nil.to_json).at_path(href_path) }
 
@@ -507,7 +507,7 @@ RSpec.describe "API v3 Work package resource",
             shared_examples_for "valid user assignment" do
               let(:title) { assigned_user.name.to_s.to_json }
 
-              it { expect(response.status).to eq(200) }
+              it { expect(response).to have_http_status(:ok) }
 
               it {
                 expect(response.body)
@@ -614,7 +614,7 @@ RSpec.describe "API v3 Work package resource",
         context "valid" do
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with the work package assigned to the version" do
             expect(subject.body)
@@ -630,7 +630,7 @@ RSpec.describe "API v3 Work package resource",
 
           include_context "patch request"
 
-          it { expect(response.status).to eq(422) }
+          it { expect(response).to have_http_status(:unprocessable_entity) }
 
           it "has a readonly error" do
             expect(response.body)
@@ -651,7 +651,7 @@ RSpec.describe "API v3 Work package resource",
         context "valid" do
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with the work package assigned to the category" do
             expect(subject.body)
@@ -674,7 +674,7 @@ RSpec.describe "API v3 Work package resource",
         context "valid" do
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with the work package assigned to the priority" do
             expect(subject.body)
@@ -698,7 +698,7 @@ RSpec.describe "API v3 Work package resource",
         context "valid" do
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with the work package and its new budget" do
             expect(subject.body).to be_json_eql(target_budget.subject.to_json)
@@ -742,7 +742,7 @@ RSpec.describe "API v3 Work package resource",
         context "valid" do
           include_context "patch request"
 
-          it { expect(response.status).to eq(200) }
+          it { expect(response).to have_http_status(:ok) }
 
           it "responds with the work package assigned to the new value" do
             expect(subject.body)

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
     context "authorized" do
       context "valid" do
         it "returns HTTP 200" do
-          expect(last_response.status).to be(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "returns a collection of schemas" do
@@ -79,7 +79,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
         let(:filter_values) { ["#{0}-#{type.id}"] }
 
         it "returns HTTP 200" do
-          expect(last_response.status).to be(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "returns an empty collection" do
@@ -93,7 +93,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
         let(:filter_values) { ["#{project.id}-#{0}"] }
 
         it "returns HTTP 200" do
-          expect(last_response.status).to be(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "returns an empty collection" do
@@ -107,7 +107,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
         let(:filter_values) { ["bogus"] }
 
         it "returns HTTP 400" do
-          expect(last_response.status).to be(400)
+          expect(last_response).to have_http_status(:bad_request)
         end
 
         it "returns an error" do
@@ -122,7 +122,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
       let(:role) { create(:project_role, permissions: []) }
 
       it "returns HTTP 403" do
-        expect(last_response.status).to be(403)
+        expect(last_response).to have_http_status(:forbidden)
       end
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
 
       context "valid schema" do
         it "returns HTTP 200" do
-          expect(last_response.status).to be(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         it "sets a weak ETag" do
@@ -195,7 +195,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI do
 
       context "valid schema" do
         it "returns HTTP 200" do
-          expect(last_response.status).to be(200)
+          expect(last_response).to have_http_status(:ok)
         end
 
         # Further fields are tested in the representer specs

--- a/spec/requests/oauth_clients/callback_flow_spec.rb
+++ b/spec/requests/oauth_clients/callback_flow_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "OAuthClient callback endpoint" do
   context "when user is not logged in" do
     it "requires login" do
       get uri.to_s
-      expect(last_response.status).to eq(401)
+      expect(last_response).to have_http_status(:unauthorized)
     end
   end
 
@@ -79,24 +79,23 @@ RSpec.describe "OAuthClient callback endpoint" do
       set_cookie "oauth_state_asdf1234=#{state_cookie}"
     end
 
-    # rubocop:disable RSpecRails/HaveHttpStatus
     shared_examples "with errors and state param with cookie, not being admin" do
       it "redirects to URI referenced in the state param and held in a cookie" do
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
         expect(response.location).to eq redirect_uri
       end
     end
 
     shared_examples "with errors, being an admin" do
       it "redirects to admin settings for the storage" do
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
         expect(URI(response.location).path).to eq edit_admin_settings_storage_path(oauth_client.integration)
       end
     end
 
     shared_examples "fallback redirect" do
       it "redirects to home" do
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
         expect(URI(response.location).path).to eq API::V3::Utilities::PathHelper::ApiV3Path::root_path
       end
     end
@@ -110,7 +109,7 @@ RSpec.describe "OAuthClient callback endpoint" do
 
         it "redirects to the URL that was referenced by the state param and held by a cookie" do
           expect(rack_oauth2_client).to have_received(:authorization_code=).with(code)
-          expect(response.status).to eq 302
+          expect(response).to have_http_status :found
           expect(response.location).to eq redirect_uri
           expect(OAuthClientToken.count).to eq 1
           expect(OAuthClientToken.last.access_token).to eq "xyzaccesstoken"
@@ -185,6 +184,5 @@ RSpec.describe "OAuthClient callback endpoint" do
 
       it_behaves_like "fallback redirect"
     end
-    # rubocop:enable RSpecRails/HaveHttpStatus
   end
 end

--- a/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
+++ b/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
     context "when user is not logged in" do
       it "requires login" do
         get oauth_clients_ensure_connection_url(oauth_client_id: oauth_client.client_id)
-        expect(last_response.status).to eq(401)
+        expect(last_response).to have_http_status(:unauthorized)
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
 
       it "responds with 400 when storage_id parameter is absent" do
         get oauth_clients_ensure_connection_url(oauth_client_id: oauth_client.client_id)
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_http_status(:bad_request)
         expect(last_response.body).to eq("Required parameter missing: storage_id")
       end
 
@@ -77,7 +77,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
               get oauth_clients_ensure_connection_url(oauth_client_id: oauth_client.client_id, storage_id: storage.id)
 
               oauth_client = storage.oauth_client
-              expect(last_response.status).to eq(302)
+              expect(last_response).to have_http_status(:found)
               expect(last_response.location).to eq(
                 "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
                 "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
@@ -98,7 +98,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
                                                         destination_url: "#{root_url}123")
 
                 oauth_client = storage.oauth_client
-                expect(last_response.status).to eq(302)
+                expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq(
                   "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
                   "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
@@ -118,7 +118,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
                                                         destination_url: "#{storage.host}/index.php")
 
                 oauth_client = storage.oauth_client
-                expect(last_response.status).to eq(302)
+                expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq(
                   "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
                   "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
@@ -153,7 +153,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
             it "redirects to root_url" do
               get oauth_clients_ensure_connection_url(oauth_client_id: oauth_client.client_id, storage_id: storage.id)
 
-              expect(last_response.status).to eq(302)
+              expect(last_response).to have_http_status(:found)
               expect(last_response.location).to eq("http://www.example.com/")
               expect(last_response.cookies.keys).to eq(["_open_project_session"])
             end
@@ -167,7 +167,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
                                                         destination_url: "#{root_url}123")
 
                 storage.oauth_client
-                expect(last_response.status).to eq(302)
+                expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq("http://www.example.com/123")
                 expect(last_response.cookies.keys).to eq(["_open_project_session"])
               end
@@ -180,7 +180,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
                                                         destination_url: "#{storage.host}/index.php")
 
                 storage.oauth_client
-                expect(last_response.status).to eq(302)
+                expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq("http://www.example.com/")
                 expect(last_response.cookies.keys).to eq(["_open_project_session"])
               end

--- a/spec/requests/openid_google_provider_callback_spec.rb
+++ b/spec/requests/openid_google_provider_callback_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "OpenID Google provider callback", with_ee: %i[openid_providers] 
     }
   } do
     response = get uri.to_s
-    expect(response.status).to eq(302)
+    expect(response).to have_http_status(:found)
     expect(response.location).to eq("http://example.org/two_factor_authentication/request")
   end
 end

--- a/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe "Rate limiting APIv3",
              nil,
              "CONTENT_TYPE" => "application/json"
 
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_http_status :ok
       end
 
       post "/api/v3/work_packages/form",
            nil,
            "CONTENT_TYPE" => "application/json"
-      expect(last_response.status).to eq 429
+      expect(last_response).to have_http_status :too_many_requests
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe "Rate limiting APIv3",
              nil,
              "CONTENT_TYPE" => "application/json"
 
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_http_status :ok
       end
     end
   end

--- a/spec/support/have_http_status_with_rack_response.rb
+++ b/spec/support/have_http_status_with_rack_response.rb
@@ -32,10 +32,9 @@ module HaveHttpStatusWithRackResponse
       # `have_http_status` matcher would fail if the response object is a
       # `Rack::MockResponse`. Hack to disguise `Rack::MockResponse` into a
       # `ActionDispatch::TestResponse` object.
-      obj = ActionDispatch::Response.new(obj.status, obj.headers, obj.body).tap do |resp|
-        resp.request = ActionDispatch::Request.new({})
-      end
-      ::ActionDispatch::TestResponse.from_response(obj)
+      response = ActionDispatch::Response.new(obj.status, obj.headers, obj.body)
+      response.request = ActionDispatch::Request.new({})
+      ::ActionDispatch::TestResponse.from_response(response)
     else
       super
     end

--- a/spec/support/have_http_status_with_rack_response.rb
+++ b/spec/support/have_http_status_with_rack_response.rb
@@ -24,34 +24,22 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
+#++
 
-require "spec_helper"
-require "rack/test"
-require_relative "create_shared_examples"
-
-RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
-               "create" do
-  current_user { user }
-
-  describe "admin user" do
-    let(:user) { build(:admin) }
-
-    it_behaves_like "create placeholder user request flow"
-  end
-
-  describe "user with manage_placeholder_user permission" do
-    let(:user) { create(:user, global_permissions: %i[manage_placeholder_user]) }
-
-    it_behaves_like "create placeholder user request flow"
-  end
-
-  describe "unauthorized user" do
-    include_context "create placeholder user request context"
-    let(:user) { build(:user) }
-
-    it "returns an erroneous response" do
-      send_request
-      expect(last_response).to have_http_status(:forbidden)
+module HaveHttpStatusWithRackResponse
+  def as_test_response(obj)
+    if obj.is_a?(Rack::MockResponse)
+      # `have_http_status` matcher would fail if the response object is a
+      # `Rack::MockResponse`. Hack to disguise `Rack::MockResponse` into a
+      # `ActionDispatch::TestResponse` object.
+      obj = ActionDispatch::Response.new(obj.status, obj.headers, obj.body).tap do |resp|
+        resp.request = ActionDispatch::Request.new({})
+      end
+      ::ActionDispatch::TestResponse.from_response(obj)
+    else
+      super
     end
   end
 end
+
+RSpec::Rails::Matchers::HaveHttpStatus.prepend(HaveHttpStatusWithRackResponse)

--- a/spec/support/queries/shared_get_individual_query_examples.rb
+++ b/spec/support/queries/shared_get_individual_query_examples.rb
@@ -44,7 +44,7 @@ RSpec.shared_examples_for "GET individual query" do
   end
 
   it "succeeds" do
-    expect(last_response.status).to eq(200)
+    expect(last_response).to have_http_status(:ok)
   end
 
   it "has the right endpoint set for the self reference" do
@@ -140,7 +140,7 @@ RSpec.shared_examples_for "GET individual query" do
 
       context "with EE", with_ee: %i[baseline_comparison] do
         it "succeeds" do
-          expect(last_response.status).to eq(200)
+          expect(last_response).to have_http_status(:ok)
         end
       end
 


### PR DESCRIPTION
`have_http_status` matcher fails if the response object is a `Rack::MockResponse`, yet `RSpecRails/HaveHttpStatus` cop keeps complaining about it.

With a little hackery, disguise `Rack::MockResponse` into a `ActionDispatch::TestResponse` object to make it work and use `have_http_status` everywhere possible.