### PR TITLE
Remove required clause on Projects::CustomFields

### DIFF
--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -42,7 +42,6 @@ module Projects::CustomFields
       return all_visible_custom_fields if new_record?
 
       all_visible_custom_fields.where(id: project_custom_field_project_mappings.select(:custom_field_id))
-                               .or(required_visible_custom_fields)
     end
 
     # Note:
@@ -62,10 +61,6 @@ module Projects::CustomFields
 
     def all_visible_custom_fields
       all_available_custom_fields.visible(project: self)
-    end
-
-    def required_visible_custom_fields
-      ProjectCustomField.required.visible(project: self)
     end
 
     def custom_field_values_to_validate


### PR DESCRIPTION
Follow up refactor on [50844](https://community.openproject.org/wp/50844)
It is not necessary anymore, because the required fields are already returned in the project mapping clause, because required custom fields also have a read-only mapping created.