### PR TITLE
Remove no permission alert

### DIFF
--- a/app/components/shares/invite_user_form_component.html.erb
+++ b/app/components/shares/invite_user_form_component.html.erb
@@ -1,7 +1,6 @@
 <%=
   component_wrapper do
-    if strategy.manageable?
-      primer_form_with(
+    primer_form_with(
         model: new_share,
         url: url_for([entity, Member]),
         data: { controller: 'user-limit shares--user-selected',
@@ -17,7 +16,7 @@
           invite_form.with_area('permission') do
             render(Shares::PermissionButtonComponent.new(
               share: new_share,
-              available_roles: strategy.available_roles,
+              strategy: strategy,
               form_arguments: { builder: form, name: "role_id" },
               data: { 'test-selector': 'op-share-dialog-invite-role' })
             )
@@ -92,7 +91,6 @@
             end
           end
         end
-      end
     end
   end
 %>

--- a/app/components/shares/invite_user_form_component.html.erb
+++ b/app/components/shares/invite_user_form_component.html.erb
@@ -93,8 +93,6 @@
           end
         end
       end
-    else
-      render(Primer::Alpha::Banner.new(icon: :info)) { I18n.t('sharing.denied', entities: entity.model_name.human(count: 2)) }
     end
   end
 %>

--- a/app/components/shares/modal_body_component.html.erb
+++ b/app/components/shares/modal_body_component.html.erb
@@ -8,8 +8,10 @@
         end
       end
 
-      modal_content.with_row do
-        render(Shares::InviteUserFormComponent.new(strategy:, errors: errors))
+      if strategy.manageable?
+        modal_content.with_row do
+          render(Shares::InviteUserFormComponent.new(strategy:, errors: errors))
+        end
       end
 
       modal_content.with_row(data: { 'test-selector': 'op-share-dialog-active-list',

--- a/app/components/shares/modal_body_component.sass
+++ b/app/components/shares/modal_body_component.sass
@@ -4,8 +4,8 @@
 
   &--user-row
     display: grid
-    grid-template-columns: minmax(31px, auto) 1fr // 31px is the width needed to display a group avatar
-    grid-template-areas: "avatar user_details"
+    grid-template-columns: minmax(31px, auto) 1fr auto // 31px is the width needed to display a group avatar
+    grid-template-areas: "avatar user_details button"
     grid-column-gap: 10px
 
     &_manageable

--- a/app/components/shares/permission_button_component.html.erb
+++ b/app/components/shares/permission_button_component.html.erb
@@ -1,28 +1,30 @@
 <%=
   component_wrapper do
-    render(Primer::Alpha::ActionMenu.new(**{ select_variant: :single,
-                                             size: :small,
-                                             dynamic_label: true,
-                                             anchor_align: :end,
-                                             color: :subtle }.deep_merge(@system_arguments))) do |menu|
-      menu.with_show_button(data: { 'shares--bulk-selection-target': 'userRowRole',
-                                    'share-id': share.id,
-                                    'active-role-name': permission_name(active_role.id)}) do |button|
-        button.with_trailing_action_icon(icon: :"triangle-down")
-        permission_name(active_role.id)
-      end
+    content_tag(:div, class: tooltip_wrapper_classes, data: { tooltip: tooltip_message }) do
+      render(Primer::Alpha::ActionMenu.new(**{ select_variant: :single,
+                                              size: :small,
+                                              dynamic_label: true,
+                                              anchor_align: :end,
+                                              color: :subtle }.deep_merge(@system_arguments))) do |menu|
+        menu.with_show_button(disabled: !strategy.manageable?, data: { 'shares--bulk-selection-target': 'userRowRole',
+                                      'share-id': share.id,
+                                      'active-role-name': permission_name(active_role.id)}) do |button|
+          button.with_trailing_action_icon(icon: :"triangle-down")
+          permission_name(active_role.id)
+        end
 
-      @available_roles.each do |role_hash|
-        menu.with_item(label: role_hash[:label],
-                       href: update_path,
-                       method: :patch,
-                       active: role_active?(role_hash),
-                       data: { value: role_hash[:value] },
-                       form_arguments: {
-                         method: :patch,
-                         inputs: form_inputs(role_hash[:value])
-                       }) do |item|
-          item.with_description.with_content(role_hash[:description])
+        strategy.available_roles.each do |role_hash|
+          menu.with_item(label: role_hash[:label],
+                        href: update_path,
+                        method: :patch,
+                        active: role_active?(role_hash),
+                        data: { value: role_hash[:value] },
+                        form_arguments: {
+                          method: :patch,
+                          inputs: form_inputs(role_hash[:value])
+                        }) do |item|
+            item.with_description.with_content(role_hash[:description])
+          end
         end
       end
     end

--- a/app/components/shares/permission_button_component.html.erb
+++ b/app/components/shares/permission_button_component.html.erb
@@ -6,7 +6,7 @@
                                               dynamic_label: true,
                                               anchor_align: :end,
                                               color: :subtle }.deep_merge(@system_arguments))) do |menu|
-        menu.with_show_button(disabled: !strategy.manageable?, data: { 'shares--bulk-selection-target': 'userRowRole',
+        menu.with_show_button(disabled: !editable?, data: { 'shares--bulk-selection-target': 'userRowRole',
                                       'share-id': share.id,
                                       'active-role-name': permission_name(active_role.id)}) do |button|
           button.with_trailing_action_icon(icon: :"triangle-down")

--- a/app/components/shares/permission_button_component.rb
+++ b/app/components/shares/permission_button_component.rb
@@ -92,5 +92,9 @@ module Shares
 
       ["tooltip--left"]
     end
+
+    def editable?
+      strategy.manageable? && share.principal != User.current
+    end
   end
 end

--- a/app/components/shares/permission_button_component.rb
+++ b/app/components/shares/permission_button_component.rb
@@ -32,10 +32,10 @@ module Shares
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    def initialize(share:, available_roles:, **system_arguments)
+    def initialize(share:, strategy:, **system_arguments)
       super
 
-      @available_roles = available_roles
+      @strategy = strategy
       @share = share
       @system_arguments = system_arguments
     end
@@ -58,7 +58,7 @@ module Shares
 
     private
 
-    attr_reader :share, :available_roles
+    attr_reader :share, :strategy
 
     def active_role
       if share.persisted?
@@ -71,7 +71,7 @@ module Shares
     end
 
     def permission_name(value)
-      available_roles.find { |role_hash| role_hash[:value] == value }[:label]
+      strategy.available_roles.find { |role_hash| role_hash[:value] == value }[:label]
     end
 
     def form_inputs(role_id)
@@ -79,6 +79,18 @@ module Shares
         inputs << { name: "role_ids[]", value: role_id }
         inputs << { name: "filters", value: params[:filters] } if params[:filters]
       end
+    end
+
+    def tooltip_message
+      return if strategy.manageable?
+
+      I18n.t("sharing.denied", entities: strategy.entity.class.model_name.human(count: 2))
+    end
+
+    def tooltip_wrapper_classes
+      return [] if strategy.manageable?
+
+      ["tooltip--left"]
     end
   end
 end

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -1,6 +1,6 @@
 <%=
 container.with_row do
-  content_tag(:div, class: wrapper_classes, data: { tooltip: tooltip }) do
+  content_tag(:div, class: tooltip_wrapper_classes, data: { tooltip: tooltip_message }) do
     render(Primer::Forms::ToggleSwitchForm.new(
       name: "publish_project_query",
       label: t("sharing.project_queries.public_flag.label", instance_name: Setting.app_title),

--- a/app/components/shares/project_queries/public_flag_component.html.erb
+++ b/app/components/shares/project_queries/public_flag_component.html.erb
@@ -1,14 +1,16 @@
 <%=
 container.with_row do
-  render(Primer::Forms::ToggleSwitchForm.new(
-        name: "publish_project_query",
-        label: t('sharing.project_queries.public_flag.label', instance_name: Setting.app_title),
-        caption: t('sharing.project_queries.public_flag.caption'),
-        src: toggle_public_flag_link,
-        csrf_token: form_authenticity_token,
-        status_label_position: :start,
-        checked: published?,
-        enabled: can_publish?
-      ))
+  content_tag(:div, class: wrapper_classes, data: { tooltip: tooltip }) do
+    render(Primer::Forms::ToggleSwitchForm.new(
+      name: "publish_project_query",
+      label: t("sharing.project_queries.public_flag.label", instance_name: Setting.app_title),
+      caption: t("sharing.project_queries.public_flag.caption"),
+      src: toggle_public_flag_link,
+      csrf_token: form_authenticity_token,
+      status_label_position: :start,
+      checked: published?,
+      enabled: can_publish?
+    ))
+  end
 end
 %>

--- a/app/components/shares/project_queries/public_flag_component.rb
+++ b/app/components/shares/project_queries/public_flag_component.rb
@@ -64,9 +64,9 @@ module Shares
       end
 
       def tooltip_wrapper_classes
-        return ["d-flex", "flex-column"] if can_publish?
-
-        ["tooltip--bottom", "d-flex", "flex-column"]
+        ["d-flex", "flex-column"].tap do |classlist|
+          classlist << "tooltip--bottom" unless can_publish?
+        end
       end
     end
   end

--- a/app/components/shares/project_queries/public_flag_component.rb
+++ b/app/components/shares/project_queries/public_flag_component.rb
@@ -57,13 +57,13 @@ module Shares
         User.current.allowed_globally?(:manage_public_project_queries)
       end
 
-      def tooltip
+      def tooltip_message
         return if can_publish?
 
         I18n.t("sharing.project_queries.publishing_denied")
       end
 
-      def wrapper_classes
+      def tooltip_wrapper_classes
         return ["d-flex", "flex-column"] if can_publish?
 
         ["tooltip--bottom", "d-flex", "flex-column"]

--- a/app/components/shares/project_queries/public_flag_component.rb
+++ b/app/components/shares/project_queries/public_flag_component.rb
@@ -56,6 +56,18 @@ module Shares
       def can_publish?
         User.current.allowed_globally?(:manage_public_project_queries)
       end
+
+      def tooltip
+        return if can_publish?
+
+        I18n.t("sharing.project_queries.publishing_denied")
+      end
+
+      def wrapper_classes
+        return ["d-flex", "flex-column"] if can_publish?
+
+        ["tooltip--bottom", "d-flex", "flex-column"]
+      end
     end
   end
 end

--- a/app/components/shares/share_row_component.html.erb
+++ b/app/components/shares/share_row_component.html.erb
@@ -20,13 +20,13 @@
         render(Shares::UserDetailsComponent.new(share:, manager_mode: share_editable?))
       end
 
-      if share_editable?
-        user_row_grid.with_area(:button, tag: :div, color: :subtle) do
-          render(Shares::PermissionButtonComponent.new(share:,
-                                                       available_roles: @available_roles,
-                                                       data: { 'test-selector': 'op-share-dialog-update-role' }))
-        end
+      user_row_grid.with_area(:button, tag: :div, color: :subtle) do
+        render(Shares::PermissionButtonComponent.new(share:,
+        strategy: strategy,
+                                                      data: { 'test-selector': 'op-share-dialog-update-role' }))
+      end
 
+      if share_editable?
         user_row_grid.with_area(:remove, tag: :div) do
           form_with url: url_for([entity, share]), method: :delete do
             render(Primer::Beta::IconButton.new(icon: "trash",

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -223,7 +223,7 @@ class SharesController < ApplicationController
     replace_via_turbo_stream(
       component: Shares::PermissionButtonComponent.new(
         share: @share,
-        available_roles: sharing_strategy.available_roles,
+        strategy: sharing_strategy,
         data: { "test-selector": "op-share-dialog-update-role" }
       )
     )
@@ -265,7 +265,7 @@ class SharesController < ApplicationController
       replace_via_turbo_stream(
         component: Shares::PermissionButtonComponent.new(
           share:,
-          available_roles: sharing_strategy.available_roles,
+          strategy: sharing_strategy,
           data: { "test-selector": "op-share-dialog-update-role" }
         )
       )

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -51,14 +51,13 @@ module Queries::BaseQuery
       :activerecord
     end
 
-    # Use the Query class' error messages.
-    # So everything under
+    # Also use the Query class' as a lookup ancestor so that error messages, etc can be shared.
+    # So if nothing is defined for the specific query class, we fall back to the generic query class.
     #
+    # This is useful for error messages, because we can fall back to error messages, etc in
     # activerecord.errors.models.query
-    #
-    # is found.
     def lookup_ancestors
-      [Query]
+      super + [Query]
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1221,6 +1221,9 @@ en:
         other: "Notifications"
       placeholder_user: "Placeholder user"
       project: "Project"
+      project_query:
+        one: "Project list"
+        other: "Project lists"
       query: "Custom query"
       role:
         one: "Role"
@@ -3695,6 +3698,7 @@ en:
       additional_privileges_group: "Might have additional privileges (as group member)"
       additional_privileges_project_or_group: "Might have additional privileges (as project or group member)"
     project_queries:
+      publishing_denied: "You do not have permission to make project lists public."
       access_warning: "Users will only see the projects they have access to. Sharing project lists does not impact individual project permissions."
       public_flag:
         label: "Share with everyone at %{instance_name}"

--- a/spec/support/components/work_packages/share_modal.rb
+++ b/spec/support/components/work_packages/share_modal.rb
@@ -298,9 +298,10 @@ module Components
                 expect(page).to have_button(role_name),
                                 "Expected share with #{user.name.inspect} to have button #{role_name}."
               end
+
               unless editable
-                expect(page).not_to have_button,
-                                    "Expected share with #{user.name.inspect} not to be editable (expected no buttons)."
+                expect(page).to have_button(role_name, disabled: true),
+                                "Expected share with #{user.name.inspect} not to be editable (expected disabled button)."
               end
             end
           end
@@ -323,8 +324,7 @@ module Components
 
       def expect_no_invite_option
         within_modal do
-          expect(page)
-            .to have_text(I18n.t("sharing.denied", entities: WorkPackage.model_name.human(count: 2)))
+          expect(page).to have_no_css('[data-test-selector="op-share-dialog-invite-autocomplete"]')
         end
       end
 


### PR DESCRIPTION
In the old version we rendered two alert boxes, primer states that this is not desirable. So, instead we removed the alert that the user is not allowed to edit the permissions and instead show a tooltip on the disabled input elements.

Also, we now show the role even for those that do not have permission to change the role. That information was already "leaked" anyway via the filters and the dialog makes a lot more sense this way.

---

Closes https://community.openproject.org/work_packages/56242/activity