### PR TITLE
[56590] Colors of types in WP create button are gone

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -172,9 +172,9 @@ module ColorsHelper
     mode = User.current.pref.theme
 
     if mode == "light_high_contrast"
-      "color: hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - (var(--color-l) * 0.5)) * 1%), 1); !important;"
+      "color: hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - (var(--color-l) * 0.5)) * 1%), 1) !important;"
     else
-      "color: hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - (var(--color-l) * 0.22)) * 1%), 1); !important;"
+      "color: hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - (var(--color-l) * 0.22)) * 1%), 1) !important;"
     end
   end
   # rubocop:enable Layout/LineLength


### PR DESCRIPTION
Remove too early `;` which cause the `!important` to be ignored

https://community.openproject.org/projects/openproject/work_packages/56590/activity