### PR TITLE
Smaller fixes in the docs regarding file storages

### DIFF
--- a/docs/system-admin-guide/integrations/nextcloud/README.md
+++ b/docs/system-admin-guide/integrations/nextcloud/README.md
@@ -376,7 +376,7 @@ You have setup the *Project folder* in both environments (Nextcloud and OpenProj
       If you do not posses the application password anymore, you can reset it. Make sure not to forget updating the settings of the file storage in OpenProject accordingly. The following cURL command should respond with an XML containing details for the **OpenProject** user (**Please make sure to use the right application-password and Nextcloud host name**):
 
       ```shell
-      curl -u 'OpenProject:<application-password>' https://<nextcloud-host-name>/ocs/v1.php/cloud/users/OpenProject -H 'OCS-APIRequest: true' -v`
+      curl -u 'OpenProject:<application-password>' https://<nextcloud-host-name>/ocs/v1.php/cloud/users/OpenProject -H 'OCS-APIRequest: true' -v
       ```
 
 ## Getting support

--- a/docs/user-guide/file-management/README.md
+++ b/docs/user-guide/file-management/README.md
@@ -17,8 +17,6 @@ keywords: files, attachment, Nextcloud, OneDrive, SharePoint
 
 There are several ways of adding or linking files to work packages in OpenProject. You can manually attach files directly to work packages or use one of the integrations with file management systems.
 
-> Note: in order to use Nextcloud or OneDrive/SharePoint integrations you first need to activate the [File storages module](../projects/project-settings/files/) in your project settings.
-
 ## Manual upload
 
 For the manual upload please refer to documentation on [attaching files to work packages](../work-packages/create-work-package/#add-attachments-to-work-packages).


### PR DESCRIPTION
- **remove trailing back-tick**
- **No, you don't need to activate the module in the project settings anymore**
