### PR TITLE
Bug/57316 robots follow action links unnecessarily

### DIFF
--- a/app/components/projects/configure_view_modal_component.rb
+++ b/app/components/projects/configure_view_modal_component.rb
@@ -29,6 +29,8 @@
 # ++
 
 class Projects::ConfigureViewModalComponent < ApplicationComponent
+  include OpTurbo::Streamable
+
   MODAL_ID = "op-project-list-configure-dialog"
   QUERY_FORM_ID = "op-project-list-configure-query-form"
   COLUMN_HTML_NAME = "columns"

--- a/app/components/projects/delete_list_modal_component.rb
+++ b/app/components/projects/delete_list_modal_component.rb
@@ -28,7 +28,9 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-class Projects::DeleteListModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+class Projects::DeleteListModalComponent < ApplicationComponent
+  include OpTurbo::Streamable
+
   MODAL_ID = "op-project-list-delete-dialog"
 
   options :query

--- a/app/components/projects/export_list_modal_component.rb
+++ b/app/components/projects/export_list_modal_component.rb
@@ -28,7 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-class Projects::ExportListModalComponent < ApplicationComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+class Projects::ExportListModalComponent < ApplicationComponent
+  include OpTurbo::Streamable
   MODAL_ID = "op-project-list-export-dialog"
 
   options :query

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -122,8 +122,10 @@
       end
 
       menu.with_item(
+        tag: :a,
         label: t('js.label_export'),
-        content_arguments: { 'data-show-dialog-id': Projects::ExportListModalComponent::MODAL_ID }
+        href: export_list_modal_projects_path(projects_query_params),
+        content_arguments: { data: { controller: "async-dialog" } }
       ) do |item|
         item.with_leading_visual_icon(icon: 'sign-out')
       end
@@ -151,5 +153,4 @@
 <% if show_state? %>
   <%= render(Projects::ConfigureViewModalComponent.new(query:)) %>
   <%= render(Projects::DeleteListModalComponent.new(query:)) if query.persisted? %>
-  <%= render(Projects::ExportListModalComponent.new(query:)) %>
 <% end %>

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -99,7 +99,8 @@
       menu.with_item(
         tag: :a,
         label: t(:label_overall_activity),
-        href: activities_path
+        href: activities_path,
+        content_arguments: { rel: "nofollow" }
       ) do |item|
         item.with_leading_visual_icon(icon: 'tasklist')
       end
@@ -125,7 +126,7 @@
         tag: :a,
         label: t('js.label_export'),
         href: export_list_modal_projects_path(projects_query_params),
-        content_arguments: { data: { controller: "async-dialog" } }
+        content_arguments: { data: { controller: "async-dialog" }, rel: "nofollow" }
       ) do |item|
         item.with_leading_visual_icon(icon: 'sign-out')
       end

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -140,9 +140,11 @@
 
       if query.persisted?
         menu.with_item(
+          tag: :a,
           label: t(:button_delete),
           scheme: :danger,
-          content_arguments: { 'data-show-dialog-id': Projects::DeleteListModalComponent::MODAL_ID }
+          href: destroy_confirmation_modal_project_query_path(query.id),
+          content_arguments: { data: { controller: "async-dialog" }}
         ) do |item|
           item.with_leading_visual_icon(icon: 'trash')
         end
@@ -153,5 +155,4 @@
 
 <% if show_state? %>
   <%= render(Projects::ConfigureViewModalComponent.new(query:)) %>
-  <%= render(Projects::DeleteListModalComponent.new(query:)) if query.persisted? %>
 <% end %>

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -132,8 +132,10 @@
       end
 
       menu.with_item(
+        tag: :a,
         label: t(:'queries.configure_view.heading'),
-        content_arguments: { 'data-show-dialog-id': Projects::ConfigureViewModalComponent::MODAL_ID }
+        href: configure_view_modal_project_queries_path(projects_query_params),
+        content_arguments: { data: { controller: "async-dialog" }}
       ) do |item|
         item.with_leading_visual_icon(icon: :gear)
       end
@@ -152,7 +154,3 @@
     end
   end
 %>
-
-<% if show_state? %>
-  <%= render(Projects::ConfigureViewModalComponent.new(query:)) %>
-<% end %>

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -29,11 +29,12 @@
 class Projects::QueriesController < ApplicationController
   include Projects::QueryLoading
   include OpTurbo::ComponentStream
+  include OpTurbo::DialogStreamHelper
 
   # No need for a more specific authorization check. That is carried out in the contracts.
-  no_authorization_required! :show, :new, :create, :rename, :update, :toggle_public, :destroy
+  no_authorization_required! :show, :new, :create, :rename, :update, :toggle_public, :destroy, :destroy_confirmation_modal
   before_action :require_login
-  before_action :find_query, only: %i[show rename update destroy toggle_public]
+  before_action :find_query, only: %i[show rename update destroy toggle_public destroy_confirmation_modal]
   before_action :build_query_or_deny_access, only: %i[new create]
 
   current_menu_item [:new, :rename, :create, :update] do
@@ -99,6 +100,10 @@ class Projects::QueriesController < ApplicationController
                                                     .call
 
     redirect_to projects_path
+  end
+
+  def destroy_confirmation_modal
+    respond_with_dialog Projects::DeleteListModalComponent.new(query: @query)
   end
 
   private

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -32,10 +32,11 @@ class Projects::QueriesController < ApplicationController
   include OpTurbo::DialogStreamHelper
 
   # No need for a more specific authorization check. That is carried out in the contracts.
-  no_authorization_required! :show, :new, :create, :rename, :update, :toggle_public, :destroy, :destroy_confirmation_modal
-  before_action :require_login
+  no_authorization_required! :show, :new, :create, :rename, :update, :toggle_public, :destroy, :destroy_confirmation_modal,
+                             :configure_view_modal
+  before_action :require_login, except: %i[configure_view_modal]
   before_action :find_query, only: %i[show rename update destroy toggle_public destroy_confirmation_modal]
-  before_action :build_query_or_deny_access, only: %i[new create]
+  before_action :build_query_or_deny_access, only: %i[new create configure_view_modal]
 
   current_menu_item [:new, :rename, :create, :update] do
     :projects
@@ -104,6 +105,10 @@ class Projects::QueriesController < ApplicationController
 
   def destroy_confirmation_modal
     respond_with_dialog Projects::DeleteListModalComponent.new(query: @query)
+  end
+
+  def configure_view_modal
+    respond_with_dialog Projects::ConfigureViewModalComponent.new(query: @query)
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,19 +30,20 @@ class ProjectsController < ApplicationController
   menu_item :overview
   menu_item :roadmap, only: :roadmap
 
-  before_action :find_project, except: %i[index new]
-  before_action :load_query_or_deny_access, only: %i[index]
+  before_action :find_project, except: %i[index new export_list_modal]
+  before_action :load_query_or_deny_access, only: %i[index export_list_modal]
   before_action :authorize, only: %i[copy deactivate_work_package_attachments]
   before_action :authorize_global, only: %i[new]
   before_action :require_admin, only: %i[destroy destroy_info]
 
-  no_authorization_required! :index
+  no_authorization_required! :index, :export_list_modal
 
   include SortHelper
   include PaginationHelper
   include QueriesHelper
   include ProjectsHelper
   include Projects::QueryLoading
+  include OpTurbo::DialogStreamHelper
 
   helper_method :has_managed_project_folders?
 
@@ -103,6 +104,10 @@ class ProjectsController < ApplicationController
     else
       head :no_content
     end
+  end
+
+  def export_list_modal
+    respond_with_dialog Projects::ExportListModalComponent.new(query: @query)
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -44,7 +44,7 @@ class Project < ApplicationRecord
   IDENTIFIER_MAX_LENGTH = 100
 
   # reserved identifiers
-  RESERVED_IDENTIFIERS = %w[new menu queries].freeze
+  RESERVED_IDENTIFIERS = %w[new menu queries export_list_modal].freeze
 
   has_many :members, -> {
     # TODO: check whether this should

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
     member do
       get :rename
       post :toggle_public
+      get :destroy_confirmation_modal
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,10 @@ Rails.application.routes.draw do
       post :toggle_public
       get :destroy_confirmation_modal
     end
+
+    collection do
+      get :configure_view_modal
+    end
   end
 
   namespace :projects do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,10 @@ Rails.application.routes.draw do
       post :deactivate_work_package_attachments
     end
 
+    collection do
+      get :export_list_modal
+    end
+
     resources :versions, only: %i[new create] do
       collection do
         put :close_completed

--- a/lookbook/docs/patterns/05-dialogs.md.erb
+++ b/lookbook/docs/patterns/05-dialogs.md.erb
@@ -38,6 +38,18 @@ class TestController < ApplicationControler
 end
 ```
 
+For this to work, the `OpTurbo::Streamable` module needs to be included in the modal component:
+
+```ruby
+class MyDialogComponent < ApplicationControler
+  # include the module
+  include OpTurbo::Streamable
+
+  # ...
+end
+```
+
+
 Assuming the MyDialogComponent template looks like this:
 
 ```erb

--- a/spec/routing/project_queries_routing_spec.rb
+++ b/spec/routing/project_queries_routing_spec.rb
@@ -46,4 +46,8 @@ RSpec.describe "Project query routes" do
     expect(get("/project_queries/42/destroy_confirmation_modal")).to route_to("projects/queries#destroy_confirmation_modal",
                                                                               id: "42")
   end
+
+  it "/project_queries/:id/configure_view_modal GET routes to projects/queries#configure_view_modal" do
+    expect(get("/project_queries/configure_view_modal")).to route_to("projects/queries#configure_view_modal")
+  end
 end

--- a/spec/routing/project_queries_routing_spec.rb
+++ b/spec/routing/project_queries_routing_spec.rb
@@ -41,4 +41,9 @@ RSpec.describe "Project query routes" do
     expect(delete("/project_queries/42")).to route_to("projects/queries#destroy",
                                                       id: "42")
   end
+
+  it "/project_queries/:id/destroy_confirmation_modal GET routes to projects/queries#destroy_confirmation_modal" do
+    expect(get("/project_queries/42/destroy_confirmation_modal")).to route_to("projects/queries#destroy_confirmation_modal",
+                                                                              id: "42")
+  end
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe ProjectsController do
     end
   end
 
+  describe "export_list_modal" do
+    it do
+      expect(get("/projects/export_list_modal")).to route_to(
+        controller: "projects", action: "export_list_modal"
+      )
+    end
+  end
+
   describe "templated" do
     it do
       expect(delete("/projects/123/templated"))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57316

# What are you trying to accomplish?
Avoid robots triggering exports of project lists. Also preventing the access to activities. That should already be covered by the robots.txt so this is an extra safety net.

To prepare for loading the whole page repeatedly once the projects list are powered by turbo, the three modals have been changed to be rendered asynchronously.

