### PR TITLE
Exclude avatar from principal

### DIFF
--- a/modules/storages/spec/features/storages/admin/index_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/index_storages_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe "Admin List File storages",
     end
 
     it "renders content that is accessible" do
-      expect(page).to be_axe_clean.within("#content")
+      expect(page)
+        .to be_axe_clean
+              .within("#content")
+              .excluding("opce-principal")
     end
   end
 


### PR DESCRIPTION
We generate more colors now by adding the ID in the avatar, which broke a spec