### PR TITLE
[56655] Onboarding tour buttons are hard to see with a bright primary color

### DIFF
--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -43,6 +43,9 @@ See COPYRIGHT and LICENSE files for more details.
         --primary-button-color--minor2: <%= design_color.lighten 0.6 %>;
         --primary-button-color--dark-mode: <%= design_color.lighten 0.4 %>;
         --font-color-on-primary: <%= design_color.contrasting_font_color %>;
+        <% if design_color.bright? %>
+          --button--primary-border-color: #d0d7de;
+        <% end %>
     <% end %>
     <% if design_color.variable == "accent-color" %>
         --accent-color--major1: <%= design_color.darken 0.2 %>;

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -79,7 +79,7 @@ a.button
   &.-primary
     @include button-style(var(--button--primary-background-color), var(--button--primary-background-hover-color), var(--button--primary-font-color))
     @include button-style(var(--button--primary-background-color), var(--button--primary-background-hover-color), var(--button--primary-font-color))
-    border-color: var(--button--primary-background-color)
+    border-color: var(--button--primary-border-color)
 
     &:hover, &:focus
       border-color: var(--button--primary-background-hover-color)

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -121,6 +121,7 @@
   --button--primary-background-color: var(--primary-button-color);
   --button--primary-background-hover-color: var(--primary-button-color--major1);
   --button--primary-background-disabled-color: var(--primary-button-color--minor2);
+  --button--primary-border-color: var(--button--primary-background-color);
   --button--primary-border-disabled-color: var(--primary-button-color--minor2);
   --button--primary-font-color: var(--font-color-on-primary);
   --generic-table--header-font-size: 0.875rem;

--- a/frontend/src/global_styles/vendor/_enjoyhint.sass
+++ b/frontend/src/global_styles/vendor/_enjoyhint.sass
@@ -1,7 +1,7 @@
 @mixin onboarding-button-styles
   color: var(--button--primary-font-color)
   border: 2px solid
-  border-color: var(--primary-button-color)
+  border-color: var(--button--primary-border-color)
   background: var(--primary-button-color)
   -webkit-box-sizing: content-box
   box-sizing: content-box

--- a/frontend/src/global_styles/vendor/_enjoyhint.sass
+++ b/frontend/src/global_styles/vendor/_enjoyhint.sass
@@ -1,5 +1,5 @@
 @mixin onboarding-button-styles
-  color: white
+  color: var(--button--primary-font-color)
   border: 2px solid
   border-color: var(--primary-button-color)
   background: var(--primary-button-color)
@@ -139,9 +139,9 @@
   background: transparent
   color: var(--primary-button-color)
   &:hover
-    color: white
+    color: var(--button--primary-font-color)
   &:active
-    color: white
+    color: var(--button--primary-font-color)
 
 #kinetic_container, .enjoyhint_canvas
   width: 100%


### PR DESCRIPTION
* Use primary button colors for enjoyhint buttons
* Introduce a border around the primary buttons if the color is very bright

https://community.openproject.org/projects/14/work_packages/56655/activity
