### PR TITLE
Fix tmp folder permissions

### DIFF
--- a/docker/prod/setup/postinstall-common.sh
+++ b/docker/prod/setup/postinstall-common.sh
@@ -2,7 +2,7 @@
 set -eox pipefail
 
 # Ensure we can write in /tmp/op_uploaded_files (cf. #29112)
-mkdir -p /tmp/op_uploaded_files/ && chown -R $APP_USER:$APP_USER /tmp/op_uploaded_files/
+mkdir -p /tmp/op_uploaded_files/ && chown -R $APP_USER:$APP_USER /tmp/op_uploaded_files/ && chmod g+rw /tmp/op_uploaded_files/
 
 # Remove any existing config/database.yml
 rm -f ./config/database.yml


### PR DESCRIPTION
Add group read/write permissions to /tmp/op_uploaded_files folder to allow access when running with uid other than 1000 (app) but with an allowed supplemental group (1000).