### PR TITLE
[56704]Search bar stays open when redirecting to search results page

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -123,15 +123,15 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     getOptionsFn: this.getAutocompleterData,
   };
 
-  /** Remember the current value */
-  public currentValue = '';
-
-  public isFocusedDirectly = (this.globalSearchService.searchTerm.length > 0);
-
   /** Remember the item that best matches the query.
    * That way, it will be highlighted (as we manually mark the selected item) and we can handle enter.
    * */
-  public selectedItem:WorkPackageResource|SearchOptionItem|undefined;
+  public selectedItem:WorkPackageResource|SearchOptionItem|undefined = undefined;
+
+  /** Remember the current value */
+  public currentValue = '';
+
+  public isFocusedDirectly = this.globalSearchService.searchTerm.length > 0 && this.selectedItem instanceof HalResource;
 
   private unregisterGlobalListener:(() => unknown)|undefined;
 


### PR DESCRIPTION
Focus and open to the global input box only when the selected entry is a WP.

https://community.openproject.org/projects/openproject/work_packages/56704/activity