### PR TITLE
[56168] Fixed flash messages for api tokens

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -163,11 +163,9 @@ class MyController < ApplicationController
     result = APITokens::CreateService.new(user: current_user).call(token_name: params[:token_api][:token_name])
 
     result.on_success do |r|
-      flash[:info] = [
-        t("my.access_token.notice_reset_token", type: "API").html_safe,
-        content_tag(:strong, r.result.plain_value),
-        t("my.access_token.token_value_warning")
-      ]
+      token = Primer::Beta::Text.new(font_weight: :bold).render_in(view_context) { r.result.plain_value }
+      message = "#{t('my.access_token.notice_reset_token', type: 'API')} #{token} #{t('my.access_token.token_value_warning')}"
+      flash[:primer_banner] = { message:, scheme: :success }
 
       redirect_to action: "access_token"
     end
@@ -181,6 +179,7 @@ class MyController < ApplicationController
       respond_with_turbo_streams
     end
   end
+
   # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/AbcSize
@@ -189,12 +188,13 @@ class MyController < ApplicationController
 
     # rubocop:disable Rails/ActionControllerFlashBeforeRender
     result.on_success do
-      flash[:info] = t("my.access_token.notice_api_token_revoked")
+      flash[:primer_banner] = { message: t("my.access_token.notice_api_token_revoked") }
     end
 
-    result.on_failure do
-      Rails.logger.error "Failed to revoke api token ##{current_user.id}: #{e}"
-      flash[:error] = t("my.access_token.failed_to_revoke_token", error: e.message)
+    result.on_failure do |r|
+      error = r.errors.map(&:message).join("; ")
+      Rails.logger.error("Failed to revoke api token ##{current_user.id}: #{error}")
+      flash[:primer_banner] = { message: t("my.access_token.failed_to_revoke_token", error:), scheme: :danger }
     end
     # rubocop:enable Rails/ActionControllerFlashBeforeRender
 

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -31,6 +31,7 @@ class MyController < ApplicationController
   include Accounts::UserPasswordChange
   include ActionView::Helpers::TagHelper
   include OpTurbo::ComponentStream
+  include FlashMessagesOutputSafetyHelper
 
   layout "my"
 
@@ -163,9 +164,16 @@ class MyController < ApplicationController
     result = APITokens::CreateService.new(user: current_user).call(token_name: params[:token_api][:token_name])
 
     result.on_success do |r|
-      token = Primer::Beta::Text.new(font_weight: :bold).render_in(view_context) { r.result.plain_value }
-      message = "#{t('my.access_token.notice_reset_token', type: 'API')} #{token} #{t('my.access_token.token_value_warning')}"
-      flash[:primer_banner] = { message:, scheme: :success }
+      flash[:primer_banner] = {
+        scheme: :success,
+        message: join_flash_messages(
+          [
+            t("my.access_token.notice_reset_token", type: "API"),
+            Primer::Beta::Text.new(font_weight: :bold).render_in(view_context) { r.result.plain_value },
+            t("my.access_token.token_value_warning")
+          ]
+        )
+      }
 
       redirect_to action: "access_token"
     end

--- a/modules/meeting/app/components/banner_message_component.html.erb
+++ b/modules/meeting/app/components/banner_message_component.html.erb
@@ -35,5 +35,5 @@ See COPYRIGHT and LICENSE files for more details.
                                    icon:,
                                    scheme:,
                                    test_selector:,
-                                   )) { message }
+                                   )) { message.html_safe }
 %>

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -309,8 +309,8 @@ RSpec.describe MyController do
           new_token = user.reload.api_tokens.last
           expect(new_token).to be_present
 
-          expect(flash[:info]).to be_present
-          expect(flash[:error]).not_to be_present
+          expect(flash[:primer_banner]).to be_present
+          expect(flash[:primer_banner]).to include(scheme: :success)
 
           expect(response).to redirect_to action: :access_token
         end
@@ -327,8 +327,8 @@ RSpec.describe MyController do
           new_token = user.reload.api_tokens.last
           expect(new_token).not_to eq(key)
           expect(new_token.value).not_to eq(key.value)
-          expect(flash[:info]).to be_present
-          expect(flash[:error]).not_to be_present
+          expect(flash[:primer_banner]).to be_present
+          expect(flash[:primer_banner]).to include(scheme: :success)
 
           expect(response).to redirect_to action: :access_token
         end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/56168

This PR replaces classic flash messages for **Access Tokens** for the API tokens section with Primers banners to circumvent the problem of a not working close action on the old style flash messges.

![image](https://github.com/opf/openproject/assets/480983/6725faa8-57a0-4ede-9726-57e2732f690f)

![image](https://github.com/opf/openproject/assets/480983/29bf6d63-2872-45c2-81e4-6e86d1b95532)