### PR TITLE
[OP#55966] Define "Add Projects" dialog that allows selecting one or many projects for activation with include subprojects option

### DIFF
--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -49,7 +49,7 @@ module Projects::CustomFields
 
         group.check_box(
           name: :include_sub_projects,
-          label: I18n.t("projects.settings.project_custom_fields.new_project_mapping_form.include_sub_projects"),
+          label: I18n.t(:label_include_sub_projects),
           checked: false,
           label_arguments: { class: "no-wrap" }
         )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2161,6 +2161,7 @@ en:
   label_inactive: "Inactive"
   label_incoming_emails: "Incoming emails"
   label_includes: "includes"
+  label_include_sub_projects: Include sub-projects
   label_index_by_date: "Index by date"
   label_index_by_title: "Index by title"
   label_information: "Information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,8 +336,6 @@ en:
         is_required_blank_slate:
           heading: Required in all projects
           description: This project attribute is activated in all projects since the "Required in all projects" option is checked. It cannot be deactivated for individual projects.
-        new_project_mapping_form:
-          include_sub_projects: Include sub-projects
       types:
         no_results_title_text: There are currently no types available.
         form:

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -46,6 +46,18 @@ See COPYRIGHT and LICENSE files for more details.
             render(Storages::Admin::Storages::AddProjectsAutocompleterForm.new(form, project_storage:))
           end
 
+          flex.with_row(mb: 3) do
+            render(Primer::Alpha::ActionList::Divider.new(scheme: :subtle))
+          end
+
+          flex.with_row(mb: 2) do
+            render(Primer::Beta::Heading.new(tag: :h4)) { t(:"storages.label_project_folder") }
+          end
+
+          flex.with_row(mb: 3) do
+            render(Primer::Beta::Text.new) { t(:"storages.help_texts.project_folder") }
+          end
+
           flex.with_row do
             render(Storages::Admin::ProjectStorages::ProjectFolderModeForm.new(form, project_storage:))
           end

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -55,7 +55,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
 
           flex.with_row(mb: 3) do
-            render(Primer::Beta::Text.new) { t(:"storages.help_texts.project_folder") }
+            render(Primer::Beta::Text.new) { t(:"storages.help_texts.project_folder_bulk") }
           end
 
           flex.with_row do

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -41,12 +41,15 @@ See COPYRIGHT and LICENSE files for more details.
         test_selector: dialog_body_id,
         aria: { label: title }
       )) do
-        render(
-          Primer::Forms::FormList.new(
-            Storages::Admin::Storages::AddProjectsAutocompleterForm.new(form, project_storage:),
-          Storages::Admin::ProjectStorages::ProjectFolderModeForm.new(form, project_storage:)
-          )
-        )
+        flex_layout do |flex|
+          flex.with_row(mb: 3) do
+            render(Storages::Admin::Storages::AddProjectsAutocompleterForm.new(form, project_storage:))
+          end
+
+          flex.with_row do
+            render(Storages::Admin::ProjectStorages::ProjectFolderModeForm.new(form, project_storage:))
+          end
+        end
       end)
 
       concat(render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     primer_form_with(
       class: "op-new-project-storage-form",
       model: @project_storage,
-      url: admin_settings_storage_project_storages_path(@storage),
+      url: admin_settings_storage_project_storages_path(project_storage.storage),
       data: { turbo: true },
       method: :post
     ) do |form|

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -1,0 +1,54 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  component_wrapper do
+    primer_form_with(
+      class: "op-new-project-storage-form",
+      model: @project_storage,
+      url: admin_settings_storage_project_storages_path(@storage),
+      data: { turbo: true },
+      method: :post
+    ) do |form|
+      concat(render(Primer::Alpha::Dialog::Body.new(
+        id: dialog_body_id,
+        test_selector: dialog_body_id,
+        aria: { label: title },
+        style: "min-height: 300px"
+      )) do
+        render(Storages::Admin::Storages::AddProjectsForm.new(form, project_storage: @project_storage))
+      end)
+
+      concat(render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do
+        concat(render(Primer::ButtonComponent.new(data: { 'close-dialog-id': dialog_id })) { cancel_button_text })
+        concat(render(Primer::ButtonComponent.new(scheme: :primary, type: :submit)) { submit_button_text })
+      end)
+    end
+  end
+%>

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.html.erb
@@ -39,10 +39,14 @@ See COPYRIGHT and LICENSE files for more details.
       concat(render(Primer::Alpha::Dialog::Body.new(
         id: dialog_body_id,
         test_selector: dialog_body_id,
-        aria: { label: title },
-        style: "min-height: 300px"
+        aria: { label: title }
       )) do
-        render(Storages::Admin::Storages::AddProjectsForm.new(form, project_storage: @project_storage))
+        render(
+          Primer::Forms::FormList.new(
+            Storages::Admin::Storages::AddProjectsAutocompleterForm.new(form, project_storage:),
+          Storages::Admin::ProjectStorages::ProjectFolderModeForm.new(form, project_storage:)
+          )
+        )
       end)
 
       concat(render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
@@ -29,7 +29,7 @@
 module Storages
   module Admin
     module Storages
-      class AddProjectsFormModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+      class AddProjectsFormModalComponent < ApplicationComponent
         include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
 

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
@@ -30,6 +30,7 @@ module Storages
   module Admin
     module Storages
       class AddProjectsFormModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+        include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
 
         def initialize(project_storage:, **)

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -28,47 +26,35 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Storages::Admin::Storages::ProjectStoragesController < ApplicationController
-  include OpTurbo::ComponentStream
-  include OpTurbo::DialogStreamHelper
+module Storages
+  module Admin
+    module Storages
+      class AddProjectsFormModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+        include OpTurbo::Streamable
 
-  layout "admin"
+        def initialize(project_storage:, **)
+          @project_storage = project_storage
+          @storage = project_storage.storage
+          super(@project_storage, **)
+        end
 
-  model_object Storages::Storage
+        private
 
-  before_action :require_admin
-  before_action :find_model_object
+        def dialog_id = Storages::AddProjectsModalComponent::DIALOG_ID
+        def dialog_body_id = Storages::AddProjectsModalComponent::DIALOG_BODY_ID
 
-  menu_item :external_file_storages
+        def title
+          I18n.t(:label_add_projects)
+        end
 
-  def index
-    @project_query = ProjectQuery.new(
-      name: "project-storage-mappings-#{@storage.id}"
-    ) do |query|
-      query.where(:storages, "=", [@storage.id])
-      query.select(:name)
-      query.order("lft" => "asc")
+        def cancel_button_text
+          I18n.t("button_cancel")
+        end
+
+        def submit_button_text
+          I18n.t("button_add")
+        end
+      end
     end
-
-    # Prepare data for project_folder_type column
-    @project_folder_modes_per_project = Storages::ProjectStorage
-      .where(storage_id: @storage.id)
-      .pluck(:project_id, :project_folder_mode)
-      .to_h
-  end
-
-  def new
-    @project_storage = ::Storages::ProjectStorage.new(storage: @storage)
-    respond_with_dialog Storages::Admin::Storages::AddProjectsModalComponent.new(project_storage: @project_storage)
-  end
-
-  def create; end
-  def destroy; end
-
-  private
-
-  def find_model_object(object_id = :storage_id)
-    super
-    @storage = @object
   end
 end

--- a/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_form_modal_component.rb
@@ -35,7 +35,6 @@ module Storages
 
         def initialize(project_storage:, **)
           @project_storage = project_storage
-          @storage = project_storage.storage
           super(@project_storage, **)
         end
 

--- a/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.html.erb
@@ -4,7 +4,7 @@
       id: dialog_id,
       title:,
       test_selector: dialog_id,
-      size: :large
+      size: :xlarge
     )
   ) do |dialog|
     dialog.with_header(

--- a/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.html.erb
@@ -1,0 +1,18 @@
+<%=
+  render(
+    Primer::Alpha::Dialog.new(
+      id: dialog_id,
+      title:,
+      test_selector: dialog_id,
+      size: :large
+    )
+  ) do |dialog|
+    dialog.with_header(
+      show_divider: false,
+      visually_hide_title: false,
+      variant: :large
+    )
+
+    render(::Storages::Admin::Storages::AddProjectsFormModalComponent.new(project_storage:))
+  end
+%>

--- a/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.rb
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2012-2023 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -28,47 +26,32 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Storages::Admin::Storages::ProjectStoragesController < ApplicationController
-  include OpTurbo::ComponentStream
-  include OpTurbo::DialogStreamHelper
+module Storages
+  module Admin
+    module Storages
+      class AddProjectsModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+        include OpTurbo::Streamable
 
-  layout "admin"
+        DIALOG_ID = "storages--add-projects-modal".freeze
+        DIALOG_BODY_ID = "storages--add-projects-modal-body".freeze
 
-  model_object Storages::Storage
+        def initialize(project_storage:, **)
+          @project_storage = project_storage
+          @storage = project_storage.storage
+          super(@project_storage, **)
+        end
 
-  before_action :require_admin
-  before_action :find_model_object
+        private
 
-  menu_item :external_file_storages
+        def dialog_id = DIALOG_ID
+        def dialog_body_id = DIALOG_BODY_ID
 
-  def index
-    @project_query = ProjectQuery.new(
-      name: "project-storage-mappings-#{@storage.id}"
-    ) do |query|
-      query.where(:storages, "=", [@storage.id])
-      query.select(:name)
-      query.order("lft" => "asc")
+        attr_reader :project_storage, :storage
+
+        def title
+          I18n.t(:label_add_projects)
+        end
+      end
     end
-
-    # Prepare data for project_folder_type column
-    @project_folder_modes_per_project = Storages::ProjectStorage
-      .where(storage_id: @storage.id)
-      .pluck(:project_id, :project_folder_mode)
-      .to_h
-  end
-
-  def new
-    @project_storage = ::Storages::ProjectStorage.new(storage: @storage)
-    respond_with_dialog Storages::Admin::Storages::AddProjectsModalComponent.new(project_storage: @project_storage)
-  end
-
-  def create; end
-  def destroy; end
-
-  private
-
-  def find_model_object(object_id = :storage_id)
-    super
-    @storage = @object
   end
 end

--- a/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.rb
+++ b/modules/storages/app/components/storages/admin/storages/add_projects_modal_component.rb
@@ -29,7 +29,7 @@
 module Storages
   module Admin
     module Storages
-      class AddProjectsModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+      class AddProjectsModalComponent < ApplicationComponent
         include OpTurbo::Streamable
 
         DIALOG_ID = "storages--add-projects-modal".freeze

--- a/modules/storages/app/components/storages/project_storages/projects/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/row_component.rb
@@ -29,7 +29,7 @@
 # Purpose: Defines how to format the components within a table row of Projects
 # associated with a Storage
 module Storages::ProjectStorages::Projects
-  class RowComponent < Projects::RowComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+  class RowComponent < Projects::RowComponent
     def project_folder_type
       project_folder_mode = table.project_folder_modes_per_project[project.id]
       I18n.t("project_storages.project_folder_mode.#{project_folder_mode}")

--- a/modules/storages/app/components/storages/project_storages/projects/table_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/projects/table_component.html.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= component_wrapper(tag: "div", data: { turbo: true }) do %>
+  <%= render_parent %>
+<% end %>

--- a/modules/storages/app/components/storages/project_storages/projects/table_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/table_component.rb
@@ -31,7 +31,7 @@
 # See also: row_component.rb, which contains a method
 # for every "column" defined below.
 module Storages::ProjectStorages::Projects
-  class TableComponent < Projects::TableComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+  class TableComponent < Projects::TableComponent
     include OpTurbo::Streamable
 
     options :project_folder_modes_per_project

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -58,7 +58,11 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   end
 
   def new
-    @project_storage = ::Storages::ProjectStorage.new(storage: @storage)
+    @project_storage =
+      ::Storages::ProjectStorages::SetAttributesService
+        .new(user: current_user, model: ::Storages::ProjectStorage.new, contract_class: EmptyContract)
+        .call(storage: @storage)
+        .result
     respond_with_dialog Storages::Admin::Storages::AddProjectsModalComponent.new(project_storage: @project_storage)
   end
 

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -40,19 +40,15 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   before_action :require_admin
   before_action :find_model_object
 
-  before_action :storage_projects_query, only: :index
+  before_action :storage_projects_query,
+                :project_folder_modes_per_project,
+                only: :index
   before_action :initialize_project_storage, only: :new
   before_action :find_projects_to_activate_for_storage, only: :create
 
   menu_item :external_file_storages
 
-  def index
-    # Prepare data for project_folder_type column
-    @project_folder_modes_per_project = Storages::ProjectStorage
-      .where(storage_id: @storage.id)
-      .pluck(:project_id, :project_folder_mode)
-      .to_h
-  end
+  def index; end
 
   def new
     respond_with_dialog Storages::Admin::Storages::AddProjectsModalComponent.new(project_storage: @project_storage)
@@ -108,6 +104,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
     update_via_turbo_stream(
       component: Storages::ProjectStorages::Projects::TableComponent.new(
         query: storage_projects_query,
+        project_folder_modes_per_project:,
         params: { url_for_action: }
       )
     )
@@ -119,6 +116,13 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
       query.select(:name)
       query.order("lft" => "asc")
     end
+  end
+
+  def project_folder_modes_per_project
+    @project_folder_modes_per_project ||= Storages::ProjectStorage
+      .where(storage_id: @storage.id)
+      .pluck(:project_id, :project_folder_mode)
+      .to_h
   end
 
   def initialize_project_storage

--- a/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
+++ b/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
@@ -34,10 +34,12 @@ module Storages
           radio_form.radio_button_group(
             name: :project_folder_mode
           ) do |radio_group|
-            radio_group.radio_button(value: "inactive", label: I18n.t(:"storages.label_no_specific_folder"),
-                                     caption: I18n.t(:"storages.instructions.no_specific_folder"))
+            if @project_storage.project_folder_mode_possible?("inactive")
+              radio_group.radio_button(value: "inactive", label: I18n.t(:"storages.label_no_specific_folder"),
+                                       caption: I18n.t(:"storages.instructions.no_specific_folder"))
+            end
 
-            if @project_storage.automatic_management_possible?
+            if @project_storage.project_folder_mode_possible?("automatic")
               radio_group.radio_button(value: "automatic", label: I18n.t(:"storages.label_automatic_folder"),
                                        caption: I18n.t(:"storages.instructions.automatic_folder"))
             end

--- a/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
+++ b/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
@@ -41,9 +41,6 @@ module Storages
               radio_group.radio_button(value: "automatic", label: I18n.t(:"storages.label_automatic_folder"),
                                        caption: I18n.t(:"storages.instructions.automatic_folder"))
             end
-
-            radio_group.radio_button(value: "manual", label: I18n.t(:"storages.label_existing_manual_folder"),
-                                     caption: I18n.t(:"storages.instructions.existing_manual_folder"))
           end
         end
 

--- a/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
+++ b/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
@@ -32,9 +32,7 @@ module Storages
       class ProjectFolderModeForm < ApplicationForm
         form do |radio_form|
           radio_form.radio_button_group(
-            name: :project_folder_mode,
-            label: I18n.t(:"storages.label_project_folder"),
-            caption: I18n.t(:"storages.help_texts.project_folder")
+            name: :project_folder_mode
           ) do |radio_group|
             radio_group.radio_button(value: "inactive", label: I18n.t(:"storages.label_no_specific_folder"),
                                      caption: I18n.t(:"storages.instructions.no_specific_folder"))

--- a/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
+++ b/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
@@ -31,9 +31,7 @@ module Storages
     module ProjectStorages
       class ProjectFolderModeForm < ApplicationForm
         form do |radio_form|
-          radio_form.radio_button_group(
-            name: :project_folder_mode
-          ) do |radio_group|
+          radio_form.radio_button_group(name: :project_folder_mode) do |radio_group|
             if @project_storage.project_folder_mode_possible?("inactive")
               radio_group.radio_button(value: "inactive", label: I18n.t(:"storages.label_no_specific_folder"),
                                        caption: I18n.t(:"storages.instructions.no_specific_folder"))

--- a/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
+++ b/modules/storages/app/forms/storages/admin/project_storages/project_folder_mode_form.rb
@@ -28,33 +28,30 @@
 
 module Storages
   module Admin
-    module Storages
-      class AddProjectsFormModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
-        include OpTurbo::Streamable
+    module ProjectStorages
+      class ProjectFolderModeForm < ApplicationForm
+        form do |radio_form|
+          radio_form.radio_button_group(
+            name: :project_folder_mode,
+            label: I18n.t(:"storages.label_project_folder"),
+            caption: I18n.t(:"storages.help_texts.project_folder")
+          ) do |radio_group|
+            radio_group.radio_button(value: "inactive", label: I18n.t(:"storages.label_no_specific_folder"),
+                                     caption: I18n.t(:"storages.instructions.no_specific_folder"))
 
-        def initialize(project_storage:, **)
+            if @project_storage.automatic_management_possible?
+              radio_group.radio_button(value: "automatic", label: I18n.t(:"storages.label_automatic_folder"),
+                                       caption: I18n.t(:"storages.instructions.automatic_folder"))
+            end
+
+            radio_group.radio_button(value: "manual", label: I18n.t(:"storages.label_existing_manual_folder"),
+                                     caption: I18n.t(:"storages.instructions.existing_manual_folder"))
+          end
+        end
+
+        def initialize(project_storage:)
+          super()
           @project_storage = project_storage
-          @storage = project_storage.storage
-          super(@project_storage, **)
-        end
-
-        private
-
-        attr_reader :project_storage, :storage
-
-        def dialog_id = Storages::AddProjectsModalComponent::DIALOG_ID
-        def dialog_body_id = Storages::AddProjectsModalComponent::DIALOG_BODY_ID
-
-        def title
-          I18n.t(:label_add_projects)
-        end
-
-        def cancel_button_text
-          I18n.t("button_cancel")
-        end
-
-        def submit_button_text
-          I18n.t("button_add")
         end
       end
     end

--- a/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
+++ b/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
@@ -29,9 +29,7 @@
 module Storages
   module Admin
     module Storages
-      class AddProjectsForm < ApplicationForm
-        include OpPrimer::ComponentHelpers
-
+      class AddProjectsAutocompleterForm < ApplicationForm
         form do |form|
           form.group(layout: :vertical) do |group|
             group.project_autocompleter(

--- a/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
+++ b/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
@@ -43,7 +43,7 @@ module Storages
                 multiple: true,
                 dropdownPosition: "bottom",
                 disabledProjects: projects_with_storage_mapping,
-                inputName: "project_storage[project_ids]"
+                inputName: "storages_project_storage[project_ids]"
               }
             )
 

--- a/modules/storages/app/forms/storages/admin/storages/add_projects_form.rb
+++ b/modules/storages/app/forms/storages/admin/storages/add_projects_form.rb
@@ -1,0 +1,85 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Admin
+    module Storages
+      class AddProjectsForm < ApplicationForm
+        include OpPrimer::ComponentHelpers
+
+        form do |form|
+          form.group(layout: :vertical) do |group|
+            group.project_autocompleter(
+              name: :id,
+              label: Project.model_name.human,
+              visually_hide_label: true,
+              validation_message: project_ids_error_message,
+              autocomplete_options: {
+                openDirectly: false,
+                focusDirectly: false,
+                multiple: true,
+                dropdownPosition: "bottom",
+                disabledProjects: projects_with_storage_mapping,
+                inputName: "project_storage[project_ids]"
+              }
+            )
+
+            group.check_box(
+              name: :include_sub_projects,
+              label: I18n.t(:label_include_sub_projects),
+              checked: false,
+              label_arguments: { class: "no-wrap" }
+            )
+          end
+        end
+
+        def initialize(project_storage:)
+          super()
+          @project_storage = project_storage
+        end
+
+        private
+
+        def project_ids_error_message
+          @project_storage
+            .errors
+            .messages_for(:project_ids)
+            .to_sentence
+            .presence
+        end
+
+        def projects_with_storage_mapping
+          ::Storages::ProjectStorage
+            .where(storage_id: @project_storage.storage.id)
+            .pluck(:project_id)
+            .to_h { |id| [id, id] }
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/services/storages/last_project_folders/bulk_create_service.rb
+++ b/modules/storages/app/services/storages/last_project_folders/bulk_create_service.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages::LastProjectFolders
+  class BulkCreateService < ::BaseServices::BaseCallable
+    def initialize(user:, project_storages:)
+      super()
+      @user = user
+      @project_storages = project_storages
+    end
+
+    def perform
+      service_call = validate_permissions
+      service_call = validate_contract(service_call) if service_call.success?
+      service_call = perform_bulk_create(service_call) if service_call.success?
+
+      service_call
+    end
+
+    private
+
+    def validate_permissions
+      return ServiceResult.failure(errors: I18n.t(:label_not_found)) if incoming_projects.empty?
+
+      if @user.allowed_in_project?(:manage_files_in_project, incoming_projects)
+        ServiceResult.success
+      else
+        ServiceResult.failure(errors: I18n.t("activerecord.errors.messages.error_unauthorized"))
+      end
+    end
+
+    def validate_contract(service_call)
+      set_attributes_results = @project_storages.map do |project_storage|
+        set_attributes(project_storage_id: project_storage.id, origin_folder_id: project_storage.project_folder_id,
+                       mode: project_storage.project_folder_mode)
+      end
+
+      if (failures = set_attributes_results.select(&:failure?)).any?
+        service_call.success = false
+        service_call.errors = failures.map(&:errors)
+      else
+        service_call.result = set_attributes_results.map(&:result)
+      end
+
+      service_call
+    end
+
+    def perform_bulk_create(service_call)
+      bulk_insertion = ::Storages::LastProjectFolder.insert_all(
+        service_call.result.map { |model| model.attributes.slice("project_storage_id", "origin_folder_id", "mode") },
+        returning: %w[id]
+      )
+      service_call.result = ::Storages::LastProjectFolder.where(id: bulk_insertion.rows.flatten)
+
+      service_call
+    end
+
+    def incoming_projects
+      @incoming_projects ||= Project.where(id: @project_storages.pluck(:project_id))
+    end
+
+    def set_attributes(params)
+      attributes_service_class
+        .new(user: @user,
+             model: instance(params),
+             contract_class: default_contract_class,
+             contract_options: {})
+        .call(params)
+    end
+
+    def instance(params)
+      ::Storages::LastProjectFolder.new(params)
+    end
+
+    def attributes_service_class
+      Storages::LastProjectFolders::SetAttributesService
+    end
+
+    def default_contract_class
+      Storages::LastProjectFolders::CreateContract
+    end
+  end
+end

--- a/modules/storages/app/services/storages/project_storages/bulk_create_service.rb
+++ b/modules/storages/app/services/storages/project_storages/bulk_create_service.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages::ProjectStorages
+  class BulkCreateService < ::BaseServices::BaseCallable
+    def initialize(user:, projects:, storage:, project_folder_mode:, include_sub_projects: false)
+      super()
+      @user = user
+      @projects = projects
+      @storage = storage
+      @project_folder_mode = project_folder_mode
+      @include_sub_projects = include_sub_projects
+    end
+
+    def perform
+      service_call = validate_permissions
+      service_call = validate_contract(service_call, incoming_activations_ids) if service_call.success?
+      service_call = perform_bulk_create(service_call) if service_call.success?
+      service_call = create_last_project_folders(service_call) if service_call.success?
+      broadcast_project_storages_created if service_call.success?
+
+      service_call
+    end
+
+    private
+
+    def validate_permissions
+      return ServiceResult.failure(errors: I18n.t(:label_not_found)) if incoming_projects.empty?
+
+      if @user.allowed_in_project?(:manage_files_in_project, incoming_projects)
+        ServiceResult.success
+      else
+        ServiceResult.failure(errors: I18n.t("activerecord.errors.messages.error_unauthorized"))
+      end
+    end
+
+    def validate_contract(service_call, project_ids)
+      set_attributes_results = project_ids.map do |id|
+        set_attributes(project_id: id, storage_id: @storage.id, project_folder_mode: @project_folder_mode)
+      end
+
+      if (failures = set_attributes_results.select(&:failure?)).any?
+        service_call.success = false
+        service_call.errors = failures.map(&:errors)
+      else
+        service_call.result = set_attributes_results.map(&:result)
+      end
+
+      service_call
+    end
+
+    def perform_bulk_create(service_call)
+      bulk_insertion = ::Storages::ProjectStorage.insert_all(
+        service_call.result.map do |model|
+          model.attributes.slice("project_id", "storage_id", "project_folder_mode", "creator_id")
+        end,
+        unique_by: %i[project_id storage_id],
+        returning: %w[id]
+      )
+      service_call.result = ::Storages::ProjectStorage.where(id: bulk_insertion.rows.flatten)
+
+      service_call
+    end
+
+    def create_last_project_folders(service_call)
+      return service_call if @project_folder_mode.to_sym == :inactive
+
+      last_project_folders = ::Storages::LastProjectFolders::BulkCreateService
+        .new(user: @user, project_storages: service_call.result)
+        .call
+
+      service_call.add_dependent!(last_project_folders)
+      service_call
+    end
+
+    def broadcast_project_storages_created
+      OpenProject::Notifications.send(
+        OpenProject::Events::PROJECT_STORAGE_CREATED,
+        project_folder_mode: @project_folder_mode,
+        storage: @storage
+      )
+    end
+
+    def incoming_activations_ids
+      project_ids = incoming_projects.pluck(:id)
+      project_ids - existing_project_storages(project_ids)
+    end
+
+    def incoming_projects
+      @projects.each_with_object(Set.new) do |project, projects_set|
+        next unless project.active?
+
+        projects_set << project
+        projects_set.merge(project.active_subprojects.to_a) if @include_sub_projects
+      end.to_a
+    end
+
+    def existing_project_storages(project_ids)
+      ::Storages::ProjectStorage
+        .where(storage_id: @storage.id, project_id: project_ids)
+        .pluck(:project_id)
+    end
+
+    def set_attributes(params)
+      attributes_service_class
+        .new(user: @user,
+             model: instance(params),
+             contract_class: default_contract_class,
+             contract_options: {})
+        .call(params)
+    end
+
+    def instance(params)
+      ::Storages::ProjectStorage.new(params)
+    end
+
+    def attributes_service_class
+      ::Storages::ProjectStorages::SetAttributesService
+    end
+
+    def default_contract_class
+      ::Storages::ProjectStorages::CreateContract
+    end
+  end
+end

--- a/modules/storages/app/views/storages/admin/storages/project_storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/project_storages/index.html.erb
@@ -27,13 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  render(Storages::Admin::EditFormHeaderComponent.new(
-      storage: @storage,
-      selected: :project_storages
-    )
-  )
-%>
+<%= render(Storages::Admin::EditFormHeaderComponent.new(storage: @storage, selected: :project_storages)) %>
 
 <%=
   render(Primer::OpenProject::SubHeader.new) do |component|
@@ -52,9 +46,11 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <%=
-  render(Storages::ProjectStorages::Projects::TableComponent.new(
-    query: @project_query,
-    project_folder_modes_per_project: @project_folder_modes_per_project,
-    params:)
+  render(
+    Storages::ProjectStorages::Projects::TableComponent.new(
+      query: @storage_projects_query,
+      project_folder_modes_per_project: @project_folder_modes_per_project,
+      params:
+    )
   )
 %>

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -137,7 +137,8 @@ en:
       title: Email notifications
       unsubscribe: Unsubscribe
     help_texts:
-      project_folder: The project folder is the default folder for file uploads for all the projects selected. You can modify this individually in each project settings. Users can nevertheless still upload files to other locations.
+      project_folder: The project folder is the default folder for file uploads for this project. Users can nevertheless still upload files to other locations.
+      project_folder_bulk: The project folder is the default folder for file uploads for all the projects selected. You can modify this individually in each project settings. Users can nevertheless still upload files to other locations.
     instructions:
       all_available_storages_already_added: All available storages are already added to the project.
       automatic_folder: This will automatically create a root folder for this project and manage the access permissions for each project member.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
       title: Email notifications
       unsubscribe: Unsubscribe
     help_texts:
-      project_folder: The project folder is the default folder for file uploads for this project. Users can nevertheless still upload files to other locations.
+      project_folder: The project folder is the default folder for file uploads for all the projects selected. You can modify this individually in each project settings. Users can nevertheless still upload files to other locations.
     instructions:
       all_available_storages_already_added: All available storages are already added to the project.
       automatic_folder: This will automatically create a root folder for this project and manage the access permissions for each project member.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
           attributes:
             project_folder_mode:
               mode_unavailable: is not available for this storage.
+            project_ids:
+              blank: Please select a project.
         storages/storage:
           attributes:
             host:

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -33,7 +33,7 @@ require_module_spec_helper
 
 RSpec.describe "Admin lists project mappings for a storage",
                :js,
-               :storage_server_helpers,
+               :with_cuprite,
                with_flag: { enable_storage_for_multiple_projects: true } do
   shared_let(:admin) { create(:admin, preferences: { time_zone: "Etc/UTC" }) }
   shared_let(:non_admin) { create(:user) }
@@ -108,6 +108,53 @@ RSpec.describe "Admin lists project mappings for a storage",
         within "#project-table" do
           expect(page).to have_text("#{project.name} Automatically managed")
           expect(page).to have_text("#{archived_project.name} No specific folder")
+        end
+      end
+    end
+
+    it "shows an error in the dialog when no project is selected before adding" do
+      create(:project)
+      expect(page).to have_no_css("dialog")
+      click_on "Add projects"
+
+      page.within("dialog") do
+        click_on "Add"
+
+        wait_for(page).to have_text("Please select a project.")
+      end
+    end
+
+    it "allows linking a project to a storage" do
+      project = create(:project)
+      subproject = create(:project, parent: project)
+      click_on "Add projects"
+
+      within("dialog") do
+        autocompleter = page.find(".op-project-autocompleter")
+        autocompleter.fill_in with: project.name
+
+        expect(page).to have_no_text(archived_project.name)
+
+        find(".ng-option-label", text: project.name).click
+        check "Include sub-projects"
+
+        expect(page.find_by_id("storages_project_storage_project_folder_mode_automatic")).to be_checked
+
+        click_on "Add"
+      end
+
+      expect(page).to have_text(project.name)
+      expect(page).to have_text(subproject.name)
+
+      aggregate_failures "pagination links maintain the correct url" do
+        within ".op-pagination" do
+          pagination_links = page.all(".op-pagination--item-link")
+          expect(pagination_links.size).to be_positive
+
+          pagination_links.each do |pagination_link|
+            uri = URI.parse(pagination_link["href"])
+            expect(uri.path).to eq(admin_settings_storage_project_storages_path(storage))
+          end
         end
       end
     end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe "Admin lists project mappings for a storage",
 
       aggregate_failures "shows the correct project mappings including archived projects and their folder modes" do
         within "#project-table" do
-          expect(page).to have_text("#{project.name} Automatically managed")
-          expect(page).to have_text("#{archived_project.name} No specific folder")
+          expect(page).to have_text(project.name.to_s).and have_text("Automatically managed")
+          expect(page).to have_text("ARCHIVED #{archived_project.name}").and have_text("No specific folder")
         end
       end
     end

--- a/modules/storages/spec/services/storages/last_project_folders/bulk_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/last_project_folders/bulk_create_service_spec.rb
@@ -1,0 +1,110 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Storages::LastProjectFolders::BulkCreateService do
+  subject(:create_service) { described_class.new(user:, project_storages:) }
+
+  shared_association_default(:storage) { create(:nextcloud_storage) }
+  shared_association_default(:project) { create(:project) }
+  shared_let(:project_storages) { create_list(:project_storage, 5, project_folder_mode: "automatic") }
+  shared_let(:user) { create(:admin) }
+
+  context "with admin permissions" do
+    it "creates the corresponding last project folders", :aggregate_failures do
+      expect { create_service.call }
+        .to change(Storages::LastProjectFolder, :count).by(project_storages.size)
+
+      project_storages.each do |project_storage|
+        last_project_folders = project_storage.reload.last_project_folders
+        expect(last_project_folders.count).to eq(1)
+        expect(last_project_folders.pluck(:origin_folder_id, :mode))
+          .to eq([[project_storage.project_folder_id, project_storage.project_folder_mode]])
+      end
+    end
+  end
+
+  context "with non-admin but sufficient permissions" do
+    let(:user) do
+      create(:user,
+             member_with_permissions: {
+               project => %w[view_work_packages
+                             edit_project
+                             manage_files_in_project]
+             })
+    end
+
+    it "creates the corresponding last project folders", :aggregate_failures do
+      expect { create_service.call }
+        .to change(Storages::LastProjectFolder, :count).by(project_storages.size)
+
+      project_storages.each do |project_storage|
+        last_project_folders = project_storage.reload.last_project_folders
+        expect(last_project_folders.count).to eq(1)
+        expect(last_project_folders.pluck(:origin_folder_id, :mode))
+          .to eq([[project_storage.project_folder_id, project_storage.project_folder_mode]])
+      end
+    end
+  end
+
+  context "without sufficient permissions" do
+    let(:user) do
+      create(:user,
+             member_with_permissions: {
+               project => %w[view_work_packages
+                             edit_project]
+             })
+    end
+
+    it "does not create any records" do
+      expect { create_service.call }.not_to change(Storages::LastProjectFolder, :count)
+      expect(create_service.call).to be_failure
+    end
+  end
+
+  context "with empty projects storages" do
+    let(:project_storages) { [] }
+
+    it "does not create any project storages" do
+      service_result = create_service.call
+      expect(service_result).to be_failure
+      expect(service_result.errors).to eq("not found")
+    end
+  end
+
+  context "with broken contract" do
+    let(:project_storages) { create_list(:project_storage, 2, project_folder_mode: "inactive") }
+
+    it "does not create any records" do
+      expect { create_service.call }.not_to change(Storages::LastProjectFolder, :count)
+      expect(create_service.call).to be_failure
+    end
+  end
+end

--- a/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
@@ -1,0 +1,226 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Storages::ProjectStorages::BulkCreateService do
+  shared_let(:user) { create(:admin) }
+  shared_let(:storage) { create(:nextcloud_storage, :as_automatically_managed) }
+
+  let(:project_folder_mode) { "automatic" }
+
+  before { allow(OpenProject::Notifications).to(receive(:send)) }
+
+  context "with admin permissions" do
+    context "with a single project" do
+      let(:project) { create(:project) }
+      let(:project_folder_mode) { "inactive" }
+      let(:instance) { described_class.new(user:, projects: [project], storage:, project_folder_mode:) }
+
+      it "activates the storage for the given project", :aggregate_failures do
+        expect { instance.call }
+          .to change(Storages::ProjectStorage, :count).by(1)
+
+        project_storage = Storages::ProjectStorage.last
+        expect(project_storage.project).to eq(project)
+        expect(project_storage.storage).to eq(storage)
+
+        aggregate_failures "does not create last project folders for inactive project folder mode" do
+          expect(project_storage.reload.last_project_folders.count).to be_zero
+        end
+
+        aggregate_failures "broadcasts projects storages created event" do
+          expect(OpenProject::Notifications).to have_received(:send)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+        end
+      end
+    end
+
+    context "with subprojects" do
+      let(:projects) { create_list(:project, 2) }
+      let!(:subproject) { create(:project, parent: projects.first) }
+      let!(:subproject2) { create(:project, parent: subproject) }
+
+      it "activates the storage for the project and sub-projects", :aggregate_failures do
+        create_service = described_class.new(user:, projects: projects.map(&:reload), storage:,
+                                             project_folder_mode:, include_sub_projects: true)
+
+        expect { create_service.call }
+          .to change(Storages::ProjectStorage, :count).by(4)
+          .and change(Storages::LastProjectFolder, :count).by(4)
+
+        expect(Storages::ProjectStorage.where(storage:).pluck(:project_id))
+          .to contain_exactly(*projects.map(&:id), subproject.id, subproject2.id)
+
+        aggregate_failures "broadcasts projects storages created event" do
+          expect(OpenProject::Notifications).to have_received(:send)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+        end
+      end
+    end
+
+    context "with multiple projects including subprojects" do
+      let(:project) { create(:project) }
+      let!(:subproject) { create(:project, parent: project) }
+
+      it "activates the storage for the project and sub-projects" do
+        create_service = described_class.new(user:, projects: [project.reload, subproject], storage:,
+                                             project_folder_mode:, include_sub_projects: true)
+
+        expect { create_service.call }
+          .to change(Storages::ProjectStorage, :count).by(2)
+          .and change(Storages::LastProjectFolder, :count).by(2)
+
+        expect(Storages::ProjectStorage.where(storage:).pluck(:project_id))
+          .to contain_exactly(project.id, subproject.id)
+
+        aggregate_failures "broadcasts projects storages created event" do
+          expect(OpenProject::Notifications).to have_received(:send)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+        end
+      end
+    end
+
+    context "with duplicates" do
+      let(:project) { create(:project) }
+
+      it "activates the storage only once" do
+        create_service = described_class.new(user:, projects: [project, project], storage:, project_folder_mode:)
+
+        expect { create_service.call }
+          .to change(Storages::ProjectStorage, :count).by(1)
+          .and change(Storages::LastProjectFolder, :count).by(1)
+
+        project_storage = Storages::ProjectStorage.last
+        expect(project_storage.project).to eq(project)
+        expect(project_storage.storage).to eq(storage)
+
+        aggregate_failures "broadcasts projects storages created event" do
+          expect(OpenProject::Notifications).to have_received(:send)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+        end
+      end
+    end
+  end
+
+  context "with non-admin but sufficient permissions" do
+    let(:user) do
+      create(:user,
+             member_with_permissions: {
+               project => %w[view_work_packages
+                             edit_project
+                             manage_files_in_project]
+             })
+    end
+
+    let(:project) { create(:project) }
+    let(:project_folder_mode) { "inactive" }
+
+    it "activates the storage" do
+      create_service = described_class.new(user:, projects: [project], storage:, project_folder_mode:)
+
+      expect { create_service.call }
+        .to change(Storages::ProjectStorage, :count).by(1)
+
+      project_storage = Storages::ProjectStorage.last
+      expect(project_storage.project).to eq(project)
+      expect(project_storage.storage).to eq(storage)
+
+      aggregate_failures "broadcasts projects storages created event" do
+        expect(OpenProject::Notifications).to have_received(:send)
+          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+      end
+    end
+  end
+
+  context "without sufficient permissions" do
+    let(:user) do
+      create(:user,
+             member_with_permissions: {
+               project => %w[view_work_packages
+                             edit_project]
+             })
+    end
+    let(:project) { create(:project) }
+    let(:project_folder_mode) { "inactive" }
+    let(:instance) { described_class.new(user:, projects: [project], storage:, project_folder_mode:) }
+
+    it "does not create any project storages" do
+      expect { instance.call }.not_to change(Storages::ProjectStorage, :count)
+      expect(instance.call).to be_failure
+      expect(OpenProject::Notifications).not_to have_received(:send)
+        .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+    end
+  end
+
+  context "with empty projects" do
+    let(:instance) { described_class.new(user:, projects: [], storage:, project_folder_mode:) }
+
+    it "does not create any project storages" do
+      service_result = instance.call
+      expect(service_result).to be_failure
+      expect(service_result.errors).to eq("not found")
+      expect(OpenProject::Notifications).not_to have_received(:send)
+    end
+  end
+
+  context "with archived projects" do
+    let(:archived_project) { create(:project, active: false) }
+    let(:active_project) { create(:project) }
+
+    it "only creates the project storage for the active project", :aggregate_failures do
+      create_service = described_class.new(user:, projects: [archived_project, active_project], storage:,
+                                           project_folder_mode:)
+
+      expect { create_service.call }
+        .to change(Storages::ProjectStorage, :count).by(1)
+        .and change(Storages::LastProjectFolder, :count).by(1)
+
+      expect(Storages::ProjectStorage.where(storage:).pluck(:project_id))
+        .to contain_exactly(active_project.id)
+
+      aggregate_failures "broadcasts projects storages created event" do
+        expect(OpenProject::Notifications).to have_received(:send)
+          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+      end
+    end
+  end
+
+  context "with broken contract" do
+    let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed) }
+    let(:project) { create(:project) }
+    let(:project_folder_mode) { "automatic" }
+
+    it "does not create any records" do
+      create_service = described_class.new(user:, projects: [project], storage:, project_folder_mode:)
+
+      expect { create_service.call }.not_to change(Storages::ProjectStorage, :count)
+      expect(create_service.call).to be_failure
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55966

Follows https://github.com/opf/openproject/pull/16018

🚧 _**Manual Folder Selection is not included**_, it will be added separately with the File Picker implementation


https://github.com/user-attachments/assets/13d96967-95c3-4e11-aa64-50cc5b1abe13

