### PR TITLE
[56461] Datepicker dialog arrow has wrong color

### DIFF
--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -81,8 +81,11 @@ $datepicker--selected-border-radius: 5px
   box-shadow: none !important
   @include spot-caption
 
-  &.open.arrowTop:before
-    border-bottom-color: var(--body-background)
+  &.open.arrowTop
+    &:before
+      border-bottom-color: var(--borderColor-default)
+    &:after
+      border-bottom-color: var(--body-background)
 
   .flatpickr-months
     min-height: 45px
@@ -265,7 +268,7 @@ $datepicker--selected-border-radius: 5px
         border-color: var(--bgColor-disabled) !important
 
 .flatpickr-calendar:not(.inline)
-  box-shadow: var(--shadow-resting-medium) !important
+  box-shadow: var(--shadow-floating-small) !important
   padding: $spot-spacing-0_5 !important
   width: max-content !important
 


### PR DESCRIPTION
Correctly style the datepicker arrow and frame border


**Before**

<img width="400" alt="Bildschirmfoto 2024-07-29 um 11 52 40" src="https://github.com/user-attachments/assets/4c0040d5-b1cf-4670-8691-2dc8f42fbfae">

<img width="400" alt="Bildschirmfoto 2024-07-29 um 11 52 50" src="https://github.com/user-attachments/assets/4804ca7e-eccf-4e65-9691-0868bffeda68">

**After**

<img width="400" alt="Bildschirmfoto 2024-07-29 um 11 51 41" src="https://github.com/user-attachments/assets/e14a8971-792f-474b-8b5f-f2a59bdcba99">

<img width="400" alt="Bildschirmfoto 2024-07-29 um 11 51 29" src="https://github.com/user-attachments/assets/76b5b87a-aeb6-4d4d-8f0a-0a38b63aef78">

https://community.openproject.org/projects/14/work_packages/56461/activity