### PR TITLE
[56587] Some administration pages are missing breadcrumbs and html titles

### DIFF
--- a/app/controllers/admin/settings/api_settings_controller.rb
+++ b/app/controllers/admin/settings/api_settings_controller.rb
@@ -30,10 +30,6 @@ module Admin::Settings
   class APISettingsController < ::Admin::SettingsController
     menu_item :api
 
-    def default_breadcrumb
-      t(:label_api_access_key_type)
-    end
-
     def settings_params
       super.tap do |settings|
         settings["apiv3_cors_origins"] = settings["apiv3_cors_origins"].split(/\r?\n/)

--- a/app/controllers/admin/settings/experimental_settings_controller.rb
+++ b/app/controllers/admin/settings/experimental_settings_controller.rb
@@ -28,10 +28,6 @@
 
 module Admin::Settings
   class ExperimentalSettingsController < ::Admin::SettingsController
-    menu_item :settings
-
-    def default_breadcrumb
-      t(:label_experimental)
-    end
+    menu_item :settings_experimental
   end
 end

--- a/app/controllers/admin/settings/general_settings_controller.rb
+++ b/app/controllers/admin/settings/general_settings_controller.rb
@@ -34,9 +34,5 @@ module Admin::Settings
       super
       @guessed_host = request.host_with_port.dup
     end
-
-    def default_breadcrumb
-      t(:label_general)
-    end
   end
 end

--- a/app/controllers/admin/settings/icalendar_settings_controller.rb
+++ b/app/controllers/admin/settings/icalendar_settings_controller.rb
@@ -29,9 +29,5 @@
 module Admin::Settings
   class IcalendarSettingsController < ::Admin::SettingsController
     menu_item :icalendar
-
-    def default_breadcrumb
-      t(:label_calendar_subscriptions)
-    end
   end
 end

--- a/app/controllers/admin/settings/languages_settings_controller.rb
+++ b/app/controllers/admin/settings/languages_settings_controller.rb
@@ -30,10 +30,6 @@ module Admin::Settings
   class LanguagesSettingsController < ::Admin::SettingsController
     menu_item :settings_languages
 
-    def default_breadcrumb
-      t(:label_languages)
-    end
-
     protected
 
     def update_service

--- a/app/controllers/admin/settings/projects_settings_controller.rb
+++ b/app/controllers/admin/settings/projects_settings_controller.rb
@@ -29,9 +29,5 @@
 module Admin::Settings
   class ProjectsSettingsController < ::Admin::SettingsController
     menu_item :project_lists_settings
-
-    def default_breadcrumb
-      t(:label_project_list_plural)
-    end
   end
 end

--- a/app/controllers/admin/settings/repositories_settings_controller.rb
+++ b/app/controllers/admin/settings/repositories_settings_controller.rb
@@ -29,9 +29,5 @@
 module Admin::Settings
   class RepositoriesSettingsController < ::Admin::SettingsController
     menu_item :settings_repositories
-
-    def default_breadcrumb
-      t(:label_repository_plural)
-    end
   end
 end

--- a/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
+++ b/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
@@ -30,10 +30,6 @@ module Admin::Settings
   class WorkingDaysAndHoursSettingsController < ::Admin::SettingsController
     menu_item :working_days_and_hours
 
-    def default_breadcrumb
-      t(:label_working_days_and_hours)
-    end
-
     def failure_callback(call)
       @modified_non_working_days = modified_non_working_days_for(call.result)
       flash[:error] = call.message || I18n.t(:notice_internal_server_error)

--- a/app/views/admin/settings/api_settings/show.html.erb
+++ b/app/views/admin/settings/api_settings/show.html.erb
@@ -26,7 +26,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_api_access_key_type) %>
+<% html_title t(:label_administration), t(:label_api_access_key_type) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_api_access_key_type) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
+                             t(:label_api_access_key_type)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_api_path, method: :patch) do %>
   <section class="form--section">

--- a/app/views/admin/settings/date_format_settings/show.html.erb
+++ b/app/views/admin/settings/date_format_settings/show.html.erb
@@ -27,7 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= toolbar title: t(:label_date_format) %>
+<% html_title t(:label_administration), t(:label_date_format) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_date_format) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_working_days_and_hours_path, text: t(:label_calendars_and_dates) },
+                             t(:label_date_format)])
+  end
+%>
 
 <%= styled_form_tag(
       admin_settings_date_format_path,

--- a/app/views/admin/settings/experimental_settings/show.html.erb
+++ b/app/views/admin/settings/experimental_settings/show.html.erb
@@ -26,7 +26,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_experimental) %>
+<% html_title t(:label_administration), t(:label_experimental) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_experimental) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_general_path, text: t(:label_system_settings) },
+                             t(:label_experimental)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_update_experimental_path, method: :patch) do %>
   <section class="form--section">

--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -26,7 +26,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_general) %>
+
+<% html_title t(:label_administration), t(:label_general) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_general) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_general_path, text: t(:label_system_settings) },
+                             t(:label_general)])
+  end
+%>
+
 
 <%= styled_form_tag(admin_settings_update_general_path, method: :patch) do %>
   <section class="form--section">

--- a/app/views/admin/settings/icalendar_settings/show.html.erb
+++ b/app/views/admin/settings/icalendar_settings/show.html.erb
@@ -27,7 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= toolbar title: t(:label_calendar_subscriptions) %>
+<% html_title t(:label_administration), t(:label_calendar_subscriptions) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_calendar_subscriptions) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_working_days_and_hours_path, text: t(:label_calendars_and_dates) },
+                             t(:label_calendar_subscriptions)])
+  end
+%>
 
 <%= styled_form_tag(
       admin_settings_icalendar_path,

--- a/app/views/admin/settings/languages_settings/show.html.erb
+++ b/app/views/admin/settings/languages_settings/show.html.erb
@@ -27,7 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= toolbar title: t(:label_languages) %>
+<% html_title t(:label_administration), t(:label_languages) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_languages) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_general_path, text: t(:label_system_settings) },
+                             t(:label_languages)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_update_languages_path, method: :patch) do %>
 

--- a/app/views/admin/settings/projects_settings/show.html.erb
+++ b/app/views/admin/settings/projects_settings/show.html.erb
@@ -27,7 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title t(:label_administration), t(:label_project_list_plural) %>
-<%= toolbar title: t(:label_project_list_plural) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_project_list_plural) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_project_custom_fields_path, text: t(:label_project_plural) },
+                             t(:label_project_list_plural)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_projects_path, method: :patch) do %>
   <fieldset class="form--fieldset">

--- a/app/views/admin/settings/repositories_settings/show.html.erb
+++ b/app/views/admin/settings/repositories_settings/show.html.erb
@@ -26,7 +26,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_repository_plural) %>
+
+<% html_title t(:label_administration), t(:label_repository_plural) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_repository_plural) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_general_path, text: t(:label_system_settings) },
+                             t(:label_repository_plural)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_update_repositories_path, method: :patch) do %>
   <section class="form--section">

--- a/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
+++ b/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
@@ -27,7 +27,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= toolbar title: t(:label_working_days_and_hours) %>
+<% html_title t(:label_administration), t(:label_working_days_and_hours) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title(test_selector: "op-working-days-admin-settings--title") { t(:label_working_days_and_hours) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_working_days_and_hours_path, text: t(:label_calendars_and_dates) },
+                             t(:label_working_days_and_hours)])
+    end
+%>
 
 <%= styled_form_tag(
       admin_settings_working_days_and_hours_path,

--- a/modules/calendar/spec/features/calendar_sharing_spec.rb
+++ b/modules/calendar/spec/features/calendar_sharing_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "Calendar sharing via ical", :js do
         click_link "Calendars and dates"
       end
 
-      expect(page).to have_css(".title-container", text: "Working days")
+      expect(page).to have_test_selector("op-working-days-admin-settings--title", text: "Working days")
       click_link I18n.t(:label_calendar_subscriptions)
 
       expect(page)

--- a/modules/github_integration/app/views/deploy_targets/index.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/index.html.erb
@@ -27,14 +27,28 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t(:label_github_integration) %>
-<%= toolbar title: t(:label_deploy_target_plural) do %>
-  <li class="toolbar-item">
-    <a href="<%= new_deploy_target_path %>" aria-label="<%= t(:button_add_deploy_target) %>" title="<%= t(:button_add_deploy_target) %>" class="button -primary">
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t(:label_deploy_target) %></span>
-    </a>
-  </li>
-<% end %>
+<% html_title t(:label_administration), t(:label_github_integration), t(:label_deploy_target_plural) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_deploy_target_plural) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: deploy_targets_path, text: t(:label_github_integration) },
+                             t(:label_deploy_target_plural)])
+  end
+%>
+
+<%=
+  render(Primer::OpenProject::SubHeader.new) do |subheader|
+    subheader.with_action_button(scheme: :primary,
+                                 aria: { label: I18n.t(:button_add_deploy_target) },
+                                 title: I18n.t(:button_add_deploy_target),
+                                 tag: :a,
+                                 href: new_deploy_target_path) do |button|
+      button.with_leading_visual_icon(icon: :plus)
+      t(:label_deploy_target)
+    end
+  end
+%>
 
 <%= render DeployTargets::TableComponent.new(rows: @deploy_targets, current_user: ) %>

--- a/modules/github_integration/app/views/deploy_targets/new.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/new.html.erb
@@ -27,10 +27,17 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title t(:label_administration), t("label_deploy_target_new") %>
-<% local_assigns[:additional_breadcrumb] = t(:label_deploy_target_new) %>
+<% html_title t(:label_administration), t(:label_github_integration), t(:label_deploy_target_new) %>
 
-<%= toolbar title: t(:label_deploy_target_new) %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_deploy_target_new) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: deploy_targets_path, text: t(:label_github_integration) },
+                             { href: deploy_targets_path, text: t(:label_deploy_target_plural) },
+                             t(:label_deploy_target_new)])
+  end
+%>
 
 <%= error_messages_for @deploy_target %>
 

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/show_page_header_component.html.erb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/show_page_header_component.html.erb
@@ -1,0 +1,61 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2024 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { @webhook.name }
+    header.with_breadcrumbs(breadcrumb_items)
+
+    header.with_action_button(tag: :a,
+                              mobile_icon: :pencil,
+                              mobile_label: t(:button_edit),
+                              size: :medium,
+                              href: edit_admin_outgoing_webhook_path(@webhook),
+                              aria: { label: I18n.t(:button_edit) },
+                              title: I18n.t(:button_edit)) do |button|
+      button.with_leading_visual_icon(icon: :pencil)
+      t(:button_edit)
+    end
+
+    header.with_action_button(tag: :a,
+                              scheme: :danger,
+                              mobile_icon: :trash,
+                              mobile_label: t(:button_delete),
+                              size: :medium,
+                              href: admin_outgoing_webhook_path(@webhook),
+                              aria: { label: I18n.t(:button_delete) },
+                              data: {
+                                confirm: t(:text_are_you_sure),
+                                method: :delete,
+                              },
+                              title: I18n.t(:button_delete)) do |button|
+      button.with_leading_visual_icon(icon: :trash)
+      t(:button_delete)
+    end
+  end
+%>

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/show_page_header_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/show_page_header_component.rb
@@ -1,6 +1,8 @@
-#-- copyright
+# frozen_string_literal: true
+
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,31 +26,26 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module Admin::Settings
-  class DateFormatSettingsController < ::Admin::SettingsController
-    menu_item :date_format
+module ::Webhooks
+  module Outgoing
+    module Webhooks
+      class ShowPageHeaderComponent < ApplicationComponent
+        include OpPrimer::ComponentHelpers
+        include ApplicationHelper
 
-    before_action :validate_start_of_week_and_first_week_of_year_combination, only: :update
+        def initialize(webhook:)
+          super
+          @webhook = webhook
+        end
 
-    def update # rubocop:disable Lint/UselessMethodDefinition
-      super
-    end
-
-    private
-
-    def validate_start_of_week_and_first_week_of_year_combination
-      start_of_week = settings_params[:start_of_week]
-      start_of_year = settings_params[:first_week_of_year]
-
-      if start_of_week.present? ^ start_of_year.present?
-        flash[:error] = I18n.t(
-          "settings.date_format.first_date_of_week_and_year_set",
-          first_week_setting_name: I18n.t(:setting_first_week_of_year),
-          day_of_week_setting_name: I18n.t(:setting_start_of_week)
-        )
-        redirect_to action: :show
+        def breadcrumb_items
+          [{ href: admin_index_path, text: t("label_administration") },
+           { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
+           { href: admin_outgoing_webhooks_path, text: t("webhooks.plural") },
+           @webhook.name]
+        end
       end
     end
   end

--- a/modules/webhooks/app/controllers/webhooks/outgoing/admin_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/outgoing/admin_controller.rb
@@ -74,12 +74,10 @@ module Webhooks
       end
 
       def show_local_breadcrumb
-        true
+        false
       end
 
-      def default_breadcrumb
-        []
-      end
+      def default_breadcrumb; end
     end
   end
 end

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/edit.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/edit.html.erb
@@ -1,12 +1,14 @@
+<% html_title t(:label_administration), t("webhooks.plural"), @webhook.name %>
 
-<% html_title(t(:label_administration), t('webhooks.outgoing.label_edit')) -%>
-<% local_assigns[:additional_breadcrumb] = [
-  link_to(t('webhooks.plural'), admin_outgoing_webhooks_path),
-  t('webhooks.outgoing.label_edit')
-  ]
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title {  @webhook.name }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
+                             { href: admin_outgoing_webhooks_path, text: t("webhooks.plural") },
+                             @webhook.name])
+  end
 %>
-
-<%= toolbar title: t('webhooks.outgoing.label_edit') %>
 
 <%= error_messages_for @webhook %>
 

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
@@ -1,17 +1,26 @@
-<% html_title(t(:label_administration), t('webhooks.plural')) -%>
-<% local_assigns[:additional_breadcrumb] = t('webhooks.plural') %>
+<% html_title t(:label_administration), t("webhooks.plural") %>
 
-<%= toolbar title: t('webhooks.plural') do %>
-  <li class="toolbar-item">
-    <%= link_to new_admin_outgoing_webhook_path,
-          { class: 'button -primary',
-            aria: {label: t('webhooks.outgoing.label_add_new')},
-            title: t('webhooks.outgoing.label_add_new')} do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('webhooks.singular') %></span>
-    <% end %>
-  </li>
-<% end %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t("webhooks.plural") }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
+                             t("webhooks.plural")])
+  end
+%>
+
+<%=
+  render(Primer::OpenProject::SubHeader.new) do |subheader|
+    subheader.with_action_button(scheme: :primary,
+                                 aria: { label: I18n.t("webhooks.outgoing.label_add_new") },
+                                 title: I18n.t("webhooks.outgoing.label_add_new"),
+                                 tag: :a,
+                                 href: new_admin_outgoing_webhook_path) do |button|
+      button.with_leading_visual_icon(icon: :plus)
+      t("webhooks.singular")
+    end
+  end
+%>
 
 <p>
   <%= t('webhooks.outgoing.explanation.text',

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/new.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/new.html.erb
@@ -1,11 +1,14 @@
-<% html_title(t(:label_administration), t('webhooks.outgoing.label_add_new')) -%>
-<% local_assigns[:additional_breadcrumb] = [
-  link_to(t('webhooks.plural'), admin_outgoing_webhooks_path),
-  t('webhooks.outgoing.label_add_new')
-  ]
-%>
+<% html_title t(:label_administration), t("webhooks.outgoing.label_add_new") %>
 
-<%= toolbar title: t('webhooks.outgoing.label_add_new') %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t("webhooks.outgoing.label_add_new") }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
+                             { href: admin_outgoing_webhooks_path, text: t("webhooks.plural") },
+                             t("webhooks.outgoing.label_add_new")])
+  end
+%>
 
 <%= error_messages_for @webhook %>
 

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/show.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/show.html.erb
@@ -1,29 +1,8 @@
-<% html_title(t(:label_administration), t('webhooks.singular'), @webhook.name) -%>
-<% local_assigns[:additional_breadcrumb] = [
-  link_to(t('webhooks.plural'), admin_outgoing_webhooks_path),
-  @webhook.name
-  ]
-%>
+<% html_title t(:label_administration), t("webhooks.plural"), @webhook.name %>
 
-<%= toolbar title: "#{t('webhooks.singular')} - #{@webhook.name}" do %>
-  <li class="toolbar-item">
-    <%= link_to edit_admin_outgoing_webhook_path(@webhook),
-          { class: 'button',
-            aria: {label: t(:label_edit)},
-            title: t(:label_edit)} do %>
-      <%= op_icon('button--icon icon-edit') %>
-      <span class="button--text"><%= t(:label_edit) %></span>
-    <% end %>
-  </li>
-  <li class="toolbar-item">
-    <%= link_to admin_outgoing_webhook_path(@webhook),
-                class: 'button -danger',
-                data: { method: 'delete', confirm: I18n.t(:text_are_you_sure) } do %>
-      <%= op_icon('button--icon icon-delete') %>
-      <span class="button--text"><%= t(:button_delete) %></span>
-    <% end %>
-  </li>
-<% end %>
+<%=
+  render Webhooks::Outgoing::Webhooks::ShowPageHeaderComponent.new(webhook: @webhook)
+%>
 
 <%= render ::Components::OnOffStatusComponent.new({
              is_on: @webhook.enabled?,


### PR DESCRIPTION
Add missing breadcrumb and html titles with the help of Primer::OpenProject::PageHeader for

- [x] Calendar and dates
  - [x] Working days and hours
  - [x] Date format
  - [x] Calendar subscriptions
- [x] System settings
  - [x] General
  - [x] Languages
  - [x] Repositories
  - [x] Projects
  - [x] Experimental
- [x] API and webhooks 
  - [x] API
  - [x] Webhooks
- [x] GitHub integration
  - [x] Deploy targets

https://community.openproject.org/projects/14/work_packages/56587/activity