### PR TITLE
Allow lookup of already removed journal class

### DIFF
--- a/db/migrate/20220818074159_fix_deleted_data_journals.rb
+++ b/db/migrate/20220818074159_fix_deleted_data_journals.rb
@@ -116,9 +116,7 @@ class FixDeletedDataJournals < ActiveRecord::Migration[7.0]
     Journal
       .pluck("DISTINCT(journable_type)")
       .to_h do |journable_type|
-      journal_class = journable_type.constantize.journal_class
-      table_name = journal_class.table_name
-
+      table_name = lookup_journal_class_table(journable_type)
       relation = Journal
         .joins("LEFT OUTER JOIN #{table_name} ON journals.data_type = '#{journal_class}' AND #{table_name}.id = journals.data_id")
         .where("#{table_name}.id IS NULL")
@@ -128,6 +126,15 @@ class FixDeletedDataJournals < ActiveRecord::Migration[7.0]
         .includes(:journable)
 
       [journable_type, relation]
+    end
+  end
+
+  # Lookup table for items that were already deleted
+  def lookup_journal_class_table(journable_type)
+    lookup = { "WikiContent" => "wiki_content_journals" }
+    lookup.fetch(journable_type) do
+      journal_class = journable_type.constantize.journal_class
+      journal_class.table_name
     end
   end
 


### PR DESCRIPTION
When trying to migrate `FixDeletedDataJournals` directly to 14.x, we stumble upon the error that `WikiContent` has already been merged into `WikiPage`. But for the sake of migrations, we still want to fix that error.

So instead of relying on constantize, provide a lookup for the data table class manually.

https://community.openproject.org/work_packages/56846
