### PR TITLE
Await an idle network when possible while applying filters

### DIFF
--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -214,6 +214,7 @@ module Pages
       def apply_filters
         within(".advanced-filters--filters") do
           click_on "Apply"
+          page.driver.wait_for_network_idle if using_cuprite?
         end
       end
 


### PR DESCRIPTION
Since this currently involves full-page reloads, specs for filtering projects become a bit flaky under heavy load in CI. This alleviates it by awaiting an idle network before trying to proceed further with other expectations throughout the rest spec.