### PR TITLE
[56445] Buttons in Attribute help text modal are too close

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/action-bar.sass
+++ b/frontend/src/app/spot/styles/sass/components/action-bar.sass
@@ -23,7 +23,7 @@
       // see #47994 and #49729
       margin: $spot-spacing-1 $spot-spacing-1 $spot-spacing-0-75 0
 
-      &:last-of-type
+      &:last-child
         margin-right: 0
 
   @media #{$spot-mq-action-bar-change}


### PR DESCRIPTION
Take care that there is enough space between the actionBar elements even if one is a button and the other a link


https://community.openproject.org/projects/14/work_packages/56445/activity