### PR TITLE
No need right padding as spot-icon_dropdown takes 24px already.

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button"
+    class="button -no-padding"
     [class.-active]="opened"
     (click)="toggleOpen()"
     [title]="text.toggle_title"

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button -no-padding"
+    class="button -has-dropdown"
     [class.-active]="opened"
     (click)="toggleOpen()"
     [title]="text.toggle_title"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -1,6 +1,6 @@
 <div class="wp-create-button">
   <button
-    class="button -primary add-work-package -no-padding"
+    class="button -primary add-work-package -has-dropdown"
     [disabled]="disabled"
     [attr.aria-label]="text.explanation"
     opTypesCreateDropdown

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -1,6 +1,6 @@
 <div class="wp-create-button">
   <button
-    class="button -primary add-work-package"
+    class="button -primary add-work-package -no-padding"
     [disabled]="disabled"
     [attr.aria-label]="text.explanation"
     opTypesCreateDropdown

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -1,5 +1,5 @@
 <button
-  class="button -no-padding"
+  class="button -has-dropdown"
   [attr.id]="buttonId"
   [attr.accesskey]="accessKey"
   [attr.title]="title"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -1,5 +1,5 @@
 <button
-  class="button"
+  class="button -no-padding"
   [attr.id]="buttonId"
   [attr.accesskey]="accessKey"
   [attr.title]="title"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button"
+    class="button -no-padding"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
     data-test-selector="project-include-button"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button -no-padding"
+    class="button -has-dropdown"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
     data-test-selector="project-include-button"

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -159,6 +159,9 @@ $nm-color-success-background: #d8fdd1
     @include toolbar-element-sizing
     border: 1px solid var(--button-default-borderColor-rest)
 
+    &.-no-padding
+      padding-right: 0
+
   .button,
   .toolbar-input--affix
     background: var(--button-default-bgColor-rest)

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -159,7 +159,7 @@ $nm-color-success-background: #d8fdd1
     @include toolbar-element-sizing
     border: 1px solid var(--button-default-borderColor-rest)
 
-    &.-no-padding
+    &.-has-dropdown
       padding-right: 0
 
   .button,


### PR DESCRIPTION
The purpose of PR is remove extra right padding for toolbar button `Create`, `Include projects`, `Baseline` and `Filter`, so given more space for query name.

#### Before:

<img width="1221" alt="Old-EN_2024-07-12_11 13 36" src="https://github.com/user-attachments/assets/b88ba38e-22f5-4c5f-82ed-e8d43a2c9627">

<img width="1228" alt="Old-CN_2024-07-12_11 13 08" src="https://github.com/user-attachments/assets/45ae1237-97fd-4992-8638-4007dd1cfd3b">

#### After:

<img width="1221" alt="New-EN_2024-07-12_11 11 31" src="https://github.com/user-attachments/assets/8f10dfe2-d96f-4953-b61d-8a51b0c83f66">

<img width="1223" alt="New-CN_2024-07-12_11 10 14" src="https://github.com/user-attachments/assets/f479b822-284f-41dd-bcfc-d1a4753aae6b">
