### PR TITLE
[56150] Introduced groups for top menu

### DIFF
--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -40,6 +40,8 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
               :engine,
               :enterprise_feature
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/PerceivedComplexity
   def initialize(name, url, options)
     raise ArgumentError, "Invalid option :if for menu item '#{name}'" if options[:if] && !options[:if].respond_to?(:call)
     raise ArgumentError, "Invalid option :html for menu item '#{name}'" if options[:html] && !options[:html].is_a?(Hash)
@@ -72,8 +74,12 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
     @engine = options[:engine]
     @allow_deeplink = options[:allow_deeplink]
     @skip_permissions_check = !!options[:skip_permissions_check]
+    @is_heading = options[:is_heading]
     super(@name.to_sym)
   end
+
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def caption(project = nil)
     if @caption.is_a?(Proc)
@@ -161,5 +167,9 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
                  else
                    ->(project) { new_condition.call(project) }
                  end
+  end
+
+  def heading?
+    @is_heading || false
   end
 end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -187,7 +187,6 @@ module Redmine::MenuManager::TopMenuHelper
 
       item_group[:items].each do |item|
         menu_group.with_item(
-          tag: :a,
           href: url_for(item.url),
           label: item.caption,
           test_selector: "op-menu--item-action"

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -162,8 +162,8 @@ module Redmine::MenuManager::TopMenuHelper
     render partial:
   end
 
-  def render_module_top_menu_node(items = more_top_menu_items)
-    unless items.empty?
+  def render_module_top_menu_node(item_groups = module_top_menu_item_groups)
+    unless item_groups.empty?
       render Primer::Alpha::ActionMenu.new(classes: "op-app-menu--item",
                                            menu_id: "op-app-header--modules-menu",
                                            anchor_align: :end) do |menu|
@@ -173,13 +173,26 @@ module Redmine::MenuManager::TopMenuHelper
                               title: I18n.t("label_modules"),
                               test_selector: "op-app-header--modules-menu-button",
                               "aria-label": I18n.t("label_modules"))
-        items.each do |item|
-          menu.with_item(tag: :a,
-                         href: url_for(item.url),
-                         label: item.caption,
-                         test_selector: "op-menu--item-action") do |menu_item|
-            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
-          end
+
+        item_groups.each do |item_group|
+          render_menu_item_group(menu, item_group)
+        end
+      end
+    end
+  end
+
+  def render_menu_item_group(menu, item_group)
+    menu.with_group do |menu_group|
+      menu_group.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
+
+      item_group[:items].each do |item|
+        menu_group.with_item(
+          tag: :a,
+          href: url_for(item.url),
+          label: item.caption,
+          test_selector: "op-menu--item-action"
+        ) do |menu_item|
+          menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
         end
       end
     end
@@ -201,6 +214,27 @@ module Redmine::MenuManager::TopMenuHelper
     split_top_menu_into_main_or_more_menus[:modules]
   end
 
+  def module_top_menu_item_groups
+    items = more_top_menu_items
+    item_groups = []
+
+    # add untitled group, if no heading is present
+    unless items.first.heading?
+      item_groups = [{ title: nil, items: [] }]
+    end
+
+    # create item groups
+    items.reduce(item_groups) do |groups, item|
+      if item.heading?
+        groups << { title: item.caption, items: [] }
+      else
+        groups.last[:items] << item
+      end
+
+      groups
+    end
+  end
+
   def project_menu_items
     split_top_menu_into_main_or_more_menus[:projects]
   end
@@ -211,7 +245,7 @@ module Redmine::MenuManager::TopMenuHelper
 
   # Split the :top_menu into separate :main and :modules items
   def split_top_menu_into_main_or_more_menus
-    @top_menu_split ||= begin
+    @split_top_menu_into_main_or_more_menus ||= begin
       items = Hash.new { |h, k| h[k] = [] }
       first_level_menu_items_for(:top_menu) do |item|
         if item.name == :help


### PR DESCRIPTION
# WAT?

https://community.openproject.org/projects/openproject/work_packages/56150

In order to support menu groups like described by Primer (https://qa.openproject-edge.com/lookbook/inspect/primer/alpha/action_menu/with_items_and_groups), menu item groups need to be prepared and rendered. This works the following way:

- The current structure of a flat list of menu items is maintained
- `Redmine::MenuManager::MenuItem` initializer taken a new option in the `options` hash called `is_heading`
  - If `is_heading` is set to `true`, the item's cation is rendered as a new group in the menu (e.g. `[heading(title1), item1(url), item2(url), heading(title2), item3(url), item4(url), ...]`)
- rendering prepares groups out of item list with heading
- groups are rendered

It is mainly only used for plugins to have the possibility to create groups. In OpenProject there are currently no menu groups therefor an "empty" group is created which is rendered without a heading.