### PR TITLE
Add endless scroll on table in manual sorting mode

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -500,6 +500,10 @@ module Settings
         description: "Forced page size for manually sorted work package views",
         default: 250
       },
+      forced_load_more_size: {
+        description: "Forced load more size for manually sorted work package views",
+        default: 50
+      },
       good_job_queues: {
         description: "",
         format: :string,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1055,6 +1055,7 @@ en:
         title: No work packages to display.
         description: Either none have been created or all work packages are filtered out.
       limited_results: Only %{count} work packages can be shown in manual sorting mode. Please reduce the results by filtering, or switch to automatic sorting.
+      endless_scroll: Scroll to the bottom to load more work packages.
       property_groups:
         details: "Details"
         people: "People"

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -228,6 +228,8 @@ export class WorkPackagesListService {
    * Load the query from the given state params
    */
   public loadCurrentQueryFromParams(projectIdentifier?:string):Promise<QueryResource> {
+    this.adjustQueryPropsForManualSort();
+
     return firstValueFrom(this.fromQueryParams(this.$state.params as { query_id?:string|null, query_props?:string }, projectIdentifier));
   }
 
@@ -464,5 +466,18 @@ export class WorkPackagesListService {
 
   private reloadSidemenu(selectedQueryId:string|null):void {
     this.submenuService.reloadSubmenu(selectedQueryId);
+  }
+
+  private adjustQueryPropsForManualSort():void {
+    if (!this.$state.params.query_props) {
+      return;
+    }
+    
+    const query_props = JSON.parse(this.$state.params.query_props);
+    
+    if (query_props && query_props['t'] == 'manualSorting:asc') {
+      query_props['pa'] = 1
+      this.$state.params.query_props = JSON.stringify(query_props);
+    }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.ts
@@ -64,7 +64,7 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
     readonly wpTableSortBy:WorkPackageViewSortByService,
     readonly I18n:I18nService,
   ) {
-    super(paginationService, cdRef, I18n);
+    super(paginationService, cdRef, I18n, wpTableSortBy);
   }
 
   ngOnInit() {
@@ -109,8 +109,7 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
 
   public paginationInfoText(work_packages:WorkPackageCollectionResource) {
     if (this.isManualSortingMode && (work_packages.count < work_packages.total)) {
-      return I18n.t('js.work_packages.limited_results',
-        { count: work_packages.count });
+      return I18n.t('js.work_packages.endless_scroll');
     }
     return undefined;
   }

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
@@ -245,6 +245,8 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
 
     if (visibly) {
       promise = promise.then((loadedQuery:QueryResource) => {
+        this.appendToExistingIfManualSorted(loadedQuery);
+
         this.wpStatesInitialization.initialize(loadedQuery, loadedQuery.results);
         return this.additionalLoadingTime()
           .then(() => loadedQuery);
@@ -304,5 +306,14 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
 
   private queryTitle(query:QueryResource):string {
     return isPersistedResource(query) ? query.name : this.staticQueryName(query);
+  }
+
+  private appendToExistingIfManualSorted(loadedQuery:QueryResource):void {
+    const loadedWorkPackages = loadedQuery.results;
+
+    if (this.querySpace.query.value && loadedWorkPackages.offset != 1 && loadedQuery.sortBy[0].column.href!.endsWith('/manualSorting')) {
+      loadedQuery.results.elements = this.querySpace.query.value.results.elements.concat(loadedWorkPackages.elements)
+      loadedQuery.results.offset = this.wpTablePagination.current.page;
+    }
   }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.html
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.html
@@ -7,6 +7,8 @@
 <wp-table *ngIf="tableInformationLoaded && showTableView"
           [projectIdentifier]="CurrentProject.identifier"
           [configuration]="wpTableConfiguration"
+          [manualSortForcedPageSize]="manualSortForcedPageSize"
+          (manualSortForcedPageSizeChange)="setManualSortForcedPageSize($event)"
           (itemClicked)="handleWorkPackageClicked($event)"
           (stateLinkClicked)="openStateLink($event)"
           class="work-packages-split-view--tabletimeline-content">
@@ -28,5 +30,5 @@
 <!-- Footer -->
 <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
      *ngIf="tableInformationLoaded">
-     <wp-table-pagination></wp-table-pagination>
+     <wp-table-pagination [manualSortForcedPageSize]="manualSortForcedPageSize"></wp-table-pagination>
 </div>

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
@@ -88,6 +88,8 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
   /** Whether we should render a blocked view */
   showResultOverlay$ = this.wpViewFilters.incomplete$;
 
+  manualSortForcedPageSize:number = 0;
+
   public baselineEnabled:boolean;
 
   /** */
@@ -205,6 +207,10 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
     } else {
       this.handleWorkPackageClicked(event);
     }
+  }
+
+  setManualSortForcedPageSize(newPageSize:number):void {
+    this.manualSortForcedPageSize = newPageSize;
   }
 
   private openInFullView(workPackageId:string) {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-packages-view.base.ts
@@ -220,6 +220,7 @@ export abstract class WorkPackagesViewBase extends UntilDestroyedMixin implement
         const newQuery = queryState.value!;
         const triggerUpdate = service.applyToQuery(newQuery);
         this.querySpace.query.putValue(newQuery);
+        this.assignFirstPageIfManualSort();
 
         // Update the current checksum
         this.wpListChecksumService
@@ -249,6 +250,7 @@ export abstract class WorkPackagesViewBase extends UntilDestroyedMixin implement
         filter((events:HalEvent[]) => this.filterRefreshEvents(events)),
       )
       .subscribe((events:HalEvent[]) => {
+        this.assignFirstPageIfManualSort();
         this.refresh(false, false);
       });
 
@@ -313,5 +315,11 @@ export abstract class WorkPackagesViewBase extends UntilDestroyedMixin implement
         this.queryLoaded = true;
         this.cdRef.detectChanges();
       });
+  }
+
+  private assignFirstPageIfManualSort() {
+    if (this.wpTableSortBy.isManualSortingMode) {
+      this.wpTablePagination.current.page = 1;
+    }
   }
 }

--- a/frontend/src/app/shared/components/table-pagination/pagination-instance.ts
+++ b/frontend/src/app/shared/components/table-pagination/pagination-instance.ts
@@ -40,6 +40,10 @@ export class PaginationInstance {
     return Math.min(this.perPage * this.page, limit);
   }
 
+  public getUpperPageBoundForManualSort(limit:number, firstPageSize:number) {
+    return Math.min(this.perPage * (this.page - 1) + firstPageSize, limit);
+  }
+
   public nextPage() {
     this.page += 1;
   }

--- a/frontend/src/app/shared/components/table-pagination/table-pagination.component.ts
+++ b/frontend/src/app/shared/components/table-pagination/table-pagination.component.ts
@@ -39,6 +39,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { PaginationInstance } from 'core-app/shared/components/table-pagination/pagination-instance';
 import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
+import { WorkPackageViewSortByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service';
 
 @Component({
   selector: '[tablePagination]',
@@ -55,6 +56,8 @@ export class TablePaginationComponent extends UntilDestroyedMixin implements OnI
   @Input() showPageSelections = true;
 
   @Input() infoText?:string;
+
+  @Input() manualSortForcedPageSize:number;
 
   @Output() updateResults = new EventEmitter<PaginationInstance>();
 
@@ -81,6 +84,8 @@ export class TablePaginationComponent extends UntilDestroyedMixin implements OnI
     protected paginationService:PaginationService,
     protected cdRef:ChangeDetectorRef,
     protected I18n:I18nService,
+    readonly wpTableSortBy:WorkPackageViewSortByService,
+
   ) {
     super();
   }
@@ -129,8 +134,15 @@ export class TablePaginationComponent extends UntilDestroyedMixin implements OnI
   public updateCurrentRangeLabel() {
     if (this.pagination.total) {
       const totalItems = this.pagination.total;
-      const lowerBound = this.pagination.getLowerPageBound();
-      const upperBound = this.pagination.getUpperPageBound(this.pagination.total);
+      let lowerBound, upperBound;
+      // Adjust cuurent range when loading more items in manual sorting mode. 
+      if(this.wpTableSortBy.isManualSortingMode && this.pagination.page != 1) {
+        lowerBound = 1;
+        upperBound = this.pagination.getUpperPageBoundForManualSort(totalItems, this.manualSortForcedPageSize);
+      } else {
+        lowerBound = this.pagination.getLowerPageBound();
+        upperBound = this.pagination.getUpperPageBound(totalItems);
+      }
 
       this.currentRange = `(${lowerBound} - ${upperBound}/${totalItems})`;
     } else {


### PR DESCRIPTION
# Ticket
[https://community.openproject.org/projects/openproject/work_packages/35152](https://community.openproject.org/projects/openproject/work_packages/35152)

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
At the moment the limit for work packages per page in manual sorting mode are at 250.

As an OpenProject user, I want to display all (or more) work packages of a big project on one page so that hierarchies are intact and all children belonging to a parent work package are displayed together.

# What approach did you choose and why?
I added endless scrolling to the work packages table in manual sorting mode, enabling hierarchies to be indented and allowing more work packages to be sorted.

# Merge checklist

- [ ] Added/updated tests 
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
