### PR TITLE
[56194] Follow-up remaining issues for the Dark mode (second round)

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -40,7 +40,6 @@
     --ck-color-list-button-hover-background: var(--control-transparent-bgColor-hover);
     --ck-color-panel-background: var(--overlay-bgColor);
     --ck-color-input-background: var(--overlay-bgColor);
-    --table-border-color: var(--borderColor-default);
     --toolbar-item--bg-color: var(--button-default-bgColor-rest);
     --toolbar-item--border-color: var(--borderColor-default);
     --status-selector-border-color: var(--button-default-borderColor-rest);

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/tabs.sass
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/tabs.sass
@@ -98,10 +98,10 @@
       width: 100%
 
       tr:first-child
-        border-top: 1px solid var(--table-border-color)
+        border-top: 1px solid var(--borderColor-default)
 
       tr
-        border-bottom: 1px solid var(--table-border-color)
+        border-bottom: 1px solid var(--borderColor-default)
 
       td:first-child
         font-weight: var(--base-text-weight-bold)

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -28,7 +28,7 @@ $subject-font-size: 14px
     border-bottom: 1px solid var(--borderColor-default)
 
   &_selected
-    background: $ian-bg-selected-color
+    background: $ian-bg-selected-color !important
     &:hover
       background: $ian-bg-selected-hover-color
 

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -5,7 +5,7 @@ $ian-bg-hover-color: var(--bgColor-neutral-muted)
 $ian-bg-read-color: var(--bgColor-muted)
 $ian-bg-read-hover-color: hsl(from $ian-bg-read-color h s calc(l - 0.07))
 $ian-bg-selected-color: var(--selection-bgColor)
-$ian-bg-selected-hover-color: hsl(from $ian-bg-selected-color calc(h - 7) s l)
+$ian-bg-selected-hover-color: hsl(from $ian-bg-selected-color calc(h - 5) s l)
 // This needs to be set in the itemSize of
 // the virtual scroller
 $ian-height: 100px
@@ -28,7 +28,7 @@ $subject-font-size: 14px
     border-bottom: 1px solid var(--borderColor-default)
 
   &_selected
-    background: $ian-bg-selected-color !important
+    background: $ian-bg-selected-color
     &:hover
       background: $ian-bg-selected-hover-color
 

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -5,7 +5,7 @@ $ian-bg-hover-color: var(--bgColor-neutral-muted)
 $ian-bg-read-color: var(--bgColor-muted)
 $ian-bg-read-hover-color: hsl(from $ian-bg-read-color h s calc(l - 0.07))
 $ian-bg-selected-color: var(--selection-bgColor)
-$ian-bg-selected-hover-color: hsl(from $ian-bg-selected-color calc(h - 5) s l)
+$ian-bg-selected-hover-color: hsl(from var(--selection-bgColor) h calc(s - 30) l)
 // This needs to be set in the itemSize of
 // the virtual scroller
 $ian-height: 100px

--- a/frontend/src/app/shared/components/op-content-loader/op-content-loader.component.html
+++ b/frontend/src/app/shared/components/op-content-loader/op-content-loader.component.html
@@ -1,6 +1,6 @@
 <content-loader
   [backgroundColor]="'var(--skeletonLoader-bgColor)'"
-  [foregroundColor]="'var(--data-gray-color-muted)'"
+  [foregroundColor]="'var(--bgColor-neutral-muted)'"
   [baseUrl]="baseUrl"
   [speed]="3"
   [viewBox]="viewBox"

--- a/frontend/src/app/shared/components/op-content-loader/op-content-loader.component.html
+++ b/frontend/src/app/shared/components/op-content-loader/op-content-loader.component.html
@@ -1,5 +1,5 @@
 <content-loader
-  [backgroundColor]="'var(--bgColor-muted)'"
+  [backgroundColor]="'var(--skeletonLoader-bgColor)'"
   [foregroundColor]="'var(--data-gray-color-muted)'"
   [baseUrl]="baseUrl"
   [speed]="3"

--- a/frontend/src/app/shared/components/table/table.sass
+++ b/frontend/src/app/shared/components/table/table.sass
@@ -8,7 +8,7 @@
     text-align: center
 
     &_heading
-      background-color: var(--display-gray-bgColor-muted)
+      background-color: var(--bgColor-muted)
       font-weight: var(--base-text-weight-bold)
       text-align: left
 

--- a/frontend/src/app/shared/components/table/table.sass
+++ b/frontend/src/app/shared/components/table/table.sass
@@ -8,7 +8,7 @@
     text-align: center
 
     &_heading
-      background-color: var(--fc-neutral-bg-color)
+      background-color: var(--display-gray-bgColor-muted)
       font-weight: var(--base-text-weight-bold)
       text-align: left
 

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -144,7 +144,7 @@ table.generic-table
 
   tbody
     tr:not(.-no-highlighting)
-      border-bottom: 1px solid var(--table-border-color)
+      border-bottom: 1px solid var(--borderColor-default)
 
     @media screen
       td:not(.-no-ellipsis)
@@ -266,7 +266,7 @@ thead.-sticky th
   line-height:  var(--generic-table--header-height)
   height:  var(--generic-table--header-height)
   z-index:      1
-  border-bottom: 1px solid var(--table-border-color)
+  border-bottom: 1px solid var(--borderColor-default)
 
   &:hover,
   &.hover
@@ -287,7 +287,7 @@ thead.-sticky th
 .generic-table--empty-header
   height:        var(--generic-table--header-height)
   line-height:   var(--generic-table--header-height)
-  border-bottom: 1px solid var(--table-border-color)
+  border-bottom: 1px solid var(--borderColor-default)
   z-index:       1
 
   // In case the table header contains invisible content for screen readers

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -41,6 +41,10 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
     th[style^="width:"]
       word-break: break-all
 
+  .table table th
+    border-color: var(--borderColor-muted) !important
+    background-color: var(--bgColor-neutral-muted) !important
+
 .ck .ck-widget.op-ckeditor--code-block
   // Display content as pre
   white-space: pre-wrap

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -42,8 +42,8 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
       word-break: break-all
 
   .table table th
-    border-color: var(--borderColor-muted) !important
-    background-color: var(--bgColor-neutral-muted) !important
+    border-color: var(--borderColor-default) !important
+    background-color: var(--bgColor-muted) !important
 
 .ck .ck-widget.op-ckeditor--code-block
   // Display content as pre

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -7,7 +7,7 @@
     padding-left: 2px !important
 
   .ck-content .table table th
-    @include table-header-styles
+    @include op-uc-table-header-styles
 
 // Wrapper for full text element
 ckeditor-augmented-textarea .op-ckeditor--wrapper

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -6,6 +6,9 @@
   &.ck-editor__editable_inline
     padding-left: 2px !important
 
+  .ck-content .table table th
+    @include table-header-styles
+
 // Wrapper for full text element
 ckeditor-augmented-textarea .op-ckeditor--wrapper
   margin-bottom: 2rem
@@ -40,10 +43,6 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
     th[style*=";width:"],
     th[style^="width:"]
       word-break: break-all
-
-  .table table th
-    border-color: var(--borderColor-default) !important
-    background-color: var(--bgColor-muted) !important
 
 .ck .ck-widget.op-ckeditor--code-block
   // Display content as pre
@@ -129,3 +128,5 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
 .ck-icon_inherit-color
   path
     fill: var(--body-font-color) !important
+
+

--- a/frontend/src/global_styles/content/user-content/_table.sass
+++ b/frontend/src/global_styles/content/user-content/_table.sass
@@ -3,11 +3,11 @@
   border-collapse: collapse
   border-spacing: 0
   width: 100%
-  border: 1px solid var(--table-border-color)
+  border: 1px solid var(--borderColor-default)
 
   &--row
     &:not(:last-child)
-      border-bottom: 1px solid var(--table-border-color)
+      border-bottom: 1px solid var(--borderColor-default)
 
     @at-root .op-uc-container:not(.op-uc-container_editing) &:hover
       background: rgba(26, 103, 163, 0.05)
@@ -18,7 +18,7 @@
     padding: 0.75rem
 
     &:not(:last-child):not([colspan])
-      border-right: 1px solid var(--table-border-color)
+      border-right: 1px solid var(--borderColor-default)
 
     @include user-content-children
 
@@ -26,9 +26,8 @@
       background: rgba(26, 103, 163, 0.05)
 
     &_head
-      background: rgb(242, 242, 242)
-      background-clip: padding-box
-      border-bottom: 1px solid rgba(0, 0, 0, 0.1)
+      background: var(--display-gray-bgColor-muted)
+      border-bottom: 1px solid var(--borderColor-default)
 
     &.ck-editor__editable_selected
       background: rgba(26, 103, 163, 0.1)

--- a/frontend/src/global_styles/content/user-content/_table.sass
+++ b/frontend/src/global_styles/content/user-content/_table.sass
@@ -26,8 +26,9 @@
       background: rgba(26, 103, 163, 0.05)
 
     &_head
-      background: var(--display-gray-bgColor-muted)
+      background: var(--bgColor-muted)
       border-bottom: 1px solid var(--borderColor-default)
+      background-clip: padding-box
 
     &.ck-editor__editable_selected
       background: rgba(26, 103, 163, 0.1)

--- a/frontend/src/global_styles/content/user-content/_table.sass
+++ b/frontend/src/global_styles/content/user-content/_table.sass
@@ -26,7 +26,7 @@
       background: rgba(26, 103, 163, 0.05)
 
     &_head
-      background: var(--bgColor-muted)
+      @include table-header-styles
       border-bottom: 1px solid var(--borderColor-default)
       background-clip: padding-box
 

--- a/frontend/src/global_styles/content/user-content/_table.sass
+++ b/frontend/src/global_styles/content/user-content/_table.sass
@@ -26,7 +26,7 @@
       background: rgba(26, 103, 163, 0.05)
 
     &_head
-      @include table-header-styles
+      @include op-uc-table-header-styles
       border-bottom: 1px solid var(--borderColor-default)
       background-clip: padding-box
 

--- a/frontend/src/global_styles/content/work_packages/_table_drag_and_drop.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_drag_and_drop.sass
@@ -2,7 +2,7 @@
 // Drag & Drop styles for the table
 //
 .wp--row.gu-mirror
-  border: 1px solid var(--table-border-color)
+  border: 1px solid var(--borderColor-default)
   border-radius: 5px
   background: white !important
 

--- a/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
@@ -53,7 +53,7 @@
 
 // Add bottom border to timeline
 .wp-table-timeline--body
-  outline: 1px solid var(--table-border-color)
+  outline: 1px solid var(--borderColor-default)
 
 .wp-timeline-cell
   // Ensure the height of table and timeline rows

--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_hover.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_hover.sass
@@ -10,7 +10,7 @@
       display: inline-block
 
     .diamond
-      border: 1px solid var(--table-border-color)
+      border: 1px solid var(--borderColor-default)
 
     .hide-on-hover
       display: none !important

--- a/frontend/src/global_styles/openproject/_generic.sass
+++ b/frontend/src/global_styles/openproject/_generic.sass
@@ -48,13 +48,13 @@ a
 
 // Table borders
 .-table-border-top
-  border-top: 1px solid var(--table-border-color)
+  border-top: 1px solid var(--borderColor-default)
 .-table-border-bottom
-  border-bottom: 1px solid var(--table-border-color)
+  border-bottom: 1px solid var(--borderColor-default)
 .-table-border-left
-  border-left: 1px solid var(--table-border-color)
+  border-left: 1px solid var(--borderColor-default)
 .-table-border-right
-  border-right: 1px solid var(--table-border-color)
+  border-right: 1px solid var(--borderColor-default)
 
 .autoscroll
   overflow-x: auto

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -365,3 +365,7 @@ $scrollbar-size: 10px
     display: table
   &:after
     clear: both
+
+@mixin table-header-styles
+  border-color: var(--borderColor-default)
+  background-color: var(--bgColor-muted)

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -366,6 +366,6 @@ $scrollbar-size: 10px
   &:after
     clear: both
 
-@mixin table-header-styles
+@mixin op-uc-table-header-styles
   border-color: var(--borderColor-default)
   background-color: var(--bgColor-muted)

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -113,7 +113,6 @@
   --inplace-edit--color--very-dark: #cacaca;
   --inplace-edit--color--disabled: var(--control-fgColor-disabled);
   --inplace-edit--bg-color--disabled: var(--control-bgColor-disabled);
-  --table-border-color: #E7E7E7;
   --table-row-highlighting-outline-color: #00A6FF;
   --button--font-color: #222222;
   --button--background-color: var(--gray-light);


### PR DESCRIPTION
- [x] Hover over a selected notification: It has the same color as the background, making it unclear that something is selected.
- [x] Bg color of skeletons in notification center is very dark in dark mode.
- [x] White bg color in show mode in tables when activating header columns and header row


https://community.openproject.org/work_packages/56194/activity
https://community.openproject.org/work_packages/56502/activity