### PR TITLE
Fix package.json version of primer view components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.18.0",
-        "@openproject/primer-view-components": "^0.41.0",
+        "@openproject/primer-view-components": "^0.41.1",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.3.3",
         "@types/hotwired__turbo": "^8.0.1",
@@ -4891,9 +4891,10 @@
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.41.0.tgz",
-      "integrity": "sha512-5oofJDjUViqb+TLykEkRU2SNPpABYdsddXXLvbNjbROnU5/ascRitPWiGjgIomQbKWrP7PiDaYRsTLGvHb9rBw==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.41.1.tgz",
+      "integrity": "sha512-MNOM3Ag7WM68n6VKnvKZ6aJ4c0lr64GC/qL4tzgNhsPqkyLF9E+jdW4JTr3XkP3uLW7B7AmLRznNhRDKAYAiww==",
+      "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25418,7 +25419,7 @@
       "integrity": "sha512-h2ITbCj415T1JpWQDeQd1xYL6TrzkehfUOXxnV0FpblYyMsVBAks6LL7HGJ+ZrydG+Ds0i1rvvi8Q61jErieNA==",
       "requires": {
         "@primer/primitives": "^8.2.0",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.41.0"
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.41.1"
       }
     },
     "@primer/primitives": {
@@ -25427,9 +25428,9 @@
       "integrity": "sha512-K8A/DA6xv8P/kD/9DupFn+KYlo06OpcrwfwJf+sKp+KnX7ZRwLLDg1AaEGAoRoaykXRY/gfrXlgDfK7laOTWyA=="
     },
     "@primer/view-components": {
-      "version": "npm:@openproject/primer-view-components@0.41.0",
-      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.41.0.tgz",
-      "integrity": "sha512-5oofJDjUViqb+TLykEkRU2SNPpABYdsddXXLvbNjbROnU5/ascRitPWiGjgIomQbKWrP7PiDaYRsTLGvHb9rBw==",
+      "version": "npm:@openproject/primer-view-components@0.41.1",
+      "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.41.1.tgz",
+      "integrity": "sha512-MNOM3Ag7WM68n6VKnvKZ6aJ4c0lr64GC/qL4tzgNhsPqkyLF9E+jdW4JTr3XkP3uLW7B7AmLRznNhRDKAYAiww==",
       "requires": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.18.0",
-    "@openproject/primer-view-components": "^0.41.0",
+    "@openproject/primer-view-components": "^0.41.1",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.3.3",
     "@types/hotwired__turbo": "^8.0.1",
@@ -177,6 +177,6 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.41.0"
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.41.1"
   }
 }


### PR DESCRIPTION
I merged the bump by dependabot, but saw that it does not reflect the most current version in package.json. To ensure we don't forget the override, I'm adjusting this https://github.com/opf/openproject/pull/16370/files