### PR TITLE
[#56440] Add 🔍 to projects autocompleter

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -7,5 +7,4 @@
 @import "open_project/common/submenu_component"
 @import "filter/filters_component"
 @import "projects/row_component"
-@import "settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component"
 @import "op_primer/border_box_table_component"

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/new_project_mapping_component.sass
@@ -1,8 +1,0 @@
-@import 'helpers'
-
-.op-new-project-mapping-form
-  .ng-placeholder
-    @extend .icon-search
-    &:before
-      @include icon-font-common
-      margin-right: 10px

--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -38,6 +38,7 @@ module Projects::CustomFields
           visually_hide_label: true,
           validation_message: project_ids_error_message,
           autocomplete_options: {
+            with_search_icon: true,
             openDirectly: false,
             focusDirectly: false,
             multiple: true,

--- a/frontend/src/global_styles/content/_index.sass
+++ b/frontend/src/global_styles/content/_index.sass
@@ -54,6 +54,7 @@
 @import autocomplete
 @import autocomplete_primerized
 @import diff
+@import projects_autocomplete_with_search_icon
 @import projects_list
 @import project_list_modal
 @import datepicker

--- a/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
+++ b/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
@@ -1,11 +1,12 @@
 @import 'helpers'
 
 .projects-autocomplete-with-search-icon
-  ng-select
-    .ng-placeholder
+  ng-select[ng-reflect-multiple='false']
+    input
       margin-left: 18px
-    .ng-value-container
+  ng-select
+    .ng-select-container
       @extend .icon-search
       &:before
         @include icon-font-common
-        padding-right: 5px
+        padding-left: 10px

--- a/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
+++ b/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
@@ -1,0 +1,11 @@
+@import 'helpers'
+
+.projects-autocomplete-with-search-icon
+  ng-select
+    .ng-placeholder
+      margin-left: 18px
+    .ng-value-container
+      @extend .icon-search
+      &:before
+        @include icon-font-common
+        padding-right: 5px

--- a/lib/primer/open_project/forms/autocompleter.html.erb
+++ b/lib/primer/open_project/forms/autocompleter.html.erb
@@ -11,14 +11,16 @@
                  append_to: @autocomplete_options.fetch(:append_to, 'body')
                } %>
   <% else %>
-    <%= angular_component_tag @autocomplete_options.fetch(:component),
-                              data: @autocomplete_options.delete(:data) { {} },
-                              inputs: @autocomplete_options.merge(
-                                classes: "ng-select--primerized #{@input.invalid? ? '-error' : ''}",
-                                inputName: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
-                                inputValue: @autocomplete_options.fetch(:inputValue) { builder.object.send(@input.name) },
-                                defaultData: @autocomplete_options.fetch(:defaultData) { true }
-                              )
-    %>
+    <%= content_tag(:div, class: ("projects-autocomplete-with-search-icon" if @autocomplete_options.delete(:with_search_icon))) do %>
+      <%= angular_component_tag @autocomplete_options.fetch(:component),
+                                data: @autocomplete_options.delete(:data) { {} },
+                                inputs: @autocomplete_options.merge(
+                                  classes: "ng-select--primerized #{@input.invalid? ? '-error' : ''}",
+                                  inputName: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
+                                  inputValue: @autocomplete_options.fetch(:inputValue) { builder.object.send(@input.name) },
+                                  defaultData: @autocomplete_options.fetch(:defaultData) { true }
+                                )
+      %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lookbook/docs/patterns/03-autocompleters.md.erb
+++ b/lookbook/docs/patterns/03-autocompleters.md.erb
@@ -76,6 +76,12 @@ Keep in mind that this component uses the live projects API, so results will dep
 
 <%= embed OpenProject::Common::AutocompletePreview, :project, panels: %i[source] %>
 
+#### Project autocompletion with search icon
+
+There is also an flag for a search icon within the select:
+
+<%= embed OpenProject::Common::AutocompletePreview, :project_with_search_icon, panels: %i[source] %>
+
 ### Outside primer
 
 If you're not in a primer form, you can render the autocomplete directly like so:

--- a/lookbook/previews/open_project/common/autocomplete_preview.rb
+++ b/lookbook/previews/open_project/common/autocomplete_preview.rb
@@ -44,6 +44,10 @@ module OpenProject
       def project
         render_with_template
       end
+
+      def project_with_search_icon
+        render_with_template
+      end
     end
   end
 end

--- a/lookbook/previews/open_project/common/autocomplete_preview/project_with_search_icon.html.erb
+++ b/lookbook/previews/open_project/common/autocomplete_preview/project_with_search_icon.html.erb
@@ -1,0 +1,28 @@
+<%
+  the_form = Class.new(ApplicationForm) do
+    form do |f|
+      f.project_autocompleter(
+        name: :id,
+        label: Project.model_name.human,
+        visually_hide_label: true,
+        autocomplete_options: {
+          with_search_icon: true,
+          openDirectly: false,
+          focusDirectly: false,
+          dropdownPosition: 'bottom',
+          disabledProjects: Project.visible.take(10).pluck(:id).to_h { |id| [id, "Disabled reason!"] },
+        }
+      )
+    end
+  end
+
+  model = Project.new
+%>
+
+<%= primer_form_with(
+      model:,
+      url: '/abc',
+      id: 'asdf') do |f|
+  render(the_form.new(f))
+end
+%>

--- a/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
+++ b/modules/storages/app/forms/storages/admin/storages/add_projects_autocompleter_form.rb
@@ -38,6 +38,7 @@ module Storages
               visually_hide_label: true,
               validation_message: project_ids_error_message,
               autocomplete_options: {
+                with_search_icon: true,
                 openDirectly: false,
                 focusDirectly: false,
                 multiple: true,


### PR DESCRIPTION
# What are you trying to accomplish?

- Add the magnifier icon to the projects select for enabling a storage for multiple projects at once
- Fix the cursor position in relation to the magnifier icon on the projects select for project attributes
- Have a reusable implementation for both that does not copy the sass code
- Have a simple / pure CSS solution to not mess with the angular component which is used in multiple places and not only for projects

## Screenshots

Before:
![Screenshot from 2024-08-15 10-46-33](https://github.com/user-attachments/assets/10f10bb6-aac5-47d4-98fb-95ee590ae3cd)

After:
![Screenshot from 2024-08-15 10-47-12](https://github.com/user-attachments/assets/92789a46-88bf-4dd2-91fb-4a5cb140f1c6)

# What approach did you choose and why?

Have an additional CSS class that controls the icon being added, so the angular code of the component does not have to be reworked.

# Ticket

https://community.openproject.org/work_packages/56440

# Merge checklist

- [ ] Added/updated tests => not necessary, since it's only styling
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers 
   - [x] Chrome
   - [x] Firefox
   - [x] Edge
