### PR TITLE
[56507] Transform modules menu in top menu into a Primer menu

### DIFF
--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -26,6 +26,7 @@
     border-left: 1px solid transparent
     border-top: 0
     border-bottom: var(--header-border-bottom-width) solid transparent
+    border-radius: 0
     display: flex
     justify-content: center
     align-items: center

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -73,3 +73,11 @@ page-header
     .FormControl-horizontalGroup
       flex-direction: column
       row-gap: 1rem
+
+.Button.op-app-header--primer-button,
+.Button.op-app-header--primer-button .Button-visual
+  color: var(--header-item-font-color)
+
+  &:hover
+    background: var(--header-item-bg-hover-color)
+    color: var(--header-item-font-hover-color)

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -164,12 +164,24 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_module_top_menu_node(items = more_top_menu_items)
     unless items.empty?
-      render_menu_dropdown_with_items(
-        label: "",
-        label_options: { icon: "icon-menu", title: I18n.t("label_modules") },
-        items:,
-        options: { drop_down_id: "more-menu", drop_down_class: "drop-down--modules ", menu_item_class: "hidden-for-mobile" }
-      )
+      render Primer::Alpha::ActionMenu.new(classes: "op-app-menu--item",
+                                           menu_id: "op-app-header--modules-menu",
+                                           anchor_align: :end) do |menu|
+        menu.with_show_button(icon: "op-grid-menu",
+                              scheme: :invisible,
+                              classes: "op-app-menu--item-action op-app-header--primer-button hidden-for-mobile",
+                              title: I18n.t("label_modules"),
+                              test_selector: "op-app-header--modules-menu-button",
+                              "aria-label": I18n.t("label_modules"))
+        items.each do |item|
+          menu.with_item(tag: :a,
+                         href: url_for(item.url),
+                         label: item.caption,
+                         test_selector: "op-menu--item-action") do |menu_item|
+            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
+          end
+        end
+      end
     end
   end
 

--- a/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
+++ b/modules/boards/spec/features/menu_items/top_menu_item_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Top menu item for boards", :js, :with_cuprite do
   shared_let(:user) { create(:user) }
   shared_let(:project) { create(:project) }
 
-  let(:menu) { find(".op-app-menu a[title='#{I18n.t('label_modules')}']") }
+  let(:menu) { page.find_test_selector("op-app-header--modules-menu-button") }
   let(:boards) { I18n.t("boards.label_boards") }
 
   current_user { admin }
@@ -42,7 +42,7 @@ RSpec.describe "Top menu item for boards", :js, :with_cuprite do
     it "sends the user to the boards overview when clicked" do
       menu.click
 
-      within "#more-menu" do
+      within "#op-app-header--modules-menu-list" do
         click_on boards
       end
 
@@ -70,7 +70,7 @@ RSpec.describe "Top menu item for boards", :js, :with_cuprite do
       current_user { user }
 
       it "does not display the menu item" do
-        within "#more-menu", visible: false do
+        within "#op-app-header--modules-menu-list", visible: false do
           expect(page).to have_no_link boards
         end
       end

--- a/modules/calendar/spec/features/calendars_index_spec.rb
+++ b/modules/calendar/spec/features/calendars_index_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe "Calendars", "index", :with_cuprite do
 
     context "with the modules menu" do
       before do
-        find("a[title='Modules']").click
+        page.find_test_selector("op-app-header--modules-menu-button").click
 
-        within "#more-menu" do
+        within "#op-app-header--modules-menu-list" do
           click_on "Calendars"
         end
       end

--- a/modules/reporting/spec/features/top_menu_item_spec.rb
+++ b/modules/reporting/spec/features/top_menu_item_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Top menu items", :js do
     # if the menu is not completely expanded (e.g. if the frontend thread is too fast),
     # the click might be ignored
 
-    within ".op-app-menu--item_has-dropdown .op-app-menu--dropdown[aria-expanded=true]" do
+    within "#op-app-header--modules-menu-list" do
       expect(page).to have_no_css("[style~=overflow]")
 
       page.click_link(title)
@@ -75,7 +75,7 @@ RSpec.describe "Top menu items", :js do
   end
 
   describe "Modules" do
-    let!(:top_menu) { find(:css, "[title=#{I18n.t('label_modules')}]") }
+    let!(:top_menu) { page.find_test_selector("op-app-header--modules-menu-button") }
 
     let(:reporting_item) { I18n.t("cost_reports_title") }
 

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Top menu items", :js, :with_cuprite do
   end
 
   def click_link_in_open_menu(title)
-    within ".op-app-menu--dropdown[aria-expanded=true]" do
+    within "#op-app-header--modules-menu-list" do
       expect(page).to have_no_css("[style~=overflow]")
 
       click_link(title)

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -157,7 +157,7 @@ module Pages
     def navigate_to_modules_menu_item(link_title)
       visit root_path
 
-      within "#more-menu", visible: false do
+      within "#op-app-header--modules-menu-list", visible: false do
         click_on link_title, visible: false
       end
     end


### PR DESCRIPTION
Render the "Modules" menu in the app header with `Primer::Alpha::ActionMenu`

https://community.openproject.org/projects/openproject/work_packages/56507/activity

**Before**

<img width="500" alt="Bildschirmfoto 2024-07-17 um 09 52 04" src="https://github.com/user-attachments/assets/a133922a-b44d-4754-848f-f48bbda5084d">

**After**

<img width="500" alt="Bildschirmfoto 2024-07-17 um 09 39 19" src="https://github.com/user-attachments/assets/547e7b61-3896-43a0-a3da-fc46af2ceef0">

