### PR TITLE
Inline create support dark theme.

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_table_inline_create.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_inline_create.sass
@@ -14,10 +14,10 @@
     line-height: 1.6
 
 .wp-inline-create-row
-  background: #BEF3CA
+  background: var(--display-green-bgColor-muted)
 
   &:hover
-    background: darken(#BEF3CA, 5%) !important
+    background: var(--display-pine-bgColor-muted)
 
 .wp-table--cancel-create-td
   text-align: center !important


### PR DESCRIPTION
### Before:

<img width="780" alt="iShot_2024-06-25_17 24 29" src="https://github.com/opf/openproject/assets/1131536/3e11b898-c673-41a3-a726-1bc43dd43e4d">

### After:

##### On dark:

<img width="673" alt="iShot_2024-06-25_17 24 47" src="https://github.com/opf/openproject/assets/1131536/8f647bd2-f138-4207-acfd-7b9a527ce748">

<img width="682" alt="iShot_2024-06-25_17 25 05" src="https://github.com/opf/openproject/assets/1131536/e118f76c-d879-4a32-828e-ec7c71ffa6df">

##### On Light:

<img width="679" alt="iShot_2024-06-25_17 33 42" src="https://github.com/opf/openproject/assets/1131536/a1473bcf-d1e1-4884-89ac-7a1330f8584d">

<img width="596" alt="iShot_2024-06-25_17 33 52" src="https://github.com/opf/openproject/assets/1131536/44af85ee-a27c-413d-be3a-fa1694d1f92f">
