### PR TITLE
[55803] Allow free input of status % complete in administration

### DIFF
--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -31,12 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <section class="form--section">
   <div class="form--field -required"><%= f.text_field "name", required: true, container_class: "-middle" %></div>
-  <div class="form--field">
-    <%= f.select :default_done_ratio,
-                 (0..100).step(10).map { |r| ["#{r} %", r] },
-                 container_class: "-xslim",
-                 label: WorkPackage.human_attribute_name(:done_ratio) %>
-  </div>
+  <div class="form--field"><%= f.number_field "default_done_ratio", min: 0, max: 100, container_class: "-tiny" %></div>
   <div class="form--field"><%= f.check_box "is_closed" %></div>
   <% unless @status.is_default? %>
     <div class="form--field"><%= f.check_box "is_default" %></div>

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <section class="form--section">
   <div class="form--field -required"><%= f.text_field "name", required: true, container_class: "-middle" %></div>
-  <div class="form--field"><%= f.number_field "default_done_ratio", min: 0, max: 100, container_class: "-tiny" %></div>
+  <div class="form--field"><%= f.number_field "default_done_ratio", min: 0, max: 100, container_class: "-xslim" %></div>
   <div class="form--field"><%= f.check_box "is_closed" %></div>
   <% unless @status.is_default? %>
     <div class="form--field"><%= f.check_box "is_default" %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -728,6 +728,7 @@ en:
         is_closed: "Work package closed"
         is_readonly: "Work package read-only"
         excluded_from_totals: "Exclude from calculation of totals in hierarchy"
+        default_done_ratio: "% Complete"
       journal:
         notes: "Notes"
       member:
@@ -1073,6 +1074,11 @@ en:
               hours_per_day_are_missing: "The number of hours per day must be defined."
               durations_are_not_positive_numbers: "The durations must be positive numbers."
               hours_per_day_is_out_of_bounds: "Hours per day can't be more than 24"
+        status:
+          attributes:
+            default_done_ratio:
+              inclusion: "must be between 0 and 100."
+          readonly_default_exlusive: "can not be activated for statuses that are marked default."
         time_entry:
           attributes:
             hours:
@@ -1187,8 +1193,6 @@ en:
         version:
           undeletable_archived_projects: "The version cannot be deleted as it has work packages attached to it."
           undeletable_work_packages_attached: "The version cannot be deleted as it has work packages attached to it."
-        status:
-          readonly_default_exlusive: "can not be activated for statuses that are marked default."
         token/api:
           attributes:
             token_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -673,17 +673,6 @@ en:
       attribute_help_text:
         attribute_name: "Attribute"
         help_text: "Help text"
-      ldap_auth_source:
-        account: "Account"
-        attr_firstname: "Firstname attribute"
-        attr_lastname: "Lastname attribute"
-        attr_login: "Username attribute"
-        attr_mail: "Email attribute"
-        base_dn: "Base DN"
-        host: "Host"
-        onthefly: "Automatic user creation"
-        port: "Port"
-        tls_certificate_string: "LDAP server SSL certificate"
       changeset:
         repository: "Repository"
       color:
@@ -708,6 +697,14 @@ en:
         visible: "Visible"
       custom_value:
         value: "Value"
+      doorkeeper/application:
+        uid: "Client ID"
+        secret: "Client secret"
+        owner: "Owner"
+        redirect_uri: "Redirect URI"
+        client_credentials_user_id: "Client Credentials User ID"
+        scopes: "Scopes"
+        confidential: "Confidential"
       enterprise_token:
         starts_at: "Valid since"
         subscriber: "Subscriber"
@@ -718,21 +715,25 @@ en:
         row_count: "Number of rows"
         column_count: "Number of columns"
         widgets: "Widgets"
-      oauth_client:
-        client: "Client ID"
-      relation:
-        lag: "Lag"
-        from: "Work package"
-        to: "Related work package"
-      status:
-        is_closed: "Work package closed"
-        is_readonly: "Work package read-only"
-        excluded_from_totals: "Exclude from calculation of totals in hierarchy"
-        default_done_ratio: "% Complete"
       journal:
         notes: "Notes"
+      ldap_auth_source:
+        account: "Account"
+        attr_firstname: "Firstname attribute"
+        attr_lastname: "Lastname attribute"
+        attr_login: "Username attribute"
+        attr_mail: "Email attribute"
+        base_dn: "Base DN"
+        host: "Host"
+        onthefly: "Automatic user creation"
+        port: "Port"
+        tls_certificate_string: "LDAP server SSL certificate"
       member:
         roles: "Roles"
+      oauth_client:
+        client: "Client ID"
+      planning_element_type_color:
+        hexcode: Hex code
       project:
         active_value:
           true: "unarchived"
@@ -762,6 +763,8 @@ en:
         types: "Types"
         versions: "Versions"
         work_packages: "Work Packages"
+      project_custom_field:
+        custom_field_section: Section
       query:
         column_names: "Columns"
         relations_to_type_column: "Relations to %{type}"
@@ -769,10 +772,19 @@ en:
         group_by: "Group results by"
         filters: "Filters"
         timeline_labels: "Timeline labels"
+      relation:
+        lag: "Lag"
+        from: "Work package"
+        to: "Related work package"
       repository:
         url: "URL"
       role:
         permissions: "Permissions"
+      status:
+        is_closed: "Work package closed"
+        is_readonly: "Work package read-only"
+        excluded_from_totals: "Exclude from calculation of totals in hierarchy"
+        default_done_ratio: "% Complete"
       time_entry:
         activity: "Activity"
         hours: "Hours"
@@ -815,10 +827,6 @@ en:
       wiki_page:
         parent_title: "Parent page"
         redirect_existing_links: "Redirect existing links"
-      planning_element_type_color:
-        hexcode: Hex code
-      project_custom_field:
-        custom_field_section: Section
       work_package:
         begin_insertion: "Begin of the insertion"
         begin_deletion: "Begin of the deletion"
@@ -853,14 +861,6 @@ en:
         type: "Type"
         version: "Version"
         watcher: "Watcher"
-      "doorkeeper/application":
-        uid: "Client ID"
-        secret: "Client secret"
-        owner: "Owner"
-        redirect_uri: "Redirect URI"
-        client_credentials_user_id: "Client Credentials User ID"
-        scopes: "Scopes"
-        confidential: "Confidential"
 
     errors:
       messages:


### PR DESCRIPTION
https://community.openproject.org/wp/55803

In Administration > Work packages > Statuses, when creating or editing a status, the % complete field has been replaced by an input field. Before it was a select with 10% steps which made it impossible to set values like "45%".