### PR TITLE
[#55939] OneDrive/SharePoint storage with AMPF can be added as manual folder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,6 +236,8 @@ RSpec/DescribeMethod:
 # Don't force the second argument of describe
 # to match the exact file name
 RSpec/SpecFilePathFormat:
+  CustomTransform:
+    OAuthClients: oauth_clients
   IgnoreMethods: true
 
 # Prevent  "fit" or similar to be committed

--- a/modules/storages/app/contracts/storages/project_storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/base_contract.rb
@@ -52,7 +52,7 @@ module Storages::ProjectStorages
       end
     end
 
-    validate :project_folder_automatic_mode, unless: -> { errors.include?(:project_folder_mode) }
+    validate :project_folder_mode_available_for_storage, unless: -> { errors.include?(:project_folder_mode) }
 
     private
 
@@ -60,10 +60,8 @@ module Storages::ProjectStorages
       @model.project_folder_manual?
     end
 
-    def project_folder_automatic_mode
-      return unless @model.project_folder_automatic?
-
-      unless @model.automatic_management_possible?
+    def project_folder_mode_available_for_storage
+      if storage&.available_project_folder_modes&.exclude?(@model.project_folder_mode)
         errors.add :project_folder_mode, :mode_unavailable
       end
     end

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -54,6 +54,14 @@ module Storages
       end
     end
 
+    def available_project_folder_modes
+      if automatic_management_enabled?
+        ProjectStorage.project_folder_modes.keys
+      else
+        ["inactive", "manual"]
+      end
+    end
+
     def configuration_checks
       {
         storage_oauth_client_configured: oauth_client.present?,

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -57,6 +57,10 @@ module Storages
       end
     end
 
+    def manual_management_possible?
+      !automatic_management_enabled?
+    end
+
     def oauth_configuration
       Peripherals::OAuthConfigurations::OneDriveConfiguration.new(self)
     end

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -57,8 +57,12 @@ module Storages
       end
     end
 
-    def manual_management_possible?
-      !automatic_management_enabled?
+    def available_project_folder_modes
+      if automatic_management_enabled?
+        ["inactive", "automatic"]
+      else
+        ["inactive", "manual"]
+      end
     end
 
     def oauth_configuration

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -57,12 +57,8 @@ module Storages
         .where(storage: Storage.automatic_management_enabled)
     end
 
-    def automatic_management_possible?
-      storage.present? && storage.automatic_management_enabled?
-    end
-
-    def manual_management_possible?
-      storage&.manual_management_possible?
+    def project_folder_mode_possible?(project_folder_mode)
+      storage&.available_project_folder_modes&.include?(project_folder_mode)
     end
 
     def managed_project_folder_path

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -58,7 +58,7 @@ module Storages
     end
 
     def project_folder_mode_possible?(project_folder_mode)
-      storage&.available_project_folder_modes&.include?(project_folder_mode)
+      storage.present? && storage.available_project_folder_modes&.include?(project_folder_mode)
     end
 
     def managed_project_folder_path

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -61,6 +61,10 @@ module Storages
       storage.present? && storage.automatic_management_enabled?
     end
 
+    def manual_management_possible?
+      storage&.manual_management_possible?
+    end
+
     def managed_project_folder_path
       managed_folder_identifier.path
     end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -149,8 +149,12 @@ module Storages
 
     alias automatic_management_enabled automatically_managed
 
-    def manual_management_possible?
-      true
+    def available_project_folder_modes
+      if automatic_management_enabled?
+        ProjectStorage.project_folder_modes.keys
+      else
+        ["inactive", "manual"]
+      end
     end
 
     def configured?

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -149,6 +149,10 @@ module Storages
 
     alias automatic_management_enabled automatically_managed
 
+    def manual_management_possible?
+      true
+    end
+
     def configured?
       configuration_checks.values.all?
     end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -150,11 +150,7 @@ module Storages
     alias automatic_management_enabled automatically_managed
 
     def available_project_folder_modes
-      if automatic_management_enabled?
-        ProjectStorage.project_folder_modes.keys
-      else
-        ["inactive", "manual"]
-      end
+      raise Errors::SubclassResponsibility
     end
 
     def configured?

--- a/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
@@ -103,18 +103,20 @@ See COPYRIGHT and LICENSE files for more details.
     </span>
   <% end %>
 
-  <div class="form--field-container">
-    <%= f.label :project_folder_mode, value: 'manual', class: "form--label-with-radio-button" do %>
-      <%= f.radio_button :project_folder_mode,
-                         'manual',
-                         no_label: true,
-                         data: { action: 'project-storage-form#updateForm' } %>
-      <%= t(:"storages.label_existing_manual_folder") %>
-    <% end %>
-  </div>
-  <span class="form--field-instructions -xwide -with-bottom-spacing">
-    <%= t(:"storages.instructions.existing_manual_folder") %>
-  </span>
+  <% if @project_storage.manual_management_possible? %>
+    <div class="form--field-container">
+      <%= f.label :project_folder_mode, value: 'manual', class: "form--label-with-radio-button" do %>
+        <%= f.radio_button :project_folder_mode,
+                           'manual',
+                           no_label: true,
+                           data: { action: 'project-storage-form#updateForm' } %>
+        <%= t(:"storages.label_existing_manual_folder") %>
+      <% end %>
+    </div>
+    <span class="form--field-instructions -xwide -with-bottom-spacing">
+      <%= t(:"storages.instructions.existing_manual_folder") %>
+    </span>
+  <% end %>
 
   <div
     style="display: none;"

--- a/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
@@ -75,20 +75,22 @@ See COPYRIGHT and LICENSE files for more details.
                               }
     %>
   <% end %>
-  <div class="form--field-container">
-    <%= f.label :project_folder_mode, value: 'inactive', class: "form--label-with-radio-button" do %>
-      <%= f.radio_button :project_folder_mode,
-                         'inactive',
-                         no_label: true,
-                         data: { action: 'project-storage-form#updateForm' } %>
-      <%= t(:"storages.label_no_specific_folder") %>
-    <% end %>
-  </div>
-  <span class="form--field-instructions -with-bottom-spacing">
-    <%= t(:"storages.instructions.no_specific_folder") %>
-  </span>
+  <% if @project_storage.project_folder_mode_possible?('inactive') %>
+    <div class="form--field-container">
+      <%= f.label :project_folder_mode, value: 'inactive', class: "form--label-with-radio-button" do %>
+        <%= f.radio_button :project_folder_mode,
+                           'inactive',
+                           no_label: true,
+                           data: { action: 'project-storage-form#updateForm' } %>
+        <%= t(:"storages.label_no_specific_folder") %>
+      <% end %>
+    </div>
+    <span class="form--field-instructions -with-bottom-spacing">
+      <%= t(:"storages.instructions.no_specific_folder") %>
+    </span>
+  <% end %>
 
-  <% if @project_storage.automatic_management_possible? %>
+  <% if @project_storage.project_folder_mode_possible?('automatic') %>
     <div class="form--field-container">
       <%= f.label :project_folder_mode, value: 'automatic', class: "form--label-with-radio-button" do %>
         <%= f.radio_button :project_folder_mode,
@@ -103,7 +105,7 @@ See COPYRIGHT and LICENSE files for more details.
     </span>
   <% end %>
 
-  <% if @project_storage.manual_management_possible? %>
+  <% if @project_storage.project_folder_mode_possible?('manual')  %>
     <div class="form--field-container">
       <%= f.label :project_folder_mode, value: 'manual', class: "form--label-with-radio-button" do %>
         <%= f.radio_button :project_folder_mode,

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -119,8 +119,24 @@ RSpec.describe Storages::ProjectStorage do
     end
 
     context "when the storage is not automatically managed" do
-      context "when the storage is a generic storage" do
-        let(:storage) { build_stubbed(:storage, :as_generic, :as_not_automatically_managed) }
+      context "when the storage is a one drive storage" do
+        let(:storage) { build_stubbed(:one_drive_storage, :as_not_automatically_managed) }
+
+        it "returns true for project_folder_mode inactive" do
+          expect(project_storage.project_folder_mode_possible?("inactive")).to be true
+        end
+
+        it "returns false for project_folder_mode automatic" do
+          expect(project_storage.project_folder_mode_possible?("automatic")).to be false
+        end
+
+        it "returns true for project_folder_mode manual" do
+          expect(project_storage.project_folder_mode_possible?("manual")).to be true
+        end
+      end
+
+      context "when the storage is a nextcloud storage" do
+        let(:storage) { build_stubbed(:nextcloud_storage, :as_not_automatically_managed) }
 
         it "returns true for project_folder_mode inactive" do
           expect(project_storage.project_folder_mode_possible?("inactive")).to be true

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -113,6 +113,38 @@ RSpec.describe Storages::ProjectStorage do
     end
   end
 
+  describe "#manual_management_possible?" do
+    let(:project_storage) { build_stubbed(:project_storage, storage:) }
+
+    context "when the storage is not a OneDriveStorage" do
+      let(:storage) { build_stubbed(:storage, :as_generic) }
+
+      it "returns true" do
+        expect(project_storage.manual_management_possible?).to be true
+      end
+    end
+
+    context "when the storage is a OneDriveStorage" do
+      let(:storage) { build_stubbed(:one_drive_storage) }
+
+      context "when the storage is not automatically managed" do
+        it "returns true" do
+          expect(project_storage.manual_management_possible?).to be true
+        end
+      end
+
+      context "when the storage is automatically managed" do
+        before do
+          storage.automatically_managed = true
+        end
+
+        it "returns false" do
+          expect(project_storage.manual_management_possible?).to be false
+        end
+      end
+    end
+  end
+
   describe "#project_folder_mode" do
     let(:project_storage) { build(:project_storage) }
 

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -81,65 +81,57 @@ RSpec.describe Storages::ProjectStorage do
     end
   end
 
-  describe "#automatic_management_possible?" do
+  describe "#project_folder_mode_possible?" do
     let(:project_storage) { build_stubbed(:project_storage, storage:) }
 
-    context "when the storage is not a NextcloudStorage" do
-      let(:storage) { build_stubbed(:storage, :as_generic) }
+    context "when the storage is automatically managed" do
+      context "when the storage is a one drive storage" do
+        let(:storage) { build_stubbed(:one_drive_storage, :as_automatically_managed) }
 
-      it "returns false" do
-        expect(project_storage.automatic_management_possible?).to be false
+        it "returns true for project_folder_mode inactive" do
+          expect(project_storage.project_folder_mode_possible?("inactive")).to be true
+        end
+
+        it "returns true for project_folder_mode automatic" do
+          expect(project_storage.project_folder_mode_possible?("automatic")).to be true
+        end
+
+        it "returns false for project_folder_mode manual" do
+          expect(project_storage.project_folder_mode_possible?("manual")).to be false
+        end
+      end
+
+      context "when the storage is a nextcloud storage" do
+        let(:storage) { build_stubbed(:nextcloud_storage, :as_automatically_managed) }
+
+        it "returns true for project_folder_mode inactive" do
+          expect(project_storage.project_folder_mode_possible?("inactive")).to be true
+        end
+
+        it "returns true for project_folder_mode automatic" do
+          expect(project_storage.project_folder_mode_possible?("automatic")).to be true
+        end
+
+        it "returns true for project_folder_mode manual" do
+          expect(project_storage.project_folder_mode_possible?("manual")).to be true
+        end
       end
     end
 
-    context "when the storage is a NextcloudStorage" do
-      let(:storage) { build_stubbed(:nextcloud_storage) }
+    context "when the storage is not automatically managed" do
+      context "when the storage is a generic storage" do
+        let(:storage) { build_stubbed(:storage, :as_generic, :as_not_automatically_managed) }
 
-      context "when the storage is not automatically managed" do
-        it "returns false" do
-          expect(project_storage.automatic_management_possible?).to be false
-        end
-      end
-
-      context "when the storage is automatically managed" do
-        before do
-          storage.automatically_managed = true
+        it "returns true for project_folder_mode inactive" do
+          expect(project_storage.project_folder_mode_possible?("inactive")).to be true
         end
 
-        it "returns true" do
-          expect(project_storage.automatic_management_possible?).to be true
-        end
-      end
-    end
-  end
-
-  describe "#manual_management_possible?" do
-    let(:project_storage) { build_stubbed(:project_storage, storage:) }
-
-    context "when the storage is not a OneDriveStorage" do
-      let(:storage) { build_stubbed(:storage, :as_generic) }
-
-      it "returns true" do
-        expect(project_storage.manual_management_possible?).to be true
-      end
-    end
-
-    context "when the storage is a OneDriveStorage" do
-      let(:storage) { build_stubbed(:one_drive_storage) }
-
-      context "when the storage is not automatically managed" do
-        it "returns true" do
-          expect(project_storage.manual_management_possible?).to be true
-        end
-      end
-
-      context "when the storage is automatically managed" do
-        before do
-          storage.automatically_managed = true
+        it "returns false for project_folder_mode automatic" do
+          expect(project_storage.project_folder_mode_possible?("automatic")).to be false
         end
 
-        it "returns false" do
-          expect(project_storage.manual_management_possible?).to be false
+        it "returns true for project_folder_mode manual" do
+          expect(project_storage.project_folder_mode_possible?("manual")).to be true
         end
       end
     end

--- a/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
+RSpec.describe OAuthClients::ConnectionManager, :oauth_connection_helpers, :webmock, type: :model do
   let(:user) { create(:user) }
   let(:storage) { create(:one_drive_storage, :with_oauth_client, tenant_id: "consumers") }
   let(:token) { create(:oauth_client_token, oauth_client: storage.oauth_client, user:) }
@@ -50,31 +50,14 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
         refresh_token: "AwABAAAAvPM1KaPlrEqdFSBzjqfTGAMxZGUTdM0t4B4..."
       }.to_json
     end
-    let(:me_response) do
-      {
-        businessPhones: [
-          "+45 123 4567 8901"
-        ],
-        displayName: "Sheev Palpatine ",
-        givenName: "Sheev",
-        jobTitle: "Galatic Senator",
-        mail: "palpatine@senate.com",
-        mobilePhone: "+45 123 4567 8901",
-        officeLocation: "500 Republica",
-        preferredLanguage: "en-US",
-        surname: "Palpatine",
-        userPrincipalName: "palpatine@senate.com",
-        id: "87d349ed-44d7-43e1-9a83-5f2406dee5bd"
-      }.to_json
-    end
 
     before do
       stub_request(:post, "https://login.microsoftonline.com/consumers/oauth2/v2.0/token")
         .to_return(status: 200, body: code_to_token_response, headers: { "Content-Type" => "application/json" })
 
-      stub_request(:get, "https://graph.microsoft.com/v1.0/me")
-        .with(headers: { Authorization: "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q..." })
-        .to_return(status: 200, body: me_response, headers: { "Content-Type" => "application/json" })
+      mock_one_drive_authorization_validation(
+        with: { headers: { Authorization: "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q..." } }
+      )
     end
 
     it "fills in the origin_user_id" do

--- a/spec/support/oauth_connections_helpers.rb
+++ b/spec/support/oauth_connections_helpers.rb
@@ -1,0 +1,30 @@
+module OAuthConnectionsHelpers
+  def mock_one_drive_authorization_validation(with: {})
+    me_response = {
+      businessPhones: [
+        "+45 123 4567 8901"
+      ],
+      displayName: "Sheev Palpatine ",
+      givenName: "Sheev",
+      jobTitle: "Galactic Senator",
+      mail: "palpatine@senate.com",
+      mobilePhone: "+45 123 4567 8901",
+      officeLocation: "500 Republica",
+      preferredLanguage: "en-US",
+      surname: "Palpatine",
+      userPrincipalName: "palpatine@senate.com",
+      id: "87d349ed-44d7-43e1-9a83-5f2406dee5bd"
+    }.to_json
+
+    stub = stub_request(:get, "https://graph.microsoft.com/v1.0/me")
+      .to_return(status: 200, body: me_response, headers: { "Content-Type" => "application/json" })
+
+    if with.present?
+      stub.with(with)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include OAuthConnectionsHelpers, :oauth_connection_helpers
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55939

Because managing of permissions is complex on OneDrive, a storage with automatically managed access and folders can not host projects with manually managed permissions.

---

Please notice that an existing file had to be renamed due to rubocop complaining.