### PR TITLE
fix translation key typo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2209,8 +2209,8 @@ en:
   label_member_all_admin: "(All roles due to admin status)"
   label_member_plural: "Members"
   label_membership_plural: "Memberships"
-  lable_membership_added: "Member added"
-  lable_membership_updated: "Member updated"
+  label_membership_added: "Member added"
+  label_membership_updated: "Member updated"
   label_menu: "Menu"
   label_menu_badge:
     pre_alpha: "pre-alpha"


### PR DESCRIPTION
Can't find usage, went unnoticed probably due to [lots of unrelated changes](https://github.com/opf/openproject/pull/14065/files#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7)