### PR TITLE
[56866] Change the styling of the split screen layout in the notification center

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   flex_layout(classes: "op-work-package-details-tab-component") do |flex|
     flex.with_column(flex: 1, classes: "op-work-package-details-tab-component--tabs") do
-      render(Primer::Alpha::UnderlineNav.new(align: :left, label: "Tabs")) do |component|
+      render(Primer::Alpha::UnderlineNav.new(align: :left, label: "Tabs", classes: "op-primer-adjustment--UnderlineNav_spaciousLeft")) do |component|
         menu_items.each do |node|
           component.with_tab(selected: @tab == node.name,
                              href: url_for(node.url),

--- a/app/components/work_packages/details/tab_component.sass
+++ b/app/components/work_packages/details/tab_component.sass
@@ -11,3 +11,6 @@
     // This is one of the ugliest hacks I ever had to write. Please remove that as soon as the actions are part of the Splitscreen header
     padding-bottom: 7px
     border-bottom: 1px solid var(--borderColor-muted)
+
+    &:last-of-type
+      padding-right: 8px

--- a/app/components/work_packages/split_view_component.sass
+++ b/app/components/work_packages/split_view_component.sass
@@ -1,10 +1,10 @@
 .op-work-package-split-view
   height: 100%
+  width: 580px
   justify-content: space-around
   border-left: 1px solid var(--borderColor-muted)
   border-top: 1px solid var(--borderColor-muted)
+  border-right: 1px solid var(--borderColor-muted)
 
-  // border-top-left-radius: 8px
-  // border-top-right-radius: 8px
-  // border-right: 1px solid var(--borderColor-muted)
-  // margin-right: 20px
+  border-top-left-radius: var(--borderRadius-medium)
+  border-top-right-radius: var(--borderRadius-medium)

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -7,6 +7,12 @@
 
   &--content
     height: 100%
+    border: 1px solid var(--borderColor-muted)
+    border-radius: var(--borderRadius-medium)
+    border-bottom-left-radius: 0
+    border-bottom-right-radius: 0
+    // Do not remove easily. Otherwise the children will overlap the rounded corners
+    overflow: hidden
 
     &_empty
       display: flex

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -18,7 +18,6 @@ $subject-font-size: 14px
   padding: 15px 10px
   font-size: 0.9rem
   border-top: 1px solid var(--borderColor-default)
-  border-radius: 2px
   height: $ian-height
 
   &:hover

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -119,7 +119,7 @@ $left-space: 20px
   overflow-x: hidden
 
   // Special rules for pages that still follow the old layout and render everything inside the content-body
-  .accessibility-helper ~ &
+  .accessibility-helper + &
     padding-top: $top-space
   &:last-child
     padding-right: $right-space
@@ -130,7 +130,7 @@ $left-space: 20px
 
 #content-bodyRight
   grid-area: bodyRight
-  padding: 0
+  padding: 0 $right-space 0 0
   overflow: auto
   @include styled-scroll-bar
 

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -62,7 +62,7 @@ body.router--work-packages-partitioned-split-view-new
   height:     55px
   width:      100%
   background: var(--bgColor-muted)
-  border:     1px solid var(--borderColor-default)
+  border-top: 1px solid var(--borderColor-muted)
   padding:    0 1rem 10px
 
   @media print

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -262,6 +262,7 @@ $scrollbar-size: 10px
       margin-left: 20px
 
 @mixin extended-content--right
+  #content-bodyRight,
   #content-body,
   #content-header
     padding-right: 0
@@ -270,6 +271,10 @@ $scrollbar-size: 10px
       padding-right: 15px
     .work-packages--filters-optional-container
       margin-right: 15px
+
+@mixin space-between-content-and-split-screen
+  #content-bodyRight > *
+    margin-left: 12px
 
 @mixin modifying--placeholder
   border: 1px dashed var(--accent-color)

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -208,33 +208,6 @@ $scrollbar-size: 10px
     background: transparent
     visibility: hidden
 
-@mixin two-column-layout
-  column-count: 2
-  column-gap: 3rem
-
-  .attributes-key-value.-column-start
-    column-break-before: always !important
-    break-before: column
-
-  @supports (column-span: all)
-        // Let some elements still span both columns
-        .attributes-key-value.-span-all-columns
-          column-span: all
-          .attributes-key-value--key
-            flex-basis: calc(22.5% - (4rem / 6))
-          .attributes-key-value--value-container
-            flex-basis: calc(77.5% + (4rem / 6))
-            max-width: calc(77.5% + (4rem / 6))
-
-  .attributes-key-value
-    -webkit-column-break-inside: avoid
-    page-break-inside: avoid
-    break-inside: avoid
-    // For some reason chrome seems to treat a two column layout
-    // as if it would result in showing the backside of this element.
-    // This leads to input and select elements not showing their values.
-    backface-visibility: visible
-
 @mixin overlay-background
   position: absolute
   top: 0

--- a/frontend/src/global_styles/openproject/_notifications.sass
+++ b/frontend/src/global_styles/openproject/_notifications.sass
@@ -27,5 +27,8 @@
 //++
 
 .controller-notifications
+  @include extended-content--bottom
+  @include space-between-content-and-split-screen
+
   #content
     height: 100%

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -52,6 +52,9 @@ action-menu
   &-body
     margin-left: 12px
 
+  &.op-primer-adjustment--UnderlineNav_spaciousLeft
+    padding-left: 12px
+
 /* Remove margin-left: 2rem from Breadcrumbs */
 #breadcrumb,
 page-header,


### PR DESCRIPTION
# What are you trying to accomplish?
The design for the new split screen in the notification center should be changed according to the visuals.

## Screenshots
<img width="1000" alt="Bildschirmfoto 2024-08-02 um 11 58 24" src="https://github.com/user-attachments/assets/10e0d3d2-8d2c-4e3b-87d7-6ef4a51ed7de">


# What approach did you choose and why?
* This is meant as a quick fix. The whole concept of the split screen may be reworked later on. So (in agreement with the product team) this PR focusses mostly on spacings and borders.
  * The split screen for now has a fixed width of 580px. The resizing will be done separately. 
* One important part is that `#content-bodyRight` now always has a spacing to the right and is not glued any more. This is the current state of design for the split screen but might change later. Thus we also [fix a bug](https://community.openproject.org/projects/openproject/work_packages/56910/activity) that there is space missing on most pages on the right side. That was introduced by the notifications rework:

<img width="400" alt="Bildschirmfoto 2024-08-02 um 12 44 53" src="https://github.com/user-attachments/assets/d8c141fd-168a-4a20-8b16-d3b4859175e3">

# Ticket
https://community.openproject.org/projects/14/work_packages/56866/activity

# Merge checklist

- [x] ~Added/updated tests~  Not necessary
- [x] ~Added/updated documentation in Lookbook (patterns, previews, etc)~  Not necessary
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

Related to https://github.com/opf/openproject/pull/16309
