### PR TITLE
[50607] "Time 1" label in Email reminders truncated when language=FR

### DIFF
--- a/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.sass
+++ b/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.sass
@@ -20,7 +20,7 @@
     flex: 0 0 25px
 
   &--label
-    flex: 0 0 60px
+    flex: 0 0 80px
     margin-bottom: 0
     @include text-shortener
 


### PR DESCRIPTION
Increase space for label otherwise it will be cut off in some languages

https://community.openproject.org/projects/14/work_packages/50607/activity