### PR TITLE
Don't blink custom fields form when hiding parts depending on field format

### DIFF
--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -27,6 +27,44 @@
 #++
 
 module CustomFieldsHelper
+  class FormatDependent
+    CONFIG = {
+      allowNonOpenVersions: [:only, %w[version]],
+      defaultBool: [:only, %w[bool]],
+      defaultLongText: [:only, %w[text]],
+      defaultText: [:except, %w[list bool date text user version]],
+      length: [:except, %w[list bool date user version link]],
+      multiSelect: [:only, %w[list user version]],
+      possibleValues: [:only, %w[list]],
+      regexp: [:except, %w[list bool date user version]],
+      searchable: [:except, %w[bool date float int user version]],
+      textOrientation: [:only, %w[text]]
+    }.freeze
+
+    def self.stimulus_config
+      CONFIG.map { |target_name, (operator, formats)| [target_name, operator, formats] }
+    end
+
+    attr_reader :format
+
+    def initialize(format)
+      @format = format # rubocop:disable Rails/HelperInstanceVariable
+    end
+
+    def attributes(target_name)
+      operator, formats = CONFIG[target_name.to_sym]
+
+      fail ArgumentError, "Unknown target name #{target_name}" unless formats
+
+      visible = operator == :only ? format.in?(formats) : !format.in?(formats)
+
+      ApplicationController.helpers.tag.attributes(
+        "data-admin--custom-fields-target": target_name,
+        hidden: !visible
+      )
+    end
+  end
+
   def custom_fields_tabs
     [
       {
@@ -210,4 +248,6 @@ module CustomFieldsHelper
       format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
     end
   end
+
+  def custom_fields_format_config = CustomFieldsHelper::FormatDependent.stimulus_config
 end

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -27,44 +27,6 @@
 #++
 
 module CustomFieldsHelper
-  class FormatDependent
-    CONFIG = {
-      allowNonOpenVersions: [:only, %w[version]],
-      defaultBool: [:only, %w[bool]],
-      defaultLongText: [:only, %w[text]],
-      defaultText: [:except, %w[list bool date text user version]],
-      length: [:except, %w[list bool date user version link]],
-      multiSelect: [:only, %w[list user version]],
-      possibleValues: [:only, %w[list]],
-      regexp: [:except, %w[list bool date user version]],
-      searchable: [:except, %w[bool date float int user version]],
-      textOrientation: [:only, %w[text]]
-    }.freeze
-
-    def self.stimulus_config
-      CONFIG.map { |target_name, (operator, formats)| [target_name, operator, formats] }.to_json
-    end
-
-    attr_reader :format
-
-    def initialize(format)
-      @format = format # rubocop:disable Rails/HelperInstanceVariable
-    end
-
-    def attributes(target_name)
-      operator, formats = CONFIG[target_name.to_sym]
-
-      fail ArgumentError, "Unknown target name #{target_name}" unless formats
-
-      visible = operator == :only ? format.in?(formats) : !format.in?(formats)
-
-      ApplicationController.helpers.tag.attributes(
-        "data-admin--custom-fields-target": target_name,
-        hidden: !visible
-      )
-    end
-  end
-
   def custom_fields_tabs
     [
       {

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -42,7 +42,7 @@ module CustomFieldsHelper
     }.freeze
 
     def self.stimulus_config
-      CONFIG.map { |target_name, (operator, formats)| [target_name, operator, formats] }
+      CONFIG.map { |target_name, (operator, formats)| [target_name, operator, formats] }.to_json
     end
 
     attr_reader :format
@@ -248,6 +248,4 @@ module CustomFieldsHelper
       format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
     end
   end
-
-  def custom_fields_format_config = CustomFieldsHelper::FormatDependent.stimulus_config
 end

--- a/app/views/admin/settings/project_custom_fields/edit.html.erb
+++ b/app/views/admin/settings/project_custom_fields/edit.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_administration), t("settings.project_attributes.heading"), @custom_field.name %>
 
-<% content_controller 'admin--custom-fields', dynamic: true %>
+<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
 
 <% local_assigns[:additional_breadcrumb] = @custom_field.name %>
 

--- a/app/views/admin/settings/project_custom_fields/edit.html.erb
+++ b/app/views/admin/settings/project_custom_fields/edit.html.erb
@@ -26,10 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+
 <% html_title t(:label_administration), t("settings.project_attributes.heading"), @custom_field.name %>
-
-<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
-
 <% local_assigns[:additional_breadcrumb] = @custom_field.name %>
 
 <%=

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<% content_controller 'admin--custom-fields', dynamic: true %>
+<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
 
 <% html_title t(:label_administration), t("settings.project_attributes.heading"), t('settings.project_attributes.new.heading') %>
 <% local_assigns[:additional_breadcrumb] = t('settings.project_attributes.new.heading') %>

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
 
 <% html_title t(:label_administration), t("settings.project_attributes.heading"), t('settings.project_attributes.new.heading') %>
 <% local_assigns[:additional_breadcrumb] = t('settings.project_attributes.new.heading') %>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -26,6 +26,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+
+<% format_dependent = CustomFieldsHelper::FormatDependent.new(@custom_field.field_format) %>
+
 <section class="form--section" id="custom_field_form">
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name, required: true, container_class: '-middle' %>
@@ -50,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
                  }
     %>
   </div>
-  <div class="form--grouping" id="custom_field_length" data-admin--custom-fields-target="length">
+  <div class="form--grouping" id="custom_field_length" <%= format_dependent.attributes(:length) %>>
     <div class="form--grouping-label">
       <%= t(:label_min_max_length) %> <br>
       <small>(<%= t(:text_min_max_length_info) %>)</small>
@@ -67,7 +70,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
   </div>
 
-  <div class="form--field" data-admin--custom-fields-target="regexp">
+  <div class="form--field" <%= format_dependent.attributes(:regexp) %>>
     <%= f.text_field :regexp,
                      size: 50,
                      container_class: '-wide' %>
@@ -77,12 +80,12 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 
   <% if @custom_field.new_record? || @custom_field.list? || @custom_field.multi_value_possible? %>
-    <div class="form--field" data-admin--custom-fields-target="multiSelect" hidden>
+    <div class="form--field" <%= format_dependent.attributes(:multiSelect) %>>
       <%= f.check_box :multi_value,
                       data: { action: 'admin--custom-fields#checkOnlyOne' } %>
     </div>
 
-    <fieldset class="form--fieldset" data-admin--custom-fields-target="possibleValues" hidden>
+    <fieldset class="form--fieldset" <%= format_dependent.attributes(:possibleValues) %>>
       <legend class="form--fieldset-legend"><%= I18n.t("activerecord.attributes.custom_field.possible_values") %></legend>
       <% if @custom_field.persisted? %>
         <div class="form--toolbar">
@@ -110,13 +113,13 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 
   <% if @custom_field.new_record? || @custom_field.version? || @custom_field.allow_non_open_versions_possible? %>
-    <div class="form--field" data-admin--custom-fields-target="allowNonOpenVersions" hidden>
+    <div class="form--field" <%= format_dependent.attributes(:allowNonOpenVersions) %>>
       <%= f.check_box :allow_non_open_versions %>
     </div>
   <% end %>
 
   <% if @custom_field.new_record? || !%w[text bool].include?(@custom_field.field_format) %>
-    <div class="form--field" id="default_value_text" data-admin--custom-fields-target="defaultText">
+    <div class="form--field" id="default_value_text" <%= format_dependent.attributes(:defaultText) %>>
       <%= f.text_field :default_value,
                        id: 'custom_fields_default_value_text',
                        for: 'custom_fields_default_value_text',
@@ -124,14 +127,14 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
   <% end %>
   <% if @custom_field.new_record? || @custom_field.field_format == 'bool' %>
-    <div class="form--field" data-admin--custom-fields-target="defaultBool" hidden>
+    <div class="form--field" <%= format_dependent.attributes(:defaultBool) %>>
       <%= f.check_box :default_value,
                       id: 'custom_fields_default_value_bool',
                       for: 'custom_fields_default_value_bool' %>
     </div>
   <% end %>
   <% if @custom_field.new_record? || @custom_field.field_format == 'text' %>
-    <div class="form--field" data-admin--custom-fields-target="defaultLongText" hidden>
+    <div class="form--field" <%= format_dependent.attributes(:defaultLongText) %>>
       <%= f.text_area :default_value,
                       id: 'custom_fields_default_value_longtext',
                       for: 'custom_fields_default_value_longtext',
@@ -166,13 +169,13 @@ See COPYRIGHT and LICENSE files for more details.
         <p><%= t('custom_fields.instructions.is_filter') %></p>
       </div>
     </div>
-    <div class="form--field" data-admin--custom-fields-target="searchable">
+    <div class="form--field" <%= format_dependent.attributes(:searchable) %>>
       <%= f.check_box :searchable %>
       <div class="form--field-instructions">
         <p><%= t('custom_fields.instructions.searchable') %></p>
       </div>
     </div>
-    <div class="form--field" data-admin--custom-fields-target="textOrientation" hidden>
+    <div class="form--field" <%= format_dependent.attributes(:textOrientation) %>>
       <%= f.check_box :content_right_to_left %>
     </div>
   <% when "UserCustomField" %>
@@ -207,7 +210,7 @@ See COPYRIGHT and LICENSE files for more details.
         <p><%= t('custom_fields.instructions.visible') %></p>
       </div>
     </div>
-    <div class="form--field" data-admin--custom-fields-target="searchable">
+    <div class="form--field" <%= format_dependent.attributes(:searchable) %>>
       <%= f.check_box :searchable %>
       <div class="form--field-instructions">
         <p><%= t('custom_fields.instructions.searchable') %></p>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -29,6 +29,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% format_dependent = CustomFieldsHelper::FormatDependent.new(@custom_field.field_format) %>
 
+<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
+
 <section class="form--section" id="custom_field_form">
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name, required: true, container_class: '-middle' %>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -29,9 +29,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% format_dependent = CustomFieldsHelper::FormatDependent.new(@custom_field.field_format) %>
 
-<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
-
-<section class="form--section" id="custom_field_form">
+<section
+  class="form--section"
+  id="custom_field_form"
+  data-controller="admin--custom-fields"
+  data-application-target="dynamic"
+  data-admin--custom-fields-format-config-value="<%= CustomFieldsHelper::FormatDependent.stimulus_config %>"
+>
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name, required: true, container_class: '-middle' %>
   </div>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -27,14 +27,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% format_dependent = CustomFieldsHelper::FormatDependent.new(@custom_field.field_format) %>
+<% format_dependent = OpenProject::CustomFieldFormatDependent.new(@custom_field.field_format) %>
 
 <section
   class="form--section"
   id="custom_field_form"
   data-controller="admin--custom-fields"
   data-application-target="dynamic"
-  data-admin--custom-fields-format-config-value="<%= CustomFieldsHelper::FormatDependent.stimulus_config %>"
+  data-admin--custom-fields-format-config-value="<%= OpenProject::CustomFieldFormatDependent.stimulus_config %>"
 >
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name, required: true, container_class: '-middle' %>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% content_controller 'admin--custom-fields', dynamic: true %>
+<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{CustomField.model_name.human} #{h @custom_field.name}" %>
 <% local_assigns[:additional_breadcrumb] = [

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -27,8 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
-
 <% html_title t(:label_administration), "#{t(:label_edit)} #{CustomField.model_name.human} #{h @custom_field.name}" %>
 <% local_assigns[:additional_breadcrumb] = [
   link_to(I18n.t(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% content_controller 'admin--custom-fields', dynamic: true %>
+<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
 
 <% html_title t(:label_administration), t(:label_custom_field_new) %>
 <% local_assigns[:additional_breadcrumb] = [

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -27,8 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% content_controller 'admin--custom-fields', dynamic: true, 'admin--custom-fields-format-config-value': custom_fields_format_config %>
-
 <% html_title t(:label_administration), t(:label_custom_field_new) %>
 <% local_assigns[:additional_breadcrumb] = [
   link_to(I18n.t(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -50,6 +50,12 @@ export default class CustomFieldsController extends Controller {
     'textOrientation',
   ];
 
+  static values = {
+    formatConfig: Array,
+  };
+
+  declare readonly formatConfigValue:[string, string, string[]][];
+
   declare readonly formatTarget:HTMLInputElement;
   declare readonly dragContainerTarget:HTMLElement;
   declare readonly hasDragContainerTarget:boolean;
@@ -236,15 +242,12 @@ export default class CustomFieldsController extends Controller {
   }
 
   private toggleFormat(format:string) {
-    this.setActive(this.allowNonOpenVersionsTargets, format === 'version');
-    this.setActive(this.defaultBoolTargets, format === 'bool');
-    this.setActive(this.defaultLongTextTargets, format === 'text');
-    this.setActive(this.defaultTextTargets, !['list', 'bool', 'date', 'text', 'user', 'version'].includes(format));
-    this.setActive(this.lengthTargets, !['list', 'bool', 'date', 'user', 'version', 'link'].includes(format));
-    this.setActive(this.multiSelectTargets, ['list', 'user', 'version'].includes(format));
-    this.setActive(this.possibleValuesTargets, format === 'list');
-    this.setActive(this.regexpTargets, !['list', 'bool', 'date', 'user', 'version'].includes(format));
-    this.setActive(this.searchableTargets, !['bool', 'date', 'float', 'int', 'user', 'version'].includes(format));
-    this.setActive(this.textOrientationTargets, format === 'text');
+    this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
+      const active = operator == 'only' ? formats.includes(format) : !formats.includes(format);
+      const targets = this[`${targetsName}Targets` as keyof typeof this] as HTMLElement[];
+      if (targets) {
+        this.setActive(targets, active);
+      }
+    });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -243,7 +243,7 @@ export default class CustomFieldsController extends Controller {
 
   private toggleFormat(format:string) {
     this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
-      const active = operator == 'only' ? formats.includes(format) : !formats.includes(format);
+      const active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
       const targets = this[`${targetsName}Targets` as keyof typeof this] as HTMLElement[];
       if (targets) {
         this.setActive(targets, active);

--- a/lib/open_project/custom_field_format_dependent.rb
+++ b/lib/open_project/custom_field_format_dependent.rb
@@ -59,7 +59,7 @@ module OpenProject
       visible = operator == :only ? format.in?(formats) : !format.in?(formats)
 
       ApplicationController.helpers.tag.attributes(
-        "data-admin--custom-fields-target": target_name,
+        data: { "admin--custom-fields-target": target_name },
         hidden: !visible
       )
     end

--- a/lib/open_project/custom_field_format_dependent.rb
+++ b/lib/open_project/custom_field_format_dependent.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  class CustomFieldFormatDependent
+    CONFIG = {
+      allowNonOpenVersions: [:only, %w[version]],
+      defaultBool: [:only, %w[bool]],
+      defaultLongText: [:only, %w[text]],
+      defaultText: [:except, %w[list bool date text user version]],
+      length: [:except, %w[list bool date user version link]],
+      multiSelect: [:only, %w[list user version]],
+      possibleValues: [:only, %w[list]],
+      regexp: [:except, %w[list bool date user version]],
+      searchable: [:except, %w[bool date float int user version]],
+      textOrientation: [:only, %w[text]]
+    }.freeze
+
+    def self.stimulus_config
+      CONFIG.map { |target_name, (operator, formats)| [target_name, operator, formats] }.to_json
+    end
+
+    attr_reader :format
+
+    def initialize(format)
+      @format = format
+    end
+
+    def attributes(target_name)
+      operator, formats = CONFIG[target_name.to_sym]
+
+      fail ArgumentError, "Unknown target name #{target_name}" unless formats
+
+      visible = operator == :only ? format.in?(formats) : !format.in?(formats)
+
+      ApplicationController.helpers.tag.attributes(
+        "data-admin--custom-fields-target": target_name,
+        hidden: !visible
+      )
+    end
+  end
+end

--- a/spec/lib/open_project/custom_field_format_dependent_spec.rb
+++ b/spec/lib/open_project/custom_field_format_dependent_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::CustomFieldFormatDependent do
+  describe ".stimulus_config" do
+    it "returns a json with expected structure" do
+      expect(JSON.parse(described_class.stimulus_config)).to all match([be_a(String), be_a(String), all(be_a(String))])
+    end
+  end
+
+  describe "#attributes" do
+    let(:instance) { described_class.new(format) }
+    let(:format) { "string" }
+
+    subject(:call) { instance.attributes(target_name) }
+
+    context "for targets using operator only" do
+      let(:target_name) { :defaultLongText }
+
+      context "for matching format" do
+        let(:format) { "text" }
+
+        it { is_expected.to be_html_safe & eq('data-admin--custom-fields-target="defaultLongText"') }
+      end
+
+      context "for non matching format" do
+        it { is_expected.to be_html_safe & eq('data-admin--custom-fields-target="defaultLongText" hidden="hidden"') }
+      end
+    end
+
+    context "for targets using operator except" do
+      let(:target_name) { :defaultText }
+
+      context "for matching format" do
+        let(:format) { "text" }
+
+        it { is_expected.to be_html_safe & eq('data-admin--custom-fields-target="defaultText" hidden="hidden"') }
+      end
+
+      context "for non matching format" do
+        it { is_expected.to be_html_safe & eq('data-admin--custom-fields-target="defaultText"') }
+      end
+    end
+
+    context "for unknown target" do
+      let(:target_name) { :foo }
+
+      it { expect { call }.to raise_error(ArgumentError) }
+    end
+  end
+end


### PR DESCRIPTION
[OP#56842](https://community.openproject.org/work_packages/56842) follow up for #16142 ([OP#53574](https://community.openproject.org/work_packages/53574)).
Currently correct parts of custom field form are displayed for field type string (Text), so only for new custom field and for field of that type, when editing other fields there will be a blink when stimulus controller toggles the needed parts. Move the config to backend to load correct fields at start and send that config to stimulus.