### PR TITLE
[#56986] Member user role's seed data is incorrect

### DIFF
--- a/modules/boards/app/seeders/common.yml
+++ b/modules/boards/app/seeders/common.yml
@@ -34,6 +34,7 @@ modules_permissions:
   - role: :default_role_member
     add:
     - :show_board_views
+    - :manage_public_queries
     - :manage_board_views
   - role: :default_role_reader
     add:


### PR DESCRIPTION
# What are you trying to accomplish?
The seeded permissions are not correct as navigating to the `Go to Administration > Users and permissions > Roles and permissions > Member` page on a freshly seeded instance displays an error message saying "Permissions need to also include 'Manage public views' as 'Manage boards' is selected."

## Screenshots
![image](https://github.com/user-attachments/assets/8e650089-be73-45df-9ca5-78718172e29f)


# What approach did you choose and why?
Update the seeded role to include the `:manage_public_queries` where the `:manage_board_views` is added.

# Ticket
https://community.openproject.org/work_packages/56986

# Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
