### PR TITLE
Update workflow action versions docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -165,7 +165,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           context: git
           labels: |
@@ -258,7 +258,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,7 +85,7 @@ jobs:
           ./docker/prod/setup/precompile-assets.sh
           # public/assets will be saved as artifact, so temporarily copying config file there as well
           cp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: public/
           name: public-assets-${{ github.sha }}
@@ -134,7 +134,7 @@ jobs:
         run: |
           cp ./docker/prod/Dockerfile ./Dockerfile
       - name: Download precompiled public assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: public-assets-${{ github.sha }}
           path: public/
@@ -226,7 +226,7 @@ jobs:
           digest="${{ steps.push.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.target }}
           path: /tmp/digests/*
@@ -242,7 +242,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests-${{ matrix.target }}
           path: /tmp/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           path: public/
           name: public-assets-${{ github.sha }}
+          overwrite: true
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
       checkout_ref: ${{ steps.extract_version.outputs.checkout_ref }}
@@ -232,6 +233,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
   merge:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -178,7 +178,7 @@ jobs:
             ${{ env.REGISTRY_IMAGE }}
       - name: Build image
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -210,7 +210,7 @@ jobs:
           wget -O- --retry-on-http-error=503,502 --retry-connrefused http://localhost:8080/api/v3
       - name: Push image
         id: push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}


### PR DESCRIPTION
update actions/upload-artifact and actions/download-artifact to v4 - promises speed up, "upwards of 90% improvement in worst case scenarios". Enabled `overwrite` option to not fail if re-running ([migration notes](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)).

update docker/build-push-action to v6 - switch to node20 runtime and exporting build record and generate build summary

update docker/metadata-action to v5 - switch to node20 runtime