### PR TITLE
[#57059] Confusing UX when cancelling editing Nextcloud OAuth settings

### DIFF
--- a/modules/storages/app/components/storages/admin/oauth_client_info_component.rb
+++ b/modules/storages/app/components/storages/admin/oauth_client_info_component.rb
@@ -65,7 +65,7 @@ module Storages::Admin
       {}.tap do |data_h|
         if oauth_client_configured?
           provider_type = I18n.t("storages.provider_types.#{storage.short_provider_type}.name")
-          data_h[:confirm] = I18n.t("storages.confirm_replace_oauth_client", provider_type:)
+          data_h[:turbo_confirm] = I18n.t("storages.confirm_replace_oauth_client", provider_type:)
         end
         data_h[:turbo_stream] = true
       end

--- a/modules/storages/spec/components/storages/admin/oauth_client_info_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_client_info_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Storages::Admin::OAuthClientInfoComponent, type: :component do # 
         component = described_class.new(storage:, oauth_client: storage.oauth_client)
         expect(component.edit_icon_button_options)
           .to include(icon: :sync,
-                      data: { confirm:
+                      data: { turbo_confirm:
                                 "This action will reset the current OAuth credentials. After confirming you will " \
                                 "have to enter new credentials from the storage provider and all users will have " \
                                 "to authorize against Nextcloud again. Are you sure you want to proceed?",


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The confirm modal was not honored. 

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

![turbo-confirm](https://github.com/user-attachments/assets/af137ca4-00e3-41a5-8f3a-2de8021ccf95)


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Migrate the OAuth client form GET from Rails UJS `data-confirm` to Turbo `data-turbo-confirm` that works with turbo

See: https://gorails.com/episodes/turbo-data-confirm-method-and-disable

# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/work_packages/57059

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
