### PR TITLE
[22517] PDF export of meeting agenda and meeting 

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
@@ -24,7 +24,7 @@
 
     <span
       *ngIf="showTimestamp"
-      class="op-file-list--item-text"
+      class="op-file-list--item-text hide-when-print"
       [textContent]="timestampText"
     ></span>
 

--- a/frontend/src/app/shared/components/attachments/attachments.component.html
+++ b/frontend/src/app/shared/components/attachments/attachments.component.html
@@ -54,7 +54,7 @@
 
 <div
   *ngIf="allowUploading && resource.canAddAttachments"
-  class="op-file-section--actions"
+  class="op-file-section--actions hide-when-print"
 >
   <button
     *ngIf="!externalUploadButton"

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -62,3 +62,7 @@
     font-size: 1.5em
   h3
     font-size: 1.17em
+
+  .-browser-firefox *
+    // Needed for Firefox only. Otherwise, background-colors (e.g. of buttons) are not correctly printed
+    print-color-adjust: exact

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -33,6 +33,11 @@
   #content
     overflow: visible !important
 
+    &:not(.content--split)
+      // Otherwise content will be cut off weirdly between the pages in all browser
+      // and Firefox will show only the first page
+      display: inline-block
+
   .autoscroll
     overflow-x: visible
 

--- a/modules/meeting/app/components/_index.sass
+++ b/modules/meeting/app/components/_index.sass
@@ -2,3 +2,4 @@
 @import "./meeting_agenda_items/form_component.sass"
 @import "./meeting_sections/header_component.sass"
 @import "./meetings/side_panel/state_component.sass"
+@import "./meetings/side_panel/participants_component.sass"

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -2,7 +2,7 @@
   component_wrapper do
     grid_layout('op-meeting-agenda-item', tag: :div, id: "item-#{@meeting_agenda_item.id}") do |grid|
       if drag_and_drop_enabled?
-        grid.with_area(:'drag-handle', tag: :div) do
+        grid.with_area(:'drag-handle', tag: :div, classes: "hide-when-print") do
           render(Primer::OpenProject::DragHandle.new(classes: 'handle'))
         end
       end
@@ -61,7 +61,7 @@
         end
       end
 
-      grid.with_area(:actions, tag: :div, justify_self: :end) do
+      grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
         if edit_enabled?
           render(Primer::Alpha::ActionMenu.new) do |menu|
             menu.with_show_button(icon: "kebab-horizontal",
@@ -72,7 +72,7 @@
             edit_action_item(menu) if @meeting_agenda_item.editable?
             add_note_action_item(menu) if @meeting_agenda_item.editable? && @meeting_agenda_item.notes.blank?
             unless first? && last?
-              menu.with_divider 
+              menu.with_divider
               move_actions(menu)
             end
             menu.with_divider

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   component_wrapper(style: "position: relative") do
-    render(Primer::Alpha::ActionMenu.new) do |component|
+    render(Primer::Alpha::ActionMenu.new(classes: "hide-when-print")) do |component|
       component.with_show_button(scheme: button_scheme, disabled: @disabled) do |button|
         button.with_leading_visual_icon(icon: :plus)
         t("button_add")

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -2,7 +2,7 @@
   component_wrapper(class: "op-meeting-section-container", data: wrapper_data_attributes) do
     if @state == :show
       grid_layout('op-meeting-section', tag: :div) do |grid|
-        grid.with_area(:'drag-handle', tag: :div) do
+        grid.with_area(:'drag-handle', tag: :div, classes: "hide-when-print") do
           if editable?
             render(Primer::OpenProject::DragHandle.new(classes: 'handle'))
           end
@@ -19,7 +19,7 @@
             end
           end
         end
-        grid.with_area(:actions, tag: :div, justify_self: :end) do
+        grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
           if editable?
             render(Primer::Alpha::ActionMenu.new(data: { test_selector: "meeting-section-action-menu" })) do |menu|
               menu.with_show_button(icon: "kebab-horizontal", 'aria-label': t("settings.project_attributes.label_section_actions"), scheme: :invisible)

--- a/modules/meeting/app/components/meeting_sections/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/show_component.html.erb
@@ -8,7 +8,7 @@
       end
       if render_new_button_in_section?
         component.with_row(data: { 'empty-list-item': true }) do
-          flex_layout(align_items: :center, justify_content: :space_between) do |empty_list_container|
+          flex_layout(align_items: :center, justify_content: :space_between, classes: "hide-when-print") do |empty_list_container|
             empty_list_container.with_column(mr: 2) do
               render(Primer::Beta::Text.new(color: :subtle)) { t("meeting_section.empty_text") }
             end

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -14,6 +14,7 @@
       header.with_action_menu(menu_arguments: {},
                               button_arguments: { icon: "kebab-horizontal",
                                                   "aria-label": t("label_meeting_actions"),
+                                                  classes: "hide-when-print",
                                                   test_selector: 'op-meetings-header-action-trigger'}) do |menu|
         menu.with_item(label: t("label_meeting_edit_title"),
                        href: edit_meeting_path(@meeting),

--- a/modules/meeting/app/components/meetings/side_panel/attachments_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/attachments_component.html.erb
@@ -6,7 +6,8 @@
       section.with_counter { @meeting.attachments.count }
 
       section.with_footer_button(
-        id: "meetings-add-attachments"
+        id: "meetings-add-attachments",
+        classes: "hide-when-print"
       ) do |button|
         button.with_leading_visual_icon(icon: "op-attachmentadd")
         t("js.label_add_attachments")

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -9,6 +9,7 @@
           scheme: :invisible,
           tag: :a,
           href: details_dialog_meeting_path(@meeting),
+          classes: "hide-when-print",
           data: { controller: 'async-dialog' },
           'aria-label': t(:label_meeting_details_edit),
           test_selector: "edit-meeting-details-button",
@@ -97,6 +98,7 @@
                   underline: false,
                   tag: :a,
                   href: participants_dialog_meeting_path(@meeting),
+                  classes: "hide-when-print",
                   data: { controller: 'async-dialog' }
                 )) do
                   t("label_meeting_show_all_participants")

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -80,7 +80,7 @@
           end
         end
 
-        details.with_row(mt: 2, classes: 'meeting-detail-participants', display: [nil, nil, :none]) do
+        details.with_row(mt: 2, classes: 'meeting-detail-participants hide-when-print', display: [nil, nil, :none]) do
           render_meeting_attribute_row(:people) do
             flex_layout(align_items: :center) do |people|
               people.with_column(mr: 2) do

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
@@ -11,6 +11,7 @@
           scheme: :invisible,
           tag: :a,
           href: participants_dialog_meeting_path(@meeting),
+          classes: "hide-when-print",
           data: { controller: 'async-dialog' },
           'aria-label': t("label_meeting_manage_participants"),
           test_selector: "manage-participants-button",
@@ -42,6 +43,7 @@
                 font_weight: :bold,
                 tag: :a,
                 href: participants_dialog_meeting_path(@meeting),
+                classes: "hide-when-print",
                 data: { controller: 'async-dialog' }
               )) do |button|
                 button.with_leading_visual_icon(icon: "person-add")

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.sass
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.sass
@@ -1,0 +1,3 @@
+.meetings-side-panel--participants-section
+  @media print
+    display: table-cell !important

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -25,6 +25,7 @@
             section.with_footer_button(
               tag: :a,
               href: change_state_meeting_path(@meeting, state: 'closed'),
+              classes: "hide-when-print",
               data: { 'turbo-stream': true, 'turbo-method': 'put' }
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)
@@ -54,6 +55,7 @@
             section.with_footer_button(
               tag: :a,
               href: change_state_meeting_path(@meeting, state: 'open'),
+              classes: "hide-when-print",
               data: { 'turbo-stream': true, 'turbo-method': 'put' }
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)

--- a/modules/meeting/app/components/meetings/side_panel_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel_component.html.erb
@@ -6,7 +6,7 @@
 
       desktop_grid_row_arguments = { display: [:none, nil, :"table_cell"] }
       panel.with_section(Meetings::SidePanel::ParticipantsComponent.new(meeting: @meeting),
-                         grid_row_arguments: desktop_grid_row_arguments)
+                         grid_row_arguments: desktop_grid_row_arguments.merge({classes: "meetings-side-panel--participants-section"}))
 
       panel.with_section(Meetings::SidePanel::AttachmentsComponent.new(meeting: @meeting),
                          grid_row_arguments: desktop_grid_row_arguments)


### PR DESCRIPTION
# What are you trying to accomplish?
Improve PDF print view of meetings module 

## Screenshots
<img width="250" alt="Bildschirmfoto 2024-08-07 um 13 41 08" src="https://github.com/user-attachments/assets/0aef6e62-30f3-4e60-89ca-6263a5a0b8cc">


# What approach did you choose and why?
* This is a CSS-only quick win solution. On the long run there will be real PDF export of the meetings module.
* For Firefox, there is a special bug solved which caused the PDF to show only page (see bug ticket).
* There is a special solution for the participants section, which is explicitly shown although it is normally collapsed in the mobile layout which is also applied in the print view  

# Ticket
Feature: https://community.openproject.org/work_packages/22517/activity
FF Bug: https://community.openproject.org/work_packages/57027/activity

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
