### PR TITLE
[57095] Remaining bugs in dark mode 

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -29,7 +29,6 @@
     --avatar-border-color: var(--avatar-borderColor);
     --list-item-hover--border-color: var(--control-transparent-borderColor-hover);
     --list-item-hover--color: var(--fgColor-default);
-    --inplace-edit--border-color: var(--borderColor-default);
     --ck-color-toolbar-border: var(--borderColor-default);
     --ck-color-list-background: var(--overlay-bgColor);
     --ck-color-base-border: var(--borderColor-default);

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -713,7 +713,7 @@ input[readonly].-clickable
   &.-focus
     text-decoration: none
     color: var(--body-font-color)
-    border-color: var(--inplace-edit--border-color)
+    border-color: var(--borderColor-default)
 
     .form--selected-value--remover
       visibility: visible

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -31,7 +31,7 @@
     border-style: solid
     &:hover
       cursor: text
-      border-color: var(--inplace-edit--border-color)
+      border-color: var(--borderColor-default)
       background: var(--control-bgColor-activ)
 
   .delete-group,

--- a/frontend/src/global_styles/content/modules/_2fa.sass
+++ b/frontend/src/global_styles/content/modules/_2fa.sass
@@ -44,7 +44,7 @@
     width: 100%
 
 .mobile-otp-new-device
-  border: 1px solid #f1f1f1
+  border: 1px solid var(--borderColor-default)
   padding: 20px
   margin-right: 10px
   flex: 1 0 25%

--- a/frontend/src/global_styles/content/modules/_2fa.sass
+++ b/frontend/src/global_styles/content/modules/_2fa.sass
@@ -84,8 +84,8 @@
   // Avoid stretching the columns too much
   max-width: 500px
   margin: 2rem 0
-  background: #f8f8f8
-  border: 1px solid #f1f1f1
+  background: var(--bgColor-muted)
+  border: 1px solid var(--borderColor-default)
   border-radius: 5px
 
   ul

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -158,7 +158,7 @@ display-field
 
   &:hover,
   &:focus
-    border-color: var(--inplace-edit--border-color)
+    border-color: var(--borderColor-default)
 
     &.-multiline
       white-space: inherit

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_textareas.sass
@@ -50,8 +50,7 @@
   width: 80px
   height: 40px
   background: var(--control-bgColor-rest)
-  border: 1px solid var(--inplace-edit--color--very-dark)
-  box-shadow: 2px 2px 4px var(--inplace-edit--border-color)
+  border: 1px solid var(--borderColor-default)
   text-align: center
   // Align controls via flex
   display: flex
@@ -84,7 +83,7 @@
   text-decoration: none
 
   &:hover, &:active
-    border-color: var(--inplace-edit--border-color)
+    border-color: var(--borderColor-default)
 
   .icon-context:before
     padding: 0

--- a/frontend/src/global_styles/content/work_packages/single_view/_work_package_comment.sass
+++ b/frontend/src/global_styles/content/work_packages/single_view/_work_package_comment.sass
@@ -6,14 +6,14 @@
   padding: 0
   margin: 0
   background: none
-  border: 1px solid var(--inplace-edit--border-color)
+  border: 1px solid var(--borderColor-default)
   cursor: pointer
   height: 42px
 
 
   &:hover &,
   &:focus &
-    border-color: var(--inplace-edit--border-color)
+    border-color: var(--borderColor-default)
     text-decoration: none
     color: var(--body-font-color)
 
@@ -30,8 +30,8 @@
     height: 100%
     text-align: center
     width: 32px
-    background: var(--gray-light)
-    border-left: 1px solid var(--inplace-edit--border-color)
+    background: var(--bgColor-muted)
+    border-left: 1px solid var(--borderColor-default)
     color: var(--body-font-color)
     visibility: hidden
     // Align the icon centered

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -109,7 +109,6 @@
   --drop-down-hover-bg-color: #EFEFEF;
   --wiki-default-font-size: var(--body-font-size);
   --user-avatar-border-radius: 50%;
-  --inplace-edit--border-color: #ddd;
   --inplace-edit--color--very-dark: #cacaca;
   --table-row-highlighting-outline-color: #00A6FF;
   --button--font-color: #222222;

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -109,7 +109,6 @@
   --drop-down-hover-bg-color: #EFEFEF;
   --wiki-default-font-size: var(--body-font-size);
   --user-avatar-border-radius: 50%;
-  --inplace-edit--color--very-dark: #cacaca;
   --table-row-highlighting-outline-color: #00A6FF;
   --button--font-color: #222222;
   --button--background-color: var(--gray-light);


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?
Fix background color in icon of WP comment and background of backup codes in 2FA page

## Screenshots

Before:

<img width="871" alt="Screenshot 2024-08-06 at 23 10 03" src="https://github.com/user-attachments/assets/a32df34e-2684-459a-bd0f-3e2051134058">

![Screenshot 2024-08-09 at 06 51 36](https://github.com/user-attachments/assets/0e7f7d4f-9042-48be-b790-284494244615)


After:

![Screenshot 2024-08-09 at 13 33 22](https://github.com/user-attachments/assets/e719f24d-91c9-4472-ae0f-9f906ffacf84)

![Screenshot 2024-08-09 at 13 32 49](https://github.com/user-attachments/assets/361f26fb-1ce9-4c87-829a-e8b361a1a379)

# What approach did you choose and why?
Replace our CSS custom variables with Primer variables.

# Ticket

https://community.openproject.org/work_packages/57095/activity

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
