### PR TITLE
Set verify_partial_doubles=true

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -208,6 +208,8 @@ Rails/DynamicFindBy:
     - 'spec/features/**/*.rb'
     - 'spec/support/**/*.rb'
     - 'modules/*/spec/features/**/*.rb'
+  Whitelist:
+    - find_by_login
 
 # We have config.active_record.belongs_to_required_by_default = false ,
 # which means, we do have to declare presence validators on belongs_to relations.

--- a/modules/auth_plugins/spec/requests/auth_plugins_spec.rb
+++ b/modules/auth_plugins/spec/requests/auth_plugins_spec.rb
@@ -50,17 +50,21 @@ RSpec.describe OpenProject::Plugins::AuthPlugin, with_ee: %i[board_view] do
     app = Object.new
     omniauth_builder = Object.new
 
-    allow(omniauth_builder).to receive(:provider) { |strategy|
-      middlewares << strategy
-    }
+    without_partial_double_verification do
+      allow(omniauth_builder).to receive(:provider) { |strategy|
+        middlewares << strategy
+      }
 
-    allow(app).to receive_message_chain(:config, :middleware, :use) { |_mw, &block| # rubocop:disable RSpec/MessageChain
-      omniauth_builder.instance_eval(&block)
-    }
+      allow(app).to receive_message_chain(:config, :middleware, :use) { |_mw, &block| # rubocop:disable RSpec/MessageChain
+        omniauth_builder.instance_eval(&block)
+      }
+    end
 
     allow(described_class).to receive(:strategies).and_return(strategies)
-    allow(dummy_engine_klass).to receive(:engine_name).and_return("foobar")
-    allow(dummy_engine_klass).to receive(:initializer) { |_, &block| app.instance_eval(&block) }
+    without_partial_double_verification do
+      allow(dummy_engine_klass).to receive(:engine_name).and_return("foobar")
+      allow(dummy_engine_klass).to receive(:initializer) { |_, &block| app.instance_eval(&block) }
+    end
   end
 
   describe "ProviderBuilder" do

--- a/modules/auth_plugins/spec/views/base.html.erb_spec.rb
+++ b/modules/auth_plugins/spec/views/base.html.erb_spec.rb
@@ -36,9 +36,8 @@ RSpec.describe "layouts/base" do
 
     before do
       without_partial_double_verification do
-        allow(view).to receive(:current_menu_item).and_return("overview")
         allow(view).to receive(:default_breadcrumb)
-        allow(view).to receive(:current_user).and_return anonymous
+        allow(view).to receive_messages(current_menu_item: "overview", current_user: anonymous)
       end
       allow(OpenProject::Plugins::AuthPlugin).to receive(:providers).and_return([provider])
     end

--- a/modules/auth_plugins/spec/views/base.html.erb_spec.rb
+++ b/modules/auth_plugins/spec/views/base.html.erb_spec.rb
@@ -35,9 +35,11 @@ RSpec.describe "layouts/base" do
     let(:anonymous) { build_stubbed(:anonymous) }
 
     before do
-      allow(view).to receive(:current_menu_item).and_return("overview")
-      allow(view).to receive(:default_breadcrumb)
-      allow(view).to receive(:current_user).and_return anonymous
+      without_partial_double_verification do
+        allow(view).to receive(:current_menu_item).and_return("overview")
+        allow(view).to receive(:default_breadcrumb)
+        allow(view).to receive(:current_user).and_return anonymous
+      end
       allow(OpenProject::Plugins::AuthPlugin).to receive(:providers).and_return([provider])
     end
 

--- a/modules/backlogs/spec/controllers/backlogs_settings_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs_settings_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe BacklogsSettingsController do
       it "does not update the settings" do
         expect(Setting)
           .not_to(receive(:[]=))
-          .with("plugin_openproject_backlogs")
+          .with("plugin_openproject_backlogs", any_args)
 
         subject
 
@@ -97,7 +97,7 @@ RSpec.describe BacklogsSettingsController do
         it "does not update the settings" do
           expect(Setting)
             .not_to(receive(:[]=))
-            .with("plugin_openproject_backlogs")
+            .with("plugin_openproject_backlogs", any_args)
 
           subject
 

--- a/modules/bim/spec/views/bim/ifc_models/ifc_models/index.html.erb_spec.rb
+++ b/modules/bim/spec/views/bim/ifc_models/ifc_models/index.html.erb_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe "bim/ifc_models/ifc_models/index" do
   before do
     assign(:project, project)
     ifc_models = [ifc_model]
-    allow(ifc_models).to receive(:defaults).and_return(ifc_models)
+
+    without_partial_double_verification do
+      allow(ifc_models).to receive(:defaults).and_return(ifc_models)
+    end
+
     assign(:ifc_models, ifc_models)
 
     controller.request.path_parameters[:project_id] = project.id

--- a/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
+++ b/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
 
   before do
     without_partial_double_verification do
-      allow(subject).to receive(:current_user).and_return(user)
-      allow(subject).to receive(:represented).and_return(work_package)
+      allow(subject).to receive_messages(current_user: user, represented: work_package) # rubocop:disable RSpec/SubjectStub
     end
 
     mock_permissions_for(user) do |mock|

--- a/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
+++ b/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
@@ -52,8 +52,10 @@ RSpec.describe API::V3::CostsApiUserPermissionCheck do
   let(:work_package) { build_stubbed(:work_package, project:) }
 
   before do
-    allow(subject).to receive(:current_user).and_return(user)
-    allow(subject).to receive(:represented).and_return(work_package)
+    without_partial_double_verification do
+      allow(subject).to receive(:current_user).and_return(user)
+      allow(subject).to receive(:represented).and_return(work_package)
+    end
 
     mock_permissions_for(user) do |mock|
       mock.allow_in_project :view_time_entries, project: work_package.project if view_time_entries

--- a/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
@@ -29,37 +29,10 @@
 require "spec_helper"
 
 RSpec.describe Queries::TimeEntries::Filters::ActivityFilter do
-  let(:time_entry_activity1) { build_stubbed(:time_entry_activity) }
-  let(:time_entry_activity2) { build_stubbed(:time_entry_activity) }
-  let(:activities) { [time_entry_activity1, time_entry_activity2] }
+  shared_let(:activities) { create_list(:time_entry_activity, 2) }
+
   let(:plucked_allowed_values) do
     activities.map { |x| [x.name, x.id] }
-  end
-
-  before do
-    allow(TimeEntryActivity)
-      .to receive(:shared)
-      .and_return(activities)
-
-    allow(TimeEntryActivity)
-      .to receive_message_chain(:where, :or)
-      .and_return(activities)
-
-    without_partial_double_verification do
-      allow(activities)
-        .to receive(:where)
-        .and_return(activities)
-
-      allow(activities)
-        .to receive(:pluck)
-        .with(:id)
-        .and_return(activities.map(&:id))
-
-      allow(activities)
-        .to receive(:pluck)
-        .with(:name, :id)
-        .and_return(activities.map { |x| [x.name, x.id] })
-    end
   end
 
   it_behaves_like "basic query filter" do

--- a/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
@@ -45,19 +45,21 @@ RSpec.describe Queries::TimeEntries::Filters::ActivityFilter do
       .to receive_message_chain(:where, :or)
       .and_return(activities)
 
-    allow(activities)
-      .to receive(:where)
-      .and_return(activities)
+    without_partial_double_verification do
+      allow(activities)
+        .to receive(:where)
+        .and_return(activities)
 
-    allow(activities)
-      .to receive(:pluck)
-      .with(:id)
-      .and_return(activities.map(&:id))
+      allow(activities)
+        .to receive(:pluck)
+        .with(:id)
+        .and_return(activities.map(&:id))
 
-    allow(activities)
-      .to receive(:pluck)
-      .with(:name, :id)
-      .and_return(activities.map { |x| [x.name, x.id] })
+      allow(activities)
+        .to receive(:pluck)
+        .with(:name, :id)
+        .and_return(activities.map { |x| [x.name, x.id] })
+    end
   end
 
   it_behaves_like "basic query filter" do

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TwoFactorAuthentication::AuthenticationController, with_settings:
     session[:stage_secrets] = { two_factor_authentication: "asdf" }
 
     without_partial_double_verification do
-      allow_any_instance_of(User).to receive(:any_active_memberships?).and_return(true)
+      allow_any_instance_of(User).to receive(:any_active_memberships?).and_return(true) # rubocop:disable RSpec/AnyInstance
     end
   end
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe TwoFactorAuthentication::AuthenticationController, with_settings:
   before do
     # Assume the user has any memberships
     session[:stage_secrets] = { two_factor_authentication: "asdf" }
-    allow_any_instance_of(User).to receive(:any_active_memberships?).and_return(true)
+
+    without_partial_double_verification do
+      allow_any_instance_of(User).to receive(:any_active_memberships?).and_return(true)
+    end
   end
 
   describe "with no active strategy", with_settings: { "plugin_openproject_two_factor_authentication" => {} } do

--- a/spec/components/members/delete_member_dialog_component_spec.rb
+++ b/spec/components/members/delete_member_dialog_component_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe Members::DeleteMemberDialogComponent, type: :component do
       let(:principal) { build_stubbed(:user) }
 
       before do
-        allow(member).to receive(:inherited_shared_work_packages_count?).and_return(true)
+        without_partial_double_verification do
+          allow(member).to receive(:inherited_shared_work_packages_count?).and_return(true)
+        end
       end
 
       it "renders dialog" do
@@ -107,7 +109,9 @@ RSpec.describe Members::DeleteMemberDialogComponent, type: :component do
     let(:stubs) { { can_delete?: false, can_delete_roles?: true, may_delete_shares?: true, shared_work_packages?: true } }
 
     before do
-      allow(member).to receive(:inherited_shared_work_packages_count?).and_return(true)
+      without_partial_double_verification do
+        allow(member).to receive(:inherited_shared_work_packages_count?).and_return(true)
+      end
     end
 
     it "renders dialog" do

--- a/spec/components/members/delete_work_package_shares_dialog_component_spec.rb
+++ b/spec/components/members/delete_work_package_shares_dialog_component_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe Members::DeleteWorkPackageSharesDialogComponent, type: :component
   let(:may_manage_user?) { true }
 
   before do
-    allow(member).to receive_messages(stubs)
+    without_partial_double_verification do
+      allow(member).to receive_messages(stubs)
+    end
   end
 
   context "when there are direct, inherited and shares with filtered out role" do

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -519,8 +519,6 @@ RSpec.describe AccountController, :skip_2fa_stage do
 
       context "with a valid token" do
         before do
-          allow(controller).to receive(:allow_lost_password_recovery?).and_return(true)
-
           post :lost_password, params: { token: token.value }
         end
 
@@ -732,7 +730,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
         end
 
         it "doesn't activate the user but sends out a token instead" do
-          expect(User.find_by_login("register")).not_to be_active # rubocop:disable Rails/DynamicFindBy
+          expect(User.find_by_login("register")).not_to be_active
           token = Token::Invitation.last
           expect(token.user.mail).to eq("register@example.com")
           expect(token).not_to be_expired
@@ -778,7 +776,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
         end
 
         it "doesn't activate the user" do
-          expect(User.find_by_login("register")).not_to be_active # rubocop:disable Rails/DynamicFindBy
+          expect(User.find_by_login("register")).not_to be_active
         end
 
         it "calls the user_registered callback" do

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
 
       context "with a valid token" do
         before do
-          allow(controller).to receive(:allow_lost_password_recovery).and_return(true)
+          allow(controller).to receive(:allow_lost_password_recovery?).and_return(true)
 
           post :lost_password, params: { token: token.value }
         end

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe AccountController, :skip_2fa_stage do # rubocop:disable RSpec/Spe
 
           auth_source_registration = omniauth_hash.merge(
             omniauth: true,
-            timestamp: Time.zone.now
+            timestamp: Time.current
           )
           session[:auth_source_registration] = auth_source_registration
           post :register,

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
             end
 
             it "is rejected against google" do
-              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user)
+              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user, any_args)
 
               post :omniauth_login, params: { provider: :google }
 
@@ -416,7 +416,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
             end
 
             it "is rejected against any other provider too" do
-              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user)
+              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user, any_args)
 
               omniauth_hash.provider = "any other"
               post :omniauth_login, params: { provider: :google }
@@ -434,7 +434,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
             end
 
             it "is rejected against google" do
-              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user)
+              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user, any_args)
 
               post :omniauth_login, params: { provider: :google }
 
@@ -461,7 +461,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
 
             # ... and to confirm that, here's what happens when the authorization fails
             it "is rejected against any other provider with the wrong email" do
-              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user)
+              expect(OpenProject::OmniAuth::Authorization).not_to receive(:after_login!).with(user, any_args)
 
               omniauth_hash.provider = "yet another"
               config.global_email = "yarrrr@joro.es"

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -389,11 +389,10 @@ RSpec.describe AccountController, :skip_2fa_stage do # rubocop:disable RSpec/Spe
           context "with wrong email address" do
             before do
               config.global_email = "other@mail.com"
+              allow(OpenProject::OmniAuth::Authorization).to receive(:after_login!)
             end
 
             it "is rejected against google" do
-              allow(OpenProject::OmniAuth::Authorization).to receive(:after_login!)
-
               post :omniauth_login, params: { provider: :google }
 
               expect(response).to redirect_to signin_path
@@ -403,8 +402,6 @@ RSpec.describe AccountController, :skip_2fa_stage do # rubocop:disable RSpec/Spe
             end
 
             it "is rejected against any other provider too" do
-              allow(OpenProject::OmniAuth::Authorization).to receive(:after_login!)
-
               omniauth_hash.provider = "any other"
               post :omniauth_login, params: { provider: :google }
 

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -322,7 +322,6 @@ RSpec.describe CustomStylesController do
       context "if it exists" do
         before do
           allow(CustomStyle).to receive(:current).and_return(custom_style)
-          allow(custom_style).to receive(:remove_cover).and_call_original
           delete :export_cover_delete
         end
 

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -152,10 +152,13 @@ RSpec.describe SettingsHelper do
     before do
       allow(Setting).to receive(:host_name).at_least(:once).and_return("2")
       allow(Setting).to receive(:protocol).at_least(:once).and_return("3")
-      allow(Setting).to receive_messages(
-        host_name_writable?: true,
-        protocol_writable?: true
-      )
+
+      without_partial_double_verification do
+        allow(Setting).to receive_messages(
+          host_name_writable?: true,
+          protocol_writable?: true
+        )
+      end
     end
 
     it_behaves_like "not wrapped in container"

--- a/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
+++ b/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
@@ -43,25 +43,33 @@ RSpec.describe "Models acting as list (acts_as_list)" do
     end
 
     it "moves to top when wanting to move highest" do
-      expect(includer).to receive :move_to_top
+      without_partial_double_verification do
+        expect(includer).to receive :move_to_top
+      end
 
       includer.move_to = "highest"
     end
 
     it "moves to bottom when wanting to move lowest" do
-      expect(includer).to receive :move_to_bottom
+      without_partial_double_verification do
+        expect(includer).to receive :move_to_bottom
+      end
 
       includer.move_to = "lowest"
     end
 
     it "moves higher when wanting to move higher" do
-      expect(includer).to receive :move_higher
+      without_partial_double_verification do
+        expect(includer).to receive :move_higher
+      end
 
       includer.move_to = "higher"
     end
 
     it "moves lower when wanting to move lower" do
-      expect(includer).to receive :move_lower
+      without_partial_double_verification do
+        expect(includer).to receive :move_lower
+      end
 
       includer.move_to = "lower"
     end

--- a/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
+++ b/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
@@ -28,50 +28,65 @@
 
 require "spec_helper"
 
-RSpec.describe "Models acting as list (acts_as_list)" do
+RSpec.describe "Models acting as list (acts_as_list)" do # rubocop:disable RSpec/DescribeClass
   it "includes the patch" do
     expect(ActiveRecord::Acts::List::InstanceMethods.included_modules).to include(OpenProject::Patches::ActsAsList)
   end
 
   describe "#move_to=" do
     let(:includer) do
-      class ActsAsListPatchIncluder
+      clazz = Class.new do
         include OpenProject::Patches::ActsAsList
+
+        def move_to_top; end
+
+        def move_to_bottom; end
+
+        def move_higher; end
+
+        def move_lower; end
       end
 
-      ActsAsListPatchIncluder.new
+      clazz.new
+    end
+
+    before do
+      allow(includer).to receive(:move_to_top)
+      allow(includer).to receive(:move_to_bottom)
+      allow(includer).to receive(:move_higher)
+      allow(includer).to receive(:move_lower)
     end
 
     it "moves to top when wanting to move highest" do
-      without_partial_double_verification do
-        expect(includer).to receive :move_to_top
-      end
-
       includer.move_to = "highest"
+
+      without_partial_double_verification do
+        expect(includer).to have_received :move_to_top
+      end
     end
 
     it "moves to bottom when wanting to move lowest" do
-      without_partial_double_verification do
-        expect(includer).to receive :move_to_bottom
-      end
-
       includer.move_to = "lowest"
+
+      without_partial_double_verification do
+        expect(includer).to have_received :move_to_bottom
+      end
     end
 
     it "moves higher when wanting to move higher" do
-      without_partial_double_verification do
-        expect(includer).to receive :move_higher
-      end
-
       includer.move_to = "higher"
+
+      without_partial_double_verification do
+        expect(includer).to have_received :move_higher
+      end
     end
 
     it "moves lower when wanting to move lower" do
-      without_partial_double_verification do
-        expect(includer).to receive :move_lower
-      end
-
       includer.move_to = "lower"
+
+      without_partial_double_verification do
+        expect(includer).to have_received :move_lower
+      end
     end
   end
 end

--- a/spec/lib/api/decorators/link_object_spec.rb
+++ b/spec/lib/api/decorators/link_object_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe API::Decorators::LinkObject do
 
     before do
       represented.foo_id = 1
-      allow(api_v3_paths).to receive(:foo) { |id| "/api/v3/foos/#{id}" }
+      without_partial_double_verification do
+        allow(api_v3_paths).to receive(:foo) { |id| "/api/v3/foos/#{id}" }
+      end
     end
 
     describe "generation" do
@@ -89,7 +91,10 @@ RSpec.describe API::Decorators::LinkObject do
 
     before do
       represented.getter = 1
-      allow(api_v3_paths).to receive(:foo_path) { |id| "/api/v3/fuhs/#{id}" }
+
+      without_partial_double_verification do
+        allow(api_v3_paths).to receive(:foo_path) { |id| "/api/v3/fuhs/#{id}" }
+      end
     end
 
     describe "generation" do

--- a/spec/lib/api/v3/groups/group_collection_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_collection_representer_spec.rb
@@ -32,19 +32,21 @@ RSpec.describe API::V3::Groups::GroupCollectionRepresenter do
   let(:self_base_link) { "/api/v3/groups" }
   let(:groups) do
     build_stubbed_list(:group, 3).tap do |groups|
-      allow(groups)
-        .to receive(:offset)
-        .with(page - 1)
-        .and_return(groups)
+      without_partial_double_verification do
+        allow(groups)
+          .to receive(:offset)
+          .with(page - 1)
+          .and_return(groups)
 
-      allow(groups)
-        .to receive(:limit)
-        .with(page_size)
-        .and_return(groups)
+        allow(groups)
+          .to receive(:limit)
+          .with(page_size)
+          .and_return(groups)
 
-      allow(groups)
-        .to receive(:count)
-        .and_return(total)
+        allow(groups)
+          .to receive(:count)
+          .and_return(total)
+      end
     end
   end
   let(:current_user) { build_stubbed(:user) }

--- a/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
@@ -32,19 +32,21 @@ RSpec.describe API::V3::Memberships::MembershipCollectionRepresenter do
   let(:self_base_link) { "/api/v3/members" }
   let(:members) do
     build_stubbed_list(:member, 3).tap do |members|
-      allow(members)
-        .to receive(:limit)
-        .with(page_size)
-        .and_return(members)
+      without_partial_double_verification do
+        allow(members)
+          .to receive(:limit)
+          .with(page_size)
+          .and_return(members)
 
-      allow(members)
-        .to receive(:offset)
-        .with(page - 1)
-        .and_return(members)
+        allow(members)
+          .to receive(:offset)
+          .with(page - 1)
+          .and_return(members)
 
-      allow(members)
-        .to receive(:count)
-        .and_return(3)
+        allow(members)
+          .to receive(:count)
+          .and_return(3)
+      end
     end
   end
   let(:current_user) { build_stubbed(:user) }

--- a/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
@@ -34,19 +34,21 @@ RSpec.describe API::V3::Notifications::NotificationCollectionRepresenter do
   let(:notification_list) { build_stubbed_list(:notification, 3) }
   let(:notifications) do
     notification_list.tap do |items|
-      allow(items)
+      without_partial_double_verification do
+        allow(items)
         .to receive(:limit)
               .with(page_size)
               .and_return(items)
 
-      allow(items)
-        .to receive(:offset)
-              .with(page - 1)
-              .and_return(items)
+        allow(items)
+          .to receive(:offset)
+                .with(page - 1)
+                .and_return(items)
 
-      allow(items)
-        .to receive(:count)
-              .and_return(total)
+        allow(items)
+          .to receive(:count)
+                .and_return(total)
+      end
     end
   end
   let(:current_user) { build_stubbed(:user) }

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
@@ -40,19 +40,21 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUserCollectionRepresenter d
   let(:placeholders) do
     placeholders = build_stubbed_list(:placeholder_user,
                                       actual_count)
-    allow(placeholders)
-      .to receive(:limit)
-      .with(page_size)
-      .and_return(placeholders)
+    without_partial_double_verification do
+      allow(placeholders)
+        .to receive(:limit)
+        .with(page_size)
+        .and_return(placeholders)
 
-    allow(placeholders)
-      .to receive(:offset)
-      .with(page - 1)
-      .and_return(placeholders)
+      allow(placeholders)
+        .to receive(:offset)
+        .with(page - 1)
+        .and_return(placeholders)
 
-    allow(placeholders)
-      .to receive(:count)
-      .and_return(total)
+      allow(placeholders)
+        .to receive(:count)
+        .and_return(total)
+    end
 
     placeholders
   end

--- a/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
@@ -35,19 +35,21 @@ RSpec.describe API::V3::Relations::RelationPaginatedCollectionRepresenter do
 
   let(:relations) do
     build_stubbed_list(:relation, total).tap do |relations|
-      allow(relations)
-        .to receive(:limit)
-              .with(page_size)
-              .and_return(relations)
+      without_partial_double_verification do
+        allow(relations)
+          .to receive(:limit)
+                .with(page_size)
+                .and_return(relations)
 
-      allow(relations)
-        .to receive(:offset)
-              .with(page - 1)
-              .and_return(relations)
+        allow(relations)
+          .to receive(:offset)
+                .with(page - 1)
+                .and_return(relations)
 
-      allow(relations)
-        .to receive(:count)
-              .and_return(relations.length)
+        allow(relations)
+          .to receive(:count)
+                .and_return(relations.length)
+      end
     end
   end
 

--- a/spec/lib/api/v3/shares/share_collection_representer_spec.rb
+++ b/spec/lib/api/v3/shares/share_collection_representer_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe API::V3::Shares::ShareCollectionRepresenter do
   let(:self_base_link) { "/api/v3/shares" }
   let(:members) do
     build_stubbed_list(:work_package_member, 3).tap do |members|
-      allow(members).to receive(:limit).with(page_size).and_return(members)
-      allow(members).to receive(:offset).with(page - 1).and_return(members)
-      allow(members).to receive(:count).and_return(3)
+      without_partial_double_verification do
+        allow(members).to receive(:limit).with(page_size).and_return(members)
+        allow(members).to receive(:offset).with(page - 1).and_return(members)
+        allow(members).to receive(:count).and_return(3)
+      end
     end
   end
   let(:current_user) { build_stubbed(:user) }

--- a/spec/lib/api/v3/users/user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_collection_representer_spec.rb
@@ -39,19 +39,21 @@ RSpec.describe API::V3::Users::UserCollectionRepresenter do
   let(:users) do
     users = build_stubbed_list(:user,
                                actual_count)
-    allow(users)
-      .to receive(:limit)
-      .with(page_size)
-      .and_return(users)
+    without_partial_double_verification do
+      allow(users)
+        .to receive(:limit)
+        .with(page_size)
+        .and_return(users)
 
-    allow(users)
-      .to receive(:offset)
-      .with(page - 1)
-      .and_return(users)
+      allow(users)
+        .to receive(:offset)
+        .with(page - 1)
+        .and_return(users)
 
-    allow(users)
-      .to receive(:count)
-      .and_return(total)
+      allow(users)
+        .to receive(:count)
+        .and_return(total)
+    end
 
     users
   end

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -89,11 +89,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
               .with(:wrapped?)
               .and_return(true)
       allow(wp)
-        .to receive(:available_custom_fields)
-        .and_return(available_custom_fields)
-      allow(wp)
-        .to receive(:custom_field_values)
-        .and_return([custom_value])
+        .to receive_messages(available_custom_fields:, custom_field_values: [custom_value])
     end
   end
   let(:timestamp) { Timestamp.new(1.day.ago) }
@@ -109,23 +105,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
       # Mimicking the eager loading wrapper
       without_partial_double_verification do
         allow(model)
-          .to receive(:timestamp)
-                .and_return(timestamp)
-        allow(model)
-          .to receive(:attributes_changed_to_baseline)
-                .and_return(attributes_changed_to_baseline)
-        allow(model)
-          .to receive(:exists_at_timestamp?)
-                .and_return(exists_at_timestamp)
-        allow(model)
-          .to receive(:with_query?)
-                .and_return(with_query)
-        allow(model)
-          .to receive(:matches_filters_at_timestamp?)
-                .and_return(matches_filters_at_timestamp)
-        allow(model)
-          .to receive(:exists_at_current_timestamp?)
-                .and_return(exists_at_current_timestamp)
+          .to receive_messages(timestamp:, attributes_changed_to_baseline:,
+                               exists_at_timestamp?: exists_at_timestamp,
+                               with_query?: with_query,
+                               matches_filters_at_timestamp?: matches_filters_at_timestamp,
+                               exists_at_current_timestamp?: exists_at_current_timestamp)
       end
     end
   end

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -107,24 +107,26 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
   let(:model) do
     work_package.tap do |model|
       # Mimicking the eager loading wrapper
-      allow(model)
-        .to receive(:timestamp)
-              .and_return(timestamp)
-      allow(model)
-        .to receive(:attributes_changed_to_baseline)
-              .and_return(attributes_changed_to_baseline)
-      allow(model)
-        .to receive(:exists_at_timestamp?)
-              .and_return(exists_at_timestamp)
-      allow(model)
-        .to receive(:with_query?)
-              .and_return(with_query)
-      allow(model)
-        .to receive(:matches_filters_at_timestamp?)
-              .and_return(matches_filters_at_timestamp)
-      allow(model)
-        .to receive(:exists_at_current_timestamp?)
-              .and_return(exists_at_current_timestamp)
+      without_partial_double_verification do
+        allow(model)
+          .to receive(:timestamp)
+                .and_return(timestamp)
+        allow(model)
+          .to receive(:attributes_changed_to_baseline)
+                .and_return(attributes_changed_to_baseline)
+        allow(model)
+          .to receive(:exists_at_timestamp?)
+                .and_return(exists_at_timestamp)
+        allow(model)
+          .to receive(:with_query?)
+                .and_return(with_query)
+        allow(model)
+          .to receive(:matches_filters_at_timestamp?)
+                .and_return(matches_filters_at_timestamp)
+        allow(model)
+          .to receive(:exists_at_current_timestamp?)
+                .and_return(exists_at_current_timestamp)
+      end
     end
   end
 

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -470,7 +470,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   context "when passing groups" do
     let(:groups) do
       group = { "custom" => "object" }
-      allow(group).to receive(:has_sums?).and_return false
+
+      without_partial_double_verification do
+        allow(group).to receive(:has_sums?).and_return false
+      end
+
       [group]
     end
 
@@ -482,7 +486,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   context "when passing groups with sums" do
     let(:groups) do
       group = { "sums" => {} }
-      allow(group).to receive(:has_sums?).and_return true
+
+      without_partial_double_verification do
+        allow(group).to receive(:has_sums?).and_return true
+      end
+
       [group]
     end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1510,14 +1510,16 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
         end
 
         it "factors in the eager loaded cache_checksum" do
-          allow(work_package)
-            .to receive(:cache_checksum)
-                  .and_return(srand)
+          without_partial_double_verification do
+            allow(work_package)
+              .to receive(:cache_checksum)
+                    .and_return(srand)
 
-          representer.json_cache_key
+            representer.json_cache_key
 
-          expect(work_package)
-            .to have_received(:cache_checksum)
+            expect(work_package)
+              .to have_received(:cache_checksum)
+          end
         end
       end
     end

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -58,9 +58,11 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     before do
-      allow(resource)
-        .to receive(custom_field.attribute_getter)
-              .and_return(typed_value)
+      without_partial_double_verification do
+        allow(resource)
+          .to receive(custom_field.attribute_getter)
+                .and_return(typed_value)
+      end
     end
 
     subject(:output) do
@@ -259,9 +261,11 @@ RSpec.describe CustomFieldFormBuilder do
       before do
         custom_field.field_format = "user"
 
-        allow(project)
-          .to receive(custom_field.attribute_getter)
-          .and_return typed_value
+        without_partial_double_verification do
+          allow(project)
+            .to receive(custom_field.attribute_getter)
+            .and_return typed_value
+        end
 
         allow(project)
           .to(receive(:principals))
@@ -314,13 +318,16 @@ RSpec.describe CustomFieldFormBuilder do
 
       before do
         custom_field.field_format = "version"
-        allow(project)
-          .to receive(custom_field.attribute_getter)
-                .and_return typed_value
 
-        allow(project)
-          .to receive(:shared_versions)
-                .and_return([version1, version2])
+        without_partial_double_verification do
+          allow(project)
+            .to receive(custom_field.attribute_getter)
+                  .and_return typed_value
+
+          allow(project)
+            .to receive(:shared_versions)
+                  .and_return([version1, version2])
+        end
       end
 
       it_behaves_like "wrapped in container", "select-container" do

--- a/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
@@ -37,34 +37,36 @@ RSpec.describe "OpenProject child pages macro" do
     # no-op
   end
 
-  let(:project) do
+  shared_let(:project) do
     create(:valid_project,
            enabled_module_names: %w[wiki])
   end
-  let(:input) {}
-  let(:member_project) do
+  shared_let(:member_project) do
     create(:valid_project,
            identifier: "member-project",
            enabled_module_names: %w[wiki])
   end
-  let(:invisible_project) do
+  shared_let(:invisible_project) do
     create(:valid_project,
            identifier: "other-project",
            enabled_module_names: %w[wiki])
   end
-  let(:role) { create(:project_role, permissions: [:view_wiki_pages]) }
-  let(:user) do
-    create(:user, member_with_roles: { project => role, member_project => role })
+  shared_let(:user) do
+    create(:user, member_with_permissions: { project => [:view_wiki_pages],
+                                             member_project => [:view_wiki_pages] })
   end
 
-  let(:current_page) do
+  before_all do
+    set_factory_default(:user, user)
+  end
+
+  shared_let(:current_page) do
     create(:wiki_page,
            title: "Current page",
-           wiki: project.wiki,
-           text: input)
+           wiki: project.wiki)
   end
 
-  let(:middle_page) do
+  shared_let(:middle_page) do
     create(:wiki_page,
            title: "Node from same project",
            wiki: project.wiki,
@@ -72,14 +74,14 @@ RSpec.describe "OpenProject child pages macro" do
            text: "# Node Page from same project")
   end
 
-  let(:node_page_invisible_project) do
+  shared_let(:node_page_invisible_project) do
     create(:wiki_page,
            title: "Node page from invisible project",
            wiki: invisible_project.wiki,
            text: "# Page from invisible project")
   end
 
-  let(:leaf_page) do
+  shared_let(:leaf_page) do
     create(:wiki_page,
            title: "Leaf page from same project",
            parent_id: middle_page.id,
@@ -87,7 +89,7 @@ RSpec.describe "OpenProject child pages macro" do
            text: "# Leaf page from same project")
   end
 
-  let(:leaf_page_invisible_project) do
+  shared_let(:leaf_page_invisible_project) do
     create(:wiki_page,
            title: "Leaf page from invisible project",
            parent_id: node_page_invisible_project.id,
@@ -95,24 +97,19 @@ RSpec.describe "OpenProject child pages macro" do
            text: "# Leaf page from invisible project")
   end
 
-  let(:leaf_page_member_project) do
+  shared_let(:leaf_page_member_project) do
     create(:wiki_page,
            title: "Leaf page from member project",
            wiki: member_project.wiki,
            text: "# Leaf page from member project")
   end
 
-  subject { format_text(current_page, :text) }
-
-  before do
-    login_as user
-    leaf_page
-    leaf_page_invisible_project
-
-    without_partial_double_verification do
-      allow(Setting).to receive(:text_formatting).and_return("markdown")
-    end
+  subject do
+    current_page.update(text: input)
+    format_text(current_page, :text)
   end
+
+  current_user { user }
 
   def error_html(exception_msg)
     "<p class=\"op-uc-p\"><macro class=\"macro-unavailable\" data-macro-name=\"child_pages\">" \
@@ -125,7 +122,7 @@ RSpec.describe "OpenProject child pages macro" do
     it { is_expected.to be_html_eql(error_html("Cannot find the wiki page 'Invalid'.")) }
   end
 
-  context "old macro syntax no longer works" do
+  describe "old macro syntax no longer works" do
     let(:input) { "{{child_pages(whatever)}}" }
 
     it { is_expected.to be_html_eql("<p class=\"op-uc-p\">#{input}</p>") }
@@ -183,8 +180,6 @@ RSpec.describe "OpenProject child pages macro" do
     let(:input) do
       '<macro class="child_pages" data-page="member-project:leaf-page-from-member-project" data-include-parent="true"></macro>'
     end
-
-    before { leaf_page_member_project }
 
     it { is_expected.to match(leaf_page_member_project.title) }
   end

--- a/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
@@ -108,7 +108,10 @@ RSpec.describe "OpenProject child pages macro" do
     login_as user
     leaf_page
     leaf_page_invisible_project
-    allow(Setting).to receive(:text_formatting).and_return("markdown")
+
+    without_partial_double_verification do
+      allow(Setting).to receive(:text_formatting).and_return("markdown")
+    end
   end
 
   def error_html(exception_msg)

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -66,9 +66,11 @@ RSpec.describe DigestMailer do
         .to receive(:where)
               .and_return(notifications)
 
-      allow(notifications)
-        .to receive(:includes)
-              .and_return(notifications)
+      without_partial_double_verification do
+        allow(notifications)
+          .to receive(:includes)
+                .and_return(notifications)
+      end
     end
   end
 

--- a/spec/migrations/fix_untranslated_work_package_roles_spec.rb
+++ b/spec/migrations/fix_untranslated_work_package_roles_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe FixUntranslatedWorkPackageRoles, type: :model do
 
       describe "when #{env_var_name} is set with an unsupported language", :settings_reset do
         it "uses the English name", :settings_reset do
-          allow(Settings).to receive(:default_language).and_return("pt-br")
+          allow(Setting).to receive(:default_language).and_return("pt-br")
           run_migration
 
           expect(WorkPackageRole.find_by(builtin: WorkPackageRole::BUILTIN_WORK_PACKAGE_EDITOR))

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -614,15 +614,19 @@ RSpec.describe CustomActions::Actions::CustomField do
       let(:custom_field) { send(:"#{type}_custom_field") }
 
       it "sets the value for #{type} custom fields" do
-        allow(work_package)
-          .to receive(custom_field.attribute_setter)
+        without_partial_double_verification do
+          allow(work_package)
+            .to receive(custom_field.attribute_setter)
+        end
 
         instance.values = 42
         instance.apply(work_package)
 
-        expect(work_package)
-          .to have_received(custom_field.attribute_setter)
-          .with([42])
+        without_partial_double_verification do
+          expect(work_package)
+            .to have_received(custom_field.attribute_setter)
+            .with([42])
+        end
       end
     end
 
@@ -630,15 +634,17 @@ RSpec.describe CustomActions::Actions::CustomField do
       let(:custom_field) { date_custom_field }
 
       it "sets the value to today for a dynamic value" do
-        allow(work_package)
-          .to receive(custom_field.attribute_setter)
+        without_partial_double_verification do
+          allow(work_package)
+            .to receive(custom_field.attribute_setter)
 
-        instance.values = "%CURRENT_DATE%"
-        instance.apply(work_package)
+          instance.values = "%CURRENT_DATE%"
+          instance.apply(work_package)
 
-        expect(work_package)
-          .to have_received(custom_field.attribute_setter)
-                .with(Date.current)
+          expect(work_package)
+            .to have_received(custom_field.attribute_setter)
+                  .with(Date.current)
+        end
       end
     end
   end

--- a/spec/models/queries/work_packages/filter/principal_loader_spec.rb
+++ b/spec/models/queries/work_packages/filter/principal_loader_spec.rb
@@ -96,9 +96,11 @@ RSpec.describe Queries::WorkPackages::Filter::PrincipalLoader do
         .to receive(:visible)
         .and_return(matching_principals)
 
-      allow(matching_principals)
-        .to receive(:not_builtin)
-              .and_return(matching_principals)
+      without_partial_double_verification do
+        allow(matching_principals)
+          .to receive(:not_builtin)
+                .and_return(matching_principals)
+      end
     end
 
     describe "#user_values" do

--- a/spec/models/queries/work_packages/filter/project_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/project_filter_spec.rb
@@ -45,14 +45,16 @@ RSpec.describe Queries::WorkPackages::Filter::ProjectFilter do
         .to receive(:active)
               .and_return(visible_projects)
 
-      allow(visible_projects)
-        .to receive(:exists?)
-              .and_return(visible_projects.any?)
+      without_partial_double_verification do
+        allow(visible_projects)
+          .to receive(:exists?)
+                .and_return(visible_projects.any?)
 
-      allow(visible_projects)
-        .to receive(:where) do |args|
-        ids = args[:id]
-        visible_projects.select { |p| ids.include?(p.id) }
+        allow(visible_projects)
+          .to receive(:where) do |args|
+          ids = args[:id]
+          visible_projects.select { |p| ids.include?(p.id) }
+        end
       end
     end
 

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = false
+    mocks.verify_partial_doubles = true
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will

--- a/spec/services/oauth_clients/connection_manager_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_spec.rb
@@ -510,20 +510,25 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
 
       before do
         allow(instance).to receive(:refresh_token).and_return refresh_service_result
-        allow(yield_double_object)
-          .to receive(:yield_twice_method)
-                .and_return(
-                  yield_service_result1,
-                  yield_service_result2
-                )
+
+        without_partial_double_verification do
+          allow(yield_double_object)
+            .to receive(:yield_twice_method)
+                  .and_return(
+                    yield_service_result1,
+                    yield_service_result2
+                  )
+        end
       end
 
       it "returns a ServiceResult with success, without refresh" do
-        expect(subject.success).to be_truthy
-        expect(subject).to be yield_service_result2
-        expect(instance).to have_received(:refresh_token)
-        expect(oauth_client_token).to have_received(:reload)
-        expect(yield_double_object).to have_received(:yield_twice_method).twice
+        without_partial_double_verification do
+          expect(subject.success).to be_truthy
+          expect(subject).to be yield_service_result2
+          expect(instance).to have_received(:refresh_token)
+          expect(oauth_client_token).to have_received(:reload)
+          expect(yield_double_object).to have_received(:yield_twice_method).twice
+        end
       end
     end
   end

--- a/spec/services/projects/delete_service_spec.rb
+++ b/spec/services/projects/delete_service_spec.rb
@@ -39,13 +39,15 @@ RSpec.describe Projects::DeleteService, type: :model do
   context "if authorized" do
     context "when destroy succeeds" do
       it "destroys the projects" do
-        allow(project).to receive(:archive)
-        allow(Projects::DeleteProjectJob).to receive(:new)
+        without_partial_double_verification do
+          allow(project).to receive(:archive)
+          allow(Projects::DeleteProjectJob).to receive(:new)
 
-        expect { subject }.to change(Project, :count).by(-1)
-        expect(project).not_to have_received(:archive)
-        expect(Projects::DeleteProjectJob)
-          .not_to have_received(:new)
+          expect { subject }.to change(Project, :count).by(-1)
+          expect(project).not_to have_received(:archive)
+          expect(Projects::DeleteProjectJob)
+            .not_to have_received(:new)
+        end
       end
 
       context "when the file storages are involved", :webmock do

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -135,17 +135,6 @@ RSpec.describe Projects::SetAttributesService, type: :model do
               .to eql "lorem"
           end
         end
-
-        context "with no identifier provided" do
-          it "stays nil" do
-            allow(Project)
-              .to receive(:next_identifier)
-              .and_return("ipsum")
-
-            expect(subject.result.identifier)
-              .to be_nil
-          end
-        end
       end
 
       describe "public default value", with_settings: { default_projects_public: true } do

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Users::LoginService, type: :model do
 
   before do
     allow(Sessions::DropOtherSessionsService)
-      .to receive(:call)
+      .to receive(:call!)
       .with(input_user, session)
 
     allow(controller)

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1583,20 +1583,18 @@ RSpec.describe WorkPackages::SetAttributesService,
     end
 
     before do
-      allow(new_project)
-        .to receive(:shared_versions)
-              .and_return(new_versions)
-      allow(new_project_categories)
+      without_partial_double_verification do
+        allow(new_project_categories)
         .to receive(:find_by)
               .with(name: category.name)
               .and_return nil
-      allow(new_project)
-        .to receive(:types)
-              .and_return(new_types)
-      allow(new_types)
-        .to receive(:order)
-              .with(:position)
-              .and_return(new_types)
+        allow(new_project)
+          .to receive_messages(shared_versions: new_versions, types: new_types)
+        allow(new_types)
+          .to receive(:order)
+                .with(:position)
+                .and_return(new_types)
+      end
     end
 
     shared_examples_for "updating the project" do
@@ -1775,7 +1773,7 @@ RSpec.describe WorkPackages::SetAttributesService,
     subject { instance.call(call_attributes) }
 
     context "for non existing fields" do
-      let(:call_attributes) { { custom_field_891: "1" } } # rubocop:disable Naming/VariableNumber
+      let(:call_attributes) { { custom_field_891: "1" } }
 
       before do
         subject

--- a/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
+++ b/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
@@ -30,9 +30,11 @@ RSpec.shared_context "eager loaded work package representer" do
   before do
     allow(API::V3::WorkPackages::WorkPackageEagerLoadingWrapper)
       .to receive(:wrap_one) do |work_package, _user|
-      allow(work_package)
-        .to receive(:cache_checksum)
-        .and_return(srand)
+      without_partial_double_verification do
+        allow(work_package)
+          .to receive(:cache_checksum)
+          .and_return(srand)
+      end
 
       work_package
     end

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -106,7 +106,8 @@ class WithDirectUploads
 
     if redirect
       stub_with_redirect
-    else # use status response instead of redirect by default
+    else
+      # use status response instead of redirect by default
       stub_with_status
     end
   end
@@ -147,15 +148,17 @@ class WithDirectUploads
   def stub_uploader
     creds = config[:fog][:credentials]
 
-    allow_any_instance_of(FogFileUploader).to receive(:fog_credentials).and_return creds
+    without_partial_double_verification do
+      allow_any_instance_of(FogFileUploader).to receive(:fog_credentials).and_return creds
 
-    allow_any_instance_of(FogFileUploader).to receive(:aws_access_key_id).and_return creds[:aws_access_key_id]
-    allow_any_instance_of(FogFileUploader).to receive(:aws_secret_access_key).and_return creds[:aws_secret_access_key]
-    allow_any_instance_of(FogFileUploader).to receive(:provider).and_return creds[:provider]
-    allow_any_instance_of(FogFileUploader).to receive(:region).and_return creds[:region]
-    allow_any_instance_of(FogFileUploader).to receive(:directory).and_return config[:fog][:directory]
+      allow_any_instance_of(FogFileUploader).to receive(:aws_access_key_id).and_return creds[:aws_access_key_id]
+      allow_any_instance_of(FogFileUploader).to receive(:aws_secret_access_key).and_return creds[:aws_secret_access_key]
+      allow_any_instance_of(FogFileUploader).to receive(:provider).and_return creds[:provider]
+      allow_any_instance_of(FogFileUploader).to receive(:region).and_return creds[:region]
+      allow_any_instance_of(FogFileUploader).to receive(:directory).and_return config[:fog][:directory]
 
-    allow(OpenProject::Configuration).to receive(:direct_uploads?).and_return(true)
+      allow(OpenProject::Configuration).to receive(:direct_uploads?).and_return(true)
+    end
   end
 
   def stub_config(example)

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -149,6 +149,7 @@ class WithDirectUploads
     creds = config[:fog][:credentials]
 
     without_partial_double_verification do
+      # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(FogFileUploader).to receive(:fog_credentials).and_return creds
 
       allow_any_instance_of(FogFileUploader).to receive(:aws_access_key_id).and_return creds[:aws_access_key_id]
@@ -158,6 +159,7 @@ class WithDirectUploads
       allow_any_instance_of(FogFileUploader).to receive(:directory).and_return config[:fog][:directory]
 
       allow(OpenProject::Configuration).to receive(:direct_uploads?).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
     end
   end
 

--- a/spec/support_spec/mocked_permission_helper_spec.rb
+++ b/spec/support_spec/mocked_permission_helper_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe MockedPermissionHelper do
     end
 
     it "allows the project permission when querying with controller and action hash" do
-      expect(user).to be_allowed_in_project({ controller: "work_packages", action: "index", project_id: project.id })
+      expect(user).to be_allowed_in_project({ controller: "work_packages", action: "index", project_id: project.id }, nil)
       expect(user).to be_allowed_in_any_project({ controller: "work_packages", action: "index" })
     end
 

--- a/spec/views/layouts/admin.html.erb_spec.rb
+++ b/spec/views/layouts/admin.html.erb_spec.rb
@@ -36,13 +36,12 @@ RSpec.describe "layouts/admin" do
 
   before do
     without_partial_double_verification do
-      allow(view).to receive(:current_menu_item).and_return("overview")
       allow(view).to receive(:default_breadcrumb)
-      allow(view).to receive(:current_user).and_return admin
 
       parent_menu_item = Object.new
       allow(parent_menu_item).to receive(:name).and_return :root
-      allow(view).to receive(:admin_first_level_menu_entry).and_return parent_menu_item
+      allow(view).to receive_messages(current_menu_item: "overview", current_user: admin,
+                                      admin_first_level_menu_entry: parent_menu_item)
 
       allow(controller).to receive(:default_search_scope)
       allow(view).to receive(:render_to_string)

--- a/spec/views/layouts/admin.html.erb_spec.rb
+++ b/spec/views/layouts/admin.html.erb_spec.rb
@@ -35,18 +35,20 @@ RSpec.describe "layouts/admin" do
   helper Redmine::MenuManager::MenuHelper
 
   before do
-    allow(view).to receive(:current_menu_item).and_return("overview")
-    allow(view).to receive(:default_breadcrumb)
-    allow(controller).to receive(:default_search_scope)
+    without_partial_double_verification do
+      allow(view).to receive(:current_menu_item).and_return("overview")
+      allow(view).to receive(:default_breadcrumb)
+      allow(view).to receive(:current_user).and_return admin
 
-    parent_menu_item = Object.new
-    allow(view).to receive(:admin_first_level_menu_entry).and_return parent_menu_item
-    allow(parent_menu_item).to receive(:name).and_return :root
+      parent_menu_item = Object.new
+      allow(parent_menu_item).to receive(:name).and_return :root
+      allow(view).to receive(:admin_first_level_menu_entry).and_return parent_menu_item
+
+      allow(controller).to receive(:default_search_scope)
+      allow(view).to receive(:render_to_string)
+    end
 
     allow(User).to receive(:current).and_return admin
-    allow(view).to receive(:current_user).and_return admin
-    allow(view)
-      .to receive(:render_to_string)
   end
 
   # All password-based authentication is to be hidden and disabled if

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -42,11 +42,10 @@ RSpec.describe "layouts/base" do
 
   before do
     without_partial_double_verification do
-      allow(view).to receive(:current_menu_item).and_return("overview")
       allow(view).to receive(:default_breadcrumb)
       allow(controller).to receive(:default_search_scope)
       allow(view).to receive(:render_to_string)
-      allow(view).to receive(:current_user).and_return current_user
+      allow(view).to receive_messages(current_menu_item: "overview", current_user:)
     end
 
     allow(User).to receive(:current).and_return current_user

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -41,14 +41,15 @@ RSpec.describe "layouts/base" do
   let(:anonymous) { build_stubbed(:anonymous) }
 
   before do
-    allow(view).to receive(:current_menu_item).and_return("overview")
-    allow(view).to receive(:default_breadcrumb)
-    allow(controller).to receive(:default_search_scope)
-    allow(view)
-      .to receive(:render_to_string)
+    without_partial_double_verification do
+      allow(view).to receive(:current_menu_item).and_return("overview")
+      allow(view).to receive(:default_breadcrumb)
+      allow(controller).to receive(:default_search_scope)
+      allow(view).to receive(:render_to_string)
+      allow(view).to receive(:current_user).and_return current_user
+    end
 
     allow(User).to receive(:current).and_return current_user
-    allow(view).to receive(:current_user).and_return current_user
   end
 
   describe "Sign in button" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe "users/edit" do
       assign(:user, user)
       assign(:auth_sources, [])
 
-      allow(view).to receive(:current_user).and_return(admin)
+      without_partial_double_verification do
+        allow(view).to receive(:current_user).and_return(admin)
+      end
     end
 
     it "shows the authentication provider" do
@@ -75,7 +77,9 @@ RSpec.describe "users/edit" do
 
     context "for an admin" do
       before do
-        allow(view).to receive(:current_user).and_return(admin)
+        without_partial_double_verification do
+          allow(view).to receive(:current_user).and_return(admin)
+        end
         render
       end
 
@@ -88,7 +92,9 @@ RSpec.describe "users/edit" do
       let(:non_admin) { create(:user, global_permissions: [:manage_user]) }
 
       before do
-        allow(view).to receive(:current_user).and_return(non_admin)
+        without_partial_double_verification do
+          allow(view).to receive(:current_user).and_return(non_admin)
+        end
         render
       end
 
@@ -105,7 +111,9 @@ RSpec.describe "users/edit" do
       assign(:user, user)
       assign(:auth_sources, [])
 
-      allow(view).to receive(:current_user).and_return(admin)
+      without_partial_double_verification do
+        allow(view).to receive(:current_user).and_return(admin)
+      end
       render
     end
 
@@ -121,7 +129,9 @@ RSpec.describe "users/edit" do
       assign :user, user
       assign :auth_sources, []
 
-      allow(view).to receive(:current_user).and_return(admin)
+      without_partial_double_verification do
+        allow(view).to receive(:current_user).and_return(admin)
+      end
     end
 
     context "with password login disabled" do

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -39,9 +39,11 @@ RSpec.describe "users/index" do
     assign(:status, "all")
     assign(:groups, Group.all)
 
-    allow(view).to receive(:current_user).and_return(admin)
-    allow(view).to receive(:controller_name).and_return("users")
-    allow(view).to receive(:action_name).and_return("index")
+    without_partial_double_verification do
+      allow(view).to receive(:current_user).and_return(admin)
+      allow(view).to receive(:controller_name).and_return("users")
+      allow(view).to receive(:action_name).and_return("index")
+    end
   end
 
   subject { rendered.squish }

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe "users/index" do
     assign(:groups, Group.all)
 
     without_partial_double_verification do
-      allow(view).to receive(:current_user).and_return(admin)
-      allow(view).to receive(:controller_name).and_return("users")
-      allow(view).to receive(:action_name).and_return("index")
+      allow(view).to receive_messages(current_user: admin, controller_name: "users", action_name: "index")
     end
   end
 

--- a/spec/views/wiki/new.html.erb_spec.rb
+++ b/spec/views/wiki/new.html.erb_spec.rb
@@ -41,9 +41,12 @@ RSpec.describe "wiki/new" do
     assign(:wiki,    wiki)
     assign(:page,    page)
     assign(:content, content)
-    allow(view)
-      .to receive(:current_user)
-      .and_return(user)
+
+    without_partial_double_verification do
+      allow(view)
+        .to receive(:current_user)
+        .and_return(user)
+    end
   end
 
   it "renders a form which POSTs to create_project_wiki_index_path" do

--- a/spec/workers/mails/shared/member_job.rb
+++ b/spec/workers/mails/shared/member_job.rb
@@ -67,23 +67,25 @@ RSpec.shared_examples "member job" do
     build_stubbed(:group).tap do |g|
       scope = group_user_members
 
-      allow(Member)
-        .to receive(:of_project)
-              .with(project)
-              .and_return(scope)
+      without_partial_double_verification do
+        allow(Member)
+          .to receive(:of_project)
+                .with(project)
+                .and_return(scope)
 
-      allow(scope)
-        .to receive(:where)
-              .with(principal: group_users)
-              .and_return(scope)
+        allow(scope)
+          .to receive(:where)
+                .with(principal: group_users)
+                .and_return(scope)
 
-      allow(scope)
-        .to receive(:includes)
-              .and_return(scope)
+        allow(scope)
+          .to receive(:includes)
+                .and_return(scope)
 
-      allow(g)
-        .to receive(:users)
-              .and_return(group_users)
+        allow(g)
+          .to receive(:users)
+                .and_return(group_users)
+      end
     end
   end
   let(:group_user_members) { [] }

--- a/spec/workers/mails/shared/watcher_job.rb
+++ b/spec/workers/mails/shared/watcher_job.rb
@@ -53,9 +53,11 @@ RSpec.shared_examples "watcher job" do |action|
         .to receive(:notification_settings)
               .and_return(notification_settings)
 
-      allow(notification_settings)
-        .to receive(:applicable)
-              .and_return(notification_settings)
+      without_partial_double_verification do
+        allow(notification_settings)
+          .to receive(:applicable)
+                .and_return(notification_settings)
+      end
     end
   end
 

--- a/spec/workers/mails/work_package_shared_job_spec.rb
+++ b/spec/workers/mails/work_package_shared_job_spec.rb
@@ -82,21 +82,23 @@ RSpec.describe Mails::WorkPackageSharedJob, type: :model do
                 .with(work_package)
                 .and_return(group_user_members)
 
-        allow(scope)
-          .to receive_messages(joins: scope, references: scope)
+        without_partial_double_verification do
+          allow(scope)
+            .to receive_messages(joins: scope, references: scope)
 
-        allow(scope)
-          .to receive(:where)
-                .with(principal: group_users)
-                .and_return(scope)
+          allow(scope)
+            .to receive(:where)
+                  .with(principal: group_users)
+                  .and_return(scope)
 
-        allow(scope)
-          .to receive_messages(group: scope, having: scope, select: group_user_members_due_an_email.map(&:id))
+          allow(scope)
+            .to receive_messages(group: scope, having: scope, select: group_user_members_due_an_email.map(&:id))
 
-        allow(Member)
-          .to receive(:where)
-                .with(id: group_user_members_due_an_email.map(&:id))
-                .and_return(group_user_members_due_an_email)
+          allow(Member)
+            .to receive(:where)
+                  .with(id: group_user_members_due_an_email.map(&:id))
+                  .and_return(group_user_members_due_an_email)
+        end
       end
     end
     let(:group_member_role) do


### PR DESCRIPTION
Enable `verify_partial_doubles`: https://www.rubydoc.info/github/rspec/rspec-mocks/RSpec%2FMocks%2FConfiguration:verify_partial_doubles=

For those tests that fail and aren't easily corrected, use `without_partial_double_verification` block