### PR TITLE
[#56792] No custom field section created for cloud trial installation

### DIFF
--- a/app/seeders/basic_data/project_custom_field_section_seeder.rb
+++ b/app/seeders/basic_data/project_custom_field_section_seeder.rb
@@ -25,23 +25,17 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module Standard
-  class BasicDataSeeder < ::BasicDataSeeder
-    def data_seeder_classes
-      [
-        ::BasicData::BuiltinUsersSeeder,
-        ::BasicData::ProjectRoleSeeder,
-        ::BasicData::WorkPackageRoleSeeder,
-        ::BasicData::ProjectQueryRoleSeeder,
-        ::BasicData::GlobalRoleSeeder,
-        ::BasicData::TimeEntryActivitySeeder,
-        ::BasicData::ColorSeeder,
-        ::BasicData::ColorSchemeSeeder,
-        ::BasicData::WorkflowSeeder,
-        ::BasicData::PrioritySeeder,
-        ::BasicData::SettingSeeder,
-        ::BasicData::ProjectCustomFieldSectionSeeder
-      ]
+module BasicData
+  class ProjectCustomFieldSectionSeeder < ModelSeeder
+    self.model_class = ProjectCustomFieldSection
+    self.seed_data_model_key = "project_custom_field_sections"
+    self.attribute_names_for_lookups = %i[position]
+
+    def model_attributes(section_data)
+      {
+        name: section_data["name"],
+        position: section_data["position"]
+      }
     end
   end
 end

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -45,231 +45,11 @@ priorities:
     color_name: grape-5
     position: 4
 
-statuses:
-- reference: :default_status_new
-  t_name: New
-  color_name: cyan-7
-  default_done_ratio: 0
-  is_default: true
-  position: 1
-- reference: :default_status_in_specification
-  t_name: In specification
-  color_name: blue-2
-  default_done_ratio: 10
-  position: 2
-- reference: :default_status_specified
-  t_name: Specified
-  color_name: blue-2
-  default_done_ratio: 20
-  position: 3
-- reference: :default_status_confirmed
-  t_name: Confirmed
-  color_name: violet-2
-  default_done_ratio: 20
-  position: 4
-- reference: :default_status_to_be_scheduled
-  t_name: To be scheduled
-  color_name: yellow-2
-  default_done_ratio: 20
-  position: 5
-- reference: :default_status_scheduled
-  t_name: Scheduled
-  color_name: lime-2
-  default_done_ratio: 20
-  position: 6
-- reference: :default_status_in_progress
-  t_name: In progress
-  color_name: grape-5
-  default_done_ratio: 40
-  position: 7
-- reference: :default_status_developed
-  t_name: Developed
-  color_name: green-3
-  default_done_ratio: 70
-  position: 8
-- reference: :default_status_in_testing
-  t_name: In testing
-  color_name: cyan-5
-  default_done_ratio: 80
-  position: 9
-- reference: :default_status_tested
-  t_name: Tested
-  color_name: teal-6
-  default_done_ratio: 90
-  position: 10
-- reference: :default_status_test_failed
-  t_name: Test failed
-  color_name: red-5
-  default_done_ratio: 70
-  position: 11
-- reference: :default_status_closed
-  t_name: Closed
-  color_name: gray-3
-  default_done_ratio: 100
-  is_closed: true
-  position: 12
-- reference: :default_status_on_hold
-  t_name: On hold
-  color_name: orange-3
-  default_done_ratio: 0
-  position: 13
-- reference: :default_status_rejected
-  t_name: Rejected
-  color_name: red-3
-  default_done_ratio: 0
-  is_closed: true
-  position: 14
+project_custom_field_sections:
+  - reference: :default_project_attributes
+    name: Project attributes
+    position: 1
 
-time_entry_activities:
-- t_name: Management
-  is_default: true
-  position: 1
-- t_name: Specification
-  position: 2
-- t_name: Development
-  position: 3
-- t_name: Testing
-  position: 4
-- t_name: Support
-  position: 5
-- t_name: Other
-  position: 6
-
-types:
-- reference: :default_type_task
-  t_name: Task
-  is_default: true
-  color_name: :default_color_blue
-  is_in_roadmap: true
-  position: 1
-- reference: :default_type_milestone
-  t_name: Milestone
-  is_default: true
-  color_name: :default_color_green_light
-  is_milestone: true
-  position: 2
-- reference: :default_type_phase
-  t_name: Phase
-  is_default: true
-  color_name: 'orange-5'
-  position: 3
-- reference: :default_type_feature
-  t_name: Feature
-  color_name: 'indigo-5'
-  is_in_roadmap: true
-  position: 4
-- reference: :default_type_epic
-  t_name: Epic
-  color_name: 'violet-5'
-  is_in_roadmap: true
-  position: 5
-- reference: :default_type_user_story
-  t_name: User story
-  color_name: :default_color_blue_light
-  is_in_roadmap: true
-  position: 6
-- reference: :default_type_bug
-  t_name: Bug
-  color_name: 'red-7'
-  is_in_roadmap: true
-  position: 7
-
-workflows:
-- type: :default_type_task
-  statuses:
-  - :default_status_new
-  - :default_status_in_progress
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_milestone
-  statuses:
-  - :default_status_new
-  - :default_status_to_be_scheduled
-  - :default_status_scheduled
-  - :default_status_in_progress
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_phase
-  statuses:
-  - :default_status_new
-  - :default_status_to_be_scheduled
-  - :default_status_scheduled
-  - :default_status_in_progress
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_feature
-  statuses:
-  - :default_status_new
-  - :default_status_in_specification
-  - :default_status_specified
-  - :default_status_in_progress
-  - :default_status_developed
-  - :default_status_in_testing
-  - :default_status_tested
-  - :default_status_test_failed
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_epic
-  statuses:
-  - :default_status_new
-  - :default_status_in_specification
-  - :default_status_specified
-  - :default_status_in_progress
-  - :default_status_developed
-  - :default_status_in_testing
-  - :default_status_tested
-  - :default_status_test_failed
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_user_story
-  statuses:
-  - :default_status_new
-  - :default_status_in_specification
-  - :default_status_specified
-  - :default_status_in_progress
-  - :default_status_developed
-  - :default_status_in_testing
-  - :default_status_tested
-  - :default_status_test_failed
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-- type: :default_type_bug
-  statuses:
-  - :default_status_new
-  - :default_status_confirmed
-  - :default_status_in_progress
-  - :default_status_developed
-  - :default_status_in_testing
-  - :default_status_tested
-  - :default_status_test_failed
-  - :default_status_on_hold
-  - :default_status_rejected
-  - :default_status_closed
-
-welcome:
-  t_title: "Welcome to OpenProject!"
-  t_text: |
-    OpenProject is the leading open source project management software. It supports classic, agile as well as hybrid project management and gives you full control over your data.
-
-    Core features and use cases:
-
-    * [Project Portfolio Management](https://www.openproject.org/collaboration-software-features/project-portfolio-management/)
-    * [Project Planning and Scheduling](https://www.openproject.org/collaboration-software-features/project-planning-scheduling/)
-    * [Task Management and Issue Tracking](https://www.openproject.org/collaboration-software-features/task-management/)
-    * [Agile Boards (Scrum and Kanban)](https://www.openproject.org/collaboration-software-features/agile-project-management/)
-    * [Requirements Management and Release Planning](https://www.openproject.org/collaboration-software-features/product-development/)
-    * [Time and Cost Tracking, Budgets](https://www.openproject.org/collaboration-software-features/time-tracking/)
-    * [Team Collaboration and Documentation](https://www.openproject.org/collaboration-software-features/team-collaboration/)
-
-    Welcome to the future of project management.
-
-    For Admins: You can change this welcome text [here]({{opSetting:base_url}}/admin/settings/general).
 projects:
   demo-project:
     t_name: Demo project
@@ -997,3 +777,229 @@ projects:
       * Time boxed (3 h).
       * After Sprint Review, will be moderated by Scrum Master.
       * The team discusses the sprint: what went well, what needs to be improved to be more productive for the next sprint or even have more fun.
+
+statuses:
+  - reference: :default_status_new
+    t_name: New
+    color_name: cyan-7
+    default_done_ratio: 0
+    is_default: true
+    position: 1
+  - reference: :default_status_in_specification
+    t_name: In specification
+    color_name: blue-2
+    default_done_ratio: 10
+    position: 2
+  - reference: :default_status_specified
+    t_name: Specified
+    color_name: blue-2
+    default_done_ratio: 20
+    position: 3
+  - reference: :default_status_confirmed
+    t_name: Confirmed
+    color_name: violet-2
+    default_done_ratio: 20
+    position: 4
+  - reference: :default_status_to_be_scheduled
+    t_name: To be scheduled
+    color_name: yellow-2
+    default_done_ratio: 20
+    position: 5
+  - reference: :default_status_scheduled
+    t_name: Scheduled
+    color_name: lime-2
+    default_done_ratio: 20
+    position: 6
+  - reference: :default_status_in_progress
+    t_name: In progress
+    color_name: grape-5
+    default_done_ratio: 40
+    position: 7
+  - reference: :default_status_developed
+    t_name: Developed
+    color_name: green-3
+    default_done_ratio: 70
+    position: 8
+  - reference: :default_status_in_testing
+    t_name: In testing
+    color_name: cyan-5
+    default_done_ratio: 80
+    position: 9
+  - reference: :default_status_tested
+    t_name: Tested
+    color_name: teal-6
+    default_done_ratio: 90
+    position: 10
+  - reference: :default_status_test_failed
+    t_name: Test failed
+    color_name: red-5
+    default_done_ratio: 70
+    position: 11
+  - reference: :default_status_closed
+    t_name: Closed
+    color_name: gray-3
+    default_done_ratio: 100
+    is_closed: true
+    position: 12
+  - reference: :default_status_on_hold
+    t_name: On hold
+    color_name: orange-3
+    default_done_ratio: 0
+    position: 13
+  - reference: :default_status_rejected
+    t_name: Rejected
+    color_name: red-3
+    default_done_ratio: 0
+    is_closed: true
+    position: 14
+
+time_entry_activities:
+  - t_name: Management
+    is_default: true
+    position: 1
+  - t_name: Specification
+    position: 2
+  - t_name: Development
+    position: 3
+  - t_name: Testing
+    position: 4
+  - t_name: Support
+    position: 5
+  - t_name: Other
+    position: 6
+
+types:
+  - reference: :default_type_task
+    t_name: Task
+    is_default: true
+    color_name: :default_color_blue
+    is_in_roadmap: true
+    position: 1
+  - reference: :default_type_milestone
+    t_name: Milestone
+    is_default: true
+    color_name: :default_color_green_light
+    is_milestone: true
+    position: 2
+  - reference: :default_type_phase
+    t_name: Phase
+    is_default: true
+    color_name: 'orange-5'
+    position: 3
+  - reference: :default_type_feature
+    t_name: Feature
+    color_name: 'indigo-5'
+    is_in_roadmap: true
+    position: 4
+  - reference: :default_type_epic
+    t_name: Epic
+    color_name: 'violet-5'
+    is_in_roadmap: true
+    position: 5
+  - reference: :default_type_user_story
+    t_name: User story
+    color_name: :default_color_blue_light
+    is_in_roadmap: true
+    position: 6
+  - reference: :default_type_bug
+    t_name: Bug
+    color_name: 'red-7'
+    is_in_roadmap: true
+    position: 7
+
+workflows:
+  - type: :default_type_task
+    statuses:
+    - :default_status_new
+    - :default_status_in_progress
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_milestone
+    statuses:
+    - :default_status_new
+    - :default_status_to_be_scheduled
+    - :default_status_scheduled
+    - :default_status_in_progress
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_phase
+    statuses:
+    - :default_status_new
+    - :default_status_to_be_scheduled
+    - :default_status_scheduled
+    - :default_status_in_progress
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_feature
+    statuses:
+    - :default_status_new
+    - :default_status_in_specification
+    - :default_status_specified
+    - :default_status_in_progress
+    - :default_status_developed
+    - :default_status_in_testing
+    - :default_status_tested
+    - :default_status_test_failed
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_epic
+    statuses:
+    - :default_status_new
+    - :default_status_in_specification
+    - :default_status_specified
+    - :default_status_in_progress
+    - :default_status_developed
+    - :default_status_in_testing
+    - :default_status_tested
+    - :default_status_test_failed
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_user_story
+    statuses:
+    - :default_status_new
+    - :default_status_in_specification
+    - :default_status_specified
+    - :default_status_in_progress
+    - :default_status_developed
+    - :default_status_in_testing
+    - :default_status_tested
+    - :default_status_test_failed
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+  - type: :default_type_bug
+    statuses:
+    - :default_status_new
+    - :default_status_confirmed
+    - :default_status_in_progress
+    - :default_status_developed
+    - :default_status_in_testing
+    - :default_status_tested
+    - :default_status_test_failed
+    - :default_status_on_hold
+    - :default_status_rejected
+    - :default_status_closed
+
+welcome:
+  t_title: "Welcome to OpenProject!"
+  t_text: |
+    OpenProject is the leading open source project management software. It supports classic, agile as well as hybrid project management and gives you full control over your data.
+
+    Core features and use cases:
+
+    * [Project Portfolio Management](https://www.openproject.org/collaboration-software-features/project-portfolio-management/)
+    * [Project Planning and Scheduling](https://www.openproject.org/collaboration-software-features/project-planning-scheduling/)
+    * [Task Management and Issue Tracking](https://www.openproject.org/collaboration-software-features/task-management/)
+    * [Agile Boards (Scrum and Kanban)](https://www.openproject.org/collaboration-software-features/agile-project-management/)
+    * [Requirements Management and Release Planning](https://www.openproject.org/collaboration-software-features/product-development/)
+    * [Time and Cost Tracking, Budgets](https://www.openproject.org/collaboration-software-features/time-tracking/)
+    * [Team Collaboration and Documentation](https://www.openproject.org/collaboration-software-features/team-collaboration/)
+
+    Welcome to the future of project management.
+
+    For Admins: You can change this welcome text [here]({{opSetting:base_url}}/admin/settings/general).

--- a/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
@@ -54,15 +54,14 @@ RSpec.describe BasicData::ProjectCustomFieldSectionSeeder do
       SEEDING_DATA_YAML
     end
 
-    it "creates the corresponding sections with the given attributes" do
+    it "creates the corresponding sections with the given attributes", :aggregate_failures do
       expect(ProjectCustomFieldSection.count).to eq(2)
       expect(ProjectCustomFieldSection.find_by(name: "Project Attributes"))
         .to have_attributes(position: 1)
       expect(ProjectCustomFieldSection.find_by(name: "Project Attributes Two"))
         .to have_attributes(position: 2)
-    end
 
-    it "references the section in the seed data" do
+      # references the section in the seed data
       created_status = ProjectCustomFieldSection.last
       expect(seed_data.find_reference(:section_two)).to eq(created_status)
     end

--- a/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe BasicData::ProjectCustomFieldSectionSeeder do
+  include_context "with basic seed data"
+
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { basic_seed_data.merge(Source::SeedData.new(data_hash)) }
+
+  before do
+    seeder.seed!
+  end
+
+  context "with some sections defined" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        project_custom_field_sections:
+          - reference: :section_one
+            name: Project Attributes
+            position: 1
+          - reference: :section_two
+            name: Project Attributes Two
+            position: 2
+      SEEDING_DATA_YAML
+    end
+
+    it "creates the corresponding sections with the given attributes" do
+      expect(ProjectCustomFieldSection.count).to eq(2)
+      expect(ProjectCustomFieldSection.find_by(name: "Project Attributes"))
+        .to have_attributes(position: 1)
+      expect(ProjectCustomFieldSection.find_by(name: "Project Attributes Two"))
+        .to have_attributes(position: 2)
+    end
+
+    it "references the section in the seed data" do
+      created_status = ProjectCustomFieldSection.last
+      expect(seed_data.find_reference(:section_two)).to eq(created_status)
+    end
+
+    context "when seeding a second time" do
+      subject(:second_seeder) { described_class.new(second_seed_data) }
+
+      let(:second_seed_data) { basic_seed_data.merge(Source::SeedData.new(data_hash)) }
+
+      before do
+        second_seeder.seed!
+      end
+
+      it "registers existing matching sections as references in the seed data" do
+        # using the first seed data as the expected value
+        expect(second_seed_data.find_reference(:section_one))
+          .to eq(seed_data.find_reference(:section_one))
+        expect(second_seed_data.find_reference(:section_two))
+          .to eq(seed_data.find_reference(:section_two))
+      end
+    end
+  end
+
+  context "without sections defined" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        nothing here: ''
+      SEEDING_DATA_YAML
+    end
+
+    it "creates no sections" do
+      expect(ProjectCustomFieldSection.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
# What are you trying to accomplish?

Seed the default `ProjectCustomFieldSection` via the seeder.

## Screenshots
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/0ba6d5b6-e8f4-4640-850f-bd835977c10e">

# What approach did you choose and why?
Created a `BasicData::ProjectCustomFieldSectionSeeder` in order to seed the missing section with the basic data. Seeding via the basic data ensures that we will have the default section created on all seeding environments.

# Ticket
https://community.openproject.org/work_packages/56792

# Merge checklist

- [x] Added/updated tests
