### PR TITLE
Use xlarge, not default size for meeting dialog

### DIFF
--- a/modules/meeting/app/views/meetings/history.turbo_stream.erb
+++ b/modules/meeting/app/views/meetings/history.turbo_stream.erb
@@ -1,6 +1,7 @@
 <%=
   turbo_stream.dialog do
     render(Primer::Alpha::Dialog.new(title: t(:label_history),
+                                     size: :xlarge,
                                      id: 'meeting-history-dialog')) do |d|
       d.with_header(variant: :large)
       d.with_body do


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/56814/activity?query_id=5393
