### PR TITLE
[56447] Info banner breaks autocompleter dropdown in status board

### DIFF
--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
@@ -195,6 +195,7 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
       })
       .catch(() => {});
     this.showWarning = this.ngSelectComponent.ngSelectInstance.searchTerm !== undefined && (values.length === 0);
+    this.ngSelectComponent.repositionDropdown();
     this.cdRef.detectChanges();
   }
 }


### PR DESCRIPTION
Reposition drop down when there is a warning.


https://community.openproject.org/projects/14/work_packages/56447/activity