### PR TITLE
Introduce RemoteIndentity to decouple remote user ids from oauth tokens

### DIFF
--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -28,6 +28,7 @@
 
 class OAuthClient < ApplicationRecord
   belongs_to :integration, polymorphic: true
+  has_many :remote_identities, dependent: :destroy
 
   def redirect_uri
     File.join(Rails.application.root_url, "oauth_clients", client_id, "callback")

--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -28,7 +28,7 @@
 
 class OAuthClient < ApplicationRecord
   belongs_to :integration, polymorphic: true
-  has_many :remote_identities, dependent: :destroy
+  has_many :remote_identities
 
   def redirect_uri
     File.join(Rails.application.root_url, "oauth_clients", client_id, "callback")

--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -28,7 +28,7 @@
 
 class OAuthClient < ApplicationRecord
   belongs_to :integration, polymorphic: true
-  has_many :remote_identities
+  has_many :remote_identities, dependent: :destroy
 
   def redirect_uri
     File.join(Rails.application.root_url, "oauth_clients", client_id, "callback")

--- a/app/models/remote_identity.rb
+++ b/app/models/remote_identity.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -28,11 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :oauth_client_token, class: "::OAuthClientToken" do
-    sequence(:access_token) { |n| "1234567890-#{n}" }
-    sequence(:refresh_token) { |n| "2345678901-#{n}" }
-    oauth_client factory: :oauth_client
-    user factory: :user
-  end
+class RemoteIdentity < ApplicationRecord
+  belongs_to :user
+  belongs_to :oauth_client, class_name: "OAuthClient"
+
+  validates :user, uniqueness: { scope: :oauth_client }
+  validates :origin_user_id, :user, :oauth_client, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < Principal
            inverse_of: :user,
            dependent: :destroy
 
-  has_many :remote_identities
+  has_many :remote_identities, dependent: :destroy
 
   # Users blocked via brute force prevention
   # use lambda here, so time is evaluated on each query

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < Principal
            inverse_of: :user,
            dependent: :destroy
 
-  has_many :remote_identities, dependent: :destroy
+  has_many :remote_identities
 
   # Users blocked via brute force prevention
   # use lambda here, so time is evaluated on each query

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,8 @@ class User < Principal
            inverse_of: :user,
            dependent: :destroy
 
+  has_many :remote_identities, dependent: :destroy
+
   # Users blocked via brute force prevention
   # use lambda here, so time is evaluated on each query
   scope :blocked, -> { create_blocked_scope(self, true) }

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -59,7 +59,6 @@ module OAuthClients
     end
 
     # rubocop:disable Metrics/AbcSize
-
     # The bearer/access token has expired or is due for renew for other reasons.
     # Talk to OAuth2 Authorization Server to exchange the renew_token for a new bearer token.
     def refresh_token
@@ -103,28 +102,18 @@ module OAuthClients
         update_oauth_client_token(oauth_client_token, service_result.result)
       else
         rack_access_token = service_result.result
-        oauth_client_token =
-          OAuthClientToken.create(
-            user: @user,
-            oauth_client: @oauth_client,
-            origin_user_id: @config.extract_origin_user_id(rack_access_token), # ID of user at OAuth2 Authorization Server
-            access_token: rack_access_token.access_token,
-            token_type: rack_access_token.token_type, # :bearer
-            refresh_token: rack_access_token.refresh_token,
-            expires_in: rack_access_token.raw_attributes[:expires_in],
-            scope: rack_access_token.scope
-          )
-        return ServiceResult.failure(errors: oauth_client_token.errors) unless oauth_client_token.valid?
+        OAuthClientToken.transaction do
+          oauth_client_token = create_client_token(rack_access_token)
 
-        OpenProject::Notifications.send(
-          OpenProject::Events::OAUTH_CLIENT_TOKEN_CREATED,
-          integration_type: @oauth_client.integration_type
-        )
+          oauth_client_token.save!
+          RemoteIdentities::CreateService.call(user: @user, oauth_config: @config, oauth_token: rack_access_token)
+                                         .on_failure { raise ActiveRecord::Rollback }
+        end
+
+        ServiceResult.new(success: oauth_client_token.errors.empty?, result: oauth_client_token,
+                          errors: oauth_client_token.errors)
       end
-
-      ServiceResult.success(result: oauth_client_token)
     end
-
     # rubocop:enable Metrics/AbcSize
 
     # @returns ServiceResult with result to be :error or any type of object with data
@@ -146,6 +135,20 @@ module OAuthClients
     end
 
     private
+
+    # @param rack_access_token [Rack::OAuth2::Token] - rack token to be used as a base
+    # @return [OAuthClientToken]
+    def create_client_token(rack_access_token)
+      OAuthClientToken.new(
+        user: @user,
+        oauth_client: @oauth_client,
+        access_token: rack_access_token.access_token,
+        token_type: rack_access_token.token_type, # :bearer
+        refresh_token: rack_access_token.refresh_token,
+        expires_in: rack_access_token.raw_attributes[:expires_in],
+        scope: rack_access_token.scope
+      )
+    end
 
     # Check if a OAuthClientToken already exists and return nil otherwise.
     # Don't handle the case of an expired token.

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -60,7 +60,6 @@ module OAuthClients
     end
 
     # rubocop:disable Metrics/AbcSize
-
     # The bearer/access token has expired or is due for renew for other reasons.
     # Talk to OAuth2 Authorization Server to exchange the renew_token for a new bearer token.
     def refresh_token
@@ -104,28 +103,18 @@ module OAuthClients
         update_oauth_client_token(oauth_client_token, service_result.result)
       else
         rack_access_token = service_result.result
-        oauth_client_token =
-          OAuthClientToken.create(
-            user: @user,
-            oauth_client: @oauth_client,
-            origin_user_id: @config.extract_origin_user_id(rack_access_token), # ID of user at OAuth2 Authorization Server
-            access_token: rack_access_token.access_token,
-            token_type: rack_access_token.token_type, # :bearer
-            refresh_token: rack_access_token.refresh_token,
-            expires_in: rack_access_token.raw_attributes[:expires_in],
-            scope: rack_access_token.scope
-          )
-        return ServiceResult.failure(errors: oauth_client_token.errors) unless oauth_client_token.valid?
+        OAuthClientToken.transaction do
+          oauth_client_token = create_client_token(rack_access_token)
 
-        OpenProject::Notifications.send(
-          OpenProject::Events::OAUTH_CLIENT_TOKEN_CREATED,
-          integration_type: @oauth_client.integration_type
-        )
+          oauth_client_token.save!
+          RemoteIdentities::CreateService.call(user: @user, oauth_config: @config, oauth_token: rack_access_token)
+                                         .on_failure { raise ActiveRecord::Rollback }
+        end
+
+        ServiceResult.new(success: oauth_client_token.errors.empty?, result: oauth_client_token,
+                          errors: oauth_client_token.errors)
       end
-
-      ServiceResult.success(result: oauth_client_token)
     end
-
     # rubocop:enable Metrics/AbcSize
 
     # @returns ServiceResult with result to be :error or any type of object with data
@@ -147,6 +136,20 @@ module OAuthClients
     end
 
     private
+
+    # @param rack_access_token [Rack::OAuth2::Token] - rack token to be used as a base
+    # @return [OAuthClientToken]
+    def create_client_token(rack_access_token)
+      OAuthClientToken.new(
+        user: @user,
+        oauth_client: @oauth_client,
+        access_token: rack_access_token.access_token,
+        token_type: rack_access_token.token_type, # :bearer
+        refresh_token: rack_access_token.refresh_token,
+        expires_in: rack_access_token.raw_attributes[:expires_in],
+        scope: rack_access_token.scope
+      )
+    end
 
     # Check if a OAuthClientToken already exists and return nil otherwise.
     # Don't handle the case of an expired token.

--- a/app/services/remote_identities/delete_service.rb
+++ b/app/services/remote_identities/delete_service.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -28,11 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :oauth_client_token, class: "::OAuthClientToken" do
-    sequence(:access_token) { |n| "1234567890-#{n}" }
-    sequence(:refresh_token) { |n| "2345678901-#{n}" }
-    oauth_client factory: :oauth_client
-    user factory: :user
+module RemoteIdentities
+  class DeleteService < BaseServices::Delete
   end
 end

--- a/db/migrate/20240806144333_create_remote_identities.rb
+++ b/db/migrate/20240806144333_create_remote_identities.rb
@@ -28,11 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :oauth_client_token, class: "::OAuthClientToken" do
-    sequence(:access_token) { |n| "1234567890-#{n}" }
-    sequence(:refresh_token) { |n| "2345678901-#{n}" }
-    oauth_client factory: :oauth_client
-    user factory: :user
+class CreateRemoteIdentities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :remote_identities do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :oauth_client, index: true, foreign_key: true
+
+      t.string :origin_user_id, null: false, index: true
+
+      t.timestamps
+      t.index %i[user_id oauth_client_id], unique: true
+    end
   end
 end

--- a/db/migrate/20240806144333_create_remote_identities.rb
+++ b/db/migrate/20240806144333_create_remote_identities.rb
@@ -31,8 +31,8 @@
 class CreateRemoteIdentities < ActiveRecord::Migration[7.1]
   def change
     create_table :remote_identities do |t|
-      t.references :user, index: true, foreign_key: true
-      t.references :oauth_client, index: true, foreign_key: true
+      t.references :user, index: true, null: false, foreign_key: { to_table: :users, on_delete: :cascade }
+      t.references :oauth_client, index: true, null: false, foreign_key: { to_table: :oauth_clients, on_delete: :cascade }
 
       t.string :origin_user_id, null: false, index: true
 

--- a/lib/open_project/events.rb
+++ b/lib/open_project/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -37,44 +39,46 @@ module OpenProject
   # @note Does not include all events but it should!
   # @see OpenProject::Notifications
   module Events
-    AGGREGATED_WORK_PACKAGE_JOURNAL_READY = "aggregated_work_package_journal_ready".freeze
-    AGGREGATED_WIKI_JOURNAL_READY = "aggregated_wiki_journal_ready".freeze
-    AGGREGATED_NEWS_JOURNAL_READY = "aggregated_news_journal_ready".freeze
-    AGGREGATED_MESSAGE_JOURNAL_READY = "aggregated_message_journal_ready".freeze
+    AGGREGATED_WORK_PACKAGE_JOURNAL_READY = "aggregated_work_package_journal_ready"
+    AGGREGATED_WIKI_JOURNAL_READY = "aggregated_wiki_journal_ready"
+    AGGREGATED_NEWS_JOURNAL_READY = "aggregated_news_journal_ready"
+    AGGREGATED_MESSAGE_JOURNAL_READY = "aggregated_message_journal_ready"
 
-    ATTACHMENT_CREATED = "attachment_created".freeze
+    ATTACHMENT_CREATED = "attachment_created"
 
-    JOURNAL_CREATED = "journal_created".freeze
+    JOURNAL_CREATED = "journal_created"
 
-    MEMBER_CREATED = "member_created".freeze
-    MEMBER_UPDATED = "member_updated".freeze
-    MEMBER_DESTROYED = "member_destroyed".freeze
+    MEMBER_CREATED = "member_created"
+    MEMBER_UPDATED = "member_updated"
+    MEMBER_DESTROYED = "member_destroyed"
 
-    OAUTH_CLIENT_TOKEN_CREATED = "oauth_client_token_created".freeze
+    OAUTH_CLIENT_TOKEN_CREATED = "oauth_client_token_created"
 
-    TIME_ENTRY_CREATED = "time_entry_created".freeze
+    TIME_ENTRY_CREATED = "time_entry_created"
 
-    NEWS_COMMENT_CREATED = "news_comment_created".freeze
+    NEWS_COMMENT_CREATED = "news_comment_created"
 
-    PROJECT_CREATED = "project_created".freeze
-    PROJECT_UPDATED = "project_updated".freeze
-    PROJECT_RENAMED = "project_renamed".freeze
-    PROJECT_ARCHIVED = "project_archived".freeze
-    PROJECT_UNARCHIVED = "project_unarchived".freeze
+    PROJECT_CREATED = "project_created"
+    PROJECT_UPDATED = "project_updated"
+    PROJECT_RENAMED = "project_renamed"
+    PROJECT_ARCHIVED = "project_archived"
+    PROJECT_UNARCHIVED = "project_unarchived"
 
-    PROJECT_STORAGE_CREATED = "project_storage_created".freeze
-    PROJECT_STORAGE_UPDATED = "project_storage_updated".freeze
-    PROJECT_STORAGE_DESTROYED = "project_storage_destroyed".freeze
+    PROJECT_STORAGE_CREATED = "project_storage_created"
+    PROJECT_STORAGE_UPDATED = "project_storage_updated"
+    PROJECT_STORAGE_DESTROYED = "project_storage_destroyed"
 
-    STORAGE_TURNED_UNHEALTHY = "storage_turned_unhealthy".freeze
-    STORAGE_TURNED_HEALTHY = "storage_turned_healthy".freeze
+    STORAGE_TURNED_UNHEALTHY = "storage_turned_unhealthy"
+    STORAGE_TURNED_HEALTHY = "storage_turned_healthy"
 
-    ROLE_UPDATED = "role_updated".freeze
-    ROLE_DESTROYED = "role_destroyed".freeze
+    REMOTE_IDENTITY_CREATED = "remote_identity_created"
 
-    WATCHER_ADDED = "watcher_added".freeze
-    WATCHER_DESTROYED = "watcher_destroyed".freeze
+    ROLE_UPDATED = "role_updated"
+    ROLE_DESTROYED = "role_destroyed"
 
-    WORK_PACKAGE_SHARED = "work_package_shared".freeze
+    WATCHER_ADDED = "watcher_added"
+    WATCHER_DESTROYED = "watcher_destroyed"
+
+    WORK_PACKAGE_SHARED = "work_package_shared"
   end
 end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
@@ -65,10 +65,10 @@ module Storages
             def token(user:, configuration:, &)
               connection_manager = OAuthClients::ConnectionManager.new(user:, configuration:)
               connection_manager.get_access_token.match(
-                on_success: ->(token) do
+                on_success: lambda do |token|
                   connection_manager.request_with_token_refresh(token) { yield token }
                 end,
-                on_failure: ->(_) do
+                on_failure: lambda do |_|
                   error(:unauthorized,
                         "Query could not be created! No access token found!",
                         StorageErrorData.new(source: connection_manager))
@@ -85,8 +85,8 @@ module Storages
               when :basic_auth
                 ServiceResult.success(result: storage.username)
               when :oauth_user_token
-                origin_user_id = OAuthClientToken.where(user_id: auth_strategy.user, oauth_client: storage.oauth_client)
-                                                 .pick(:origin_user_id)
+                origin_user_id = RemoteIdentity.where(user_id: auth_strategy.user, oauth_client: storage.oauth_client)
+                                               .pick(:origin_user_id)
                 if origin_user_id.present?
                   ServiceResult.success(result: origin_user_id)
                 else

--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -104,7 +106,7 @@ module Storages::ProjectStorages::Members
 
     def oauth_client_connected?
       storage.oauth_client.present? &&
-        member.oauth_client_tokens.any? { |token| token.oauth_client_id == storage.oauth_client.id }
+        member.principal.remote_identities.exists?(oauth_client: storage.oauth_client)
     end
 
     def can_read_files?

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -56,10 +56,10 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
 
   def create
     create_service = ::Storages::ProjectStorages::BulkCreateService
-                         .new(user: current_user, projects: @projects, storage: @storage,
-                              project_folder_mode: params.to_unsafe_h[:storages_project_storage][:project_folder_mode],
-                              include_sub_projects: include_sub_projects?)
-                         .call
+                     .new(user: current_user, projects: @projects, storage: @storage,
+                          project_folder_mode: params.to_unsafe_h[:storages_project_storage][:project_folder_mode],
+                          include_sub_projects: include_sub_projects?)
+                     .call
 
     create_service.on_success { update_project_list_via_turbo_stream(url_for_action: :index) }
 
@@ -81,7 +81,10 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   end
 
   def destroy
-    @project_storage.destroy
+    Storages::ProjectStorages::DeleteService
+      .new(user: current_user, model: @project_storage)
+      .call
+
     redirect_to admin_settings_storage_project_storages_path(@storage)
   end
 
@@ -141,9 +144,9 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
 
   def initialize_project_storage
     @project_storage = ::Storages::ProjectStorages::SetAttributesService
-        .new(user: current_user, model: ::Storages::ProjectStorage.new, contract_class: EmptyContract)
-        .call(storage: @storage)
-        .result
+                       .new(user: current_user, model: ::Storages::ProjectStorage.new, contract_class: EmptyContract)
+                       .call(storage: @storage)
+                       .result
   end
 
   def include_sub_projects?

--- a/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
+++ b/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -40,9 +42,9 @@ class Storages::ProjectSettings::ProjectStorageMembersController < Projects::Set
 
   def index
     @memberships = Member
-      .of_project(@project)
-      .includes(:principal, :oauth_client_tokens, roles: :role_permissions)
-      .paginate(page: page_param, per_page: per_page_param)
+                   .of_project(@project)
+                   .includes(principal: :remote_identities, roles: :role_permissions)
+                   .paginate(page: page_param, per_page: per_page_param)
 
     render "/storages/project_settings/project_storage_members/index"
   end

--- a/modules/storages/app/services/storages/nextcloud_group_folder_properties_sync_service.rb
+++ b/modules/storages/app/services/storages/nextcloud_group_folder_properties_sync_service.rb
@@ -312,7 +312,7 @@ module Storages
     end
 
     def client_tokens_scope
-      OAuthClientToken.where(oauth_client: @storage.oauth_client)
+      RemoteIdentity.where(oauth_client: @storage.oauth_client)
     end
 
     def auth_strategy
@@ -320,7 +320,7 @@ module Storages
     end
 
     def admin_client_tokens_scope
-      OAuthClientToken.where(oauth_client: @storage.oauth_client, user: User.admin.active)
+      RemoteIdentity.where(oauth_client: @storage.oauth_client, user: User.admin.active)
     end
   end
 end

--- a/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
@@ -209,9 +209,9 @@ module Storages
       @storage.project_storages.active.automatic
     end
 
-    def client_tokens_scope = OAuthClientToken.where(oauth_client: @storage.oauth_client)
+    def client_tokens_scope = RemoteIdentity.where(oauth_client: @storage.oauth_client)
 
-    def admin_client_tokens_scope = OAuthClientToken.where(oauth_client: @storage.oauth_client, user: User.admin.active)
+    def admin_client_tokens_scope = RemoteIdentity.where(oauth_client: @storage.oauth_client, user: User.admin.active)
 
     def root_folder = Peripherals::ParentFolder.new("/")
     def auth_strategy = userless.call

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -141,8 +141,10 @@ FactoryBot.define do
                                      "MISSING_NEXTCLOUD_LOCAL_OAUTH_CLIENT_ACCESS_TOKEN"),
              refresh_token: ENV.fetch("NEXTCLOUD_LOCAL_OAUTH_CLIENT_REFRESH_TOKEN",
                                       "MISSING_NEXTCLOUD_LOCAL_OAUTH_CLIENT_REFRESH_TOKEN"),
-             token_type: "bearer",
-             origin_user_id: "admin")
+             token_type: "bearer")
+
+      create(:remote_identity, oauth_client: storage.oauth_client, user: evaluator.oauth_client_token_user,
+                               origin_user_id: "admin")
     end
   end
 

--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Managing file links in work package", :js, :webmock do
   let(:storage) { create(:nextcloud_storage, name: "My Storage", oauth_application:) }
   let(:oauth_client) { create(:oauth_client, integration: storage) }
   let(:oauth_client_token) { create(:oauth_client_token, oauth_client:, user: current_user) }
+  let(:remote_identity) { create(:remote_identity, oauth_client:, user: current_user, origin_user_id: "admin") }
   let(:project_storage) { create(:project_storage, project:, storage:, project_folder_id: nil, project_folder_mode: "inactive") }
   let(:file_link) { create(:file_link, container: work_package, storage:, origin_id: "22", origin_name: "jingle.ogg") }
 
@@ -66,11 +67,12 @@ RSpec.describe "Managing file links in work package", :js, :webmock do
       ->(_) { ServiceResult.success }
     )
 
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{oauth_client_token.origin_user_id}")
+    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}")
       .to_return(status: 207, body: root_xml_response, headers: {})
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{oauth_client_token.origin_user_id}/Folder1")
+    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
       .to_return(status: 207, body: folder1_xml_response, headers: {})
 
+    oauth_client_token
     project_storage
     file_link
 

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe("Activation of storages in projects",
 
   let(:oauth_client) { create(:oauth_client, integration: storage) }
   let(:oauth_client_token) { create(:oauth_client_token, oauth_client:, user:) }
+  let(:remote_identity) { create(:remote_identity, user:, oauth_client:, origin_user_id: "admin") }
 
   let(:location_picker) { Components::FilePickerDialog.new }
 
@@ -84,9 +85,9 @@ RSpec.describe("Activation of storages in projects",
   before do
     oauth_client_token
 
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{oauth_client_token.origin_user_id}")
+    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}")
       .to_return(status: 207, body: root_xml_response, headers: {})
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{oauth_client_token.origin_user_id}/Folder1")
+    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
       .to_return(status: 207, body: folder1_xml_response, headers: {})
     stub_request(:get, "#{storage.host}/ocs/v1.php/apps/integration_openproject/fileinfo/11")
       .to_return(status: 200, body: folder1_fileinfo_response.to_json, headers: {})
@@ -98,6 +99,7 @@ RSpec.describe("Activation of storages in projects",
 
     storage
     project
+    oauth_client_token
     login_as user
   end
 

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe "Admin lists project mappings for a storage",
 
   current_user { admin }
 
+  before do
+    Storages::Peripherals::Registry
+      .stub("#{storage.short_provider_type}.commands.delete_folder", ->(_) { ServiceResult.success })
+  end
+
   context "with insufficient permissions" do
     it "is not accessible" do
       login_as(non_admin)

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "Project storage members connection status view" do
   let(:oauth_client) { create(:oauth_client, integration: storage) }
 
   before do
-    create_oauth_client_tokens_for_users(oauth_client:,
-                                         users: [connected_user, admin_user,
-                                                 connected_no_permissions_user])
+    create_remote_identities_for_users(oauth_client:,
+                                       users: [connected_user, admin_user,
+                                               connected_no_permissions_user])
   end
 
   it "cannot be accessed without being logged in" do
@@ -122,9 +122,9 @@ RSpec.describe "Project storage members connection status view" do
     create(:nextcloud_storage, :as_automatically_managed, oauth_application:)
   end
 
-  def create_oauth_client_tokens_for_users(oauth_client:, users:)
+  def create_remote_identities_for_users(oauth_client:, users:)
     users.each do |user|
-      create(:oauth_client_token, oauth_client:, user:)
+      create(:remote_identity, oauth_client:, user:, origin_user_id: "origin-user-id-#{user.id}")
     end
   end
 end

--- a/modules/storages/spec/services/storages/nextcloud_group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_group_folder_properties_sync_service_spec.rb
@@ -636,9 +636,9 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
   describe "#call" do
     before do
-      create(:oauth_client_token, origin_user_id: "Obi-Wan", user: multiple_projects_user, oauth_client:)
-      create(:oauth_client_token, origin_user_id: "Yoda", user: single_project_user, oauth_client:)
-      create(:oauth_client_token, origin_user_id: "Darth Vader", user: admin, oauth_client:)
+      create(:remote_identity, origin_user_id: "Obi-Wan", user: multiple_projects_user, oauth_client:)
+      create(:remote_identity, origin_user_id: "Yoda", user: single_project_user, oauth_client:)
+      create(:remote_identity, origin_user_id: "Darth Vader", user: admin, oauth_client:)
 
       setup_request_stubs
     end
@@ -670,13 +670,13 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
         context "on a handled error case" do
           before do
             request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                                 .with(
-                                   body: propfind_request_body,
-                                   headers: {
-                                     "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                                     "Depth" => "1"
-                                   }
-                                 ).to_return(status: 404, body: "", headers: {})
+                               .with(
+                                 body: propfind_request_body,
+                                 headers: {
+                                   "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                                   "Depth" => "1"
+                                 }
+                               ).to_return(status: 404, body: "", headers: {})
           end
 
           it "stops the flow immediately if the response is anything but a success" do
@@ -691,7 +691,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
             expect(Rails.logger)
               .to have_received(:error)
-                    .with(folder: "OpenProject", error_code: :not_found, data: { status: 404, body: "" }, message: /not found/)
+              .with(folder: "OpenProject", error_code: :not_found, data: { status: 404, body: "" }, message: /not found/)
           end
 
           it "returns a failure" do
@@ -706,26 +706,26 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
         it "raises an error when dealing with an unhandled error case" do
           request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                               .with(
-                                 body: propfind_request_body,
-                                 headers: {
-                                   "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                                   "Depth" => "1"
-                                 }
-                               ).to_return(status: 500, body: "", headers: {})
+                             .with(
+                               body: propfind_request_body,
+                               headers: {
+                                 "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                                 "Depth" => "1"
+                               }
+                             ).to_return(status: 500, body: "", headers: {})
 
           expect(described_class.new(storage).call).to be_failure
         end
 
         it "raises an error when dealing with a socket or connection error" do
           request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                               .with(
-                                 body: propfind_request_body,
-                                 headers: {
-                                   "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                                   "Depth" => "1"
-                                 }
-                               ).to_timeout
+                             .with(
+                               body: propfind_request_body,
+                               headers: {
+                                 "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                                 "Depth" => "1"
+                               }
+                             ).to_timeout
 
           expect(described_class.new(storage).call).to be_failure
         end
@@ -735,10 +735,10 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
         context "on a handled error case" do
           before do
             request_stubs[1] = stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                                 .with(
-                                   body: root_folder_set_permissions_request_body,
-                                   headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" }
-                                 ).to_return(status: 401, body: "Heute nicht", headers: {})
+                               .with(
+                                 body: root_folder_set_permissions_request_body,
+                                 headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" }
+                               ).to_return(status: 401, body: "Heute nicht", headers: {})
           end
 
           it "interrupts the flow" do
@@ -754,10 +754,10 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
             expect(Rails.logger)
               .to have_received(:error)
-                    .with(folder: "OpenProject",
-                          message: /not authorized/,
-                          error_code: :unauthorized,
-                          data: { status: 401, body: "Heute nicht" })
+              .with(folder: "OpenProject",
+                    message: /not authorized/,
+                    error_code: :unauthorized,
+                    data: { status: 401, body: "Heute nicht" })
           end
 
           it "returns a failure" do
@@ -799,10 +799,10 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(folder_name: "/OpenProject/[Sample] Project Name | Ehuu (#{project1.id})/",
-                        message: /not found/,
-                        error_code: :not_found,
-                        data: "not found")
+            .with(folder_name: "/OpenProject/[Sample] Project Name | Ehuu (#{project1.id})/",
+                  message: /not found/,
+                  error_code: :not_found,
+                  data: "not found")
         end
       end
 
@@ -811,11 +811,11 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
           request_stubs[5] = stub_request(:move,
                                           "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Lost%20Jedi%20Project%20Folder%20%233")
-                               .with(headers:
+                             .with(headers:
                                        { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
                                          "Destination" => "/remote.php/dav/files/OpenProject/OpenProject/" \
                                                           "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29" })
-                               .to_return(status: 404, body: "", headers: {})
+                             .to_return(status: 404, body: "", headers: {})
         end
 
         it "we stop processing to avoid issues with permissions" do
@@ -829,11 +829,11 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(folder_id: project_storage2.project_folder_id,
-                        error_code: :not_found,
-                        message: /not found/,
-                        folder_name: "Jedi Project Folder ||| (#{project2.id})",
-                        data: { status: 404, body: "" })
+            .with(folder_id: project_storage2.project_folder_id,
+                  error_code: :not_found,
+                  message: /not found/,
+                  folder_name: "Jedi Project Folder ||| (#{project2.id})",
+                  data: { status: 404, body: "" })
         end
       end
 
@@ -842,11 +842,11 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
           request_stubs[6] = stub_request(:proppatch,
                                           "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Lost%20Jedi%20Project%20Folder%20%232")
-                               .with(body: hide_folder_set_permissions_request_body,
-                                     headers: {
-                                       "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg="
-                                     })
-                               .to_return(status: 500, body: "A server error occurred", headers: {})
+                             .with(body: hide_folder_set_permissions_request_body,
+                                   headers: {
+                                     "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg="
+                                   })
+                             .to_return(status: 500, body: "A server error occurred", headers: {})
         end
 
         it "does not interrupt the flow" do
@@ -861,11 +861,11 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(context: "hide_folder",
-                        folder: "/OpenProject/Lost Jedi Project Folder #2/",
-                        message: /request failed/,
-                        error_code: :error,
-                        data: { status: 500, body: "A server error occurred" })
+            .with(context: "hide_folder",
+                  folder: "/OpenProject/Lost Jedi Project Folder #2/",
+                  message: /request failed/,
+                  error_code: :error,
+                  data: { status: 500, body: "A server error occurred" })
         end
       end
 
@@ -874,11 +874,11 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
           request_stubs[8] = stub_request(:proppatch,
                                           "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29")
-                               .with(body: set_permissions_request_body,
-                                     headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" })
-                               .to_return(status: 500,
-                                          body: "Divide by cucumber error. Please reinstall universe and reboot.",
-                                          headers: {})
+                             .with(body: set_permissions_request_body,
+                                   headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" })
+                             .to_return(status: 500,
+                                        body: "Divide by cucumber error. Please reinstall universe and reboot.",
+                                        headers: {})
         end
 
         it "does not interrupt the flow" do
@@ -893,23 +893,23 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(folder: "/OpenProject/Jedi Project Folder ||| (#{project2.id})/",
-                        message: /failed/,
-                        error_code: :error,
-                        data: { status: 500, body: "Divide by cucumber error. Please reinstall universe and reboot." })
+            .with(folder: "/OpenProject/Jedi Project Folder ||| (#{project2.id})/",
+                  message: /failed/,
+                  error_code: :error,
+                  data: { status: 500, body: "Divide by cucumber error. Please reinstall universe and reboot." })
         end
       end
 
       context "when adding a user to the group fails" do
         before do
           request_stubs[12] = stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Obi-Wan/groups")
-                                .with(
-                                  body: "groupid=OpenProject",
-                                  headers: {
-                                    "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                                    "Ocs-Apirequest" => "true"
-                                  }
-                                ).to_return(status: 302, body: "", headers: {})
+                              .with(
+                                body: "groupid=OpenProject",
+                                headers: {
+                                  "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                                  "Ocs-Apirequest" => "true"
+                                }
+                              ).to_return(status: 302, body: "", headers: {})
         end
 
         it "does not interrupt te flow" do
@@ -924,12 +924,12 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(group: "OpenProject",
-                        user: "Obi-Wan",
-                        message: /failed/,
-                        error_code: :error,
-                        reason: "Outbound request failed",
-                        data: { status: 302, body: "" })
+            .with(group: "OpenProject",
+                  user: "Obi-Wan",
+                  message: /failed/,
+                  error_code: :error,
+                  reason: "Outbound request failed",
+                  data: { status: 302, body: "" })
         end
       end
 
@@ -960,12 +960,12 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
           expect(Rails.logger)
             .to have_received(:error)
-                  .with(group: "OpenProject",
-                        user: "Darth Maul",
-                        message: /SubAdmin/,
-                        error_code: :failed_to_remove,
-                        reason: /SubAdmin/,
-                        data: { status: 200, body: remove_user_from_group_response })
+            .with(group: "OpenProject",
+                  user: "Darth Maul",
+                  message: /SubAdmin/,
+                  error_code: :failed_to_remove,
+                  reason: /SubAdmin/,
+                  data: { status: 200, body: remove_user_from_group_response })
         end
       end
     end
@@ -976,26 +976,26 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
   def setup_request_stubs
     # 0 - Root folder FileIds
     request_stubs << stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                       .with(
-                         body: propfind_request_body,
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                           "Depth" => "1"
-                         }
-                       ).to_return(status: 207,
-                                   body: root_folder_propfind_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       body: propfind_request_body,
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                         "Depth" => "1"
+                       }
+                     ).to_return(status: 207,
+                                 body: root_folder_propfind_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     # 1 - Root folder SetPermissions
     request_stubs << stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
-                       .with(
-                         body: root_folder_set_permissions_request_body,
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg="
-                         }
-                       ).to_return(status: 207,
-                                   body: root_folder_set_permissions_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       body: root_folder_set_permissions_request_body,
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg="
+                       }
+                     ).to_return(status: 207,
+                                 body: root_folder_set_permissions_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     # 2 - OpenProject Project Folder Creation
     request_stubs << stub_request(
@@ -1120,48 +1120,48 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
     # 12 - Get all user in the remote group
     request_stubs << stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/groups/#{storage.group}")
-                       .with(
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                           "OCS-APIRequest" => "true"
-                         }
-                       ).to_return(status: 200,
-                                   body: group_users_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                         "OCS-APIRequest" => "true"
+                       }
+                     ).to_return(status: 200,
+                                 body: group_users_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     # 13 - Add user to group
     request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Obi-Wan/groups")
-                       .with(
-                         body: "groupid=OpenProject",
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                           "Ocs-Apirequest" => "true"
-                         }
-                       ).to_return(status: 200,
-                                   body: add_user_to_group_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       body: "groupid=OpenProject",
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                         "Ocs-Apirequest" => "true"
+                       }
+                     ).to_return(status: 200,
+                                 body: add_user_to_group_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Yoda/groups")
-                       .with(
-                         body: "groupid=OpenProject",
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                           "Ocs-Apirequest" => "true"
-                         }
-                       ).to_return(status: 200,
-                                   body: add_user_to_group_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       body: "groupid=OpenProject",
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                         "Ocs-Apirequest" => "true"
+                       }
+                     ).to_return(status: 200,
+                                 body: add_user_to_group_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Vader/groups")
-                       .with(
-                         body: "groupid=OpenProject",
-                         headers: {
-                           "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
-                           "Ocs-Apirequest" => "true"
-                         }
-                       ).to_return(status: 200,
-                                   body: add_user_to_group_response_body,
-                                   headers: { "Content-Type" => "application/xml" })
+                     .with(
+                       body: "groupid=OpenProject",
+                       headers: {
+                         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
+                         "Ocs-Apirequest" => "true"
+                       }
+                     ).to_return(status: 200,
+                                 body: add_user_to_group_response_body,
+                                 headers: { "Content-Type" => "application/xml" })
 
     # remove user from group
     request_stubs << stub_request(

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
   # USER FACTORIES
   shared_let(:single_project_user) { create(:user) }
   shared_let(:single_project_user_token) do
-    create(:oauth_client_token,
+    create(:remote_identity,
            user: single_project_user,
            oauth_client: storage.oauth_client,
            origin_user_id: "2ff33b8f-2843-40c1-9a17-d786bca17fba")
@@ -54,7 +54,7 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
 
   shared_let(:multiple_projects_user) { create(:user) }
   shared_let(:multiple_project_user_token) do
-    create(:oauth_client_token,
+    create(:remote_identity,
            user: multiple_projects_user,
            oauth_client: storage.oauth_client,
            origin_user_id: "248aeb72-b231-4e71-a466-67fa7df2a285")

--- a/spec/factories/remote_identity_factory.rb
+++ b/spec/factories/remote_identity_factory.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -29,10 +29,10 @@
 #++
 
 FactoryBot.define do
-  factory :oauth_client_token, class: "::OAuthClientToken" do
-    sequence(:access_token) { |n| "1234567890-#{n}" }
-    sequence(:refresh_token) { |n| "2345678901-#{n}" }
-    oauth_client factory: :oauth_client
-    user factory: :user
+  factory :remote_identity do
+    user
+    oauth_client
+
+    sequence(:origin_user_id) { |n| "remote-user-identifier-#{n}" }
   end
 end

--- a/spec/lib/open_project/events_spec.rb
+++ b/spec/lib/open_project/events_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -59,7 +61,7 @@ RSpec.describe OpenProject::Events do
       end
 
       context "when payload contains automatic project_folder_mode" do
-        let(:payload) { { project_folder_mode: :automatic, storage: create(:nextcloud_storage) } }
+        let(:payload) { { project_folder_mode: "automatic", storage: create(:nextcloud_storage) } }
 
         it do
           subject

--- a/spec/models/remote_identity_spec.rb
+++ b/spec/models/remote_identity_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -28,11 +28,39 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :oauth_client_token, class: "::OAuthClientToken" do
-    sequence(:access_token) { |n| "1234567890-#{n}" }
-    sequence(:refresh_token) { |n| "2345678901-#{n}" }
-    oauth_client factory: :oauth_client
-    user factory: :user
+require "spec_helper"
+
+RSpec.describe RemoteIdentity do
+  let(:user) { create(:user) }
+  let(:oauth_client) { create(:oauth_client) }
+
+  it "a user can have multiple identities in different oauth clients" do
+    other_client = create(:oauth_client)
+    create(:remote_identity, user:, oauth_client:)
+    second_identity = build(:remote_identity, user:, oauth_client: other_client)
+
+    expect(second_identity).to be_valid
+  end
+
+  it "a user can only have one identity per oauth client" do
+    create(:remote_identity, user:, oauth_client:)
+
+    invalid = build(:remote_identity, user:, oauth_client:)
+
+    expect(invalid).not_to be_valid
+    p invalid.errors
+    expect(invalid.errors.size).to eq(1)
+  end
+
+  it "is destroyed when a user is destroyed" do
+    create(:remote_identity, user:)
+
+    expect { user.destroy }.to change(described_class, :count).by(-1)
+  end
+
+  it "is destroyed when the related oauth client is destroyed" do
+    create(:remote_identity, oauth_client:)
+
+    expect { oauth_client.destroy }.to change(described_class, :count).by(-1)
   end
 end

--- a/spec/requests/oauth_clients/callback_flow_spec.rb
+++ b/spec/requests/oauth_clients/callback_flow_spec.rb
@@ -71,9 +71,10 @@ RSpec.describe "OAuthClient callback endpoint" do
       allow(Rack::OAuth2::Client).to receive(:new).and_return(rack_oauth2_client)
       allow(rack_oauth2_client)
         .to receive(:access_token!)
-              .with(:body)
-              .and_return(Rack::OAuth2::AccessToken::Bearer.new(access_token: "xyzaccesstoken",
-                                                                refresh_token: "xyzrefreshtoken"))
+        .with(:body)
+        .and_return(Rack::OAuth2::AccessToken::Bearer.new(access_token: "xyzaccesstoken",
+                                                          refresh_token: "xyzrefreshtoken",
+                                                          user_id: "g-root"))
       allow(rack_oauth2_client).to receive(:authorization_code=)
       state_cookie = CGI.escape({ href: redirect_uri, storageId: oauth_client.integration_id }.to_json)
       set_cookie "oauth_state_asdf1234=#{state_cookie}"

--- a/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
@@ -61,12 +61,9 @@ RSpec.describe OAuthClients::ConnectionManager, :oauth_connection_helpers, :webm
     end
 
     it "fills in the origin_user_id" do
-      expect { subject.code_to_token(code) }.to change(OAuthClientToken, :count).by(1)
+      expect { subject.code_to_token(code) }.to change(OAuthClientToken, :count).by(1).and(change(RemoteIdentity, :count).by(1))
 
-      last_token = OAuthClientToken
-                     .where(access_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q...")
-                     .last
-
+      last_token = RemoteIdentity.find_by!(user:, oauth_client: storage.oauth_client)
       expect(last_token.origin_user_id).to eq("87d349ed-44d7-43e1-9a83-5f2406dee5bd")
     end
 

--- a/spec/services/oauth_clients/connection_manager_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_spec.rb
@@ -113,16 +113,16 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
       end
 
       it "returns a valid ClientToken object and issues an appropriate event" do
-        expect(OpenProject::Notifications)
-          .to(receive(:send))
-          .with(OpenProject::Events::OAUTH_CLIENT_TOKEN_CREATED, integration_type: "Storages::Storage")
+        allow(OpenProject::Notifications)
+          .to receive(:send).with(OpenProject::Events::REMOTE_IDENTITY_CREATED, integration: storage).once
+
         expect(subject.success).to be_truthy
         expect(subject.result).to be_a OAuthClientToken
       end
 
       it "fills in the origin_user_id" do
-        expect { subject }.to change(OAuthClientToken, :count).by(1)
-        last_token = OAuthClientToken.where(access_token: "yjTDZ...RYvRH").last
+        expect { subject }.to change(OAuthClientToken, :count).by(1).and(change(RemoteIdentity, :count).by(1))
+        last_token = RemoteIdentity.find_by!(user:, oauth_client:)
 
         expect(last_token.origin_user_id).to eq("admin")
       end
@@ -510,12 +510,15 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
 
       before do
         allow(instance).to receive(:refresh_token).and_return refresh_service_result
-        allow(yield_double_object)
-          .to receive(:yield_twice_method)
-                .and_return(
-                  yield_service_result1,
-                  yield_service_result2
-                )
+
+        without_partial_double_verification do
+          allow(yield_double_object)
+            .to receive(:yield_twice_method)
+            .and_return(
+              yield_service_result1,
+              yield_service_result2
+            )
+        end
       end
 
       it "returns a ServiceResult with success, without refresh" do

--- a/spec/services/remote_identities/create_service_spec.rb
+++ b/spec/services/remote_identities/create_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "services/base_services/behaves_like_create_service"
+
+RSpec.describe RemoteIdentities::CreateService, type: :model do
+  let(:user) { create(:user) }
+  let(:storage) { create(:nextcloud_storage_configured) }
+  let(:oauth_config) { storage.oauth_configuration }
+  let(:oauth_token) { Rack::OAuth2::AccessToken.new(access_token: "sudo-access-token", user_id: "bob-from-accounting") }
+
+  subject(:service) { described_class.new(user:, oauth_config:, oauth_token:) }
+
+  describe ".call" do
+    it "requires a user, a oauth configuration and a rack token" do
+      method = described_class.method :call
+
+      expect(method.parameters).to contain_exactly(%i[keyreq user], %i[keyreq oauth_config], %i[keyreq oauth_token])
+    end
+
+    it "succeeds" do
+      expect(described_class.call(user:, oauth_config:, oauth_token:)).to be_success
+    end
+  end
+
+  describe "#user" do
+    it "exposes a user which is available as a getter" do
+      expect(service.user).to eq(user)
+    end
+  end
+
+  describe "#call" do
+    it "succeeds" do
+      expect(service.call).to be_success
+    end
+
+    it "returns the model as a result" do
+      result = service.call.result
+      expect(result).to be_a RemoteIdentity
+    end
+
+    context "if creation fails" do
+      let(:oauth_token) { Rack::OAuth2::AccessToken.new(access_token: "sudo-access-token") }
+
+      it "is unsuccessful" do
+        expect(service.call).to be_failure
+      end
+
+      it "exposes the errors" do
+        result = service.call
+        expect(result.errors.size).to eq(1)
+        expect(result.errors[:origin_user_id]).to eq(["can't be blank."])
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### ⚠️ Related WP: [OP#57029](https://community.openproject.org/projects/openproject/work_packages/57029)

## Why

Right now, every time a OAuth Token is removed the user might lose access to any AMPF enabled project storages.

Of course, that's an unintended side effect from the way we deal with our data.

## What

`OAuthClientToken`s have a property called `origin_user_id` that we use to set permissions on remote folders for any given storage.

The same tokens can be revoked and removed for a bunch of different reasons and this can end up with users losing access to the project folders on the storage provider.

This PR introduces the missing abstraction that will deal with this issue.

## How

This PR introduces a new model called `RemoteIdentity` that links a `User` to an `OAuthClient` and contains an `origin_user_id`.

The idea is that this model will always hold the latest known remote identity for a given user on a oauth client, so that even if the token is gone, we can still know who this `User` is on the `storage provider` and therefore add/remove them from AMPF folders.


## Needed steps
- [x] Create RemoteIndentity
- [x] Update the ConnectionManager to create the RemoteIdentity
- [x] Update the Sync Jobs to use it
- [x] Update the Commands and Queries that rely on `origin_user_id`
- [x] Update the `Connected Users` list to rely on RemoteIdentity rather than tokens
- [x] Introduce an event on RemoteIdentity creation
- [ ] Introduce an event on RemoteIdentity removal (it is redundant but why not?)
- [x] Create a migration to move the identifier from `OAuthClientToken` to `RemoteIdentity`
- [ ] Create a migration to drop the `origin_user_id` column from `OAuthClientToken`
- [x] Quick sanity check through the UI