### PR TITLE
[56918] Add numbers to Relations and File tab in new notification split screen

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -10,7 +10,7 @@
           ) do |c|
             c.with_text { t("js.work_packages.tabs.#{node.name}") }
             count = node.badge(work_package:).to_i
-            c.with_counter(count:, test_selector: "wp-details-tab-component--tab-counter") if count > 0
+            c.with_counter(count:, hide_if_zero: true, id: "wp-details-tab-#{node.name}-counter", test_selector: "wp-details-tab-component--tab-counter")
           end
         end
       end

--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -10,7 +10,7 @@
           ) do |c|
             c.with_text { t("js.work_packages.tabs.#{node.name}") }
             count = node.badge(work_package:).to_i
-            c.with_counter(count:, hide_if_zero: true, id: "wp-details-tab-#{node.name}-counter", test_selector: "wp-details-tab-component--tab-counter")
+            c.with_counter(count:, hide_if_zero: true, id: "wp-details-tab-#{node.name}-counter", test_selector: "wp-details-tab-component--#{node.name}-counter")
           end
         end
       end

--- a/app/components/work_packages/details/update_counter_component.rb
+++ b/app/components/work_packages/details/update_counter_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class WorkPackages::Details::UpdateCounterComponent < ApplicationComponent
+  include OpPrimer::ComponentHelpers
+  include OpTurbo::Streamable
+
+  attr_reader :work_package, :menu_name
+
+  def initialize(work_package:, menu_name:)
+    super
+
+    @work_package = work_package
+    @menu = find_menu_item(menu_name)
+  end
+
+  def call
+    render Primer::Beta::Counter
+      .new(count:,
+           hide_if_zero: true,
+           id: wrapper_key,
+           test_selector: "wp-details-tab-component--tab-counter")
+  end
+
+  # We don't need a wrapper component, but wrap on the counter id
+  def wrapped?
+    true
+  end
+
+  def wrapper_key
+    "wp-details-tab-#{@menu.name}-counter"
+  end
+
+  def render?
+    @menu.present?
+  end
+
+  def count
+    @menu
+      .badge(work_package:)
+      .to_i
+  end
+
+  def find_menu_item(menu_name)
+    Redmine::MenuManager
+        .items(:work_package_split_view, nil)
+        .root
+        .children
+        .detect { |node| node.name.to_s == menu_name }
+  end
+end

--- a/app/components/work_packages/details/update_counter_component.rb
+++ b/app/components/work_packages/details/update_counter_component.rb
@@ -18,7 +18,7 @@ class WorkPackages::Details::UpdateCounterComponent < ApplicationComponent
       .new(count:,
            hide_if_zero: true,
            id: wrapper_key,
-           test_selector: "wp-details-tab-component--tab-counter")
+           test_selector: "wp-details-tab-component--#{@menu.name}-counter")
   end
 
   # We don't need a wrapper component, but wrap on the counter id

--- a/app/controllers/concerns/work_packages/with_split_view.rb
+++ b/app/controllers/concerns/work_packages/with_split_view.rb
@@ -32,31 +32,10 @@ module WorkPackages
 
     included do
       helper_method :split_view_base_route
-
-      before_action :find_work_package, only: %i[split_view update_counter]
-      before_action :find_counter_menu, only: %i[update_counter]
     end
 
     def split_view_work_package_id
       params[:work_package_id].to_i
-    end
-
-    def update_counter
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: [
-            turbo_stream.replace("wp-details-tab-#{@counter_menu.name}-counter") do
-              count = @counter_menu.badge(work_package: @work_package).to_i
-              Primer::Beta::Counter
-                .new(count:,
-                     hide_if_zero: true,
-                     id: "wp-details-tab-#{@counter_menu.name}-counter",
-                     test_selector: "wp-details-tab-component--tab-counter")
-                .render_in(view_context)
-            end
-          ]
-        end
-      end
     end
 
     def close_split_view
@@ -85,25 +64,6 @@ module WorkPackages
 
         yield(format) if format_block
       end
-    end
-
-    private
-
-    def find_work_package
-      @work_package = WorkPackage.visible.find(params[:work_package_id])
-    rescue ActiveRecord::RecordNotFound
-      flash[:error] = I18n.t(:error_work_package_id_not_found)
-      redirect_to split_view_base_route
-    end
-
-    def find_counter_menu
-      @counter_menu = Redmine::MenuManager
-        .items(:work_package_split_view, nil)
-        .root
-        .children
-        .detect { |node| node.name.to_s == params[:counter] }
-
-      render_400 if @counter_menu.nil?
     end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -31,7 +31,7 @@ class NotificationsController < ApplicationController
 
   before_action :require_login
   before_action :filtered_query, only: :mark_all_read
-  no_authorization_required! :index, :split_view, :close_split_view, :mark_all_read, :date_alerts, :share_upsale
+  no_authorization_required! :index, :split_view, :update_counter, :close_split_view, :mark_all_read, :date_alerts, :share_upsale
 
   def index
     render_notifications_layout

--- a/app/controllers/work_packages/split_view_controller.rb
+++ b/app/controllers/work_packages/split_view_controller.rb
@@ -1,0 +1,72 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rack/utils"
+
+class WorkPackages::SplitViewController < ApplicationController
+  # Authorization is checked in the find_work_package action
+  no_authorization_required! :update_counter
+  before_action :find_work_package, only: %i[update_counter]
+  before_action :find_counter_menu, only: %i[update_counter]
+
+  def update_counter
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace("wp-details-tab-#{@counter_menu.name}-counter") do
+            count = @counter_menu.badge(work_package: @work_package).to_i
+            Primer::Beta::Counter
+              .new(count:,
+                   hide_if_zero: true,
+                   id: "wp-details-tab-#{@counter_menu.name}-counter",
+                   test_selector: "wp-details-tab-component--tab-counter")
+              .render_in(view_context)
+          end
+        ]
+      end
+    end
+  end
+
+  private
+
+  def find_work_package
+    @work_package = WorkPackage.visible.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render_404 message: I18n.t(:error_work_package_id_not_found)
+  end
+
+  def find_counter_menu
+    @counter_menu = Redmine::MenuManager
+      .items(:work_package_split_view, nil)
+      .root
+      .children
+      .detect { |node| node.name.to_s == params[:counter] }
+
+    render_400 if @counter_menu.nil?
+  end
+end

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -103,14 +103,6 @@ class Relation < ApplicationRecord
   scope :follows_with_lag,
         -> { follows.where("lag > 0") }
 
-  scope :visible_involved,
-        ->(work_package) do
-          visible_sql = WorkPackage.visible(User.current).select(:id).to_sql
-          where("(from_id IN (?) AND to_id IN (#{visible_sql})) OR (to_id IN (?) AND from_id IN (#{visible_sql}))",
-                work_package,
-                work_package)
-        end
-
   validates :lag, numericality: { allow_nil: true }
 
   validates :to, uniqueness: { scope: :from }

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -103,6 +103,14 @@ class Relation < ApplicationRecord
   scope :follows_with_lag,
         -> { follows.where("lag > 0") }
 
+  scope :visible_involved,
+        ->(work_package) do
+          visible_sql = WorkPackage.visible(User.current).select(:id).to_sql
+          where("(from_id IN (?) AND to_id IN (#{visible_sql})) OR (to_id IN (?) AND from_id IN (#{visible_sql}))",
+                work_package,
+                work_package)
+        end
+
   validates :lag, numericality: { allow_nil: true }
 
   validates :to, uniqueness: { scope: :from }

--- a/app/views/notifications/menus/_menu.html.erb
+++ b/app/views/notifications/menus/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "notifications_sidemenu",
-                    src: notifications_menu_path(**params.permit(:filter, :name)),
+                    src: notifications_menu_path(**params.slice(:filter, :name).permit!),
                     target: '_top',
                     data: { turbo: false },
                     loading: :lazy %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -654,10 +654,18 @@ Redmine::MenuManager.map :work_package_split_view do |menu|
   menu.push :files,
             { tab: :files },
             skip_permissions_check: true,
+            badge: ->(work_package:, **) {
+              Attachment.where(container_type: "WorkPackage",
+                               container_id: work_package)
+                        .count
+            },
             caption: :"js.work_packages.tabs.files"
   menu.push :relations,
             { tab: :relations },
             skip_permissions_check: true,
+            badge: ->(work_package:, **) {
+              Relation.visible_involved(work_package).count + WorkPackage.where(parent_id: work_package).count
+            },
             caption: :"js.work_packages.tabs.relations"
   menu.push :watchers,
             { tab: :watchers },

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -655,16 +655,18 @@ Redmine::MenuManager.map :work_package_split_view do |menu|
             { tab: :files },
             skip_permissions_check: true,
             badge: ->(work_package:, **) {
-              Attachment.where(container_type: "WorkPackage",
-                               container_id: work_package)
-                        .count
+              count = Storages::FileLink.where(container_type: "WorkPackage", container_id: work_package).count
+              unless work_package.hide_attachments?
+                count += work_package.attachments.count
+              end
+              count
             },
             caption: :"js.work_packages.tabs.files"
   menu.push :relations,
             { tab: :relations },
             skip_permissions_check: true,
             badge: ->(work_package:, **) {
-              Relation.visible_involved(work_package).count + WorkPackage.where(parent_id: work_package).count
+              work_package.relations.count + work_package.children.count
             },
             caption: :"js.work_packages.tabs.relations"
   menu.push :watchers,

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -670,5 +670,8 @@ Redmine::MenuManager.map :work_package_split_view do |menu|
   menu.push :watchers,
             { tab: :watchers },
             skip_permissions_check: true,
+            badge: ->(work_package:, **) {
+              work_package.watchers.count
+            },
             caption: :"js.work_packages.tabs.watchers"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -701,21 +701,22 @@ Rails.application.routes.draw do
 
   concern :with_split_view do |options|
     get "details/:work_package_id(/:tab)",
-        on: :collection,
         action: options.fetch(:action, :split_view),
         defaults: { tab: :overview },
         as: :details,
         work_package_split_view: true
 
     get "/:work_package_id/close",
-        on: :collection,
         action: :close_split_view
+
+    get "/:work_package_id/update_counter",
+        action: :update_counter
   end
 
   resources :notifications, only: :index do
-    concerns :with_split_view, base_route: :notifications_path
-
     collection do
+      concerns :with_split_view, base_route: :notifications_path
+
       post :mark_all_read
       resource :menu, module: :notifications, only: %i[show], as: :notifications_menu
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,12 +561,15 @@ Rails.application.routes.draw do
                as: :work_package_progress
     end
 
+    get "/split_view/update_counter" => "work_packages/split_view#update_counter",
+        on: :member
+
     # states managed by client-side (angular) routing on work_package#show
     get "/" => "work_packages#index", on: :collection, as: "index"
     get "/create_new" => "work_packages#index", on: :collection, as: "new_split"
     get "/new" => "work_packages#index", on: :collection, as: "new", state: "new"
     # We do not want to match the work package export routes
-    get "(/*state)" => "work_packages#show", on: :member, as: "", constraints: { id: /\d+/, state: /(?!shares).+/ }
+    get "(/*state)" => "work_packages#show", on: :member, as: "", constraints: { id: /\d+/, state: /(?!(shares|split_view)).+/ }
     get "/share_upsale" => "work_packages#index", on: :collection, as: "share_upsale"
     get "/edit" => "work_packages#show", on: :member, as: "edit"
   end
@@ -708,9 +711,6 @@ Rails.application.routes.draw do
 
     get "/:work_package_id/close",
         action: :close_split_view
-
-    get "/:work_package_id/update_counter",
-        action: :update_counter
   end
 
   resources :notifications, only: :index do

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -288,6 +288,10 @@ export class PathHelperService {
     return `${this.workPackagePath(workPackageId)}/progress/edit`;
   }
 
+  public workPackageUpdateCounterPath(workPackageId:string|number, counter:string) {
+    return `${this.workPackagePath(workPackageId)}/split_view/update_counter?counter=${counter}`;
+  }
+
   // Work Package Bulk paths
 
   public workPackagesBulkEditPath() {

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-query.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-query.component.ts
@@ -43,6 +43,7 @@ import { HalEventsService } from 'core-app/features/hal/services/hal-events.serv
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { GroupDescriptor } from 'core-app/features/work-packages/components/wp-single-view/wp-single-view.component';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { WorkPackageRelationsService } from 'core-app/features/work-packages/components/wp-relations/wp-relations.service';
 
 @Component({
   selector: 'wp-children-query',
@@ -76,13 +77,16 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
     ),
   ];
 
-  constructor(protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
+  constructor(
+    protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
     protected PathHelper:PathHelperService,
     protected wpInlineCreate:WorkPackageInlineCreateService,
     protected halEvents:HalEventsService,
     protected apiV3Service:ApiV3Service,
     protected queryUrlParamsHelper:UrlParamsHelperService,
-    readonly I18n:I18nService) {
+    readonly I18n:I18nService,
+    readonly wpRelations:WorkPackageRelationsService,
+    ) {
     super(queryUrlParamsHelper);
   }
 
@@ -116,6 +120,9 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
         filter(() => !!this.embeddedTable?.isInitialized),
         this.untilDestroyed(),
       )
-      .subscribe(() => this.refreshTable());
+      .subscribe(() => {
+        this.wpRelations.updateCounter(this.workPackage);
+        this.refreshTable();
+      });
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -197,6 +197,8 @@ export class WorkPackageRelationRowComponent extends UntilDestroyedMixin impleme
           .cache
           .updateWorkPackage(this.relatedWorkPackage);
 
+        this.wpRelations.updateCounter(this.workPackage);
+
         this.notificationService.showSave(this.relatedWorkPackage);
       })
       .catch((err:any) => this.notificationService.handleRawError(err,

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -1,5 +1,8 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  Input,
+} from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
@@ -29,21 +32,12 @@ export class WorkPackageRelationsCreateComponent {
     addNewRelation: this.I18n.t('js.relation_buttons.add_new_relation'),
   };
 
-  constructor(readonly I18n:I18nService,
+  constructor(
+    readonly I18n:I18nService,
     protected wpRelations:WorkPackageRelationsService,
     protected notificationService:WorkPackageNotificationService,
-    protected halEvents:HalEventsService) {
-  }
-
-  public createRelation() {
-    if (!this.selectedRelationType || !this.selectedWpId) {
-      return;
-    }
-
-    this.isDisabled = true;
-    this.createCommonRelation()
-      .catch(() => this.isDisabled = false)
-      .then(() => this.isDisabled = false);
+    protected halEvents:HalEventsService,
+  ) {
   }
 
   public onSelected(workPackage?:WorkPackageResource) {
@@ -64,6 +58,7 @@ export class WorkPackageRelationsCreateComponent {
           relationType: this.selectedRelationType,
         });
         this.notificationService.showSave(this.workPackage);
+        this.wpRelations.updateCounter(this.workPackage);
         this.toggleRelationsCreateForm();
       })
       .catch((err) => {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
@@ -11,6 +11,7 @@ import {
 } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { RelationResource } from 'core-app/features/hal/resources/relation-resource';
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 
 export type RelationsStateValue = { [relationId:string]:RelationResource };
 
@@ -27,9 +28,12 @@ export class RelationStateGroup extends StatesGroup {
 
 @Injectable()
 export class WorkPackageRelationsService extends StateCacheService<RelationsStateValue> {
-  constructor(private PathHelper:PathHelperService,
+  constructor(
+    private PathHelper:PathHelperService,
     private apiV3Service:ApiV3Service,
-    private halResource:HalResourceService) {
+    private halResource:HalResourceService,
+    readonly turboRequests:TurboRequestsService,
+  ) {
     super(new RelationStateGroup().relations);
   }
 
@@ -170,6 +174,13 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
         this.insertIntoStates(relation);
         return relation;
       });
+  }
+
+  public updateCounter(workPackage:WorkPackageResource) {
+    if (workPackage.id) {
+      const url = this.PathHelper.workPackageUpdateCounterPath(workPackage.id, 'relations');
+      void this.turboRequests.request(url);
+    }
   }
 
   /**

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
@@ -15,7 +15,11 @@
       <span class="op-tab-content--header-text" [textContent]="text.attachments.label"></span>
     </div>
 
-    <op-attachments [resource]="workPackage"></op-attachments>
+    <op-attachments
+      [resource]="workPackage"
+      (attachmentRemoved)="attachmentRemoved()"
+      (attachmentAdded)="attachmentAdded()"
+    ></op-attachments>
   </section>
 
   <section
@@ -28,6 +32,8 @@
       [projectStorage]="storage"
       [allowUploading]="allowManageFileLinks$ | async"
       [allowLinking]="allowManageFileLinks$ | async"
+      (fileRemoved)="attachmentRemoved()"
+      (fileAdded)="attachmentAdded()"
     ></op-storage>
   </section>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
@@ -1,4 +1,4 @@
-//-- copyright
+// -- copyright
 // OpenProject is an open source project management software.
 // Copyright (C) the OpenProject GmbH
 //
@@ -41,6 +41,8 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ProjectStoragesResourceService } from 'core-app/core/state/project-storages/project-storages.service';
 import { IProjectStorage } from 'core-app/core/state/project-storages/project-storage.model';
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Component({
   selector: 'op-files-tab',
@@ -68,6 +70,8 @@ export class WorkPackageFilesTabComponent implements OnInit {
     private readonly i18n:I18nService,
     private readonly currentUserService:CurrentUserService,
     private readonly projectStoragesResourceService:ProjectStoragesResourceService,
+    private readonly pathHelper:PathHelperService,
+    private readonly turboRequests:TurboRequestsService,
   ) { }
 
   ngOnInit():void {
@@ -95,5 +99,20 @@ export class WorkPackageFilesTabComponent implements OnInit {
     ).pipe(
       map(([storages, viewPermission]) => storages.length > 0 && viewPermission),
     );
+  }
+
+  attachmentRemoved() {
+    this.updateCounter();
+  }
+
+  attachmentAdded() {
+    this.updateCounter();
+  }
+
+  private updateCounter() {
+    if (this.workPackage.id) {
+      const url = this.pathHelper.workPackageUpdateCounterPath(this.workPackage.id, 'files');
+      void this.turboRequests.request(url);
+    }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -42,6 +42,7 @@ import {
 } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { TurboRequestsService } from "core-app/core/turbo/turbo-requests.service";
 
 @Component({
   templateUrl: './watchers-tab.html',
@@ -89,6 +90,7 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
     readonly cdRef:ChangeDetectorRef,
     readonly pathHelper:PathHelperService,
     readonly apiV3Service:ApiV3Service,
+    readonly turboRequests:TurboRequestsService,
   ) {
     super();
   }
@@ -97,6 +99,7 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
     this.$element = jQuery(this.elementRef.nativeElement);
     const { workPackageId } = this.uiRouterGlobals.params as unknown as { workPackageId:string };
     this.workPackageId = (this.workPackage.id as string) || workPackageId;
+
     this
       .apiV3Service
       .work_packages
@@ -150,6 +153,8 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
           .id(this.workPackage)
           .refresh();
 
+        this.updateCounter();
+
         this.cdRef.detectChanges();
       })
       .catch((error:any) => this.notificationService.showError(error, this.workPackage));
@@ -168,8 +173,16 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
           .work_packages
           .id(this.workPackage)
           .refresh();
+
+        this.updateCounter();
+
         this.cdRef.detectChanges();
       })
       .catch((error:any) => this.notificationService.showError(error, this.workPackage));
+  }
+
+  public updateCounter() {
+    const url = this.pathHelper.notificationsPath() + `/${this.workPackageId}/update_counter?counter=watchers`;
+    void this.turboRequests.request(url);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -182,7 +182,7 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
   }
 
   public updateCounter() {
-    const url = this.pathHelper.notificationsPath() + `/${this.workPackageId}/update_counter?counter=watchers`;
+    const url = `${this.pathHelper.workPackagePath(this.workPackageId)}/split_view/update_counter?counter=watchers`;
     void this.turboRequests.request(url);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -182,7 +182,7 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
   }
 
   public updateCounter() {
-    const url = `${this.pathHelper.workPackagePath(this.workPackageId)}/split_view/update_counter?counter=watchers`;
+    const url = this.pathHelper.workPackageUpdateCounterPath(this.workPackageId, 'watchers');
     void this.turboRequests.request(url);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -42,7 +42,7 @@ import {
 } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { TurboRequestsService } from "core-app/core/turbo/turbo-requests.service";
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 
 @Component({
   templateUrl: './watchers-tab.html',

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
@@ -1,4 +1,4 @@
-//-- copyright
+// -- copyright
 // OpenProject is an open source project management software.
 // Copyright (C) the OpenProject GmbH
 //
@@ -26,7 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { IAttachment } from 'core-app/core/state/attachments/attachment.model';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { AttachmentsResourceService } from 'core-app/core/state/attachments/attachments.service';
@@ -43,6 +50,8 @@ export class OpAttachmentListComponent extends UntilDestroyedMixin implements On
 
   @Input() public showTimestamp = true;
 
+  @Output() public attachmentRemoved = new EventEmitter<void>();
+
   constructor(
     private readonly attachmentsResourceService:AttachmentsResourceService,
   ) {
@@ -54,5 +63,6 @@ export class OpAttachmentListComponent extends UntilDestroyedMixin implements On
 
   public removeAttachment(attachment:IAttachment):void {
     this.attachmentsResourceService.removeAttachment(this.collectionKey, attachment).subscribe();
+    this.attachmentRemoved.emit();
   }
 }

--- a/frontend/src/app/shared/components/attachments/attachments.component.html
+++ b/frontend/src/app/shared/components/attachments/attachments.component.html
@@ -7,6 +7,7 @@
   [attachments]="attachments$ | async"
   [collectionKey]="collectionKey"
   [showTimestamp]="showTimestamp"
+  (attachmentRemoved)="attachmentRemoved.emit()"
 ></op-attachment-list>
 
 <input

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -1,4 +1,4 @@
-//-- copyright
+// -- copyright
 // OpenProject is an open source project management software.
 // Copyright (C) the OpenProject GmbH
 //
@@ -31,10 +31,12 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   HostBinding,
   Input,
   OnDestroy,
   OnInit,
+  Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -79,6 +81,10 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
   @Input() public externalUploadButton:string|null = null;
 
   @Input() public showTimestamp = true;
+
+  @Output() public attachmentRemoved = new EventEmitter<void>();
+
+  @Output() public attachmentAdded = new EventEmitter<void>();
 
   public attachments$:Observable<IAttachment[]>;
 
@@ -258,7 +264,7 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
       .attachmentsResourceService
       .attachFiles(this.resource, filesWithoutFolders)
       .subscribe({
-        next: () => {},
+        next: () => { this.attachmentAdded.emit(); },
         error: (error:HttpErrorResponse) => this.toastService.addError(error),
       });
   }

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -1,4 +1,4 @@
-//-- copyright
+// -- copyright
 // OpenProject is an open source project management software.
 // Copyright (C) the OpenProject GmbH
 //
@@ -31,9 +31,11 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnDestroy,
   OnInit,
+  Output,
   ViewChild,
 } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -120,6 +122,10 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
   @Input() public allowLinking = true;
 
   @ViewChild('hiddenFileInput') public filePicker:ElementRef<HTMLInputElement>;
+
+  @Output() public fileRemoved = new EventEmitter<void>();
+
+  @Output() public fileAdded = new EventEmitter<void>();
 
   fileLinks:Observable<IFileLink[]>;
 
@@ -291,7 +297,7 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
         switchMap((key) => this.fileLinkResourceService.remove(key, fileLink)),
       )
       .subscribe({
-        next: () => { /* Do nothing */ },
+        next: () => { this.fileRemoved.emit(); },
         error: (error:HttpErrorResponse) => this.toastService.addError(error),
       });
   }
@@ -412,6 +418,7 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
       .subscribe({
         next: (collection) => {
           this.toastService.addSuccess(this.text.toast.successFileLinksCreated(collection.count));
+          this.fileAdded.emit();
         },
         error: (error) => {
           if (isUploadError) {

--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -57,3 +57,6 @@ en:
           draft: 'drafted'
           merged: 'merged'
           ready_for_review: 'marked ready for review'
+    work_packages:
+      tabs:
+        github: "GitHub"

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -81,9 +81,11 @@ module OpenProject::GithubIntegration
            if: ->(project) {
              User.current.allowed_in_project?(:show_github_content, project)
            },
-           parent: :admin_github_integration,
-           caption: :label_deploy_target_plural,
-           icon: "cloud"
+           skip_permissions_check: true,
+           badge: ->(work_package:, **) {
+             work_package.github_pull_requests.count
+           },
+           caption: :project_module_github
     end
 
     initializer "github.register_hook" do

--- a/modules/github_integration/spec/features/work_package_github_tab_spec.rb
+++ b/modules/github_integration/spec/features/work_package_github_tab_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Open the GitHub tab", :js do
       it "does not show the github tab" do
         work_package_page.visit!
 
-        github_tab.expect_tab_not_present
+        work_package_page.expect_no_tab "Github"
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe "Open the GitHub tab", :js do
       it "does not show the github tab" do
         work_package_page.visit!
 
-        github_tab.expect_tab_not_present
+        work_package_page.expect_no_tab "Github"
       end
     end
   end
@@ -129,6 +129,14 @@ RSpec.describe "Open the GitHub tab", :js do
 
   describe "work package split view" do
     let(:work_package_page) { Pages::SplitWorkPackage.new(work_package) }
+
+    it_behaves_like "a github tab"
+  end
+
+  describe "primerized work package split view" do
+    let(:work_package_page) { Pages::PrimerizedSplitWorkPackage.new(work_package) }
+    let(:tabs) { Components::WorkPackages::PrimerizedTabs.new }
+    let(:github_tab_element) { "github" }
 
     it_behaves_like "a github tab"
   end

--- a/modules/github_integration/spec/support/pages/work_package_github_tab.rb
+++ b/modules/github_integration/spec/support/pages/work_package_github_tab.rb
@@ -55,10 +55,6 @@ module Pages
       page.send_keys(meta_key, "v")
     end
 
-    def expect_tab_not_present
-      expect(page).to have_no_css(".op-tab-row--link", text: "GITHUB")
-    end
-
     private
 
     def osx?

--- a/modules/gitlab_integration/config/locales/js-en.yml
+++ b/modules/gitlab_integration/config/locales/js-en.yml
@@ -55,3 +55,6 @@ en:
         empty: There are no merge requests linked yet. Link an existing MR by using the code <code>OP#%{wp_id}</code> (or <code>PP#%{wp_id}</code> for private links) in the MR title/description or create a new MR.
       gitlab_pipelines: Pipelines
       updated_on: Updated on
+    work_packages:
+      tabs:
+        gitlab: "GitLab"

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
@@ -47,20 +47,20 @@ module OpenProject::GitlabIntegration
         permission(:show_gitlab_content,
                    {},
                    permissible_on: %i[work_package project])
-
-        menu :work_package_split_view,
-             :gitlab,
-             { tab: :gitlab },
-             if: ->(project) {
-               User.current.allowed_in_project?(:show_gitlab_content, project)
-             },
-             skip_permissions_check: true,
-             badge: ->(work_package:, **) {
-               work_package.gitlab_merge_requests.count +
-                 work_package.gitlab_issues.count
-             },
-             caption: :project_module_github
       end
+
+      menu :work_package_split_view,
+           :gitlab,
+           { tab: :gitlab },
+           if: ->(project) {
+             User.current.allowed_in_project?(:show_gitlab_content, project)
+           },
+           skip_permissions_check: true,
+           badge: ->(work_package:, **) {
+             work_package.gitlab_merge_requests.count +
+               work_package.gitlab_issues.count
+           },
+           caption: :project_module_github
     end
 
     patches %w[WorkPackage]

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
@@ -47,6 +47,19 @@ module OpenProject::GitlabIntegration
         permission(:show_gitlab_content,
                    {},
                    permissible_on: %i[work_package project])
+
+        menu :work_package_split_view,
+             :gitlab,
+             { tab: :gitlab },
+             if: ->(project) {
+               User.current.allowed_in_project?(:show_gitlab_content, project)
+             },
+             skip_permissions_check: true,
+             badge: ->(work_package:, **) {
+               work_package.gitlab_merge_requests.count +
+                 work_package.gitlab_issues.count
+             },
+             caption: :project_module_github
       end
     end
 

--- a/modules/meeting/app/controllers/concerns/meetings/work_package_meetings_tab_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/work_package_meetings_tab_component_streams.rb
@@ -63,6 +63,12 @@ module Meetings
           )
         )
       end
+
+      def replace_tab_counter_via_turbo_stream(work_package: @work_package)
+        replace_via_turbo_stream(
+          component: WorkPackages::Details::UpdateCounterComponent.new(work_package:, menu_name: "meetings")
+        )
+      end
     end
   end
 end

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -83,6 +83,11 @@ class WorkPackageMeetingsTabController < ApplicationController
         upcoming_meetings_count: @upcoming_meetings_count,
         past_meetings_count: @past_meetings_count
       )
+
+      replace_via_turbo_stream(
+        component: WorkPackages::Details::UpdateCounterComponent.new(work_package: @work_package, menu_name: "meetings")
+      )
+
       # TODO: show success message?
     else
       # show errors in form

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -84,9 +84,7 @@ class WorkPackageMeetingsTabController < ApplicationController
         past_meetings_count: @past_meetings_count
       )
 
-      replace_via_turbo_stream(
-        component: WorkPackages::Details::UpdateCounterComponent.new(work_package: @work_package, menu_name: "meetings")
-      )
+      replace_tab_counter_via_turbo_stream(work_package: @work_package)
 
       # TODO: show success message?
     else

--- a/modules/meeting/config/locales/js-en.yml
+++ b/modules/meeting/config/locales/js-en.yml
@@ -29,3 +29,6 @@
 en:
   js:
     label_meetings: 'Meetings'
+    work_packages:
+      tabs:
+        meetings: 'Meetings'

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -124,6 +124,18 @@ module OpenProject::Meeting
            parent: :meetings,
            partial: "meetings/menus/menu"
 
+      menu :work_package_split_view,
+           :meetings,
+           { tab: :meetings },
+           skip_permissions_check: true,
+           if: ->(_project) {
+             User.current.allowed_in_any_project?(:view_meetings)
+           },
+           badge: ->(work_package:, **) {
+             work_package.meetings.count
+           },
+           caption: :label_meeting_plural
+
       should_render_global_menu_item = Proc.new do
         (User.current.logged? || !Setting.login_required?) &&
           User.current.allowed_in_any_project?(:view_meetings)

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -132,7 +132,7 @@ module OpenProject::Meeting
              User.current.allowed_in_any_project?(:view_meetings)
            },
            badge: ->(work_package:, **) {
-             work_package.meetings.count
+             work_package.meetings.where(meetings: { start_time: Time.zone.today.beginning_of_day.. }).count
            },
            caption: :label_meeting_plural
 

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
   let(:center) { Pages::Notifications::Center.new }
   let(:side_menu) { Components::Submenu.new }
   let(:toaster) { PageObjects::Notifications.new(page) }
-  let(:activity_tab) { Components::WorkPackages::Activities.new(notification_wp_due_today) }
+  let(:tabs) { Components::WorkPackages::PrimerizedTabs.new }
 
   # Converts "hh:mm" into { hour: h, min: m }
   def time_hash(time)
@@ -254,7 +254,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       wait_for_network_idle
 
       # We expect no badge count
-      split_screen.expect_no_notification_badge
+      tabs.expect_no_counter "activity"
 
       # The same is true for the mention item that is opened in date alerts filter
       center.click_item notification_wp_double_date_alert
@@ -263,7 +263,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       wait_for_network_idle
 
       # We expect one badge
-      split_screen.expect_notification_count 1
+      tabs.expect_counter "activity", 1
 
       # When a work package is updated to a different date
       wp_double_notification.update_column(:due_date, time_zone.now + 5.days)

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -36,9 +36,6 @@ RSpec.shared_examples "work package relations tab", :js, :selenium do
   let(:project) { create(:project) }
   let(:work_package) { create(:work_package, project:) }
   let(:relations) { Components::WorkPackages::Relations.new(work_package) }
-  let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
-
-  let(:relations_tab) { find(".op-tab-row--link_selected", text: "RELATIONS") }
 
   let(:visit) { true }
 
@@ -266,14 +263,28 @@ RSpec.shared_examples "work package relations tab", :js, :selenium do
   end
 end
 
-RSpec.context "Split screen" do
+RSpec.context "within a split screen" do
   let(:wp_page) { Pages::SplitWorkPackage.new(work_package) }
+  let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
+
+  let(:relations_tab) { find(".op-tab-row--link_selected", text: "RELATIONS") }
 
   it_behaves_like "work package relations tab"
 end
 
-RSpec.context "Full screen" do
+RSpec.context "within a primerized split screen" do
+  let(:wp_page) { Pages::PrimerizedSplitWorkPackage.new(work_package) }
+  let(:tabs) { Components::WorkPackages::PrimerizedTabs.new }
+  let(:relations_tab) { "relations" }
+
+  it_behaves_like "work package relations tab"
+end
+
+RSpec.context "within a full screen" do
   let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
+  let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
+
+  let(:relations_tab) { find(".op-tab-row--link_selected", text: "RELATIONS") }
 
   it_behaves_like "work package relations tab"
 end

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -28,19 +28,15 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package relations tab", :js, :selenium do
+RSpec.shared_examples "Work package relations tab", :js, :selenium do
   include_context "ng-select-autocomplete helpers"
 
   let(:user) { create(:admin) }
 
   let(:project) { create(:project) }
   let(:work_package) { create(:work_package, project:) }
-  let(:work_packages_page) { Pages::SplitWorkPackage.new(work_package) }
   let(:full_wp) { Pages::FullWorkPackage.new(work_package) }
   let(:relations) { Components::WorkPackages::Relations.new(work_package) }
-  let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
-
-  let(:relations_tab) { find(".op-tab-row--link_selected", text: "RELATIONS") }
 
   let(:visit) { true }
 
@@ -198,7 +194,7 @@ RSpec.describe "Work package relations tab", :js, :selenium do
         tabs.expect_counter(relations_tab, 1)
 
         # Switch to full view
-        find(".work-packages--details-fullscreen-icon").click
+        work_packages_page.switch_to_fullscreen
 
         # Expect to have row
         relations.hover_action(relatable, :delete)
@@ -277,4 +273,21 @@ RSpec.describe "Work package relations tab", :js, :selenium do
       end
     end
   end
+end
+
+RSpec.context "within a split screen" do
+  let(:work_packages_page) { Pages::SplitWorkPackage.new(work_package) }
+  let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
+
+  let(:relations_tab) { find(".op-tab-row--link_selected", text: "RELATIONS") }
+
+  it_behaves_like "Work package relations tab"
+end
+
+RSpec.context "within a primerized split screen" do
+  let(:work_packages_page) { Pages::PrimerizedSplitWorkPackage.new(work_package) }
+  let(:tabs) { Components::WorkPackages::PrimerizedTabs.new }
+  let(:relations_tab) { "relations" }
+
+  it_behaves_like "Work package relations tab"
 end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Watcher tab", :js, :selenium do
       login_as(user)
       wp_page.visit_tab! :watchers
       expect_angular_frontend_initialized
-      expect(page).to have_css(".op-tab-row--link_selected", text: "WATCHERS")
+      wp_page.expect_tab "Watchers"
     end
 
     it "modifying the watcher list modifies the watch button" do
@@ -113,13 +113,21 @@ RSpec.describe "Watcher tab", :js, :selenium do
     end
   end
 
-  context "split screen" do
+  context "within a split screen" do
     let(:wp_page) { Pages::SplitWorkPackage.new(work_package) }
 
     it_behaves_like "watchers tab"
   end
 
-  context "full screen" do
+  context "within a primerized split screen" do
+    let(:wp_page) { Pages::PrimerizedSplitWorkPackage.new(work_package) }
+    let(:tabs) { Components::WorkPackages::PrimerizedTabs.new }
+    let(:watchers_tab) { "watchers" }
+
+    it_behaves_like "watchers tab"
+  end
+
+  context "within a full screen" do
     let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
 
     it_behaves_like "watchers tab"

--- a/spec/models/queries/relations/filters/involved_filter_spec.rb
+++ b/spec/models/queries/relations/filters/involved_filter_spec.rb
@@ -67,12 +67,6 @@ RSpec.describe Queries::Relations::Filters::InvolvedFilter do
 
         expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
-
-      it "is the same as the visible_involved scope" do
-        expected = Relation.visible_involved("1")
-
-        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
-      end
     end
 
     context 'for "!"' do

--- a/spec/models/queries/relations/filters/involved_filter_spec.rb
+++ b/spec/models/queries/relations/filters/involved_filter_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Queries::Relations::Filters::InvolvedFilter do
 
         expect(instance.apply_to(model).to_sql).to eql expected.to_sql
       end
+
+      it "is the same as the visible_involved scope" do
+        expected = Relation.visible_involved("1")
+
+        expect(instance.apply_to(model).to_sql).to eql expected.to_sql
+      end
     end
 
     context 'for "!"' do

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -46,14 +46,6 @@ module Components
         end
       end
 
-      def expect_notification_count(count)
-        expect(page).to have_css('[data-test-selector="tab-counter-Activity"] span', text: count)
-      end
-
-      def expect_no_notification_badge
-        expect(page).to have_no_css('[data-test-selector="tab-counter-Activity"] span')
-      end
-
       def hover_action(journal_id, action)
         retry_block do
           # Focus type edit to expose buttons

--- a/spec/support/components/work_packages/primerized_tabs.rb
+++ b/spec/support/components/work_packages/primerized_tabs.rb
@@ -1,0 +1,19 @@
+module Components
+  module WorkPackages
+    class PrimerizedTabs
+      include Capybara::DSL
+      include Capybara::RSpecMatchers
+      include RSpec::Matchers
+
+      # Check value of counter for the given tab
+      def expect_counter(tab, count)
+        expect(page).to have_test_selector("wp-details-tab-component--#{tab}-counter", text: count)
+      end
+
+      # Counter should not be displayed, if there are no relations or watchers
+      def expect_no_counter(tab)
+        expect(page).not_to have_test_selector("wp-details-tab-component--#{tab}-counter")
+      end
+    end
+  end
+end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -53,6 +53,10 @@ module Pages
       expect(page).to have_css(".op-tab-row--link_selected", text: tab.to_s.upcase)
     end
 
+    def expect_no_tab(tab)
+      expect(page).to have_no_css(".op-tab-row--link", text: tab.to_s.upcase)
+    end
+
     def within_active_tab(&)
       within(".work-packages-full-view--split-right .work-packages--panel-inner", &)
     end

--- a/spec/support/pages/work_packages/primerized_split_work_package.rb
+++ b/spec/support/pages/work_packages/primerized_split_work_package.rb
@@ -59,12 +59,8 @@ module Pages
       within(".work-packages--details-content", &)
     end
 
-    def expect_notification_count(count)
-      expect(page).to have_test_selector("wp-details-tab-component--tab-counter", text: count)
-    end
-
-    def expect_no_notification_badge
-      expect(page).not_to have_test_selector("wp-details-tab-component--tab-counter")
+    def path(tab = "overview")
+      details_notifications_path(work_package.id, tab:)
     end
 
     private


### PR DESCRIPTION
# What are you trying to accomplish?
The new split screen which is used in the notification center is missing some functionality. This PR aims to show the counter values in the split screen tabs.

- [x] Show correct numbers in the following tabs (in notification center):
  - [x] Activity
  - [x] Relations
  - [x] Files
  - [x] Watchers
  - [x] Meetings
  - [x] GitHub
  - [x] GitLab
- [x] Update automtatically when the number changes (e.g a watcher or relation beeing removed/added)
  - [x] Activity
  - [x] Relations
  - [x] Files
  - [x] Watchers
  - [x] Meetings


# Ticket
https://community.openproject.org/projects/openproject/work_packages/56918/github?query_id=5490

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
