### PR TITLE
[#56253] Correct missing filter value in notification translation string

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -679,7 +679,7 @@ en:
         mentioned: "Mentioned"
         watched: "Watcher"
         assigned: "Assignee"
-        responsible: "Accountable"
+        accountable: "Accountable"
         created: "Created"
         scheduled: "Scheduled"
         commented: "Commented"


### PR DESCRIPTION
Bug work package: https://community.openproject.org/work_packages/56253

Changes "responsible" to "accountable"