### PR TITLE
fix(Admin Menu Item): Use absolute path to mitigate routing exception red herring

### DIFF
--- a/modules/webhooks/lib/open_project/webhooks/engine.rb
+++ b/modules/webhooks/lib/open_project/webhooks/engine.rb
@@ -39,7 +39,7 @@ module OpenProject::Webhooks
              author_url: "https://www.openproject.org" do
       menu :admin_menu,
            :plugin_webhooks,
-           { controller: "webhooks/outgoing/admin", action: :index },
+           { controller: "/webhooks/outgoing/admin", action: :index },
            if: Proc.new { User.current.admin? },
            parent: :api_and_webhooks,
            caption: :"webhooks.plural"


### PR DESCRIPTION


Without absolute paths, the routing definitions seem to implicitly scope within the current engine/namespace (not sure) Causing an exception like so:

```ruby
# lib/redmine/menu_manager/menu_helper.rb:387 Redmine::MenuManager::MenuHelper#node_url:
[7] pry(#<#<Class:0x0000fffef642dd58>>)> e
=> #<ActionController::UrlGenerationError: No route matches {:action=>"index", :controller=>"storages/webhooks/outgoing/admin", :layout=>nil, :storage_id=>"20"}>
```

---

From [@klaustopher's](https://matrix.to/#/!fyQrllnnogDxQuleQW:openproject.org/$nO-kY0NegsJ9E3w-P1Lx3YtgeQeutrQ_ohR0xpsljjg?via=openproject.org) impression it seems using `namespace:` routes is the root cause. But this is still an odd and difficult bug to solve so we should probably think around improving it.