### PR TITLE
[#55898] Add uniqueness index to project_custom_field_project_mappings

### DIFF
--- a/app/services/project_custom_field_project_mappings/bulk_create_service.rb
+++ b/app/services/project_custom_field_project_mappings/bulk_create_service.rb
@@ -75,7 +75,8 @@ module ProjectCustomFieldProjectMappings
 
     def perform_bulk_create(service_call)
       ProjectCustomFieldProjectMapping.insert_all(
-        service_call.result.map { |model| model.attributes.slice("project_id", "custom_field_id") }
+        service_call.result.map { |model| model.attributes.slice("project_id", "custom_field_id") },
+        unique_by: %i[project_id custom_field_id]
       )
 
       service_call

--- a/app/services/project_custom_field_project_mappings/bulk_update_service.rb
+++ b/app/services/project_custom_field_project_mappings/bulk_update_service.rb
@@ -101,7 +101,10 @@ module ProjectCustomFieldProjectMappings
       new_mappings = custom_field_ids.map do |id|
         { project_id: @project.id, custom_field_id: id }
       end
-      ProjectCustomFieldProjectMapping.insert_all(new_mappings)
+      ProjectCustomFieldProjectMapping.insert_all(
+        new_mappings,
+        unique_by: %i[project_id custom_field_id]
+      )
     end
   end
 end

--- a/db/migrate/20240625075139_add_uniqueness_index_to_project_custom_field_project_mappings.rb
+++ b/db/migrate/20240625075139_add_uniqueness_index_to_project_custom_field_project_mappings.rb
@@ -1,0 +1,19 @@
+class AddUniquenessIndexToProjectCustomFieldProjectMappings < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM project_custom_field_project_mappings AS pcfpm_1
+        USING project_custom_field_project_mappings AS pcfpm_2
+      WHERE pcfpm_1.project_id = pcfpm_2.project_id
+        AND pcfpm_1.custom_field_id = pcfpm_2.custom_field_id
+        AND pcfpm_1.id > pcfpm_2.id;
+    SQL
+
+    add_index :project_custom_field_project_mappings, %i[project_id custom_field_id],
+              unique: true,
+              name: "index_project_custom_field_project_mappings_unique"
+  end
+
+  def down
+    remove_index :project_custom_field_project_mappings, name: "index_project_custom_field_project_mappings_unique"
+  end
+end

--- a/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
@@ -82,6 +82,20 @@ RSpec.describe ProjectCustomFieldProjectMappings::BulkCreateService do
         end
       end
     end
+
+    context "with duplicates" do
+      let(:project) { create(:project) }
+      let(:instance) { described_class.new(user:, projects: [project, project], project_custom_field:) }
+
+      it "creates the mappings only once" do
+        expect { instance.call }.to change(ProjectCustomFieldProjectMapping, :count).by(1)
+
+        aggregate_failures "creates the mapping for the correct project and custom field" do
+          expect(ProjectCustomFieldProjectMapping.last.project).to eq(project)
+          expect(ProjectCustomFieldProjectMapping.last.project_custom_field).to eq(project_custom_field)
+        end
+      end
+    end
   end
 
   context "with non-admin but sufficient permissions" do


### PR DESCRIPTION
to avoid duplicate rows if ActiveModel validations are bypassed.

https://community.openproject.org/work_packages/55898