### PR TITLE
[56890] Adapt mobile behavior for new notification center

### DIFF
--- a/app/components/work_packages/split_view_component.sass
+++ b/app/components/work_packages/split_view_component.sass
@@ -8,3 +8,7 @@
 
   border-top-left-radius: var(--borderRadius-medium)
   border-top-right-radius: var(--borderRadius-medium)
+
+  @media screen and (max-width: $breakpoint-sm)
+    // Unfortunately, we have to enforce this style via !important as the resizer writes the width directly on the element as inline style
+    width: unset !important

--- a/app/controllers/concerns/work_packages/with_split_view.rb
+++ b/app/controllers/concerns/work_packages/with_split_view.rb
@@ -30,6 +30,9 @@ module WorkPackages
   module WithSplitView
     extend ActiveSupport::Concern
 
+    SPLIT_CONTENT_CLASS = "content--split".freeze
+    CONTENT_SELECTOR = "#content".freeze
+
     included do
       helper_method :split_view_base_route
     end
@@ -44,7 +47,8 @@ module WorkPackages
           render turbo_stream: [
             turbo_stream.remove("work-package-details-#{split_view_work_package_id}"),
             turbo_stream.push_state(url: split_view_base_route),
-            turbo_stream.set_title(title: helpers.page_title(I18n.t("js.notifications.title")))
+            turbo_stream.set_title(title: helpers.page_title(I18n.t("js.notifications.title"))),
+            turbo_stream.remove_css_class(CONTENT_SELECTOR, SPLIT_CONTENT_CLASS)
           ]
         end
         format.html do
@@ -58,7 +62,8 @@ module WorkPackages
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.update("content-bodyRight", helpers.split_view_instance.render_in(view_context)),
-            turbo_stream.push_state(url: request.fullpath)
+            turbo_stream.push_state(url: request.fullpath),
+            turbo_stream.add_css_class(CONTENT_SELECTOR, SPLIT_CONTENT_CLASS)
           ]
         end
 

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -61,13 +61,25 @@
     min-height: calc(100vh - var(--header-height))
   // ------------------- END CHANGED SCROLL BEHAVIOR
 
-  #content-body,
-  #content-header
-    padding-left: 15px
-    padding-right: 15px
+  #content
+    grid-template-columns: 1fr
+
+    // Show split view full width if it is opened
+    &.content--split
+      #content-body
+        display: none
+      #content-bodyRight
+        display: initial
+        width: 100vw
 
   #content-bodyRight
     display: none
+
+  #content-body,
+  #content-bodyRight,
+  #content-header
+    padding-left: 15px
+    padding-right: 15px
 
   #main
     grid-template-columns: auto

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -45,8 +45,6 @@ body.router--work-packages-partitioned-split-view-new
   height: 100%
   position: relative
   width: 100%
-  // Min-width is actually 530px but the border already needs 2px
-  min-width: 528px
 
   @media only screen and (max-width: $breakpoint-xl)
     @at-root

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -246,8 +246,9 @@ $scrollbar-size: 10px
       margin-right: 15px
 
 @mixin space-between-content-and-split-screen
-  #content-bodyRight > *
-    margin-left: 12px
+  @media screen and (min-width: $breakpoint-sm)
+    #content-bodyRight > *
+      margin-left: 12px
 
 @mixin modifying--placeholder
   border: 1px dashed var(--accent-color)


### PR DESCRIPTION
# Goal
With the new split screen, we also want to implement a new mobile behavior. Currently there is always a redirect to the full view, which has drawbacks on mobile as you have to scroll the whole page before you reach the tabs

That is why, the new split screen should be used as the moble display of a Workpacke.

# Todo

- [x] Clicking a notification item technically opens the split screen (like in desktop), to be seen in the URL
- [x] The split screen spans the whole width of the screen
- [ ] Closing the split screen via the "x" gets you back to the same view you saw before 

https://community.openproject.org/projects/openproject/work_packages/56890/activity