### PR TITLE
[55656] Remove derivedRemainingTime from form payload

### DIFF
--- a/lib/api/utilities/payload_representer.rb
+++ b/lib/api/utilities/payload_representer.rb
@@ -51,12 +51,15 @@ module API
 
           # Note: `:writeable` is not a typo, it's used by declarative gem
           writable = property[:writeable]
+
+          # If writable is a lambda, rely on it to determine if the property should be output
+          # else if writable is explicitly false, do not output the property
+          # else rely on #writable_attributes (through UnwritablePropertyFilter) to know if the property should be output
+          next if writable.respond_to?(:call)
+
           if writable == false
             property.merge!(readable: false)
-          end
-
-          # Only filter unwritable if not a lambda
-          unless writable.respond_to?(:call)
+          else
             add_filter(property, UnwritablePropertyFilter)
           end
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -418,7 +418,6 @@ module API
                    datetime_formatter.format_duration_from_hours(represented.derived_remaining_hours,
                                                                  allow_nil: true)
                  end,
-                 writable: ->(*) { !WorkPackage.use_status_for_done_ratio? },
                  render_nil: true
 
         property :duration,

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackagePayloadRepresenter do
         end
       end
 
+      describe "derived remaining hours" do
+        context "when set" do
+          let(:work_package) { build(:work_package, derived_remaining_hours: 5) }
+
+          it { is_expected.not_to have_json_path("derivedRemainingTime") }
+        end
+      end
+
       describe "startDate" do
         before do
           allow(work_package)


### PR DESCRIPTION
`derivedRemainingTime` is not writeable. That's specified in the work package contract. But as the payload representer was using a lambda for `:writable` for `derivedRemainingTime`, the writability given by the contract was ignored, and it was always added if the lambda returned `true` (and it always returned true in work-based mode).

It produced issues like when copying a work package having a `derivedRemainingTime` being set, as reported in
https://community.openproject.org/wp/55656.

Removing the lambda makes the representer solely rely on the contract to determine the writability of the `derivedRemainingTime` property, and fixes the issue.