### PR TITLE
Feature/56045 add link to storage provider in storage edit view

### DIFF
--- a/modules/storages/app/components/storages/admin/general_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/general_info_component.html.erb
@@ -8,11 +8,14 @@
 
       grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-description') do
         concat(render(Primer::Beta::Text.new) { storage_description })
-        concat(render(Primer::Beta::Text.new) { " - " })
-        concat(render(Primer::Beta::Link.new(href: "#")) do
-          concat(render(Primer::Beta::Text.new) { "Open storage " })
-          concat(render(Primer::Beta::Octicon.new(icon: "link-external", size: :small)))
-        end)
+
+        if open_link_was_generated
+          concat(render(Primer::Beta::Text.new) { " - " })
+          concat(render(Primer::Beta::Link.new(href: open_href)) do
+            concat(render(Primer::Beta::Text.new) { "Open storage " })
+            concat(render(Primer::Beta::Octicon.new(icon: "link-external", size: :small)))
+          end)
+        end
       end
 
       if editable_storage?

--- a/modules/storages/app/components/storages/admin/general_info_component.html.erb
+++ b/modules/storages/app/components/storages/admin/general_info_component.html.erb
@@ -7,7 +7,12 @@
       end
 
       grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-description') do
-        render(Primer::Beta::Text.new) { storage_description }
+        concat(render(Primer::Beta::Text.new) { storage_description })
+        concat(render(Primer::Beta::Text.new) { " - " })
+        concat(render(Primer::Beta::Link.new(href: "#")) do
+          concat(render(Primer::Beta::Text.new) { "Open storage " })
+          concat(render(Primer::Beta::Octicon.new(icon: "link-external", size: :small)))
+        end)
       end
 
       if editable_storage?
@@ -20,7 +25,7 @@
                   tag: :a,
                   scheme: :invisible,
                   href: edit_host_admin_settings_storage_path(storage),
-                  aria: { label: I18n.t('storages.label_edit_storage_host') } ,
+                  aria: { label: I18n.t('storages.label_edit_storage_host') },
                   test_selector: 'storage-edit-host-button',
                   data: { turbo_stream: true }
                 )

--- a/modules/storages/app/components/storages/admin/general_info_component.rb
+++ b/modules/storages/app/components/storages/admin/general_info_component.rb
@@ -37,5 +37,26 @@ module Storages::Admin
     alias_method :storage, :model
 
     def self.wrapper_key = :storage_general_info_section
+
+    def initialize(model = nil, **options)
+      super
+
+      auth_strategy = ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
+                        .strategy
+                        .with_user(User.current)
+
+      @href_result = ::Storages::Peripherals::Registry
+                       .resolve("#{storage.short_provider_type}.queries.open_storage")
+                       .call(storage:, auth_strategy:)
+    end
+
+    def open_link_was_generated
+      @href_result.on_success { return true }
+      @href_result.on_failure { return false }
+    end
+
+    def open_href
+      @href_result.result
+    end
   end
 end

--- a/modules/storages/spec/components/storages/admin/general_info_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/general_info_component_spec.rb
@@ -27,36 +27,19 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
-module Storages::Admin
-  class GeneralInfoComponent < ApplicationComponent
-    include OpPrimer::ComponentHelpers
-    include OpTurbo::Streamable
-    include StorageViewInformation
 
-    alias_method :storage, :model
+require "spec_helper"
+require_module_spec_helper
 
-    def self.wrapper_key = :storage_general_info_section
-
-    def initialize(model = nil, **options)
-      auth_strategy = ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-                        .strategy
-                        .with_user(User.current)
-
-      @href_result = ::Storages::Peripherals::Registry
-                       .resolve("#{model.short_provider_type}.queries.open_storage")
-                       .call(storage: model, auth_strategy:)
-
-      super
-    end
-
-    def open_link_was_generated
-      @href_result.on_success { return true }
-      @href_result.on_failure { return false }
-    end
-
-    def open_href
-      @href_result.result
+RSpec.describe Storages::Admin::GeneralInfoComponent, type: :component do
+  describe "#description" do
+    context "with storage configured" do
+      it "must show a link to the storage" do
+        storage = create(:nextcloud_storage)
+        component = described_class.new(storage)
+        expect(component.open_link_was_generated).to be_truthy
+        expect(component.open_href).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/56045/activity

## what?

This PR adds a link to the storage's main directory to the edit page in admin settings.

It calculates the href by using the `:open_storage` query implementation of either type.