### PR TITLE
[55997] Add duration_format setting with hours_only by default

### DIFF
--- a/app/services/duration_converter.rb
+++ b/app/services/duration_converter.rb
@@ -28,11 +28,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-# We use BigDecimal to handle floating point arithmetic and avoid
-# weird floating point results on decimal operations when converting
-# hours to seconds on duration outputting.
-require "bigdecimal"
-
 class DurationConverter
   UNIT_ABBREVIATION_MAP = {
     "seconds" => "seconds",
@@ -107,14 +102,14 @@ class DurationConverter
 
       # :days_and_hours format return "0h" when parsing 0.
       ChronicDuration.output(seconds,
-                             format: :days_and_hours,
+                             format:,
                              **duration_length_options)
     end
 
     private
 
-    def convert_duration_to_seconds(duration_in_hours)
-      (BigDecimal(duration_in_hours.to_s) * 3600).to_f
+    def format
+      Setting.duration_format == "days_and_hours" ? :days_and_hours : :hours_only
     end
 
     def duration_length_options

--- a/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
+++ b/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= styled_form_tag(
       admin_settings_working_days_and_hours_path,
       method: :patch,
-      class: 'op-working-days-admin-settings'
+      class: "op-working-days-admin-settings"
     ) do %>
 
   <section class="form--section">
@@ -43,12 +43,18 @@ See COPYRIGHT and LICENSE files for more details.
                                container_class: "-wide" %>
         <div class="form--field-instructions"><%= t("setting_hours_per_day_explanation") %></div>
       </div>
+      <div class="form--field">
+        <%= setting_select :duration_format,
+                           Settings::Definition[:duration_format].allowed.collect { |f| [t("setting_duration_format_#{f}"), f] },
+                           container_class: "-wide" %>
+        <div class="form--field-instructions"><%= t("setting_duration_format_instructions") %></div>
+      </div>
     </fieldset>
   </section>
 
   <section class="form--section">
     <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= t('settings.working_days.section_work_week') %></legend>
+      <legend class="form--fieldset-legend"><%= t("settings.working_days.section_work_week") %></legend>
       <div class="op-toast -warning -with-bottom-spacing">
         <div class="op-toast--content">
           <p>
@@ -62,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
 
       <div class="form--field op-working-days-admin-settings--day-selectors" id="setting_working_days">
         <%= setting_multiselect :working_days,
-                                I18n.t('date.day_names').rotate.zip(WeekDay::DAY_RANGE),
+                                I18n.t("date.day_names").rotate.zip(WeekDay::DAY_RANGE),
                                 direction: :horizontal %>
       </div>
     </fieldset>
@@ -70,18 +76,16 @@ See COPYRIGHT and LICENSE files for more details.
 
   <section class="form--section">
     <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= t('settings.working_days.section_holidays_and_closures') %></legend>
+      <legend class="form--fieldset-legend"><%= t("settings.working_days.section_holidays_and_closures") %></legend>
 
       <p>
         <%= t("working_days.instance_wide_info") %>
       </p>
-      <%= angular_component_tag 'op-non-working-days-list',
+      <%= angular_component_tag "op-non-working-days-list",
                                 data: { modified_non_working_days: @modified_non_working_days } %>
 
     </fieldset>
   </section>
 
-
-
-  <%= styled_button_tag t(:button_apply_changes), class: '-primary -with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_apply_changes), class: "-primary -with-icon icon-checkmark" %>
 <% end %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -386,6 +386,11 @@ module Settings
         description: "Destroy all sessions for current_user on login",
         default: false
       },
+      duration_format: {
+        description: "Format for displaying durations",
+        default: "hours_only",
+        allowed: %w[days_and_hours hours_only]
+      },
       edition: {
         format: :string,
         default: "standard",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1473,7 +1473,7 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   create_new_page: "Wiki page"
 
   date:
-    abbr_day_names: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ]
+    abbr_day_names: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
     abbr_month_names:
       [
         ~,
@@ -3130,6 +3130,10 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   setting_default_projects_public: "New projects are public by default"
   setting_diff_max_lines_displayed: "Max number of diff lines displayed"
   setting_display_subprojects_work_packages: "Display subprojects work packages on main projects by default"
+  setting_duration_format: "Duration format"
+  setting_duration_format_hours_only: "Hours only"
+  setting_duration_format_days_and_hours: "Days and hours"
+  setting_duration_format_instructions: "This defines how Work, Remaining work, and Time spent durations are displayed."
   setting_emails_footer: "Emails footer"
   setting_emails_header: "Emails header"
   setting_email_login: "Use email as login"
@@ -3142,8 +3146,8 @@ Project attributes and sections are defined in the <a href=%{admin_settings_url}
   setting_host_name: "Host name"
   setting_hours_per_day: "Hours per day"
   setting_hours_per_day_explanation: >-
-    This will define what is considered a "day" when displaying duration in a more natural
-    way (for example, if a day is 8 hours, 32 hours would be 4 days).
+    This defines what is considered a "day" when displaying duration in days and hours
+    (for example, if a day is 8 hours, 32 hours would be 4 days).
   setting_invitation_expiration_days: "Activation email expires after"
   setting_work_package_done_ratio: "Progress calculation"
   setting_work_package_done_ratio_field: "Work-based"

--- a/docs/api/apiv3/components/schemas/configuration_model.yml
+++ b/docs/api/apiv3/components/schemas/configuration_model.yml
@@ -15,6 +15,10 @@ properties:
     description: Page size steps to be offered in paginated list UI
     items:
       type: integer
+  durationFormat:
+    type: string
+    description: The format used to display Work, Remaining Work, and Spent time durations
+    readOnly: true
   activeFeatureFlags:
     type: array
     description: The list of all feature flags that are active

--- a/docs/api/apiv3/paths/configuration.yml
+++ b/docs/api/apiv3/paths/configuration.yml
@@ -20,6 +20,7 @@ get:
                   - 1
                   - 10
                   - 100
+                durationFormat: 'hours_only'
                 activeFeatureFlags:
                   - 'aFeatureFlag'
                   - 'anotherFeatureFlag'
@@ -28,7 +29,7 @@ get:
       description: OK
       headers: {}
   tags:
-  - Configuration
+    - Configuration
   description: ''
   operationId: View_configuration
   summary: View configuration

--- a/docs/api/apiv3/tags/configuration.yml
+++ b/docs/api/apiv3/tags/configuration.yml
@@ -16,10 +16,11 @@ description: |-
 
   ## Local Properties
 
-  | Property                  | Description                                        | Type       | Condition         | Supported operations |
-  | :-----------------------: | -------------------------------------------------- | ---------- | ----------------- | -------------------- |
-  | maximumAttachmentFileSize | The maximum allowed size of an attachment in Bytes | Integer    |                   | READ                 |
-  | perPageOptions            | Page size steps to be offered in paginated list UI | Integer[]  |                   | READ                 |
-  | hostName                  | The host name configured for the system            | String     |                   | READ                 |
-  | activeFeatureFlags        | The list of all feature flags that are active      | String[]   |                   | READ                 |
+  | Property                  | Description                                                                | Type       | Condition         | Supported operations |
+  | :-----------------------: | -------------------------------------------------------------------------- | ---------- | ----------------- | -------------------- |
+  | maximumAttachmentFileSize | The maximum allowed size of an attachment in Bytes                         | Integer    |                   | READ                 |
+  | perPageOptions            | Page size steps to be offered in paginated list UI                         | Integer[]  |                   | READ                 |
+  | hostName                  | The host name configured for the system                                    | String     |                   | READ                 |
+  | durationFormat            | The format used to display Work, Remaining Work, and Spent time durations. | String     |                   | READ                 |
+  | activeFeatureFlags        | The list of all feature flags that are active                              | String[]   |                   | READ                 |
 name: Configuration

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -95,6 +95,10 @@ export class ConfigurationService {
     return this.systemPreference('dateFormat');
   }
 
+  public durationFormat():string {
+    return this.systemPreference('durationFormat');
+  }
+
   public hoursPerDay():number {
     return this.systemPreference('hoursPerDay');
   }

--- a/frontend/src/app/core/datetime/timezone.service.ts
+++ b/frontend/src/app/core/datetime/timezone.service.ts
@@ -149,7 +149,7 @@ export class TimezoneService {
   }
 
   public formattedChronicDuration(durationString:string, opts = {
-    format: 'daysAndHours',
+    format: this.configurationService.durationFormat(),
     hoursPerDay: this.configurationService.hoursPerDay(),
     daysPerMonth: this.configurationService.daysPerMonth(),
   }):string {

--- a/frontend/src/app/shared/helpers/chronic_duration.js
+++ b/frontend/src/app/shared/helpers/chronic_duration.js
@@ -253,7 +253,10 @@ export function outputChronicDuration(seconds, opts = {}) {
   const month = daysPerMonth * day;
   const year = SECONDS_PER_YEAR;
 
-  if (units.seconds >= SECONDS_PER_YEAR && units.seconds % year < units.seconds % month) {
+  if (opts.format === 'hours_only') {
+    units.hours = seconds / 3600;
+    units.seconds = 0;
+  } else if (units.seconds >= SECONDS_PER_YEAR && units.seconds % year < units.seconds % month) {
     units.years = Math.trunc(units.seconds / year);
     units.months = Math.trunc((units.seconds % year) / month);
     units.days = Math.trunc(((units.seconds % year) % month) / day);
@@ -330,9 +333,8 @@ export function outputChronicDuration(seconds, opts = {}) {
         pluralize: true,
       };
       break;
-    case 'daysAndHours':
+    case 'days_and_hours':
       dividers = {
-        // days: 'd',
         hours: 'h',
         keepZero: true,
       };
@@ -348,6 +350,15 @@ export function outputChronicDuration(seconds, opts = {}) {
       }
 
       units.hours += (((units.minutes * 60) + units.seconds) / 3600.0)
+      units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
+
+      break
+    case 'hours_only':
+      dividers = {
+        hours: 'h',
+        keepZero: true,
+      };
+
       units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
 
       break

--- a/frontend/src/app/shared/helpers/chronic_duration.spec.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.spec.ts
@@ -160,7 +160,8 @@ describe('outputChronicDuration', () => {
       short: '1m 20s',
       default: '1 min 20 secs',
       long: '1 minute 20 seconds',
-      daysAndHours: '0.02h',
+      days_and_hours: '0.02h',
+      hours_only: '0.02h',
       chrono: '1:20',
     },
     [60 + 20.51]: {
@@ -168,7 +169,8 @@ describe('outputChronicDuration', () => {
       short: '1m 20.51s',
       default: '1 min 20.51 secs',
       long: '1 minute 20.51 seconds',
-      daysAndHours: '0.02h',
+      days_and_hours: '0.02h',
+      hours_only: '0.02h',
       chrono: '1:20.51',
     },
     [60 + 20.51928]: {
@@ -176,7 +178,8 @@ describe('outputChronicDuration', () => {
       short: '1m 20.51928s',
       default: '1 min 20.51928 secs',
       long: '1 minute 20.51928 seconds',
-      daysAndHours: '0.02h',
+      days_and_hours: '0.02h',
+      hours_only: '0.02h',
       chrono: '1:20.51928',
     },
     [4 * 3600 + 60 + 1]: {
@@ -184,7 +187,8 @@ describe('outputChronicDuration', () => {
       short: '4h 1m 1s',
       default: '4 hrs 1 min 1 sec',
       long: '4 hours 1 minute 1 second',
-      daysAndHours: '4.02h',
+      days_and_hours: '4.02h',
+      hours_only: '4.02h',
       chrono: '4:01:01',
     },
     [2 * 3600 + 20 * 60]: {
@@ -192,7 +196,8 @@ describe('outputChronicDuration', () => {
       short: '2h 20m',
       default: '2 hrs 20 mins',
       long: '2 hours 20 minutes',
-      daysAndHours: '2.33h',
+      days_and_hours: '2.33h',
+      hours_only: '2.33h',
       chrono: '2:20:00',
     },
     [8 * 24 * 3600 + 3 * 3600 + 30 * 60]: {
@@ -200,7 +205,8 @@ describe('outputChronicDuration', () => {
       short: '8d 3h 30m',
       default: '8 days 3 hrs 30 mins',
       long: '8 days 3 hours 30 minutes',
-      daysAndHours: '8d 3.5h',
+      days_and_hours: '8d 3.5h',
+      hours_only: '195.5h',
       chrono: '8:03:30:00'
     },
     [6 * 30 * 24 * 3600 + 24 * 3600]: {
@@ -208,7 +214,8 @@ describe('outputChronicDuration', () => {
       short: '6mo 1d',
       default: '6 mos 1 day',
       long: '6 months 1 day',
-      daysAndHours: '181d 0h',
+      days_and_hours: '181d 0h',
+      hours_only: '4344h',
       chrono: '6:01:00:00:00', // Yuck. FIXME
     },
     [365.25 * 24 * 3600 + 24 * 3600]: {
@@ -216,7 +223,8 @@ describe('outputChronicDuration', () => {
       short: '1y 1d',
       default: '1 yr 1 day',
       long: '1 year 1 day',
-      daysAndHours: '366d 0h',
+      days_and_hours: '366d 0h',
+      hours_only: '8790h',
       chrono: '1:00:01:00:00:00',
     },
     [3 * 365.25 * 24 * 3600 + 24 * 3600]: {
@@ -224,7 +232,8 @@ describe('outputChronicDuration', () => {
       short: '3y 1d',
       default: '3 yrs 1 day',
       long: '3 years 1 day',
-      daysAndHours: '1096d 0h',
+      days_and_hours: '1096d 0h',
+      hours_only: '26322h',
       chrono: '3:00:01:00:00:00',
     },
     [6 * 365.25 * 24 * 3600 + 3 * 3600]: {
@@ -232,7 +241,8 @@ describe('outputChronicDuration', () => {
       short: '6y 3h',
       default: '6 yrs 3 hrs',
       long: '6 years 3 hours',
-      daysAndHours: '2191d 3h',
+      days_and_hours: '2191d 3h',
+      hours_only: '52599h',
       chrono: '6:00:00:03:00:00',
     },
     [3600 * 24 * 30 * 18]: {
@@ -240,7 +250,8 @@ describe('outputChronicDuration', () => {
       short: '18mo',
       default: '18 mos',
       long: '18 months',
-      daysAndHours: '540d 0h',
+      days_and_hours: '540d 0h',
+      hours_only: '12960h',
       chrono: '18:00:00:00:00',
     },
   };
@@ -354,7 +365,7 @@ describe('outputChronicDuration', () => {
   Object.entries(EXEMPLARS).forEach(([seconds, formatSpec]) => {
     const secondsF = parseFloat(seconds);
     Object.keys(formatSpec).forEach((format) => {
-      if (format === 'daysAndHours') return;
+      if (format === 'days_and_hours' || format === 'hours_only') return;
 
       it(`outputs a duration for ${seconds} that parses back to the same thing when using the ${format} format`, () => {
         expect(parseChronicDuration(outputChronicDuration(secondsF, { format }))).toBe(secondsF);

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -63,6 +63,9 @@ module API
                  exec_context: :decorator,
                  render_nil: true
 
+        property :duration_format,
+                 render_nil: true
+
         property :time_format,
                  exec_context: :decorator,
                  render_nil: true

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -102,7 +102,10 @@ module ChronicDuration
     month = days_per_month * day
     year = SECONDS_PER_YEAR
 
-    if seconds >= SECONDS_PER_YEAR && seconds % year < seconds % month
+    if opts[:format] == :hours_only
+      hours = seconds / 3600.0
+      seconds = 0
+    elsif seconds >= SECONDS_PER_YEAR && seconds % year < seconds % month
       years = seconds / year
       months = seconds % year / month
       days = seconds % year % month / day
@@ -173,6 +176,14 @@ module ChronicDuration
       hours_int = hours.to_i
       hours = hours_int if hours - hours_int == 0 # if hours end with .0
       minutes = seconds = 0
+    when :hours_only
+      dividers = {
+        hours: "h", keep_zero: true
+      }
+
+      hours = hours.round(2)
+      hours_int = hours.to_i
+      hours = hours_int if hours - hours_int == 0 # if hours end with .0
     when :chrono
       dividers = {
         years: ":", months: ":", weeks: ":", days: ":", hours: ":", minutes: ":", seconds: ":", keep_zero: true

--- a/modules/costs/spec/features/time_entries_spec.rb
+++ b/modules/costs/spec/features/time_entries_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Work Package table cost entries", :js do
     parent_row = wp_table.row(parent)
     wp_row = wp_table.row(work_package)
 
-    expect(parent_row).to have_css(".inline-edit--container.spentTime", text: "1d 4.5h")
+    expect(parent_row).to have_css(".inline-edit--container.spentTime", text: "12.5h")
     expect(wp_row).to have_css(".inline-edit--container.spentTime", text: "2.5h")
   end
 

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
 
       # Check row after header row
       hours = sheet.rows[1].values_at(2)
-      expect(hours).to include("3d 3.5h")
+      expect(hours).to include("27.5h")
     end
   end
 
@@ -326,7 +326,7 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
     it "adapts the datetime fields to the user time zone" do
       work_package.reload
       estimated_cell = sheet.rows.last.to_a.last
-      expect(estimated_cell).to eq "· Σ 1d 7h"
+      expect(estimated_cell).to eq "· Σ 15h"
     end
   end
 
@@ -347,8 +347,8 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
     it "outputs both values" do
       work_package.reload
       estimated_cell, remaining_cell = sheet.rows.last.to_a.last(2)
-      expect(estimated_cell).to eq "0h · Σ 1d 7h"
-      expect(remaining_cell).to eq "0h · Σ 1d 0h"
+      expect(estimated_cell).to eq "0h · Σ 15h"
+      expect(remaining_cell).to eq "0h · Σ 8h"
     end
   end
 end

--- a/spec/features/activities/work_package_activity_spec.rb
+++ b/spec/features/activities/work_package_activity_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
     it "displays changed attributes in the activity tab", :aggregate_failures do
       within("activity-entry", text: admin.name) do
         expect(page).to have_list_item(text: "% Complete set to 95%")
-        expect(page).to have_list_item(text: "Work set to 12d 4h")
+        expect(page).to have_list_item(text: "Work set to 100h")
         expect(page).to have_list_item(text: "Remaining work set to 5h")
-        expect(page).to have_list_item(text: "Total work set to 13d 6h")
-        expect(page).to have_list_item(text: "Total remaining work set to 1d 0h")
+        expect(page).to have_list_item(text: "Total work set to 110h")
+        expect(page).to have_list_item(text: "Total remaining work set to 8h")
         expect(page).to have_list_item(text: "Total % complete set to 93%")
       end
     end

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "edit work package", :js do
                               responsible: manager.name,
                               assignee: manager.name,
                               combinedDate: "03/04/2013 - 03/20/2013",
-                              estimatedTime: "1d 2h",
+                              estimatedTime: "10h",
                               remainingTime: "7h",
                               percentageDone: "30%",
                               subject: "a new subject",

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe "Work package index sums", :js do
     # Expect the total sums row
     aggregate_failures do
       within(:row, "Total sum") do |row|
-        expect(row).to have_css(".estimatedTime", text: "3d 1h")
-        expect(row).to have_css(".remainingTime", text: "1d 4.5h")
+        expect(row).to have_css(".estimatedTime", text: "25h")
+        expect(row).to have_css(".remainingTime", text: "12.5h")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
         expect(row).to have_css(".laborCosts", text: "15.00 EUR")
@@ -164,8 +164,8 @@ RSpec.describe "Work package index sums", :js do
 
     aggregate_failures do
       within(:row, "Total sum") do |row|
-        expect(row).to have_css(".estimatedTime", text: "4d 3h")
-        expect(row).to have_css(".remainingTime", text: "2d 3.5h")
+        expect(row).to have_css(".estimatedTime", text: "35h")
+        expect(row).to have_css(".remainingTime", text: "19.5h")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
         expect(row).to have_css(".laborCosts", text: "15.00 EUR")
@@ -184,8 +184,8 @@ RSpec.describe "Work package index sums", :js do
     first_sum_row, second_sum_row = *find_all(:row, "Sum")
     # First status row
     aggregate_failures do
-      expect(first_sum_row).to have_css(".estimatedTime", text: "2d 4h")
-      expect(first_sum_row).to have_css(".remainingTime", text: "1d 4h")
+      expect(first_sum_row).to have_css(".estimatedTime", text: "20h")
+      expect(first_sum_row).to have_css(".remainingTime", text: "12h")
       expect(first_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "5")
       expect(first_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "5.5")
       expect(first_sum_row).to have_css(".laborCosts", text: "15.00 EUR")
@@ -195,7 +195,7 @@ RSpec.describe "Work package index sums", :js do
 
     # Second status row
     aggregate_failures do
-      expect(second_sum_row).to have_css(".estimatedTime", text: "1d 7h")
+      expect(second_sum_row).to have_css(".estimatedTime", text: "15h")
       expect(second_sum_row).to have_css(".remainingTime", text: "7.5h")
       expect(second_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "7")
       expect(second_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "7.7")
@@ -207,8 +207,8 @@ RSpec.describe "Work package index sums", :js do
     # Total sums row is unchanged
     aggregate_failures do
       within(:row, "Total sum") do |row|
-        expect(row).to have_css(".estimatedTime", text: "4d 3h")
-        expect(row).to have_css(".remainingTime", text: "2d 3.5h")
+        expect(row).to have_css(".estimatedTime", text: "35h")
+        expect(row).to have_css(".remainingTime", text: "19.5h")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
         expect(row).to have_css(".laborCosts", text: "15.00 EUR")
@@ -282,8 +282,8 @@ RSpec.describe "Work package index sums", :js do
       # Expect the total sums row without filtering
       aggregate_failures do
         within(:row, "Total sum") do |row|
-          expect(row).to have_css(".estimatedTime", text: "6d 2h")
-          expect(row).to have_css(".remainingTime", text: "3d 1h")
+          expect(row).to have_css(".estimatedTime", text: "50h")
+          expect(row).to have_css(".remainingTime", text: "25h")
           expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "24")
           expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "26.4")
           expect(row).to have_css(".laborCosts", text: "40.00 EUR")
@@ -295,7 +295,6 @@ RSpec.describe "Work package index sums", :js do
       # Filter
       filters.open
       filters.add_filter_by("Type", "is (OR)", type_task.name)
-      puts Capybara::Screenshot.screenshot_and_save_page
 
       # Expect 2 work packages shown
       expect(page).to have_row("WorkPackage", count: 2) # works because the subject name includes "WorkPackage"
@@ -303,8 +302,8 @@ RSpec.describe "Work package index sums", :js do
       # Expect the total sums row to have changed
       aggregate_failures do
         within(:row, "Total sum") do |row|
-          expect(row).to have_css(".estimatedTime", text: "3d 6h")
-          expect(row).to have_css(".remainingTime", text: "1d 7h")
+          expect(row).to have_css(".estimatedTime", text: "30h")
+          expect(row).to have_css(".remainingTime", text: "15h")
           expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "14")
           expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "15.4")
           expect(row).to have_css(".laborCosts", text: "", exact_text: true)
@@ -328,7 +327,7 @@ RSpec.describe "Work package index sums", :js do
       first_sum_row, second_sum_row = *find_all(:row, "Sum")
       # First status row
       aggregate_failures do
-        expect(first_sum_row).to have_css(".estimatedTime", text: "1d 2h")
+        expect(first_sum_row).to have_css(".estimatedTime", text: "10h")
         expect(first_sum_row).to have_css(".remainingTime", text: "5h")
         expect(first_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "5")
         expect(first_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "5.5")
@@ -339,7 +338,7 @@ RSpec.describe "Work package index sums", :js do
 
       # Second status row
       aggregate_failures do
-        expect(second_sum_row).to have_css(".estimatedTime", text: "1d 7h")
+        expect(second_sum_row).to have_css(".estimatedTime", text: "15h")
         expect(second_sum_row).to have_css(".remainingTime", text: "7.5h")
         expect(second_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "7")
         expect(second_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "7.7")
@@ -351,8 +350,8 @@ RSpec.describe "Work package index sums", :js do
       # Total sum
       aggregate_failures do
         within(:row, "Total sum") do |row|
-          expect(row).to have_css(".estimatedTime", text: "3d 1h")
-          expect(row).to have_css(".remainingTime", text: "1d 4.5h")
+          expect(row).to have_css(".estimatedTime", text: "25h")
+          expect(row).to have_css(".remainingTime", text: "12.5h")
           expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
           expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
           expect(row).to have_css(".laborCosts", text: "15.00 EUR")

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
           work_edit_field.activate!
 
-          work_edit_field.expect_modal_field_value("1d 2h")
+          work_edit_field.expect_modal_field_value("10h")
           remaining_work_edit_field.expect_modal_field_value("2.12h") # 2h 7m
           percent_complete_edit_field.expect_modal_field_value("78", readonly: true)
         end
@@ -538,7 +538,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite do
 
         work_edit_field.set_value("14")
         page.driver.wait_for_network_idle # Wait for live-update to finish
-        remaining_work_edit_field.expect_modal_field_value("1d 0h")
+        remaining_work_edit_field.expect_modal_field_value("8h")
       end
 
       specify "Case 3: when work is set to 2h, " \

--- a/spec/features/work_packages/remaining_time_spec.rb
+++ b/spec/features/work_packages/remaining_time_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Work packages remaining time", :js, :with_cuprite do
     # need to update work first to enable the remaining work field
     wp_page.update_attributes estimatedTime: "200" # rubocop:disable Rails/ActiveRecordAliases
     wp_page.update_attributes remainingTime: "125" # rubocop:disable Rails/ActiveRecordAliases
-    wp_page.expect_attributes remainingTime: "15d 5h"
+    wp_page.expect_attributes remainingTime: "125h"
 
     work_package.reload
     expect(work_package.remaining_hours).to eq 125.0
@@ -70,8 +70,8 @@ RSpec.describe "Work packages remaining time", :js, :with_cuprite do
     # need to update work first to enable the remaining work field
     wp_table_page.update_work_package_attributes work_package, estimatedTime: "200"
     wp_table_page.update_work_package_attributes work_package, remainingTime: "125"
-    wp_table_page.expect_work_package_with_attributes work_package, remainingTime: "15d 5h"
-    wp_table_page.expect_sums_row_with_attributes remainingTime: "15d 5h"
+    wp_table_page.expect_work_package_with_attributes work_package, remainingTime: "125h"
+    wp_table_page.expect_sums_row_with_attributes remainingTime: "125h"
 
     work_package.reload
     expect(work_package.remaining_hours).to eq 125.0

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -75,6 +75,6 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
     expect(data.last).to include(work_package.description)
     expect(data.last).to include(current_user.name)
     expect(data.last).to include(work_package.updated_at.localtime.strftime("%m/%d/%Y %I:%M %p"))
-    expect(data.last).to include("· Σ 1d 7h")
+    expect(data.last).to include("· Σ 15h")
   end
 end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -252,8 +252,8 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           ["category", category.name],
           ["createdAt", export_time_formatted],
           ["updatedAt", export_time_formatted],
-          ["estimatedTime", "1d 2h"],
-          ["remainingTime", "1d 1h"],
+          ["estimatedTime", "10h"],
+          ["remainingTime", "9h"],
           ["version", version.name],
           ["responsible", user.name],
           ["dueDate", "05/30/2024"],
@@ -388,7 +388,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
         DESCRIPTION
       end
 
-      it "contains resolved attributes and labels" do
+      it "contains resolved attributes and labels" do # rubocop:disable RSpec/ExampleLength
         result = pdf[:strings]
         expected_result = [
           *expected_details,

--- a/spec/services/duration_converter_spec.rb
+++ b/spec/services/duration_converter_spec.rb
@@ -58,31 +58,80 @@ RSpec.describe DurationConverter do
       expect(described_class.output(nil)).to be_nil
     end
 
-    it "returns 0 h when given 0" do
+    it "returns 0h when given 0" do
       expect(described_class.output(0)).to eq("0h")
     end
 
-    it "works with ChronicDuration defaults otherwise in :days_and_hours format" do
-      expect(described_class.output(5.75))
-        .to eq("5.75h")
-      expect(described_class.output(5.754321))
-        .to eq("5.75h")
-      expect(described_class.output(8))
-        .to eq("1d 0h")
-      expect(described_class.output(804))
-        .to eq("100d 4h")
+    context "when duration format is set to days_and_hours",
+            with_settings: { duration_format: "days_and_hours" } do
+      it "displays the duration in days and hours" do
+        expect(described_class.output(5.75))
+            .to eq("5.75h")
+        expect(described_class.output(5.754321))
+          .to eq("5.75h")
+        expect(described_class.output(804))
+          .to eq("100d 4h")
+      end
+
+      it "does not display days if it would be 0 days (like '3h')" do
+        expect(described_class.output(3))
+          .to eq("3h")
+        expect(described_class.output(7))
+          .to eq("7h")
+        expect(described_class.output(7.99))
+          .to eq("7.99h")
+      end
+
+      it "displays hours even when it's zero (like '2d 0h')" do
+        expect(described_class.output(8))
+          .to eq("1d 0h")
+        expect(described_class.output(2 * 8))
+          .to eq("2d 0h")
+      end
+
+      it "ignores seconds and keep the nearest minute, displayed as hours" do
+        expect(described_class.output(0.28))
+          .to eq("0.28h")
+        expect(described_class.output(2.23))
+          .to eq("2.23h")
+      end
+
+      it "deals well with floating point maths" do
+        expect(described_class.output(1.89))
+          .to eq("1.89h")
+      end
     end
 
-    it "ignores seconds and keep the nearest minute, displayed as hours" do
-      expect(described_class.output(0.28))
-        .to eq("0.28h")
-      expect(described_class.output(2.23))
-        .to eq("2.23h")
-    end
+    context "when duration format is set to hours_only",
+            with_settings: { duration_format: "hours_only" } do
+      it "displays the duration in hours only" do
+        expect(described_class.output(0))
+            .to eq("0h")
+        expect(described_class.output(5.75))
+            .to eq("5.75h")
+        expect(described_class.output(5.754321))
+          .to eq("5.75h")
+        expect(described_class.output(8))
+          .to eq("8h")
+        expect(described_class.output(804.32))
+          .to eq("804.32h")
+      end
 
-    it "deals well with floating point maths" do
-      expect(described_class.output(1.89))
-        .to eq("1.89h")
+      it "ignores seconds and keep the nearest minute, displayed as hours" do
+        expect(described_class.output(0.28))
+          .to eq("0.28h")
+        expect(described_class.output(2.23))
+          .to eq("2.23h")
+      end
+
+      it "deals well with floating point maths" do
+        expect(described_class.output(1.89))
+          .to eq("1.89h")
+        expect(described_class.output(1.9997222222)) # 1h59m59s
+          .to eq("2h")
+        expect(described_class.output(1.9916666667)) # 1h59m30s
+          .to eq("1.99h")
+      end
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/55997

The `duration_format` setting can take two values: "hours_only" or "days_and_hours". The default value is "hours_only".

The `duration_format` setting is used to determine how durations are displayed in the frontend and in some exports.

It can be changed in Administration > Calendar and Dates > Working days and hours.

![image](https://github.com/opf/openproject/assets/176055/9f42d50a-5bda-4518-8692-bb9154cf6cf0)
