### PR TITLE
Make VCR `cassette_library_dir` configurable through test metadata

### DIFF
--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/copy_template_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/copy_template_folder_command_spec.rb
@@ -35,17 +35,11 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::CopyTemplate
   shared_let(:storage) { create(:sharepoint_dev_drive_storage) }
 
   shared_let(:original_folders) do
-    WebMock.enable! && VCR.turn_on!
-    VCR.use_cassette("one_drive/copy_template_folder_existing_folders") { existing_folder_tuples }
-  ensure
-    VCR.turn_off! && WebMock.disable!
+    use_storages_vcr_cassette("one_drive/copy_template_folder_existing_folders") { existing_folder_tuples }
   end
 
   shared_let(:base_template_folder) do
-    WebMock.enable! && VCR.turn_on!
-    VCR.use_cassette("one_drive/copy_template_folder_base_folder") { create_base_folder }
-  ensure
-    VCR.turn_off! && WebMock.disable!
+    use_storages_vcr_cassette("one_drive/copy_template_folder_base_folder") { create_base_folder }
   end
 
   shared_let(:source_path) { base_template_folder.id }
@@ -76,17 +70,11 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::CopyTemplate
   describe "#call" do
     # rubocop:disable RSpec/BeforeAfterAll
     before(:all) do
-      WebMock.enable! && VCR.turn_on!
-      VCR.use_cassette("one_drive/copy_template_folder_setup") { setup_template_folder }
-    ensure
-      VCR.turn_off! && WebMock.disable!
+      use_storages_vcr_cassette("one_drive/copy_template_folder_setup") { setup_template_folder }
     end
 
     after(:all) do
-      WebMock.enable! && VCR.turn_on!
-      VCR.use_cassette("one_drive/copy_template_folder_teardown") { delete_template_folder }
-    ensure
-      VCR.turn_off! && WebMock.disable!
+      use_storages_vcr_cassette("one_drive/copy_template_folder_teardown") { delete_template_folder }
     end
     # rubocop:enable RSpec/BeforeAfterAll
 

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
@@ -105,12 +105,9 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
   # otherwise it will run the request every test suite run.
   # Then we disable both VCR and WebMock to return to the usual state
   shared_let(:original_folder_ids) do
-    WebMock.enable! && VCR.turn_on!
-    VCR.use_cassette("one_drive/sync_service_original_folders") do
+    use_storages_vcr_cassette("one_drive/sync_service_original_folders") do
       original_folders(storage)
     end
-  ensure
-    VCR.turn_off! && WebMock.disable!
   end
 
   subject(:service) { described_class.new(storage) }

--- a/modules/storages/spec/spec_helper.rb
+++ b/modules/storages/spec/spec_helper.rb
@@ -36,6 +36,8 @@
 require "spec_helper"
 require "dry/container/stub"
 
+STORAGES_CASSETTE_LIBRARY_DIR = "modules/storages/spec/support/fixtures/vcr_cassettes"
+
 # Record Storages Cassettes in module
 VCR.configure do |config|
   config.filter_sensitive_data("<ACCESS_TOKEN>") do
@@ -46,6 +48,16 @@ VCR.configure do |config|
   end
 end
 
+def use_storages_vcr_cassette(name, options = {}, &)
+  WebMock.enable! && VCR.turn_on!
+  VCR.configure do |vcr_config|
+    vcr_config.cassette_library_dir = STORAGES_CASSETTE_LIBRARY_DIR
+  end
+  VCR.use_cassette(name, options, &)
+ensure
+  VCR.turn_off! && WebMock.disable!
+end
+
 # Loads files from relative support/ directory
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
@@ -54,6 +66,6 @@ RSpec.configure do |config|
   config.append_after { Storages::Peripherals::Registry.unstub }
 
   config.define_derived_metadata(file_path: %r{/modules/storages/spec}) do |metadata|
-    metadata[:vcr_cassette_library_dir] = "modules/storages/spec/support/fixtures/vcr_cassettes"
+    metadata[:vcr_cassette_library_dir] = STORAGES_CASSETTE_LIBRARY_DIR
   end
 end

--- a/modules/storages/spec/spec_helper.rb
+++ b/modules/storages/spec/spec_helper.rb
@@ -38,7 +38,6 @@ require "dry/container/stub"
 
 # Record Storages Cassettes in module
 VCR.configure do |config|
-  config.cassette_library_dir = "modules/storages/spec/support/fixtures/vcr_cassettes"
   config.filter_sensitive_data("<ACCESS_TOKEN>") do
     ENV.fetch("ONE_DRIVE_TEST_OAUTH_CLIENT_ACCESS_TOKEN", "MISSING_ONE_DRIVE_TEST_OAUTH_CLIENT_ACCESS_TOKEN")
   end
@@ -53,4 +52,8 @@ Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 RSpec.configure do |config|
   config.prepend_before { Storages::Peripherals::Registry.enable_stubs! }
   config.append_after { Storages::Peripherals::Registry.unstub }
+
+  config.define_derived_metadata(file_path: %r{/modules/storages/spec}) do |metadata|
+    metadata[:vcr_cassette_library_dir] = "modules/storages/spec/support/fixtures/vcr_cassettes"
+  end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -42,7 +42,6 @@ module VCRTimeoutHelper
 end
 
 VCR.configure do |config|
-  config.cassette_library_dir = "spec/support/fixtures/vcr_cassettes"
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.before_record do |i|
@@ -80,6 +79,10 @@ RSpec.configure do |config|
     # Only enable VCR's webmock integration for tests tagged with :vcr otherwise interferes with WebMock
     # See: https://github.com/vcr/vcr/issues/146
     #
+    VCR.configure do |vcr_config|
+      cassette_library_dir = example.metadata[:vcr_cassette_library_dir] || "spec/support/fixtures/vcr_cassettes"
+      vcr_config.cassette_library_dir = cassette_library_dir
+    end
     VCR.turn_on!
     example.run
   ensure


### PR DESCRIPTION
Specify the `cassette_library_dir` with `:vcr_cassette_library_dir` spec metadata:

  it "foo", vcr_cassette_library_dir: "modules/repositories/spec/fixtures" { ... }

Automatically set `vcr_cassette_library_dir: "modules/storages/spec/support/fixtures/vcr_cassettes"` metdata when the spec path matches `/modules/storages/spec` directory.

The code hardcoding the cassette library dir in storages module has been removed, aallowing the use of VCR with cassettes from "spec/support/fixtures/" even when tests from storages module are run.