### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/brakeman-scan-core.yml
+++ b/.github/workflows/brakeman-scan-core.yml
@@ -25,7 +25,7 @@ jobs:
       RUBY_GC_HEAP_INIT_SLOTS: 100000
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -41,7 +41,7 @@ jobs:
           - dev
           - "${{ needs.setup.outputs.latest_release_branch }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 1

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3.3'
-      - uses: MeilCli/danger-action@v5
+      - uses: MeilCli/danger-action@v6
         with:
           danger_file: 'Dangerfile'
           danger_id: 'danger-pr'

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.13'
           cache: npm

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -14,7 +14,7 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v3

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'opf/openproject'
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - run: ./script/api/validate_spec

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Generate .env.pullpreview file
       run: |
         echo "OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET=false" >> .env.pullpreview


### PR DESCRIPTION
These seems to be only about node runtime version:
actions/checkout to v4
actions/setup-node to v4
MeilCli/danger-action to v6
