### PR TITLE
Add vietnamese as a new default language

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -154,7 +154,7 @@ module Settings
         format: :array,
         # Manually managed list with languages that have ~50+ translation ratio in Crowdin
         # https://crowdin.com/project/openproject
-        default: %w[ca cs de el en es fr hu id it ja ko lt nl no pl pt-BR pt-PT ro ru sk sl sv tr uk zh-CN zh-TW].freeze,
+        default: %w[ca cs de el en es fr hu id it ja ko lt nl no pl pt-BR pt-PT ro ru sk sl sv tr uk vi zh-CN zh-TW].freeze,
         allowed: -> { Redmine::I18n.all_languages }
       },
       avatar_link_expiry_seconds: {


### PR DESCRIPTION
Vietnamese has been optionally selectable for some time, but now is 100% translated, so we can add it as a default available language.