### PR TITLE
[56920] Backlogs and GitHub have unnecessarily nested menu nodes

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -542,12 +542,6 @@ Redmine::MenuManager.map :admin_menu do |menu|
             if: Proc.new { User.current.admin? },
             caption: :label_backlogs,
             icon: "op-backlogs"
-
-  menu.push :backlogs_settings,
-            { controller: "/backlogs_settings", action: :show },
-            if: Proc.new { User.current.admin? },
-            caption: :label_setting_plural,
-            parent: :admin_backlogs
 end
 
 Redmine::MenuManager.map :project_menu do |menu|

--- a/modules/backlogs/app/controllers/backlogs_settings_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs_settings_controller.rb
@@ -28,7 +28,7 @@
 
 class BacklogsSettingsController < ApplicationController
   layout "admin"
-  menu_item :backlogs_settings
+  menu_item :admin_backlogs
 
   before_action :require_admin
   before_action :check_valid_settings, only: :update
@@ -43,12 +43,10 @@ class BacklogsSettingsController < ApplicationController
   end
 
   def show_local_breadcrumb
-    true
+    false
   end
 
-  def default_breadcrumb
-    I18n.t(:label_backlogs)
-  end
+  def default_breadcrumb; end
 
   private
 

--- a/modules/backlogs/app/views/backlogs_settings/show.html.erb
+++ b/modules/backlogs/app/views/backlogs_settings/show.html.erb
@@ -29,6 +29,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), t(:label_backlogs) %>
 
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_backlogs) }
+    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
+                             t(:label_backlogs)])
+  end
+%>
+
 <%= form_tag(:admin_backlogs_settings, method: :put, name: 'admin_backlogs_form') do %>
   <div class="form--field">
     <%= styled_label_tag("settings[story_types]", t(:backlogs_story_type)) %>

--- a/modules/github_integration/app/controllers/deploy_targets_controller.rb
+++ b/modules/github_integration/app/controllers/deploy_targets_controller.rb
@@ -29,6 +29,8 @@
 class DeployTargetsController < ApplicationController
   layout "admin"
 
+  menu_item :admin_github_integration
+
   before_action :require_admin
 
   def index

--- a/modules/github_integration/app/views/deploy_targets/index.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/index.html.erb
@@ -31,10 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t(:label_deploy_target_plural) }
+    header.with_title { t(:label_github_integration) }
     header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
-                             { href: deploy_targets_path, text: t(:label_github_integration) },
-                             t(:label_deploy_target_plural)])
+                             t(:label_github_integration)])
   end
 %>
 

--- a/modules/github_integration/app/views/deploy_targets/new.html.erb
+++ b/modules/github_integration/app/views/deploy_targets/new.html.erb
@@ -34,7 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:label_deploy_target_new) }
     header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
                              { href: deploy_targets_path, text: t(:label_github_integration) },
-                             { href: deploy_targets_path, text: t(:label_deploy_target_plural) },
                              t(:label_deploy_target_new)])
   end
 %>

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -75,14 +75,6 @@ module OpenProject::GithubIntegration
                    enabled: -> { OpenProject::FeatureDecisions.deploy_targets_active? } # can only be enable at start-time
       end
 
-      menu :admin_menu,
-           :deploy_targets,
-           { controller: "/deploy_targets", action: "index" },
-           if: ->(*) { OpenProject::FeatureDecisions.deploy_targets_active? && User.current.admin? },
-           parent: :admin_github_integration,
-           caption: :label_deploy_target_plural,
-           icon: "cloud"
-
       menu :work_package_split_view,
            :github,
            { tab: :github },


### PR DESCRIPTION
# What are you trying to accomplish?
Remove nesting of modules for Backlogs and GitHub integration as they only have one submenu entry

## Screenshots
<img width="250" alt="Bildschirmfoto 2024-08-05 um 11 28 34" src="https://github.com/user-attachments/assets/b4193669-a013-40da-bd2c-776ea59bb216">


<img width="250" alt="Bildschirmfoto 2024-08-05 um 11 28 23" src="https://github.com/user-attachments/assets/499fd70d-75ff-4f67-840f-56600b9216f9">


# Ticket
https://community.openproject.org/projects/14/work_packages/56920/activity

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
