### PR TITLE
[#56188] restrict results show in dropdown of filter autocompleter

### DIFF
--- a/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
+++ b/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
@@ -18,6 +18,8 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
  */
 export const MAGIC_PAGE_NUMBER = -1;
 
+export const MAGIC_FILTER_AUTOCOMPLETE_PAGE_SIZE = 100;
+
 /**
  * Right now, we still support HAL-class based collections as well as interface-based responses.
  */


### PR DESCRIPTION
[#56188](https://community.openproject.org/work_packages/56188)

### WAT?

- set page size to 100
  - assumption: no one should scroll through 100 items of the autocompleter without narrowing the search
  - improvement: no timeouts are long loading times when there are thousands of results (e.g. work packages)