### PR TITLE
[57033] New status field rendering not vertically aligned correctly in notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -57,7 +57,7 @@ $subject-font-size: 14px
     grid-template-areas: "status wpIdLink project reason count buttons"
     grid-column-gap: 5px
     font-size: var(--body-font-size)
-    align-items: center
+    align-items: baseline
 
   &--middle-line
     grid-area: body

--- a/frontend/src/app/features/in-app-notifications/entry/status/in-app-notification-status.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/status/in-app-notification-status.component.sass
@@ -11,7 +11,6 @@
   border-radius: 2px
   max-width: 100%
   font-size: 12px
-  display: inline-block
   min-height: 16px
   line-height: 16px
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57033/activity

# What are you trying to accomplish?
Align status field in notification item

## Screenshots
**Before**
<img width="248" alt="Bildschirmfoto 2024-08-19 um 09 13 41" src="https://github.com/user-attachments/assets/b4d0fbda-ce4a-4249-81c1-c7393c0b469a">

**After**
<img width="234" alt="Bildschirmfoto 2024-08-19 um 09 13 12" src="https://github.com/user-attachments/assets/f9a9a112-f14e-4329-9ca0-2866aedc792f">


# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
