### PR TITLE
MIME prefix constraint removed

### DIFF
--- a/modules/bim/app/services/bim/bcf/viewpoints/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/bcf/viewpoints/set_attributes_service.rb
@@ -62,8 +62,7 @@ module Bim::Bcf
       def snapshot_data_complete?
         viewpoint["snapshot"] &&
           snapshot_extension &&
-          snapshot_base64 &&
-          snapshot_url_parts.length > 1
+          snapshot_base64
       end
 
       def snapshot_content_type
@@ -89,11 +88,11 @@ module Bim::Bcf
       end
 
       def snapshot_binary_contents
-        Base64.decode64(snapshot_url_parts[2])
-      end
-
-      def snapshot_url_parts
-        snapshot_base64.match(/\Adata:([-\w]+\/[-\w+.]+)?;base64,(.*)/m) || []
+        if snapshot_base64.include?('base64,')
+          Base64.decode64(snapshot_base64.split('base64,').last)
+        else
+          Base64.decode64(snapshot_base64)
+        end
       end
 
       def viewpoint

--- a/modules/bim/app/services/bim/bcf/viewpoints/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/bcf/viewpoints/set_attributes_service.rb
@@ -88,8 +88,8 @@ module Bim::Bcf
       end
 
       def snapshot_binary_contents
-        if snapshot_base64.include?('base64,')
-          Base64.decode64(snapshot_base64.split('base64,').last)
+        if snapshot_base64.include?("base64,")
+          Base64.decode64(snapshot_base64.split("base64,").last)
         else
           Base64.decode64(snapshot_base64)
         end


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?
The imposition of providing a MIME prefix on BCF snapshots could be a problem.
**snapshot_url_parts.length > 1**

Some of the BIM platforms that offer a BCF API, for example BIMcollab, have the opposite constraint: do not accept the MIME prefix.
In the case of a client application that adapts to this constraint, this will not work with OpenProject.

Ideally, OpenProject would also accept the case where the prefix is ​​not provided.

# What approach did you choose and why?
- Removing the imposition of a prefix
- Support for both cases (with or without prefix)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
