### PR TITLE
[#57030] Fix storage delete button in "Enabled in projects" tab

### DIFF
--- a/modules/storages/app/components/storages/admin/edit_form_header_component.html.erb
+++ b/modules/storages/app/components/storages/admin/edit_form_header_component.html.erb
@@ -26,41 +26,48 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%=
-  render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title(test_selector: 'storage-new-page-header--title') do
-      render OpTurbo::FrameComponent.new(@storage, context: :edit_storage_header) do
-        label_storage_name_with_provider_label
-      end
-    end
 
-    header.with_breadcrumbs(breadcrumbs_items)
-
-    header.with_action_button(scheme: :danger,
-                              mobile_icon: :trash,
-                              mobile_label: I18n.t("button_delete"),
-                              type: :submit,
-                              aria: { label: I18n.t("storages.label_delete_storage") },
-                              test_selector: "storage-delete-button") do |button|
-      button.with_leading_visual_icon(icon: :trash)
-      I18n.t("button_delete")
-    end
-
-    if OpenProject::FeatureDecisions.enable_storage_for_multiple_projects_active?
-      header.with_tab_nav(label: nil, test_selector: :storage_detail_header) do |tab_nav|
-        tab_nav.with_tab(
-          selected: tab_selected?(:edit),
-          href: edit_admin_settings_storage_path(@storage)
-        ) do |tab|
-          tab.with_text { t(:label_details) }
-        end
-        tab_nav.with_tab(
-          selected: tab_selected?(:project_storages),
-          href: admin_settings_storage_project_storages_path(@storage)
-        ) do |tab|
-          tab.with_text { t(:label_project_mappings) }
+<%= primer_form_with(
+      model: @storage,
+      url: confirm_destroy_admin_settings_storage_path(@storage),
+      method: :get
+    ) do %>
+  <%=
+    render(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title(test_selector: 'storage-new-page-header--title') do
+        render OpTurbo::FrameComponent.new(@storage, context: :edit_storage_header) do
+          label_storage_name_with_provider_label
         end
       end
+
+      header.with_breadcrumbs(breadcrumbs_items)
+
+      header.with_action_button(scheme: :danger,
+                                mobile_icon: :trash,
+                                mobile_label: I18n.t("button_delete"),
+                                type: :submit,
+                                aria: { label: I18n.t("storages.label_delete_storage") },
+                                test_selector: "storage-delete-button") do |button|
+        button.with_leading_visual_icon(icon: :trash)
+        I18n.t("button_delete")
+      end
+
+      if OpenProject::FeatureDecisions.enable_storage_for_multiple_projects_active?
+        header.with_tab_nav(label: nil, test_selector: :storage_detail_header) do |tab_nav|
+          tab_nav.with_tab(
+            selected: tab_selected?(:edit),
+            href: edit_admin_settings_storage_path(@storage)
+          ) do |tab|
+            tab.with_text { t(:label_details) }
+          end
+          tab_nav.with_tab(
+            selected: tab_selected?(:project_storages),
+            href: admin_settings_storage_project_storages_path(@storage)
+          ) do |tab|
+            tab.with_text { t(:label_project_mappings) }
+          end
+        end
+      end
     end
-  end
-%>
+  %>
+<% end %>

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -29,18 +29,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), t("project_module_storages"), t('label_edit_x', x: @storage.name) %>
 
-<%= primer_form_with(
-      model: @storage,
-      url: confirm_destroy_admin_settings_storage_path(@storage),
-      method: :get
-    ) do %>
-  <%=
-    render(Storages::Admin::EditFormHeaderComponent.new(
-      storage: @storage,
-      selected: :edit
-    ))
-  %>
-<% end %>
+<%= render(Storages::Admin::EditFormHeaderComponent.new(
+    storage: @storage,
+    selected: :edit
+  ))
+%>
 
 <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg)) do |component| %>
   <% component.with_main do %>

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -178,6 +178,13 @@ RSpec.describe "Admin lists project mappings for a storage",
       end
     end
 
+    it "links to the delete page of a storage" do
+      page.find_test_selector("storage-delete-button").click
+
+      expect(page).to have_text("DELETE FILE STORAGE")
+      expect(page).to have_current_path("#{confirm_destroy_admin_settings_storage_path(storage)}?utf8=%E2%9C%93")
+    end
+
     describe "Linking a project to a storage with a manually managed folder" do
       context "when the user has granted OAuth access" do
         let(:oauth_client_token) { create(:oauth_client_token, oauth_client: storage.oauth_client, user: admin) }


### PR DESCRIPTION
https://community.openproject.org/work_packages/57030

# What are you trying to accomplish?
The storage delete button should also work in the "Enabled in projects" tab, not only on the "Details" tab.

# Ticket
[<!-- Provide the link to respective work package -->](https://community.openproject.org/work_packages/57030)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) => not necessary for this
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) => not necessary for this
