### PR TITLE
Fix wiki pages being cut off with new content layout

### DIFF
--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -30,6 +30,9 @@
     background: #fff
     overflow: visible !important
 
+  #content
+    overflow: visible !important
+
   .autoscroll
     overflow-x: visible
 


### PR DESCRIPTION
`#content` also needs to be visible on wiki pages. Merging for 14.4 due to marked as high prio

# Ticket
https://community.openproject.org/work_packages/56576

# Merge checklist
