### PR TITLE
[57209] Attachment headlines are semi-transparent and overlapped by content

### DIFF
--- a/frontend/src/global_styles/content/work_packages/tabs/_tab_content.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_tab_content.sass
@@ -47,6 +47,7 @@
     align-items: center
     position: sticky
     top: 0
+    background: var(--body-background)
     z-index: 1
 
     &-text


### PR DESCRIPTION

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57209/activity


# What are you trying to accomplish?
Re-add background for tab header which was removed accidentally. Without that, sticky headers are semi-transparent and you can see the scrolled items behind them.


## Screenshots

**Before**
<img width="533" alt="Bildschirmfoto 2024-08-19 um 08 54 32" src="https://github.com/user-attachments/assets/9bfd9e71-7487-4f50-8ea0-71015dd35bae">

**After**
<img width="475" alt="Bildschirmfoto 2024-08-19 um 08 54 49" src="https://github.com/user-attachments/assets/c3b1da45-44eb-4cc3-879e-9b53c17b0a48">
