### PR TITLE
add rel="nofollow" to table sort links

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -286,7 +286,7 @@ module SortHelper
     allowed_params ||= %w[filters per_page expand columns]
 
     # Don't lose other params.
-    link_to_content_update(h(caption), safe_query_params(allowed_params).merge(sort_options), html_options)
+    link_to_content_update(h(caption), safe_query_params(allowed_params).merge(sort_options), html_options.merge(rel: :nofollow))
   end
 
   # Returns a table header <th> tag with a sort link for the named column

--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
@@ -17,7 +17,8 @@
        [ngClass]="[directionClass && 'sort', directionClass]"
        lang-attribute
        lang="{{locale}}"
-       id="{{ headerColumn.id }}">{{headerColumn.name}}</a>
+       id="{{ headerColumn.id }}"
+       rel="nofollow">{{headerColumn.name}}</a>
     <a *ngIf="!sortable">{{headerColumn.name}}</a>
 
     <op-icon icon-classes="dropdown-indicator icon-small icon-pulldown"
@@ -47,7 +48,8 @@
        [ngClass]="[directionClass && 'sort', directionClass]"
        lang-attribute
        lang="{{locale}}"
-       id="{{ headerColumn.id }}">{{headerColumn.name}}</a>
+       id="{{ headerColumn.id }}"
+       rel="nofollow">{{headerColumn.name}}</a>
 
     <a *ngIf="!sortable">{{headerColumn.name}}</a>
 

--- a/spec/helpers/sort_helper_spec.rb
+++ b/spec/helpers/sort_helper_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe SortHelper do
             <div class="generic-table--sort-header">
               <span>
                 <a href="/work_packages?sort=sort_criteria_params"
+                   rel="nofollow"
                    title="Sort by &quot;Id&quot;">Id</a>
               </span>
             </div>
@@ -166,6 +167,7 @@ RSpec.describe SortHelper do
               <div class="generic-table--sort-header">
                 <span class="sort asc">
                   <a href="/work_packages?sort=sort_criteria_params"
+                     rel="nofollow"
                      title="Ascending sorted by &quot;Id&quot;">Id</a>
                 </span>
               </div>
@@ -186,6 +188,7 @@ RSpec.describe SortHelper do
               <div class="generic-table--sort-header">
                 <span class="sort desc">
                   <a href="/work_packages?sort=sort_criteria_params"
+                     rel="nofollow"
                      title="Descending sorted by &quot;Id&quot;">Id</a>
                 </span>
               </div>
@@ -216,6 +219,7 @@ RSpec.describe SortHelper do
                 <div class="generic-table--sort-header">
                   <span>
                     <a href="/work_packages?columns=a%2Cb%2Cc&amp;expand=nope&amp;filters=xyz&amp;per_page=42&amp;sort=sort_criteria_params"
+                       rel="nofollow"
                        title="Sort by &quot;Id&quot;">Id</a>
                   </span>
                 </div>
@@ -235,6 +239,7 @@ RSpec.describe SortHelper do
                 <div class="generic-table--sort-header">
                   <span>
                     <a href="/work_packages?baz=foo&amp;foo=bar&amp;sort=sort_criteria_params"
+                       rel="nofollow"
                        title="Sort by &quot;Id&quot;">Id</a>
                   </span>
                 </div>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57306

# What are you trying to accomplish?

Have robots not follow the links in the table headers of index actions.

# What approach did you choose and why?

Add `rel="nofollow"` to the helpers used for rendering tables.

