### PR TITLE
[56059] Can't change default work package lists columns

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -223,7 +223,7 @@ module WorkPackagesHelper
 
   def selected_work_packages_columns_options
     Setting[:work_package_list_default_columns]
-      .map { |column| work_packages_columns_options.find { |c| c[:id] == column } }
+      .filter_map { |column| work_packages_columns_options.find { |c| c[:id] == column } }
   end
 
   def protected_work_packages_columns_options


### PR DESCRIPTION
Some columns for the Work Package table are only available with an EE token. There is a special case when the user adds such a column to the list of default columns, and the EE token expires or gets removed afterwards. The autocompleter then has to filter out these options.


https://community.openproject.org/projects/openproject/work_packages/56059/activity