### PR TITLE
Filter the project storage members to show only users

### DIFF
--- a/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
+++ b/modules/storages/app/controllers/storages/project_settings/project_storage_members_controller.rb
@@ -41,9 +41,11 @@ class Storages::ProjectSettings::ProjectStorageMembersController < Projects::Set
   model_object Storages::ProjectStorage
 
   def index
-    @memberships = Member
+    @project_users = Member
                    .of_project(@project)
-                   .includes(principal: :remote_identities, roles: :role_permissions)
+                   .joins(:principal)
+                   .preload(roles: :role_permissions, principal: :remote_identities)
+                   .where(principal: { type: "User" })
                    .paginate(page: page_param, per_page: per_page_param)
 
     render "/storages/project_settings/project_storage_members/index"

--- a/modules/storages/app/views/storages/project_settings/project_storage_members/index.html.erb
+++ b/modules/storages/app/views/storages/project_settings/project_storage_members/index.html.erb
@@ -43,4 +43,4 @@ See COPYRIGHT and LICENSE files for more details.
     storage_name_link: link_to(@storage.name, edit_admin_settings_storage_path(@storage))).html_safe
 ) %>
 
-<%= render(::Storages::ProjectStorages::Members::TableComponent.new(rows: @memberships, storage: @storage)) %>
+<%= render(::Storages::ProjectStorages::Members::TableComponent.new(rows: @project_users, storage: @storage)) %>

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -33,10 +33,13 @@ require_module_spec_helper
 
 RSpec.describe "Project storage members connection status view" do
   let(:user) { create(:user) }
+  let(:group) { create(:group, members: [group_user]) }
+  let(:placeholder_user) { create(:placeholder_user) }
   let(:admin_user) { create(:admin) }
   let(:connected_user) { create(:user) }
   let(:connected_no_permissions_user) { create(:user) }
   let(:disconnected_user) { create(:user) }
+  let(:group_user) { create(:user) }
 
   let!(:storage) { create_nextcloud_storage_with_oauth_application }
   let!(:project) { create_project_with_storage_and_members }
@@ -76,10 +79,15 @@ RSpec.describe "Project storage members connection status view" do
         [admin_user, "Connected"],
         [connected_user, "Connected"],
         [connected_no_permissions_user, "User role has no storages permissions"],
-        [disconnected_user, "Not connected. The user should login to the storage via the following link."]
+        [disconnected_user, "Not connected. The user should login to the storage via the following link."],
+        [group_user, "Not connected. The user should login to the storage via the following link."]
       ].each do |(principal, status)|
         expect(page).to have_css("#member-#{principal.id} .name", text: principal.name)
         expect(page).to have_css("#member-#{principal.id} .status", text: status)
+      end
+
+      [placeholder_user, group].each do |principal|
+        expect(page).to have_no_css("#member-#{principal.id} .name", text: principal.name)
       end
     end
   end
@@ -113,7 +121,9 @@ RSpec.describe "Project storage members connection status view" do
                       admin_user => role_cannot_read_files,
                       connected_user => role_can_read_files,
                       connected_no_permissions_user => role_cannot_read_files,
-                      disconnected_user => role_can_read_files },
+                      disconnected_user => role_can_read_files,
+                      placeholder_user => role_can_read_files,
+                      group => role_can_read_files },
            enabled_module_names: %i[storages])
   end
 


### PR DESCRIPTION
# What are you trying to accomplish?

The Project Storage Members list was raising an exception since the inclusion of `RemoteIdentity`.

This was caused by the lack of filtering out groups and placeholder users as those cannot login on storage anyway.

# What approach did you choose and why?

Simplest fix was to change the `includes` call to a `preload` and filter the members to only `User`s.

# Ticket

Related WP: [OP#57260](https://community.openproject.org/projects/openproject/work_packages/57260/)

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
