### PR TITLE
Fix 2FA download link

### DIFF
--- a/frontend/src/app/core/setup/globals/global-listeners/link-hijacking.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/link-hijacking.ts
@@ -37,7 +37,7 @@ export function openExternalLinksInNewTab(evt:MouseEvent, linkElement:HTMLAnchor
 
   const link = linkElement.href || '';
 
-  if (link === '') {
+  if (link === '' || !!linkElement.download) {
     return false;
   }
 


### PR DESCRIPTION
Since loading external links in new tabs, this breaks links with the `[download]` attribute unless clicked with a modifier.

https://community.openproject.org/work_packages/57146
