### PR TITLE
Introduce `Primer::OpenProject::PageHeader` in some Admin modules

### DIFF
--- a/app/components/colors/edit_page_header_component.html.erb
+++ b/app/components/colors/edit_page_header_component.html.erb
@@ -26,22 +26,27 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-
-<% html_title t(:label_administration), t("colors.new.label_new_color") %>
-
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t("colors.new.label_new_color") }
-    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
-                             { href: colors_path, text: t(:label_color_plural) },
-                             t("colors.new.label_new_color") ])
+    header.with_title { @color.name }
+    header.with_breadcrumbs(breadcrumb_items)
+
+    if @color.persisted?
+      header.with_action_button(tag: :a,
+                                scheme: :danger,
+                                mobile_icon: :trash,
+                                mobile_label: t(:button_delete),
+                                size: :medium,
+                                href: color_path(@color),
+                                aria: { label: I18n.t(:button_delete) },
+                                data: {
+                                  confirm: I18n.t(:text_are_you_sure),
+                                  method: :delete
+                                },
+                                title: I18n.t(:button_delete)) do |button|
+        button.with_leading_visual_icon(icon: :trash)
+        t(:button_delete)
+      end
+    end
   end
 %>
-
-<%= labelled_tabular_form_for @color,
-            url: colors_url,
-            html: {method: 'post'},
-            as: :color do |f| %>
-  <%= render partial: 'form',
-             locals: {f: f, color: @color} %>
-<% end %>

--- a/app/components/colors/edit_page_header_component.rb
+++ b/app/components/colors/edit_page_header_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Colors
+  class EditPageHeaderComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include ApplicationHelper
+
+    def initialize(color:)
+      super
+      @color = color
+    end
+
+    def breadcrumb_items
+      [
+        { href: admin_index_path, text: t(:label_administration) },
+        { href: colors_path, text: t(:label_color_plural) },
+        @color.name
+      ]
+    end
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -89,17 +89,10 @@ class AdminController < ApplicationController
     @storage_information = OpenProject::Storage.mount_information
   end
 
-  def default_breadcrumb
-    case params[:action]
-    when "plugins"
-      t(:label_plugins)
-    when "info"
-      t(:label_information)
-    end
-  end
+  def default_breadcrumb; end
 
   def show_local_breadcrumb
-    true
+    false
   end
 
   private

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -20,12 +20,8 @@ class AnnouncementsController < ApplicationController
 
   private
 
-  def default_breadcrumb
-    t(:label_announcement)
-  end
-
   def show_local_breadcrumb
-    true
+    false
   end
 
   def announcement_params

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -102,17 +102,11 @@ class ColorsController < ApplicationController
 
   protected
 
-  def default_breadcrumb
-    if action_name == "index"
-      t(:label_color_plural)
-    else
-      ActionController::Base.helpers.link_to(t(:label_color_plural), colors_path)
-    end
+  def show_local_breadcrumb
+    false
   end
 
-  def show_local_breadcrumb
-    true
-  end
+  def default_breadcrumb; end
 
   def require_admin_unless_readonly_api_request
     require_admin unless %w[index show].include? params[:action] and

--- a/app/controllers/enumerations_controller.rb
+++ b/app/controllers/enumerations_controller.rb
@@ -102,17 +102,11 @@ class EnumerationsController < ApplicationController
 
   protected
 
-  def default_breadcrumb
-    if action_name == "index"
-      t(:label_enumerations)
-    else
-      ActionController::Base.helpers.link_to(t(:label_enumerations), enumerations_path)
-    end
+  def show_local_breadcrumb
+    false
   end
 
-  def show_local_breadcrumb
-    true
-  end
+  def default_breadcrumb; end
 
   def find_enumeration
     @enumeration = Enumeration.find(params[:id])

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -29,7 +29,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title(t(:label_administration), t(:label_overview)) -%>
 
-<%= toolbar title: t(:label_overview) %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_overview) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_overview)])
+  end
+%>
 
 <div class="menu-blocks--container" data-test-selector="menu-blocks--container">
   <% @menu_nodes.each do |menu_node| -%>

--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -29,11 +29,17 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title(t(:label_administration), t(:label_information_plural)) -%>
 
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_information_plural) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_information_plural)])
+  end
+%>
+
 <%= call_hook(:view_admin_info_top) %>
 
 <%= render(AttributeGroups::AttributeGroupComponent.new) do |component|
-  component.with_header(title: I18n.t('label_information_plural'))
-
   if Setting.show_product_version?
     core_link = linked_sha_reference(OpenProject::VERSION.core_sha, OpenProject::VERSION.core_url)
     component.with_attribute(key: t(:label_core_build), value: core_link) if core_link.present?

--- a/app/views/admin/plugins.html.erb
+++ b/app/views/admin/plugins.html.erb
@@ -27,7 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title t(:label_administration), t(:label_plugins) %>
-<%= toolbar title: t(:label_plugins) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_plugins) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_plugins) ])
+  end
+%>
+
 <% if @plugins.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">

--- a/app/views/announcements/edit.html.erb
+++ b/app/views/announcements/edit.html.erb
@@ -1,8 +1,14 @@
 <% html_title t(:label_administration), t(:label_announcement) %>
 
-<%= error_messages_for 'announcement' %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { "#{t(:label_announcement)} (#{notice_annoucement_active})" }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_announcement)])
+  end
+%>
 
-<%= toolbar title: "#{t(:label_announcement)} (#{notice_annoucement_active})" %>
+<%= error_messages_for 'announcement' %>
 
 <%= labelled_tabular_form_for @announcement,
              :url => {:action => :update},
@@ -21,6 +27,5 @@
   <div class="form--field">
     <%= f.check_box :active, label: t(:label_active) %>
   </div>
-  <hr class="form-separator">
   <%= styled_button_tag t(:button_save), class: '-primary -with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -29,23 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'color' %>
 
-<%= toolbar title: (color.new_record? ? t('.label_new_color') : t('.label_edit_color')) do %>
-  <% if color.persisted? %>
-  <li class="toolbar-item">
-    <%= link_to color_path(color),
-                method: :delete,
-                data: { confirm: t('text_are_you_sure') },
-                class: "button -danger" do %>
-      <%= op_icon 'button--icon icon-delete' %>
-      <span class="button--text"><%= t :button_delete %></span>
-    <% end %>
-  </li>
-  <% end %>
-<% end %>
-
 <fieldset class="form--fieldset">
-  <legend class="form--fieldset-legend"><%= t('colors.label_properties') %></legend>
-
   <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-slim' %>
   </div>

--- a/app/views/colors/edit.html.erb
+++ b/app/views/colors/edit.html.erb
@@ -30,6 +30,8 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), "#{t('.label_edit_color')} #{h @color.name}" %>
 <% local_assigns[:additional_breadcrumb] = @color.name %>
 
+<%= render Colors::EditPageHeaderComponent.new(color: @color) %>
+
 <%= labelled_tabular_form_for @color,
             url: color_url(@color),
             html: {method: 'put'}, as: :color do |f| %>

--- a/app/views/colors/index.html.erb
+++ b/app/views/colors/index.html.erb
@@ -29,17 +29,25 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), t(:label_color_plural) %>
 
-<%= toolbar title: t(:label_color_plural) do %>
-  <li class="toolbar-item">
-    <%= link_to new_color_path,
-          { class: 'button -primary',
-            aria: {label: t('.label_new_color')},
-            title: t('.label_new_color')} do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('activerecord.attributes.type.color') %></span>
-    <% end %>
-  </li>
-<% end %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_color_plural) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_color_plural)])
+  end
+%>
+<%=
+  render(Primer::OpenProject::SubHeader.new) do |subheader|
+    subheader.with_action_button(scheme: :primary,
+                                 aria: { label: I18n.t("colors.index.label_new_color") },
+                                 title: I18n.t("colors.index.label_new_color"),
+                                 tag: :a,
+                                 href: new_color_path) do |button|
+      button.with_leading_visual_icon(icon: :plus)
+      t("activerecord.attributes.type.color")
+    end
+  end
+%>
 
 <% if @colors.any? %>
   <div class="color--preview-patch-field">

--- a/app/views/enumerations/edit.html.erb
+++ b/app/views/enumerations/edit.html.erb
@@ -29,8 +29,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), "#{t(:label_edit)} #{Enumeration.model_name.human} #{h @enumeration.name}" %>
 
-<% local_assigns[:additional_breadcrumb] =  @enumeration %>
-<%= breadcrumb_toolbar @enumeration %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { h @enumeration.name }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             { href: enumerations_path, text: t(:label_enumerations) },
+                             I18n.t("menus.breadcrumb.nested_element", section_header: t(@enumeration.option_name), title: h(@enumeration.name)).html_safe],
+                            selected_item_font_weight: :normal)
+  end
+%>
 
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -27,7 +27,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% html_title t(:label_administration), t(:label_enumerations) %>
-<%= toolbar title: t(:label_enumerations) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_enumerations) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             t(:label_enumerations)])
+  end
+%>
+
 <% Enumeration.subclasses.each do |klass| %>
   <h3 class="-no-border"><%= t(klass::OptionName) %></h3>
   <%= render(::Enumerations::TableComponent.new(rows: klass.shared)) %>

--- a/app/views/enumerations/new.html.erb
+++ b/app/views/enumerations/new.html.erb
@@ -28,8 +28,17 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% html_title t(:label_administration), t(:label_enumeration_new) %>
-<% local_assigns[:additional_breadcrumb] =  t(:label_enumeration_new) %>
-<%= breadcrumb_toolbar t(:label_enumeration_new) %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_enumeration_new) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
+                             { href: enumerations_path, text: t(:label_enumerations) },
+                             I18n.t("menus.breadcrumb.nested_element", section_header: t(@enumeration.option_name), title: t(:label_enumeration_new)).html_safe],
+                            selected_item_font_weight: :normal)
+  end
+%>
+
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= styled_button_tag t(:button_create), class: '-primary -with-icon icon-checkmark' %>


### PR DESCRIPTION
I had some time at hand and introduced the PageHeader component in some modules in the administration:

* Overview
* Colors
* Enumerations
* Announcements
* Plugins
* Information

https://community.openproject.org/projects/14/work_packages/53808/activity