### PR TITLE
Add an option to unselect projects via the global project selector

### DIFF
--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -29,6 +29,7 @@
 class HomescreenController < ApplicationController
   skip_before_action :check_if_login_required, only: [:robots]
   no_authorization_required! :index, :robots
+  before_action :jump_to_module
 
   layout "global"
 
@@ -51,6 +52,13 @@ class HomescreenController < ApplicationController
       render template: "homescreen/robots-login-required", format: :text
     else
       @projects = Project.active.public_projects
+    end
+  end
+
+  def jump_to_module
+    if params[:jump]
+      # try to redirect to the requested menu item
+      redirect_to_global_menu_item(params[:jump]) && return
     end
   end
 end

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -13,6 +13,7 @@
     type="button"
     slot="trigger"
     (click)="toggleDropModal()"
+    data-test-selector="op-projects-menu"
   >
     <span
       class="op-app-menu--item-title ellipsis"

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -60,7 +60,7 @@
         <ul
           *ngIf="anyProjectsFound(projects, (favorites$ | async)); else noResultsTemplate"
           op-header-project-select-list
-          [ngClass]="{ 'spot-list_active': textFieldFocused }"
+          class="spot-list_active"
           [projects]="projects"
           [displayMode]="displayMode"
           [favored]="favorites$ | async"

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -15,6 +15,7 @@
     [href]="extendedUrl(project.id)"
     [attr.data-list-selector]="projectListActionIdentifier"
     [attr.data-project-id]="project.id"
+    [attr.data-test-selector]="currentProjectService.id === project.id.toString() ? 'op-header-project-select--active-item' : null"
   >
     <span
       class="spot-list--item-title spot-list--item-title_ellipse-text"
@@ -32,8 +33,11 @@
       ></svg>
     </span>
 
-    <a [href]="extendedUrl(null)"
-       *ngIf="currentProjectService.id === project.id.toString()">
+    <a
+      [href]="extendedUrl(null)"
+      *ngIf="currentProjectService.id === project.id.toString()"
+      data-test-selector="op-header-project-select--item-remove-icon"
+    >
       <svg
         x-circle-icon
         size="small"

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -12,25 +12,32 @@
       'spot-list--item-action_disabled': project.disabled,
       'spot-list--item-action_active': (searchableProjectListService.selectedItemID$ | async) === project.id
     }"
-    [href]="extendedProjectUrl(project.id)"
+    [href]="extendedUrl(project.id)"
     [attr.data-list-selector]="projectListActionIdentifier"
     [attr.data-project-id]="project.id"
   >
-  <span
-    class="spot-list--item-title spot-list--item-title_ellipse-text"
-    data-test-selector="op-header-project-select--item-title"
-  >
     <span
-      [opSearchHighlight]="searchText"
-      [textContent]="project.name"></span>
+      class="spot-list--item-title spot-list--item-title_ellipse-text"
+      data-test-selector="op-header-project-select--item-title"
+    >
+      <span
+        [opSearchHighlight]="searchText"
+        [textContent]="project.name"></span>
 
-    <svg
-      *ngIf="favored?.includes(project.id.toString())"
-      star-fill-icon
-      class="op-primer--star-icon"
-      size="small"
-    ></svg>
-  </span>
+      <svg
+        *ngIf="favored?.includes(project.id.toString())"
+        star-fill-icon
+        class="op-primer--star-icon"
+        size="small"
+      ></svg>
+    </span>
+
+    <a [href]="extendedUrl(null)"
+       *ngIf="currentProjectService.id === project.id.toString()">
+      <svg
+        x-circle-icon
+        size="small"
+      ></svg></a>
   </a>
   <span
     *ngIf="project.disabled"

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
@@ -18,6 +18,7 @@ import {
 import { IProjectData } from 'core-app/shared/components/searchable-project-list/project-data';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 @Component({
   selector: '[op-header-project-select-list]',
@@ -56,6 +57,7 @@ export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
     readonly searchableProjectListService:SearchableProjectListService,
     readonly elementRef:ElementRef,
     readonly cdRef:ChangeDetectorRef,
+    readonly currentProjectService:CurrentProjectService,
   ) { }
 
   ngOnInit():void {
@@ -102,9 +104,9 @@ export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
     return this.favored.includes(project.id.toString());
   }
 
-  extendedProjectUrl(projectId:string):string {
+  extendedUrl(projectId:string|null):string {
     const currentMenuItem = document.querySelector('meta[name="current_menu_item"]') as HTMLMetaElement;
-    const url = this.pathHelper.projectPath(projectId);
+    const url = projectId === null ? window.appBasePath : this.pathHelper.projectPath(projectId);
 
     if (!currentMenuItem) {
       return url;

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -44,6 +44,7 @@ import {
   OpGitlabPipelineStatusSkippedIconComponent,
   OpGitlabPipelineStatusSuccessIconComponent,
   OpGitlabPipelineStatusWaitingIconComponent,
+  XCircleIconComponent,
 } from '@openproject/octicons-angular';
 
 @NgModule({
@@ -93,6 +94,7 @@ import {
     OpGitlabPipelineStatusSkippedIconComponent,
     OpGitlabPipelineStatusSuccessIconComponent,
     OpGitlabPipelineStatusWaitingIconComponent,
+    XCircleIconComponent,
   ],
   declarations: [
     OpIconComponent,
@@ -144,6 +146,7 @@ import {
     OpGitlabPipelineStatusSkippedIconComponent,
     OpGitlabPipelineStatusSuccessIconComponent,
     OpGitlabPipelineStatusWaitingIconComponent,
+    XCircleIconComponent,
   ],
 })
 export class IconModule {}

--- a/lib/redmine/menu_manager/menu_controller.rb
+++ b/lib/redmine/menu_manager/menu_controller.rb
@@ -92,13 +92,30 @@ module Redmine::MenuManager::MenuController
   # Returns false if user is not authorized
   def redirect_to_project_menu_item(project, name)
     item = project_menu_item(name)
-    if user_allowed_to_access_item?(project, item)
+    if user_allowed_to_see_item?(project, item)
       engine = item.engine ? send(item.engine) : main_app
 
       redirect_to(engine.url_for({ item.param => project }.merge(item.url(project))))
       return true
     end
     false
+  end
+
+  # Redirects user to the global menu item
+  # Returns false if user is not authorized
+  def redirect_to_global_menu_item(name)
+    item = global_menu_item(name)
+    if globally_allowed_to_see_item?(item)
+      engine = item.engine ? send(item.engine) : main_app
+
+      redirect_to(engine.url_for(item.url))
+      return true
+    end
+    false
+  end
+
+  def global_menu_item(name)
+    Redmine::MenuManager.items(:global_menu).detect { |i| i.name.to_s == name.to_s }
   end
 
   def project_menu_item(name)
@@ -109,7 +126,11 @@ module Redmine::MenuManager::MenuController
     Redmine::MenuManager.items(:admin_menu).detect { |i| i.name.to_s == name.to_s }
   end
 
-  def user_allowed_to_access_item?(project, item)
+  def user_allowed_to_see_item?(project, item)
     item && User.current.allowed_in_project?(item.url(project), project) && (item.condition.nil? || item.condition.call(project))
+  end
+
+  def globally_allowed_to_see_item?(item)
+    item && User.current.allowed_in_any_project?(item.url) && (item.condition.nil? || item.condition.call)
   end
 end

--- a/spec/features/projects/navigation_spec.rb
+++ b/spec/features/projects/navigation_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Projects navigation", :js, :with_cuprite do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) do
+    create(:user, member_with_permissions: {
+             project => %i[view_work_packages edit_work_packages]
+           })
+  end
+  shared_let(:admin) { create(:admin) }
+
+  context "as a user with all permissions" do
+    before do
+      login_as admin
+    end
+
+    it "can deselect the current project and keep the module" do
+      visit project_work_packages_path(project)
+      page.find_test_selector("op-projects-menu").click
+
+      # The currently active project is highlighted and removable
+      page.within_test_selector("op-header-project-select--list") do
+        expect(page).to have_test_selector("op-header-project-select--item-remove-icon", count: 1)
+        expect(page).to have_test_selector("op-header-project-select--active-item", count: 1)
+
+        page.find_test_selector("op-header-project-select--item-remove-icon").click
+      end
+
+      # Once removed, the user is redirected to the global WorkPackages page
+      expect(page).to have_current_path(work_packages_path)
+
+      # Navigate to another module in a project
+      visit project_roadmap_path(project)
+
+      # Remove the project again
+      page.find_test_selector("op-projects-menu").click
+      page.within_test_selector("op-header-project-select--list") do
+        page.find_test_selector("op-header-project-select--item-remove-icon").click
+      end
+
+      # Once removed, the user is redirected to the home page
+      expect(page).to have_current_path(home_path(jump: "roadmap"))
+    end
+  end
+
+  context "as a user with limited permissions" do
+    before do
+      login_as user
+    end
+
+    it "does not redirect to the global menu" do
+      visit home_path(jump: "calendar_view")
+
+      # The user is not redirected to the module but remains on the home page
+      expect(page).to have_no_current_path(project_calendars_path(project))
+      expect(page).to have_current_path(home_path(jump: "calendar_view"))
+    end
+  end
+end


### PR DESCRIPTION
- [x] An "X" icon will be added at the end of the currently selected project list item and a grey background will indicate the selection.
- [x] The "X" icon will unselect the current project and bring the user back to the global module keeping the current module they are in (eg. If they unselect the project from the Calendars module they'll end in the Calendars global module).
- [x] Add test case to the code


https://community.openproject.org/projects/openproject/work_packages/53026/activity