### PR TITLE
[#57052] Add optimistic locking to oauth_client_tokens

### DIFF
--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -33,7 +33,6 @@ require "uri/http"
 
 module OAuthClients
   class ConnectionManager
-    # Nextcloud API endpoint to check if Bearer token is valid
     TOKEN_IS_FRESH_DURATION = 10.seconds.freeze
 
     def initialize(user:, configuration:)

--- a/db/migrate/20240808133947_add_lock_version_to_oauth_client_tokens.rb
+++ b/db/migrate/20240808133947_add_lock_version_to_oauth_client_tokens.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal:true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddLockVersionToOAuthClientTokens < ActiveRecord::Migration[7.1]
+  def change
+    add_column :oauth_client_tokens, :lock_version, :integer, default: 0, null: false
+  end
+end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
@@ -39,6 +39,7 @@ module Storages
 
           def initialize(user)
             @user = user
+            @retried_after_stale_object_update = false
           end
 
           # rubocop:disable Metrics/AbcSize
@@ -56,6 +57,12 @@ module Storages
 
               refresh_and_retry(httpx_oauth_config, http_options, token.result, &)
             end
+          rescue ActiveRecord::StaleObjectError => e
+            raise e if @retried_after_stale_object_update
+
+            @retried_after_stale_object_update = true
+            Rails.logger.error("#{e.inspect} happend for User ##{@user.id} #{@user.name}")
+            retry
           end
 
           # rubocop:enable Metrics/AbcSize

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -68,7 +68,11 @@ VCR.configure do |config|
     end
   end
 
-  config.default_cassette_options = { record: ENV.fetch("VCR_RECORD_MODE", :once).to_sym, drop_unused_requests: true }
+  config.default_cassette_options = {
+    record: ENV.fetch("VCR_RECORD_MODE", :once).to_sym,
+    allow_playback_repeats: true,
+    drop_unused_requests: true
+  }
 end
 
 VCR.turn_off!


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
I try to prevent race condition on `oauth_client_token` updates. This race condition can lead to an inconsistent state when OP has already dead refresh_token which NC does not accept. Then user has to go through OAuth grant flow again. 


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

I enable optimistic locking for `oauth_client_tokens`. It prevents a race condition for update and destroy calls. `ActiveRecord::StaleObjectError` is raised then. The exception is caught and retry happens once. 
https://api.rubyonrails.org/v7.1.3.4/classes/ActiveRecord/Locking/Optimistic.html
![image](https://github.com/user-attachments/assets/125f5672-6a67-40e6-90d4-792e0e61c7b1)

# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/57052
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)


