### PR TITLE
[#56251] Fix share modal mobile styling and layouting bugs

### DIFF
--- a/app/components/shares/invite_user_form_component.sass
+++ b/app/components/shares/invite_user_form_component.sass
@@ -11,3 +11,9 @@
   // userSelectedWarning userSelectedWarning userSelectedWarning
   //
   grid-column-gap: 0.5rem
+
+  // Fix overflow on mobile by providing a max width to the input
+  //
+  // We subtract the width and right padding of the dropdown arrow
+  .ng-placeholder
+    max-width: calc(100% - 25px - 5px)

--- a/app/components/shares/invite_user_form_component.sass
+++ b/app/components/shares/invite_user_form_component.sass
@@ -11,9 +11,3 @@
   // userSelectedWarning userSelectedWarning userSelectedWarning
   //
   grid-column-gap: 0.5rem
-
-  // Fix overflow on mobile by providing a max width to the input
-  //
-  // We subtract the width and right padding of the dropdown arrow
-  .ng-placeholder
-    max-width: calc(100% - 25px - 5px)

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -1,16 +1,21 @@
 <%=
 container.with_row do
-  content_tag(:div, class: tooltip_wrapper_classes, data: { tooltip: tooltip_message }) do
-    render(Primer::Forms::ToggleSwitchForm.new(
-      name: "publish_project_query",
-      label: t("sharing.project_queries.public_flag.label", instance_name: Setting.app_title),
-      caption: t("sharing.project_queries.public_flag.caption"),
-      src: toggle_public_flag_link,
-      csrf_token: form_authenticity_token,
-      status_label_position: :start,
-      checked: published?,
-      enabled: can_publish?
-    ))
+  render(Primer::Box.new(border: true,
+                         border_radius: BOX_BORDER_RADIUS,
+                         p: BOX_PADDING)) do
+    content_tag(:div, class: tooltip_wrapper_classes, data: { tooltip: tooltip_message }) do
+      render(Primer::Forms::ToggleSwitchForm.new(
+        name: "publish_project_query",
+        label: t("sharing.project_queries.public_flag.label", instance_name: Setting.app_title),
+        caption: t("sharing.project_queries.public_flag.caption"),
+        src: toggle_public_flag_link,
+        csrf_token: form_authenticity_token,
+        status_label_position: :start,
+        checked: published?,
+        enabled: can_publish?
+        ))
+      end
+    end
   end
 end
 %>

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -13,8 +13,7 @@ container.with_row do
         status_label_position: :start,
         checked: published?,
         enabled: can_publish?
-        ))
-      end
+      ))
     end
   end
 end

--- a/app/components/shares/project_queries/public_flag_component.rb
+++ b/app/components/shares/project_queries/public_flag_component.rb
@@ -31,6 +31,8 @@
 module Shares
   module ProjectQueries
     class PublicFlagComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+      BOX_PADDING = 3
+      BOX_BORDER_RADIUS = 2
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -130,6 +130,12 @@ div.autocomplete
   .ng-value-label
     display: initial !important
 
+  .ng-placeholder
+    // Fix overflow by providing a max width to the input
+    //
+    // We subtract the width and right padding of the dropdown arrow
+    max-width: calc(100% - 25px - 5px)
+
 // Ensure dropdown is above modals
 .ng-dropdown-panel
   z-index: 9500 !important


### PR DESCRIPTION
- [x] Add missing border to public toggle
- [x] Fix overflow in user invite form dropdown
- [x] Fix layout on mobile for user invite form
  - [x] The current styling seems to be intended by Primer even on mobile. They use a flex container with all labels/captions as one flex item and the toggle itself as the other flex item in their template. See https://github.com/primer/view_components/blob/main/lib/primer/forms/toggle_switch.html.erb

---

Related work package: https://community.openproject.org/work_packages/56251