### PR TITLE
Shared spec for acts as favorable

### DIFF
--- a/lib_static/open_project/acts/favorable.rb
+++ b/lib_static/open_project/acts/favorable.rb
@@ -80,10 +80,6 @@ module OpenProject
       end
 
       module InstanceMethods
-        def self.prepended(base)
-          base.extend ClassMethods
-        end
-
         def add_favoring_user(user)
           return if favorites.exists?(user_id: user.id)
 

--- a/lib_static/open_project/acts/watchable.rb
+++ b/lib_static/open_project/acts/watchable.rb
@@ -91,6 +91,10 @@ module OpenProject
       end
 
       module InstanceMethods
+        def self.prepended(base)
+          base.extend AddClassMethods
+        end
+
         def possible_watcher?(user)
           user.allowed_based_on_permission_context?(self.class.acts_as_watchable_permission,
                                                     project:,
@@ -156,7 +160,7 @@ module OpenProject
               watcher_user_ids.any? { |uid| uid == user.id })
         end
 
-        module ClassMethods
+        module AddClassMethods
           def acts_as_watchable_permission
             acts_as_watchable_options[:permission] || :"view_#{name.underscore.pluralize}"
           end

--- a/lib_static/open_project/acts/watchable.rb
+++ b/lib_static/open_project/acts/watchable.rb
@@ -91,10 +91,6 @@ module OpenProject
       end
 
       module InstanceMethods
-        def self.prepended(base)
-          base.extend ClassMethods
-        end
-
         def possible_watcher?(user)
           user.allowed_based_on_permission_context?(self.class.acts_as_watchable_permission,
                                                     project:,

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -60,6 +60,7 @@ module Redmine
 
       module InstanceMethods
         def self.included(base)
+          base.extend AddClassMethods
           base.extend HumanAttributeName
         end
 
@@ -437,7 +438,7 @@ module Redmine
           @custom_field_values_cache ||= {}
         end
 
-        module ClassMethods
+        module AddClassMethods
           def available_custom_fields(_model)
             RequestStore.fetch(:"#{name.underscore}_custom_fields") do
               CustomField.where(type: "#{name}CustomField").order(:position)

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -60,7 +60,6 @@ module Redmine
 
       module InstanceMethods
         def self.included(base)
-          base.extend ClassMethods
           base.extend HumanAttributeName
         end
 

--- a/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
+++ b/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
@@ -92,9 +92,6 @@ module Redmine
             option
           end
         end
-
-        module ClassMethods
-        end
       end
     end
   end

--- a/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
+++ b/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
@@ -56,10 +56,6 @@ module Redmine
       end
 
       module InstanceMethods
-        def self.included(base)
-          base.extend ClassMethods
-        end
-
         %w(datetime title description author name type).each do |attr|
           src = <<-END_SRC
             def event_#{attr}

--- a/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
+++ b/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
@@ -73,7 +73,11 @@ module Redmine
       end
 
       module InstanceMethods
-        module ClassMethods
+        def self.included(base)
+          base.extend AddClassMethods
+        end
+
+        module AddClassMethods
           # Searches the model for the given tokens
           # projects argument can be either nil (will search all projects), a project or an array of projects
           # Returns the results and the results count

--- a/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
+++ b/lib_static/plugins/acts_as_searchable/lib/acts_as_searchable.rb
@@ -73,10 +73,6 @@ module Redmine
       end
 
       module InstanceMethods
-        def self.included(base)
-          base.extend ClassMethods
-        end
-
         module ClassMethods
           # Searches the model for the given tokens
           # projects argument can be either nil (will search all projects), a project or an array of projects

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Attachment do
     end
   end
 
-  include_examples "creates an audit trail on destroy" do
+  it_behaves_like "creates an audit trail on destroy" do
     subject { create(:attachment) }
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Group do
     it { expect(group).to validate_uniqueness_of :name }
   end
 
-  include_examples "creates an audit trail on destroy" do
+  it_behaves_like "creates an audit trail on destroy" do
     subject { create(:attachment) }
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Project do
     end
   end
 
-  include_examples "creates an audit trail on destroy" do
+  it_behaves_like "creates an audit trail on destroy" do
     subject { create(:attachment) }
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -237,10 +237,6 @@ RSpec.describe Project do
     end
   end
 
-  include_examples "creates an audit trail on destroy" do
-    subject { create(:attachment) }
-  end
-
   describe "#close_completed_versions" do
     let!(:completed_version) do
       create(:version, project:, effective_date: Date.parse("2000-01-01")).tap do |v|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -403,6 +403,10 @@ RSpec.describe Project do
     end
   end
 
+  it_behaves_like "acts_as_favorable included" do
+    let(:instance) { project }
+  end
+
   it_behaves_like "acts_as_customizable included" do
     let(:model_instance) { project }
     let(:custom_field) { create(:string_project_custom_field) }

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe ProjectQuery do
   shared_let(:user) { create(:user) }
   shared_let(:admin) { create(:admin) }
 
+  it_behaves_like "acts_as_favorable included" do
+    let(:instance) { create(:project_query) }
+  end
+
   context "when persisting" do
     let(:properties) do
       {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe User do
     end
   end
 
-  include_examples "creates an audit trail on destroy" do
+  it_behaves_like "creates an audit trail on destroy" do
     subject { create(:attachment) }
   end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe WorkPackage do
     end
   end
 
-  include_examples "creates an audit trail on destroy" do
+  it_behaves_like "creates an audit trail on destroy" do
     subject { create(:work_package) }
   end
 

--- a/spec/support/shared/acts_as_favorable.rb
+++ b/spec/support/shared/acts_as_favorable.rb
@@ -1,0 +1,159 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_examples_for "acts_as_favorable included" do
+  shared_let(:favoring_user) { create(:user) }
+  shared_let(:other_user) { create(:user) }
+
+  before do
+    Favorite.create(user: favoring_user, favored: instance)
+  end
+
+  it { is_expected.to have_many(:favorites).dependent(:delete_all) }
+  it { is_expected.to have_many(:favoring_users).through(:favorites) }
+
+  describe ".favored_by" do
+    it "returns instance for favoring user" do
+      expect(described_class.favored_by(favoring_user).to_a).to eq [instance]
+    end
+
+    it "returns no instance for non favoring user" do
+      expect(described_class.favored_by(other_user).to_a).not_to eq [instance]
+    end
+  end
+
+  describe ".with_favored_by_user" do
+    subject { described_class.with_favored_by_user(user).to_a }
+
+    context "for favoring user" do
+      let(:user) { favoring_user }
+
+      it "returns instance for favoring user" do
+        expect(subject).to eq [instance]
+      end
+
+      it "marks instance as favored" do
+        expect(subject).to all(have_attributes(favored: true))
+      end
+    end
+
+    context "for non favoring user" do
+      let(:user) { other_user }
+
+      it "returns instance for favoring user" do
+        expect(subject).to eq [instance]
+      end
+
+      it "marks instance as not favored" do
+        expect(subject).to all(have_attributes(favored: false))
+      end
+    end
+  end
+
+  describe "#add_favoring_user" do
+    context "for favoring user" do
+      let(:user) { favoring_user }
+
+      it "does nothing" do
+        expect do
+          instance.add_favoring_user(user)
+        end.not_to change { described_class.favored_by(user).to_a }.from([instance])
+      end
+    end
+
+    context "for non favoring user" do
+      let(:user) { other_user }
+
+      it "adds to favorites" do
+        expect do
+          instance.add_favoring_user(user)
+        end.to change { described_class.favored_by(user).to_a }.from([]).to([instance])
+      end
+    end
+  end
+
+  describe "#remove_favoring_user" do
+    context "for favoring user" do
+      let(:user) { favoring_user }
+
+      it "removes from favorites" do
+        expect do
+          instance.remove_favoring_user(user)
+        end.to change { described_class.favored_by(user).to_a }.from([instance]).to([])
+      end
+    end
+
+    context "for non favoring user" do
+      let(:user) { other_user }
+
+      it "does nothing" do
+        expect do
+          instance.remove_favoring_user(user)
+        end.not_to change { described_class.favored_by(user).to_a }
+      end
+    end
+  end
+
+  describe "#set_favored" do
+    before do
+      allow(instance).to receive(:add_favoring_user)
+      allow(instance).to receive(:remove_favoring_user)
+    end
+
+    it "calls add_favoring_user by default" do
+      instance.set_favored(favoring_user)
+
+      expect(instance).to have_received(:add_favoring_user).with(favoring_user)
+      expect(instance).not_to have_received(:remove_favoring_user)
+    end
+
+    it "calls add_favoring_user when called with favored: true" do
+      instance.set_favored(favoring_user, favored: true)
+
+      expect(instance).to have_received(:add_favoring_user).with(favoring_user)
+      expect(instance).not_to have_received(:remove_favoring_user)
+    end
+
+    it "calls remove_favoring_user when called with favored: false" do
+      instance.set_favored(favoring_user, favored: false)
+
+      expect(instance).not_to have_received(:add_favoring_user)
+      expect(instance).to have_received(:remove_favoring_user).with(favoring_user)
+    end
+  end
+
+  describe "#favored_by?" do
+    it "returns true for favoring user" do
+      expect(instance).to be_favored_by(favoring_user)
+    end
+
+    it "returns false for non favoring user" do
+      expect(instance).not_to be_favored_by(other_user)
+    end
+  end
+end


### PR DESCRIPTION
Follow up for #15992

Besides the shared spec:
* Use it_behaves_like for "creates an audit trail on destroy" shared examples, as otherwise the subject overrides the one in outer scope + remove duplicate inclusion in Project spec
* Disambiguate module naming in acts as modules, as besides `ClassMethods` on top level, some had `ClassMethods` inside `InstanceMethods` with confusing `base.extend ClassMethods` both in `included` on top and `included`/`prepended` of `InstanceMethods`