### PR TITLE
Allow disabling spec profiling via ENV

### DIFF
--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -100,7 +100,7 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   # Disabled on CI to have a cleaner log output.
-  config.profile_examples = 10 unless ENV["CI"]
+  config.profile_examples = 10 unless ENV["CI"] || ENV["NO_PROFILE_EXAMPLES"]
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
When I'm not actively looking to profile spec performance and am in the process of writing new specs/fixing them, The spec profiling info pollutes the output and just increases vertical scrolling for me. I'd like to be able to on-demand turn off solely profiling without having to run in CI mode completely with `CI=true`.

I proposed `NO_PROFILE_EXAMPLES` as the env name.