### PR TITLE
[#56011] reset user tokens when refreshing token fails

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/failures.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/failures.rb
@@ -34,7 +34,7 @@ module Storages
       module AuthenticationStrategies
         module Failures
           Builder = ->(code:, log_message:, data:) do
-            storage_error = ::Storages::StorageError.new(code:, log_message:, data:)
+            storage_error = StorageError.new(code:, log_message:, data:)
             ServiceResult.failure(result: code, errors: storage_error)
           end
 
@@ -49,7 +49,11 @@ module Storages
                 response.body.to_s
               end
 
-            ::Storages::StorageErrorData.new(source:, payload:)
+            StorageErrorData.new(source:, payload:)
+          end
+
+          TimeoutErrorData = ->(error:, source:) do
+            StorageErrorData.new(source:, payload: error.to_s)
           end
         end
       end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_client_credentials.rb
@@ -95,6 +95,10 @@ module Storages
             Failures::Builder.call(code: :unauthorized,
                                    log_message: "Error while fetching OAuth access token.",
                                    data: Failures::ErrorData.call(response: e.response, source: self.class))
+          rescue HTTPX::TimeoutError => e
+            Failures::Builder.call(code: :unauthorized,
+                                   log_message: "Timeout while fetching OAuth token.",
+                                   data: Failures::TimeoutErrorData.call(error: e, source: self.class))
           end
 
           def build_failure(storage)

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
@@ -124,11 +124,6 @@ module Storages
             token.update(access_token:, refresh_token:)
           end
 
-          def log_and_destroy_token(token, log_message)
-            Rails.logger.error(log_message)
-            token.destroy
-          end
-
           def handle_http_error_on_refresh(token, exception)
             log_message = "Error while refreshing OAuth token."
             data = Failures::ErrorData.call(response: exception.response, source: self.class)

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Authentication, :webmo
       context "with incomplete storage configuration (missing oauth client)" do
         let(:storage) { create(:nextcloud_storage) }
 
-        it "must return unauthorized" do
+        it "must return error" do
           result = described_class[auth_strategy].call(storage:, http_options:) { |http| make_request(http) }
           expect(result).to be_failure
 
           error = result.errors
-          expect(error.code).to eq(:unauthorized)
+          expect(error.code).to eq(:error)
           expect(error.data.source)
             .to be(Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken)
         end
@@ -200,12 +200,12 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Authentication, :webmo
       context "with incomplete storage configuration (missing oauth client)" do
         let(:storage) { create(:one_drive_storage) }
 
-        it "must return unauthorized" do
+        it "must return error" do
           result = described_class[auth_strategy].call(storage:) { |http| make_request(http) }
           expect(result).to be_failure
 
           error = result.errors
-          expect(error.code).to eq(:unauthorized)
+          expect(error.code).to eq(:error)
           expect(error.data.source)
             .to be(Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken)
         end


### PR DESCRIPTION
[#56011](https://community.openproject.org/work_packages/56011)

### WAT?

- handle timeouts in token refreshes, too
- handle nextcloud brute force throttling