### PR TITLE
[57027] Avoid empty first page when printing in Firefox

### DIFF
--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -63,6 +63,10 @@
   h3
     font-size: 1.17em
 
-  .-browser-firefox *
-    // Needed for Firefox only. Otherwise, background-colors (e.g. of buttons) are not correctly printed
-    print-color-adjust: exact
+  .-browser-firefox
+    #content-wrapper
+      // Needed to prevent an empty first page when printing in Firefox
+      display: inline-block
+    *
+      // Needed for Firefox only. Otherwise, background-colors (e.g. of buttons) are not correctly printed
+      print-color-adjust: exact


### PR DESCRIPTION
# What are you trying to accomplish?
When printing long pages in Firefox, there was always a blank page at the beginning. It happens on (but is not limited to) wiki pages and meetings home page.


# Ticket
https://community.openproject.org/work_packages/57027/activity


