### PR TITLE
[#56994] Fix git snippet appears broken (although it isn't) 

### DIFF
--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
@@ -31,7 +31,7 @@ describe('GitActionsMenuComponent', () => {
   }
 
   beforeEach(async () => {
-    const gitActionsServiceSpy = jasmine.createSpyObj('GitActionsService', ['gitCommand', 'commitMessage', 'branchName']);
+    const gitActionsServiceSpy = jasmine.createSpyObj('GitActionsService', ['gitCommand', 'commitMessage', 'commitMessageDisplayText', 'branchName']);
 
     await TestBed
       .configureTestingModule({

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -72,16 +72,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.branch_name'),
+      textToDisplay: () => this.gitActions.branchName(this.workPackage),
       textToCopy: () => this.gitActions.branchName(this.workPackage),
     },
     {
       id: 'message',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.commit_message'),
+      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
       textToCopy: () => this.gitActions.commitMessage(this.workPackage),
     },
     {
       id: 'command',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.cmd'),
+      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
       textToCopy: () => this.gitActions.gitCommand(this.workPackage),
     },
   ];

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -5,7 +5,7 @@
     <label class="spot-form-field--label-wrap">
       <div class="spot-form-field--label">{{ snippet.name }}</div>
       <div class="spot-form-field--input">
-        <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToCopy()">
+        <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
         <button
           class="button copy-button"
           type="button"

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -78,6 +78,10 @@ ${url}
 `.replace(/\n\n+/g, '\n\n');
   }
 
+  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
+    return this.commitMessage(workPackage).replace(/\n\n/g, ' ');
+  }
+
   public gitCommand(workPackage:WorkPackageResource):string {
     const branch = this.branchName(workPackage);
     const commit = this.commitMessage(workPackage);

--- a/modules/github_integration/frontend/module/state/github-pull-request.model.ts
+++ b/modules/github_integration/frontend/module/state/github-pull-request.model.ts
@@ -7,6 +7,7 @@ import { ID } from '@datorama/akita';
 export interface ISnippet {
   id:string;
   name:string;
+  textToDisplay:() => string;
   textToCopy:() => string
 }
 

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -67,16 +67,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.branch_name'),
+      textToDisplay: () => this.gitActions.branchName(this.workPackage),
       textToCopy: () => this.gitActions.branchName(this.workPackage)
     },
     {
       id: 'message',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.commit_message'),
+      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
       textToCopy: () => this.gitActions.commitMessage(this.workPackage)
     },
     {
       id: 'command',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.cmd'),
+      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
       textToCopy: () => this.gitActions.gitCommand(this.workPackage)
     },
   ];

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -5,7 +5,7 @@
     <label class="op-form-field--label-wrap">
       <div class="op-form-field--label">{{ snippet.name }}</div>
       <div class="op-form-field--input">
-        <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToCopy()">
+        <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
         <button class="button copy-button"
             type="button"
             [attr.aria-label]="text.copyButtonHelpText"
@@ -18,5 +18,3 @@
   </div>
 
 </div>
-
-

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -81,6 +81,10 @@ ${url}
 `.replace(/\n\n+/g, '\n\n');
   }
 
+  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
+    return this.commitMessage(workPackage).replace(/\n\n/g, ' ');
+  }
+
   public gitCommand(workPackage:WorkPackageResource):string {
     const branch = this.branchName(workPackage);
     const commit = this.commitMessage(workPackage);

--- a/modules/gitlab_integration/frontend/module/typings.d.ts
+++ b/modules/gitlab_integration/frontend/module/typings.d.ts
@@ -33,6 +33,7 @@ import { HalResourceClass } from 'core-app/modules/hal/resources/hal-resource';
 export interface ISnippet {
   id:string;
   name:string;
+  textToDisplay:()=>string;
   textToCopy:()=>string
 }
 

--- a/modules/gitlab_integration/spec/features/work_package_gitlab_tab_spec.rb
+++ b/modules/gitlab_integration/spec/features/work_package_gitlab_tab_spec.rb
@@ -78,22 +78,44 @@ RSpec.describe "Open the Gitlab tab", :js do
       work_package_page.switch_to_tab(tab: "gitlab")
     end
 
-    it "shows the gitlab tab when the user is allowed to see it" do
-      work_package_page.visit!
-      work_package_page.switch_to_tab(tab: "gitlab")
+    context "when the user is allowed to see the gitlab tab" do
+      before do
+        work_package_page.visit!
+        work_package_page.switch_to_tab(tab: "gitlab")
+      end
 
-      tabs.expect_counter(gitlab_tab_element, 2)
+      it "shows the issues and merge requests associated with the work package" do
+        tabs.expect_counter(gitlab_tab_element, 2)
 
-      gitlab_tab.git_actions_menu_button.click
-      gitlab_tab.git_actions_copy_branch_name_button.click
-      expect(page).to have_text("Copied!")
-      expect_clipboard_content("#{work_package.type.name.downcase}/#{work_package.id}-a-test-work_package")
+        expect(page).to have_text("A Test Issue title")
+        expect(page).to have_text("Open")
 
-      expect(page).to have_text("A Test Issue title")
-      expect(page).to have_text("Open")
+        expect(page).to have_text("A Test MR title")
+        expect(page).to have_text("Pending")
+      end
 
-      expect(page).to have_text("A Test MR title")
-      expect(page).to have_text("Pending")
+      it "allows the user to copy the branch name to the clipboard" do
+        gitlab_tab.git_actions_menu_button.click
+        gitlab_tab.git_actions_copy_branch_name_button.click
+
+        expect(page).to have_text("Copied!")
+        expect_clipboard_content("#{work_package.type.name.downcase}/#{work_package.id}-a-test-work_package")
+      end
+
+      it "shows a commit message with space between title and link" do
+        gitlab_tab.git_actions_menu_button.click
+
+        commit_message_input_text = page.find_field("Commit message").value
+        expect(commit_message_input_text).to include("A test work_package http://")
+      end
+
+      it "allows the user to copy a commit message with newlines between title and link to the clipboard" do
+        gitlab_tab.git_actions_menu_button.click
+        gitlab_tab.git_actions_copy_commit_message_button.click
+
+        expect(page).to have_text("Copied!")
+        expect_clipboard_content("A test work_package\nhttp://")
+      end
     end
 
     context "when there are no merge requests or issues" do

--- a/modules/gitlab_integration/spec/support/pages/work_package_gitlab_tab.rb
+++ b/modules/gitlab_integration/spec/support/pages/work_package_gitlab_tab.rb
@@ -50,6 +50,10 @@ module Pages
       find(".git-actions-menu .copy-button:not([disabled])", match: :first)
     end
 
+    def git_actions_copy_commit_message_button
+      all(".git-actions-menu .copy-button:not([disabled])")[1]
+    end
+
     def paste_clipboard_content
       meta_key = osx? ? :command : :control
       page.send_keys(meta_key, "v")


### PR DESCRIPTION
# What are you trying to accomplish?
In the Git Snippets Input for a commit message it appears as though there is missing a space between title and link. This is because when using the "copy" button, there will be newlines between them. For short Work Package titles this is visible and looks broken. So I added an space here.

## Screenshots
Before:
![Screenshot from 2024-08-05 15-30-10-2](https://github.com/user-attachments/assets/b5fe4ef2-190e-495c-9f2f-372cf4291ae8)

After:
![Screenshot from 2024-08-12 16-46-31](https://github.com/user-attachments/assets/438df764-0357-4be0-9059-3ee8446af546)

# Ticket
https://community.openproject.org/projects/openproject/work_packages/56994

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) => Nothing to do
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) => Chrome and Firefox
