### PR TITLE
[#55299] Update Project attributes searchable hint text

### DIFF
--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -213,13 +213,13 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field">
       <%= f.check_box :admin_only %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.admin_only_for_project') %></p>
+        <p><%= t('custom_fields.instructions.admin_only') %></p>
       </div>
     </div>
     <div class="form--field" <%= format_dependent.attributes(:searchable) %>>
       <%= f.check_box :searchable %>
       <div class="form--field-instructions">
-        <p><%= t('custom_fields.instructions.searchable') %></p>
+        <p><%= t('custom_fields.instructions.searchable_for_project') %></p>
       </div>
     </div>
   <% when "TimeEntryCustomField" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,10 +238,10 @@ en:
       is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources."
       is_required_for_project: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."
       is_for_all: "Mark the custom field as available in all existing and new projects."
-      searchable: "Check to make this attribute available as a filter in project lists."
+      searchable: "Include the field values when using the global search functionality."
+      searchable_for_project: "Check to make this attribute available as a filter in project lists."
       editable: "Allow the field to be editable by users themselves."
       admin_only: "Check to make this attribute only visible to administrators. Users without admin rights will not be able to view or edit it."
-      admin_only_for_project: "Make field visible for all users (non-admins) in the project overview and displayed in the project details widget on the Project Overview."
       is_filter: >
         Allow the custom field to be used in a filter in work package views.
         Note that only with 'For all projects' selected, the custom field will show up in global views.


### PR DESCRIPTION
Follow up modification for the WP:
https://community.openproject.org/work_packages/55299

Added the missing project attributes searchable field hint text.