### PR TITLE
Switch empty state when public flag is toggled

### DIFF
--- a/app/components/shares/modal_body_component.rb
+++ b/app/components/shares/modal_body_component.rb
@@ -48,7 +48,7 @@ module Shares
     end
 
     def self.wrapper_key
-      "share_list"
+      "share_modal_body"
     end
 
     private

--- a/app/components/shares/modal_upsale_component.rb
+++ b/app/components/shares/modal_upsale_component.rb
@@ -33,7 +33,7 @@ module Shares
     include OpPrimer::ComponentHelpers
 
     def self.wrapper_key
-      "share_list"
+      "share_modal_body"
     end
   end
 end

--- a/app/components/shares/project_queries/empty_state_component.rb
+++ b/app/components/shares/project_queries/empty_state_component.rb
@@ -62,7 +62,7 @@ module Shares
 
       def unfiltered_blankslate_config
         {
-          icon: :people,
+          icon: "share-android",
           heading_text: I18n.t("sharing.project_queries.blank_state.private.header"),
           description_text: I18n.t("sharing.project_queries.blank_state.private.description")
         }

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -8,8 +8,7 @@ container.with_row do
         csrf_token: form_authenticity_token,
         status_label_position: :start,
         checked: published?,
-        enabled: can_publish?,
-        data: { turbo: true }
+        enabled: can_publish?
       ))
 end
 %>

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -8,7 +8,8 @@ container.with_row do
         csrf_token: form_authenticity_token,
         status_label_position: :start,
         checked: published?,
-        enabled: can_publish?
+        enabled: can_publish?,
+        data: { turbo: true }
       ))
 end
 %>

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -73,7 +73,7 @@ class Projects::QueriesController < ApplicationController
   end
 
   def toggle_public # rubocop:disable Metrics/AbcSize
-    to_be_public = !@query.public?
+    to_be_public = ActiveRecord::Type::Boolean.new.cast(params["value"])
     i18n_key = to_be_public ? "lists.publish" : "lists.unpublish"
 
     call = Queries::Projects::ProjectQueries::PublishService

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -80,12 +80,15 @@ class Projects::QueriesController < ApplicationController
              .new(user: current_user, model: @query)
              .call(public: to_be_public)
 
-    # Load shares and replace the modal
-    strategy = SharingStrategies::ProjectQueryStrategy.new(@query, user: current_user)
-    shares = strategy.shares_query({}).results
-    replace_via_turbo_stream(component: Shares::ModalBodyComponent.new(strategy:, shares:, errors: []))
+    respond_to do |format|
+      format.turbo_stream do
+        # Load shares and replace the modal
+        strategy = SharingStrategies::ProjectQueryStrategy.new(@query, user: current_user)
+        shares = strategy.shares_query({}).results
+        replace_via_turbo_stream(component: Shares::ModalBodyComponent.new(strategy:, shares:, errors: []))
+        render turbo_stream: turbo_streams, status:
+      end
 
-    respond_with_turbo_streams do |format|
       format.html do
         render_result(call, success_i18n_key: "#{i18n_key}.success", error_i18n_key: "#{i18n_key}.failure")
       end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -72,7 +72,7 @@ class Projects::QueriesController < ApplicationController
     render_result(call, success_i18n_key: "lists.update.success", error_i18n_key: "lists.update.failure")
   end
 
-  def toggle_public
+  def toggle_public # rubocop:disable Metrics/AbcSize
     to_be_public = !@query.public?
     i18n_key = to_be_public ? "lists.publish" : "lists.unpublish"
 

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -326,22 +326,7 @@ class SharesController < ApplicationController
   end
 
   def load_query
-    return @query if defined?(@query)
-
-    @query = ParamsToQueryService
-               .new(Member, current_user, query_class: Queries::Members::NonInheritedMemberQuery)
-               .call(params)
-
-    # Set default filter on the entity
-    @query.where("entity_id", "=", @entity.id)
-    @query.where("entity_type", "=", @entity.class.name)
-    if @project
-      @query.where("project_id", "=", @project.id)
-    end
-
-    @query.order(name: :asc) unless params[:sortBy]
-
-    @query
+    @query = sharing_strategy.shares_query(params)
   end
 
   def load_shares

--- a/app/models/sharing_strategies/base_strategy.rb
+++ b/app/models/sharing_strategies/base_strategy.rb
@@ -79,5 +79,24 @@ module SharingStrategies
     def empty_state_component
       nil
     end
+
+    def shares_query(params) # rubocop:disable Metrics/AbcSize
+      return @query if defined?(@query)
+
+      @query = ParamsToQueryService
+                 .new(Member, user, query_class: Queries::Members::NonInheritedMemberQuery)
+                 .call(params)
+
+      # Set default filter on the entity
+      @query.where("entity_id", "=", entity.id)
+      @query.where("entity_type", "=", entity.class.name)
+      if entity.respond_to?(:project)
+        @query.where("project_id", "=", entity.project.id)
+      end
+
+      @query.order(name: :asc) unless params[:sortBy]
+
+      @query
+    end
   end
 end

--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.html
@@ -26,7 +26,7 @@
   <div class="spot-modal--body spot-container">
     <turbo-frame
       #frameElement
-      id="share_list"
+      id="share_modal_body"
       src="{{this.frameSrc}}">
       <op-content-loader
         viewBox="0 0 180 80"

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Projects::QueriesController do
       end
 
       it "calls publish service on query" do
-        post "toggle_public", params: { id: 42 }
+        post "toggle_public", params: { id: 42, value: 1 }
 
         expect(service_instance).to have_received(:call).with(query_params)
       end
@@ -301,7 +301,7 @@ RSpec.describe Projects::QueriesController do
         it "redirects to projects" do
           allow(I18n).to receive(:t).with("lists.publish.success").and_return("foo")
 
-          post "toggle_public", params: { id: 42 }
+          post "toggle_public", params: { id: 42, value: 1 }
 
           expect(flash[:notice]).to eq("foo")
           expect(response).to redirect_to(projects_path(query_id: query.id))
@@ -319,7 +319,7 @@ RSpec.describe Projects::QueriesController do
         it "renders projects/index" do
           allow(I18n).to receive(:t).with("lists.publish.failure", errors: "something\nwent\nwrong").and_return("bar")
 
-          post "toggle_public", params: { id: 42 }
+          post "toggle_public", params: { id: 42, value: 1 }
 
           expect(flash[:error]).to eq("bar")
           expect(response).to render_template("projects/index")
@@ -328,7 +328,7 @@ RSpec.describe Projects::QueriesController do
         it "passes variables to template" do
           allow(controller).to receive(:render).and_call_original
 
-          post "toggle_public", params: { id: 42 }
+          post "toggle_public", params: { id: 42, value: 1 }
 
           expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
         end

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Projects::QueriesController do
     let(:service_class) { Queries::Projects::ProjectQueries::PublishService }
 
     it "requires login" do
-      post "toggle_public", params: { id: 42 }
+      post "toggle_public", params: { id: "42", value: "1" }
 
       expect(response).not_to be_successful
     end
@@ -275,62 +275,75 @@ RSpec.describe Projects::QueriesController do
     context "when logged in" do
       let(:query) { build_stubbed(:project_query, user:) }
       let(:query_id) { "42" }
-      let(:query_params) { { public: true } }
       let(:service_instance) { instance_double(service_class) }
       let(:service_result) { instance_double(ServiceResult, success?: success?, result: query) }
       let(:success?) { true }
 
-      before do
-        allow(controller).to receive(:permitted_query_params).and_return(query_params)
-        scope = instance_double(ActiveRecord::Relation)
-        allow(ProjectQuery).to receive(:visible).and_return(scope)
-        allow(scope).to receive(:find).with(query_id).and_return(query)
-        allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
-        allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
+      [true, false].each do |public_value|
+        context "when toggling to #{public_value ? 'public' : 'private'}" do
+          let(:query_params) { { public: public_value } }
+          let(:params) do
+            {
+              id: query_id,
+              value: public_value ? "1" : "0"
+            }
+          end
 
-        login_as user
-      end
+          let(:i18n_scope) { public_value ? "lists.publish" : "lists.unpublish" }
 
-      it "calls publish service on query" do
-        post "toggle_public", params: { id: 42, value: 1 }
+          before do
+            allow(controller).to receive(:permitted_query_params).and_return(query_params)
+            scope = instance_double(ActiveRecord::Relation)
+            allow(ProjectQuery).to receive(:visible).and_return(scope)
+            allow(scope).to receive(:find).with(query_id).and_return(query)
+            allow(service_class).to receive(:new).with(model: query, user:).and_return(service_instance)
+            allow(service_instance).to receive(:call).with(query_params).and_return(service_result)
 
-        expect(service_instance).to have_received(:call).with(query_params)
-      end
+            login_as user
+          end
 
-      context "when service call succeeds" do
-        it "redirects to projects" do
-          allow(I18n).to receive(:t).with("lists.publish.success").and_return("foo")
+          it "calls publish service on query" do
+            post("toggle_public", params:)
 
-          post "toggle_public", params: { id: 42, value: 1 }
+            expect(service_instance).to have_received(:call).with(query_params)
+          end
 
-          expect(flash[:notice]).to eq("foo")
-          expect(response).to redirect_to(projects_path(query_id: query.id))
-        end
-      end
+          context "when service call succeeds" do
+            it "redirects to projects" do
+              allow(I18n).to receive(:t).with("#{i18n_scope}.success").and_return("foo")
 
-      context "when service call fails" do
-        let(:success?) { false }
-        let(:errors) { instance_double(ActiveModel::Errors, full_messages: ["something", "went", "wrong"]) }
+              post("toggle_public", params:)
 
-        before do
-          allow(service_result).to receive(:errors).and_return(errors)
-        end
+              expect(flash[:notice]).to eq("foo")
+              expect(response).to redirect_to(projects_path(query_id: query.id))
+            end
+          end
 
-        it "renders projects/index" do
-          allow(I18n).to receive(:t).with("lists.publish.failure", errors: "something\nwent\nwrong").and_return("bar")
+          context "when service call fails" do
+            let(:success?) { false }
+            let(:errors) { instance_double(ActiveModel::Errors, full_messages: ["something", "went", "wrong"]) }
 
-          post "toggle_public", params: { id: 42, value: 1 }
+            before do
+              allow(service_result).to receive(:errors).and_return(errors)
+            end
 
-          expect(flash[:error]).to eq("bar")
-          expect(response).to render_template("projects/index")
-        end
+            it "renders projects/index" do
+              allow(I18n).to receive(:t).with("#{i18n_scope}.failure", errors: "something\nwent\nwrong").and_return("bar")
 
-        it "passes variables to template" do
-          allow(controller).to receive(:render).and_call_original
+              post("toggle_public", params:)
 
-          post "toggle_public", params: { id: 42, value: 1 }
+              expect(flash[:error]).to eq("bar")
+              expect(response).to render_template("projects/index")
+            end
 
-          expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+            it "passes variables to template" do
+              allow(controller).to receive(:render).and_call_original
+
+              post("toggle_public", params:)
+
+              expect(controller).to have_received(:render).with(include(locals: { query:, state: :edit }))
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
One more left over ticket from #15971: When toggling the public state of the project list, re-render the modal 