### PR TITLE
[57003]  OpenProject Dark Mode: selection colour of table rows

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -73,10 +73,6 @@ body[class*="router--"]
     // That also have to be important (cf. 30863)
     background: var(--bgColor-neutral-muted) !important
 
-    td
-      border-top: 1px solid var(--borderColor-neutral-muted) !important
-      border-bottom: 1px solid var(--borderColor-neutral-muted) !important
-
     &.-checked
       background-color: hsl(from var(--selection-bgColor) h calc(s - 30) l) !important
 

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -71,7 +71,14 @@ body[class*="router--"]
   div.row-hovered
     // Use important to override the background styles from __hl classes
     // That also have to be important (cf. 30863)
-    background: var(--bgColor-muted) !important
+    background: var(--bgColor-neutral-muted) !important
+
+    td
+      border-top: 1px solid var(--borderColor-neutral-muted) !important
+      border-bottom: 1px solid var(--borderColor-neutral-muted) !important
+
+    &.-checked
+      background-color: hsl(from var(--selection-bgColor) h calc(s - 30) l) !important
 
 // Left part of the split view
 // == flex container for (table|timeline)


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?
Unify bg-color and border color for hover and select effects in notification center and WPs table row.

## Screenshots
Before:
Hover over a row:
![Screenshot 2024-08-12 at 11 53 23](https://github.com/user-attachments/assets/25ae8725-f35f-40ce-85d3-4a9b9aa2dd0d)

Hover over a selected row:
![Screenshot 2024-08-12 at 11 52 16](https://github.com/user-attachments/assets/02b5d1b5-bb21-4c95-90db-2bfa48028644)

After:
Hover over a row:
![Screenshot 2024-08-12 at 11 51 11](https://github.com/user-attachments/assets/1a2ac19f-bbeb-4b64-890c-1463613165e4)

Hover over a selected row:
![Screenshot 2024-08-12 at 11 51 37](https://github.com/user-attachments/assets/bd0f95b0-e648-4614-93ca-21914630f34b)


# What approach did you choose and why?
Use same primer variable for hover effect colors in notification center and WPs table.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57003/activity

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
