### PR TITLE
Set hosts config when present in config

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -532,6 +532,10 @@ module Settings
           production: nil
         },
       },
+      additional_host_names: {
+        description: "Additional allowed host names for the application.",
+        default: []
+      },
       hours_per_day: {
         description: "This will define what is considered a “day” when displaying duration in a more natural way " \
                      "(for example, if a day is 8 hours, 32 hours would be 4 days).",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -188,6 +188,9 @@ Rails.application.configure do
         base = OpenProject::Configuration["rails_relative_url_root"]
         request.path.start_with?("#{base}/health_check") ||
           request.path.start_with?("#{base}/sys")
+      end,
+      response_app: -> env do
+        [400, { "Content-Type" => "text/plain" }, ["Invalid host_name configuration"]]
       end
     }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -179,11 +179,14 @@ Rails.application.configure do
     }
   end
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  if OpenProject::Configuration.host_name.present?
+    # Enable DNS rebinding protection and other `Host` header attacks.
+    config.hosts = [OpenProject::Configuration.host_name] + OpenProject::Configuration.additional_host_names
+    # Skip DNS rebinding protection for the default health check endpoint.
+    config.host_authorization = {
+      exclude: ->(request) do
+        request.path.start_with?("#{OpenProject::Configuration["rails_relative_url_root"]}/health_check")
+      end
+    }
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -185,7 +185,9 @@ Rails.application.configure do
     # Skip DNS rebinding protection for the default health check endpoint.
     config.host_authorization = {
       exclude: ->(request) do
-        request.path.start_with?("#{OpenProject::Configuration["rails_relative_url_root"]}/health_check")
+        base = OpenProject::Configuration["rails_relative_url_root"]
+        request.path.start_with?("#{base}/health_check") ||
+          request.path.start_with?("#{base}/sys")
       end
     }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -186,10 +186,9 @@ Rails.application.configure do
     config.host_authorization = {
       exclude: ->(request) do
         base = OpenProject::Configuration["rails_relative_url_root"]
-        request.path.start_with?("#{base}/health_check") ||
-          request.path.start_with?("#{base}/sys")
+        request.path.start_with?("#{base}/health_check", "#{base}/sys")
       end,
-      response_app: -> env do
+      response_app: -> do
         [400, { "Content-Type" => "text/plain" }, ["Invalid host_name configuration"]]
       end
     }

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -63,7 +63,11 @@ namespace :packager do
     # Persist configuration
     Setting.sys_api_enabled = 1
     Setting.sys_api_key = ENV.fetch("SYS_API_KEY", nil)
-    Setting.host_name = ENV.fetch("SERVER_HOSTNAME", Setting.host_name) if Setting.host_name_writable?
+    env_host_name = ENV["SERVER_HOSTNAME"]
+    # Write the ENV provided host name as a setting so it is no longer writable
+    if env_host_name.present?
+      shell_setup(["config:set", "OPENPROJECT_HOST__NAME=#{host_name}"])
+    end
 
     # SERVER_PROTOCOL is set by the packager apache2 addon
     # other SERVER_PROTOCOL_xxx variables can be manually set by user


### PR DESCRIPTION
If we have an OPENPROJECT_HOST__NAME present in ENV, it is expected that this is the sole host that OpenProject should respond to. If it's present, we can add it to `config.hosts` to get host header protections from Rails.

https://community.openproject.org/work_packages/55937