### PR TITLE
[52233] Fix multiple issues related to % complete being editable

### DIFF
--- a/app/components/work_packages/progress/work_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.html.erb
@@ -40,7 +40,12 @@
 
       <% modal_body.with_row(mt: 3) do |_tooltip| %>
         <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { t("work_package.progress.label_note") } %>
-        <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text") } %>
+        <% if OpenProject::FeatureDecisions.percent_complete_edition_active? %>
+          <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text") } %>
+        <% else %>
+          <%# This condition branch to be removed in 15.0 with :percent_complete_edition feature flag removal %>
+          <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text_pre_14_4_without_percent_complete_edition") } %>
+        <% end %>
         <%= render(Primer::Beta::Link.new(href: learn_more_href)) { t(:label_learn_more) } %>
       <% end %>
 

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -387,6 +387,8 @@ module WorkPackages
     end
 
     def validate_percent_complete_is_set_when_work_and_remaining_work_are_set
+      return if remaining_work_exceeds_work? # avoid too many error messages at the same time
+
       if work_set_and_valid? && remaining_work_set_and_valid? && work != 0 && percent_complete_unset?
         errors.add(:done_ratio, :must_be_set_when_work_and_remaining_work_are_set)
       end

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -393,9 +393,7 @@ module WorkPackages
     end
 
     def validate_percent_complete_matches_work_and_remaining_work
-      return if WorkPackage.status_based_mode? || percent_complete_unset? || work == 0 || percent_complete == 100
-      return if invalid_work_or_remaining_work_values? # avoid too many error messages at the same time
-      return unless work_set? && remaining_work_set?
+      return if percent_complete_derivation_unapplicable?
 
       if percent_complete != percent_complete_derived_from_work_and_remaining_work
         errors.add(:done_ratio, :does_not_match_work_and_remaining_work)
@@ -470,6 +468,13 @@ module WorkPackages
 
     def percent_complete_unset?
       percent_complete.nil?
+    end
+
+    def percent_complete_derivation_unapplicable?
+      WorkPackage.status_based_mode? || # only applicable in work-based mode
+        work_unset? || remaining_work_unset? || percent_complete_unset? || # only applicable if all 3 values are set
+        work == 0 || percent_complete == 100 || # only applicable if not in special cases leading to divisions by zero
+        invalid_work_or_remaining_work_values? # only applicable if work and remaining work values are valid
     end
 
     def percent_complete_derived_from_work_and_remaining_work

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -382,7 +382,7 @@ module WorkPackages
     # rubocop:disable Metrics/AbcSize
     def validate_percent_complete_matches_work_and_remaining_work
       return if WorkPackage.status_based_mode? || percent_complete_unset? || work == 0
-      return if remaining_work_exceeds_work? # avoid too many error messages at the same time
+      return if invalid_work_or_remaining_work_values? # avoid too many error messages at the same time
       return unless work_set? && remaining_work_set?
 
       work_done = work - remaining_work
@@ -434,8 +434,14 @@ module WorkPackages
       remaining_work.nil?
     end
 
+    def invalid_work_or_remaining_work_values?
+      (work_set? && work.negative?) ||
+        (remaining_work_set? && remaining_work.negative?) ||
+      remaining_work_exceeds_work?
+    end
+
     def remaining_work_exceeds_work?
-      work_set? && remaining_work_set? && remaining_work > work
+      work_set_and_valid? && remaining_work_set_and_valid? && remaining_work > work
     end
 
     def percent_complete

--- a/app/forms/work_packages/pre_14_4_progress_form.rb
+++ b/app/forms/work_packages/pre_14_4_progress_form.rb
@@ -134,7 +134,11 @@ class WorkPackages::Pre144ProgressForm < ApplicationForm
   end
 
   def focused_field_by_selection(field)
-    field
+    if field == :remaining_hours && disabled_remaining_work_field?
+      :estimated_hours
+    else
+      field
+    end
   end
 
   def render_text_field(group,

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -144,7 +144,8 @@ class WorkPackages::ProgressForm < ApplicationForm
     text_field_options = {
       name:,
       value: field_value(name),
-      label:
+      label:,
+      validation_message: validation_message(name)
     }
     text_field_options.reverse_merge!(default_field_options(name))
 
@@ -177,6 +178,12 @@ class WorkPackages::ProgressForm < ApplicationForm
     else
       DurationConverter.output(@work_package.public_send(name))
     end
+  end
+
+  def validation_message(name)
+    # it's ok to take the first error only, that's how primer_view_component does it anyway.
+    message = @work_package.errors.messages_for(name).first
+    message&.upcase_first
   end
 
   def as_percent(value)

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -62,56 +62,20 @@ class WorkPackages::ProgressForm < ApplicationForm
   form do |query_form|
     query_form.group(layout: :horizontal) do |group|
       if mode == :status_based
-        select_field_options =
-          default_field_options(:status_id)
-            .merge(
-              name: :status_id,
-              label: I18n.t(:label_percent_complete),
-              disabled: @work_package.new_record?
-            )
+        select_status_list(group)
+        text_field(group, name: :estimated_hours, label: I18n.t(:label_work))
+        readonly_text_field(group, name: :remaining_hours, label: I18n.t(:label_remaining_work))
 
-        group.select_list(**select_field_options) do |select_list|
-          WorkPackages::UpdateContract.new(@work_package, User.current)
-                                      .assignable_statuses
-                                      .each do |status| # avoid find_each to keep ordering by position
-            select_list.option(
-              label: "#{status.name} (#{status.default_done_ratio}%)",
-              value: status.id
-            )
-          end
-        end
-
-        render_text_field(group, name: :estimated_hours, label: I18n.t(:label_work))
-        render_readonly_text_field(group, name: :remaining_hours, label: I18n.t(:label_remaining_work))
-
-        # Add a hidden field in create forms as the select field is disabled and is otherwise not included in the form payload
-        group.hidden(name: :status_id) if @work_package.new_record?
-
-        group.hidden(name: :status_id_touched,
-                     value: @touched_field_map["status_id_touched"] || false,
-                     data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
-                             "referrer-field": "work_package[status_id]" })
-        group.hidden(name: :estimated_hours_touched,
-                     value: @touched_field_map["estimated_hours_touched"] || false,
-                     data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
-                             "referrer-field": "work_package[estimated_hours]" })
+        hidden_touched_field(group, name: :status_id)
+        hidden_touched_field(group, name: :estimated_hours)
       else
-        render_text_field(group, name: :estimated_hours, label: I18n.t(:label_work))
-        render_text_field(group, name: :remaining_hours, label: I18n.t(:label_remaining_work))
-        render_text_field(group, name: :done_ratio, label: I18n.t(:label_percent_complete))
+        text_field(group, name: :estimated_hours, label: I18n.t(:label_work))
+        text_field(group, name: :remaining_hours, label: I18n.t(:label_remaining_work))
+        text_field(group, name: :done_ratio, label: I18n.t(:label_percent_complete))
 
-        group.hidden(name: :estimated_hours_touched,
-                     value: @touched_field_map["estimated_hours_touched"] || false,
-                     data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
-                             "referrer-field": "work_package[estimated_hours]" })
-        group.hidden(name: :remaining_hours_touched,
-                     value: @touched_field_map["remaining_hours_touched"] || false,
-                     data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
-                             "referrer-field": "work_package[remaining_hours]" })
-        group.hidden(name: :done_ratio_touched,
-                     value: @touched_field_map["done_ratio_touched"] || false,
-                     data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
-                             "referrer-field": "work_package[done_ratio]" })
+        hidden_touched_field(group, name: :estimated_hours)
+        hidden_touched_field(group, name: :remaining_hours)
+        hidden_touched_field(group, name: :done_ratio)
       end
       group.fields_for(:initial) do |builder|
         InitialValuesForm.new(builder, work_package:, mode:)
@@ -138,35 +102,67 @@ class WorkPackages::ProgressForm < ApplicationForm
     field
   end
 
-  def render_text_field(group,
-                        name:,
-                        label:)
-    text_field_options = {
+  def select_status_list(group)
+    # status selection is disabled in create forms
+    disabled = work_package.new_record?
+
+    select_field_options =
+      default_field_options(:status_id)
+        .merge(
+          name: :status_id,
+          label: I18n.t(:label_percent_complete),
+          disabled:
+        )
+
+    group.select_list(**select_field_options) do |select_list|
+      WorkPackages::UpdateContract.new(work_package, User.current)
+                                  .assignable_statuses
+                                  .each do |status| # avoid find_each to keep ordering by position
+        select_list.option(
+          label: "#{status.name} (#{status.default_done_ratio}%)",
+          value: status.id
+        )
+      end
+    end
+
+    # Add a hidden field if the select field is disabled, otherwise it would not be included in the form payload
+    group.hidden(name: :status_id) if disabled
+  end
+
+  def text_field(group,
+                 name:,
+                 label:)
+    text_field_options = default_field_options(name).merge(
       name:,
       value: field_value(name),
       label:,
       validation_message: validation_message(name)
-    }
-    text_field_options.reverse_merge!(default_field_options(name))
+    )
 
     group.text_field(**text_field_options)
   end
 
-  def render_readonly_text_field(group,
-                                 name:,
-                                 label:,
-                                 placeholder: true)
-    text_field_options = {
+  def readonly_text_field(group,
+                          name:,
+                          label:,
+                          placeholder: true)
+    text_field_options = default_field_options(name).merge(
       name:,
       value: field_value(name),
       label:,
       readonly: true,
       classes: "input--readonly",
       placeholder: ("-" if placeholder)
-    }
-    text_field_options.reverse_merge!(default_field_options(name))
+    )
 
     group.text_field(**text_field_options)
+  end
+
+  def hidden_touched_field(group, name:)
+    group.hidden(name: :"#{name}_touched",
+                 value: @touched_field_map["#{name}_touched"] || false,
+                 data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
+                         "referrer-field": "work_package[#{name}]" })
   end
 
   def field_value(name)

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -73,7 +73,7 @@ class WorkPackages::ProgressForm < ApplicationForm
         group.select_list(**select_field_options) do |select_list|
           WorkPackages::UpdateContract.new(@work_package, User.current)
                                       .assignable_statuses
-                                      .find_each do |status|
+                                      .each do |status| # avoid find_each to keep ordering by position
             select_list.option(
               label: "#{status.name} (#{status.default_done_ratio}%)",
               value: status.id

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -160,9 +160,13 @@ class WorkPackages::ProgressForm < ApplicationForm
 
   def hidden_touched_field(group, name:)
     group.hidden(name: :"#{name}_touched",
-                 value: @touched_field_map["#{name}_touched"] || false,
+                 value: touched(name),
                  data: { "work-packages--progress--touched-field-marker-target": "touchedFieldInput",
                          "referrer-field": "work_package[#{name}]" })
+  end
+
+  def touched(name)
+    @touched_field_map["#{name}_touched"] || false
   end
 
   def field_value(name)

--- a/app/forms/work_packages/progress_form/initial_values_form.rb
+++ b/app/forms/work_packages/progress_form/initial_values_form.rb
@@ -40,21 +40,25 @@ class WorkPackages::ProgressForm
 
     form do |form|
       if mode == :status_based
-        form.hidden(name: :status_id,
-                    value: work_package.status_id_was)
-        form.hidden(name: :estimated_hours,
-                    value: work_package.estimated_hours_was)
+        hidden_initial_field(form, name: :status_id)
+        hidden_initial_field(form, name: :estimated_hours)
       else
-        form.hidden(name: :estimated_hours,
-                    value: work_package.estimated_hours_was)
-        form.hidden(name: :remaining_hours,
-                    value: work_package.remaining_hours_was)
+        hidden_initial_field(form, name: :estimated_hours)
+        hidden_initial_field(form, name: :remaining_hours)
         # next line to be removed in 15.0 with :percent_complete_edition feature flag removal
         next unless OpenProject::FeatureDecisions.percent_complete_edition_active?
 
-        form.hidden(name: :done_ratio,
-                    value: work_package.done_ratio_was)
+        hidden_initial_field(form, name: :done_ratio)
       end
+    end
+
+    private
+
+    def hidden_initial_field(form, name:)
+      form.hidden(name:,
+                  value: work_package.public_send(:"#{name}_was"),
+                  data: { "work-packages--progress--touched-field-marker-target": "initialValueInput",
+                          "referrer-field": "work_package[#{name}]" })
     end
   end
 end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -328,6 +328,10 @@ class WorkPackage < ApplicationRecord
     write_attribute :remaining_hours, convert_duration_to_hours(hours)
   end
 
+  def done_ratio=(value)
+    write_attribute :done_ratio, convert_value_to_percentage(value)
+  end
+
   def duration_in_hours
     duration ? duration * 24 : nil
   end
@@ -557,6 +561,13 @@ class WorkPackage < ApplicationRecord
       rescue ChronicDuration::DurationParseError
         # keep invalid value, error shall be caught by numericality validator
       end
+    end
+    value
+  end
+
+  def convert_value_to_percentage(value)
+    if value.is_a?(String) && PercentageConverter.valid?(value)
+      value = PercentageConverter.parse(value)
     end
     value
   end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
@@ -30,8 +30,6 @@ class WorkPackages::SetAttributesService
   class DeriveProgressValuesBase
     attr_reader :work_package
 
-    PROGRESS_ATTRIBUTES = %i[work remaining_work percent_complete].freeze
-
     def initialize(work_package)
       @work_package = work_package
     end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
@@ -55,11 +55,11 @@ class WorkPackages::SetAttributesService
       work.present?
     end
 
-    def work_unset?
+    def work_empty?
       work.nil?
     end
 
-    def work_was_unset?
+    def work_was_empty?
       work_package.estimated_hours_was.nil?
     end
 
@@ -87,11 +87,11 @@ class WorkPackages::SetAttributesService
       remaining_work.present?
     end
 
-    def remaining_work_unset?
+    def remaining_work_empty?
       remaining_work.nil?
     end
 
-    def remaining_work_was_unset?
+    def remaining_work_was_empty?
       work_package.remaining_hours_was.nil?
     end
 
@@ -119,11 +119,11 @@ class WorkPackages::SetAttributesService
       percent_complete.present?
     end
 
-    def percent_complete_unset?
+    def percent_complete_empty?
       percent_complete.nil?
     end
 
-    def percent_complete_was_unset?
+    def percent_complete_was_empty?
       work_package.done_ratio_was.nil?
     end
 
@@ -157,7 +157,7 @@ class WorkPackages::SetAttributesService
     end
 
     def remaining_work_from_percent_complete_and_work
-      return nil if work_unset? || percent_complete_unset?
+      return nil if work_empty? || percent_complete_empty?
 
       completed_work = work * percent_complete / 100.0
       remaining_work = (work - completed_work).round(2)

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -86,7 +86,7 @@ class WorkPackages::SetAttributesService
 
       if work_set? && remaining_work_unset? && percent_complete_unset?
         self.remaining_work = work
-      elsif work_changed? && work_set? && remaining_work_set? && !percent_complete_changed?
+      elsif work_changed? && work_set? && remaining_work_set? && percent_complete_not_provided_by_user?
         delta = work - work_was
         self.remaining_work = (remaining_work + delta).clamp(0.0, work)
       elsif work_unset? || percent_complete_unset?
@@ -123,7 +123,7 @@ class WorkPackages::SetAttributesService
 
     def remaining_work_set_greater_than_work?
       (work_was_unset? || remaining_work_came_from_user?) \
-        && !percent_complete_came_from_user? \
+        && percent_complete_not_provided_by_user? \
         && work && remaining_work && remaining_work > work
     end
 

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -46,6 +46,7 @@ class WorkPackages::SetAttributesService
       work&.negative? \
         || remaining_work&.negative? \
         || percent_complete_out_of_range? \
+        || percent_complete_unparsable? \
         || remaining_work_set_greater_than_work?
     end
 
@@ -111,6 +112,10 @@ class WorkPackages::SetAttributesService
 
       remaining_percent_complete = 1.0 - ((percent_complete || 0) / 100.0)
       remaining_work / remaining_percent_complete
+    end
+
+    def percent_complete_unparsable?
+      !PercentageConverter.valid?(work_package.done_ratio_before_type_cast)
     end
 
     def remaining_work_set_greater_than_work?

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -119,11 +119,9 @@ class WorkPackages::SetAttributesService
     end
 
     def remaining_work_set_greater_than_work?
-      attributes_from_user == %i[remaining_work] && work && remaining_work && remaining_work > work
-    end
-
-    def attributes_from_user
-      @attributes_from_user ||= PROGRESS_ATTRIBUTES.filter { |attr| public_send(:"#{attr}_came_from_user?") }
+      remaining_work_came_from_user? \
+        && !percent_complete_came_from_user? \
+        && work && remaining_work && remaining_work > work
     end
 
     def work_set_and_no_user_inputs_provided_for_both_remaining_work_and_percent_complete?

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -68,6 +68,7 @@ class WorkPackages::SetAttributesService
     def update_work
       return if work_set_and_no_user_inputs_provided_for_both_remaining_work_and_percent_complete?
       return if remaining_work_unset? && percent_complete_unset?
+      return if percent_complete == 100 # would be Infinity if computed when % complete is 100%
 
       self.work = work_from_percent_complete_and_remaining_work
     end

--- a/app/views/admin/settings/work_packages_settings/show.html.erb
+++ b/app/views/admin/settings/work_packages_settings/show.html.erb
@@ -38,12 +38,11 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-
-
 <%= styled_form_tag({ action: :update }, method: :patch) do %>
   <section class="form--section"
            data-application-target="dynamic"
-           data-controller="admin--work-packages-settings">
+           data-controller="admin--work-packages-settings"
+           data-admin--work-packages-settings-percent-complete-edition-active-value="<%= OpenProject::FeatureDecisions.percent_complete_edition_active? %>">
     <div class="form--field"><%= setting_check_box :cross_project_work_package_relations %></div>
     <div class="form--field"><%= setting_check_box :display_subprojects_work_packages %></div>
     <div class="form--field"><%= setting_check_box :work_package_startdate_is_adddate %></div>
@@ -53,7 +52,14 @@ See COPYRIGHT and LICENSE files for more details.
                          container_class: "-middle",
                          data: { admin__work_packages_settings_target: "progressCalculationModeSelect",
                                  action: "change->admin--work-packages-settings#displayWarning" } %>
-      <div class="form--field-instructions"><%= t("setting_work_package_done_ratio_explanation_html") %></div>
+      <div class="form--field-instructions"><%=
+        if OpenProject::FeatureDecisions.percent_complete_edition_active?
+          t("setting_work_package_done_ratio_explanation_html")
+        else
+          # This condition branch to be removed in 15.0 with :percent_complete_edition feature flag removal
+          t("setting_work_package_done_ratio_explanation_pre_14_4_without_percent_complete_edition_html")
+        end
+                                            %></div>
     </div>
     <div class="op-toast -warning -with-bottom-spacing"
          hidden
@@ -76,7 +82,7 @@ See COPYRIGHT and LICENSE files for more details.
                    ee_feature: :conditional_highlighting,
                    explanation: t("js.work_packages.table_configuration.upsale.attribute_highlighting"),
                    link_out: {
-                     href: "https://www.openproject.org/enterprise-edition/?op_edtion=community-edition&op_referrer=settings-wp-attribute-highlighting#attribute-highlighting",
+                     href: "https://www.openproject.org/enterprise-edition/?op_edition=community-edition&op_referrer=settings-wp-attribute-highlighting#attribute-highlighting",
                      caption: t("js.work_packages.table_configuration.upsale.check_out_link")
                    }
                  } %>

--- a/app/workers/work_packages/progress/apply_statuses_change_job.rb
+++ b/app/workers/work_packages/progress/apply_statuses_change_job.rb
@@ -58,21 +58,26 @@ class WorkPackages::Progress::ApplyStatusesChangeJob < WorkPackages::Progress::J
     @changes = changes
 
     with_temporary_progress_table do
-      if WorkPackage.use_status_for_done_ratio?
-        set_p_complete_from_status
-        if OpenProject::FeatureDecisions.percent_complete_edition_active?
-          fix_remaining_work_set_with_100p_complete
-          derive_unset_work_from_remaining_work_and_p_complete
-        end
-        derive_remaining_work_from_work_and_p_complete
-      end
+      adjust_progress_values
       update_totals
-
       copy_progress_values_to_work_packages_and_update_journals(journal_cause)
     end
   end
 
   private
+
+  def adjust_progress_values
+    if WorkPackage.work_based_mode?
+      clear_percent_complete_when_0h_work
+    elsif WorkPackage.status_based_mode?
+      set_p_complete_from_status
+      if OpenProject::FeatureDecisions.percent_complete_edition_active?
+        fix_remaining_work_set_with_100p_complete
+        derive_unset_work_from_remaining_work_and_p_complete
+      end
+      derive_remaining_work_from_work_and_p_complete
+    end
+  end
 
   def journal_cause
     assert_valid_cause_type!
@@ -112,5 +117,13 @@ class WorkPackages::Progress::ApplyStatusesChangeJob < WorkPackages::Progress::J
     if changes.nil?
       raise ArgumentError, "changes must be provided"
     end
+  end
+
+  def clear_percent_complete_when_0h_work
+    execute(<<~SQL.squish)
+      UPDATE temp_wp_progress_values
+      SET done_ratio = NULL
+      WHERE estimated_hours = 0
+    SQL
   end
 end

--- a/app/workers/work_packages/progress/apply_statuses_change_job.rb
+++ b/app/workers/work_packages/progress/apply_statuses_change_job.rb
@@ -60,6 +60,10 @@ class WorkPackages::Progress::ApplyStatusesChangeJob < WorkPackages::Progress::J
     with_temporary_progress_table do
       if WorkPackage.use_status_for_done_ratio?
         set_p_complete_from_status
+        if OpenProject::FeatureDecisions.percent_complete_edition_active?
+          fix_remaining_work_set_with_100p_complete
+          derive_unset_work_from_remaining_work_and_p_complete
+        end
         derive_remaining_work_from_work_and_p_complete
       end
       update_totals

--- a/app/workers/work_packages/progress/migrate_values_job.rb
+++ b/app/workers/work_packages/progress/migrate_values_job.rb
@@ -76,17 +76,6 @@ class WorkPackages::Progress::MigrateValuesJob < WorkPackages::Progress::Job
     SQL
   end
 
-  def fix_remaining_work_set_with_100p_complete
-    execute(<<~SQL.squish)
-      UPDATE temp_wp_progress_values
-      SET estimated_hours = remaining_hours,
-          remaining_hours = 0
-      WHERE estimated_hours IS NULL
-        AND remaining_hours IS NOT NULL
-        AND done_ratio = 100
-    SQL
-  end
-
   def fix_remaining_work_exceeding_work
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
@@ -129,20 +118,6 @@ class WorkPackages::Progress::MigrateValuesJob < WorkPackages::Progress::Job
         )
       WHERE estimated_hours IS NOT NULL
         AND remaining_hours IS NULL
-        AND done_ratio IS NOT NULL
-    SQL
-  end
-
-  def derive_unset_work_from_remaining_work_and_p_complete
-    execute(<<~SQL.squish)
-      UPDATE temp_wp_progress_values
-      SET estimated_hours =
-        CASE done_ratio
-          WHEN 0 THEN remaining_hours
-          ELSE ROUND((remaining_hours * 100 / (100 - done_ratio))::numeric, 2)
-        END
-      WHERE estimated_hours IS NULL
-        AND remaining_hours IS NOT NULL
         AND done_ratio IS NOT NULL
     SQL
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3217,7 +3217,8 @@ en:
   setting_work_package_done_ratio_field: "Work-based"
   setting_work_package_done_ratio_status: "Status-based"
   setting_work_package_done_ratio_explanation_html: >
-    In <b>work-based</b> mode, % Complete is calculated from how much work is done in relation to total work.
+    In <b>work-based</b> mode, % Complete can be freely set to any value.
+    If you optionally enter a value for Work, Remaining work will automatically be derived.
     In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
   setting_work_package_properties: "Work package properties"
   setting_work_package_startdate_is_adddate: "Use current date as start date for new work packages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1155,7 +1155,7 @@ en:
               must_be_set_when_work_and_percent_complete_are_set: "required when Work and % Complete are set."
               must_be_set_to_zero_hours_when_work_is_set_and_percent_complete_is_100p: >-
                 must be 0h when Work is set and % Complete is 100%.
-              must_be_unset_when_work_is_unset_and_percent_complete_is_100p: >-
+              must_be_empty_when_work_is_empty_and_percent_complete_is_100p: >-
                 must be empty when Work is empty and % Complete is 100%.
           readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
         type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1154,6 +1154,10 @@ en:
               cant_exceed_work: "Cannot be higher than Work."
               must_be_set_when_work_is_set: "Required when Work is set."
               must_be_set_when_work_and_percent_complete_are_set: "Required when Work and % Complete are set."
+              must_be_set_to_zero_hours_when_work_is_set_and_percent_complete_is_100p: >-
+                must be set to 0h when Work is set and % Complete is 100%.
+              must_be_unset_when_work_is_unset_and_percent_complete_is_100p: >-
+                must be unset when Work is unset and % Complete is 100%.
               format: "%{message}"
           readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
         type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3220,10 +3220,13 @@ en:
   setting_work_package_done_ratio: "Progress calculation"
   setting_work_package_done_ratio_field: "Work-based"
   setting_work_package_done_ratio_status: "Status-based"
+  setting_work_package_done_ratio_explanation_pre_14_4_without_percent_complete_edition_html: >
+    In <b>work-based</b> mode, % Complete is calculated from how much work is done in relation to total work.
+    In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
   setting_work_package_done_ratio_explanation_html: >
-    In <b>work-based</b> mode, % Complete can be freely set to any value.
+    In <b>work-based</b> mode, % Complete can be freely set to any value.
     If you optionally enter a value for Work, Remaining work will automatically be derived.
-    In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
+    In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
   setting_work_package_properties: "Work package properties"
   setting_work_package_startdate_is_adddate: "Use current date as start date for new work packages"
   setting_work_packages_projects_export_limit: "Work packages / Projects export limit"
@@ -3691,7 +3694,8 @@ en:
     progress:
       label_note: "Note:"
       modal:
-        work_based_help_text: "% Complete is automatically derived from Work and Remaining work."
+        work_based_help_text: "Each field is automatically calculated from the two others when possible."
+        work_based_help_text_pre_14_4_without_percent_complete_edition: "% Complete is automatically derived from Work and Remaining work."
         status_based_help_text: "% Complete is set by work package status."
         migration_warning_text: "In work-based progress calculation mode, % Complete cannot be manually set and is tied to Work. The existing value has been kept but cannot be edited. Please input Work first."
     permissions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1113,10 +1113,10 @@ en:
             assigned_to:
               format: "%{message}"
             done_ratio:
-              does_not_match_work_and_remaining_work: "does not match work and remaining work"
-              cannot_be_set_when_work_is_zero: "cannot be set when work is zero"
-              must_be_set_when_remaining_work_is_set: "Required when Remaining work is set."
-              must_be_set_when_work_and_remaining_work_are_set: "Required when Work and Remaining work are set."
+              does_not_match_work_and_remaining_work: "does not match Work and Remaining work"
+              cannot_be_set_when_work_is_zero: "cannot be set when Work is 0h"
+              must_be_set_when_remaining_work_is_set: "required when Remaining work is set."
+              must_be_set_when_work_and_remaining_work_are_set: "required when Work and Remaining work are set."
               inclusion: "must be between 0 and 100."
             due_date:
               not_start_date: "is not on start date, although this is required for milestones."
@@ -1146,19 +1146,17 @@ en:
               does_not_exist: "The specified category does not exist."
             estimated_hours:
               not_a_number: "is not a valid duration."
-              cant_be_inferior_to_remaining_work: "Cannot be lower than Remaining work."
-              must_be_set_when_remaining_work_and_percent_complete_are_set: "Required when Remaining work and % Complete are set."
-              format: "%{message}"
+              cant_be_inferior_to_remaining_work: "cannot be lower than Remaining work."
+              must_be_set_when_remaining_work_and_percent_complete_are_set: "required when Remaining work and % Complete are set."
             remaining_hours:
               not_a_number: "is not a valid duration."
-              cant_exceed_work: "Cannot be higher than Work."
-              must_be_set_when_work_is_set: "Required when Work is set."
-              must_be_set_when_work_and_percent_complete_are_set: "Required when Work and % Complete are set."
+              cant_exceed_work: "cannot be higher than Work."
+              must_be_set_when_work_is_set: "required when Work is set."
+              must_be_set_when_work_and_percent_complete_are_set: "required when Work and % Complete are set."
               must_be_set_to_zero_hours_when_work_is_set_and_percent_complete_is_100p: >-
-                must be set to 0h when Work is set and % Complete is 100%.
+                must be 0h when Work is set and % Complete is 100%.
               must_be_unset_when_work_is_unset_and_percent_complete_is_100p: >-
-                must be unset when Work is unset and % Complete is 100%.
-              format: "%{message}"
+                must be empty when Work is empty and % Complete is 100%.
           readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
         type:
           attributes:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -306,6 +306,12 @@ en:
           Are you sure you want to continue?
 
       work_packages_settings:
+        warning_progress_calculation_mode_change_from_status_to_field_pre_14_4_without_percent_complete_edition_html: >-
+          Changing progress calculation mode from status-based to work-based will make
+          <i>% Complete</i> a non-editable field whose value is derived from <i>Work</i>
+          and <i>Remaining work</i>. Existing values for <i>% Complete</i> are preserved.
+          If values for <i>Work</i> and <i>Remaining work</i> were not present, they
+          will be required in order to change <i>% Complete</i>.
         warning_progress_calculation_mode_change_from_status_to_field_html: >-
           Changing progress calculation mode from status-based to work-based will make
           the <i>% Complete</i> field freely editable. If you optionally enter values

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -308,10 +308,9 @@ en:
       work_packages_settings:
         warning_progress_calculation_mode_change_from_status_to_field_html: >-
           Changing progress calculation mode from status-based to work-based will make
-          <i>% Complete</i> a non-editable field whose value is derived from <i>Work</i>
-          and <i>Remaining work</i>. Existing values for <i>% Complete</i> are preserved.
-          If values for <i>Work</i> and <i>Remaining work</i> were not present, they
-          will be required in order to change <i>% Complete</i>.
+          the <i>% Complete</i> field freely editable. If you optionally enter values
+          for <i>Work</i> or <i>Remaining work</i>, they will also be linked to <i>% Complete</i>.
+          Changing <i>Remaining work</i> can then update <i>% Complete</i>.
         warning_progress_calculation_mode_change_from_field_to_status_html: >-
           Changing progress calculation mode from work-based to status-based will result
           in all existing <i>% Complete</i> values to be lost and replaced with values

--- a/frontend/src/stimulus/controllers/dynamic/admin/work-packages-settings.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/work-packages-settings.controller.ts
@@ -64,6 +64,9 @@ export default class WorkPackagesSettingsController extends Controller {
 
   getWarningMessageHtml():string {
     const newMode = this.progressCalculationModeSelectTarget.value;
+    if (newMode === this.initialMode) {
+      return '';
+    }
 
     // to be removed in 15.0 with :percent_complete_edition feature flag removal
     if (!this.percentCompleteEditionActiveValue && newMode === 'field') {

--- a/frontend/src/stimulus/controllers/dynamic/admin/work-packages-settings.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/work-packages-settings.controller.ts
@@ -31,11 +31,17 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class WorkPackagesSettingsController extends Controller {
+  static values = {
+    percentCompleteEditionActive: Boolean,
+  };
+
   static targets = [
     'progressCalculationModeSelect',
     'warningText',
     'warningToast',
   ];
+
+  declare readonly percentCompleteEditionActiveValue:boolean;
 
   declare readonly progressCalculationModeSelectTarget:HTMLSelectElement;
   declare readonly warningTextTarget:HTMLElement;
@@ -58,9 +64,16 @@ export default class WorkPackagesSettingsController extends Controller {
 
   getWarningMessageHtml():string {
     const newMode = this.progressCalculationModeSelectTarget.value;
+
+    // to be removed in 15.0 with :percent_complete_edition feature flag removal
+    if (!this.percentCompleteEditionActiveValue && newMode === 'field') {
+      return I18n.t(
+        'js.admin.work_packages_settings.warning_progress_calculation_mode_change_from_status_to_field_pre_14_4_without_percent_complete_edition_html',
+      );
+    }
+
     return I18n.t(
       `js.admin.work_packages_settings.warning_progress_calculation_mode_change_from_${this.initialMode}_to_${newMode}_html`,
-      { defaultValue: '' },
     );
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview-progress.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview-progress.controller.ts
@@ -91,19 +91,21 @@ export default class PreviewProgressController extends Controller {
     const formData = new FormData(form) as unknown as undefined;
     const formParams = new URLSearchParams(formData);
     const wpParams = [
-      ['work_package[initial][remaining_hours]', formParams.get('work_package[initial][remaining_hours]') || ''],
       ['work_package[initial][estimated_hours]', formParams.get('work_package[initial][estimated_hours]') || ''],
+      ['work_package[initial][remaining_hours]', formParams.get('work_package[initial][remaining_hours]') || ''],
       ['work_package[initial][done_ratio]', formParams.get('work_package[initial][done_ratio]') || ''],
-      ['work_package[remaining_hours]', formParams.get('work_package[remaining_hours]') || ''],
       ['work_package[estimated_hours]', formParams.get('work_package[estimated_hours]') || ''],
+      ['work_package[remaining_hours]', formParams.get('work_package[remaining_hours]') || ''],
       ['work_package[done_ratio]', formParams.get('work_package[done_ratio]') || ''],
       ['work_package[status_id]', formParams.get('work_package[status_id]') || ''],
       ['field', field?.name ?? ''],
-      ['work_package[estimated_hours_touched]', formParams.get('work_package[estimated_hours_touched]') || ''],
-      ['work_package[remaining_hours_touched]', formParams.get('work_package[remaining_hours_touched]') || ''],
-      ['work_package[done_ratio_touched]', formParams.get('work_package[done_ratio_touched]') || ''],
-      ['work_package[status_id_touched]', formParams.get('work_package[status_id_touched]') || ''],
     ];
+
+    this.progressInputTargets.forEach((progressInput) => {
+      const touchedInputName = progressInput.name.replace(']', '_touched]');
+      const touchedValue = formParams.get(touchedInputName) || '';
+      wpParams.push([touchedInputName, touchedValue]);
+    });
 
     const wpPath = this.ensureValidPathname(form.action);
     const wpAction = wpPath.endsWith('/work_packages/new/progress') ? 'new' : 'edit';

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
@@ -45,12 +45,15 @@ export default class TouchedFieldMarkerController extends Controller {
 
   private markFieldAsTouched(event:{ target:HTMLInputElement }) {
     this.targetFieldName = event.target.name.replace(/^work_package\[([^\]]+)\]$/, '$1');
-    const touchedInput = this.findTouchedInput(this.targetFieldName);
+    this.markTouched(this.targetFieldName);
 
-    if (touchedInput) {
-      touchedInput.value = 'true';
+    if (this.isWorkBasedMode()) {
       this.keepWorkValue();
     }
+  }
+
+  private isWorkBasedMode() {
+    return this.findValueInput('done_ratio') !== undefined;
   }
 
   private keepWorkValue() {
@@ -79,7 +82,11 @@ export default class TouchedFieldMarkerController extends Controller {
   }
 
   private untouchFieldsWhenRemainingWorkIsEdited() {
-    if (this.isValueSet('estimated_hours')) {
+    if (this.isValueEmpty('estimated_hours') && this.isTouched('estimated_hours') && this.isValueSet('done_ratio')) {
+      // force work recalculation
+      this.markUntouched('estimated_hours');
+      this.markTouched('done_ratio');
+    } else if (this.isValueSet('estimated_hours')) {
       this.markUntouched('done_ratio');
     }
   }
@@ -142,6 +149,13 @@ export default class TouchedFieldMarkerController extends Controller {
   private isValueSet(fieldName:string) {
     const valueInput = this.findValueInput(fieldName);
     return valueInput !== undefined && valueInput.value !== '';
+  }
+
+  private markTouched(fieldName:string) {
+    const touchedInput = this.findTouchedInput(fieldName);
+    if (touchedInput) {
+      touchedInput.value = 'true';
+    }
   }
 
   private markUntouched(fieldName:string) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
@@ -78,12 +78,16 @@ export default class TouchedFieldMarkerController extends Controller {
       } else {
         this.markUntouched('remaining_hours');
       }
+    } else if (this.isTouchedAndEmpty('remaining_hours') && this.isValueSet('done_ratio')) {
+      // force remaining work derivation
+      this.markUntouched('remaining_hours');
+      this.markTouched('done_ratio');
     }
   }
 
   private untouchFieldsWhenRemainingWorkIsEdited() {
-    if (this.isValueEmpty('estimated_hours') && this.isTouched('estimated_hours') && this.isValueSet('done_ratio')) {
-      // force work recalculation
+    if (this.isTouchedAndEmpty('estimated_hours') && this.isValueSet('done_ratio')) {
+      // force work derivation
       this.markUntouched('estimated_hours');
       this.markTouched('done_ratio');
     } else if (this.isValueSet('estimated_hours')) {
@@ -129,6 +133,10 @@ export default class TouchedFieldMarkerController extends Controller {
   private findValueInput(fieldName:string):HTMLInputElement|undefined {
     return this.progressInputTargets.find((input) =>
       (input.name === fieldName) || (input.name === `work_package[${fieldName}]`));
+  }
+
+  private isTouchedAndEmpty(fieldName:string) {
+    return this.isTouched(fieldName) && this.isValueEmpty(fieldName);
   }
 
   private isTouched(fieldName:string) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
@@ -32,18 +32,122 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class TouchedFieldMarkerController extends Controller {
   static targets = [
+    'initialValueInput',
     'touchedFieldInput',
     'progressInput',
   ];
 
+  declare readonly initialValueInputTargets:HTMLInputElement[];
   declare readonly touchedFieldInputTargets:HTMLInputElement[];
   declare readonly progressInputTargets:HTMLInputElement[];
 
+  private targetFieldName:string;
+
   private markFieldAsTouched(event:{ target:HTMLInputElement }) {
-    this.touchedFieldInputTargets.forEach((input) => {
-      if (input.dataset.referrerField === event.target.name) {
-        input.value = 'true';
+    this.targetFieldName = event.target.name.replace(/^work_package\[([^\]]+)\]$/, '$1');
+    const touchedInput = this.findTouchedInput(this.targetFieldName);
+
+    if (touchedInput) {
+      touchedInput.value = 'true';
+      this.keepWorkValue();
+    }
+  }
+
+  private keepWorkValue() {
+    if (this.isInitialValueEmpty('estimated_hours') && !this.isTouched('estimated_hours')) {
+      // let work be derived
+      return;
+    }
+
+    if (this.isBeingEdited('estimated_hours')) {
+      this.untouchFieldsWhenWorkIsEdited();
+    } else if (this.isBeingEdited('remaining_hours')) {
+      this.untouchFieldsWhenRemainingWorkIsEdited();
+    } else if (this.isBeingEdited('done_ratio')) {
+      this.untouchFieldsWhenPercentCompleteIsEdited();
+    }
+  }
+
+  private untouchFieldsWhenWorkIsEdited() {
+    if (this.areBothTouched('remaining_hours', 'done_ratio')) {
+      if (this.isValueEmpty('done_ratio')) {
+        this.markUntouched('done_ratio');
+      } else {
+        this.markUntouched('remaining_hours');
       }
-    });
+    }
+  }
+
+  private untouchFieldsWhenRemainingWorkIsEdited() {
+    if (this.isValueSet('estimated_hours')) {
+      this.markUntouched('done_ratio');
+    }
+  }
+
+  private untouchFieldsWhenPercentCompleteIsEdited() {
+    if (this.isValueSet('estimated_hours')) {
+      this.markUntouched('remaining_hours');
+    }
+  }
+
+  private areBothTouched(fieldName1:string, fieldName2:string) {
+    return this.isTouched(fieldName1) && this.isTouched(fieldName2);
+  }
+
+  private isBeingEdited(fieldName:string) {
+    return fieldName === this.targetFieldName;
+  }
+
+  // Finds the hidden initial value input based on a field name.
+  //
+  // The initial value input field holds the initial value of the work package
+  // before being set by the user or derived.
+  private findInitialValueInput(fieldName:string):HTMLInputElement|undefined {
+    return this.initialValueInputTargets.find((input) =>
+      (input.dataset.referrerField === fieldName) || (input.dataset.referrerField === `work_package[${fieldName}]`));
+  }
+
+  // Finds the touched field input based on a field name.
+  //
+  // The touched input field is used to mark a field as touched by the user so
+  // that the backend keeps the value instead of deriving it.
+  private findTouchedInput(fieldName:string):HTMLInputElement|undefined {
+    return this.touchedFieldInputTargets.find((input) =>
+      (input.dataset.referrerField === fieldName) || (input.dataset.referrerField === `work_package[${fieldName}]`));
+  }
+
+  // Finds the value field input based on a field name.
+  //
+  // The value field input holds the current value of a progress field.
+  private findValueInput(fieldName:string):HTMLInputElement|undefined {
+    return this.progressInputTargets.find((input) =>
+      (input.name === fieldName) || (input.name === `work_package[${fieldName}]`));
+  }
+
+  private isTouched(fieldName:string) {
+    const touchedInput = this.findTouchedInput(fieldName);
+    return touchedInput?.value === 'true';
+  }
+
+  private isInitialValueEmpty(fieldName:string) {
+    const valueInput = this.findInitialValueInput(fieldName);
+    return valueInput?.value === '';
+  }
+
+  private isValueEmpty(fieldName:string) {
+    const valueInput = this.findValueInput(fieldName);
+    return valueInput?.value === '';
+  }
+
+  private isValueSet(fieldName:string) {
+    const valueInput = this.findValueInput(fieldName);
+    return valueInput !== undefined && valueInput.value !== '';
+  }
+
+  private markUntouched(fieldName:string) {
+    const touchedInput = this.findTouchedInput(fieldName);
+    if (touchedInput) {
+      touchedInput.value = 'false';
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
@@ -82,6 +82,10 @@ export default class TouchedFieldMarkerController extends Controller {
       // force remaining work derivation
       this.markUntouched('remaining_hours');
       this.markTouched('done_ratio');
+    } else if (this.isTouchedAndEmpty('done_ratio') && this.isValueSet('remaining_hours')) {
+      // force % complete derivation
+      this.markUntouched('done_ratio');
+      this.markTouched('remaining_hours');
     }
   }
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -474,6 +474,14 @@ RSpec.describe WorkPackages::BaseContract,
         it_behaves_like "contract is invalid", done_ratio: :inclusion
       end
 
+      context "when not a number" do
+        let(:estimated_hours) { nil }
+        let(:remaining_hours) { nil }
+        let(:done_ratio) { "abc" }
+
+        it_behaves_like "contract is invalid", done_ratio: :not_a_number
+      end
+
       context "when only one being set" do
         let(:estimated_hours) { nil }
         let(:remaining_hours) { nil }

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -500,13 +500,43 @@ RSpec.describe WorkPackages::BaseContract,
                                                done_ratio: nil
       end
 
-      context "when unset while remaining work is set and work is set to an invalid value" do
+      context "when set while work is set and remaining work is set to a negative value" do
+        let(:estimated_hours) { 4 }
+        let(:remaining_hours) { -3 }
+        let(:done_ratio) { 50 }
+
+        include_examples "contract is invalid", estimated_hours: nil,
+                                                remaining_hours: :greater_than_or_equal_to,
+                                                done_ratio: nil
+      end
+
+      context "when unset while remaining work is set and work is set to a negative value" do
         let(:estimated_hours) { -4 }
         let(:remaining_hours) { 3 }
         let(:done_ratio) { nil }
 
-        it_behaves_like "contract is invalid", estimated_hours: %i[cant_be_inferior_to_remaining_work greater_than_or_equal_to],
+        it_behaves_like "contract is invalid", estimated_hours: :greater_than_or_equal_to,
                                                remaining_hours: nil,
+                                               done_ratio: nil
+      end
+
+      context "when set while remaining work is set and work is set to a negative value" do
+        let(:estimated_hours) { -4 }
+        let(:remaining_hours) { 3 }
+        let(:done_ratio) { 50 }
+
+        it_behaves_like "contract is invalid", estimated_hours: :greater_than_or_equal_to,
+                                               remaining_hours: nil,
+                                               done_ratio: nil
+      end
+
+      context "when set while work and remaining work are both set to a negative values (and work > remaining work)" do
+        let(:estimated_hours) { -4 }
+        let(:remaining_hours) { -12 }
+        let(:done_ratio) { 50 }
+
+        it_behaves_like "contract is invalid", estimated_hours: :greater_than_or_equal_to,
+                                               remaining_hours: :greater_than_or_equal_to,
                                                done_ratio: nil
       end
     end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -578,6 +578,18 @@ RSpec.describe WorkPackages::BaseContract,
       end
     end
 
+    context "when remaining work exceeds work and done_ratio is unset" do
+      let(:estimated_hours) { 5.0 }
+      let(:remaining_hours) { 6.0 }
+      let(:done_ratio) { nil }
+
+      # no errors should be reported for % complete in this case to not overload
+      # the progress modal with error messages.
+      include_examples "contract is invalid", estimated_hours: :cant_be_inferior_to_remaining_work,
+                                              remaining_hours: :cant_exceed_work,
+                                              done_ratio: nil
+    end
+
     context "when all three unset" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { nil }

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe WorkPackages::BaseContract,
       include_examples "contract is valid"
     end
 
-    context "when unset while remaining work and % complete are set" do
+    context "when empty while remaining work and % complete are set" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { 2.0 }
       let(:done_ratio) { 50 }
@@ -314,7 +314,7 @@ RSpec.describe WorkPackages::BaseContract,
       include_examples "contract is invalid", estimated_hours: :must_be_set_when_remaining_work_and_percent_complete_are_set
     end
 
-    context "when unset while remaining work is set and % complete is set to an invalid value" do
+    context "when empty while remaining work is set and % complete is set to an invalid value" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { 2.0 }
       let(:done_ratio) { 200 }
@@ -324,7 +324,7 @@ RSpec.describe WorkPackages::BaseContract,
                                               done_ratio: :inclusion
     end
 
-    context "when unset while % complete is set and remaining work is set to an invalid value" do
+    context "when empty while % complete is set and remaining work is set to an invalid value" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { -2.0 }
       let(:done_ratio) { 50 }
@@ -415,7 +415,7 @@ RSpec.describe WorkPackages::BaseContract,
       include_examples "contract is valid"
     end
 
-    context "when unset while work and % complete are set" do
+    context "when empty while work and % complete are set" do
       let(:estimated_hours) { 3 }
       let(:remaining_hours) { nil }
       let(:done_ratio) { 50 }
@@ -423,7 +423,7 @@ RSpec.describe WorkPackages::BaseContract,
       include_examples "contract is invalid", remaining_hours: :must_be_set_when_work_and_percent_complete_are_set
     end
 
-    context "when unset while work is set and % complete is set to an invalid value" do
+    context "when empty while work is set and % complete is set to an invalid value" do
       let(:estimated_hours) { 3 }
       let(:remaining_hours) { nil }
       let(:done_ratio) { -1 }
@@ -433,7 +433,7 @@ RSpec.describe WorkPackages::BaseContract,
                                               done_ratio: :inclusion
     end
 
-    context "when unset while % complete is set and work is set to a negative value" do
+    context "when empty while % complete is set and work is set to a negative value" do
       let(:estimated_hours) { -3 }
       let(:remaining_hours) { nil }
       let(:done_ratio) { 50 }
@@ -490,7 +490,7 @@ RSpec.describe WorkPackages::BaseContract,
         it_behaves_like "contract is valid"
       end
 
-      context "when unset while work and remaining work are set" do
+      context "when empty while work and remaining work are set" do
         let(:estimated_hours) { 4 }
         let(:remaining_hours) { 3 }
         let(:done_ratio) { nil }
@@ -498,7 +498,7 @@ RSpec.describe WorkPackages::BaseContract,
         it_behaves_like "contract is invalid", done_ratio: :must_be_set_when_work_and_remaining_work_are_set
       end
 
-      context "when unset while work is set and remaining work is set to a negative value" do
+      context "when empty while work is set and remaining work is set to a negative value" do
         let(:estimated_hours) { 4 }
         let(:remaining_hours) { -3 }
         let(:done_ratio) { nil }
@@ -518,7 +518,7 @@ RSpec.describe WorkPackages::BaseContract,
                                                 done_ratio: nil
       end
 
-      context "when unset while remaining work is set and work is set to a negative value" do
+      context "when empty while remaining work is set and work is set to a negative value" do
         let(:estimated_hours) { -4 }
         let(:remaining_hours) { 3 }
         let(:done_ratio) { nil }
@@ -578,7 +578,7 @@ RSpec.describe WorkPackages::BaseContract,
       end
     end
 
-    context "when remaining work exceeds work and done_ratio is unset" do
+    context "when remaining work exceeds work and done_ratio is empty" do
       let(:estimated_hours) { 5.0 }
       let(:remaining_hours) { 6.0 }
       let(:done_ratio) { nil }
@@ -590,7 +590,7 @@ RSpec.describe WorkPackages::BaseContract,
                                               done_ratio: nil
     end
 
-    context "when all three unset" do
+    context "when all three empty" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { nil }
       let(:done_ratio) { nil }
@@ -630,7 +630,7 @@ RSpec.describe WorkPackages::BaseContract,
         include_examples "contract is invalid", done_ratio: :cannot_be_set_when_work_is_zero
       end
 
-      context "when % complete is unset" do
+      context "when % complete is empty" do
         let(:done_ratio) { nil }
 
         include_examples "contract is valid"
@@ -653,7 +653,7 @@ RSpec.describe WorkPackages::BaseContract,
       context "and work is set" do
         let(:estimated_hours) { 10 }
 
-        context "and remaining work is unset" do
+        context "and remaining work is empty" do
           let(:remaining_hours) { nil }
 
           include_examples "contract is invalid",
@@ -678,10 +678,10 @@ RSpec.describe WorkPackages::BaseContract,
         end
       end
 
-      context "and work is unset" do
+      context "and work is empty" do
         let(:estimated_hours) { nil }
 
-        context "and remaining work is unset" do
+        context "and remaining work is empty" do
           let(:remaining_hours) { nil }
 
           include_examples "contract is valid"
@@ -691,7 +691,7 @@ RSpec.describe WorkPackages::BaseContract,
           let(:remaining_hours) { 0 }
 
           include_examples "contract is invalid", estimated_hours: nil,
-                                                  remaining_hours: :must_be_unset_when_work_is_unset_and_percent_complete_is_100p,
+                                                  remaining_hours: :must_be_empty_when_work_is_empty_and_percent_complete_is_100p,
                                                   done_ratio: nil
         end
 
@@ -699,13 +699,13 @@ RSpec.describe WorkPackages::BaseContract,
           let(:remaining_hours) { 5 }
 
           include_examples "contract is invalid", estimated_hours: nil,
-                                                  remaining_hours: :must_be_unset_when_work_is_unset_and_percent_complete_is_100p,
+                                                  remaining_hours: :must_be_empty_when_work_is_empty_and_percent_complete_is_100p,
                                                   done_ratio: nil
         end
       end
     end
 
-    context "when work and remaining work are both unset" do
+    context "when work and remaining work are both empty" do
       let(:estimated_hours) { nil }
       let(:remaining_hours) { nil }
 
@@ -715,7 +715,7 @@ RSpec.describe WorkPackages::BaseContract,
         include_examples "contract is valid"
       end
 
-      context "when % complete is unset" do
+      context "when % complete is empty" do
         let(:done_ratio) { nil }
 
         include_examples "contract is valid"

--- a/spec/features/work_packages/display_fields/work_display_spec.rb
+++ b/spec/features/work_packages/display_fields/work_display_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Work display", :js do
     include_examples "work display", expected_text: "0h·Σ 3h"
   end
 
-  context "with just total work (parent work unset)" do
+  context "with just total work (parent work empty)" do
     let_work_packages(<<~TABLE)
       hierarchy   | work |
       parent      |      |

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         end
       end
 
-      context "with unset values" do
+      context "with empty values" do
         before do
           update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil, done_ratio: nil)
         end
@@ -430,7 +430,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
     context "given work = 10h, remaining work = 4h, % complete = 60%" do
       before { update_work_package_with(work_package, estimated_hours: 10.0, remaining_hours: 4.0) }
 
-      specify "Case 1: When I unset work it unsets remaining work" do
+      specify "Case 1: When I clear work it clears remaining work" do
         visit_progress_query_displaying_work_package
 
         progress_popover.open

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -79,32 +79,32 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
 
   let(:work_package_table) { Pages::WorkPackagesTable.new(project) }
   let(:work_package_row) { work_package_table.work_package_container(work_package) }
+  let(:progress_popover) { work_package_table.progress_popover(work_package) }
   let(:work_package_create_page) { Pages::FullWorkPackageCreate.new(project:) }
 
   current_user { user }
 
+  def visit_progress_query_displaying_work_package
+    work_package_table.visit_query(progress_query)
+    work_package_table.expect_work_package_listed(work_package)
+  end
+
   describe "clicking on a field on the work package table" do
     it "sets the cursor after the last character on the selected input field" do
-      work_package_table.visit_query(progress_query)
-      work_package_table.expect_work_package_listed(work_package)
+      visit_progress_query_displaying_work_package
 
-      work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-      modal = work_edit_field.activate!
-
-      modal.expect_cursor_at_end_of_input
+      progress_popover.open_by_clicking_on_field(:work)
+      progress_popover.expect_cursor_at_end_of_input(:work)
     end
   end
 
   describe "work based mode" do
     shared_examples_for "opens the modal with its work field in focus" do
       it "opens the modal with its work field in focus" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        modal = work_edit_field.activate!
-
-        modal.expect_modal_field_in_focus
+        progress_popover.open_by_clicking_on_field(:work)
+        progress_popover.expect_focused(:work)
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       include_examples "opens the modal with its work field in focus"
     end
 
-    describe "clicking on the work field on the work package table" \
+    describe "clicking on the work field on the work package table " \
              "with all fields set" do
       before do
         update_work_package_with(work_package, estimated_hours: 25.0, remaining_hours: 15.0)
@@ -133,14 +133,10 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       end
 
       it "opens the modal with remaining work in focus" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        remaining_work_field = ProgressEditField.new(work_package_row, :remainingTime)
-
-        remaining_work_field.activate!
-
-        remaining_work_field.expect_modal_field_in_focus
+        progress_popover.open_by_clicking_on_field(:remaining_work)
+        progress_popover.expect_focused(:remaining_work)
       end
     end
 
@@ -151,14 +147,10 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       end
 
       it "opens the modal with remaining work in focus" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        remaining_work_field = ProgressEditField.new(work_package_row, :remainingTime)
-
-        remaining_work_field.activate!
-
-        remaining_work_field.expect_modal_field_in_focus
+        progress_popover.open_by_clicking_on_field(:remaining_work)
+        progress_popover.expect_focused(:remaining_work)
       end
     end
   end
@@ -169,13 +161,10 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       before { update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil) }
 
       it "opens the modal with work in focus" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        modal = work_edit_field.activate!
-
-        modal.expect_modal_field_in_focus
+        progress_popover.open_by_clicking_on_field(:work)
+        progress_popover.expect_focused(:work)
       end
     end
 
@@ -184,26 +173,19 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       before { update_work_package_with(work_package, estimated_hours: 20.0, remaining_hours: 15.0) }
 
       it "opens the modal with work in focus" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        modal = work_edit_field.activate!
-
-        modal.expect_modal_field_in_focus
+        progress_popover.open_by_clicking_on_field(:work)
+        progress_popover.expect_focused(:work)
       end
     end
 
     describe "Remaining work field" do
       it "is readonly" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        remaining_work_field = ProgressEditField.new(work_package_row, :remainingTime)
-        work_field.activate!
-
-        remaining_work_field.expect_read_only_modal_field
+        progress_popover.open
+        progress_popover.expect_read_only(:remaining_work)
       end
     end
 
@@ -218,18 +200,13 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
                new_status: in_progress_status_with_50p_done_ratio,
                role:)
 
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
-
-        work_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        modal_status_field = ProgressEditField.new(work_package_row, :statusWithinProgressModal)
-
-        work_field.activate!
+        visit_progress_query_displaying_work_package
+        progress_popover.open
 
         # The only defined workflow is "open" to "in progress" so "complete" must
         # not be listed as an available option
-        modal_status_field.expect_select_field_with_options("open (0%)", "in progress (50%)")
-        modal_status_field.expect_select_field_with_no_options("complete (100%)")
+        progress_popover.expect_select_with_options(:status, "open (0%)", "in progress (50%)")
+        progress_popover.expect_select_without_options(:status, "complete (100%)")
 
         # Create another valid transition from "open" to "complete"
         create(:workflow,
@@ -238,26 +215,21 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
                new_status: complete_status_with_100p_done_ratio,
                role:)
 
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
+        progress_popover.open
 
-        work_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        modal_status_field = ProgressEditField.new(work_package_row, :statusWithinProgressModal)
-
-        work_field.activate!
-        modal_status_field.expect_select_field_with_options("open (0%)", "in progress (50%)", "complete (100%)")
+        progress_popover.expect_select_with_options(:status, "open (0%)", "in progress (50%)", "complete (100%)")
       end
     end
 
     context "when on a new work package form" do
+      let(:progress_popover) { Components::WorkPackages::ProgressPopover.new(create_form: true) }
+
       specify "modal renders when no default status is set for new work packages" do
         work_package_create_page.visit!
 
-        work_field = work_package_create_page.edit_field(:estimatedTime)
-        work_field.activate!
-
-        modal_status_field = work_package_create_page.edit_field(:statusWithinProgressModal)
-        modal_status_field.expect_modal_field_value(:empty_without_any_options, disabled: true)
+        progress_popover.open
+        progress_popover.expect_value(:status, :empty_without_any_options, disabled: true)
       end
 
       context "with a default status set for new work packages" do
@@ -296,31 +268,25 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
           work_package_create_page.visit!
           work_package_create_page.expect_fully_loaded
 
-          work_field = work_package_create_page.edit_field(:estimatedTime)
-          modal_status_field = work_package_create_page.edit_field(:statusWithinProgressModal)
+          progress_popover.open
+          progress_popover.expect_disabled(:status)
+          progress_popover.expect_value(:status, "open (0%)", disabled: true)
 
-          modal = work_field.activate!
-
-          modal_status_field.expect_modal_field_disabled
-          modal_status_field.expect_modal_field_value("open (0%)", disabled: true)
-
-          modal.close!
+          progress_popover.close
 
           status_field = work_package_create_page.edit_field(:status)
-
           status_field.update("in progress")
 
-          work_field.activate!
-          modal_status_field.expect_modal_field_value("in progress (50%)", disabled: true)
+          progress_popover.open
+          progress_popover.expect_value(:status, "in progress (50%)", disabled: true)
         end
 
         it "can open the modal, then save without modifying anything" do
           work_package_create_page.visit!
           work_package_create_page.set_attributes({ subject: "hello" })
 
-          work_field = work_package_create_page.edit_field(:estimatedTime)
-          work_field.activate!
-          work_field.submit_by_clicking_save
+          progress_popover.open
+          progress_popover.save
           work_package_create_page.expect_no_toaster(type: "error")
 
           work_package_create_page.save!
@@ -348,19 +314,15 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       context "with all values set" do
         before { update_work_package_with(work_package, estimated_hours: 10.0, remaining_hours: 2.12345) }
 
-        it "populates fields with correctly values formatted" do
-          work_package_table.visit_query(progress_query)
-          work_package_table.expect_work_package_listed(work_package)
+        it "populates fields with values correctly formatted" do
+          visit_progress_query_displaying_work_package
 
-          work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-          remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
-          percent_complete_edit_field = ProgressEditField.new(work_package_row, :percentageDone)
-
-          work_edit_field.activate!
-
-          work_edit_field.expect_modal_field_value("10h")
-          remaining_work_edit_field.expect_modal_field_value("2.12h") # 2h 7m
-          percent_complete_edit_field.expect_modal_field_value("79%")
+          progress_popover.open
+          progress_popover.expect_values(
+            work: "10h",
+            remaining_work: "2.12h", # 2h 7m
+            percent_complete: "79%"
+          )
         end
       end
 
@@ -411,15 +373,12 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         end
 
         it "does not lose precision due to conversion from ISO duration to hours (rounded to closest minute)" do
-          work_package_table.visit_query(progress_query)
-          work_package_table.expect_work_package_listed(work_package)
-
-          work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-          remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
+          visit_progress_query_displaying_work_package
 
           # set work to 2.5567
-          work_edit_field.activate!
-          work_edit_field.update("2.5567")
+          progress_popover.open
+          progress_popover.set_values(work: "2.5567")
+          progress_popover.save
           work_package_table.expect_and_dismiss_toaster(message: "Successful update.")
 
           # work should have been set to 2.56 and remaining work to 0.28
@@ -429,9 +388,11 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
 
           # work should be displayed as "2h 34m" ("2h 33m 36s" rounded to minutes),
           # and remaining work as "17m" ("16m 48s" rounded to minutes)
-          work_edit_field.activate!
-          work_edit_field.expect_modal_field_value("2.56h") # 2h 34m
-          remaining_work_edit_field.expect_modal_field_value("0.28h") # 17m
+          progress_popover.open
+          progress_popover.expect_values(
+            work: "2.56h", # 2h 34m
+            remaining_work: "0.28h" # 17m
+          )
         end
       end
 
@@ -441,41 +402,32 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         end
 
         it "populates all fields with blank values" do
-          work_package_table.visit_query(progress_query)
-          work_package_table.expect_work_package_listed(work_package)
+          visit_progress_query_displaying_work_package
 
-          work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-          remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
-          percent_complete_edit_field = ProgressEditField.new(work_package_row, :percentageDone)
-
-          work_edit_field.activate!
-
-          work_edit_field.expect_modal_field_value("")
-          remaining_work_edit_field.expect_modal_field_value("")
-          percent_complete_edit_field.expect_modal_field_value("")
+          progress_popover.open
+          progress_popover.expect_values(
+            work: "",
+            remaining_work: "",
+            percent_complete: ""
+          )
         end
       end
 
       describe "status field", with_settings: { work_package_done_ratio: "status" } do
         it "renders the status options as the << status_name (percent_complete_value %) >>" do
-          work_package_table.visit_query(progress_query)
-          work_package_table.expect_work_package_listed(work_package)
+          visit_progress_query_displaying_work_package
 
-          work_field = ProgressEditField.new(work_package_row, :estimatedTime)
-          status_field = ProgressEditField.new(work_package_row, :statusWithinProgressModal)
-
-          work_field.activate!
-
-          status_field.expect_select_field_with_options("open (0%)",
-                                                        "in progress (50%)",
-                                                        "complete (100%)")
+          progress_popover.open
+          progress_popover.expect_select_with_options(:status,
+                                                      "open (0%)",
+                                                      "in progress (50%)",
+                                                      "complete (100%)")
         end
       end
     end
 
     it "disables the field that triggered the modal" do
-      work_package_table.visit_query(progress_query)
-      work_package_table.expect_work_package_listed(work_package)
+      visit_progress_query_displaying_work_package
 
       work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
 
@@ -486,8 +438,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
 
     it "allows clicking on a field other than the one that triggered the modal " \
        "and opens the modal with said field selected" do
-      work_package_table.visit_query(progress_query)
-      work_package_table.expect_work_package_listed(work_package)
+      visit_progress_query_displaying_work_package
 
       work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
       remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
@@ -507,63 +458,39 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       before { update_work_package_with(work_package, estimated_hours: 10.0, remaining_hours: 4.0) }
 
       specify "Case 1: When I unset work it unsets remaining work" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
-
-        work_edit_field.activate!
-        wait_for_network_idle # Wait for initial loading to be ready
-
-        clear_input_field_contents(work_edit_field.input_element)
-        wait_for_network_idle # Wait for live-update to finish
-
-        remaining_work_edit_field.expect_modal_field_value("")
+        progress_popover.open
+        progress_popover.set_values(work: "")
+        progress_popover.expect_values(remaining_work: "")
       end
 
       specify "Case 2: when work is set to 12h, " \
               "remaining work is automatically set to 6h " \
               "and subsequently work is set to 14h, " \
               "remaining work updates to 8h" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
+        progress_popover.open
+        progress_popover.set_values(work: "12")
+        progress_popover.expect_values(remaining_work: "6h")
 
-        work_edit_field.activate!
-        wait_for_network_idle # Wait for initial loading to be ready
-
-        work_edit_field.set_value("12")
-        wait_for_network_idle # Wait for live-update to finish
-        remaining_work_edit_field.expect_modal_field_value("6h")
-
-        work_edit_field.set_value("14")
-        wait_for_network_idle # Wait for live-update to finish
-        remaining_work_edit_field.expect_modal_field_value("8h")
+        progress_popover.set_values(work: "14")
+        progress_popover.expect_values(remaining_work: "8h")
       end
 
       specify "Case 3: when work is set to 2h, " \
               "remaining work is automatically set to 0h, " \
               "and work is subsequently set to 12h, " \
               "remaining work is updated to 6h" do
-        work_package_table.visit_query(progress_query)
-        work_package_table.expect_work_package_listed(work_package)
+        visit_progress_query_displaying_work_package
 
-        work_edit_field = ProgressEditField.new(work_package_row, :estimatedTime)
-        remaining_work_edit_field = ProgressEditField.new(work_package_row, :remainingTime)
+        progress_popover.open
+        progress_popover.set_values(work: "2")
+        progress_popover.expect_values(remaining_work: "0h")
 
-        work_edit_field.activate!
-        wait_for_network_idle # Wait for initial loading to be ready
-
-        work_edit_field.set_value("2")
-        wait_for_network_idle # Wait for live-update to finish
-        remaining_work_edit_field.expect_modal_field_value("0h")
-
-        work_edit_field.set_value("12")
-        wait_for_network_idle # Wait for live-update to finish
-        remaining_work_edit_field.expect_modal_field_value("6h")
+        progress_popover.set_values(work: "12")
+        progress_popover.expect_values(remaining_work: "6h")
       end
     end
   end

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -99,59 +99,32 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
   end
 
   describe "work based mode" do
-    shared_examples_for "opens the modal with its work field in focus" do
-      it "opens the modal with its work field in focus" do
+    shared_examples_for "opens the modal with the clicked field in focus" do
+      it "when clicking on a field opens the modal and focuses on the related modal input field", :aggregate_failures do
         visit_progress_query_displaying_work_package
 
-        progress_popover.open_by_clicking_on_field(:work)
-        progress_popover.expect_focused(:work)
+        %i[work remaining_work percent_complete].each do |field_name|
+          progress_popover.open_by_clicking_on_field(field_name)
+          progress_popover.expect_focused(field_name)
+          progress_popover.close
+        end
       end
     end
 
-    describe "clicking on the work field on the work package table " \
-             "with no fields set" do
+    context "with no fields set" do
       before do
-        update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil)
+        update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil, done_ratio: nil)
       end
 
-      include_examples "opens the modal with its work field in focus"
+      include_examples "opens the modal with the clicked field in focus"
     end
 
-    describe "clicking on the work field on the work package table " \
-             "with all fields set" do
+    context "with all fields set" do
       before do
         update_work_package_with(work_package, estimated_hours: 25.0, remaining_hours: 15.0)
       end
 
-      include_examples "opens the modal with its work field in focus"
-    end
-
-    describe "clicking on the remaining work field on the work package table " \
-             "with no fields set" do
-      before do
-        update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil)
-      end
-
-      it "opens the modal with remaining work in focus" do
-        visit_progress_query_displaying_work_package
-
-        progress_popover.open_by_clicking_on_field(:remaining_work)
-        progress_popover.expect_focused(:remaining_work)
-      end
-    end
-
-    describe "clicking on the remaining work field on the work package table " \
-             "with all fields set" do
-      before do
-        update_work_package_with(work_package, estimated_hours: 20.0, remaining_hours: 15.0)
-      end
-
-      it "opens the modal with remaining work in focus" do
-        visit_progress_query_displaying_work_package
-
-        progress_popover.open_by_clicking_on_field(:remaining_work)
-        progress_popover.expect_focused(:remaining_work)
-      end
+      include_examples "opens the modal with the clicked field in focus"
     end
   end
 

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -496,6 +496,22 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         # work is derived
         progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
       end
+
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 6: when remaining work is cleared, and work is set, " \
+              "then remaining work is derived again" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        # clear work
+        progress_popover.set_values(remaining_work: "")
+        progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "60%")
+
+        # set remaining work
+        progress_popover.set_values(work: "20h")
+        # work is derived
+        progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
+      end
     end
 
     context "given work, remaining work, and % complete are all empty" do

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -480,6 +480,22 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.set_values(remaining_work: "9h")
         progress_popover.expect_values(work: "10h", percent_complete: "10%")
       end
+
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 5: when work is cleared, and remaining work is set, " \
+              "then work is derived again" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        # clear work
+        progress_popover.set_values(work: "")
+        progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "60%")
+
+        # set remaining work
+        progress_popover.set_values(remaining_work: "8h")
+        # work is derived
+        progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
+      end
     end
 
     context "given work, remaining work, and % complete are all empty" do

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -465,6 +465,39 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.set_values(work: "12")
         progress_popover.expect_values(remaining_work: "6h")
       end
+
+      specify "Case 4: when remaining work or % complete are set, work never " \
+              "changes, instead remaining work and % complete are derived" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        progress_popover.set_values(remaining_work: "2h")
+        progress_popover.expect_values(work: "10h", percent_complete: "80%")
+
+        progress_popover.set_values(percent_complete: "50%")
+        progress_popover.expect_values(work: "10h", remaining_work: "5h")
+
+        progress_popover.set_values(remaining_work: "9h")
+        progress_popover.expect_values(work: "10h", percent_complete: "10%")
+      end
+    end
+
+    context "given work, remaining work, and % complete are all empty" do
+      before do
+        update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil, done_ratio: nil)
+      end
+
+      specify "Case 1: when remaining work and % complete are both set, work " \
+              "is derived because it's empty" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        progress_popover.set_values(remaining_work: "2h", percent_complete: "50%")
+        progress_popover.expect_values(work: "4h")
+
+        progress_popover.set_values(remaining_work: "10h")
+        progress_popover.expect_values(work: "20h")
+      end
     end
   end
 end

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.expect_values(remaining_work: "6h")
       end
 
-      specify "Case 4: when remaining work or % complete are set, work never " \
+      specify "Case 23-7: when remaining work or % complete are set, work never " \
               "changes, instead remaining work and % complete are derived" do
         visit_progress_query_displaying_work_package
 
@@ -482,7 +482,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       end
 
       # scenario from https://community.openproject.org/wp/57370
-      specify "Case 5: when work is cleared, and remaining work is set, " \
+      specify "Case 23-11: when work is cleared, and remaining work is set, " \
               "then work is derived again" do
         visit_progress_query_displaying_work_package
 
@@ -498,7 +498,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       end
 
       # scenario from https://community.openproject.org/wp/57370
-      specify "Case 6: when remaining work is cleared, and work is set, " \
+      specify "Case 23-14: when remaining work is cleared, and work is set, " \
               "then remaining work is derived again" do
         visit_progress_query_displaying_work_package
 
@@ -509,8 +509,24 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
 
         # set remaining work
         progress_popover.set_values(work: "20h")
-        # work is derived
+        # => work is derived
         progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
+      end
+
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 33-14: when work and % complete are cleared, and then work " \
+              "is set again then % complete is derived again" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        # clear work and % complete
+        progress_popover.set_values(work: "", percent_complete: "")
+        progress_popover.expect_values(work: "", remaining_work: "4h", percent_complete: "")
+
+        # set work
+        progress_popover.set_values(work: "20h")
+        # => % complete is derived
+        progress_popover.expect_values(work: "20h", remaining_work: "4h", percent_complete: "80%")
       end
     end
 
@@ -519,8 +535,9 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         update_work_package_with(work_package, estimated_hours: nil, remaining_hours: nil, done_ratio: nil)
       end
 
-      specify "Case 1: when remaining work and % complete are both set, work " \
-              "is derived because it's empty" do
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 20-4: when remaining work and % complete are both set, work " \
+              "is derived because it's initially empty" do
         visit_progress_query_displaying_work_package
 
         progress_popover.open
@@ -529,6 +546,22 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
 
         progress_popover.set_values(remaining_work: "10h")
         progress_popover.expect_values(work: "20h")
+      end
+
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 30-1: when % complete is set, remaining work is set, and " \
+              "% complete is changed, then work is always derived" do
+        visit_progress_query_displaying_work_package
+
+        progress_popover.open
+        progress_popover.set_values(percent_complete: "40%")
+        progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "40%")
+
+        progress_popover.set_values(remaining_work: "60h")
+        progress_popover.expect_values(work: "100h", remaining_work: "60h", percent_complete: "40%")
+
+        progress_popover.set_values(percent_complete: "80%")
+        progress_popover.expect_values(work: "300h", remaining_work: "60h", percent_complete: "80%")
       end
     end
   end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -373,6 +373,72 @@ RSpec.describe WorkPackage do
              done_ratio: 30)
     end
 
+    it "allows empty value" do
+      work_package.done_ratio = ""
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to be_nil
+    end
+
+    it "allows blank values" do
+      work_package.done_ratio = "  "
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to be_nil
+    end
+
+    it "allows nil value" do
+      work_package.done_ratio = nil
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to be_nil
+    end
+
+    it "allows values between 0 and 100" do
+      work_package.done_ratio = 0
+      expect(work_package).to be_valid
+      work_package.done_ratio = 34
+      expect(work_package).to be_valid
+      work_package.done_ratio = 99
+      expect(work_package).to be_valid
+
+      work_package.done_ratio = "1"
+      expect(work_package).to be_valid
+      work_package.done_ratio = "100"
+      expect(work_package).to be_valid
+    end
+
+    it "disallows values outside of the 0-100 range" do
+      work_package.done_ratio = -1
+      expect(work_package).not_to be_valid
+
+      work_package.done_ratio = "-1%"
+      expect(work_package.done_ratio).to eq(-1)
+      expect(work_package).not_to be_valid
+
+      work_package.done_ratio = 101.0
+      expect(work_package.done_ratio).to eq(101)
+      expect(work_package).not_to be_valid
+    end
+
+    it "allows floats and truncates them to integer" do
+      work_package.done_ratio = 1.7
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to eq(1)
+
+      work_package.done_ratio = "1.7"
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to eq(1)
+    end
+
+    it "allows percentage like '50%'" do
+      work_package.done_ratio = "50%"
+      expect(work_package).to be_valid
+      expect(work_package.done_ratio).to eq(50)
+    end
+
+    it "disallows string values, that are not valid percentage values" do
+      work_package.done_ratio = "abc"
+      expect(work_package).not_to be_valid
+    end
+
     describe "#value" do
       context "for work-based mode",
               with_settings: { work_package_done_ratio: "field" } do

--- a/spec/services/percentage_converter_spec.rb
+++ b/spec/services/percentage_converter_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe PercentageConverter do
+  describe ".parse" do
+    it "returns nil when given blank strings or nil" do
+      expect(described_class.parse("")).to be_nil
+      expect(described_class.parse("  ")).to be_nil
+      expect(described_class.parse(" \t ")).to be_nil
+      expect(described_class.parse(nil)).to be_nil
+    end
+
+    it "returns 0.0 when given '0%'" do
+      expect(described_class.parse("0%")).to be(0.0)
+      expect(described_class.parse("0 %")).to be(0.0)
+      expect(described_class.parse(" 0 % ")).to be(0.0)
+    end
+
+    it "returns a float when given a string repsenting an integer" do
+      expect(described_class.parse("50")).to be(50.0)
+      expect(described_class.parse(" 50 ")).to be(50.0)
+      expect(described_class.parse(" -23 ")).to be(-23.0)
+      expect(described_class.parse(" +1278 ")).to be(1278.0)
+      expect(described_class.parse(" -0 ")).to eq(0.0)
+      expect(described_class.parse(" +0% ")).to be(0.0)
+    end
+
+    it "returns a float when given a string representing a float" do
+      expect(described_class.parse("5.")).to be(5.0)
+      expect(described_class.parse("5.%")).to be(5.0)
+      expect(described_class.parse("5.7%")).to be(5.7)
+      expect(described_class.parse("5.75")).to be(5.75)
+      expect(described_class.parse("5.75%")).to be(5.75)
+      expect(described_class.parse("5.75 %")).to be(5.75)
+      expect(described_class.parse("  -5.75  %  ")).to be(-5.75)
+      expect(described_class.parse("+5.75 %")).to be(5.75)
+      expect(described_class.parse("  123.321 %  ")).to be(123.321)
+      expect(described_class.parse("-456.654 %")).to be(-456.654)
+    end
+
+    it "does not get tricked with octals representation" do
+      expect(described_class.parse("09")).to be(9.0)
+      expect(described_class.parse("010")).to be(10.0)
+    end
+
+    it "raises a `ParseError` if it's not a valid percentage" do
+      expect { described_class.parse("invalid percentage") }.to raise_error(PercentageConverter::ParseError)
+    end
+  end
+
+  describe ".valid?" do
+    it "returns true for integers" do
+      expect(described_class.valid?(0)).to be(true)
+      expect(described_class.valid?(100)).to be(true)
+      expect(described_class.valid?(789)).to be(true)
+      expect(described_class.valid?(-456)).to be(true)
+    end
+
+    it "returns true for floats" do
+      expect(described_class.valid?(0.0)).to be(true)
+      expect(described_class.valid?(-0.0)).to be(true)
+      expect(described_class.valid?(23.1)).to be(true)
+      expect(described_class.valid?(100.2)).to be(true)
+      expect(described_class.valid?(789.3)).to be(true)
+      expect(described_class.valid?(-456.4)).to be(true)
+    end
+
+    it "returns true for blank values" do
+      expect(described_class.valid?(nil)).to be(true)
+      expect(described_class.valid?("")).to be(true)
+      expect(described_class.valid?("  ")).to be(true)
+      expect(described_class.valid?(" \t ")).to be(true)
+    end
+
+    it "returns true for strings representing a number or a valid percentage" do
+      expect(described_class.valid?("50")).to be(true)
+      expect(described_class.valid?(" 50 ")).to be(true)
+      expect(described_class.valid?(" -23 ")).to be(true)
+      expect(described_class.valid?(" +1278 ")).to be(true)
+      expect(described_class.valid?(" -0 ")).to be(true)
+      expect(described_class.valid?(" +0% ")).to be(true)
+      expect(described_class.valid?("5.")).to be(true)
+      expect(described_class.valid?("5.%")).to be(true)
+      expect(described_class.valid?("  -5.75   %  ")).to be(true)
+      expect(described_class.valid?("  1234.0 %  ")).to be(true)
+    end
+
+    it "rreturns false for strings not representing a number" do
+      expect(described_class.valid?("invalid")).to be(false)
+      expect(described_class.valid?("-")).to be(false)
+      expect(described_class.valid?("+")).to be(false)
+      expect(described_class.valid?("日")).to be(false)
+      expect(described_class.valid?("invalid 123")).to be(false)
+      expect(described_class.valid?("123 invalid")).to be(false)
+      expect(described_class.valid?("-  23")).to be(false)
+      expect(described_class.valid?("123.4.5")).to be(false)
+      expect(described_class.valid?("1'234.5")).to be(false)
+      expect(described_class.valid?("1,234.5")).to be(false)
+      expect(described_class.valid?("12%%")).to be(false)
+      expect(described_class.valid?("12%.4")).to be(false)
+    end
+  end
+end

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_status_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_status_based_spec.rb
@@ -83,11 +83,11 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesStatusBas
       work_package.clear_changes_information
     end
 
-    context "when work is unset" do
+    context "when work is cleared" do
       let(:set_attributes) { { estimated_hours: nil } }
       let(:expected_derived_attributes) { { remaining_hours: nil } }
 
-      include_examples "update progress values", description: "unsets remaining work"
+      include_examples "update progress values", description: "clearss remaining work"
     end
 
     context "when work is changed" do
@@ -121,7 +121,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesStatusBas
     end
   end
 
-  context "given a work package with work and remaining work unset, and a status with 0% complete" do
+  context "given a work package with work and remaining work being empty, and a status with 0% complete" do
     before do
       work_package.status = status_0_pct_complete
       work_package.done_ratio = work_package.status.default_done_ratio
@@ -135,7 +135,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesStatusBas
       let(:expected_derived_attributes) { { remaining_hours: nil } }
 
       include_examples "update progress values",
-                       description: "remaining work remains unset"
+                       description: "remaining work remains empty"
     end
 
     context "when work is set" do
@@ -143,7 +143,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesStatusBas
       let(:expected_derived_attributes) { { remaining_hours: 10.0 } }
 
       include_examples "update progress values",
-                       description: "remaining work is updated accordingly from work and % complete value of the status"
+                       description: "remaining work is derived from work and % complete value of the status"
     end
 
     context "when work is set to a negative value" do

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values", description: "keeps % complete"
     end
 
+    context "when work is changed and percent complete is set to the same value as before" do
+      let(:set_attributes) { { estimated_hours: 20.0, done_ratio: 70 } }
+      let(:expected_derived_attributes) { { remaining_hours: 6.0 } }
+
+      include_examples "update progress values", description: "derives remaining work from work and % complete"
+    end
+
     context "when both work and percent complete are unset" do
       let(:set_attributes) { { estimated_hours: nil, done_ratio: nil } }
       let(:expected_kept_attributes) { %w[remaining_hours] }

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -79,31 +79,31 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       work_package.clear_changes_information
     end
 
-    context "when work is unset" do
+    context "when work is cleared" do
       let(:set_attributes) { { estimated_hours: nil } }
       let(:expected_derived_attributes) { { remaining_hours: nil } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "keeps % complete, and unsets remaining work"
+      include_examples "update progress values", description: "keeps % complete, and clears remaining work"
     end
 
-    context "when remaining work is unset" do
+    context "when remaining work is cleared" do
       let(:set_attributes) { { remaining_hours: nil } }
       let(:expected_derived_attributes) { { estimated_hours: nil } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "keeps % complete, and unsets work"
+      include_examples "update progress values", description: "keeps % complete, and clears work"
     end
 
-    context "when % complete is unset" do
+    context "when % complete is cleared" do
       let(:set_attributes) { { done_ratio: nil } }
       let(:expected_derived_attributes) { { remaining_hours: nil } }
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
-      include_examples "update progress values", description: "keeps work, and unsets remaining work"
+      include_examples "update progress values", description: "keeps work, and clears remaining work"
     end
 
-    context "when both work and remaining work are unset" do
+    context "when both work and remaining work are cleared" do
       let(:set_attributes) { { estimated_hours: nil, remaining_hours: nil } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
@@ -117,14 +117,14 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values", description: "derives remaining work from work and % complete"
     end
 
-    context "when both work and percent complete are unset" do
+    context "when both work and percent complete are cleared" do
       let(:set_attributes) { { estimated_hours: nil, done_ratio: nil } }
       let(:expected_kept_attributes) { %w[remaining_hours] }
 
       include_examples "update progress values", description: "keeps remaining work"
     end
 
-    context "when both remaining work and percent complete are unset" do
+    context "when both remaining work and percent complete are cleared" do
       let(:set_attributes) { { remaining_hours: nil, done_ratio: nil } }
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
@@ -139,7 +139,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       end
 
       include_examples "update progress values",
-                       description: "remaining work is increased by the same amount, and % complete is updated accordingly"
+                       description: "remaining work is increased by the same amount, and % complete is derived"
     end
 
     context "when work is set to 0h" do
@@ -149,7 +149,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       end
 
       include_examples "update progress values",
-                       description: "remaining work is set to 0h and % Complete is unset"
+                       description: "remaining work is set to 0h and % Complete is cleared"
     end
 
     context "when work is decreased" do
@@ -160,7 +160,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       end
 
       include_examples "update progress values",
-                       description: "remaining work is decreased by the same amount, and % complete is updated accordingly"
+                       description: "remaining work is decreased by the same amount, and % complete is derived"
     end
 
     context "when work is decreased below remaining work value" do
@@ -195,7 +195,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:set_attributes) { { remaining_hours: 12.0, done_ratio: 40 } }
       let(:expected_derived_attributes) { { estimated_hours: 20.0 } }
 
-      include_examples "update progress values", description: "work is updated accordingly"
+      include_examples "update progress values", description: "work is derived"
     end
 
     context "when remaining work is changed and % complete is changed to 100%" do
@@ -253,32 +253,32 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values", description: "updates % complete accordingly"
     end
 
-    context "when work is changed and remaining work is unset" do
+    context "when work is changed and remaining work is cleared" do
       let(:set_attributes) { { estimated_hours: 8.0, remaining_hours: nil } }
       let(:expected_derived_attributes) { { done_ratio: nil } }
 
-      include_examples "update progress values", description: "% complete is unset"
+      include_examples "update progress values", description: "% complete is cleared"
     end
 
-    context "when percent complete is changed and work is unset" do
+    context "when percent complete is changed and work is cleared" do
       let(:set_attributes) { { done_ratio: 40, estimated_hours: nil } }
       let(:expected_derived_attributes) { { remaining_hours: nil } }
 
-      include_examples "update progress values", description: "remaining work is unset"
+      include_examples "update progress values", description: "remaining work is cleared"
     end
 
-    context "when percent complete is changed and remaining work is unset" do
+    context "when percent complete is changed and remaining work is cleared" do
       let(:set_attributes) { { done_ratio: 40, remaining_hours: nil } }
       let(:expected_derived_attributes) { { estimated_hours: nil } }
 
-      include_examples "update progress values", description: "work is unset"
+      include_examples "update progress values", description: "work is cleared"
     end
 
     context "when % complete is changed and remaining work is set to same value" do
       let(:set_attributes) { { done_ratio: 90, remaining_hours: 3 } }
       let(:expected_derived_attributes) { { estimated_hours: 30 } }
 
-      include_examples "update progress values", description: "work is updated accordingly"
+      include_examples "update progress values", description: "work is derived"
     end
 
     context "when work is set to the same value and remaining work is changed" do
@@ -286,7 +286,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { done_ratio: 90 } }
 
       include_examples "update progress values",
-                       description: "% complete is updated accordingly"
+                       description: "% complete is derived"
     end
 
     context "when work is increased and remaining work is set to its current value (to prevent it from being increased)" do
@@ -295,7 +295,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { remaining_hours: 3.0, done_ratio: 85 } }
 
       include_examples "update progress values",
-                       description: "remaining work is kept (not increased), and % complete is updated accordingly"
+                       description: "remaining work is kept (not increased), and % complete is derived"
     end
 
     context "when % complete is changed" do
@@ -303,7 +303,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { remaining_hours: 6.0 } }
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
-      include_examples "update progress values", description: "work is kept, and remaining work is updated accordingly"
+      include_examples "update progress values", description: "work is kept, and remaining work is derived"
     end
 
     context "when % complete is changed to a negative value" do
@@ -355,7 +355,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
     end
   end
 
-  context "given a work package with work and % complete being set, and remaining work being unset" do
+  context "given a work package with work and % complete being set, and remaining work being empty" do
     before do
       work_package.estimated_hours = 10
       work_package.remaining_hours = nil
@@ -368,7 +368,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { remaining_hours: 14.0 } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "% complete is kept and remaining work is updated accordingly"
+      include_examples "update progress values", description: "% complete is kept and remaining work is derived"
     end
 
     context "when work is changed to a negative value" do
@@ -385,7 +385,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { done_ratio: 90.0 } }
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
-      include_examples "update progress values", description: "work is kept and % complete is updated accordingly"
+      include_examples "update progress values", description: "work is kept and % complete is derived"
     end
 
     context "when % complete is set" do
@@ -393,11 +393,11 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { remaining_hours: 1.0 } }
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
-      include_examples "update progress values", description: "work is kept and remaining work is updated accordingly"
+      include_examples "update progress values", description: "work is kept and remaining work is derived"
     end
   end
 
-  context "given a work package with remaining work and % complete being set, and work being unset" do
+  context "given a work package with remaining work and % complete being set, and work being empty" do
     before do
       work_package.estimated_hours = nil
       work_package.remaining_hours = 2.0
@@ -410,7 +410,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { estimated_hours: 20.0 } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "% complete is kept and work is updated accordingly"
+      include_examples "update progress values", description: "% complete is kept and work is derived"
     end
 
     context "when % complete is 0% and remaining work is changed to a decimal rounded up" do
@@ -424,7 +424,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       end
 
       include_examples "update progress values",
-                       description: "% complete is kept, values are rounded, and work is updated accordingly"
+                       description: "% complete is kept, values are rounded, and work is derived"
     end
 
     context "when work is set" do
@@ -432,7 +432,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { done_ratio: 80.0 } }
       let(:expected_kept_attributes) { %w[remaining_hours] }
 
-      include_examples "update progress values", description: "remaining work is kept and % complete is updated accordingly"
+      include_examples "update progress values", description: "remaining work is kept and % complete is derived"
     end
 
     context "when % complete is changed" do
@@ -440,7 +440,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { estimated_hours: 10.0 } }
       let(:expected_kept_attributes) { %w[remaining_hours] }
 
-      include_examples "update progress values", description: "remaining work is kept and work is updated accordingly"
+      include_examples "update progress values", description: "remaining work is kept and work is derived"
     end
 
     context "when % complete is changed to 100%" do
@@ -453,7 +453,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
     end
   end
 
-  context "given a work package with work being set, and remaining work and % complete being unset" do
+  context "given a work package with work being set, and remaining work and % complete being empty" do
     before do
       work_package.estimated_hours = 10
       work_package.remaining_hours = nil
@@ -469,12 +469,12 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
                        description: "remaining work is set to the same value and % complete is set to 0%"
     end
 
-    context "when work is changed and remaining work is unset" do
+    context "when work is changed and remaining work is cleared" do
       let(:set_attributes) { { estimated_hours: 10.0, remaining_hours: nil } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
       include_examples "update progress values",
-                       description: "% complete is kept and remaining work is kept unset and not recomputed " \
+                       description: "% complete is kept and remaining work is kept empty and not recomputed " \
                                     "(error state to be detected by contract)"
     end
 
@@ -493,11 +493,11 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_kept_attributes) { %w[estimated_hours] }
 
       include_examples "update progress values",
-                       description: "work is kept and remaining work is updated accordingly"
+                       description: "work is kept and remaining work is derived"
     end
   end
 
-  context "given a work package with remaining work being set, and work and % complete being unset" do
+  context "given a work package with remaining work being set, and work and % complete being cleared" do
     before do
       work_package.estimated_hours = nil
       work_package.remaining_hours = 6.0
@@ -511,7 +511,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_kept_attributes) { %w[remaining_hours] }
 
       include_examples "update progress values",
-                       description: "remaining work is kept to the same value and % complete is updated accordingly"
+                       description: "remaining work is kept to the same value and % complete is derived"
     end
 
     context "when work is set lower than remaining work" do
@@ -554,11 +554,11 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { estimated_hours: 10.0 } }
       let(:expected_kept_attributes) { %w[remaining_hours] }
 
-      include_examples "update progress values", description: "work is updated accordingly"
+      include_examples "update progress values", description: "work is derived"
     end
   end
 
-  context "given a work package with work and remaining work set to 0h, and % complete being unset" do
+  context "given a work package with work and remaining work set to 0h, and % complete being empty" do
     before do
       work_package.estimated_hours = 0
       work_package.remaining_hours = 0
@@ -575,7 +575,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
     end
   end
 
-  context "given a work package with work and remaining work unset, and % complete being set" do
+  context "given a work package with work and remaining work being empty, and % complete being set" do
     before do
       work_package.estimated_hours = nil
       work_package.remaining_hours = nil
@@ -588,7 +588,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_derived_attributes) { { remaining_hours: 4.0 } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "% complete is kept and remaining work is updated accordingly"
+      include_examples "update progress values", description: "% complete is kept and remaining work is derived"
     end
 
     context "when work is set to a number with with 4 decimals" do
@@ -598,7 +598,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
 
       include_examples "update progress values",
                        description: "% complete is kept, work is rounded to 2 decimals, " \
-                                    "and remaining work is updated and rounded to 2 decimals"
+                                    "and remaining work is derived and rounded to 2 decimals"
     end
 
     context "when work is set to a string" do
@@ -618,14 +618,14 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:set_attributes) { { estimated_hours: 10.0, remaining_hours: 0 } }
       let(:expected_derived_attributes) { { done_ratio: 100 } }
 
-      include_examples "update progress values", description: "% complete is updated accordingly"
+      include_examples "update progress values", description: "% complete is derived"
     end
 
-    context "when work is set and remaining work is unset" do
+    context "when work is set and remaining work is clered" do
       let(:set_attributes) { { estimated_hours: 10.0, remaining_hours: nil } }
       let(:expected_derived_attributes) { { done_ratio: nil } }
 
-      include_examples "update progress values", description: "% complete is unset"
+      include_examples "update progress values", description: "% complete is cleared"
     end
 
     context "when work and remaining work are both set to negative values" do
@@ -641,11 +641,11 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_kept_attributes) { %w[estimated_hours remaining_hours] }
 
       include_examples "update progress values",
-                       description: "work and remaining work are kept unset"
+                       description: "work and remaining work are kept empty"
     end
   end
 
-  context "given a work package with work and remaining work unset, and % complete being set to 100%" do
+  context "given a work package with work and remaining work being empty, and % complete being set to 100%" do
     before do
       work_package.estimated_hours = nil
       work_package.remaining_hours = nil
@@ -678,7 +678,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:set_attributes) { { estimated_hours: 10.0, remaining_hours: 5.0 } }
       let(:expected_derived_attributes) { { done_ratio: 50 } }
 
-      include_examples "update progress values", description: "% complete is updated accordingly"
+      include_examples "update progress values", description: "% complete is derived"
     end
 
     context "when remaining work is set to 0h" do
@@ -690,7 +690,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
     end
   end
 
-  context "given a work package with work, remaining work, and % complete being unset" do
+  context "given a work package with work, remaining work, and % complete being empty" do
     before do
       work_package.estimated_hours = nil
       work_package.remaining_hours = nil
@@ -733,12 +733,12 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
                                     "and % complete and work are kept"
     end
 
-    context "when remaining work is set and work is unset" do
+    context "when remaining work is set and work is cleared" do
       let(:set_attributes) { { estimated_hours: nil, remaining_hours: 6.7 } }
       let(:expected_kept_attributes) { %w[done_ratio] }
 
       include_examples "update progress values",
-                       description: "% complete is kept and work is kept unset and not recomputed" \
+                       description: "% complete is kept and work is kept empty and not recomputed" \
                                     "(error state to be detected by contract)"
     end
 
@@ -747,7 +747,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_kept_attributes) { %w[estimated_hours remaining_hours] }
 
       include_examples "update progress values",
-                       description: "work and remaining work are kept unset"
+                       description: "work and remaining work are kept empty"
     end
   end
 end

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -207,6 +207,14 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
                        description: "is an error state (to be detected by contract), and % Complete is kept"
     end
 
+    context "when work and remaining work are both changed so that work is lower than remaining work" do
+      let(:set_attributes) { { estimated_hours: 2, remaining_hours: 9 } }
+      let(:expected_kept_attributes) { %w[done_ratio] }
+
+      include_examples "update progress values",
+                       description: "is an error state (to be detected by contract), and % Complete is kept"
+    end
+
     context "when work and remaining work are both changed to values with more than 2 decimals" do
       let(:set_attributes) { { estimated_hours: 10.123456, remaining_hours: 5.6789 } }
       let(:expected_derived_attributes) { { estimated_hours: 10.12, remaining_hours: 5.68, done_ratio: 44 } }

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -89,10 +89,10 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
 
     context "when remaining work is unset" do
       let(:set_attributes) { { remaining_hours: nil } }
-      let(:expected_derived_attributes) { { done_ratio: nil } }
-      let(:expected_kept_attributes) { %w[estimated_hours] }
+      let(:expected_derived_attributes) { { estimated_hours: nil } }
+      let(:expected_kept_attributes) { %w[done_ratio] }
 
-      include_examples "update progress values", description: "keeps work, and unsets % complete"
+      include_examples "update progress values", description: "keeps % complete, and unsets work"
     end
 
     context "when % complete is unset" do
@@ -435,6 +435,15 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
 
       include_examples "update progress values", description: "remaining work is kept and work is updated accordingly"
     end
+
+    context "when % complete is changed to 100%" do
+      let(:set_attributes) { { done_ratio: 100 } }
+      let(:expected_kept_attributes) { %w[estimated_hours remaining_hours] }
+
+      include_examples "update progress values",
+                       description: "work and remaining work are kept because work cannot be derived " \
+                                    "(error state to be detected by contract)"
+    end
   end
 
   context "given a work package with work being set, and remaining work and % complete being unset" do
@@ -458,7 +467,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       let(:expected_kept_attributes) { %w[done_ratio] }
 
       include_examples "update progress values",
-                       description: "% complete is kept and remaining work is kept unset and not recomputed" \
+                       description: "% complete is kept and remaining work is kept unset and not recomputed " \
                                     "(error state to be detected by contract)"
     end
 
@@ -496,6 +505,15 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
 
       include_examples "update progress values",
                        description: "remaining work is kept to the same value and % complete is updated accordingly"
+    end
+
+    context "when work is set lower than remaining work" do
+      let(:set_attributes) { { estimated_hours: 1.0 } }
+      let(:expected_kept_attributes) { %w[remaining_hours done_ratio] }
+
+      include_examples "update progress values",
+                       description: "is an error state (to be detected by contract), " \
+                                    "and % complete and remaining work are kept"
     end
 
     context "when work is changed to a negative value" do

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -307,6 +307,23 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
                        description: "is an error state (to be detected by contract), and work and remaining work are kept"
     end
 
+    context "when % complete is a string not representing a valid percentage" do
+      let(:set_attributes) { { done_ratio: "invalid percentage" } }
+      let(:expected_derived_attributes) { { done_ratio: 0 } } # coerced to integer by activerecord
+      let(:expected_kept_attributes) { %w[estimated_hours remaining_hours] }
+
+      it "keeps the original string value in the _before_type_cast method " \
+         "so that validation can detect it is invalid" do
+        work_package.attributes = set_attributes
+        instance.call
+
+        expect(work_package.done_ratio_before_type_cast).to eq("invalid percentage")
+      end
+
+      include_examples "update progress values",
+                       description: "is an error state (to be detected by contract), and work and remaining work are kept"
+    end
+
     context "when work, remaining work, and % complete are all changed to consistent values" do
       let(:set_attributes) { { estimated_hours: 20, remaining_hours: 12.0, done_ratio: 40 } }
       let(:expected_kept_attributes) { %w[estimated_hours remaining_hours done_ratio] }

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -211,9 +211,9 @@ RSpec.describe WorkPackages::SetAttributesService,
 
         context "when remaining work is unset" do
           let(:call_attributes) { { remaining_hours: nil } }
-          let(:expected_attributes) { { estimated_hours: 10.0, done_ratio: nil } }
+          let(:expected_attributes) { { estimated_hours: nil, done_ratio: 70 } }
 
-          it_behaves_like "service call", description: "keeps work, and unsets % complete"
+          it_behaves_like "service call", description: "keeps % complete, and unsets work"
         end
 
         context "when work is increased" do

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe WorkPackages::SetAttributesService,
         end
       end
 
-      context "given a work package with work and remaining work unset, and a status with 0% complete" do
+      context "given a work package with work and remaining work being empty, and a status with 0% complete" do
         before do
           work_package.status = status_0_pct_complete
           work_package.done_ratio = work_package.status.default_done_ratio
@@ -186,7 +186,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           let(:expected_attributes) { { remaining_hours: nil } }
 
           it_behaves_like "service call",
-                          description: "remaining work remains unset"
+                          description: "remaining work remains empty"
         end
 
         context "when work is set" do
@@ -194,7 +194,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           let(:expected_attributes) { { remaining_hours: 10.0 } }
 
           it_behaves_like "service call",
-                          description: "remaining work is updated accordingly from work and % complete value of the status"
+                          description: "remaining work is derived from work and % complete value of the status"
         end
       end
     end
@@ -209,11 +209,11 @@ RSpec.describe WorkPackages::SetAttributesService,
           work_package.clear_changes_information
         end
 
-        context "when remaining work is unset" do
+        context "when remaining work is cleared" do
           let(:call_attributes) { { remaining_hours: nil } }
           let(:expected_attributes) { { estimated_hours: nil, done_ratio: 70 } }
 
-          it_behaves_like "service call", description: "keeps % complete, and unsets work"
+          it_behaves_like "service call", description: "keeps % complete, and clears work"
         end
 
         context "when work is increased" do
@@ -224,7 +224,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           end
 
           it_behaves_like "service call",
-                          description: "remaining work is increased by the same amount, and % complete is updated accordingly"
+                          description: "remaining work is increased by the same amount, and % complete is derived"
         end
 
         context "when work and remaining work are both changed to values with more than 2 decimals" do
@@ -250,7 +250,7 @@ RSpec.describe WorkPackages::SetAttributesService,
         end
       end
 
-      context "given a work package with work and remaining work unset, and % complete being set" do
+      context "given a work package with work and remaining work being empty, and % complete being set" do
         before do
           work_package.estimated_hours = nil
           work_package.remaining_hours = nil
@@ -263,11 +263,11 @@ RSpec.describe WorkPackages::SetAttributesService,
           let(:expected_attributes) { { remaining_hours: 4.0 } }
           let(:expected_kept_attributes) { %w[done_ratio] }
 
-          it_behaves_like "service call", description: "% complete is kept and remaining work is updated accordingly"
+          it_behaves_like "service call", description: "% complete is kept and remaining work is derived"
         end
       end
 
-      context "given a work package with work, remaining work, and % complete being unset" do
+      context "given a work package with work, remaining work, and % complete being empty" do
         before do
           work_package.estimated_hours = nil
           work_package.remaining_hours = nil

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -73,16 +73,13 @@ module Components
         field(:work).submit_by_clicking_save
       end
 
-      def clear(field_name)
-        clear_input_field_contents(field(field_name).input_element)
+      def focus(field_name)
+        field(field_name).focus
       end
 
       def set_value(field_name, value)
-        if value == ""
-          clear(field_name)
-        else
-          field(field_name).set_value(value)
-        end
+        focus(field_name)
+        field(field_name).set_value(value)
       end
 
       def set_values(**field_value_pairs)

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# require_relative "../../toasts/expectations"
+
+module Components
+  module WorkPackages
+    class ProgressPopover
+      include Capybara::DSL
+      include Capybara::RSpecMatchers
+      include RSpec::Matchers
+      # include Toasts::Expectations
+
+      JS_FIELD_NAME_MAP = {
+        estimated_time: :estimatedTime,
+        percent_complete: :percentageDone,
+        percentage_done: :percentageDone,
+        remaining_work: :remainingTime,
+        remaining_time: :remainingTime,
+        status: :statusWithinProgressModal,
+        status_within_progress_modal: :statusWithinProgressModal,
+        work: :estimatedTime
+      }.freeze
+
+      attr_reader :container, :create_form
+
+      def initialize(container: page, create_form: false)
+        @container = container
+        @create_form = create_form
+      end
+
+      def open
+        open_by_clicking_on_field(:work)
+      end
+
+      def open_by_clicking_on_field(field_name)
+        field(field_name).activate!
+        wait_for_network_idle # Wait for initial loading to be ready
+      end
+
+      def close
+        field(:work).close!
+      end
+
+      def save
+        field(:work).submit_by_clicking_save
+      end
+
+      def clear(field_name)
+        clear_input_field_contents(field(field_name).input_element)
+      end
+
+      def set_value(field_name, value)
+        if value == ""
+          clear(field_name)
+        else
+          field(field_name).set_value(value)
+        end
+      end
+
+      def set_values(**field_value_pairs)
+        field_value_pairs.each do |field_name, value|
+          set_value(field_name, value)
+        end
+        wait_for_network_idle # Wait for live-update to finish
+      end
+
+      def expect_cursor_at_end_of_input(field_name)
+        field(field_name).expect_cursor_at_end_of_input
+      end
+
+      def expect_disabled(field_name)
+        field(field_name).expect_modal_field_disabled
+      end
+
+      def expect_focused(field_name)
+        field(field_name).expect_modal_field_in_focus
+      end
+
+      def expect_read_only(field_name)
+        field(field_name).expect_read_only_modal_field
+      end
+
+      def expect_select_with_options(field_name, *options)
+        field(field_name).expect_select_field_with_options(*options)
+      end
+
+      def expect_select_without_options(field_name, *options)
+        field(field_name).expect_select_field_with_no_options(*options)
+      end
+
+      def expect_value(field_name, value, **properties)
+        field(field_name).expect_modal_field_value(value, **properties)
+      end
+
+      def expect_values(**field_value_pairs)
+        aggregate_failures("progress popover expectations") do
+          field_value_pairs.each do |field_name, value|
+            expect_value(field_name, value)
+          end
+        end
+      end
+
+      private
+
+      def field(field_name)
+        field_name = js_field_name(field_name)
+        ProgressEditField.new(container, field_name, create_form:)
+      end
+
+      def js_field_name(field_name)
+        field_name = field_name.to_s.underscore.to_sym
+        JS_FIELD_NAME_MAP.fetch(field_name) do
+          raise ArgumentError, "cannot map '#{field_name.inspect}' to its javascript field name"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -73,7 +73,11 @@ class EditField
 
   def clear(with_backspace: false)
     if with_backspace
-      input_element.set(" ", fill_options: { clear: :backspace })
+      if using_cuprite?
+        clear_input_field_contents(input_element)
+      else
+        input_element.set(" ", fill_options: { clear: :backspace })
+      end
     else
       input_element.native.clear
     end

--- a/spec/support/edit_fields/progress_edit_field.rb
+++ b/spec/support/edit_fields/progress_edit_field.rb
@@ -132,6 +132,10 @@ class ProgressEditField < EditField
   # If they are the same, it means the modal field is in focus.
   # @return [Boolean] true if the modal field is in focus, false otherwise.
   def expect_modal_field_in_focus
+    expect(focused?).to be(true)
+  end
+
+  def focused?
     input_element == page.evaluate_script("document.activeElement")
   end
 
@@ -140,6 +144,10 @@ class ProgressEditField < EditField
   # If they are the same, it means the cursor is at the end of the input.
   # @return [Boolean] true if the cursor is at the end of the input, false otherwise.
   def expect_cursor_at_end_of_input
+    expect(cursor_at_end_of_input?).to be(true)
+  end
+
+  def cursor_at_end_of_input?
     input_element.evaluate_script("this.selectionStart == this.value.length;")
   end
 

--- a/spec/support/edit_fields/progress_edit_field.rb
+++ b/spec/support/edit_fields/progress_edit_field.rb
@@ -75,9 +75,33 @@ class ProgressEditField < EditField
     page.has_selector?(MODAL_SELECTOR, wait: 1)
   end
 
+  def clear
+    super(with_backspace: true)
+  end
+
   def set_value(value)
-    page.fill_in field_name, with: value
-    sleep 1
+    if value == ""
+      clear
+    else
+      page.fill_in field_name, with: value
+    end
+    wait_for_preview_to_complete
+  end
+
+  def focus
+    return if focused?
+
+    input_element.click
+    wait_for_preview_to_complete
+  end
+
+  # Wait for the popover preview to be refreshed.
+  # Preview occurs on field blur or change.
+  def wait_for_preview_to_complete
+    sleep 0.110 # the preview on popover has a debounce of 100ms
+    if using_cuprite?
+      wait_for_network_idle # Wait for preview to finish
+    end
   end
 
   def input_element

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -355,6 +355,10 @@ module Pages
       end
     end
 
+    def progress_popover(work_package)
+      Components::WorkPackages::ProgressPopover.new(container: work_package_container(work_package))
+    end
+
     protected
 
     def container

--- a/spec/workers/work_packages/progress/apply_statuses_change_job_pre_14_4_without_percent_complete_edition_spec.rb
+++ b/spec/workers/work_packages/progress/apply_statuses_change_job_pre_14_4_without_percent_complete_edition_spec.rb
@@ -28,7 +28,10 @@
 
 require "rails_helper"
 
-RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob do
+# This file can be safely deleted once the feature flag :percent_complete_edition
+# is removed, which should happen for OpenProject 15.0 release.
+RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob, "pre 14.4 without percent complete edition",
+               with_flag: { percent_complete_edition: false } do
   shared_let(:author) { create(:user) }
   shared_let(:priority) { create(:priority, name: "Normal") }
   shared_let(:project) { create(:project, name: "Main project") }
@@ -217,31 +220,6 @@ RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob do
             wp 0%       | To do (0%)  |  10h |            10h |         0%
             wp 40%      | Doing (40%) |  10h |             6h |        40%
             wp 100%     | Done (100%) |  10h |             0h |       100%
-          TABLE
-        )
-      end
-    end
-
-    context "when work packages have empty work and non-empty remaining work values" do
-      it "updates the work packages work along with the % complete value from the status" do
-        expect_performing_job_changes(
-          from: <<~TABLE,
-            subject     | status      | work | remaining work | % complete
-            wp          | Doing (40%) |      |            12h |
-            wp 0%       | To do (0%)  |      |            12h |        50%
-            wp 40%      | Doing (40%) |      |            12h |        50%
-            wp 40% 0h   | Doing (40%) |      |             0h |        50%
-            wp 100%     | Done (100%) |      |            12h |        50%
-            wp 100% 0h  | Done (100%) |      |             0h |        50%
-          TABLE
-          to: <<~TABLE
-            subject     | status      | work | remaining work | % complete
-            wp          | Doing (40%) |  20h |            12h |        40%
-            wp 0%       | To do (0%)  |  12h |            12h |         0%
-            wp 40%      | Doing (40%) |  20h |            12h |        40%
-            wp 40% 0h   | Doing (40%) |   0h |             0h |        40%
-            wp 100%     | Done (100%) |  12h |             0h |       100%
-            wp 100% 0h  | Done (100%) |   0h |             0h |       100%
           TABLE
         )
       end

--- a/spec/workers/work_packages/progress/apply_statuses_change_job_pre_14_4_without_percent_complete_edition_spec.rb
+++ b/spec/workers/work_packages/progress/apply_statuses_change_job_pre_14_4_without_percent_complete_edition_spec.rb
@@ -97,6 +97,27 @@ RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob, "pre 14.4 without
       end
     end
 
+    context "when some work packages have work set to 0h and a % complete value being set" do
+      it "clears the % complete valuedoes not change any of their progress values" do
+        expect_performing_job_changes(
+          from: <<~TABLE,
+            hierarchy    | status      | work | remaining work | % complete
+            wp 10h 40%   | To do (0%)  |  10h |             6h |        40%
+            wp 0h 0%     | To do (0%)  |   0h |             0h |         0%
+            wp 0h 40%    | Doing (40%) |   0h |             0h |        40%
+            wp 0h 100%   | Done (100%) |   0h |             0h |       100%
+          TABLE
+          to: <<~TABLE
+            subject      | status      | work | remaining work | % complete
+            wp 10h 40%   | To do (0%)  |  10h |             6h |        40%
+            wp 0h 0%     | To do (0%)  |   0h |             0h |
+            wp 0h 40%    | Doing (40%) |   0h |             0h |
+            wp 0h 100%   | Done (100%) |   0h |             0h |
+          TABLE
+        )
+      end
+    end
+
     context "when a status is being excluded from progress calculation" do
       it "computes totals of the parent having work when all children are excluded" do
         expect_performing_job_changes(

--- a/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
+++ b/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
@@ -28,7 +28,8 @@
 
 require "rails_helper"
 
-RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob do
+RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob,
+               with_flag: { percent_complete_edition: true } do
   shared_let(:author) { create(:user) }
   shared_let(:priority) { create(:priority, name: "Normal") }
   shared_let(:project) { create(:project, name: "Main project") }
@@ -89,6 +90,27 @@ RSpec.describe WorkPackages::Progress::ApplyStatusesChangeJob do
             wp 0%       | To do (0%)  |        55%
             wp 40%      | Doing (40%) |        55%
             wp 100%     | Done (100%) |        55%
+          TABLE
+        )
+      end
+    end
+
+    context "when some work packages have work set to 0h and a % complete value being set" do
+      it "clears the % complete valuedoes not change any of their progress values" do
+        expect_performing_job_changes(
+          from: <<~TABLE,
+            hierarchy    | status      | work | remaining work | % complete
+            wp 10h 40%   | To do (0%)  |  10h |             6h |        40%
+            wp 0h 0%     | To do (0%)  |   0h |             0h |         0%
+            wp 0h 40%    | Doing (40%) |   0h |             0h |        40%
+            wp 0h 100%   | Done (100%) |   0h |             0h |       100%
+          TABLE
+          to: <<~TABLE
+            subject      | status      | work | remaining work | % complete
+            wp 10h 40%   | To do (0%)  |  10h |             6h |        40%
+            wp 0h 0%     | To do (0%)  |   0h |             0h |
+            wp 0h 40%    | Doing (40%) |   0h |             0h |
+            wp 0h 100%   | Done (100%) |   0h |             0h |
           TABLE
         )
       end


### PR DESCRIPTION
<!-- Contributors: Please check our [PR guide](https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request) before opening a PR. -->

<!-- Reviewers: Please check our [Review guide](https://www.openproject.org/docs/development/code-review-guidelines/#reviewing) -->

# What are you trying to accomplish?

Multiple fixes:

- [x]  **Update administration texts**

  Update some texts in administration related to % Complete now being editable.
  See this comment for more context: 
  https://community.openproject.org/projects/openproject/work_packages/52233/activity#activity-61

  The texts must be visible only if the feature flag for % complete edition is active.

- [x] **Make error messages less noisy**

  Also update some errors messages to be more relevant: if work or remaining work are negative, then it's noisy to also tell that % complete is not consistent with work and remaining work or that remaining work exceed work.

- [x] **Handle setting remaining work when % complete is 100%**

  If the input value for % Complete is 100%, Work cannot be derived (it could be any value), so Remaining work must be unset if Work is unset, or set to 0h if Work is set. An error message is displayed otherwise.

- [x] **Make errors messages consistent**

  Work, Remaining work, and % Complete are capitalized,  first letter of the error message is capitalized, the field name is not present in the error message, the field name is still present for other usages (like API).

- [x] **Detect invalid percentage value**
  
  When given percentage value can not be parsed, an error is now displayed and the other values are not derived.

- [x] **Keep work if set**

  Currently, work is derived if remaining work and % complete are provided, regardless of work being set or empty. This is not correct.

  If work is empty, it's ok to set it from derived values, but if work is set, its value does not change. Instead if % Complete value changes, Remaining work should be derived, and if Remaining work value changes, % Complete should be derived

  Some of these scenarios are written and formalized in [Testing: Work estimates and progress: Pop-over scenarios (% Complete) (#57370)](https://community.openproject.org/projects/openproject/work_packages/57370/activity).

- [x] **Derive work when switching from work-based to status-based if only remaining work is set**

  If a work package has only remaining work being set and progress calculation mode is changed from work-based to status-based, then work package gets a % complete value.

  Remaining work and % complete being both present, work has to be derived.

- [x] **Clear % Complete when switching from status-based to work-based if work is 0h**

  It existed before making % complete editable. Better fix it now.

## Screenshots

**Update administration texts**

Before:

![image](https://github.com/user-attachments/assets/d618f351-73ef-4f29-83cc-675a7fb476a7)


After:
![image](https://github.com/user-attachments/assets/76178074-ed32-42a7-8356-9af165235350)

**Make error messages less noisy**

Before:

![image](https://github.com/user-attachments/assets/44b61bb9-0b2d-4037-a612-d57fbfe01951)

After:

![image](https://github.com/user-attachments/assets/94c73b53-eae0-4acf-99d4-d9347c681a8a)

**Handle setting remaining work when % complete is 100%**

Before:

![image](https://github.com/user-attachments/assets/74649eb1-806e-4199-bb0d-53acdf3c2016)

After:

![image](https://github.com/user-attachments/assets/2aae7321-dfcf-4ec5-966b-ca7e9d83bd18)

**Detect invalid percentage value**

Before:

![image](https://github.com/user-attachments/assets/89141060-c2de-4770-b432-28b9397bfe6b)
% Complete is changed from "50%" to "invalid", but there is no error and remaining work gets derived to "10h" (because internally % complete is coerced to 0%).

After:

![image](https://github.com/user-attachments/assets/193bb4be-f6ab-4c49-a99f-4f142f876d99)
Much better!


# What approach did you choose and why?

**Update administration texts**

Only two texts have been updated: the field hint text and the warning text when switching from status-based to work-based.

The warning text when switching from work-based to status-based has not been changed.

For the Note text in the pop-over, another PR will be opened with an alternative approach.

**Make error messages less noisy**

In work package contract, skip adding more errors if already in an error state for progress values.

**Handle setting remaining work when % complete is 100%**

More `if`s and more tests to detect the special case `done_ratio == 100`. A bit similar to work being 0h and % complete cannot be derived.

**Make errors messages consistent**

Use `validation_message` parameter of the primer input field to have finer control over the message instead of relying on primer default implementation which gets the full message and changing the `format` i18n key as it can alter the experience for error messages in other context (in the API for instance).

**Detect invalid percentage value**

Introduce a `PercentageConverter` class very much like `DurationConverter`, and coerce the percentage string at the work package level by overriding `#done_ratio=`. Checking if the string looks like a percentage is done with a regexp. `PercentageConverter` converts to float so that it can be reused elsewhere. Coercing to integer is done automatically by ActiveRecord.

**Derive work when switching from work-based to status-based if only remaining work is set**

Reuse the methods already existing from `WorkPackages::Progress::MigrateValuesJob` (used for migration to 14.0.0), move them to parent class `WorkPackages::Progress::Job` so that they are available in `WorkPackages::Progress::ApplyStatusesChangeJob`. Then call them.

# Ticket

[Feature: Allow % Complete edition in work-based progress calculation mode (#52233)](https://community.openproject.org/projects/openproject/work_packages/52233/activity)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
