### PR TITLE
Minor fixes and cleanup on CopyProjectFoldersJob

### DIFF
--- a/modules/storages/spec/workers/storages/copy_project_folders_job_spec.rb
+++ b/modules/storages/spec/workers/storages/copy_project_folders_job_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Storages::CopyProjectFoldersJob, :job, :webmock, with_good_job_ba
         batch.reload
 
         expect(batch.properties.dig(:polling, source.id.to_s, :polling_url)).to eq(polling_url)
-        expect(batch.properties.dig(:polling, source.id.to_s, :polling_state)).to eq(:ongoing)
+        expect(batch.properties.dig(:polling, source.id.to_s, :polling_state)).to eq(:completed)
       end
 
       context "when the polling completes" do


### PR DESCRIPTION
I spotted a leftover method and a couple of comparisons that should have been assignments.

Minor cleanup followed.