### PR TITLE
Show experimental settings menu item in dev environment

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -413,7 +413,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
     menu.push :"settings_#{node[:name]}",
               { controller: node[:controller], action: :show },
               caption: node[:label],
-              if: Proc.new { User.current.admin? && node[:name] != "experimental" },
+              if: Proc.new { User.current.admin? && (node[:name] != "experimental" || Rails.env.development?) },
               parent: :settings
   end
 

--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -32,9 +32,9 @@ module OpenProject
   #
   # New feature flags can automatically be added by calling
   #
-  #   Rails.application.initializer 'set flag' do
-  #     OpenProject::FeatureDecisions.add :the_name_of_the_flag
-  #   end
+  #   OpenProject::FeatureDecisions.add :the_name_of_the_flag
+  #
+  # See config/initializers/feature_decisions.rb.
   #
   # This will set up:
   # * the method `.the_name_of_the_flag_active?` for querying the state
@@ -54,6 +54,8 @@ module OpenProject
   #   context 'some description', with_flag: { the_name_of_the_flag: true } do
   #     ...
   #   end
+  #
+  # There is an interface to toggle flags on a running instance at path /admin/settings/experimental.
   #
   module FeatureDecisions
     module_function


### PR DESCRIPTION
To be able to stumble in dev on [ability to toggle](https://community.openproject.org/projects/openproject/work_packages/48815) feature flags without setting them in environment.