### PR TITLE
Show meetings in user's correct timezone 

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -90,6 +90,7 @@ import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter
 import allLocales from '@fullcalendar/core/locales-all';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 @Component({
   templateUrl: './wp-calendar.template.html',
@@ -146,6 +147,7 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     readonly dayService:DayResourceService,
     readonly apiV3Service:ApiV3Service,
     readonly pathHelper:PathHelperService,
+    readonly timezoneService:TimezoneService,
   ) {
     super();
   }
@@ -217,19 +219,19 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       .filtered(filters, { pageSize: '-1' })
       .get()
       .subscribe((meetings) => {
-        const events = meetings.elements.map((meeting:MeetingResource) => {
+        const events:EventInput[] = meetings.elements.map((meeting:MeetingResource) => {
           const sameProject = this.currentProject.id === meeting.project.id;
           const title:string = sameProject ? meeting.title : `${meeting.project.name}: ${meeting.title}`;
           return {
             title,
-            start: Date.parse(meeting.startTime),
-            end: Date.parse(meeting.endTime),
+            start: this.timezoneService.parseDatetime(meeting.startTime as string).format(),
+            end: this.timezoneService.parseDatetime(meeting.endTime as string).format(),
             editable: false,
             durationEditable: false,
             allDay: false,
             className: 'fc-event-clickable op-wp-calendar--meeting-resource',
             meeting,
-          };
+          } as EventInput;
         });
 
         successCallback(events);

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
   let(:wp_full_view) { Pages::FullWorkPackage.new(work_package, project) }
   let(:calendar) { Pages::Calendar.new project }
 
-  current_user do
+  shared_let(:current_user) do
     create(:user,
            member_with_permissions: {
              project => %w[view_work_packages view_meetings edit_work_packages view_calendar manage_overview]
@@ -58,7 +58,11 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
   end
 
   before do
+    login_as(current_user)
     overview_page.visit!
+
+    wait_for_network_idle if RSpec.current_example.metadata[:with_cuprite]
+
     # within top-left area, add an additional widget
     overview_page.add_widget(1, 1, :row, "Calendar")
 
@@ -67,9 +71,31 @@ RSpec.describe "Calendar Widget", :js, :with_cuprite, with_settings: { start_of_
 
   it "shows the meeting" do
     expect(page).to have_css(".fc-event", text: "Weekly", visible: :all)
+
     page.find(".fc-event", text: "Weekly", visible: :all).click
 
     expect(page).to have_current_path /meetings\/#{meeting.id}/
+  end
+
+  context "as a user in a different timezone" do
+    shared_let(:current_user) do
+      create(:user,
+             preferences: { time_zone: "Asia/Tokyo" },
+             member_with_permissions: {
+               project => %w[view_work_packages view_meetings edit_work_packages view_calendar manage_overview]
+             })
+    end
+
+    it "shows the meeting in the correct timezone" do
+      expect(page).to have_css(".fc-event", text: "Weekly", visible: :all)
+
+      start_time = Time.use_zone(current_user.time_zone) { meeting.start_time.strftime("%-l:%M%P") }
+      end_time = Time.use_zone(current_user.time_zone) { (meeting.start_time + 1.hour).strftime("%-l:%M%P") }
+      expect(page).to have_css(".fc-event-time", text: "#{start_time} - #{end_time}", visible: :all, exact_text: false)
+
+      page.find(".fc-event", text: "Weekly", visible: :all).click
+      expect(page).to have_current_path /meetings\/#{meeting.id}/
+    end
   end
 
   it "opens the work package full view when clicking a calendar entry" do

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -24,6 +24,8 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "old", over
     # https://github.com/grosser/parallel_tests/issues/658
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-smooth-scrolling")
+    # Disable "Select your search engine screen"
+    options.add_argument("--disable-search-engine-choice-screen")
 
     options.add_preference(:download,
                            directory_upgrade: true,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57078


# What are you trying to accomplish?
Use the correct timezone format for displaying meetings (only objects in calendars with times right now), so that they match the meeting time formatted in the backend

