### PR TITLE
migration to remove ProjectQuery namespace for entity_type of Member

### DIFF
--- a/db/migrate/20240628181954_demodulize_project_query_in_member_entity_type.rb
+++ b/db/migrate/20240628181954_demodulize_project_query_in_member_entity_type.rb
@@ -1,0 +1,9 @@
+class DemodulizeProjectQueryInMemberEntityType < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE members SET entity_type = 'ProjectQuery' WHERE entity_type = 'Queries::Projects::ProjectQuery'"
+  end
+
+  def down
+    execute "UPDATE members SET entity_type = 'Queries::Projects::ProjectQuery' WHERE entity_type = 'ProjectQuery'"
+  end
+end


### PR DESCRIPTION
Migration is needed after changes in #15983