### PR TITLE
Remember back_url/origin as RelayState in saml

### DIFF
--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -47,7 +47,7 @@ module Accounts::OmniauthLogin
   end
 
   def omniauth_login
-    params[:back_url] = request.env["omniauth.origin"] if remember_back_url?
+    params[:back_url] = omniauth_back_url if remember_back_url?
 
     # Extract auth info and perform check / login or activate user
     auth_hash = request.env["omniauth.auth"]
@@ -75,11 +75,16 @@ module Accounts::OmniauthLogin
 
   # Avoid remembering the back_url if we're coming from the login page
   def remember_back_url?
-    provided_back_url = request.env["omniauth.origin"]
-    return if provided_back_url.blank?
+    return if omniauth_back_url.blank?
 
     account_routes = /\/(login|account)/
-    omniauth_direct_login? || !provided_back_url.match?(account_routes)
+    omniauth_direct_login? || !omniauth_back_url.match?(account_routes)
+  end
+
+  # In case of SAML post bindings, we lose our session information
+  # so we need to store it in the RelayState parameter
+  def omniauth_back_url
+    request.env["omniauth.origin"].presence || params[:RelayState]
   end
 
   def show_error(error)

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -63,6 +63,9 @@ module OpenProject
             # Remember saml session values when logging in user
             h[:retain_from_session] = %w[saml_uid saml_session_index saml_transaction_id]
 
+            # remember the origin in RelayState
+            h[:idp_sso_target_url_runtime_params] = { origin: :RelayState }
+
             h[:single_sign_out_callback] = Proc.new do |prev_session, _prev_user|
               next unless h[:idp_slo_target_url]
               next unless prev_session[:saml_uid] && prev_session[:saml_session_index]


### PR DESCRIPTION
When SAML uses the HTTP-POST binding, we lose the saved back_url as the session cookie is no longer sent due to SameSite=Lax.

We also don't want to widen SameSite to None, so we need another way to keep this information. SAML has RelayState that we can use for storing this state.

https://community.openproject.org/work_packages/55188