### PR TITLE
switch to reviewdog/action-rubocop from our fork

### DIFF
--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -9,10 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch head commit of base branch
-        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
-      - uses: opf/action-rubocop@master
+      - uses: reviewdog/action-rubocop@v2
         with:
           github_token: ${{ secrets.github_token }}
           rubocop_version: gemfile


### PR DESCRIPTION
Additional fetch is done automatically, so no need to do it explicitly