### PR TITLE
Feature/31918 Collapse/Expend all work packages in hierarchy view

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-hierarchies-toggle-button/wp-hierarchies-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-hierarchies-toggle-button/wp-hierarchies-toggle-button.component.ts
@@ -1,0 +1,45 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2024 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  template: `
+    <button class="button"
+            id="wp-hierarchy-toggle-button"
+            opHierarchyToggleDropdown>
+      <op-icon icon-classes="button--icon icon-outline"></op-icon>
+      <span class="button--text"></span>
+      <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'op-wp-hierarchy-toggle-view-button',
+})
+export class WorkPackageHierarchiesToggleButtonComponent {
+}

--- a/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
@@ -127,6 +127,9 @@ import { TimeEntryCreateService } from 'core-app/shared/components/time_entries/
 import {
   WorkPackageViewCollapsedGroupsService,
 } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service';
+import {
+  WorkPackageViewCollapsedHierarchiesService,
+} from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service';
 import { WorkPackageService } from 'core-app/features/work-packages/services/work-package.service';
 import {
   WorkPackageViewBaselineService,
@@ -158,6 +161,7 @@ import { TimeEntryEditService } from 'core-app/shared/components/time_entries/ed
     WorkPackageViewPaginationService,
     WorkPackageViewGroupByService,
     WorkPackageViewCollapsedGroupsService,
+    WorkPackageViewCollapsedHierarchiesService,
     WorkPackageViewHierarchiesService,
     WorkPackageViewSortByService,
     WorkPackageViewColumnsService,

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -129,6 +129,9 @@ import {
   WorkPackageFoldToggleButtonComponent,
 } from 'core-app/features/work-packages/components/wp-buttons/wp-fold-toggle-button/wp-fold-toggle-button.component';
 import {
+  WorkPackageHierarchiesToggleButtonComponent,
+} from 'core-app/features/work-packages/components/wp-buttons/wp-hierarchies-toggle-button/wp-hierarchies-toggle-button.component';
+import {
   WpTableConfigurationModalComponent,
 } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal';
 import {
@@ -260,6 +263,9 @@ import { WorkPackagesTableComponent } from 'core-app/features/work-packages/comp
 import {
   WorkPackageGroupToggleDropdownMenuDirective,
 } from 'core-app/shared/components/op-context-menu/handlers/wp-group-toggle-dropdown-menu.directive';
+import {
+  WorkPackageHierarchyToggleDropdownMenuDirective,
+} from 'core-app/shared/components/op-context-menu/handlers/wp-hierarchy-toggle-dropdown-menu.directive';
 import {
   OpenprojectAutocompleterModule,
 } from 'core-app/shared/components/autocompleter/openproject-autocompleter.module';
@@ -515,6 +521,7 @@ import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepic
 
     // Fold/Unfold button on wp list
     WorkPackageFoldToggleButtonComponent,
+    WorkPackageHierarchiesToggleButtonComponent,
 
     // Filters
     QueryFiltersComponent,
@@ -542,6 +549,7 @@ import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepic
     WorkPackageSingleContextMenuDirective,
     WorkPackageViewDropdownMenuDirective,
     WorkPackageGroupToggleDropdownMenuDirective,
+    WorkPackageHierarchyToggleDropdownMenuDirective,
 
     // Timeline
     WorkPackageTimelineButtonComponent,

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/typings.d.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/typings.d.ts
@@ -6,3 +6,7 @@ interface IGroupsCollapseEvent {
   allGroupsChanged:boolean;
   groupedBy:string|null;
 }
+
+interface IHierarchiesCollapseEvent {
+  allHierarchiesChanged:boolean;
+}

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service.ts
@@ -44,6 +44,18 @@ export class WorkPackageViewCollapsedHierarchiesService extends WorkPackageViewB
     super(querySpace);
   }
 
+  get allHierarchiesAreCollapsed():boolean {
+    return jQuery('.wp-table--hierarchy-indicator').toArray().every((element) => {
+      return jQuery(element).hasClass('-hierarchy-collapsed');
+    });
+  }
+
+  get allHierarchiesAreExpanded():boolean {
+    return jQuery('.wp-table--hierarchy-indicator').toArray().every((element) => {
+      return !jQuery(element).hasClass('-hierarchy-collapsed');
+    });
+  }
+
   setAllHierarchiesCollapseStateTo(collapsedState:boolean):void {
     const newState = {
       allHierarchiesChanged: true,
@@ -56,6 +68,7 @@ export class WorkPackageViewCollapsedHierarchiesService extends WorkPackageViewB
     hierarchyIndicators.each((index, element) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const wpId:string = jQuery(element).closest(`.${tableRowClassName}`).data('workPackageId');
+
       if (collapsedState) {
         this.workPackageViewHierarchiesService.collapse(wpId);
       } else {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service.ts
@@ -1,0 +1,77 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2024 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Injectable } from '@angular/core';
+import { WorkPackageViewHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
+import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
+import { QueryResource } from 'core-app/features/hal/resources/query-resource';
+import { QuerySchemaResource } from 'core-app/features/hal/resources/query-schema-resource';
+import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/wp-collection-resource';
+import { WorkPackageViewBaseService } from './wp-view-base.service';
+import { tableRowClassName } from 'core-app/features/work-packages/components/wp-fast-table/builders/rows/single-row-builder';
+
+@Injectable()
+export class WorkPackageViewCollapsedHierarchiesService extends WorkPackageViewBaseService<IHierarchiesCollapseEvent> {
+  constructor(
+    protected readonly querySpace:IsolatedQuerySpace,
+    readonly workPackageViewHierarchiesService:WorkPackageViewHierarchiesService,
+  ) {
+    super(querySpace);
+  }
+
+  setAllHierarchiesCollapseStateTo(collapsedState:boolean):void {
+    const newState = {
+      allHierarchiesChanged: true,
+    };
+
+    this.update(newState);
+
+    // Find all hierarchy indicators and toggle their state
+    const hierarchyIndicators = jQuery('.wp-table--hierarchy-indicator');
+    hierarchyIndicators.each((index, element) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const wpId:string = jQuery(element).closest(`.${tableRowClassName}`).data('workPackageId');
+      if (collapsedState) {
+        this.workPackageViewHierarchiesService.collapse(wpId);
+      } else {
+        this.workPackageViewHierarchiesService.expand(wpId);
+      }
+    });
+  }
+
+  initialize(_query:QueryResource, _results:WorkPackageCollectionResource, _schema?:QuerySchemaResource) {
+  }
+
+  valueFromQuery(_query:QueryResource, _results:WorkPackageCollectionResource) {
+    return undefined;
+  }
+
+  applyToQuery(_query:QueryResource) {
+
+  }
+}

--- a/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
@@ -43,11 +43,12 @@ import { ZenModeButtonComponent } from 'core-app/features/work-packages/componen
 import { WorkPackageSettingsButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component';
 import { of } from 'rxjs';
 import { WorkPackageFoldToggleButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-fold-toggle-button/wp-fold-toggle-button.component';
+import { WorkPackageHierarchiesToggleButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-hierarchies-toggle-button/wp-hierarchies-toggle-button.component';
 import { OpProjectIncludeComponent } from 'core-app/shared/components/project-include/project-include.component';
 import { OpBaselineModalComponent } from 'core-app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component';
 
 @Component({
-  selector: 'wp-view-page',
+  selector: 'op-wp-view-page',
   templateUrl: '../partitioned-query-space-page/partitioned-query-space-page.component.html',
   styleUrls: [
     // Absolute paths do not work for styleURLs :-(
@@ -82,6 +83,10 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
     {
       component: WorkPackageFoldToggleButtonComponent,
       show: () => !!(this.currentQuery && this.currentQuery.groupBy),
+    },
+    {
+      component: WorkPackageHierarchiesToggleButtonComponent,
+      show: () => !!(this.currentQuery && this.currentQuery.showHierarchies),
     },
     {
       component: WorkPackageDetailsViewButtonComponent,

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-hierarchy-toggle-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-hierarchy-toggle-dropdown-menu.directive.ts
@@ -60,6 +60,7 @@ export class WorkPackageHierarchyToggleDropdownMenuDirective extends OpContextMe
   private buildItems() {
     this.items = [
       {
+        disabled: this.wpViewCollapsedHierarchies.allHierarchiesAreCollapsed,
         linkText: this.I18n.t('js.button_collapse_all'),
         icon: 'icon-minus2',
         onClick: (_evt:JQuery.TriggeredEvent) => {
@@ -69,6 +70,7 @@ export class WorkPackageHierarchyToggleDropdownMenuDirective extends OpContextMe
         },
       },
       {
+        disabled: this.wpViewCollapsedHierarchies.allHierarchiesAreExpanded,
         linkText: this.I18n.t('js.button_expand_all'),
         icon: 'icon-plus',
         onClick: (_evt:JQuery.TriggeredEvent) => {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-hierarchy-toggle-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-hierarchy-toggle-dropdown-menu.directive.ts
@@ -1,0 +1,82 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2024 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
+import { Directive, ElementRef } from '@angular/core';
+import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { WorkPackageViewCollapsedHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-hierarchies.service';
+
+@Directive({
+  selector: '[opHierarchyToggleDropdown]',
+})
+export class WorkPackageHierarchyToggleDropdownMenuDirective extends OpContextMenuTrigger {
+  constructor(
+    readonly elementRef:ElementRef,
+    readonly opContextMenu:OPContextMenuService,
+    readonly I18n:I18nService,
+    readonly wpViewCollapsedHierarchies:WorkPackageViewCollapsedHierarchiesService,
+  ) {
+    super(elementRef, opContextMenu);
+  }
+
+  protected open(evt:JQuery.TriggeredEvent) {
+    this.buildItems();
+    this.opContextMenu.show(this, evt);
+  }
+
+  public get locals() {
+    return {
+      items: this.items,
+      contextMenuId: 'wp-hierarchy-fold-context-menu',
+    };
+  }
+
+  private buildItems() {
+    this.items = [
+      {
+        linkText: this.I18n.t('js.button_collapse_all'),
+        icon: 'icon-minus2',
+        onClick: (_evt:JQuery.TriggeredEvent) => {
+          this.wpViewCollapsedHierarchies.setAllHierarchiesCollapseStateTo(true);
+
+          return true;
+        },
+      },
+      {
+        linkText: this.I18n.t('js.button_expand_all'),
+        icon: 'icon-plus',
+        onClick: (_evt:JQuery.TriggeredEvent) => {
+          this.wpViewCollapsedHierarchies.setAllHierarchiesCollapseStateTo(false);
+
+          return true;
+        },
+      },
+    ];
+  }
+}


### PR DESCRIPTION
Largely copy from WorkPackageViewCollapsedGroupsService but not consider the view state save in query.

https://community.openproject.org/projects/openproject/work_packages/31918/activity
