### PR TITLE
[56921] Description text shown above the editor toolbar

### DIFF
--- a/frontend/src/global_styles/content/work_packages/new/_overridden_description_wiki.sass
+++ b/frontend/src/global_styles/content/work_packages/new/_overridden_description_wiki.sass
@@ -9,3 +9,9 @@
     // as its resized automatically by content (height)
     textarea
       resize: none
+
+    // As we currently do not have a fixed header in the creation page, we need to cancel out the padding of the page content.
+    // Otherwise, the scrolled content will be visible above the toolbar
+    // see: https://community.openproject.org/projects/openproject/work_packages/56921/activity
+    .document-editor__toolbar
+      top: -10px


### PR DESCRIPTION
# What are you trying to accomplish?
Attach fixed toolbar directly to the screen top. Therefore the padding needed to be canceled out.

## Screenshots

**before**
<img width="261" alt="Bildschirmfoto 2024-08-07 um 14 51 07" src="https://github.com/user-attachments/assets/721c7ded-916b-4084-b8a4-1ba63fcf30e9">

**after**
<img width="250" alt="Bildschirmfoto 2024-08-07 um 14 49 30" src="https://github.com/user-attachments/assets/ac3acaad-1c17-4119-85f0-9900f49e6e4e">


# Ticket
https://community.openproject.org/projects/openproject/work_packages/56921/activity

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
