### PR TITLE
[56586] Some pages of Administration/Projects are missing a breadcrumb

### DIFF
--- a/app/views/admin/settings/new_project_settings/show.html.erb
+++ b/app/views/admin/settings/new_project_settings/show.html.erb
@@ -27,7 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title t(:label_administration), t(:label_project_new) %>
-<%= toolbar title: t(:label_project_new) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_project_new) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration"), text: t(:label_administration) },
+                             { href: admin_settings_project_custom_fields_path, text: t(:label_project_plural) },
+                             t(:label_project_new)])
+  end
+%>
 
 <%= styled_form_tag(admin_settings_new_project_path, method: :patch) do %>
   <fieldset class="form--fieldset">

--- a/app/views/admin/settings/new_project_settings/show.html.erb
+++ b/app/views/admin/settings/new_project_settings/show.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_project_new) }
-    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration"), text: t(:label_administration) },
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
                              { href: admin_settings_project_custom_fields_path, text: t(:label_project_plural) },
                              t(:label_project_new)])
   end


### PR DESCRIPTION
Add breadcrumb for Administration -> Projects -> New project


https://community.openproject.org/projects/14/work_packages/56586/activity