### PR TITLE
[57031] Some status indicators are missing a border

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -139,9 +139,7 @@ module ColorsHelper
   end
 
   def default_variables_light
-    "--lightness-threshold: 0.453;
-     --border-threshold: 0.75;
-     --border-alpha: max(0, min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1));"
+    "--lightness-threshold: 0.453;"
   end
 
   def highlighted_background_dark
@@ -158,7 +156,7 @@ module ColorsHelper
     if mode == "light_high_contrast"
       style += "border: 1px solid hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - 75) * 1%), 1) !important;"
     else
-      style += "border: 1px solid hsla(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - 25) * 1%), var(--border-alpha)) !important;"
+      style += "border: 1px solid hsl(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - 15) * 1%)) !important;"
     end
 
     style


### PR DESCRIPTION
# What are you trying to accomplish?
Always show a border around highlighted backgrounds in light mode (similar to how it is done in the dark mode)

## Screenshots
**Before**
<img width="150" alt="Bildschirmfoto 2024-08-12 um 11 59 54" src="https://github.com/user-attachments/assets/14897e23-2690-457d-b816-23b0a31f3efe">


**After**
<img width="150" alt="Bildschirmfoto 2024-08-12 um 11 59 20" src="https://github.com/user-attachments/assets/0d10baba-f95b-427c-a798-b7957cd058e2">

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57031/activity

