### PR TITLE
[57015] Unable to mark all project specific notifications as read

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -82,7 +82,7 @@ class NotificationsController < ApplicationController
     case params[:filter]
     when "project"
       id = params[:name].to_i
-      query.where(:project, "=", [id])
+      query.where(:project_id, "=", [id])
     when "reason"
       query.where(:reason, "=", [params[:name]])
     end

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -102,8 +102,13 @@ RSpec.describe "Notification center", :js, :with_cuprite,
     context "with more the 100 notifications" do
       let(:notifications) do
         attributes = { recipient:, project: project1, resource: work_package }
+        attributes_project2 = { recipient:, project: project2, resource: work_package2 }
+
+        # rubocop:disable FactoryBot/ExcessiveCreateList
         create_list(:notification, 100, attributes.merge(reason: :mentioned)) +
-        create_list(:notification, 105, attributes.merge(reason: :watched))
+        create_list(:notification, 105, attributes.merge(reason: :watched)) +
+        create_list(:notification, 50, attributes_project2.merge(reason: :assigned))
+        # rubocop:enable FactoryBot/ExcessiveCreateList
       end
 
       it "can dismiss all notifications of the currently selected filter" do
@@ -112,8 +117,8 @@ RSpec.describe "Notification center", :js, :with_cuprite,
         center.expect_bell_count "99+"
         center.open
 
-        # side menu items show full count of notifications (inbox has one more due to the "Created" notification)
-        side_menu.expect_item_with_count "Inbox", 206
+        # side menu items show full count of notifications (inbox has two more due to the "Created" notification)
+        side_menu.expect_item_with_count "Inbox", 257
         side_menu.expect_item_with_count "Mentioned", 100
         side_menu.expect_item_with_count "Watcher", 105
 
@@ -124,9 +129,20 @@ RSpec.describe "Notification center", :js, :with_cuprite,
         wait_for_network_idle
 
         center.expect_bell_count "99+"
-        side_menu.expect_item_with_count "Inbox", 101
+        side_menu.expect_item_with_count "Inbox", 152
         side_menu.expect_item_with_count "Mentioned", 100
         side_menu.expect_item_with_no_count "Watcher"
+
+        # select a project and mark all as read
+        side_menu.click_item project2.name
+        side_menu.finished_loading
+        center.mark_all_read
+        wait_for_network_idle
+
+        center.expect_bell_count "99+"
+        side_menu.expect_item_with_count "Inbox", 101
+        side_menu.expect_item_with_count "Mentioned", 100
+        side_menu.expect_no_item project2.name
 
         # select inbox and mark all as read
         side_menu.click_item "Inbox"


### PR DESCRIPTION
# What are you trying to accomplish?
Correctly use the project filter when marking all notifications as read

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57015/activity

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
