### PR TITLE
Move ProjectQuery model to the main namespace

### DIFF
--- a/app/components/projects/delete_list_modal_component.html.erb
+++ b/app/components/projects/delete_list_modal_component.html.erb
@@ -4,13 +4,12 @@
                                      data: { 'test-selector': MODAL_ID })) do |d| %>
   <% d.with_header(variant: :large, mb: 2) %>
   <% d.with_body { t(:'projects.lists.delete_modal.text') } %>
-
   <% d.with_footer do %>
     <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>
-    <%= form_with(url: projects_query_path(query),
+    <%= form_with(url: project_query_path(query),
                   method: :delete) do %>
       <%= render(Primer::Beta::Button.new(scheme: :danger,
                                           type: :submit)) { I18n.t(:button_delete) } %>
-      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -9,7 +9,7 @@
           header:,
           message: t("lists.can_be_saved"),
           label: t("button_save"),
-          href: projects_query_path(query, projects_query_params),
+          href: project_query_path(query, projects_query_params),
           method: :patch
         )
       elsif can_save_as?
@@ -17,7 +17,7 @@
           header:,
           message: t("lists.can_be_saved_as"),
           label: t("button_save_as"),
-          href: new_projects_query_path(projects_query_params)
+          href: new_project_query_path(projects_query_params)
         )
       end
 
@@ -32,7 +32,7 @@
         if can_rename?
           menu.with_item(
             label: t('button_rename'),
-            href: rename_projects_query_path(query),
+            href: rename_project_query_path(query),
           ) do |item|
             item.with_leading_visual_icon(icon: :pencil)
           end
@@ -62,7 +62,7 @@
           menu_save_item(
             menu:,
             label: t('button_save'),
-            href: projects_query_path(query, projects_query_params),
+            href: project_query_path(query, projects_query_params),
             method: :patch
           )
         end
@@ -71,7 +71,7 @@
           menu_save_item(
             menu:,
             label: t('button_save_as'),
-            href: new_projects_query_path(projects_query_params)
+            href: new_project_query_path(projects_query_params)
           )
         end
 
@@ -96,7 +96,7 @@
               menu.with_item(
                 label: t(:button_unpublish),
                 scheme: :danger,
-                href: unpublish_projects_query_path(query),
+                href: unpublish_project_query_path(query),
                 content_arguments: { data: { method: :post } }
               ) do |item|
                 item.with_leading_visual_icon(icon: 'eye-closed')
@@ -105,7 +105,7 @@
               menu.with_item(
                 label: t(:button_publish),
                 scheme: :default,
-                href: publish_projects_query_path(query),
+                href: publish_project_query_path(query),
                 content_arguments: { data: { method: :post } }
               ) do |item|
                 item.with_leading_visual_icon(icon: 'eye')
@@ -132,7 +132,7 @@
     render(Primer::OpenProject::PageHeader.new) do |header|
       header.with_title(data: { 'test-selector': 'project-query-name'}) do
         primer_form_with(model: query,
-                         url: @query.new_record? ? projects_queries_path(projects_query_params) : projects_query_path(@query, projects_query_params),
+                         url: @query.new_record? ? project_queries_path(projects_query_params) : project_query_path(@query, projects_query_params),
                          scope: 'query',
                          id: 'project-save-form') do |f|
           render(

--- a/app/contracts/queries/projects/project_queries/base_contract.rb
+++ b/app/contracts/queries/projects/project_queries/base_contract.rb
@@ -34,7 +34,7 @@ module Queries::Projects::ProjectQueries
     attribute :orders
 
     def self.model
-      Queries::Projects::ProjectQuery
+      ProjectQuery
     end
 
     validates :name,

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -163,7 +163,7 @@ module Admin::Settings
     end
 
     def project_custom_field_mappings_query
-      @project_custom_field_mappings_query = Queries::Projects::ProjectQuery.new(
+      @project_custom_field_mappings_query = ProjectQuery.new(
         name: "project-custom-field-mappings-#{@custom_field.id}"
       ) do |query|
         query.where(:available_project_attributes, "=", [@custom_field.id])

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -113,6 +113,6 @@ class Projects::QueriesController < ApplicationController
   end
 
   def find_query
-    @query = Queries::Projects::ProjectQuery.visible(current_user).find(params[:id])
+    @query = ProjectQuery.visible(current_user).find(params[:id])
   end
 end

--- a/app/forms/queries/projects/form.rb
+++ b/app/forms/queries/projects/form.rb
@@ -36,7 +36,7 @@ class Queries::Projects::Form < ApplicationForm
         required: true,
         autofocus: true,
         name: "name",
-        label: Queries::Projects::ProjectQuery.human_attribute_name(:name),
+        label: ProjectQuery.human_attribute_name(:name),
         placeholder: I18n.t(:"projects.lists.new.placeholder")
       )
 

--- a/app/helpers/menus/projects.rb
+++ b/app/helpers/menus/projects.rb
@@ -79,14 +79,14 @@ module Menus
     end
 
     def public_filters
-      ::Queries::Projects::ProjectQuery
+      ::ProjectQuery
         .public_lists
         .order(:name)
         .map { |query| query_menu_item(query) }
     end
 
     def my_filters
-      ::Queries::Projects::ProjectQuery
+      ::ProjectQuery
         .private_lists(user: current_user)
         .order(:name)
         .map { |query| query_menu_item(query) }

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -53,7 +53,7 @@ module ProjectsHelper
   end
 
   def projects_columns_options
-    @projects_columns_options ||= ::Queries::Projects::ProjectQuery
+    @projects_columns_options ||= ::ProjectQuery
                                     .new
                                     .available_selects
                                     .reject { |c| c.attribute == :hierarchy }

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -31,7 +31,7 @@ class Member < ApplicationRecord
 
   ALLOWED_ENTITIES = [
     "WorkPackage",
-    "Queries::Projects::ProjectQuery"
+    "ProjectQuery"
   ].freeze
 
   extend DeprecatedAlias

--- a/app/models/project_queries/scopes/allowed_to.rb
+++ b/app/models/project_queries/scopes/allowed_to.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Projects::ProjectQueries::Scopes
+module ProjectQueries::Scopes
   module AllowedTo
     extend ActiveSupport::Concern
 

--- a/app/models/project_query.rb
+++ b/app/models/project_query.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Queries::Projects::ProjectQuery < ApplicationRecord
+class ProjectQuery < ApplicationRecord
   include Queries::BaseQuery
   include Queries::Serialization::Hash
   include HasMembers

--- a/app/models/queries/projects/factory.rb
+++ b/app/models/queries/projects/factory.rb
@@ -107,7 +107,7 @@ class Queries::Projects::Factory
     private
 
     def list_with(name)
-      Queries::Projects::ProjectQuery.new(name: I18n.t(name)) do |query|
+      ProjectQuery.new(name: I18n.t(name)) do |query|
         query.order("lft" => "asc")
         query.select(*Setting.enabled_projects_columns, add_not_existing: false)
 
@@ -133,7 +133,7 @@ class Queries::Projects::Factory
     end
 
     def find_persisted_query_and_set_attributes(id, params, user, duplicate:)
-      query = Queries::Projects::ProjectQuery.visible(user).find_by(id:)
+      query = ProjectQuery.visible(user).find_by(id:)
 
       return unless query
 
@@ -150,7 +150,7 @@ class Queries::Projects::Factory
     end
 
     def duplicate_query(query)
-      Queries::Projects::ProjectQuery.new(query.attributes.slice("filters", "orders", "selects"))
+      ProjectQuery.new(query.attributes.slice("filters", "orders", "selects"))
     end
 
     def set_query_attributes(query, params, user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User < Principal
 
   # Tries to authenticate a user in the database via external auth source
   # or password stored in the database
-  def self.try_authentication_for_existing_user(user, password, session = nil)
+  def self.try_authentication_for_existing_user(user, password, session = nil) # rubocop:disable Metrics/PerceivedComplexity
     activate_user! user, session if session
 
     return nil if !user.active? || OpenProject::Configuration.disable_password_login?
@@ -255,7 +255,7 @@ class User < Principal
 
   # Returns the user who matches the given autologin +key+ or nil
   def self.try_to_autologin(key)
-    token = Token::AutoLogin.find_by_plaintext_value(key)
+    token = Token::AutoLogin.find_by_plaintext_value(key) # rubocop:disable Rails/DynamicFindBy
     # Make sure there's only 1 token that matches the key
     if token && ((token.created_at > Setting.autologin.to_i.day.ago) && token.user && token.user.active?)
       token.user
@@ -525,7 +525,7 @@ class User < Principal
 
   # Returns the anonymous user.  If the anonymous user does not exist, it is created.  There can be only
   # one anonymous user per database.
-  def self.anonymous
+  def self.anonymous # rubocop:disable Metrics/AbcSize
     RequestStore[:anonymous_user] ||= begin
       anonymous_user = AnonymousUser.first
 
@@ -675,6 +675,6 @@ class User < Principal
   end
 
   def self.default_admin_account_changed?
-    !User.active.find_by_login("admin").try(:current_password).try(:matches_plaintext?, "admin")
+    !User.active.find_by_login("admin").try(:current_password).try(:matches_plaintext?, "admin") # rubocop:disable Rails/DynamicFindBy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,11 +26,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'digest/sha1'
+require "digest/sha1"
 
 class User < Principal
   VALID_NAME_REGEX = /\A[\d\p{Alpha}\p{Mark}\p{Space}\p{Emoji}'’´\-_.,@()+&*–]+\z/
-  CURRENT_USER_LOGIN_ALIAS = 'me'.freeze
+  CURRENT_USER_LOGIN_ALIAS = "me".freeze
   USER_FORMATS_STRUCTURE = {
     firstname_lastname: %i[firstname lastname],
     firstname: [:firstname],
@@ -45,40 +45,40 @@ class User < Principal
   include ::Users::PermissionChecks
   extend DeprecatedAlias
 
-  has_many :watches, class_name: 'Watcher',
+  has_many :watches, class_name: "Watcher",
                      dependent: :delete_all
   has_many :changesets, dependent: :nullify
   has_many :passwords, -> {
-    order('id DESC')
-  }, class_name: 'UserPassword',
+    order("id DESC")
+  }, class_name: "UserPassword",
      dependent: :destroy,
      inverse_of: :user
-  has_one :rss_token, class_name: '::Token::RSS', dependent: :destroy
-  has_one :api_token, class_name: '::Token::API', dependent: :destroy
+  has_one :rss_token, class_name: "::Token::RSS", dependent: :destroy
+  has_one :api_token, class_name: "::Token::API", dependent: :destroy
 
   # The user might have one invitation token
-  has_one :invitation_token, class_name: '::Token::Invitation', dependent: :destroy
+  has_one :invitation_token, class_name: "::Token::Invitation", dependent: :destroy
 
   # everytime a user subscribes to a calendar, a new ical_token is generated
   # unlike on other token types, all previously generated ical_tokens are kept
   # in order to keep all previously generated ical urls valid and usable
-  has_many :ical_tokens, class_name: '::Token::ICal', dependent: :destroy
+  has_many :ical_tokens, class_name: "::Token::ICal", dependent: :destroy
 
   belongs_to :ldap_auth_source, optional: true
 
   # Authorized OAuth grants
   has_many :oauth_grants,
-           class_name: 'Doorkeeper::AccessGrant',
-           foreign_key: 'resource_owner_id'
+           class_name: "Doorkeeper::AccessGrant",
+           foreign_key: "resource_owner_id"
 
   # User-defined oauth applications
   has_many :oauth_applications,
-           class_name: 'Doorkeeper::Application',
+           class_name: "Doorkeeper::Application",
            as: :owner
 
   # Meeting memberships
   has_many :meeting_participants,
-           class_name: 'MeetingParticipant',
+           class_name: "MeetingParticipant",
            inverse_of: :user,
            dependent: :destroy
 
@@ -86,7 +86,7 @@ class User < Principal
            dependent: :destroy
 
   has_many :project_queries,
-           class_name: 'Queries::Projects::ProjectQuery',
+           class_name: "ProjectQuery",
            inverse_of: :user,
            dependent: :destroy
 
@@ -109,7 +109,7 @@ class User < Principal
   def self.blocked_condition(blocked)
     block_duration = Setting.brute_force_block_minutes.to_i.minutes
     blocked_if_login_since = Time.now - block_duration
-    negation = blocked ? '' : 'NOT'
+    negation = blocked ? "" : "NOT"
 
     ["#{negation} (users.failed_login_count >= ? AND users.last_failed_login_on > ?)",
      Setting.brute_force_block_after_failed_logins.to_i,
@@ -141,7 +141,7 @@ class User < Principal
   validates :password,
             confirmation: {
               allow_nil: true,
-              message: ->(*) { I18n.t('activerecord.errors.models.user.attributes.password_confirmation.confirmation') }
+              message: ->(*) { I18n.t("activerecord.errors.models.user.attributes.password_confirmation.confirmation") }
             }
 
   auto_strip_attributes :login, nullify: false
@@ -295,7 +295,7 @@ class User < Principal
   def authentication_provider
     return if identity_url.blank?
 
-    identity_url.split(':', 2).first.titleize
+    identity_url.split(":", 2).first.titleize
   end
 
   ##
@@ -531,14 +531,14 @@ class User < Principal
 
       if anonymous_user.nil?
         (anonymous_user = AnonymousUser.new.tap do |u|
-          u.lastname = 'Anonymous'
-          u.login = ''
-          u.firstname = ''
-          u.mail = ''
+          u.lastname = "Anonymous"
+          u.login = ""
+          u.firstname = ""
+          u.mail = ""
           u.status = User.statuses[:active]
         end).save
 
-        raise 'Unable to create the anonymous user.' if anonymous_user.new_record?
+        raise "Unable to create the anonymous user." if anonymous_user.new_record?
       end
       anonymous_user
     end
@@ -560,7 +560,7 @@ class User < Principal
 
       system_user.save(validate: false)
 
-      raise 'Unable to create the automatic migration user.' unless system_user.persisted?
+      raise "Unable to create the automatic migration user." unless system_user.persisted?
     end
 
     system_user
@@ -586,7 +586,7 @@ class User < Principal
 
       if former_passwords_include?(password)
         errors.add(:password,
-                   I18n.t('activerecord.errors.models.user.attributes.password.reused',
+                   I18n.t("activerecord.errors.models.user.attributes.password.reused",
                           count: Setting[:password_count_former_banned].to_i))
       end
     end
@@ -596,7 +596,7 @@ class User < Principal
 
   def self.mail_regexp(mail)
     separators = Regexp.escape(Setting.mail_suffix_separators)
-    recipient, domain = mail.split('@').map { |part| Regexp.escape(part) }
+    recipient, domain = mail.split("@").map { |part| Regexp.escape(part) }
     skip_suffix_check = recipient.nil? || Setting.mail_suffix_separators.empty? || recipient.match?(/.+[#{separators}].+/)
     regexp = "^#{recipient}([#{separators}][^@]+)*@#{domain}$"
 
@@ -675,6 +675,6 @@ class User < Principal
   end
 
   def self.default_admin_account_changed?
-    !User.active.find_by_login('admin').try(:current_password).try(:matches_plaintext?, 'admin')
+    !User.active.find_by_login("admin").try(:current_password).try(:matches_plaintext?, "admin")
   end
 end

--- a/app/services/params_to_query_service.rb
+++ b/app/services/params_to_query_service.rb
@@ -123,7 +123,9 @@ class ParamsToQueryService
                        else
                          model_name = model.name
 
-                         "#{model_name.demodulize}Query".constantize
+                         # Some queries exist as Queries::Models::ModelQuery others as ModelQuery
+                         "::Queries::#{model_name.pluralize}::#{model_name.demodulize}Query".safe_constantize ||
+                          "::#{model_name.demodulize}Query".constantize
                        end
   end
 end

--- a/app/services/params_to_query_service.rb
+++ b/app/services/params_to_query_service.rb
@@ -123,7 +123,7 @@ class ParamsToQueryService
                        else
                          model_name = model.name
 
-                         "::Queries::#{model_name.pluralize}::#{model_name.demodulize}Query".constantize
+                         "#{model_name.demodulize}Query".constantize
                        end
   end
 end

--- a/app/services/queries/projects/project_queries/create_service.rb
+++ b/app/services/queries/projects/project_queries/create_service.rb
@@ -35,4 +35,8 @@ class Queries::Projects::ProjectQueries::CreateService < BaseServices::Create
   def instance(_params)
     @from || super
   end
+
+  def instance_class
+    ProjectQuery
+  end
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -27,7 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title(t(:label_project_plural)) -%>
-
 <div class="project-list-page">
   <%= render(
         Projects::IndexPageHeaderComponent.new(
@@ -38,13 +37,10 @@ See COPYRIGHT and LICENSE files for more details.
         )
       )
   %>
-
   <%= render(Projects::IndexSubHeaderComponent.new(query:, current_user:, disable_buttons: state === :rename)) %>
-
   <%= render Projects::TableComponent.new(
     query:,
     current_user: current_user,
     params:) %>
-
   <%= render Projects::DiskUsageInformationComponent.new(current_user: current_user) %>
 </div>

--- a/app/workers/projects/export_job.rb
+++ b/app/workers/projects/export_job.rb
@@ -7,7 +7,7 @@ module Projects
     private
 
     def prepare!
-      self.query = ::Queries::Projects::ProjectQuery.from_hash(query)
+      self.query = ::ProjectQuery.from_hash(query)
     end
   end
 end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -434,7 +434,7 @@ module Settings
       },
       enabled_projects_columns: {
         default: %w[favored name project_status public created_at latest_activity_at required_disk_space],
-        allowed: -> { Queries::Projects::ProjectQuery.new.available_selects.map { |s| s.attribute.to_s } }
+        allowed: -> { ProjectQuery.new.available_selects.map { |s| s.attribute.to_s } }
       },
       enabled_scm: {
         default: %w[subversion git]
@@ -530,7 +530,7 @@ module Settings
         default_by_env: {
           # We do not want to set a localhost host name in production
           production: nil
-        },
+        }
       },
       hours_per_day: {
         description: "This will define what is considered a “day” when displaying duration in a more natural way " \
@@ -1037,7 +1037,7 @@ module Settings
       },
       smtp_timeout: {
         format: :integer,
-        default: 5,
+        default: 5
       },
       software_name: {
         description: "Override software application name",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,16 +179,17 @@ Rails.application.routes.draw do
     delete "/favorite" => "favorites#unfavorite"
   end
 
+  resources :project_queries, only: %i[show new create update destroy], controller: "projects/queries" do
+    member do
+      get :rename
+
+      post :publish
+      post :unpublish
+    end
+  end
+
   namespace :projects do
     resource :menu, only: %i[show]
-    resources :queries, only: %i[show new create update destroy] do
-      member do
-        get :rename
-
-        post :publish
-        post :unpublish
-      end
-    end
   end
 
   resources :projects, except: %i[show edit create update] do

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -100,7 +100,7 @@ module OpenProject
                            :work_package
                          when Project
                            :project
-                         when ::Queries::Projects::ProjectQuery
+                         when ::ProjectQuery
                            :project_query
                          when Symbol
                            context_type

--- a/lookbook/previews/open_project/filter/filter_button_component_preview.rb
+++ b/lookbook/previews/open_project/filter/filter_button_component_preview.rb
@@ -3,7 +3,7 @@ module OpenProject
     # @logical_path OpenProject/Filter
     class FilterButtonComponentPreview < Lookbook::Preview
       def default
-        @query = Queries::Projects::ProjectQuery.new
+        @query = ProjectQuery.new
         render(::Filter::FilterButtonComponent.new(query: @query))
       end
 
@@ -12,7 +12,7 @@ module OpenProject
       # Just register the controller in a container around both elements.
       # Unfortunately, stimulus controllers do not work in our lookbook as of now, so you will see no effect.
       def filter_section_toggle
-        @query = Queries::Projects::ProjectQuery.new
+        @query = ProjectQuery.new
         render_with_template(locals: { query: @query })
       end
     end

--- a/lookbook/previews/open_project/filter/filters_component_preview.rb
+++ b/lookbook/previews/open_project/filter/filters_component_preview.rb
@@ -3,7 +3,7 @@ module OpenProject
     # @logical_path OpenProject/Filter
     class FiltersComponentPreview < Lookbook::Preview
       def default
-        @query = Queries::Projects::ProjectQuery.new
+        @query = ProjectQuery.new
         render(Projects::ProjectsFiltersComponent.new(query: @query))
       end
     end

--- a/lookbook/previews/open_project/queries/sort_by_component_preview.rb
+++ b/lookbook/previews/open_project/queries/sort_by_component_preview.rb
@@ -2,7 +2,7 @@ module OpenProject::Queries
   # @logical_path OpenProject/Queries
   class SortByComponentPreview < Lookbook::Preview
     def default
-      query = ::Queries::Projects::ProjectQuery.new
+      query = ::ProjectQuery.new
       query.order(lft: :asc)
       query.order(created_at: :desc)
 

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -239,7 +239,7 @@ module OpenProject::Storages
           exclude filter
         end
 
-        ::Queries::Register.register(::Queries::Projects::ProjectQuery) do
+        ::Queries::Register.register(::ProjectQuery) do
           filter ::Queries::Storages::Projects::Filter::StorageIdFilter
           filter ::Queries::Storages::Projects::Filter::StorageUrlFilter
         end

--- a/spec/contracts/queries/projects/project_queries/create_contract_spec.rb
+++ b/spec/contracts/queries/projects/project_queries/create_contract_spec.rb
@@ -32,7 +32,7 @@ require_relative "shared_contract_examples"
 RSpec.describe Queries::Projects::ProjectQueries::CreateContract do
   it_behaves_like "project queries contract" do
     let(:query) do
-      Queries::Projects::ProjectQuery.new(name: query_name).tap do |query|
+      ProjectQuery.new(name: query_name).tap do |query|
         query.extend(OpenProject::ChangedBySystem)
 
         query.change_by_system do

--- a/spec/contracts/queries/projects/project_queries/loading_contract_spec.rb
+++ b/spec/contracts/queries/projects/project_queries/loading_contract_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Queries::Projects::ProjectQueries::LoadingContract do
   let(:query_orders) { [%w[name asc]] }
   let(:query_columns) { ["name", "public"] }
   let(:query) do
-    Queries::Projects::ProjectQuery.new do |query|
+    ProjectQuery.new do |query|
       query_filters.each do |key, operator, values|
         query.where(key, operator, values)
       end

--- a/spec/contracts/queries/projects/project_queries/update_contract_spec.rb
+++ b/spec/contracts/queries/projects/project_queries/update_contract_spec.rb
@@ -32,7 +32,7 @@ require_relative "shared_contract_examples"
 RSpec.describe Queries::Projects::ProjectQueries::UpdateContract do
   it_behaves_like "project queries contract" do
     let(:query) do
-      Queries::Projects::ProjectQuery.new(name: query_name).tap do |query|
+      ProjectQuery.new(name: query_name).tap do |query|
         query.extend(OpenProject::ChangedBySystem)
 
         query.change_by_system do

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Projects::QueriesController do
 
     before do
       scope = instance_double(ActiveRecord::Relation)
-      allow(Queries::Projects::ProjectQuery).to receive(:visible).with(user).and_return(scope)
+      allow(ProjectQuery).to receive(:visible).with(user).and_return(scope)
       allow(scope).to receive(:find).with(query.id.to_s).and_return(query)
 
       login_as user
@@ -97,7 +97,7 @@ RSpec.describe Projects::QueriesController do
 
       before do
         scope = instance_double(ActiveRecord::Relation)
-        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(ProjectQuery).to receive(:visible).and_return(scope)
         allow(scope).to receive(:find).with(query_id).and_return(query)
 
         login_as user
@@ -210,7 +210,7 @@ RSpec.describe Projects::QueriesController do
       before do
         allow(controller).to receive(:permitted_query_params).and_return(query_params)
         scope = instance_double(ActiveRecord::Relation)
-        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(ProjectQuery).to receive(:visible).and_return(scope)
         allow(scope).to receive(:find).with(query_id).and_return(query)
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
         allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
@@ -283,7 +283,7 @@ RSpec.describe Projects::QueriesController do
       before do
         allow(controller).to receive(:permitted_query_params).and_return(query_params)
         scope = instance_double(ActiveRecord::Relation)
-        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(ProjectQuery).to receive(:visible).and_return(scope)
         allow(scope).to receive(:find).with(query_id).and_return(query)
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
         allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
@@ -356,7 +356,7 @@ RSpec.describe Projects::QueriesController do
       before do
         allow(controller).to receive(:permitted_query_params).and_return(query_params)
         scope = instance_double(ActiveRecord::Relation)
-        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(ProjectQuery).to receive(:visible).and_return(scope)
         allow(scope).to receive(:find).with(query_id).and_return(query)
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
         allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
@@ -425,7 +425,7 @@ RSpec.describe Projects::QueriesController do
 
       before do
         scope = instance_double(ActiveRecord::Relation)
-        allow(Queries::Projects::ProjectQuery).to receive(:visible).and_return(scope)
+        allow(ProjectQuery).to receive(:visible).and_return(scope)
         allow(scope).to receive(:find).with(query_id).and_return(query)
 
         allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)

--- a/spec/factories/principal_factory.rb
+++ b/spec/factories/principal_factory.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
           create(:member, principal:, project: object, roles: Array(role_or_roles))
         when WorkPackage
           create(:member, principal:, entity: object, project: object.project, roles: Array(role_or_roles))
-        when Queries::Projects::ProjectQuery
+        when ProjectQuery
           create(:member, principal:, entity: object, project: nil, roles: Array(role_or_roles))
         end
       end

--- a/spec/factories/queries/project_query_factory.rb
+++ b/spec/factories/queries/project_query_factory.rb
@@ -27,7 +27,7 @@
 # ++
 
 FactoryBot.define do
-  factory :project_query, class: "Queries::Projects::ProjectQuery" do
+  factory :project_query, class: "ProjectQuery" do
     sequence(:name) { |n| "Project query #{n}" }
     public { false }
 

--- a/spec/helpers/menus/projects_spec.rb
+++ b/spec/helpers/menus/projects_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe Menus::Projects do
   shared_let(:current_user) { build(:user) }
 
   shared_let(:current_user_query) do
-    Queries::Projects::ProjectQuery.create!(name: "Current user query", user: current_user)
+    ProjectQuery.create!(name: "Current user query", user: current_user)
   end
 
   shared_let(:other_user_query) do
-    Queries::Projects::ProjectQuery.create!(name: "Other user query", user: build(:user))
+    ProjectQuery.create!(name: "Other user query", user: build(:user))
   end
 
   shared_let(:public_query) do
-    Queries::Projects::ProjectQuery.create!(name: "Public query", user: build(:user), public: true)
+    ProjectQuery.create!(name: "Public query", user: build(:user), public: true)
   end
 
   subject(:first_level_menu_items) { instance.first_level_menu_items }

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe ProjectsHelper do
       Queries::Projects::Selects::Status.new(:project_status)
     ]
 
-    query_instance = instance_double(Queries::Projects::ProjectQuery, available_selects: selects)
+    query_instance = instance_double(ProjectQuery, available_selects: selects)
 
-    allow(Queries::Projects::ProjectQuery)
+    allow(ProjectQuery)
       .to receive(:new)
             .and_return(query_instance)
   end

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
       it { expect(permission).to be_permissible_on(WorkPackage.new) }
       it { expect(permission).not_to be_permissible_on(Project.new) }
       it { expect(permission).not_to be_permissible_on(nil) }
-      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(ProjectQuery.new) }
       it { expect(permission).to be_permissible_on(:work_package) }
       it { expect(permission).not_to be_permissible_on(:project) }
       it { expect(permission).not_to be_permissible_on(:global) }
@@ -103,7 +103,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
       it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
       it { expect(permission).to be_permissible_on(Project.new) }
       it { expect(permission).not_to be_permissible_on(nil) }
-      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(ProjectQuery.new) }
       it { expect(permission).not_to be_permissible_on(:work_package) }
       it { expect(permission).to be_permissible_on(:project) }
       it { expect(permission).not_to be_permissible_on(:global) }
@@ -118,7 +118,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
       it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
       it { expect(permission).not_to be_permissible_on(Project.new) }
       it { expect(permission).to be_permissible_on(nil) }
-      it { expect(permission).not_to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).not_to be_permissible_on(ProjectQuery.new) }
       it { expect(permission).not_to be_permissible_on(:work_package) }
       it { expect(permission).not_to be_permissible_on(:project) }
       it { expect(permission).to be_permissible_on(:global) }
@@ -133,7 +133,7 @@ RSpec.describe OpenProject::AccessControl::Permission do
       it { expect(permission).not_to be_permissible_on(WorkPackage.new) }
       it { expect(permission).not_to be_permissible_on(Project.new) }
       it { expect(permission).not_to be_permissible_on(nil) }
-      it { expect(permission).to be_permissible_on(Queries::Projects::ProjectQuery.new) }
+      it { expect(permission).to be_permissible_on(ProjectQuery.new) }
       it { expect(permission).not_to be_permissible_on(:work_package) }
       it { expect(permission).not_to be_permissible_on(:project) }
       it { expect(permission).not_to be_permissible_on(:global) }

--- a/spec/models/project_queries/scopes/allowed_to_spec.rb
+++ b/spec/models/project_queries/scopes/allowed_to_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe Queries::Projects::ProjectQuery, "#allowed to" do # rubocop:disable RSpec/RSpec/SpecFilePathFormat
+RSpec.describe ProjectQuery, "#allowed to" do # rubocop:disable RSpec/RSpec/SpecFilePathFormat
   shared_let(:user) { create(:user) }
   shared_let(:other_user) { create(:user) }
 

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Queries::Projects::Factory,
   before do
     scope = instance_double(ActiveRecord::Relation)
 
-    allow(Queries::Projects::ProjectQuery)
+    allow(ProjectQuery)
       .to receive(:visible)
             .with(current_user)
             .and_return(scope)
@@ -87,7 +87,7 @@ RSpec.describe Queries::Projects::Factory,
     context "without id" do
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -135,7 +135,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -166,7 +166,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -197,7 +197,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -228,7 +228,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -259,7 +259,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -290,7 +290,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has a name" do
@@ -389,7 +389,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -421,7 +421,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -468,7 +468,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -515,7 +515,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -551,7 +551,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -583,7 +583,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -632,7 +632,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "keeps the name" do
@@ -677,7 +677,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "keeps the name" do
@@ -713,7 +713,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "keeps the name" do
@@ -781,7 +781,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "has no name" do
@@ -838,7 +838,7 @@ RSpec.describe Queries::Projects::Factory,
 
       it "returns a project query" do
         expect(find)
-          .to be_a(Queries::Projects::ProjectQuery)
+          .to be_a(ProjectQuery)
       end
 
       it "keeps the name" do
@@ -888,7 +888,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do
@@ -917,7 +917,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do
@@ -946,7 +946,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do
@@ -975,7 +975,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do
@@ -1004,7 +1004,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do
@@ -1033,7 +1033,7 @@ RSpec.describe Queries::Projects::Factory,
 
     it "returns a project query" do
       expect(find)
-        .to be_a(Queries::Projects::ProjectQuery)
+        .to be_a(ProjectQuery)
     end
 
     it "has a name" do

--- a/spec/models/queries/projects/filters/custom_field_filter_spec.rb
+++ b/spec/models/queries/projects/filters/custom_field_filter_spec.rb
@@ -29,7 +29,7 @@
 require "spec_helper"
 
 RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
-  let(:query) { Queries::Projects::ProjectQuery.new }
+  let(:query) { ProjectQuery.new }
   let(:bool_project_custom_field) { build_stubbed(:boolean_project_custom_field) }
   let(:int_project_custom_field) { build_stubbed(:integer_project_custom_field) }
   let(:float_project_custom_field) { build_stubbed(:float_project_custom_field) }

--- a/spec/models/queries/projects/project_query_results_spec.rb
+++ b/spec/models/queries/projects/project_query_results_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe Queries::Projects::ProjectQuery, "results" do
+RSpec.describe ProjectQuery, "results" do
   let(:instance) { described_class.new }
   let(:base_scope) { Project.order(id: :desc) }
 

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe Queries::Projects::ProjectQuery do
+RSpec.describe ProjectQuery do
   let(:instance) { described_class.new }
 
   shared_let(:user) { create(:user) }

--- a/spec/routing/project_queries_routing_spec.rb
+++ b/spec/routing/project_queries_routing_spec.rb
@@ -29,16 +29,16 @@
 require "spec_helper"
 
 RSpec.describe "Project query routes" do
-  it "/projects/queries/new GET routes to projects/queries#new" do
-    expect(get("/projects/queries/new")).to route_to("projects/queries#new")
+  it "/project_queries/new GET routes to projects/queries#new" do
+    expect(get("/project_queries/new")).to route_to("projects/queries#new")
   end
 
-  it "/projects/queries POST routes to projects/queries#create" do
-    expect(post("/projects/queries")).to route_to("projects/queries#create")
+  it "/project_queries POST routes to projects/queries#create" do
+    expect(post("/project_queries")).to route_to("projects/queries#create")
   end
 
-  it "/projects/queries/:id DELETE routes to projects/queries#destroy" do
-    expect(delete("/projects/queries/42")).to route_to("projects/queries#destroy",
-                                                       id: "42")
+  it "/project_queries/:id DELETE routes to projects/queries#destroy" do
+    expect(delete("/project_queries/42")).to route_to("projects/queries#destroy",
+                                                      id: "42")
   end
 end

--- a/spec/services/params_to_query_service_project_query_spec.rb
+++ b/spec/services/params_to_query_service_project_query_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ParamsToQueryService, "project query" do
 
       it "returns a new query" do
         expect(service_call)
-          .to be_a Queries::Projects::ProjectQuery
+          .to be_a ProjectQuery
       end
 
       it "applies the filters" do
@@ -59,7 +59,7 @@ RSpec.describe ParamsToQueryService, "project query" do
     context "when sending neither filters nor orders props" do
       it "returns a new query" do
         expect(service_call)
-          .to be_a Queries::Projects::ProjectQuery
+          .to be_a ProjectQuery
       end
 
       it "sets no name" do

--- a/spec/services/queries/projects/project_queries/create_service_spec.rb
+++ b/spec/services/queries/projects/project_queries/create_service_spec.rb
@@ -31,6 +31,7 @@ require "services/base_services/behaves_like_create_service"
 
 RSpec.describe Queries::Projects::ProjectQueries::CreateService, type: :model do
   it_behaves_like "BaseServices create service" do
+    let(:model_class) { ProjectQuery }
     let(:factory) { :project_query }
   end
 

--- a/spec/services/queries/projects/project_queries/set_attributes_service_spec.rb
+++ b/spec/services/queries/projects/project_queries/set_attributes_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
                         contract_class:,
                         contract_options: {})
   end
-  let(:model_instance) { Queries::Projects::ProjectQuery.new }
+  let(:model_instance) { ProjectQuery.new }
   let(:contract_class) do
     allow(Queries::Projects::ProjectQueries::CreateContract)
       .to receive(:new)
@@ -191,7 +191,7 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
 
   context "with the query already having order and with order params" do
     let(:model_instance) do
-      Queries::Projects::ProjectQuery.new.tap do |query|
+      ProjectQuery.new.tap do |query|
         query.order(lft: :asc)
       end
     end
@@ -224,7 +224,7 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
 
   context "with the query already having filters and with filter params" do
     let(:model_instance) do
-      Queries::Projects::ProjectQuery.new.tap do |query|
+      ProjectQuery.new.tap do |query|
         query.where("active", "=", ["t"])
       end
     end
@@ -254,7 +254,7 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
 
   context "with the query already having selects and with selects params" do
     let(:model_instance) do
-      Queries::Projects::ProjectQuery.new.tap do |query|
+      ProjectQuery.new.tap do |query|
         query.select(:id, :name)
       end
     end

--- a/spec/workers/principals/delete_job_integration_spec.rb
+++ b/spec/workers/principals/delete_job_integration_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe Principals::DeleteJob, type: :model do
       it "removes the query" do
         job
 
-        expect(Queries::Projects::ProjectQuery.find_by(id: query.id)).to be_nil
+        expect(ProjectQuery.find_by(id: query.id)).to be_nil
       end
     end
 


### PR DESCRIPTION
With the current place where the model is, we break all sorts of automations that Rails bring us (i.e. automatically building proper routes with `url_for(@project_query)`. This will become really problematic when implementing sharing #15971.

This PR moves the class to the main namespace without any namespacing so it can be accessed like any other model