### PR TITLE
fixed typos in docs

### DIFF
--- a/docs/user-guide/meetings/dynamic-meetings/README.md
+++ b/docs/user-guide/meetings/dynamic-meetings/README.md
@@ -10,7 +10,8 @@ keywords: meetings, dynamic meetings, agenda, minutes
 
 Introduced in OpenProject 13.1, dynamic meetings offer easier meeting management, improved agenda creation and the ability to link work packages to meetings and vice-versa.
 
-> **Note:** The **Meetings module needs to be activated** in the [Project Settings](../../projects/project-settings/modules/) to be able to create and edit meetings.
+> [!NOTE]
+> The **Meetings module needs to be activated** in the [Project Settings](../../projects/project-settings/modules/) to be able to create and edit meetings.
 
 | Topic                                                        | Content                                                    |
 | ------------------------------------------------------------ | ---------------------------------------------------------- |

--- a/docs/user-guide/work-packages/edit-work-package/README.md
+++ b/docs/user-guide/work-packages/edit-work-package/README.md
@@ -35,7 +35,7 @@ The green message on top of the work package indicates a successful update.
 
 All changes of a work package are documented in the work package tab [Activity](../../../getting-started/work-packages-introduction/#activity-of-work-packages).
 
-> [! NOTE]
+> [!NOTE]
 > There is no possibility to undo changes to work packages by using Ctrl+Z combination.
 
 ### How to assign a team member to a work package


### PR DESCRIPTION
Fixed a typo in docs to correct the source string for Crowdin (https://crowdin.com/editor/openproject-docs/17242/en-de?view=comfortable&filter=basic&value=3#q=1251650) 

