### PR TITLE
configure dependabot to update github action versions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,9 @@ updates:
     target-branch: "dev"
     open-pull-requests-limit: 3
     versioning-strategy: lockfile-only
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
Failed to find when searching for it, but stumbled upon https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot in https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

Kept github/codeql-action/upload-sarif@v2 for dependabot to update
Manual updates:
- https://github.com/opf/openproject/pull/16067
- https://github.com/opf/openproject/pull/16068
- https://github.com/opf/openproject/pull/16069