### PR TITLE
Set host_name default only on non-prod systems

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -525,7 +525,12 @@ module Settings
         default: 7.days
       },
       host_name: {
-        default: "localhost:3000"
+        format: :string,
+        default: "localhost:3000",
+        default_by_env: {
+          # We do not want to set a localhost host name in production
+          production: nil
+        },
       },
       hours_per_day: {
         description: "This will define what is considered a “day” when displaying duration in a more natural way " \
@@ -1172,20 +1177,25 @@ module Settings
 
     def initialize(name,
                    default:,
+                   default_by_env: {},
                    description: nil,
                    format: nil,
                    writable: true,
                    allowed: nil,
                    env_alias: nil)
       self.name = name.to_s
-      @default = default.is_a?(Hash) ? default.deep_stringify_keys : default
-      @default.freeze
-      self.value = @default.dup
+      self.value = derive_default default_by_env.fetch(Rails.env.to_sym, default)
       self.format = format ? format.to_sym : deduce_format(value)
       self.writable = writable
       self.allowed = allowed
       self.env_alias = env_alias
       self.description = description.presence || :"setting_#{name}"
+    end
+
+    def derive_default(default)
+      @default = default.is_a?(Hash) ? default.deep_stringify_keys : default
+      @default.freeze
+      @default.dup
     end
 
     def default
@@ -1276,6 +1286,7 @@ module Settings
       #  from the ENV OPENPROJECT_2FA as well.
       def add(name,
               default:,
+              default_by_env: {},
               format: nil,
               description: nil,
               writable: true,
@@ -1288,6 +1299,7 @@ module Settings
                          format:,
                          description:,
                          default:,
+                         default_by_env:,
                          writable:,
                          allowed:,
                          env_alias:)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -180,6 +180,23 @@ RSpec.describe Setting do
         .to raise_error NoMethodError
     end
 
+    context "for a setting with an environment specific default value", :settings_reset do
+      before do
+        Settings::Definition.add(
+          "my_setting",
+          format: :string,
+          default: "The default",
+          default_by_env: {
+            test: "The test default"
+          }
+        )
+      end
+
+      it "uses the test specific default" do
+        expect(described_class.my_setting).to eq("The test default")
+      end
+    end
+
     context "for a integer setting with non-nil default value", :settings_reset do
       before do
         Settings::Definition.add(


### PR DESCRIPTION
On production, we do not want a localhost default host_name