### PR TITLE
Allow users with edit permission to save the query

### DIFF
--- a/app/contracts/queries/projects/project_queries/base_contract.rb
+++ b/app/contracts/queries/projects/project_queries/base_contract.rb
@@ -65,10 +65,10 @@ module Queries::Projects::ProjectQueries
 
     def allowed_to_modify_public_query
       return unless model.public?
+      return if user.allowed_in_project_query?(:edit_project_query, model)
+      return if user.allowed_globally?(:manage_public_project_queries)
 
-      unless user.allowed_globally?(:manage_public_project_queries)
-        errors.add :base, :need_permission_to_modify_public_query
-      end
+      errors.add :base, :need_permission_to_modify_public_query
     end
 
     def name_select_included

--- a/app/contracts/queries/projects/project_queries/base_contract.rb
+++ b/app/contracts/queries/projects/project_queries/base_contract.rb
@@ -57,10 +57,10 @@ module Queries::Projects::ProjectQueries
 
     def allowed_to_modify_private_query
       return if model.public?
+      return if model.user == user
+      return if user.allowed_in_project_query?(:edit_project_query, model)
 
-      if model.user != user
-        errors.add :base, :can_only_be_modified_by_owner
-      end
+      errors.add :base, :can_only_be_modified_by_owner
     end
 
     def allowed_to_modify_public_query

--- a/spec/contracts/queries/projects/project_queries/shared_contract_examples.rb
+++ b/spec/contracts/queries/projects/project_queries/shared_contract_examples.rb
@@ -52,10 +52,22 @@ RSpec.shared_examples_for "project queries contract" do
       it_behaves_like "contract is invalid", name: :too_long
     end
 
-    context "if the user is not the current user" do
+    context "if the user is not the current user and does not have the permission" do
       let(:query_user) { build_stubbed(:user) }
 
       it_behaves_like "contract is invalid", base: :can_only_be_modified_by_owner
+    end
+
+    context "if the user is not the current user but has the permission" do
+      let(:query_user) { build_stubbed(:user) }
+
+      before do
+        mock_permissions_for(current_user) do |mock|
+          mock.allow_in_project_query :edit_project_query, project_query: query
+        end
+      end
+
+      it_behaves_like "contract is valid"
     end
 
     context "if the list is public and the editing user has the permission" do

--- a/spec/contracts/queries/projects/project_queries/shared_contract_examples.rb
+++ b/spec/contracts/queries/projects/project_queries/shared_contract_examples.rb
@@ -70,7 +70,7 @@ RSpec.shared_examples_for "project queries contract" do
       it_behaves_like "contract is valid"
     end
 
-    context "if the list is public and the editing user has the permission" do
+    context "if the list is public and the editing user has the global permission" do
       let(:query_user) { build_stubbed(:user) }
 
       before do
@@ -86,7 +86,7 @@ RSpec.shared_examples_for "project queries contract" do
       it_behaves_like "contract is valid"
     end
 
-    context "if the list is public and the editing user does not have the permission" do
+    context "if the list is public and the editing user does not have the global permission" do
       let(:query_user) { build_stubbed(:user) }
 
       before do
@@ -98,6 +98,22 @@ RSpec.shared_examples_for "project queries contract" do
       end
 
       it_behaves_like "contract is invalid", base: :need_permission_to_modify_public_query
+    end
+
+    context "if the list is public and the editing user does not have the global permission but has edit rights on the item" do
+      let(:query_user) { build_stubbed(:user) }
+
+      before do
+        query.change_by_system do
+          query.public = true
+        end
+
+        mock_permissions_for(current_user) do |mock|
+          mock.allow_in_project_query :edit_project_query, project_query: query
+        end
+      end
+
+      it_behaves_like "contract is valid"
     end
 
     context "if the list is public and the editing user does not have the permission, even if they are the owner" do


### PR DESCRIPTION
Extracted from #16032. @aaron-contreras has uncovered while writing tests that users cannot modify a query when they have the edit permission. This extracts the fix for this already so it can be tested already