### PR TITLE
[#57210] Impossible to link/create a work package from Nextcloud

### DIFF
--- a/modules/storages/app/models/queries/storages/project_storages/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/project_storages/filter/storage_url_filter.rb
@@ -49,13 +49,26 @@ module Queries::Storages::ProjectStorages::Filter
     end
 
     def where
-      operator_strategy.sql_for_field(unescape_hosts(values), Storages::Storage.table_name, "host")
+      operator_strategy.sql_for_field(prepare_host_values(values), Storages::Storage.table_name, "host")
     end
 
     private
 
-    def unescape_hosts(hosts)
-      hosts.map { |host| CGI.unescape(host).gsub(/\/+$/, "") }
+    # Host values are valid with or without a trailing slash and they match either case.
+    # Example: If the host is either "https://example.com" or "https://example.com/",
+    # both of the following values are valid:
+    # - "https://example.com"
+    # - "https://example.com/"
+    def prepare_host_values(hosts)
+      nested_host_values = hosts.map do |host|
+        host_value = CGI.unescape(host)
+        possible_host_values = [host_value]
+        possible_host_values << "#{host_value}/" unless host_value.ends_with?("/")
+        possible_host_values << host_value.chomp("/") if host_value.ends_with?("/")
+        possible_host_values
+      end
+
+      nested_host_values.flatten
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/projects/filter/storage_url_filter.rb
@@ -38,7 +38,24 @@ module Queries::Storages::Projects::Filter
     end
 
     def where_values
-      values.map { |host| CGI.unescape(host).gsub(/\/+$/, "") }
+      prepare_host_values(values)
+    end
+
+    # Host values are valid with or without a trailing slash and they match either case.
+    # Example: If the host is either "https://example.com" or "https://example.com/",
+    # both of the following values are valid:
+    # - "https://example.com"
+    # - "https://example.com/"
+    def prepare_host_values(hosts)
+      nested_host_values = hosts.map do |host|
+        host_value = CGI.unescape(host)
+        possible_host_values = [host_value]
+        possible_host_values << "#{host_value}/" unless host_value.ends_with?("/")
+        possible_host_values << host_value.chomp("/") if host_value.ends_with?("/")
+        possible_host_values
+      end
+
+      nested_host_values.flatten
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/linkable_to_storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/linkable_to_storage_url_filter.rb
@@ -43,7 +43,7 @@ module Queries::Storages::WorkPackages::Filter
     end
 
     def where_values
-      unescape_hosts(values)
+      prepare_host_values(values)
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storage_url_filter.rb
@@ -43,7 +43,7 @@ module Queries::Storages::WorkPackages::Filter
     end
 
     def where_values
-      unescape_hosts(values)
+      prepare_host_values(values)
     end
 
     def joins

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
@@ -78,4 +78,21 @@ module Queries::Storages::WorkPackages::Filter::StoragesFilterMixin
   def unescape_hosts(hosts)
     hosts.map { |host| CGI.unescape(host).gsub(/\/+$/, "") }
   end
+
+  # Host values are valid with or without a trailing slash and they match either case.
+  # Example: If the host is either "https://example.com" or "https://example.com/",
+  # both of the following values are valid:
+  # - "https://example.com"
+  # - "https://example.com/"
+  def prepare_host_values(hosts)
+    nested_host_values = hosts.map do |host|
+      host_value = CGI.unescape(host)
+      possible_host_values = [host_value]
+      possible_host_values << "#{host_value}/" unless host_value.ends_with?("/")
+      possible_host_values << host_value.chomp("/") if host_value.ends_with?("/")
+      possible_host_values
+    end
+
+    nested_host_values.flatten
+  end
 end

--- a/modules/storages/lib/api/v3/file_links/file_link_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_representer.rb
@@ -120,7 +120,8 @@ module API::V3::FileLinks
                         setter: ->(fragment:, **) {
                           break if fragment["href"].blank?
 
-                          canonical_url = fragment["href"].gsub(/\/+$/, "")
+                          # remove all trailing slashes except the last one
+                          canonical_url = "#{fragment["href"].gsub(/\/+$/, "")}/"
                           represented.storage = ::Storages::Storage.find_by(host: canonical_url)
                           represented.storage ||= ::Storages::Storage::InexistentStorage.new(host: canonical_url)
                         }

--- a/modules/storages/lib/api/v3/file_links/file_link_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_representer.rb
@@ -121,7 +121,7 @@ module API::V3::FileLinks
                           break if fragment["href"].blank?
 
                           # remove all trailing slashes except the last one
-                          canonical_url = "#{fragment["href"].gsub(/\/+$/, "")}/"
+                          canonical_url = "#{fragment['href'].gsub(/\/+$/, '')}/"
                           represented.storage = ::Storages::Storage.find_by(host: canonical_url)
                           represented.storage ||= ::Storages::Storage::InexistentStorage.new(host: canonical_url)
                         }

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
           parent: :storage,
           class: "::Storages::NextcloudStorage" do
     provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
-    sequence(:host) { |n| "https://host#{n}.example.com" }
+    sequence(:host) { |n| "https://host#{n}.example.com/" }
 
     trait :as_automatically_managed do
       automatically_managed { true }
@@ -115,7 +115,7 @@ FactoryBot.define do
     end
 
     name { "Nextcloud Local" }
-    host { "https://nextcloud.local" }
+    host { "https://nextcloud.local/" }
 
     initialize_with do
       Storages::NextcloudStorage.create_or_find_by(attributes.except(:oauth_client, :oauth_application))

--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe "Managing file links in work package", :js, :webmock do
       ->(_) { ServiceResult.success }
     )
 
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}")
+    stub_request(:propfind, "#{storage.host}remote.php/dav/files/#{remote_identity.origin_user_id}")
       .to_return(status: 207, body: root_xml_response, headers: {})
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
+    stub_request(:propfind, "#{storage.host}remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
       .to_return(status: 207, body: folder1_xml_response, headers: {})
 
     oauth_client_token

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -85,16 +85,16 @@ RSpec.describe("Activation of storages in projects",
   before do
     oauth_client_token
 
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}")
+    stub_request(:propfind, "#{storage.host}remote.php/dav/files/#{remote_identity.origin_user_id}")
       .to_return(status: 207, body: root_xml_response, headers: {})
-    stub_request(:propfind, "#{storage.host}/remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
+    stub_request(:propfind, "#{storage.host}remote.php/dav/files/#{remote_identity.origin_user_id}/Folder1")
       .to_return(status: 207, body: folder1_xml_response, headers: {})
-    stub_request(:get, "#{storage.host}/ocs/v1.php/apps/integration_openproject/fileinfo/11")
+    stub_request(:get, "#{storage.host}ocs/v1.php/apps/integration_openproject/fileinfo/11")
       .to_return(status: 200, body: folder1_fileinfo_response.to_json, headers: {})
-    stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/user").to_return(status: 200, body: "{}")
+    stub_request(:get, "#{storage.host}ocs/v1.php/cloud/user").to_return(status: 200, body: "{}")
     stub_request(
       :delete,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project%20name%20without%20sequence%20(#{project.id})"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/Project%20name%20without%20sequence%20(#{project.id})"
     ).to_return(status: 200, body: "", headers: {})
 
     storage

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Admin Edit File storage",
                                                "this window. Please copy these values into the Nextcloud " \
                                                "OpenProject Integration settings.")
           expect(warning_section).to have_link("Nextcloud OpenProject Integration settings",
-                                               href: "#{storage.host}/settings/admin/openproject")
+                                               href: "#{storage.host}settings/admin/openproject")
 
           expect(page).to have_css("#openproject_oauth_application_uid",
                                    value: storage.reload.oauth_application.uid)

--- a/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
+++ b/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
     it "adds CSP connect_src directives" do
       trigger_application_controller_before_action_hook
 
-      expect(controller).to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host])
+      expect(controller).to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
       it "does not add CSP connect_src directive" do
         trigger_application_controller_before_action_hook
 
-        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host])
+        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
       it "does not add CSP connect_src directive" do
         trigger_application_controller_before_action_hook
 
-        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host])
+        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
       end
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
   end
 
   context "with an active Nextcloud storage having a host with a non-standard port" do
-    let(:storage) { create(:nextcloud_storage, host: "http://somehost.com:8080") }
+    let(:storage) { create(:nextcloud_storage, host: "http://somehost.com:8080/") }
 
     current_user { admin }
 
@@ -136,7 +136,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
   end
 
   context "with an active Nextcloud storage having a host with a path" do
-    let(:storage) { create(:nextcloud_storage, host: "https://my.server.com/nextcloud") }
+    let(:storage) { create(:nextcloud_storage, host: "https://my.server.com/nextcloud/") }
 
     current_user { admin }
 

--- a/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
+++ b/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
     it "adds CSP connect_src directives" do
       trigger_application_controller_before_action_hook
 
-      expect(controller).to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
+      expect(controller).to have_received(:append_content_security_policy_directives)
+                              .with(connect_src: [storage.host.chomp("/")])
     end
   end
 
@@ -87,7 +88,8 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
       it "does not add CSP connect_src directive" do
         trigger_application_controller_before_action_hook
 
-        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
+        expect(controller).not_to have_received(:append_content_security_policy_directives)
+                                    .with(connect_src: [storage.host.chomp("/")])
       end
     end
 
@@ -101,7 +103,8 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
       it "does not add CSP connect_src directive" do
         trigger_application_controller_before_action_hook
 
-        expect(controller).not_to have_received(:append_content_security_policy_directives).with(connect_src: [storage.host.chomp("/")])
+        expect(controller).not_to have_received(:append_content_security_policy_directives)
+                                    .with(connect_src: [storage.host.chomp("/")])
       end
     end
   end

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Storages::ProjectStorage do
       let(:project_folder_mode) { "inactive" }
 
       it "opens storage" do
-        expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/apps/files")
+        expect(project_storage.open(user).result).to eq("#{storage.host}index.php/apps/files")
       end
     end
 
@@ -189,7 +189,7 @@ RSpec.describe Storages::ProjectStorage do
 
       context "when project_folder_id is missing" do
         it "opens storage" do
-          expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/apps/files")
+          expect(project_storage.open(user).result).to eq("#{storage.host}index.php/apps/files")
         end
       end
 
@@ -197,7 +197,7 @@ RSpec.describe Storages::ProjectStorage do
         let(:project_folder_id) { "123" }
 
         it "opens project_folder" do
-          expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/f/123?openfile=1")
+          expect(project_storage.open(user).result).to eq("#{storage.host}index.php/f/123?openfile=1")
         end
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe Storages::ProjectStorage do
         let(:project_folder_mode) { "automatic" }
 
         it "opens storage" do
-          expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/apps/files")
+          expect(project_storage.open(user).result).to eq("#{storage.host}index.php/apps/files")
         end
       end
 
@@ -218,7 +218,7 @@ RSpec.describe Storages::ProjectStorage do
 
         context "when project_folder_id is missing" do
           it "opens storage" do
-            expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/apps/files")
+            expect(project_storage.open(user).result).to eq("#{storage.host}index.php/apps/files")
           end
         end
 
@@ -226,7 +226,7 @@ RSpec.describe Storages::ProjectStorage do
           let(:project_folder_id) { "123" }
 
           it "opens project_folder" do
-            expect(project_storage.open(user).result).to eq("#{storage.host}/index.php/f/123?openfile=1")
+            expect(project_storage.open(user).result).to eq("#{storage.host}index.php/f/123?openfile=1")
           end
         end
       end

--- a/modules/storages/spec/requests/api/v3/project_storages/project_storages_spec.rb
+++ b/modules/storages/spec/requests/api/v3/project_storages/project_storages_spec.rb
@@ -138,10 +138,20 @@ RSpec.describe "API v3 project storages resource", :webmock, content_type: :json
         let(:path) { api_v3_paths.path_for(:project_storages, filters:) }
 
         describe "gets all project storages of the filtered project" do
-          let(:storage_url) { CGI.escape(storage3.host) }
+          context "if the exact storage url is provided" do
+            let(:storage_url) { CGI.escape(storage3.host) }
 
-          it_behaves_like "API V3 collection response", 2, 2, "ProjectStorage", "Collection" do
-            let(:elements) { [project_storage23, project_storage13] }
+            it_behaves_like "API V3 collection response", 2, 2, "ProjectStorage", "Collection" do
+              let(:elements) { [project_storage23, project_storage13] }
+            end
+          end
+
+          context "if the trailing slash of the storage url is not provided" do
+            let(:storage_url) { CGI.escape(storage3.host.chomp("/")) }
+
+            it_behaves_like "API V3 collection response", 2, 2, "ProjectStorage", "Collection" do
+              let(:elements) { [project_storage23, project_storage13] }
+            end
           end
         end
 

--- a/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe "API v3 projects resource with filters for the linked storages",
         let(:elements) { [project3, project2, project1] }
       end
 
+      context "if storage url is missing the trailing slash" do
+        let(:storage_url) { CGI.escape(storage1.host.chomp("/")) }
+
+        it_behaves_like "API V3 collection response", 3, 3, "Project", "Collection" do
+          let(:elements) { [project3, project2, project1] }
+        end
+      end
+
       context "if a project has the work_package_tracking module deactivated" do
         before(:all) { disable_module(project1, "work_package_tracking") }
         after(:all) { enable_module(project1, "work_package_tracking") }

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe "API v3 work packages resource with filters for the linkable to s
         let(:elements) { [work_package1, work_package2, work_package3, work_package4] }
       end
 
+      context "if storage url is missing the trailing slash" do
+        let(:storage_url) { CGI.escape(storage.host.chomp("/")) }
+
+        it_behaves_like "API V3 collection response", 4, 4, "WorkPackage", "WorkPackageCollection" do
+          let(:elements) { [work_package1, work_package2, work_package3, work_package4] }
+        end
+      end
+
       context "if user has no sufficient permissions in one project" do
         let(:role2) { create(:project_role, permissions: %i(view_work_packages view_file_links)) }
 

--- a/modules/storages/spec/requests/append_content_security_policy_spec.rb
+++ b/modules/storages/spec/requests/append_content_security_policy_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Appendix of default CSP for external file storage hosts" do
         get "/"
 
         csp = parse_csp(last_response.headers["Content-Security-Policy"])
-        expect(csp["connect-src"]).to include(storage.host)
+        expect(csp["connect-src"]).to include(storage.host.chomp("/"))
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "Appendix of default CSP for external file storage hosts" do
         get "/"
 
         csp = parse_csp(last_response.headers["Content-Security-Policy"])
-        expect(csp["connect-src"]).not_to include(storage.host)
+        expect(csp["connect-src"]).not_to include(storage.host.chomp("/"))
       end
     end
   end

--- a/modules/storages/spec/services/storages/nextcloud_group_folder_properties_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_group_folder_properties_sync_service_spec.rb
@@ -669,7 +669,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
       context "when getting the root folder properties fail" do
         context "on a handled error case" do
           before do
-            request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+            request_stubs[0] = stub_request(:propfind, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                                .with(
                                  body: propfind_request_body,
                                  headers: {
@@ -705,7 +705,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
         end
 
         it "raises an error when dealing with an unhandled error case" do
-          request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+          request_stubs[0] = stub_request(:propfind, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                              .with(
                                body: propfind_request_body,
                                headers: {
@@ -718,7 +718,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
         end
 
         it "raises an error when dealing with a socket or connection error" do
-          request_stubs[0] = stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+          request_stubs[0] = stub_request(:propfind, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                              .with(
                                body: propfind_request_body,
                                headers: {
@@ -734,7 +734,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
       context "when setting the root folder permissions fail" do
         context "on a handled error case" do
           before do
-            request_stubs[1] = stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+            request_stubs[1] = stub_request(:proppatch, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                                .with(
                                  body: root_folder_set_permissions_request_body,
                                  headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" }
@@ -773,7 +773,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
         before do
           request_stubs[2] = stub_request(
             :mkcol,
-            "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+            "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
             "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
           ).with(
             headers: {
@@ -809,7 +809,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
       context "when renaming a folder fail" do
         before do
           request_stubs[5] = stub_request(:move,
-                                          "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+                                          "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Lost%20Jedi%20Project%20Folder%20%233")
                              .with(headers:
                                        { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
@@ -840,7 +840,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
       context "when hiding a folder fail" do
         before do
           request_stubs[6] = stub_request(:proppatch,
-                                          "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+                                          "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Lost%20Jedi%20Project%20Folder%20%232")
                              .with(body: hide_folder_set_permissions_request_body,
                                    headers: {
@@ -872,7 +872,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
       context "when setting project folder permissions fail" do
         before do
           request_stubs[8] = stub_request(:proppatch,
-                                          "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+                                          "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
                                           "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29")
                              .with(body: set_permissions_request_body,
                                    headers: { "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=" })
@@ -902,7 +902,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
       context "when adding a user to the group fails" do
         before do
-          request_stubs[12] = stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Obi-Wan/groups")
+          request_stubs[12] = stub_request(:post, "#{storage.host}ocs/v1.php/cloud/users/Obi-Wan/groups")
                               .with(
                                 body: "groupid=OpenProject",
                                 headers: {
@@ -975,7 +975,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
 
   def setup_request_stubs
     # 0 - Root folder FileIds
-    request_stubs << stub_request(:propfind, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+    request_stubs << stub_request(:propfind, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                      .with(
                        body: propfind_request_body,
                        headers: {
@@ -987,7 +987,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
                                  headers: { "Content-Type" => "application/xml" })
 
     # 1 - Root folder SetPermissions
-    request_stubs << stub_request(:proppatch, "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject")
+    request_stubs << stub_request(:proppatch, "#{storage.host}remote.php/dav/files/OpenProject/OpenProject")
                      .with(
                        body: root_folder_set_permissions_request_body,
                        headers: {
@@ -1000,7 +1000,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 2 - OpenProject Project Folder Creation
     request_stubs << stub_request(
       :mkcol,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
       "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
     ).with(
       headers: {
@@ -1011,7 +1011,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 3 - OpenProject PropFind for created folder properties
     request_stubs << stub_request(
       :propfind,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
       "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
     ).with(
       body: propfind_folder_info_request_body,
@@ -1026,7 +1026,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 4 - Fetch folder information
     request_stubs << stub_request(
       :get,
-      "#{storage.host}/ocs/v1.php/apps/integration_openproject/fileinfo/#{project_storage2.project_folder_id}"
+      "#{storage.host}ocs/v1.php/apps/integration_openproject/fileinfo/#{project_storage2.project_folder_id}"
     ).with(
       headers: {
         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
@@ -1037,7 +1037,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 5 - Move/Rename Folder
     request_stubs << stub_request(
       :move,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%233"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%233"
     ).with(
       headers: {
         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
@@ -1049,7 +1049,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 6 - Set Permissions for the Created Folder
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
       "%5BSample%5D%20Project%20Name%20%7C%20Ehuu%20(#{project1.id})"
     ).with(
       body: created_folder_set_permissions_request_body,
@@ -1063,7 +1063,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 7 - Hide Unknown Inactive Folder
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%232"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/Lost%20Jedi%20Project%20Folder%20%232"
     ).with(
       body: hide_folder_set_permissions_request_body,
       headers: {
@@ -1076,7 +1076,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 8 - Hide Inactive Project Folder
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/NOT%20ACTIVE%20PROJECT"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/NOT%20ACTIVE%20PROJECT"
     ).with(
       body: set_permissions_request_body5,
       headers: {
@@ -1087,7 +1087,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 9 - Set folder Permissions
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/" \
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/" \
       "Jedi%20Project%20Folder%20%7C%7C%7C%20%28#{project2.id}%29"
     ).with(
       body: set_permissions_request_body,
@@ -1099,7 +1099,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 10 - Set public project folder permissions
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{project_public.id}%29"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/PUBLIC%20PROJECT%20%28#{project_public.id}%29"
     ).with(
       body: set_permissions_request_body6,
       headers: {
@@ -1110,7 +1110,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # 11
     request_stubs << stub_request(
       :proppatch,
-      "#{storage.host}/remote.php/dav/files/OpenProject/OpenProject/Project3%20%28#{project3.id}%29"
+      "#{storage.host}remote.php/dav/files/OpenProject/OpenProject/Project3%20%28#{project3.id}%29"
     ).with(
       body: set_permissions_request_body,
       headers: {
@@ -1119,7 +1119,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     ).to_return(status: 207, body: set_permissions_response_body7, headers: { "Content-Type" => "application/xml" })
 
     # 12 - Get all user in the remote group
-    request_stubs << stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/groups/#{storage.group}")
+    request_stubs << stub_request(:get, "#{storage.host}ocs/v1.php/cloud/groups/#{storage.group}")
                      .with(
                        headers: {
                          "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",
@@ -1130,7 +1130,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
                                  headers: { "Content-Type" => "application/xml" })
 
     # 13 - Add user to group
-    request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Obi-Wan/groups")
+    request_stubs << stub_request(:post, "#{storage.host}ocs/v1.php/cloud/users/Obi-Wan/groups")
                      .with(
                        body: "groupid=OpenProject",
                        headers: {
@@ -1141,7 +1141,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
                                  body: add_user_to_group_response_body,
                                  headers: { "Content-Type" => "application/xml" })
 
-    request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Yoda/groups")
+    request_stubs << stub_request(:post, "#{storage.host}ocs/v1.php/cloud/users/Yoda/groups")
                      .with(
                        body: "groupid=OpenProject",
                        headers: {
@@ -1152,7 +1152,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
                                  body: add_user_to_group_response_body,
                                  headers: { "Content-Type" => "application/xml" })
 
-    request_stubs << stub_request(:post, "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Vader/groups")
+    request_stubs << stub_request(:post, "#{storage.host}ocs/v1.php/cloud/users/Darth%20Vader/groups")
                      .with(
                        body: "groupid=OpenProject",
                        headers: {
@@ -1166,7 +1166,7 @@ RSpec.describe Storages::NextcloudGroupFolderPropertiesSyncService, :webmock do
     # remove user from group
     request_stubs << stub_request(
       :delete,
-      "#{storage.host}/ocs/v1.php/cloud/users/Darth%20Maul/groups?groupid=OpenProject"
+      "#{storage.host}ocs/v1.php/cloud/users/Darth%20Maul/groups?groupid=OpenProject"
     ).with(
       headers: {
         "Authorization" => "Basic T3BlblByb2plY3Q6MTIzNDU2Nzg=",

--- a/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
+++ b/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
               oauth_client = storage.oauth_client
               expect(last_response).to have_http_status(:found)
               expect(last_response.location).to eq(
-                "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
+                "#{storage.host}index.php/apps/oauth2/authorize?client_id=" \
                 "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
                 "%2Foauth_clients%2F#{oauth_client.client_id}%2F" \
                 "callback&response_type=code&state=#{nonce}"
@@ -100,7 +100,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
                 oauth_client = storage.oauth_client
                 expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq(
-                  "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
+                  "#{storage.host}index.php/apps/oauth2/authorize?client_id=" \
                   "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
                   "%2Foauth_clients%2F#{oauth_client.client_id}%2F" \
                   "callback&response_type=code&state=#{nonce}"
@@ -115,12 +115,12 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
               it "redirects to storage authorization_uri with oauth_state_* cookie set" do
                 get oauth_clients_ensure_connection_url(oauth_client_id: storage.oauth_client.client_id,
                                                         storage_id: storage.id,
-                                                        destination_url: "#{storage.host}/index.php")
+                                                        destination_url: "#{storage.host}index.php")
 
                 oauth_client = storage.oauth_client
                 expect(last_response).to have_http_status(:found)
                 expect(last_response.location).to eq(
-                  "#{storage.host}/index.php/apps/oauth2/authorize?client_id=" \
+                  "#{storage.host}index.php/apps/oauth2/authorize?client_id=" \
                   "#{oauth_client.client_id}&redirect_uri=#{CGI.escape(Rails.application.root_url)}" \
                   "%2Foauth_clients%2F#{oauth_client.client_id}%2F" \
                   "callback&response_type=code&state=#{nonce}"
@@ -139,7 +139,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
           end
 
           before do
-            stub_request(:get, "#{storage.host}/ocs/v1.php/cloud/user")
+            stub_request(:get, "#{storage.host}ocs/v1.php/cloud/user")
               .with(
                 headers: {
                   "Accept" => "application/json",
@@ -177,7 +177,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
               it "redirects to root_url" do
                 get oauth_clients_ensure_connection_url(oauth_client_id: storage.oauth_client.client_id,
                                                         storage_id: storage.id,
-                                                        destination_url: "#{storage.host}/index.php")
+                                                        destination_url: "#{storage.host}index.php")
 
                 storage.oauth_client
                 expect(last_response).to have_http_status(:found)


### PR DESCRIPTION
[#57210](https://community.openproject.org/work_packages/57210)

- make 'storageUrl' filter able to match with and without trailing slash
- Example: If the host is either "https://example.com" or "https://example.com/", both of the following values are valid:
  - "https://example.com"
  - "https://example.com/"

