### PR TITLE
[#55299] Project attributes: Fix phrasing of "required" and "visible" fields

### DIFF
--- a/app/contracts/custom_fields/base_contract.rb
+++ b/app/contracts/custom_fields/base_contract.rb
@@ -42,7 +42,7 @@ module CustomFields
     attribute :possible_values
     attribute :regexp
     attribute :searchable
-    attribute :visible
+    attribute :admin_only
     attribute :default_value
     attribute :possible_values
     attribute :multi_value

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -67,7 +67,7 @@ module Projects
       if user.admin?
         model.available_custom_fields
       else
-        model.available_custom_fields.select(&:visible?)
+        model.available_custom_fields.reject(&:admin_only?)
       end
     end
 

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -42,7 +42,7 @@ class CustomValue < ApplicationRecord
            to: :strategy
 
   delegate :editable?,
-           :visible?,
+           :admin_only?,
            :required?,
            :max_length,
            :min_length,

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -472,7 +472,7 @@ class PermittedParams
           :possible_values,
           :regexp,
           :searchable,
-          :visible,
+          :admin_only,
           :default_value,
           :possible_values,
           :multi_value,

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -43,9 +43,9 @@ class ProjectCustomField < CustomField
       if user.admin?
         all
       elsif user.allowed_in_any_project?(:select_project_custom_fields) || user.allowed_globally?(:add_project)
-        where(visible: true)
+        where(admin_only: false)
       else
-        where(visible: true).where(mappings_with_view_project_attributes_permission(user, project).exists)
+        where(admin_only: false).where(mappings_with_view_project_attributes_permission(user, project).exists)
       end
     end
 

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -207,13 +207,13 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field">
       <%= f.check_box :is_required %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.is_required') %></p>
+        <p><%= t('custom_fields.instructions.is_required_for_project') %></p>
       </div>
     </div>
     <div class="form--field">
       <%= f.check_box :admin_only %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.admin_only') %></p>
+        <p><%= t('custom_fields.instructions.admin_only_for_project') %></p>
       </div>
     </div>
     <div class="form--field" <%= format_dependent.attributes(:searchable) %>>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -192,9 +192,9 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
     </div>
     <div class="form--field">
-      <%= f.check_box :visible %>
+      <%= f.check_box :admin_only %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.visible') %></p>
+        <p><%= t('custom_fields.instructions.admin_only') %></p>
       </div>
     </div>
     <div class="form--field">
@@ -211,9 +211,9 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
     </div>
     <div class="form--field">
-      <%= f.check_box :visible %>
+      <%= f.check_box :admin_only %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.visible') %></p>
+        <p><%= t('custom_fields.instructions.admin_only') %></p>
       </div>
     </div>
     <div class="form--field" <%= format_dependent.attributes(:searchable) %>>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,11 +235,11 @@ en:
     reorder_alphabetical: "Reorder values alphabetically"
     reorder_confirmation: "Warning: The current order of available values will be lost. Continue?"
     instructions:
-      is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources."
+      is_required: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."
       is_for_all: "Mark the custom field as available in all existing and new projects."
-      searchable: "Include the field values when using the global search functionality."
+      searchable: "Check to make this attribute available as a filter in project lists."
       editable: "Allow the field to be editable by users themselves."
-      visible: "Make field visible for all users (non-admins) in the project overview and displayed in the project details widget on the Project Overview."
+      admin_only: "Check to make this attribute only visible to administrators. Users without admin rights will not be able to view or edit it."
       is_filter: >
         Allow the custom field to be used in a filter in work package views.
         Note that only with 'For all projects' selected, the custom field will show up in global views.
@@ -684,14 +684,14 @@ en:
         editable: "Editable"
         field_format: "Format"
         is_filter: "Used as a filter"
-        is_required: "Required"
+        is_required: "Required for all projects"
         max_length: "Maximum length"
         min_length: "Minimum length"
         multi_value: "Allow multi-select"
         possible_values: "Possible values"
         regexp: "Regular expression"
         searchable: "Searchable"
-        visible: "Visible"
+        admin_only: "Admin-only"
       custom_value:
         value: "Value"
       doorkeeper/application:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,11 +235,13 @@ en:
     reorder_alphabetical: "Reorder values alphabetically"
     reorder_confirmation: "Warning: The current order of available values will be lost. Continue?"
     instructions:
-      is_required: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."
+      is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources."
+      is_required_for_project: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."
       is_for_all: "Mark the custom field as available in all existing and new projects."
       searchable: "Check to make this attribute available as a filter in project lists."
       editable: "Allow the field to be editable by users themselves."
       admin_only: "Check to make this attribute only visible to administrators. Users without admin rights will not be able to view or edit it."
+      admin_only_for_project: "Make field visible for all users (non-admins) in the project overview and displayed in the project details widget on the Project Overview."
       is_filter: >
         Allow the custom field to be used in a filter in work package views.
         Note that only with 'For all projects' selected, the custom field will show up in global views.
@@ -684,7 +686,7 @@ en:
         editable: "Editable"
         field_format: "Format"
         is_filter: "Used as a filter"
-        is_required: "Required for all projects"
+        is_required: "Required"
         max_length: "Maximum length"
         min_length: "Minimum length"
         multi_value: "Allow multi-select"
@@ -761,6 +763,7 @@ en:
         versions: "Versions"
         work_packages: "Work Packages"
       project_custom_field:
+        is_required: "Required for all projects"
         custom_field_section: Section
       query:
         column_names: "Columns"

--- a/db/migrate/20240805104004_rename_visible_to_admin_only_in_custom_fields.rb
+++ b/db/migrate/20240805104004_rename_visible_to_admin_only_in_custom_fields.rb
@@ -1,0 +1,40 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "migration_utils/utils"
+
+class RenameVisibleToAdminOnlyInCustomFields < ActiveRecord::Migration[7.1]
+  include ::Migration::Utils
+
+  def change
+    rename_column :custom_fields, :visible, :admin_only
+    change_column_default :custom_fields, :admin_only, from: true, to: false
+
+    execute_sql("UPDATE custom_fields SET admin_only = NOT admin_only")
+  end
+end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -385,7 +385,7 @@ module API
             custom_fields = if current_user.admin?
                               represented.available_custom_fields
                             else
-                              represented.available_custom_fields.select(&:visible?)
+                              represented.available_custom_fields.reject(&:admin_only?)
                             end
 
             custom_field_class(custom_fields)

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -168,7 +168,7 @@ module Redmine
         end
 
         def visible_custom_field_values
-          custom_field_values.select(&:visible?)
+          custom_field_values.reject(&:admin_only?)
         end
 
         def custom_value_for(c)

--- a/spec/components/users/profile/attributes_component_spec.rb
+++ b/spec/components/users/profile/attributes_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Users::Profile::AttributesComponent, type: :component do
     end
 
     context "when user has a non-visible custom field with a present value" do
-      let(:custom_field) { create(:user_custom_field, :string, visible: false) }
+      let(:custom_field) { create(:user_custom_field, :string, admin_only: true) }
       let(:user) { build(:user, custom_values: [build(:custom_value, custom_field:, value: "Hello")]) }
 
       it { is_expected.to be(false) }
@@ -71,11 +71,11 @@ RSpec.describe Users::Profile::AttributesComponent, type: :component do
   end
 
   describe "Custom field" do
-    let(:custom_field) { create(:user_custom_field, :string, visible:) }
+    let(:custom_field) { create(:user_custom_field, :string, admin_only:) }
     let(:custom_values) do
       [build(:custom_value, custom_field:, value: "Hello custom field")]
     end
-    let(:visible) { true }
+    let(:admin_only) { false }
     let(:user) { build_stubbed(:user, custom_values:) }
 
     current_user { build(:admin) }
@@ -89,7 +89,7 @@ RSpec.describe Users::Profile::AttributesComponent, type: :component do
     end
 
     context "when not visible" do
-      let(:visible) { false }
+      let(:admin_only) { true }
 
       it "does not render the field" do
         expect(page).to have_no_text("Hello custom field")
@@ -97,8 +97,8 @@ RSpec.describe Users::Profile::AttributesComponent, type: :component do
     end
 
     context "with multiple custom fields" do
-      let(:list_custom_field) { create(:user_custom_field, :multi_list, visible:, name: "Ze list") }
-      let(:text_custom_field) { create(:user_custom_field, :text, visible:, name: "A portrait") }
+      let(:list_custom_field) { create(:user_custom_field, :multi_list, admin_only:, name: "Ze list") }
+      let(:text_custom_field) { create(:user_custom_field, :text, admin_only:, name: "A portrait") }
       let(:custom_values) do
         [
           build(:custom_value, custom_field: list_custom_field, value: list_custom_field.possible_values[0]),

--- a/spec/contracts/project_custom_field_project_mappings/base_contract_spec.rb
+++ b/spec/contracts/project_custom_field_project_mappings/base_contract_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProjectCustomFieldProjectMappings::BaseContract do
   end
 
   context "with non-visible custom field and admin user" do
-    let(:project_custom_field) { build_stubbed(:project_custom_field, visible: false) }
+    let(:project_custom_field) { build_stubbed(:project_custom_field, admin_only: true) }
 
     before do
       allow(ProjectCustomField).to receive(:all).and_return([project_custom_field])
@@ -60,7 +60,7 @@ RSpec.describe ProjectCustomFieldProjectMappings::BaseContract do
 
   context "with non-visible custom field and non-admin user" do
     let(:user) { build_stubbed(:user) }
-    let(:project_custom_field) { build_stubbed(:project_custom_field, visible: false) }
+    let(:project_custom_field) { build_stubbed(:project_custom_field, admin_only: true) }
 
     before do
       allow(ProjectCustomField).to receive(:visible).and_return([project_custom_field])

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -269,8 +269,8 @@ RSpec.shared_examples_for "project contract" do
   end
 
   describe "available_custom_fields" do
-    let(:visible_custom_field) { build_stubbed(:integer_project_custom_field, visible: true) }
-    let(:invisible_custom_field) { build_stubbed(:integer_project_custom_field, visible: false) }
+    let(:visible_custom_field) { build_stubbed(:integer_project_custom_field, admin_only: false) }
+    let(:invisible_custom_field) { build_stubbed(:integer_project_custom_field, admin_only: true) }
 
     before do
       allow(project)

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     max_length { false }
     editable { true }
     possible_values { "" }
-    visible { true }
+    admin_only { false }
     field_format { "bool" }
 
     after(:create) do

--- a/spec/factories/work_package_custom_field_factory.rb
+++ b/spec/factories/work_package_custom_field_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     max_length { false }
     editable { true }
     possible_values { "" }
-    visible { true }
+    admin_only { false }
     field_format { "bool" }
     type { "WorkPackageCustomField" }
   end

--- a/spec/features/admin/project_custom_fields/create_spec.rb
+++ b/spec/features/admin/project_custom_fields/create_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "Create project custom fields", :js do
 
       fill_in("custom_field_name", with: "New custom field")
       select(section_for_select_fields.name, from: "custom_field_custom_field_section_id")
+      check "Admin-only"
 
       click_on("Save")
 
@@ -74,6 +75,7 @@ RSpec.describe "Create project custom fields", :js do
       latest_custom_field = ProjectCustomField.reorder(created_at: :asc).last
 
       expect(latest_custom_field.name).to eq("New custom field")
+      expect(latest_custom_field.admin_only).to be(true)
       expect(latest_custom_field.project_custom_field_section).to eq(section_for_select_fields)
     end
 

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Projects copy", :js, :with_cuprite,
     context "with correct handling of invisible values" do
       let!(:invisible_field) do
         create(:string_project_custom_field, name: "Text for Admins only",
-                                             visible: false,
+                                             admin_only: true,
                                              project_custom_field_section:,
                                              projects: [project])
       end

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe "Projects", "creation",
     context "with correct handling of invisible values" do
       let!(:invisible_field) do
         create(:string_project_custom_field, name: "Text for Admins only",
-                                             visible: false,
+                                             admin_only: true,
                                              project_custom_field_section:)
       end
 

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Persisted lists on projects index page",
   shared_let(:developer) { create(:project_role, name: "Developer") }
 
   shared_let(:custom_field) { create(:text_project_custom_field) }
-  shared_let(:invisible_custom_field) { create(:project_custom_field, visible: false) }
+  shared_let(:invisible_custom_field) { create(:project_custom_field, admin_only: true) }
 
   shared_let(:project) do
     create(:project,

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
     let!(:visible_project_custom_field) do
       create(:project_custom_field,
              name: "Normal field",
-             visible: true,
+             admin_only: false,
              projects: [project],
              project_custom_field_section: section_with_invisible_fields)
     end
@@ -156,7 +156,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
     let!(:invisible_project_custom_field) do
       create(:project_custom_field,
              name: "Admin only field",
-             visible: false,
+             admin_only: true,
              projects: [project],
              project_custom_field_section: section_with_invisible_fields)
     end

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
       let(:field) { FormFields::Primerized::InputField.new(custom_field) }
 
       before do
-        all_fields.without(string_project_custom_field).each { |cf| cf.update(visible: false) }
+        all_fields.without(string_project_custom_field).each { |cf| cf.update(admin_only: true) }
       end
 
       it "does not clears them after a project admin updates" do

--- a/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
+++ b/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe "Projects custom fields mapping via project settings", :js, :with
       let!(:visible_project_custom_field) do
         create(:project_custom_field,
                name: "Normal field",
-               visible: true,
+               admin_only: false,
                projects: [project],
                project_custom_field_section: section_with_invisible_fields)
       end
@@ -340,7 +340,7 @@ RSpec.describe "Projects custom fields mapping via project settings", :js, :with
       let!(:invisible_project_custom_field) do
         create(:project_custom_field,
                name: "Admin only field",
-               visible: false,
+               admin_only: true,
                projects: [project],
                project_custom_field_section: section_with_invisible_fields)
       end

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
   shared_let(:developer) { create(:project_role, name: "Developer") }
 
   shared_let(:custom_field) { create(:text_project_custom_field) }
-  shared_let(:invisible_custom_field) { create(:project_custom_field, visible: false) }
+  shared_let(:invisible_custom_field) { create(:project_custom_field, admin_only: true) }
 
   shared_let(:project) { create(:project, name: "Plain project", identifier: "plain-project") }
   shared_let(:public_project) do

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
     end
   end
 
-  let(:int_custom_field) { build_stubbed(:integer_project_custom_field, visible: false) }
-  let(:version_custom_field) { build_stubbed(:version_project_custom_field, visible: true) }
+  let(:int_custom_field) { build_stubbed(:integer_project_custom_field, admin_only: true) }
+  let(:version_custom_field) { build_stubbed(:version_project_custom_field, admin_only: false) }
   let(:int_custom_value) do
     CustomValue.new(custom_field: int_custom_field,
                     value: "1234",
@@ -164,7 +164,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
 
       context "if the user is no admin and the field is visible" do
         before do
-          int_custom_field.visible = true
+          int_custom_field.admin_only = false
         end
 
         it "has a property for the int custom field" do
@@ -177,7 +177,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
         let(:permissions) { [] }
 
         before do
-          int_custom_field.visible = true
+          int_custom_field.admin_only = false
         end
 
         it "has no property for the int custom field" do
@@ -512,7 +512,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
             .to receive(:admin?)
                   .and_return(true)
 
-          version_custom_field.visible = false
+          version_custom_field.admin_only = true
         end
 
         it "links custom fields" do
@@ -523,7 +523,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
 
       context "if the user is no admin and the field is invisible" do
         before do
-          version_custom_field.visible = false
+          version_custom_field.admin_only = true
         end
 
         it "does not link the custom field" do

--- a/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
+++ b/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe RenameVisibleToAdminOnlyInCustomFields, type: :model do
         .to change { CustomField.first.attributes.slice("visible", "admin_only") }
         .from("visible" => false)
         .to("admin_only" => true)
+
+      # it changes the default value to false
+      ProjectCustomField.reset_column_information
+      custom_field = ProjectCustomField.new
+      custom_field.save(validate: false)
+
+      expect(custom_field.admin_only).to be false
     end
   end
 
@@ -64,6 +71,13 @@ RSpec.describe RenameVisibleToAdminOnlyInCustomFields, type: :model do
         .to change { CustomField.first.attributes.slice("visible", "admin_only") }
         .from("admin_only" => false)
         .to("visible" => true)
+
+      # it changes the default value to tru
+      ProjectCustomField.reset_column_information
+      custom_field = ProjectCustomField.new
+      custom_field.save(validate: false)
+
+      expect(custom_field.visible).to be true
     end
   end
 end

--- a/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
+++ b/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20240805104004_rename_visible_to_admin_only_in_custom_fields.rb")
+
+RSpec.describe RenameVisibleToAdminOnlyInCustomFields, type: :model do
+  after do
+    # Reset after each spec to ensure we have the column information up to date.
+    ProjectCustomField.reset_column_information
+  end
+
+  context "when migrating up" do
+    # Roll back the migration so we can migrate up
+    before do
+      ActiveRecord::Migration.suppress_messages { described_class.new.migrate(:down) }
+    end
+
+    # Silencing migration logs, since we are not interested in that during testing
+    subject { ActiveRecord::Migration.suppress_messages { described_class.new.migrate(:up) } }
+
+    it "changes the visible field to admin_only and flips the value" do
+      ProjectCustomField.new(visible: false).save(validate: false)
+
+      expect { subject }
+        .to change { CustomField.first.attributes.slice("visible", "admin_only") }
+        .from("visible" => false)
+        .to("admin_only" => true)
+    end
+  end
+
+  context "when migrating down" do
+    subject { ActiveRecord::Migration.suppress_messages { described_class.new.migrate(:down) } }
+
+    it "rolls back the admin_only field to visible and flips the value" do
+      ProjectCustomField.new(admin_only: false).save(validate: false)
+
+      expect { subject }
+        .to change { CustomField.first.attributes.slice("visible", "admin_only") }
+        .from("admin_only" => false)
+        .to("visible" => true)
+    end
+  end
+end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe PermittedParams do
     let(:attribute) { :custom_field }
 
     let(:hash) do
-      { "editable" => "0", "visible" => "0" }
+      { "editable" => "0", "admin_only" => "0" }
     end
 
     it_behaves_like "allows params"

--- a/spec/models/project_custom_field_spec.rb
+++ b/spec/models/project_custom_field_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ProjectCustomField do
   end
 
   describe ".visible" do
-    shared_let(:invisible_cf) { create(:string_project_custom_field, visible: false) }
+    shared_let(:invisible_cf) { create(:string_project_custom_field, admin_only: true) }
     shared_let(:other_cf) { create(:string_project_custom_field) }
     shared_let(:project_cf) { create(:string_project_custom_field) }
     shared_let(:public_cf) { create(:string_project_custom_field) }

--- a/spec/models/projects/exporter/exportable_project_context.rb
+++ b/spec/models/projects/exporter/exportable_project_context.rb
@@ -35,7 +35,7 @@ RSpec.shared_context "with a project with an arrangement of custom fields" do
   shared_let(:text_cf) { create(:text_project_custom_field, position: 6) }
   shared_let(:string_cf) { create(:string_project_custom_field, position: 7) }
   shared_let(:date_cf) { create(:date_project_custom_field, position: 8) }
-  shared_let(:hidden_cf) { create(:string_project_custom_field, position: 9, visible: false) }
+  shared_let(:hidden_cf) { create(:string_project_custom_field, position: 9, admin_only: true) }
 
   let!(:not_used_string_cf) { create(:string_project_custom_field, position: 10) }
 

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:project_custom_field_string) do
     create(:project_custom_field, :string,
            name: "Secret string", default_value: "admin eyes only",
-           visible: false)
+           admin_only: true)
   end
   let(:project_custom_field_long_text) do
     create(:project_custom_field, :text,

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
     create(:text_project_custom_field)
   end
   let(:invisible_custom_field) do
-    create(:text_project_custom_field, visible: false)
+    create(:text_project_custom_field, admin_only: true)
   end
   let(:custom_value) do
     CustomValue.create(custom_field:,

--- a/spec/requests/api/v3/projects/show_resource_spec.rb
+++ b/spec/requests/api/v3/projects/show_resource_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "API v3 Project resource show", content_type: :json do
                        customized: project)
   end
   let(:invisible_custom_field) do
-    create(:text_project_custom_field, visible: false)
+    create(:text_project_custom_field, admin_only: true)
   end
   let(:invisible_custom_value) do
     CustomValue.create(custom_field: invisible_custom_field,

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
     create(:text_project_custom_field)
   end
   let(:invisible_custom_field) do
-    create(:text_project_custom_field, visible: false)
+    create(:text_project_custom_field, admin_only: true)
   end
   let(:permissions) { %i[edit_project view_project_attributes edit_project_attributes] }
   let(:path) { api_v3_paths.project(project.id) }

--- a/spec/services/project_custom_field_project_mappings/bulk_update_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/bulk_update_service_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe ProjectCustomFieldProjectMappings::BulkUpdateService do
   let!(:visible_project_custom_field) do
     create(:project_custom_field,
            name: "Visible field",
-           visible: true,
+           admin_only: false,
            project_custom_field_section: section_with_invisible_fields)
   end
 
   let!(:visible_required_project_custom_field) do
     create(:project_custom_field,
            name: "Visible required field",
-           visible: true,
+           admin_only: false,
            is_required: true,
            project_custom_field_section: section_with_invisible_fields)
   end
@@ -50,7 +50,7 @@ RSpec.describe ProjectCustomFieldProjectMappings::BulkUpdateService do
   let!(:invisible_project_custom_field) do
     create(:project_custom_field,
            name: "Admin only field",
-           visible: false,
+           admin_only: true,
            project_custom_field_section: section_with_invisible_fields)
   end
 

--- a/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe ProjectCustomFieldProjectMappings::ToggleService do
   let!(:visible_project_custom_field) do
     create(:project_custom_field,
            name: "Visible field",
-           visible: true,
+           admin_only: false,
            project_custom_field_section: section_with_invisible_fields)
   end
 
   let!(:visible_required_project_custom_field) do
     create(:project_custom_field,
            name: "Visible required field",
-           visible: true,
+           admin_only: false,
            is_required: true,
            project_custom_field_section: section_with_invisible_fields)
   end
@@ -50,7 +50,7 @@ RSpec.describe ProjectCustomFieldProjectMappings::ToggleService do
   let!(:invisible_project_custom_field) do
     create(:project_custom_field,
            name: "Admin only field",
-           visible: false,
+           admin_only: true,
            project_custom_field_section: section_with_invisible_fields)
   end
 

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Projects::CreateService, type: :model do
         create(:list_project_custom_field, project_custom_field_section: section)
       end
       let!(:hidden_custom_field) do
-        create(:text_project_custom_field, project_custom_field_section: section, visible: false)
+        create(:text_project_custom_field, project_custom_field_section: section, admin_only: true)
       end
       let(:project) { subject.result }
       let(:project_attributes) { {} }


### PR DESCRIPTION
# What are you trying to accomplish?
Update custom field attribute names and descriptions for `required` and `visible`. Change the `visible` boolean field to `admin_only` and flip the logic around the flag.

# What approach did you choose and why?
  - Rename the text in the translation files.
  - Create a migration that renames `visible` to `admin_only` and flip the boolean values also flipping the default value from true to false.
  - Replace the `visible` occurences in the code with `admin_only`.

# Ticket
https://community.openproject.org/wp/55299
Also addresses https://community.openproject.org/wp/56897
# Merge checklist

- [X] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [X] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
