### PR TITLE
[#56012] all Viepoints are saved to the last BCF

### DIFF
--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -46,6 +46,7 @@ RUN apt update
 RUN apt install watchexec-cli
 
 COPY ./docker/dev/backend/scripts/setup /usr/sbin/setup
+COPY ./docker/dev/backend/scripts/setup-bim /usr/sbin/setup-bim
 COPY ./docker/dev/backend/scripts/run-app /usr/sbin/run-app
 
 # The following lines are needed to make sure the file permissions are setup correctly after the volumes are mounted

--- a/docker/dev/backend/scripts/setup-bim
+++ b/docker/dev/backend/scripts/setup-bim
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+apt-get install -y wget unzip
+
+# https://learn.microsoft.com/en-gb/dotnet/core/install/linux-debian#debian-12
+wget --quiet https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
+dpkg -i /tmp/packages-microsoft-prod.deb
+rm /tmp/packages-microsoft-prod.deb
+
+apt-get update -qq
+apt-get install -y dotnet-runtime-6.0 # required for BIM edition
+
+tmpdir=$(mktemp -d)
+cd $tmpdir
+
+# Install XKT converter
+npm install -g @xeokit/xeokit-gltf-to-xkt@1.3.1
+
+# Install COLLADA2GLTF
+wget --quiet https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
+unzip -q COLLADA2GLTF-v2.1.5-linux.zip
+mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
+
+# IFCconvert
+wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b819-linux64.zip
+unzip -q IfcConvert-v0.6.0-517b819-linux64.zip
+mv IfcConvert "/usr/local/bin/IfcConvert"
+
+wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
+tar -zxvf xeokit-metadata-linux-x64.tar.gz
+chmod +x xeokit-metadata-linux-x64/xeokit-metadata
+cp -r xeokit-metadata-linux-x64/ "/usr/lib/xeokit-metadata"
+ln -s /usr/lib/xeokit-metadata/xeokit-metadata /usr/local/bin/xeokit-metadata
+
+cd /
+rm -rf $tmpdir

--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
@@ -74,6 +74,7 @@ export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponen
         }),
       )
       .subscribe(() => {
+        this.viewpointsService.resetBcfTopic();
         this.showIndex = this.galleryViewpoints.length - 1;
       });
   }

--- a/frontend/src/app/features/bim/bcf/helper/viewpoints.service.ts
+++ b/frontend/src/app/features/bim/bcf/helper/viewpoints.service.ts
@@ -42,7 +42,7 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 @Injectable()
 export class ViewpointsService {
-  topicUUID:string|number;
+  topicUUID:string|number|null = null;
 
   @InjectField() bcfApi:BcfApiService;
 
@@ -114,8 +114,12 @@ export class ViewpointsService {
       );
   }
 
+  public resetBcfTopic():void {
+    this.topicUUID = null;
+  }
+
   public setBcfTopic$(workPackage:WorkPackageResource):Observable<string|number> {
-    if (this.topicUUID) {
+    if (this.topicUUID !== null) {
       return of(this.topicUUID);
     }
     const topicHref = (workPackage.bcfTopic as HalResource)?.href;

--- a/modules/bim/app/services/bim/ifc_models/update_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/update_service.rb
@@ -38,7 +38,6 @@ module Bim
       end
 
       def after_perform(service_result)
-        puts "update the model: #{service_result.result}"
         if service_result.success?
           # As the attachments association does not have the autosave option, we need to remove the
           # attachments ourselves

--- a/modules/bim/app/services/bim/ifc_models/update_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/update_service.rb
@@ -38,6 +38,7 @@ module Bim
       end
 
       def after_perform(service_result)
+        puts "update the model: #{service_result.result}"
         if service_result.success?
           # As the attachments association does not have the autosave option, we need to remove the
           # attachments ourselves


### PR DESCRIPTION
[#56012](https://community.openproject.org/work_packages/56012)

### WAT?

- refreshing topic state after creating a wp (topic)
  - A work package is the representation of a BCF topic in our domain
  - when a work package is created, a topic is created via the BCF API
  - the viewpoint is linked then to this topic and created alongside with the work package
  - *BEFORE*: the topic id was kept in state of the viewpoint service, so creating a second work package led to all viewpoints being referenced to the first topic 
  - *NOW*: the topic id is cleansed from the service, once the user hits the "Create" button in the frontend, so that a new topic is created, when the second work package is created
- added small script to docker dev container, that can setup the BIM dependencies