### PR TITLE
Experiment with having hints about progress values derivation in popover

### DIFF
--- a/app/components/work_packages/progress/work_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.html.erb
@@ -38,15 +38,12 @@
         <% end %>
       <% end %>
 
+      <% unless OpenProject::FeatureDecisions.percent_complete_edition_active? %>
       <% modal_body.with_row(mt: 3) do |_tooltip| %>
         <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { t("work_package.progress.label_note") } %>
-        <% if OpenProject::FeatureDecisions.percent_complete_edition_active? %>
-          <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text") } %>
-        <% else %>
-          <%# This condition branch to be removed in 15.0 with :percent_complete_edition feature flag removal %>
-          <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text_pre_14_4_without_percent_complete_edition") } %>
-        <% end %>
+        <%= render(Primer::Beta::Text.new) { t("work_package.progress.modal.work_based_help_text_pre_14_4_without_percent_complete_edition") } %>
         <%= render(Primer::Beta::Link.new(href: learn_more_href)) { t(:label_learn_more) } %>
+        <% end %>
       <% end %>
 
       <% modal_body.with_row(mt: 3) do |_actions_row| %>

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -332,6 +332,14 @@ class WorkPackage < ApplicationRecord
     write_attribute :done_ratio, convert_value_to_percentage(value)
   end
 
+  def derived_progress_hints=(hints)
+    @derived_progress_hints = hints
+  end
+
+  def derived_progress_hints
+    @derived_progress_hints ||= {}
+  end
+
   def duration_in_hours
     duration ? duration * 24 : nil
   end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -72,10 +72,10 @@ class WorkPackages::SetAttributesService
       return if percent_complete == 100 # would be Infinity if computed when % complete is 100%
 
       if remaining_work_unset?
-        work_package.derived_progress_hints[:done_ratio] = "unset because remaining work is unset"
+        set_hint(:done_ratio, "unset because remaining work is unset")
         self.work = nil
       else
-        work_package.derived_progress_hints[:done_ratio] = "derived from % complete and remaining work"
+        set_hint(:done_ratio, "derived from % complete and remaining work")
         self.work = work_from_percent_complete_and_remaining_work
       end
     end
@@ -86,24 +86,24 @@ class WorkPackages::SetAttributesService
       return if work_was_unset? && remaining_work_set? # remaining work is kept and % complete will be set
 
       if work_set? && remaining_work_unset? && percent_complete_unset?
-        work_package.derived_progress_hints[:remaining_hours] = "set to same value as work"
+        set_hint(:remaining_hours, "set to same value as work")
         self.remaining_work = work
       elsif work_changed? && work_set? && remaining_work_set? && !percent_complete_changed?
         delta = work - work_was
         if delta.positive?
-          work_package.derived_progress_hints[:remaining_hours] = "increased by same amout as work"
+          set_hint(:remaining_hours, "increased by same amout as work")
         elsif delta.negative?
-          work_package.derived_progress_hints[:remaining_hours] = "decreased by same amout as work"
+          set_hint(:remaining_hours, "decreased by same amout as work")
         end
         self.remaining_work = (remaining_work + delta).clamp(0.0, work)
       elsif work_unset?
-        work_package.derived_progress_hints[:remaining_hours] = "unset because work is unset and % complete is set"
+        set_hint(:remaining_hours, "unset because work is unset and % complete is set")
         self.remaining_work = nil
       elsif percent_complete_unset?
-        work_package.derived_progress_hints[:remaining_hours] = "unset because % complete is unset and work is set"
+        set_hint(:remaining_hours, "unset because % complete is unset and work is set")
         self.remaining_work = nil
       else
-        work_package.derived_progress_hints[:remaining_hours] = "derived from work and % complete"
+        set_hint(:remaining_hours, "derived from work and % complete")
         self.remaining_work = remaining_work_from_percent_complete_and_work
       end
     end
@@ -113,13 +113,13 @@ class WorkPackages::SetAttributesService
       return if work_unset?
 
       if work.zero?
-        work_package.derived_progress_hints[:done_ratio] = "derived from work and remaining work"
+        set_hint(:done_ratio, "derived from work and remaining work")
         self.percent_complete = nil
       elsif remaining_work_unset?
-        work_package.derived_progress_hints[:done_ratio] = "unset because remaining work is unset"
+        set_hint(:done_ratio, "unset because remaining work is unset")
         self.percent_complete = nil
       else
-        work_package.derived_progress_hints[:done_ratio] = "derived from work and remaining work"
+        set_hint(:done_ratio, "derived from work and remaining work")
         self.percent_complete = percent_complete_from_work_and_remaining_work
       end
     end
@@ -150,6 +150,10 @@ class WorkPackages::SetAttributesService
 
     def work_set_and_no_user_inputs_provided_for_both_remaining_work_and_percent_complete?
       work_set? && (remaining_work_not_provided_by_user? || percent_complete_not_provided_by_user?)
+    end
+
+    def set_hint(field, hint)
+      work_package.derived_progress_hints[field] = hint
     end
   end
 end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -72,10 +72,10 @@ class WorkPackages::SetAttributesService
       return if percent_complete == 100 # would be Infinity if computed when % complete is 100%
 
       if remaining_work_unset?
-        set_hint(:done_ratio, "unset because remaining work is unset")
+        set_hint(:work, "unset because remaining work is unset")
         self.work = nil
       else
-        set_hint(:done_ratio, "derived from % complete and remaining work")
+        set_hint(:work, "derived from % complete and remaining work")
         self.work = work_from_percent_complete_and_remaining_work
       end
     end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -83,7 +83,7 @@ class WorkPackages::SetAttributesService
     # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
     def update_remaining_work
       return if work_unset? && percent_complete_unset?
-      return if work_was_unset? && remaining_work_set? # remaining work is kept and % complete will be set
+      return if work_was_unset? && remaining_work_set? # remaining work is kept and % complete will be unset
 
       if work_set? && remaining_work_unset? && percent_complete_unset?
         set_hint(:remaining_hours, "set to same value as work")

--- a/spec/components/work_packages/progress/work_based/modal_body_component_spec.rb
+++ b/spec/components/work_packages/progress/work_based/modal_body_component_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe WorkPackages::Progress::WorkBased::ModalBodyComponent,
 
   include_examples "progress modal validations"
   include_examples "progress modal submit path"
-  include_examples "progress modal help links"
 
   describe "#mode" do
     subject(:component) { described_class.new(WorkPackage.new) }


### PR DESCRIPTION
# What are you trying to accomplish?

When using the progress pop over, give more information to the user about the automatic calculation done to derive values

## Screenshots

Before, while changing work from 3h to 5h:

![image](https://github.com/user-attachments/assets/25ae2089-3457-4e29-9a4a-a1f47262486a)

After, still while changing work from 3h to 5h:

![image](https://github.com/user-attachments/assets/ba58bf98-6b14-49bc-b502-a037058c67df)

# What approach did you choose and why?

1. Add a `derived_progress_hints` hash to `WorkPackage`.
2. The `DeriveProgressValuesWorkBased` class updates `work_package.derived_progress_hints` on each condition
3. The `work_package.derived_progress_hints` is displayed below the field as a `caption` (thanks Primer)

It's not meant to be merged yet, just valid for a pull preview.

# Ticket

[Feature: Allow % Complete edition in work-based progress calculation mode (#52233)](https://community.openproject.org/projects/openproject/work_packages/52233/activity)
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
