### PR TITLE
deps[Op#51376]: Bump `opf/primer_view_components` to v0.36.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -392,4 +392,4 @@ end
 
 gem "openproject-octicons", "~>19.15.0"
 gem "openproject-octicons_helper", "~>19.15.0"
-gem "openproject-primer_view_components", "~>0.36.1"
+gem "openproject-primer_view_components", "~>0.36.2"

--- a/Gemfile
+++ b/Gemfile
@@ -392,4 +392,4 @@ end
 
 gem "openproject-octicons", "~>19.15.0"
 gem "openproject-octicons_helper", "~>19.15.0"
-gem "openproject-primer_view_components", "~>0.36.0"
+gem "openproject-primer_view_components", "~>0.36.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,7 +776,7 @@ GEM
       actionview
       openproject-octicons (= 19.15.0)
       railties
-    openproject-primer_view_components (0.36.1)
+    openproject-primer_view_components (0.36.2)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.15.0)
@@ -1266,7 +1266,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.15.0)
   openproject-octicons_helper (~> 19.15.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.36.1)
+  openproject-primer_view_components (~> 0.36.2)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,7 +776,7 @@ GEM
       actionview
       openproject-octicons (= 19.15.0)
       railties
-    openproject-primer_view_components (0.36.0)
+    openproject-primer_view_components (0.36.1)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.15.0)
@@ -1266,7 +1266,7 @@ DEPENDENCIES
   openproject-octicons (~> 19.15.0)
   openproject-octicons_helper (~> 19.15.0)
   openproject-openid_connect!
-  openproject-primer_view_components (~> 0.36.0)
+  openproject-primer_view_components (~> 0.36.1)
   openproject-recaptcha!
   openproject-reporting!
   openproject-storages!

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.15.0",
-        "@openproject/primer-view-components": "^0.36.0",
+        "@openproject/primer-view-components": "^0.36.1",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.3.3",
         "@types/hotwired__turbo": "^8.0.1",
@@ -4816,9 +4816,10 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.0.tgz",
-      "integrity": "sha512-wU8MB2QqA082AiR5jzZqPeT7IPOJI9vr8hBWU0PQKyWpbmk+SAq+IU6vWyzH73kZpZ3FlMYyOfk+7UO/LdPstQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
+      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25358,9 +25359,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.0.tgz",
-      "integrity": "sha512-wU8MB2QqA082AiR5jzZqPeT7IPOJI9vr8hBWU0PQKyWpbmk+SAq+IU6vWyzH73kZpZ3FlMYyOfk+7UO/LdPstQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
+      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.15.0",
-        "@openproject/primer-view-components": "^0.36.1",
+        "@openproject/primer-view-components": "^0.36.2",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.3.3",
         "@types/hotwired__turbo": "^8.0.1",
@@ -4816,9 +4816,9 @@
       }
     },
     "node_modules/@openproject/primer-view-components": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
-      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.2.tgz",
+      "integrity": "sha512-2q3QshalAClN1qAHL65AUPrXYo1bC9TP6a9yItkXxomb46+mvjkc45k7lrkDiNUUg12vbeLCTiqqCg4Q10jtSA==",
       "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
@@ -4884,9 +4884,9 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
-      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.2.tgz",
+      "integrity": "sha512-2q3QshalAClN1qAHL65AUPrXYo1bC9TP6a9yItkXxomb46+mvjkc45k7lrkDiNUUg12vbeLCTiqqCg4Q10jtSA==",
       "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
@@ -25360,9 +25360,9 @@
       }
     },
     "@openproject/primer-view-components": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
-      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.2.tgz",
+      "integrity": "sha512-2q3QshalAClN1qAHL65AUPrXYo1bC9TP6a9yItkXxomb46+mvjkc45k7lrkDiNUUg12vbeLCTiqqCg4Q10jtSA==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25408,7 +25408,7 @@
       "integrity": "sha512-sThxn35+xsJVLfhPOG5HoQtnP+wTKOyMnVTNhsg/boyeetzVgJI8xka09EMl30cB36xBmCE9pcIS74B3MMPCbw==",
       "requires": {
         "@primer/primitives": "^8.2.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.1"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.2"
       }
     },
     "@primer/primitives": {
@@ -25417,9 +25417,9 @@
       "integrity": "sha512-K8A/DA6xv8P/kD/9DupFn+KYlo06OpcrwfwJf+sKp+KnX7ZRwLLDg1AaEGAoRoaykXRY/gfrXlgDfK7laOTWyA=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.36.1",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
-      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "version": "npm:@openproject/primer-view-components@0.36.2",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.2.tgz",
+      "integrity": "sha512-2q3QshalAClN1qAHL65AUPrXYo1bC9TP6a9yItkXxomb46+mvjkc45k7lrkDiNUUg12vbeLCTiqqCg4Q10jtSA==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4884,9 +4884,10 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.0.tgz",
-      "integrity": "sha512-wU8MB2QqA082AiR5jzZqPeT7IPOJI9vr8hBWU0PQKyWpbmk+SAq+IU6vWyzH73kZpZ3FlMYyOfk+7UO/LdPstQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
+      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
+      "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25407,7 +25408,7 @@
       "integrity": "sha512-sThxn35+xsJVLfhPOG5HoQtnP+wTKOyMnVTNhsg/boyeetzVgJI8xka09EMl30cB36xBmCE9pcIS74B3MMPCbw==",
       "requires": {
         "@primer/primitives": "^8.2.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.0"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.1"
       }
     },
     "@primer/primitives": {
@@ -25416,9 +25417,9 @@
       "integrity": "sha512-K8A/DA6xv8P/kD/9DupFn+KYlo06OpcrwfwJf+sKp+KnX7ZRwLLDg1AaEGAoRoaykXRY/gfrXlgDfK7laOTWyA=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.36.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.0.tgz",
-      "integrity": "sha512-wU8MB2QqA082AiR5jzZqPeT7IPOJI9vr8hBWU0PQKyWpbmk+SAq+IU6vWyzH73kZpZ3FlMYyOfk+7UO/LdPstQ==",
+      "version": "npm:@openproject/primer-view-components@0.36.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.36.1.tgz",
+      "integrity": "sha512-brMHl1p1n8SpKw6R/NKKNpUxFWkzqfcI3nW3T7BZOJhLDOxo1T2Al4Z70fKtuHBdrU5hBEdgopsERTEix5tTow==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,7 +98,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.15.0",
-    "@openproject/primer-view-components": "^0.36.0",
+    "@openproject/primer-view-components": "^0.36.1",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.3.3",
     "@types/hotwired__turbo": "^8.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,7 +98,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.15.0",
-    "@openproject/primer-view-components": "^0.36.1",
+    "@openproject/primer-view-components": "^0.36.2",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.3.3",
     "@types/hotwired__turbo": "^8.0.1",
@@ -175,6 +175,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.1"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -175,6 +175,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.0"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.36.1"
   }
 }

--- a/modules/storages/app/components/storages/admin/forms/redirect_uri_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/redirect_uri_form_component.html.erb
@@ -8,7 +8,7 @@
       ) do |form|
         flex_layout do |oauth_client_row|
           oauth_client_row.with_row(mb: 3) do
-            concat(render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
+            render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
               input_group.with_text_input(
                 name: :oauth_client_redirect_uri,
                 label: I18n.t('storages.label_redirect_uri'),
@@ -24,14 +24,11 @@
                 },
                 test_selector: 'storage-oauth-client-redirect-uri'
               )
-            end)
 
-            # NOTE: Hardcoded `FormControl-caption` class is used to align the text with the input field.
-            #      This is a workaround until Primer::OpenProject::InputGroup supports a caption.
-            #      See https://community.openproject.org/wp/51376
-            concat(render(Primer::Beta::Text.new(classes: 'FormControl-caption')) do
-              I18n.t('storages.instructions.one_drive.oauth_client_redirect_uri')
-            end)
+              input_group.with_caption do
+                I18n.t('storages.instructions.one_drive.oauth_client_redirect_uri')
+              end
+            end
           end
 
           oauth_client_row.with_row do


### PR DESCRIPTION
- https://github.com/opf/primer_view_components/releases/tag/v0.36.1
- https://github.com/opf/primer_view_components/releases/tag/v0.36.2


![Screenshot 2024-07-09 at 4 05 46 PM](https://github.com/opf/openproject/assets/17295175/6c698d5a-8ec7-4478-a851-86b3f4963b85)

