### PR TITLE
[#56235] Send invitation button broken when user tries to reinvite themselves

### DIFF
--- a/app/views/users/_toolbar.html.erb
+++ b/app/views/users/_toolbar.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
       <span class="button--text"><%= t(:label_profile) %></span>
     <% end %>
   </li>
-  <% if current_user.allowed_globally?(:create_user) %>
+  <% if current_user.allowed_globally?(:create_user) && current_user.id != @user.id %>
     <li class="toolbar-item hidden-for-tablet">
       <%= form_for(@user,
                    url: { action: :resend_invitation },


### PR DESCRIPTION
Remove send invitation button for current user, as user can't reinvite yourself.

https://community.openproject.org/projects/openproject/work_packages/56235/activity