### PR TITLE
[56864] Move some actions in the Notification center into the SubHeader

### DIFF
--- a/app/components/notifications/index_page_header_component.html.erb
+++ b/app/components/notifications/index_page_header_component.html.erb
@@ -2,38 +2,14 @@
   header.with_title { page_title }
   header.with_breadcrumbs(breadcrumb_items)
 
-  header.with_action_segmented_control("aria-label": t(:label_filter_plural)) do |control|
-    control.with_item(tag: :a,
-                      href: notifications_path(facet: nil),
-                      label: t("notifications.facets.unread"),
-                      title: t("notifications.facets.unread_title"),
-                      selected: @facet != "all")
-    control.with_item(tag: :a,
-                      href: notifications_path(facet: "all"),
-                      label: t("notifications.facets.all"),
-                      title: t("notifications.facets.all_title"),
-                      selected: @facet == "all")
-  end
-
-  header.with_action_button(tag: :a,
-                            mobile_icon: :'op-read-all',
-                            mobile_label: I18n.t("js.notifications.center.mark_all_read"),
-                            href: mark_all_read_notifications_path({ filter: @filter_type, name: @filter_name }.compact),
-                            data: { method: :post },
-                            size: :medium,
-                            aria: { label: I18n.t("js.notifications.center.mark_all_read") }) do |button|
-    button.with_leading_visual_icon(icon: :'op-read-all')
-    I18n.t("js.notifications.center.mark_all_read")
-  end
-
   header.with_action_button(tag: :a,
                             mobile_icon: :gear,
-                            mobile_label: I18n.t("js.notifications.settings.title"),
+                            mobile_label: I18n.t(:label_setting_plural),
                             href: my_notifications_path,
                             size: :medium,
                             target: "_blank",
                             aria: { label: I18n.t("js.notifications.settings.title") }) do |button|
     button.with_leading_visual_icon(icon: :gear)
-    I18n.t("js.notifications.settings.title")
+    I18n.t(:label_setting_plural)
   end
 end %>

--- a/app/components/notifications/index_sub_header_component.html.erb
+++ b/app/components/notifications/index_sub_header_component.html.erb
@@ -1,0 +1,25 @@
+<%= render(Primer::OpenProject::SubHeader.new) do |subheader|
+  subheader.with_filter_component do
+    render(Primer::Alpha::SegmentedControl.new("aria-label": I18n.t(:label_filter_plural))) do |control|
+      control.with_item(tag: :a,
+                        href: notifications_path(facet: nil),
+                        label: t("notifications.facets.unread"),
+                        title: t("notifications.facets.unread_title"),
+                        selected: @facet != "all")
+      control.with_item(tag: :a,
+                        href: notifications_path(facet: "all"),
+                        label: t("notifications.facets.all"),
+                        title: t("notifications.facets.all_title"),
+                        selected: @facet == "all")
+    end
+  end
+
+  subheader.with_action_button(tag: :a,
+                               href: mark_all_read_notifications_path({ filter: @filter_type, name: @filter_name }.compact),
+                               data: { method: :post },
+                               size: :medium,
+                               aria: { label: I18n.t("js.notifications.center.mark_all_read") }) do |button|
+    button.with_leading_visual_icon(icon: :'op-read-all')
+    I18n.t("js.notifications.center.mark_all_read")
+  end
+end %>

--- a/app/components/notifications/index_sub_header_component.rb
+++ b/app/components/notifications/index_sub_header_component.rb
@@ -29,25 +29,17 @@
 # ++
 
 module Notifications
-  class IndexPageHeaderComponent < ApplicationComponent
+  class IndexSubHeaderComponent < ApplicationComponent
     include ApplicationHelper
 
-    def initialize(project: nil)
+    attr_reader :facet, :filter_type, :filter_name
+
+    def initialize(project: nil, facet: nil, filter_type: nil, filter_name: nil)
       super
       @project = project
-    end
-
-    def page_title
-      I18n.t("js.notifications.title")
-    end
-
-    def breadcrumb_items
-      [parent_element,
-       page_title]
-    end
-
-    def parent_element
-      { href: home_path, text: I18n.t(:label_home) }
+      @facet = facet
+      @filter_type = filter_type
+      @filter_name = filter_name
     end
   end
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,7 +1,8 @@
 <% html_title t("js.notifications.title") %>
 
 <% content_for :content_header do %>
-  <%= render(Notifications::IndexPageHeaderComponent.new(
+  <%= render(Notifications::IndexPageHeaderComponent.new) %>
+  <%= render(Notifications::IndexSubHeaderComponent.new(
     facet: params[:facet],
     filter_name: params[:name],
     filter_type: params[:filter]

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -45,9 +45,6 @@ action-menu
     ul
       margin-left: 0
 
-ul.tabnav-tabs
-  margin-left: 0
-
 .UnderlineNav
   @include styled-scroll-bar
   margin-bottom: 12px
@@ -57,9 +54,13 @@ ul.tabnav-tabs
 
 /* Remove margin-left: 2rem from Breadcrumbs */
 #breadcrumb,
-page-header
-  ol
+page-header,
+sub-header,
+.op-work-package-details-tab-component
+  ol, ul
     margin-left: 0
+
+#breadcrumb
   .breadcrumb-item.breadcrumb-item-selected
     a
       pointer-events: none


### PR DESCRIPTION
# What are you trying to accomplish?
Extract "Mark all as read" and facet switch into SubHeader

## Screenshots
<img width="1896" alt="Bildschirmfoto 2024-08-02 um 11 55 55" src="https://github.com/user-attachments/assets/2151989e-0c5d-4fa5-8ce5-ce4d24128d85">

# What approach did you choose and why?
Use `Primer::OpenProject::SubHeader` 

# Ticket
https://community.openproject.org/projects/openproject/work_packages/56864/activity

# Merge checklist

- [x] ~Added/updated tests~ Not necessary
- [x] ~Added/updated documentation in Lookbook (patterns, previews, etc)~ Not necessary
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
