### PR TITLE
Display shared filters

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,7 @@ en:
       my: "My projects"
       favored: "Favorite projects"
       archived: "Archived projects"
+      shared: "Shared project lists"
       public: "Public project lists"
       my_private: "My private project lists"
       new:

--- a/spec/factories/member_factory.rb
+++ b/spec/factories/member_factory.rb
@@ -61,4 +61,9 @@ FactoryBot.define do
     entity factory: %i[work_package]
     project { entity.project }
   end
+
+  factory :project_query_member, parent: :member do
+    entity factory: %i[project_query]
+    project { nil }
+  end
 end

--- a/spec/menus/projects/menu_spec.rb
+++ b/spec/menus/projects/menu_spec.rb
@@ -49,11 +49,17 @@ RSpec.describe Projects::Menu do
     ProjectQuery.create!(name: "Public query", user: build(:user), public: true)
   end
 
+  shared_let(:shared_query) do
+    query = ProjectQuery.create!(name: "Shared query", user: build(:user))
+    create(:project_query_member, entity: query, user: current_user, roles: [create(:view_project_query_role)])
+    query
+  end
+
   subject(:menu_items) { instance.menu_items }
 
   it "returns 4 menu groups" do
     expect(menu_items).to all(be_a(OpenProject::Menu::MenuGroup))
-    expect(menu_items.length).to eq(4)
+    expect(menu_items.length).to eq(5)
   end
 
   describe "children items" do
@@ -93,6 +99,10 @@ RSpec.describe Projects::Menu do
 
     it "contains item for public query" do
       expect(children_menu_items).to include(have_attributes(title: "Public query"))
+    end
+
+    it "contains item for shared query" do
+      expect(children_menu_items).to include(have_attributes(title: "Shared query"))
     end
   end
 


### PR DESCRIPTION
This PR displays shared filters in the menu. Also, I optimized loading the persisted filters only once from the database and then working on a cached list instead of loading the list multiple times.

---

Part of https://community.openproject.org/projects/openproject/work_packages/55162