### PR TITLE
[#56899] Show storage sidebar for Nextcloud storages even when AMPF is deactivated

### DIFF
--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -42,16 +42,11 @@ See COPYRIGHT and LICENSE files for more details.
   %>
 <% end %>
 
-<% display_sidebar = @storage.provider_type_one_drive? || @storage.automatic_management_enabled? %>
-<% if display_sidebar %>
-  <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
-    <% component.with_main() do %>
-      <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
-    <% end %>
-    <% component.with_sidebar(col_placement: :end, row_placement: :end) do %>
-      <%= render(::Storages::Admin::SidePanelComponent.new(storage: @storage)) %>
-    <% end %>
+<%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
+  <% component.with_main() do %>
+    <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
   <% end %>
-<% else %>
-  <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
+  <% component.with_sidebar(col_placement: :end, row_placement: :end) do %>
+    <%= render(::Storages::Admin::SidePanelComponent.new(storage: @storage)) %>
+  <% end %>
 <% end %>

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
-  <% component.with_main() do %>
+  <% component.with_main do %>
     <%= render(::Storages::Admin::StorageViewComponent.new(@storage)) %>
   <% end %>
   <% component.with_sidebar(col_placement: :end, row_placement: :end) do %>

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe "Admin Edit File storage",
       visit edit_admin_settings_storage_path(storage)
 
       aggregate_failures "Health status" do
+        expect(page).to have_test_selector("validation-result--subtitle", text: "Connection validation")
         expect(page).to have_test_selector("storage-health-status", text: "Pending")
       end
 
@@ -242,9 +243,10 @@ RSpec.describe "Admin Edit File storage",
   context "with Nextcloud Storage and not automatically managed" do
     let(:storage) { create(:nextcloud_storage, :as_not_automatically_managed, name: "Cloud Storage") }
 
-    it "does not render health status information" do
+    it "renders health status information but without health notifications for automatically managed folders" do
       visit edit_admin_settings_storage_path(storage)
 
+      expect(page).to have_test_selector("validation-result--subtitle", text: "Connection validation")
       expect(page).not_to have_test_selector("storage-health-status")
       expect(page).not_to have_test_selector("storage-health-notifications-button")
     end
@@ -344,6 +346,7 @@ RSpec.describe "Admin Edit File storage",
       visit edit_admin_settings_storage_path(storage)
 
       aggregate_failures "Health status" do
+        expect(page).to have_test_selector("validation-result--subtitle", text: "Connection validation")
         expect(page).to have_test_selector("storage-health-status", text: "Pending")
       end
 
@@ -364,9 +367,10 @@ RSpec.describe "Admin Edit File storage",
   context "with OneDrive/SharePoint Storage and not automatically managed" do
     let(:storage) { create(:one_drive_storage, :as_not_automatically_managed, name: "Cloud Storage") }
 
-    it "does not render health status information" do
+    it "renders health status information but without health notifications for automatically managed folders" do
       visit edit_admin_settings_storage_path(storage)
 
+      expect(page).to have_test_selector("validation-result--subtitle", text: "Connection validation")
       expect(page).not_to have_test_selector("storage-health-status")
       expect(page).not_to have_test_selector("storage-health-notifications-button")
     end


### PR DESCRIPTION
https://community.openproject.org/work_packages/56899

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) => not necessary
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) => Tested in Chrome and Firefox
