### PR TITLE
[#57038] Trigger all necessary hooks when a project is removed from a storage

### DIFF
--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -109,9 +109,20 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   end
 
   def destroy
-    Storages::ProjectStorages::DeleteService
+    result = Storages::ProjectStorages::DeleteService
       .new(user: current_user, model: @project_storage)
       .call
+
+    # rubocop:disable Rails/ActionControllerFlashBeforeRender
+    result.on_success do
+      flash[:primer_banner] = { message: I18n.t(:notice_successful_delete) }
+    end
+
+    result.on_failure do |failure|
+      error = failure.errors.map(&:message).join("; ")
+      flash[:primer_banner] = { message: t("project_storages.remove_project.deletion_failure_flash", error:), scheme: :danger }
+    end
+    # rubocop:enable Rails/ActionControllerFlashBeforeRender
 
     redirect_to admin_settings_storage_project_storages_path(@storage)
   end

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -119,7 +119,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
     end
 
     result.on_failure do |failure|
-      error = failure.errors.map(&:message).join("; ")
+      error = failure.errors.map(&:message).to_sentence
       flash[:primer_banner] = { message: t("project_storages.remove_project.deletion_failure_flash", error:), scheme: :danger }
     end
     # rubocop:enable Rails/ActionControllerFlashBeforeRender

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
       inactive: No specific folder
       manual: Existing folder manually managed
     remove_project:
-      deletion_failure_flash: 'Failed to remove the project from the storage: '
+      deletion_failure_flash: Failed to remove the project from the storage. %{error}
       dialog:
         automatically_managed_appendix: Also, in this case this storage has an automatically managed project folder, this and its files will be deleted forever.
         confirmation_text: Please, confirm you understand and want to remove this file storage from this project

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -67,13 +67,13 @@ en:
       inactive: No specific folder
       manual: Existing folder manually managed
     remove_project:
+      deletion_failure_flash: 'Failed to remove the project from the storage: '
       dialog:
         automatically_managed_appendix: Also, in this case this storage has an automatically managed project folder, this and its files will be deleted forever.
         confirmation_text: Please, confirm you understand and want to remove this file storage from this project
         heading: Remove project from %{storage_type}
         text: This action is irreversible and will remove all links from work packages of this project to files and folders of that storage.
       label: Remove project
-      deletion_failure_flash: "Failed to remove the project from the storage: "
   services:
     attributes:
       nextcloud_sync_service:

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
         heading: Remove project from %{storage_type}
         text: This action is irreversible and will remove all links from work packages of this project to files and folders of that storage.
       label: Remove project
+      deletion_failure_flash: "Failed to remove the project from the storage: "
   services:
     attributes:
       nextcloud_sync_service:

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -358,9 +358,11 @@ RSpec.describe "Admin lists project mappings for a storage",
 
         page.within("dialog") do
           expect(page).to have_button("Remove", disabled: true)
-          check "Please, confirm you understand and want to remove this file storage from this project"
-          wait_for(page).to have_button("Remove", disabled: false) # ensure button is clickable
-          click_on "Remove"
+          Retryable.repeat_until_success do
+            check "Please, confirm you understand and want to remove this file storage from this project"
+            expect(page).to have_button("Remove", disabled: false) # ensure button is clickable
+            click_on "Remove"
+          end
         end
 
         expect(page).to have_text("Successful deletion.")

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -55,10 +55,6 @@ RSpec.describe "Admin lists project mappings for a storage",
 
   current_user { admin }
 
-  before do
-    Storages::Peripherals::Registry
-      .stub("#{storage.short_provider_type}.commands.delete_folder", ->(_) { ServiceResult.success })
-  end
 
   context "with insufficient permissions" do
     it "is not accessible" do
@@ -367,7 +363,7 @@ RSpec.describe "Admin lists project mappings for a storage",
           click_on "Remove"
         end
 
-        expect(page).to have_text(I18n.t(:notice_successful_delete))
+        expect(page).to have_text("Successful deletion.")
         expect(page).to have_no_text(project.name)
       end
     end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -320,6 +320,20 @@ RSpec.describe "Admin lists project mappings for a storage",
     end
 
     describe "Removal of a project from a storage" do
+      let(:success_delete_service) do
+        Class.new do
+          def initialize(user:, model:)
+            @user = user
+            @model = model
+          end
+
+          def call
+            @model.destroy!
+            ServiceResult.success
+          end
+        end
+      end
+
       it "shows a warning dialog that can be aborted" do
         expect(page).to have_text(project.name)
         project_storages_index_page.click_menu_item_of("Remove project", project)
@@ -337,13 +351,23 @@ RSpec.describe "Admin lists project mappings for a storage",
         expect(page).to have_text(project.name)
         project_storages_index_page.click_menu_item_of("Remove project", project)
 
+        # The original DeleteService would try to remove actual files from actual storages,
+        # which is of course not possible in this test since no real storage is used.
+        expect(Storages::ProjectStorages::DeleteService)
+          .to receive(:new) # rubocop:disable RSpec/MessageSpies
+          .and_wrap_original do |_original_method, *args, &_block|
+            user, model = *args.first.values
+            success_delete_service.new(user:, model:)
+          end
+
         page.within("dialog") do
           expect(page).to have_button("Remove", disabled: true)
           check "Please, confirm you understand and want to remove this file storage from this project"
-          expect(page).to have_button("Remove", disabled: false, wait: 3) # ensure button is clickable
+          wait_for(page).to have_button("Remove", disabled: false) # ensure button is clickable
           click_on "Remove"
         end
 
+        expect(page).to have_text(I18n.t(:notice_successful_delete))
         expect(page).to have_no_text(project.name)
       end
     end

--- a/spec/support/retryable.rb
+++ b/spec/support/retryable.rb
@@ -1,0 +1,65 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Retryable
+  WAIT_PERIOD = 0.05
+  RETRY_ERRORS = %w[
+    RSpec::Expectations::ExpectationNotMetError
+    Capybara::ElementNotFound
+  ].freeze
+
+  def self.repeat_until_success(max_seconds: RSpec.configuration.wait_timeout, &block)
+    repeat_started = system_time
+    tries = 0
+    begin
+      tries += 1
+      try_started = system_time
+      yield block
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      raise e unless retryable_error?(e)
+      raise e if (try_started - repeat_started) > max_seconds && (tries >= 2)
+
+      sleep(WAIT_PERIOD)
+      if system_time == repeat_started
+        raise "Time appears to be frozen, can't use Retryable!"
+      end
+
+      retry
+    end
+  end
+
+  # Use the system clock (i.e. seconds since boot) to calculate the time,
+  # because Time.now may be frozen
+  def self.system_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def self.retryable_error?(error)
+    RETRY_ERRORS.include?(error.class.name)
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/57038

# What are you trying to accomplish?
When removing a project from a storage, all necessary hooks, like e.g. deleting files for automatically managed project folders, should be run. The DeleteService takes care of that.

# Ticket
https://community.openproject.org/work_packages/57038

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) => nothing to do
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) => Tested in Chrome
