### PR TITLE
[#41852] fix undefined method path for nil class when click attachment

### DIFF
--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -86,6 +86,10 @@ module API
       end
 
       def send_attachment(attachment)
+        if attachment.diskfile.nil?
+          raise ::API::Errors::NotFound.new
+        end
+
         content_type attachment_content_type(attachment)
         header["Content-Disposition"] = attachment.content_disposition
         env["api.format"] = :binary

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -471,6 +471,13 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
           expect(subject.body)
             .to match(mock_file.read)
         end
+
+        it "responds with not found if file has been deleted" do
+          File.delete attachment.file.path
+
+          get path
+          expect(subject.status).to eq 404
+        end
       end
 
       context "for a local text file" do


### PR DESCRIPTION
Fix [[#41852]](https://community.openproject.org/wp/41852)

return 404 instead of 500 error if local attachment file has been deleted 