### PR TITLE
Fix preview of SplitViewComponent

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   flex_layout(classes: "op-work-package-details-tab-component") do |flex|
-    flex.with_column(flex: 1, classes: "op-work-package-details-tab-component--tabs") do
+    flex.with_column(flex: 1, classes: "op-work-package-details-tab-component--tabs", test_selector: "wp-details-tab-component--tabs") do
       render(Primer::Alpha::UnderlineNav.new(align: :left, label: "Tabs", classes: "op-primer-adjustment--UnderlineNav_spaciousLeft")) do |component|
         menu_items.each do |node|
           component.with_tab(selected: @tab == node.name,

--- a/app/components/work_packages/split_view_component.html.erb
+++ b/app/components/work_packages/split_view_component.html.erb
@@ -17,7 +17,7 @@
         flex.with_row(flex: 1) do
           helpers.angular_component_tag "opce-wp-split-view",
                                         inputs: {
-                                          work_package_id: params[:work_package_id],
+                                          work_package_id: params[:work_package_id] || @work_package.id,
                                           activeTab: @tab
                                         }
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -738,6 +738,9 @@ Rails.application.routes.draw do
   end
 
   if OpenProject::Configuration.lookbook_enabled?
+    # Dummy route for the split screen controller
+    get :close_split_view, controller: "homescreen"
+
     mount Lookbook::Engine, at: "/lookbook"
   end
 

--- a/frontend/src/global_styles/layout/_viewcomponent_previews.sass
+++ b/frontend/src/global_styles/layout/_viewcomponent_previews.sass
@@ -1,3 +1,4 @@
 .viewcomponent-preview
   &--content
     margin: 1rem
+    height: 100%

--- a/lookbook/previews/open_project/work_packages/split_view_component_preview.rb
+++ b/lookbook/previews/open_project/work_packages/split_view_component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module OpenProject::WorkPackages
+  # @logical_path OpenProject/WorkPackages
+  class SplitViewComponentPreview < ViewComponent::Preview
+    # @display min_height 400px
+    def default
+      render(WorkPackages::SplitViewComponent.new(id: 1, tab: "overview", base_route: work_packages_path))
+    end
+  end
+end

--- a/spec/components/previews/work_packages/split_view_component_preview.rb
+++ b/spec/components/previews/work_packages/split_view_component_preview.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class WorkPackages::SplitViewComponentPreview < ViewComponent::Preview
-  def default
-    render(WorkPackages::SplitViewComponent.new(id: "1", tab: "tab", base_url: work_packages_path))
-  end
-end

--- a/spec/components/work_packages/split_view_component_spec.rb
+++ b/spec/components/work_packages/split_view_component_spec.rb
@@ -3,13 +3,27 @@
 require "rails_helper"
 
 RSpec.describe WorkPackages::SplitViewComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include OpenProject::StaticRouting::UrlHelpers
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  let(:project)      { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+
+  subject do
+    with_request_url("/notifications/details/:work_package_id") do
+      render_inline(described_class.new(id: work_package.id, base_route: notifications_path))
+    end
+  end
+
+  before do
+    allow(WorkPackage).to receive(:visible).and_return(WorkPackage.where(id: work_package.id))
+  end
+
+  it "renders successfully" do
+    subject
+
+    expect(page).to have_text("Overview")
+    expect(page).to have_test_selector("wp-details-tab-component--tabs")
+    expect(page).to have_test_selector("wp-details-tab-component--close")
+    expect(page).to have_test_selector("wp-details-tab-component--full-screen")
+  end
 end


### PR DESCRIPTION
The preview of the SplitViewComponent was not working any more, as there was a parameter missing and a route not defined.