### PR TITLE
[#56058] Move "Copy link to clipboard" up top in the context menu

### DIFF
--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
@@ -2,6 +2,11 @@ import { WorkPackageAction } from 'core-app/features/work-packages/components/wp
 
 export const PERMITTED_CONTEXT_MENU_ACTIONS:WorkPackageAction[] = [
   {
+    key: 'copy_link_to_clipboard',
+    icon: 'icon-clipboard',
+    link: 'id',
+  },
+  {
     key: 'log_time',
     link: 'logTime',
   },
@@ -13,11 +18,6 @@ export const PERMITTED_CONTEXT_MENU_ACTIONS:WorkPackageAction[] = [
   {
     key: 'copy',
     link: 'copy',
-  },
-  {
-    key: 'copy_link_to_clipboard',
-    icon: 'icon-clipboard',
-    link: 'id',
   },
   {
     key: 'copy_to_other_project',

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -214,6 +214,7 @@ module Pages
       def apply_filters
         within(".advanced-filters--filters") do
           click_on "Apply"
+          page.driver.wait_for_network_idle if using_cuprite?
         end
       end
 


### PR DESCRIPTION
This makes the item the first of the available context menu actions for a work package itself. 

In the work package list view, right clicking/opening the context menu of a work package will still have the "copy to clipboard" menu item as the first, with the work package list specific menu items above it.

These would be:
- Open details view
- Open fullscreen view

---

Related work package: https://community.openproject.org/work_packages/56058