### PR TITLE
[57097] Notification center split screen is wider than it previously was

### DIFF
--- a/app/components/work_packages/split_view_component.sass
+++ b/app/components/work_packages/split_view_component.sass
@@ -1,6 +1,6 @@
 .op-work-package-split-view
   height: 100%
-  width: 580px
+  width: 550px
   justify-content: space-around
   border-left: 1px solid var(--borderColor-muted)
   border-top: 1px solid var(--borderColor-muted)


### PR DESCRIPTION
Decrease default width of new split view

https://community.openproject.org/projects/openproject/work_packages/57097/activity