### PR TITLE
Allow webauthn_challenge to be called

### DIFF
--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
@@ -10,6 +10,7 @@ module ::TwoFactorAuthentication
                                  :new,
                                  :confirm,
                                  :web_authn,
+                                 :webauthn_challenge,
                                  :make_default,
                                  :destroy
 


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/56988/activity?query_id=5094

Unfortunately, this cannot be tested automatically for the webauthn integration.