### PR TITLE
Change 2fa administration page title to match with the sidebar

### DIFF
--- a/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
@@ -2,10 +2,10 @@
 
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { I18n.t("two_factor_authentication.settings.title") }
+    header.with_title { I18n.t("two_factor_authentication.label_two_factor_authentication") }
     header.with_breadcrumbs([{ href: admin_index_path, text: t(:label_administration) },
                              { href: admin_settings_authentication_path, text: t(:label_authentication) },
-                             I18n.t("two_factor_authentication.settings.title")])
+                             I18n.t("two_factor_authentication.label_two_factor_authentication")])
   end
 %>
 


### PR DESCRIPTION
# What are you trying to accomplish?
Change the title and breadcrumb element of the 2fa page to match with the left hand sidebar

## Screenshots
**Before**
<img width="641" alt="Bildschirmfoto 2024-08-02 um 14 29 35" src="https://github.com/user-attachments/assets/dddced90-e37b-4ecc-ae1e-d5f159321ffb">

**After**
<img width="683" alt="Bildschirmfoto 2024-08-02 um 14 28 24" src="https://github.com/user-attachments/assets/88e90d85-37a4-4442-86c6-26f0694967ae">

# Ticket
https://community.openproject.org/projects/openproject/work_packages/56615/activity

# Merge checklist

- [x] ~Added/updated tests~
- [x] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
