### PR TITLE
[56655] Close button of onboarding tour is hard to see with a bright primary color

### DIFF
--- a/frontend/src/global_styles/vendor/_enjoyhint.sass
+++ b/frontend/src/global_styles/vendor/_enjoyhint.sass
@@ -65,7 +65,6 @@
   -webkit-border-radius: 40px
   border-radius: 40px
 
-
 .enjoyhint_skip_btn
   position: fixed
   -webkit-border-radius: 40px
@@ -95,7 +94,7 @@
     border: none
     font: 400 100%/normal Arial, Helvetica, sans-serif
     color: rgba(0, 0, 0, 1)
-    background: #fff
+    background: var(--font-color-on-primary)
     text-shadow: none
     -o-text-overflow: clip
     text-overflow: clip
@@ -109,7 +108,7 @@
     border: none
     font: 400 100%/normal Arial, Helvetica, sans-serif
     color: rgba(0, 0, 0, 1)
-    background: #fff
+    background: var(--font-color-on-primary)
     text-shadow: none
     -o-text-overflow: clip
     text-overflow: clip


### PR DESCRIPTION
# What are you trying to accomplish?
This changes the color of the closing "x" of the onboarding tour. The background uses the `--primary-button-color`, so the font should use `--font-color-on-primary`.

## Screenshots
**Before**
<img width="97" alt="Bildschirmfoto 2024-08-02 um 14 18 35" src="https://github.com/user-attachments/assets/260d2f50-0eb0-417f-b964-c078c15a2db0">


**After**
<img width="72" alt="Bildschirmfoto 2024-08-02 um 14 15 44" src="https://github.com/user-attachments/assets/7f1e621d-ce62-4377-b96e-ad20f4ed5325">

# What approach did you choose and why?
Use existing variables instead of hard coded hex value

# Ticket
https://community.openproject.org/projects/openproject/work_packages/56655/activity

# Merge checklist

- [x] ~Added/updated tests~
- [x] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] ~Tested major browsers (Chrome, Firefox, Edge, ...)~
