### PR TITLE
Feature/56573 release custom field columnsfilters in project lists to ce

### DIFF
--- a/app/components/filter/filter_component.html.erb
+++ b/app/components/filter/filter_component.html.erb
@@ -113,15 +113,5 @@
         <%= submit_tag t('button_apply'), class: 'button -small -primary', name: nil %>
       </li>
     </ul>
-    <% unless EnterpriseToken.allows_to?(:custom_fields_in_projects_list)%>
-      <%=
-        helpers.angular_component_tag 'op-enterprise-banner',
-                                      inputs: {
-                                        collapsible: true,
-                                        textMessage: t('ee.upsale.project_filters.description_html'),
-                                        moreInfoLink: OpenProject::Static::Links.links[:enterprise_docs][:custom_field_projects][:href],
-                                      }
-      %>
-    <% end %>
   </fieldset>
 <% end %>

--- a/app/components/projects/projects_filters_component.rb
+++ b/app/components/projects/projects_filters_component.rb
@@ -41,18 +41,18 @@ class Projects::ProjectsFiltersComponent < Filter::FilterComponent
 
   def allowed_filter?(filter)
     allowlist = [
+      Queries::Filters::Shared::CustomFields::Base,
       Queries::Projects::Filters::ActiveFilter,
-      Queries::Projects::Filters::TemplatedFilter,
-      Queries::Projects::Filters::PublicFilter,
-      Queries::Projects::Filters::ProjectStatusFilter,
-      Queries::Projects::Filters::MemberOfFilter,
       Queries::Projects::Filters::CreatedAtFilter,
-      Queries::Projects::Filters::LatestActivityAtFilter,
-      Queries::Projects::Filters::NameAndIdentifierFilter,
-      Queries::Projects::Filters::TypeFilter,
       Queries::Projects::Filters::FavoredFilter,
       Queries::Projects::Filters::IdFilter,
-      Queries::Filters::Shared::CustomFields::Base
+      Queries::Projects::Filters::LatestActivityAtFilter,
+      Queries::Projects::Filters::MemberOfFilter,
+      Queries::Projects::Filters::NameAndIdentifierFilter,
+      Queries::Projects::Filters::ProjectStatusFilter,
+      Queries::Projects::Filters::PublicFilter,
+      Queries::Projects::Filters::TemplatedFilter,
+      Queries::Projects::Filters::TypeFilter
     ]
 
     allowlist.any? { |clazz| filter.is_a? clazz }

--- a/app/components/projects/projects_filters_component.rb
+++ b/app/components/projects/projects_filters_component.rb
@@ -55,6 +55,6 @@ class Projects::ProjectsFiltersComponent < Filter::FilterComponent
     ]
     allowlist << Queries::Filters::Shared::CustomFields::Base if EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
 
-    allowlist.detect { |clazz| filter.is_a? clazz }
+    allowlist.any? { |clazz| filter.is_a? clazz }
   end
 end

--- a/app/components/projects/projects_filters_component.rb
+++ b/app/components/projects/projects_filters_component.rb
@@ -51,9 +51,9 @@ class Projects::ProjectsFiltersComponent < Filter::FilterComponent
       Queries::Projects::Filters::NameAndIdentifierFilter,
       Queries::Projects::Filters::TypeFilter,
       Queries::Projects::Filters::FavoredFilter,
-      Queries::Projects::Filters::IdFilter
+      Queries::Projects::Filters::IdFilter,
+      Queries::Filters::Shared::CustomFields::Base
     ]
-    allowlist << Queries::Filters::Shared::CustomFields::Base if EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
 
     allowlist.any? { |clazz| filter.is_a? clazz }
   end

--- a/app/models/queries/projects/selects/custom_field.rb
+++ b/app/models/queries/projects/selects/custom_field.rb
@@ -33,10 +33,6 @@ class Queries::Projects::Selects::CustomField < Queries::Selects::Base
     /cf_(\d+)/
   end
 
-  def self.available?
-    EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
-  end
-
   def self.all_available
     return [] unless available?
 

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -34,7 +34,6 @@ class Authorization::EnterpriseService
     board_view
     conditional_highlighting
     custom_actions
-    custom_fields_in_projects_list
     date_alerts
     define_custom_style
     edit_attribute_groups

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -29,7 +29,7 @@
 class Authorization::EnterpriseService
   attr_accessor :token
 
-  GUARDED_ACTIONS = %i(
+  GUARDED_ACTIONS = %i[
     baseline_comparison
     board_view
     conditional_highlighting
@@ -37,20 +37,20 @@ class Authorization::EnterpriseService
     date_alerts
     define_custom_style
     edit_attribute_groups
+    gantt_pdf_export
     grid_widget_wp_graph
     ldap_groups
+    one_drive_sharepoint_file_storage
     openid_providers
     placeholder_users
+    project_list_sharing
     readonly_work_packages
     team_planner_view
     two_factor_authentication
+    virus_scanning
     work_package_query_relation_columns
     work_package_sharing
-    one_drive_sharepoint_file_storage
-    virus_scanning
-    gantt_pdf_export
-    project_list_sharing
-  ).freeze
+  ].freeze
 
   def initialize(token)
     self.token = token

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -54,7 +54,7 @@ module CustomFields
     def after_perform(call)
       cf = call.result
 
-      if cf.is_a?(ProjectCustomField) && EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
+      if cf.is_a?(ProjectCustomField)
         add_cf_to_visible_columns(cf)
       end
 

--- a/app/views/admin/settings/projects_settings/show.html.erb
+++ b/app/views/admin/settings/projects_settings/show.html.erb
@@ -39,20 +39,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= styled_form_tag(admin_settings_projects_path, method: :patch) do %>
   <fieldset class="form--fieldset">
-    <% unless EnterpriseToken.allows_to?(:custom_fields_in_projects_list) %>
-      <div class="form--field">
-        <%=
-        angular_component_tag 'op-enterprise-banner',
-                              inputs: {
-                                textMessage: t('text_project_custom_field_html'),
-                                collapsible: true,
-                                moreInfoLink: OpenProject::Static::Links.links[:enterprise_docs][:custom_field_projects][:href],
-                              }
-        %>
-      </div>
-    <% end %>
-
-
     <div class="form--field -full-width">
       <div class="form--text-field-container -xwide">
         <%= angular_component_tag 'opce-draggable-autocompleter',

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -27,7 +27,9 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% if (@custom_fields_by_type[tab[:name]] || []).any? %>
+<% if @custom_fields_by_type[tab[:name]].blank? %>
+  <%= no_results_box(action_url: new_custom_field_path(type: tab[:name]), display_action: true) %>
+<% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
       <% if tab[:name] == 'WorkPackageCustomField' %>
@@ -164,6 +166,4 @@ See COPYRIGHT and LICENSE files for more details.
       </table>
     </div>
   </div>
-<% else %>
-  <%= no_results_box(action_url: new_custom_field_path(type: tab[:name]), display_action: true) %>
 <% end %>

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -27,19 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% if tab[:name] == 'ProjectCustomField' %>
-  <% unless EnterpriseToken.allows_to?(:custom_fields_in_projects_list) %>
-    <%=
-    angular_component_tag 'op-enterprise-banner',
-                          inputs: {
-                            collapsible: true,
-                            textMessage: t('text_project_custom_field_html'),
-                            moreInfoLink: OpenProject::Static::Links.links[:enterprise_docs][:custom_field_projects][:href],
-                          }
-    %>
-  <% end %>
-<% end %>
-
 <% if (@custom_fields_by_type[tab[:name]] || []).any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -61,10 +61,10 @@ module Meetings
 
     def allowed_filter?(filter)
       allowlist = [
-        Queries::Meetings::Filters::TimeFilter,
         Queries::Meetings::Filters::AttendedUserFilter,
+        Queries::Meetings::Filters::AuthorFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
-        Queries::Meetings::Filters::AuthorFilter
+        Queries::Meetings::Filters::TimeFilter
       ]
 
       if project.nil?

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -71,7 +71,7 @@ module Meetings
         allowlist << Queries::Meetings::Filters::ProjectFilter
       end
 
-      allowlist.detect { |clazz| filter.is_a? clazz }
+      allowlist.any? { |clazz| filter.is_a? clazz }
     end
   end
 end

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
       end
     end
 
-    context "for project members", with_ee: %i[custom_fields_in_projects_list] do
+    context "for project members" do
       shared_let(:user) do
         create(:user,
                member_with_roles: { development_project => developer },
@@ -131,7 +131,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
       end
     end
 
-    context "for work package members", with_ee: %i[custom_fields_in_projects_list] do
+    context "for work package members" do
       shared_let(:work_package) { create(:work_package, project: development_project) }
       shared_let(:user) do
         create(:user,
@@ -282,7 +282,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
     end
   end
 
-  describe "project attributes visibility restrictions", with_ee: %i[custom_fields_in_projects_list] do
+  describe "project attributes visibility restrictions" do
     let(:user) do
       create(:user,
              member_with_roles: {
@@ -329,18 +329,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
     end
   end
 
-  context "without valid Enterprise token" do
-    specify "CF columns and filters are not visible" do
-      load_and_open_filters admin
-
-      # CF's columns are not present:
-      expect(page).to have_no_text(custom_field.name.upcase)
-      # CF's filters are not present:
-      expect(page).to have_no_select("add_filter_select", with_options: [custom_field.name])
-    end
-  end
-
-  context "with valid Enterprise token", with_ee: %i[custom_fields_in_projects_list] do
+  context "with valid Enterprise token" do
     shared_let(:long_text_custom_field) { create(:text_project_custom_field) }
     specify "CF columns and filters are not visible by default" do
       load_and_open_filters admin
@@ -720,7 +709,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
       end
     end
 
-    describe "other filter types", with_ee: %i[custom_fields_in_projects_list] do
+    describe "other filter types" do
       context "for admins" do
         shared_let(:list_custom_field) { create(:list_project_custom_field) }
         shared_let(:date_custom_field) { create(:date_project_custom_field) }
@@ -1107,7 +1096,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
     end
   end
 
-  describe "order", with_ee: %i[custom_fields_in_projects_list] do
+  describe "order" do
     shared_let(:integer_custom_field) { create(:integer_project_custom_field) }
     # order is important here as the implementation uses lft
     # first but then reorders in ruby
@@ -1303,8 +1292,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
     end
   end
 
-  describe "column selection",
-           with_ee: %i[custom_fields_in_projects_list], with_settings: { enabled_projects_columns: %w[name created_at] } do
+  describe "column selection", with_settings: { enabled_projects_columns: %w[name created_at] } do
     # Will still receive the :view_project permission
     shared_let(:user) do
       create(:user, member_with_permissions: { project => %i(view_project_attributes),
@@ -1372,7 +1360,7 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
     end
   end
 
-  context "with a multi-value custom field", with_ee: %i[custom_fields_in_projects_list] do
+  context "with a multi-value custom field" do
     let!(:list_custom_field) do
       create(:list_project_custom_field, multi_value: true).tap do |cf|
         project.update(custom_field_values: { cf.id => [cf.value_of("A"), cf.value_of("B")] })

--- a/spec/features/projects/projects_portfolio_spec.rb
+++ b/spec/features/projects/projects_portfolio_spec.rb
@@ -28,8 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Projects index page", :js, :with_cuprite,
-               with_ee: %i[custom_fields_in_projects_list], with_settings: { login_required?: false } do
+RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login_required?: false } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   shared_let(:admin) { create(:admin) }

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -63,98 +63,90 @@ RSpec.describe Projects::Exports::CSV, "integration" do
       %w[name description project_status public] + global_project_custom_fields.map(&:column_name)
     end
 
-    context "when ee enabled", with_ee: %i[custom_fields_in_projects_list] do
-      before do
-        project # re-evaluate project to ensure it is created within the desired user context
-        parsed
+    before do
+      project # re-evaluate project to ensure it is created within the desired user context
+      parsed
+    end
+
+    context "without view_project_attributes permission" do
+      let(:permissions) { %i(view_projects) }
+
+      it "does not render project custom fields in the header" do
+        expect(parsed.size).to eq 2
+
+        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public"]
       end
 
-      context "without view_project_attributes permission" do
-        let(:permissions) { %i(view_projects) }
-
-        it "does not render project custom fields in the header" do
-          expect(parsed.size).to eq 2
-
-          expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public"]
-        end
-
-        it "does not render the custom field values in the rows if enabled for a project" do
-          expect(rows.first)
-            .to eq [project.id.to_s, project.identifier, project.name,
-                    project.description, "Off track", "false"]
-        end
-      end
-
-      context "with view_project_attributes permission" do
-        it "renders available project custom fields in the header if enabled in any project" do
-          expect(parsed.size).to eq 2
-
-          cf_names = global_project_custom_fields.map(&:name)
-
-          expect(cf_names).not_to include(not_used_string_cf.name)
-          expect(cf_names).not_to include(hidden_cf.name)
-
-          expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
-        end
-
-        it "renders the custom field values in the rows if enabled for a project" do
-          custom_values = global_project_custom_fields.map do |cf|
-            case cf
-            when bool_cf
-              "true"
-            when text_cf
-              project.typed_custom_value_for(cf)
-            when not_used_string_cf
-              ""
-            else
-              project.formatted_custom_value_for(cf)
-            end
-          end
-          expect(rows.first)
-            .to eq [project.id.to_s, project.identifier, project.name,
-                    project.description, "Off track", "false", *custom_values]
-        end
-      end
-
-      context "with admin permission" do
-        let(:current_user) { create(:admin) }
-
-        it "renders all globally available project custom fields including hidden ones in the header" do
-          expect(parsed.size).to eq 3
-
-          cf_names = global_project_custom_fields.map(&:name)
-
-          expect(cf_names).to include(not_used_string_cf.name)
-          expect(cf_names).to include(hidden_cf.name)
-
-          expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
-        end
-
-        it "renders the custom field values in the rows if enabled for a project" do
-          custom_values = global_project_custom_fields.map do |cf|
-            case cf
-            when bool_cf
-              "true"
-            when hidden_cf
-              "hidden"
-            when not_used_string_cf
-              ""
-            when text_cf
-              project.typed_custom_value_for(cf)
-            else
-              project.formatted_custom_value_for(cf)
-            end
-          end
-          expect(rows.first)
-            .to eq [project.id.to_s, project.identifier, project.name,
-                    project.description, "Off track", "false", *custom_values]
-        end
+      it "does not render the custom field values in the rows if enabled for a project" do
+        expect(rows.first)
+          .to eq [project.id.to_s, project.identifier, project.name,
+                  project.description, "Off track", "false"]
       end
     end
 
-    context "when ee not enabled" do
-      it "renders only the default columns" do
-        expect(header).to eq %w[id Identifier Name Description Status Public]
+    context "with view_project_attributes permission" do
+      it "renders available project custom fields in the header if enabled in any project" do
+        expect(parsed.size).to eq 2
+
+        cf_names = global_project_custom_fields.map(&:name)
+
+        expect(cf_names).not_to include(not_used_string_cf.name)
+        expect(cf_names).not_to include(hidden_cf.name)
+
+        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+      end
+
+      it "renders the custom field values in the rows if enabled for a project" do
+        custom_values = global_project_custom_fields.map do |cf|
+          case cf
+          when bool_cf
+            "true"
+          when text_cf
+            project.typed_custom_value_for(cf)
+          when not_used_string_cf
+            ""
+          else
+            project.formatted_custom_value_for(cf)
+          end
+        end
+        expect(rows.first)
+          .to eq [project.id.to_s, project.identifier, project.name,
+                  project.description, "Off track", "false", *custom_values]
+      end
+    end
+
+    context "with admin permission" do
+      let(:current_user) { create(:admin) }
+
+      it "renders all globally available project custom fields including hidden ones in the header" do
+        expect(parsed.size).to eq 3
+
+        cf_names = global_project_custom_fields.map(&:name)
+
+        expect(cf_names).to include(not_used_string_cf.name)
+        expect(cf_names).to include(hidden_cf.name)
+
+        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+      end
+
+      it "renders the custom field values in the rows if enabled for a project" do
+        custom_values = global_project_custom_fields.map do |cf|
+          case cf
+          when bool_cf
+            "true"
+          when hidden_cf
+            "hidden"
+          when not_used_string_cf
+            ""
+          when text_cf
+            project.typed_custom_value_for(cf)
+          else
+            project.formatted_custom_value_for(cf)
+          end
+        end
+        expect(rows.first)
+          .to eq [project.id.to_s, project.identifier, project.name,
+                  project.description, "Off track", "false", *custom_values]
       end
     end
   end

--- a/spec/models/queries/projects/factory_spec.rb
+++ b/spec/models/queries/projects/factory_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe Queries::Projects::Factory,
     end
 
     context "without id and with ee and admin privileges",
-            with_ee: %i[custom_fields_in_projects_list],
             with_settings: { enabled_projects_columns: %w[name created_at cf_1] } do
       current_user { build_stubbed(:admin) }
 
@@ -810,7 +809,6 @@ RSpec.describe Queries::Projects::Factory,
     end
 
     context "without id, as non admin and with a non existing custom field id",
-            with_ee: %i[custom_fields_in_projects_list],
             with_settings: { enabled_projects_columns: %w[name created_at cf_1 cf_42] } do
       before do
         custom_field

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe ProjectQuery do
   end
 
   describe ".available_selects" do
-    current_user { user }
-
     before do
       scope = instance_double(ActiveRecord::Relation)
 
@@ -127,52 +125,48 @@ RSpec.describe ProjectQuery do
               .and_return([23, 42])
     end
 
-    it "lists registered selects" do
-      expect(instance.available_selects.map(&:attribute))
-        .to contain_exactly(:name,
-                            :favored,
-                            :public,
-                            :description,
-                            :hierarchy,
-                            :project_status,
-                            :status_explanation)
+    # rubocop:disable Naming/VariableNumber
+    context "for non admin user" do
+      current_user { user }
+
+      it "lists registered selects" do
+        expect(instance.available_selects.map(&:attribute))
+          .to match_array(%i[
+                            name
+                            favored
+                            public
+                            description
+                            hierarchy
+                            project_status
+                            status_explanation
+                            cf_23
+                            cf_42
+                          ])
+      end
     end
 
-    context "with the user being admin" do
+    context "for admin user" do
       current_user { admin }
 
       it "includes admin columns" do
         expect(instance.available_selects.map(&:attribute))
-          .to contain_exactly(:name,
-                              :public,
-                              :favored,
-                              :description,
-                              :hierarchy,
-                              :project_status,
-                              :status_explanation,
-                              :created_at,
-                              :latest_activity_at,
-                              :required_disk_space)
+          .to match_array(%i[
+                            name
+                            favored
+                            public
+                            description
+                            hierarchy
+                            project_status
+                            status_explanation
+                            created_at
+                            latest_activity_at
+                            required_disk_space
+                            cf_23
+                            cf_42
+                          ])
       end
     end
-
-    context "with an enterprise token",
-            with_ee: %i[custom_fields_in_projects_list] do
-      # rubocop:disable Naming/VariableNumber
-      it "includes custom field columns" do
-        expect(instance.available_selects.map(&:attribute))
-          .to contain_exactly(:name,
-                              :public,
-                              :favored,
-                              :description,
-                              :hierarchy,
-                              :project_status,
-                              :status_explanation,
-                              :cf_23,
-                              :cf_42)
-      end
-      # rubocop:enable Naming/VariableNumber
-    end
+    # rubocop:enable Naming/VariableNumber
   end
 
   describe "#valid_subset!" do

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Authorization::EnterpriseService do
   let(:result) { instance.call(action) }
   let(:action) { :an_action }
 
+  describe "GUARDED_ACTIONS" do
+    it "is in alphabetical order" do
+      guarded_actions = described_class::GUARDED_ACTIONS
+
+      expect(guarded_actions).to eq(guarded_actions.sort)
+    end
+  end
+
   describe "#initialize" do
     it "has the token" do
       expect(instance.token).to eql token

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -29,19 +29,10 @@
 require "spec_helper"
 
 RSpec.describe Authorization::EnterpriseService do
-  let(:token_object) do
-    token = OpenProject::Token.new
-    token.subscriber = "Foobar"
-    token.mail = "foo@example.org"
-    token.starts_at = Date.today
-    token.expires_at = nil
-
-    token
-  end
-  let(:token) { double("EnterpriseToken", token_object:) }
   let(:instance) { described_class.new(token) }
-  let(:result) { instance.call(action) }
-  let(:action) { :an_action }
+  let(:token) { instance_double(EnterpriseToken, token_object:, expired?: expired?) }
+  let(:token_object) { OpenProject::Token.new }
+  let(:expired?) { false }
 
   describe "GUARDED_ACTIONS" do
     it "is in alphabetical order" do
@@ -57,57 +48,73 @@ RSpec.describe Authorization::EnterpriseService do
     end
   end
 
-  describe "expiry" do
-    before do
-      allow(token).to receive(:expired?).and_return(expired)
+  describe "#call" do
+    let(:result) { instance.call(action) }
+
+    shared_examples "true result" do
+      it "returns a true result" do
+        expect(result).to be_a ServiceResult
+        expect(result).to be_success
+        expect(result).to have_attributes(result: true)
+      end
     end
 
-    context "when expired" do
-      let(:expired) { true }
-
+    shared_examples "false result" do
       it "returns a false result" do
         expect(result).to be_a ServiceResult
-        expect(result.result).to be_falsey
-        expect(result.success?).to be_falsey
+        expect(result).not_to be_success
+        expect(result).to have_attributes(result: false)
       end
     end
 
-    context "when active" do
-      let(:expired) { false }
+    shared_examples "false result for any action" do
+      guarded_action = described_class::GUARDED_ACTIONS.sample
 
-      context "invalid action" do
-        it "returns false" do
-          expect(result.result).to be_falsey
-        end
+      context "for known action #{guarded_action}" do
+        let(:action) { guarded_action }
+
+        include_examples "false result"
       end
 
-      %i(baseline_comparison
-         board_view
-         conditional_highlighting
-         custom_actions
-         custom_fields_in_projects_list
-         date_alerts
-         define_custom_style
-         edit_attribute_groups
-         grid_widget_wp_graph
-         ldap_groups
-         openid_providers
-         placeholder_users
-         readonly_work_packages
-         team_planner_view
-         two_factor_authentication
-         work_package_query_relation_columns
-         work_package_sharing).each do |guarded_action|
-        context "guarded action #{guarded_action}" do
+      context "for unknown action" do
+        let(:action) { "foo" }
+
+        include_examples "false result"
+      end
+    end
+
+    context "for a valid token" do
+      described_class::GUARDED_ACTIONS.each do |guarded_action|
+        context "for known action #{guarded_action}" do
           let(:action) { guarded_action }
 
-          it "returns a true result" do
-            expect(result).to be_a ServiceResult
-            expect(result.result).to be_truthy
-            expect(result.success?).to be_truthy
-          end
+          include_examples "true result"
         end
       end
+
+      context "for unknown action" do
+        let(:action) { "foo" }
+
+        include_examples "false result"
+      end
+    end
+
+    context "for an expired token" do
+      let(:expired?) { true }
+
+      include_examples "false result for any action"
+    end
+
+    context "without a token_object" do
+      let(:token_object) { nil }
+
+      include_examples "false result for any action"
+    end
+
+    context "without a token" do
+      let(:token) { nil }
+
+      include_examples "false result for any action"
     end
   end
 end

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -31,8 +31,7 @@ require "services/base_services/behaves_like_create_service"
 
 RSpec.describe CustomFields::CreateService, type: :model do
   it_behaves_like "BaseServices create service" do
-    context "when creating a project cf",
-            with_ee: %i[custom_fields_in_projects_list] do
+    context "when creating a project cf" do
       let(:model_instance) { build_stubbed(:project_custom_field) }
 
       it "modifies the settings on successful call" do

--- a/spec/services/queries/projects/project_queries/set_attributes_service_spec.rb
+++ b/spec/services/queries/projects/project_queries/set_attributes_service_spec.rb
@@ -167,8 +167,16 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
         .to eql [[:active, "=", %w[t]]]
     end
 
-    it "assigns default selects including those for admin and ee if allowed",
-       with_ee: %i[custom_fields_in_projects_list],
+    # rubocop:disable Naming/VariableNumber
+    it "assigns default selects for non admin",
+       with_settings: { enabled_projects_columns: %w[name created_at cf_1] } do
+      subject
+
+      expect(model_instance.selects.map(&:attribute))
+        .to eql %i[favored name cf_1]
+    end
+
+    it "assigns default selects for admin",
        with_settings: { enabled_projects_columns: %w[name created_at cf_1] } do
       allow(User.current)
         .to receive(:admin?)
@@ -177,16 +185,9 @@ RSpec.describe Queries::Projects::ProjectQueries::SetAttributesService, type: :m
       subject
 
       expect(model_instance.selects.map(&:attribute))
-        .to eql %i[favored] + Setting.enabled_projects_columns.map(&:to_sym)
+        .to eql %i[favored name created_at cf_1]
     end
-
-    it "assigns default selects excluding those for admin and ee if not allowed",
-       with_settings: { enabled_projects_columns: %w[name created_at cf_1] } do
-      subject
-
-      expect(model_instance.selects.map(&:attribute))
-        .to eql %i[favored name]
-    end
+    # rubocop:enable Naming/VariableNumber
   end
 
   context "with the query already having order and with order params" do

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -121,6 +121,12 @@ module Pages
         end
       end
 
+      def expect_page_link(text)
+        within ".op-pagination--pages" do
+          expect(page).to have_css("a.op-pagination--item-link", text:)
+        end
+      end
+
       def expect_filters_container_toggled
         expect(page).to have_css(".op-filters-form")
       end
@@ -225,10 +231,8 @@ module Pages
       end
 
       def apply_filters
-        within(".advanced-filters--filters") do
-          click_on "Apply"
-          wait_for_network_idle
-        end
+        find(".advanced-filters--filters").click_on "Apply"
+        wait_for_reload
       end
 
       def set_toggle_filter(values)
@@ -402,8 +406,22 @@ module Pages
         find(".generic-table--sort-header a", text: column_name.upcase).click
       end
 
+      def expect_sort_order_via_table_header(column_name, direction:)
+        raise ArgumentError, "direction should be :asc or :desc" unless %i[asc desc].include?(direction)
+
+        find(".generic-table--sort-header .#{direction} a", text: column_name.upcase)
+      end
+
       def set_page_size(size)
-        find(".op-pagination--options .op-pagination--item", text: size).click
+        within ".op-pagination--options" do
+          find(".op-pagination--item", text: size).click
+        end
+      end
+
+      def expect_page_size(size)
+        within ".op-pagination--options" do
+          expect(page).to have_css(".op-pagination--item_current", text: size)
+        end
       end
 
       def go_to_page(page_number)

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -36,13 +36,21 @@
 # being present or gone. Instead the execution is halted until
 # requested data is done being fetched.
 def wait_for_network_idle(...)
-  page.driver.wait_for_network_idle(...) if using_cuprite?
+  if using_cuprite?
+    page.driver.wait_for_network_idle(...)
+  else
+    warn "wait_for_network_idle used in spec not using cuprite"
+  end
 end
 
 # Takes the above `wait_for_network_idle` a step further by waiting
 # for the page to be reloaded after some triggering action.
 def wait_for_reload
-  page.driver.wait_for_reload if using_cuprite?
+  if using_cuprite?
+    page.driver.wait_for_reload
+  else
+    warn "wait_for_reload used in spec not using cuprite"
+  end
 end
 
 # Ferrum is yet support `fill_options` as a Hash

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -39,7 +39,7 @@ def wait_for_network_idle(...)
   if using_cuprite?
     page.driver.wait_for_network_idle(...)
   else
-    warn "wait_for_network_idle used in spec not using cuprite"
+    warn_about_cuprite_helper_misuse(:wait_for_network_idle)
   end
 end
 
@@ -49,8 +49,14 @@ def wait_for_reload
   if using_cuprite?
     page.driver.wait_for_reload
   else
-    warn "wait_for_reload used in spec not using cuprite"
+    warn_about_cuprite_helper_misuse(:wait_for_reload)
   end
+end
+
+def warn_about_cuprite_helper_misuse(method_name)
+  stack = caller(2)
+  cause = [stack[0], stack.find { |line| line["_spec.rb:"] }].uniq.join(" … ")
+  warn "#{method_name} used in spec not using cuprite (#{cause})"
 end
 
 # Ferrum is yet support `fill_options` as a Hash


### PR DESCRIPTION
# What are you trying to accomplish?
Release custom field columns/filters in project lists to Community Edition

I also made `wait_for_network_idle` and `wait_for_reload` warn including the location if they are used in specs that are not using cuprite, which currently shows 784 places.

# Ticket
[#56573](https://community.openproject.org/projects/openproject/work_packages/56573)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
