### PR TITLE
[#56292] Fix share drop down being cut off on small modal heights

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.sass
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.sass
@@ -1,2 +1,2 @@
 .op-share-dialog-modal
-  min-height: 300px
+  min-height: 350px


### PR DESCRIPTION
Given the minimum height of the project list sharing modal, I wasn't able to reproduce the bug on it. This modal ensures two shares minimum (owner + any other share) so it's not possible for the project list modal, just the work package share modal.

See: https://community.openproject.org/work_packages/56292
