### PR TITLE
[57198] Time and cost report :  text of unit cost activity is displayed with html tag <i>

### DIFF
--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -102,7 +102,7 @@ module ReportingHelper
 
     case key.to_sym
     when :activity_id
-      mapped value, Enumeration, "<i>#{I18n.t(:caption_material_costs)}</i>"
+      mapped value, Enumeration, "<i>#{I18n.t(:caption_material_costs)}</i>".html_safe
     when :project_id
       link_to_project Project.find(value.to_i)
     when :user_id, :assigned_to_id, :author_id, :logged_by_id


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57198/activity


# What are you trying to accomplish?
Italic font was never applied but the tags simply printed in the resulting table

## Screenshots

<img width="250" alt="Bildschirmfoto 2024-08-19 um 08 45 31" src="https://github.com/user-attachments/assets/cf854a41-a87b-4e8d-a1bb-a1dabe84f8bf">

