### PR TITLE
[#57147] hardened helper method for network error responses

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
@@ -104,15 +104,18 @@ module Storages
             end
 
             def error_data_from_response(caller:, response:)
-              payload =
-                case response.content_type.mime_type
-                when "application/json"
-                  response.json
-                when "text/xml", "application/xml"
-                  response.xml
-                else
-                  response.body.to_s
-                end
+              payload = if response.respond_to?(:content_type)
+                          case response.content_type.mime_type
+                          when "application/json"
+                            response.json
+                          when "text/xml", "application/xml"
+                            response.xml
+                          else
+                            response.body.to_s
+                          end
+                        else
+                          response.to_s
+                        end
 
               StorageErrorData.new(source: caller, payload:)
             end


### PR DESCRIPTION
[#57147](https://community.openproject.org/work_packages/57147)

- added guard to handle `HTTPX::ErrorResponse` objects
