### PR TITLE
[#55988] New project filter option to include all members assigned projects automatically.

### DIFF
--- a/app/contracts/queries/base_contract.rb
+++ b/app/contracts/queries/base_contract.rb
@@ -42,6 +42,7 @@ module Queries
     attribute :show_hierarchies
     attribute :display_representation
     attribute :include_subprojects
+    attribute :include_all_members_assigned_projects
 
     attribute :column_names # => columns
     attribute :filters

--- a/app/models/queries/work_packages/filter/all_members_assigned_projects_filter.rb
+++ b/app/models/queries/work_packages/filter/all_members_assigned_projects_filter.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::WorkPackages::Filter::AllMembersAssignedProjectsFilter <
+  Queries::WorkPackages::Filter::WorkPackageFilter
+  include Queries::Filters::Shared::BooleanFilter
+
+  def available?
+    project.present?
+  end
+
+  def self.key
+    :project_id
+  end
+
+  def human_name
+    I18n.t("js.label_all_members_assigned_projects")
+  end
+
+  def where
+    "#{Project.table_name}.id IN (%s)" % ids_for_where.join(",")
+  end
+
+  protected
+
+  def ids_for_where
+    WorkPackage.where(assigned_to_id: project.members.pluck(:user_id))
+      .select(:project_id).distinct.pluck(:project_id)
+  end
+end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -398,6 +398,12 @@ class Query < ApplicationRecord
   end
 
   def project_limiting_filter
+    if include_all_members_assigned_projects?
+      all_members_assigned_projects_filter = Queries::WorkPackages::Filter::AllMembersAssignedProjectsFilter.create!
+      all_members_assigned_projects_filter.context = self
+      return all_members_assigned_projects_filter
+    end
+
     return if project_filter_set?
 
     subproject_filter = Queries::WorkPackages::Filter::SubprojectFilter.create!

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -51,6 +51,8 @@ class Query < ApplicationRecord
 
   validates :include_subprojects,
             inclusion: [true, false]
+  validates :include_all_members_assigned_projects,
+            inclusion: [true, false]
 
   validate :validate_work_package_filters
   validate :validate_columns

--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -73,6 +73,7 @@ module API
           display_representation: params[:displayRepresentation],
           show_hierarchies: boolearize(params[:showHierarchies]),
           include_subprojects: boolearize(params[:includeSubprojects]),
+          include_all_members_assigned_projects: boolearize(params[:includeAllMembersAssignedProjects]),
           timestamps: Timestamp.parse_multiple(params[:timestamps])
         }
       rescue ArgumentError => e

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -54,6 +54,8 @@ class UpdateQueryFromParamsService
 
     apply_include_subprojects(params)
 
+    apply_include_all_members_assigned_projects(params)
+
     apply_timestamps(params)
 
     disable_hierarchy_when_only_grouped_by(params)
@@ -119,6 +121,10 @@ class UpdateQueryFromParamsService
 
   def apply_include_subprojects(params)
     query.include_subprojects = params[:include_subprojects] if params.key?(:include_subprojects)
+  end
+
+  def apply_include_all_members_assigned_projects(params)
+    query.include_all_members_assigned_projects = params[:include_all_members_assigned_projects] if params.key?(:include_all_members_assigned_projects)
   end
 
   def apply_timestamps(params)

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -569,6 +569,7 @@ en:
     label_sort_lower: "Move down"
     label_sorting: "Sorting"
     label_spent_time: "Spent time"
+    label_all_members_assigned_projects: "Include all members assigned projects"
     label_star_query: "Favored"
     label_press_enter_to_save: "Press enter to save."
     label_public_query: "Public"
@@ -1138,6 +1139,7 @@ en:
         confirm_edit_cancel: "Are you sure you want to cancel editing the name of this view? Title will be set back to previous value."
         click_to_edit_query_name: "Click to edit title of this view."
         rename_query_placeholder: "Name of this view"
+        all_members_assigned_projects_text: "Mark this view including all members assigned projects and no need to select those members's projects in project list."
         star_text: "Mark this view as favorite and add to the saved views sidebar on the left."
         public_text: >
           Publish this view, allowing other users to access your view. Users with the 'Manage public views' permission can modify or remove public query.

--- a/db/migrate/20240627022151_add_include_all_members_assigned_projects_to_query.rb
+++ b/db/migrate/20240627022151_add_include_all_members_assigned_projects_to_query.rb
@@ -1,0 +1,9 @@
+class AddIncludeAllMembersAssignedProjectsToQuery < ActiveRecord::Migration[7.1]
+  def change
+    add_column :queries,
+               :include_all_members_assigned_projects,
+               :boolean,
+               null: false,
+               default: false
+  end
+end

--- a/frontend/src/app/features/hal/resources/query-resource.ts
+++ b/frontend/src/app/features/hal/resources/query-resource.ts
@@ -104,6 +104,8 @@ export class QueryResource extends HalResource {
 
   public includeSubprojects:boolean;
 
+  public includeAllMembersAssignedProjects:boolean;
+
   public ordered_work_packages:QueryOrder;
 
   public $initialize(source:any) {

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
@@ -63,6 +63,8 @@ export interface QueryProps {
   hla?:string[];
   // Display representation
   dr?:string;
+  // Include all members assigned projects
+  imp?:boolean;
   // Include subprojects
   is?:boolean;
   // Pagination
@@ -88,6 +90,7 @@ export interface QueryRequestParams {
   timelineLabels:string;
   timelineZoomLevel:string;
   displayRepresentation:string;
+  includeAllMembersAssignedProjects:boolean;
   includeSubprojects:boolean;
   highlightingMode:string;
   'highlightedAttributes[]':string[];
@@ -274,6 +277,10 @@ export class UrlParamsHelperService {
       queryData.displayRepresentation = properties.dr;
     }
 
+    if (properties.imp !== undefined) {
+      queryData.includeAllMembersAssignedProjects = properties.imp;
+    }
+
     if (properties.is !== undefined) {
       queryData.includeSubprojects = properties.is;
     }
@@ -361,6 +368,7 @@ export class UrlParamsHelperService {
       queryData.displayRepresentation = query.displayRepresentation;
     }
 
+    queryData.includeAllMembersAssignedProjects = !!query.includeAllMembersAssignedProjects;
     queryData.includeSubprojects = !!query.includeSubprojects;
     queryData.showHierarchies = !!query.showHierarchies;
     queryData.groupBy = _.get(query.groupBy, 'id', '');

--- a/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
+++ b/frontend/src/app/shared/components/modals/save-modal/save-query.modal.html
@@ -35,6 +35,7 @@
       <query-sharing-form
         [isSave]="true"
         (onChange)="setValues($event)"
+        [isShowAllMembersAssignedProjects]="includeAllMembersAssignedProjects"
         [isStarred]="isStarred"
         [isPublic]="isPublic">
       </query-sharing-form>

--- a/frontend/src/app/shared/components/modals/save-modal/save-query.modal.ts
+++ b/frontend/src/app/shared/components/modals/save-modal/save-query.modal.ts
@@ -47,6 +47,8 @@ import { States } from 'core-app/core/states/states.service';
 export class SaveQueryModalComponent extends OpModalComponent {
   public queryName = '';
 
+  public includeAllMembersAssignedProjects = false;
+
   public isStarred = false;
 
   public isPublic = false;
@@ -81,6 +83,7 @@ export class SaveQueryModalComponent extends OpModalComponent {
   }
 
   public setValues(change:QuerySharingChange):void {
+    this.includeAllMembersAssignedProjects = change.includeAllMembersAssignedProjects;
     this.isStarred = change.isStarred;
     this.isPublic = change.isPublic;
   }
@@ -102,6 +105,7 @@ export class SaveQueryModalComponent extends OpModalComponent {
 
     this.isBusy = true;
     const query = this.querySpace.query.value!;
+    query.includeAllMembersAssignedProjects = this.includeAllMembersAssignedProjects;
     query.public = this.isPublic;
 
     this.wpListService

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.component.ts
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.component.ts
@@ -7,6 +7,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 
 export interface QuerySharingChange {
+  includeAllMembersAssignedProjects:boolean;
   isStarred:boolean;
   isPublic:boolean;
 }
@@ -18,6 +19,8 @@ export interface QuerySharingChange {
 export class QuerySharingFormComponent {
   @Input() public isSave:boolean;
 
+  @Input() public isShowAllMembersAssignedProjects:boolean;
+
   @Input() public isStarred:boolean;
 
   @Input() public isPublic:boolean;
@@ -25,9 +28,11 @@ export class QuerySharingFormComponent {
   @Output() public onChange = new EventEmitter<QuerySharingChange>();
 
   public text = {
+    showAllMembersAssignedProjects: this.I18n.t('js.label_all_members_assigned_projects'),
     showInMenu: this.I18n.t('js.label_star_query'),
     visibleForOthers: this.I18n.t('js.label_public_query'),
 
+    showAllMembersAssignedProjectsText: this.I18n.t('js.work_packages.query.all_members_assigned_projects_text'),
     showInMenuText: this.I18n.t('js.work_packages.query.star_text'),
     visibleForOthersText: this.I18n.t('js.work_packages.query.public_text'),
   };
@@ -35,7 +40,12 @@ export class QuerySharingFormComponent {
   constructor(readonly states:States,
     readonly querySpace:IsolatedQuerySpace,
     readonly authorisationService:AuthorisationService,
-    readonly I18n:I18nService) {
+    readonly I18n:I18nService,
+  ) {
+  }
+
+  public get canShowAllMembersAssignedProjects() {
+    return this.authorisationService.can('query', 'updateImmediately');
   }
 
   public get canStar() {
@@ -51,6 +61,11 @@ export class QuerySharingFormComponent {
       && form.schema.public.writable;
   }
 
+  public updateShowAllMembersAssignedProjects(val:boolean) {
+    this.isShowAllMembersAssignedProjects = val;
+    this.changed();
+  }
+
   public updateStarred(val:boolean) {
     this.isStarred = val;
     this.changed();
@@ -62,6 +77,10 @@ export class QuerySharingFormComponent {
   }
 
   public changed() {
-    this.onChange.emit({ isStarred: !!this.isStarred, isPublic: !!this.isPublic });
+    this.onChange.emit({
+      includeAllMembersAssignedProjects: !!this.isShowAllMembersAssignedProjects,
+      isStarred: !!this.isStarred,
+      isPublic: !!this.isPublic,
+    });
   }
 }

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.html
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.html
@@ -33,3 +33,21 @@
     <div class="form--field-instructions -no-margin" [textContent]="text.showInMenuText"></div>
   </div>
 </div>
+
+<div class="form--field">
+  <div class="form--field-container -vertical">
+    <label class="form--label-with-check-box">
+      <div class="form--check-box-container">
+        <input type="checkbox"
+               name="show_all_members_assigned_projects"
+               id="show-all-members-assigned-projects"
+               [ngModel]="isShowAllMembersAssignedProjects"
+               (ngModelChange)="updateShowAllMembersAssignedProjects($event)"
+               [disabled]="!canShowAllMembersAssignedProjects"
+               class="form--check-box" />
+      </div>
+      {{ text.showAllMembersAssignedProjects }}
+    </label>
+    <div class="form--field-instructions -no-margin" [textContent]="text.showAllMembersAssignedProjectsText"></div>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.html
@@ -10,6 +10,7 @@
     class="spot-modal--body spot-container"
     [isSave]="false"
     (onChange)="setValues($event)"
+    [isShowAllMembersAssignedProjects]="includeAllMembersAssignedProjects"
     [isStarred]="isStarred"
     [isPublic]="isPublic">
   </query-sharing-form>

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.ts
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.ts
@@ -47,6 +47,8 @@ import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/q
 export class QuerySharingModalComponent extends OpModalComponent implements OnInit {
   public query:QueryResource;
 
+  public includeAllMembersAssignedProjects = false;
+
   public isStarred = false;
 
   public isPublic = false;
@@ -83,11 +85,13 @@ export class QuerySharingModalComponent extends OpModalComponent implements OnIn
 
     this.query = this.querySpace.query.value!;
 
+    this.includeAllMembersAssignedProjects = this.query.includeAllMembersAssignedProjects;
     this.isStarred = this.query.starred;
     this.isPublic = this.query.public;
   }
 
   public setValues(change:QuerySharingChange):void {
+    this.includeAllMembersAssignedProjects = change.includeAllMembersAssignedProjects;
     this.isStarred = change.isStarred;
     this.isPublic = change.isPublic;
   }
@@ -104,8 +108,9 @@ export class QuerySharingModalComponent extends OpModalComponent implements OnIn
     this.isBusy = true;
     const promises = [];
 
-    if (this.query.public !== this.isPublic) {
+    if (this.query.public !== this.isPublic || this.query.includeAllMembersAssignedProjects !== this.includeAllMembersAssignedProjects) {
       this.query.public = this.isPublic;
+      this.query.includeAllMembersAssignedProjects = this.includeAllMembersAssignedProjects;
 
       promises.push(this.wpListService.save(this.query));
     }

--- a/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.html
+++ b/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.html
@@ -35,6 +35,7 @@
       <query-sharing-form
         [isSave]="true"
         (onChange)="setValues($event)"
+        [isShowAllMembersAssignedProjects]="includeAllMembersAssignedProjects"
         [isStarred]="isStarred"
         [isPublic]="isPublic">
       </query-sharing-form>

--- a/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
+++ b/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
@@ -46,6 +46,8 @@ import { WorkPackagesQueryViewService } from 'core-app/features/work-packages/co
 export class ViewSettingsModalComponent extends OpModalComponent {
   public queryName = '';
 
+  public includeAllMembersAssignedProjects = false;
+
   public isStarred = false;
 
   public isPublic = false;
@@ -81,6 +83,7 @@ export class ViewSettingsModalComponent extends OpModalComponent {
   }
 
   public setValues(change:QuerySharingChange):void {
+    this.includeAllMembersAssignedProjects = change.includeAllMembersAssignedProjects;
     this.isStarred = change.isStarred;
     this.isPublic = change.isPublic;
   }
@@ -102,6 +105,7 @@ export class ViewSettingsModalComponent extends OpModalComponent {
 
     this.isBusy = true;
     const query = this.querySpace.query.value!;
+    query.includeAllMembersAssignedProjects = this.includeAllMembersAssignedProjects;
     query.public = this.isPublic;
 
     this.wpListService

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -9,11 +9,12 @@
     class="button"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
+    [disabled]="includeAllMembersAssignedProjects"
     data-test-selector="project-include-button"
   >
     {{ text.toggle_title }}
     <span
-      *ngIf="(numberOfProjectsInFilter$ | async) as count"
+      *ngIf="!includeAllMembersAssignedProjects && (numberOfProjectsInFilter$ | async) as count"
       class="badge -secondary"
       [textContent]="count"
     >

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -290,6 +290,8 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       });
   }
 
+  public includeAllMembersAssignedProjects = false;
+
   public ngOnInit():void {
     this.query$
       .pipe(
@@ -299,6 +301,15 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       .subscribe((includeSubprojects) => {
         this.includeSubprojects = includeSubprojects;
       });
+
+    this.query$
+      .pipe(
+        map((query) => query.includeAllMembersAssignedProjects),
+        distinctUntilChanged(),
+      )
+      .subscribe((includeAllMembersAssignedProjects) => {
+        this.includeAllMembersAssignedProjects = includeAllMembersAssignedProjects;
+      });      
   }
 
   public toggleIncludeSubprojects():void {

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -47,6 +47,7 @@ module API
           p = super
 
           p[:includeSubprojects] = query.include_subprojects
+          p[:includeAllMembersAssignedProjects] = query.include_all_members_assigned_projects
           p[:showHierarchies] = query.show_hierarchies
           p[:showSums] = query.display_sums?
           p[:groupBy] = query.group_by if query.group_by?

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -45,14 +45,7 @@ module API
 
         def to_h(column_key: :columns)
           p = super
-
-          p[:includeSubprojects] = query.include_subprojects
-          p[:includeAllMembersAssignedProjects] = query.include_all_members_assigned_projects
-          p[:showHierarchies] = query.show_hierarchies
-          p[:showSums] = query.display_sums?
-          p[:groupBy] = query.group_by if query.group_by?
-          p[column_key] = columns_to_v3 unless query.has_default_columns?
-
+          add_query_attributes(p, column_key)
           p
         end
 
@@ -74,6 +67,15 @@ module API
 
         def columns_to_v3
           query.column_names.map { |name| convert_to_v3(name) }
+        end
+
+        def add_query_attributes(p, column_key)
+          p[:includeSubprojects] = query.include_subprojects
+          p[:includeAllMembersAssignedProjects] = query.include_all_members_assigned_projects
+          p[:showHierarchies] = query.show_hierarchies
+          p[:showSums] = query.display_sums?
+          p[:groupBy] = query.group_by if query.group_by?
+          p[column_key] = columns_to_v3 unless query.has_default_columns?
         end
 
         attr_accessor :query

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -291,6 +291,7 @@ module API
                  exec_context: :decorator
 
         property :include_subprojects
+        property :include_all_members_assigned_projects
 
         property :display_sums, as: :sums
         property :public

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -167,6 +167,12 @@ module API
                  writable: true,
                  has_default: true
 
+          schema :include_all_members_assigned_projects,
+                 type: "Boolean",
+                 required: false,
+                 writable: true,
+                 has_default: false
+
           schema_with_allowed_collection :columns,
                                          type: "[]QueryColumn",
                                          required: false,


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/55988

The PR is my relative first feature PR, so feel free to change code for me if possible / give feedback.

It introduce a new boolean flag called `include_all_members_assigned_projects` in query object and allow user select it in query-sharing-form:

<img width="692" alt="image" src="https://github.com/opf/openproject/assets/1131536/dc4d2921-47f1-4996-a428-9492c3f8efa3">

If it not select, then using then nothing new, but if user select it, the query will automatically select the projects which current project members participate on, so work package will show all work package those member was assigned_to, which will help project manager having very confident that he see all the team member's loading in the `Team Planner` or `Gantt Chart` or similar screen.
