### PR TITLE
Fix calendar test displaying Monday as non-working week day

### DIFF
--- a/frontend/src/app/core/days/weekday.service.ts
+++ b/frontend/src/app/core/days/weekday.service.ts
@@ -59,7 +59,7 @@ export class WeekdayService {
    * @return {boolean} whether the given iso day is working or not
    */
   public isNonWorkingDay(date:Moment|Date|number):boolean {
-    const isoDayOfWeek = (typeof date === 'number') ? date : moment(date).isoWeekday();
+    const isoDayOfWeek = (typeof date === 'number') ? date : moment(`${moment(date).format('YYYY-MM-DDTHH:mm:ss')}+00:00`).isoWeekday();
     return !!(this.weekdays || []).find((wd) => wd.day === isoDayOfWeek && !wd.working);
   }
 


### PR DESCRIPTION
The test ./modules/calendar/spec/features/calendar_dates_spec.rb:50 fails locally for me as I have my local timezone being strictly positive (GMT+02). It probably passes on CI because the machine is configured to use UTC as timezone.

When trying to get the isoWeekday, it gets the utc time, which is 22:00 the previous day, and this shifts all non-working week days: Tuesday-Saturday is working, and Sunday-Monday is non-working.

The fix is a bit ugly, but works.