### PR TITLE
[#56780] Add copy to clipboard button for newly created API token

### DIFF
--- a/app/components/my/access_token/access_token_created_dialog_component.html.erb
+++ b/app/components/my/access_token/access_token_created_dialog_component.html.erb
@@ -34,10 +34,35 @@ See COPYRIGHT and LICENSE files for more details.
     size: :large
   )) do |dialog|
     dialog.with_body do
-      render(Primer::Beta::Blankslate.new) do |component|
-        component.with_visual_icon(icon: :"check-circle", color: :success)
-        component.with_heading(tag: :h1).with_content(heading)
-        component.with_description { text }
+      flex_layout do |flex|
+        flex.with_row(mb: 3) do
+          render(Primer::Beta::Heading.new(tag: :h1, text_align: :center)) do
+            render(Primer::Beta::Octicon.new(icon: :"check-circle", color: :success, size: :medium))
+          end
+        end
+        flex.with_row(mb: 1) do
+          render(Primer::Beta::Heading.new(tag: :h2, color: :default, text_align: :center)) do
+            I18n.t("my.access_token.create_dialog.header", type: "API")
+          end
+        end
+        flex.with_row(mb: 2) do
+          render(Primer::OpenProject::InputGroup.new) do |input_group|
+            input_group.with_text_input(name: :openproject_api_access_token,
+                                        label: Token::API.model_name.human,
+                                        visually_hide_label: false,
+                                        value: @token_value)
+            input_group.with_trailing_action_clipboard_copy_button(
+              value: @token_value,
+              aria: {
+                label: I18n.t('button_copy_to_clipboard')
+              })
+          end
+        end
+        flex.with_row do
+          render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert)) do
+            I18n.t("my.access_token.create_dialog.warning")
+          end
+        end
       end
     end
     dialog.with_footer do
@@ -49,4 +74,3 @@ See COPYRIGHT and LICENSE files for more details.
     end
   end
 %>
-

--- a/app/components/my/access_token/access_token_created_dialog_component.rb
+++ b/app/components/my/access_token/access_token_created_dialog_component.rb
@@ -42,24 +42,6 @@ module My
       def id
         "access-token-created-dialog"
       end
-
-      def heading
-        I18n.t("my.access_token.create_dialog.header", type: "API")
-      end
-
-      def text
-        options = {
-          tag: :div,
-          color: :subtle
-        }
-        safe_join(
-          [
-            render(Primer::Beta::Text.new(**options)) { I18n.t("my.access_token.create_dialog.text") },
-            render(Primer::Beta::Text.new(**options.merge(font_weight: :bold))) { @token_value },
-            render(Primer::Beta::Text.new(**options)) { I18n.t("my.access_token.create_dialog.warning") }
-          ]
-        )
-      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,7 +425,6 @@ en:
     access_token:
       create_dialog:
         header: The %{type} token has been generated
-        text: "Your access token is:"
         warning: Note that this is the only time you will see this token, make sure to copy it now.
       errors:
         token_name_blank: "Please provide an API token name"
@@ -1230,6 +1229,9 @@ en:
         one: "Role"
         other: "Roles"
       status: "Work package status"
+      token/api:
+        one: Access token
+        other: Access tokens
       type: "Type"
       user: "User"
       version: "Version"

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe "my", :js, :with_cuprite do
 
           within("dialog#access-token-created-dialog") do
             expect(page).to have_content "The API token has been generated"
+            click_on "Close"
           end
           expect(page).to have_content("Testing Token")
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/56780/activity

Actually, the whole layout of the dialog was changed, because of UX
implications of having a copy to clipboard button and to make the
user more aware that he has something to do.

From a technical side, I switched from using a blankslate to using
a flex layout, because the blankslate would enforce the text to be
centered and the input label and warning are left aligned and do not
look good when being centered. I also tried having them below the
blankslate (so the blankslate would only have an icon and an heading)
but then there's a large margin between the heading and the rest of
the content.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) => no new patterns
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) => Tested in Chrome 
