### PR TITLE
Fix rubocop workflow

### DIFF
--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -8,9 +8,9 @@ jobs:
     name: rubocop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2 # we are comparing PR merge head with base
+      - uses: actions/checkout@v4
+      - name: Fetch head commit of base branch
+        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
       - uses: opf/action-rubocop@master
         with:

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           rubocop_version: gemfile
-          rubocop_extensions: rubocop-inflector:gemfile rubocop-performance:gemfile rubocop-rails:gemfile rubocop-rspec:gemfile
+          rubocop_extensions: >
+            rubocop-capybara:gemfile
+            rubocop-factory_bot:gemfile
+            rubocop-performance:gemfile
+            rubocop-rails:gemfile
+            rubocop-rspec:gemfile
+            rubocop-rspec_rails:gemfile
           reporter: github-pr-check
           only_changed: true


### PR DESCRIPTION
rubocop extensions have changed and fetch depth 2 was failing in some cases, so just fetch the head of base branch in addition