### PR TITLE
Use Primer variables for setting color of disabled inplace edit fields

### DIFF
--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -637,7 +637,7 @@ select
 select
   &[disabled=disabled],
   &[disabled]
-    background-color: var(--inplace-edit--bg-color--disabled)
+    background-color: var(--control-bgColor-disabled)
     cursor: not-allowed
 
 input[readonly].-clickable

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
@@ -61,8 +61,8 @@
 
 // Disabled submit styles when not applicable
 .inplace-edit--control[disabled]
-  background-color: var(--inplace-edit--bg-color--disabled)
-  color: var(--inplace-edit--color--disabled)
+  background-color: var(--control-bgColor-disabled)
+  color: var(--control-fgColor-disabled)
   cursor: not-allowed
 
 // A single save/cancel control

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -111,8 +111,6 @@
   --user-avatar-border-radius: 50%;
   --inplace-edit--border-color: #ddd;
   --inplace-edit--color--very-dark: #cacaca;
-  --inplace-edit--color--disabled: var(--control-fgColor-disabled);
-  --inplace-edit--bg-color--disabled: var(--control-bgColor-disabled);
   --table-row-highlighting-outline-color: #00A6FF;
   --button--font-color: #222222;
   --button--background-color: var(--gray-light);


### PR DESCRIPTION
Mapping the value of a default variable to a primer variable won't work, since primer variables are not loaded when loading _variable_defaults.scss file. Therefore, we should use primer variables right in the place of setting styles for an element.