### PR TITLE
Fix flaky feature tests involving timeline

### DIFF
--- a/spec/support/pages/work_packages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages/work_packages_timeline.rb
@@ -83,6 +83,7 @@ module Pages
       else
         expect(page).to have_no_css(".wp-table-timeline--container .wp-timeline-cell", visible: true)
       end
+      wait_for_network_idle
     end
 
     def timeline_row(wp_id)

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -36,6 +36,9 @@
 # being present or gone. Instead the execution is halted until
 # requested data is done being fetched.
 def wait_for_network_idle(...)
+  # `wait_for_network_idle` is available only when driver is Cuprite.
+  return unless page.driver.respond_to?(:wait_for_network_idle)
+
   page.driver.wait_for_network_idle(...)
 end
 


### PR DESCRIPTION
Failing spec is ./spec/features/work_packages/table/context_menu/context_menu_spec.rb:68 It was failing in https://github.com/opf/openproject/actions/runs/9853177518/job/27203169350

The test is opening the context menu of a work package by right clicking in the work package list. But the `refreshView()` of the timeline is called and this closes the context menu before the test assertion run, making the test fail. Waiting for network idle when checking if the timeline is open fixes it.