### PR TITLE
[#56027] disable token caching for one drive validation

### DIFF
--- a/modules/storages/app/common/storages/peripherals/one_drive_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/one_drive_connection_validator.rb
@@ -155,7 +155,9 @@ module Storages
       end
 
       def auth_strategy
-        Peripherals::Registry.resolve("#{@storage.short_provider_type}.authentication.userless").call
+        Peripherals::Registry.resolve("#{@storage.short_provider_type}.authentication.userless")
+                             .call
+                             .with_cache(false)
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
@@ -41,7 +41,7 @@ module Storages
           when :oauth_user_token
             AuthenticationStrategies::OAuthUserToken.new(strategy.user)
           when :oauth_client_credentials
-            AuthenticationStrategies::OAuthClientCredentials.new
+            AuthenticationStrategies::OAuthClientCredentials.new(strategy.use_cache)
           else
             raise "Invalid authentication strategy '#{strategy}'"
           end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/strategy.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/strategy.rb
@@ -33,14 +33,22 @@ module Storages
     module StorageInteraction
       module AuthenticationStrategies
         class Strategy
-          attr_reader :key, :user
+          attr_reader :key, :user, :use_cache
 
           def initialize(key)
             @key = key
+            # per default authorization strategies are using the cache
+            # to reduce the number authentication requests
+            @use_cache = true
           end
 
           def with_user(user)
             @user = user
+            self
+          end
+
+          def with_cache(use_cache)
+            @use_cache = use_cache
             self
           end
         end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationStrategi
   let(:storage) { create(:sharepoint_dev_drive_storage) }
   let(:cache_key) { "storage.#{storage.id}.httpx_access_token" }
 
-  subject(:strategy) { described_class.new }
+  subject(:strategy) { described_class.new(true) }
 
   context "when the attempted request fails with a 403" do
     before do


### PR DESCRIPTION
[#56027](https://community.openproject.org/work_packages/56027)

### WAT?

- strategies now have an additional data attribute `use_cache`
  - this is per default true
  - it can be switched off with calling `with_cache(:boolean)` on the strategy
- OneDrive validator now uses an uncached strategy