### PR TITLE
[57151] OpenProject Dark Mode: diff view for description (and large text fields) not matching

### DIFF
--- a/frontend/src/global_styles/content/_diff.sass
+++ b/frontend/src/global_styles/content/_diff.sass
@@ -34,15 +34,16 @@ img.diff, div.diff, table.diff, blockquote.diff, address.diff, h1.diff, h2.diff,
 
 del
   &.diffmod, &.diffdel
-    background: #fcc
+    background: var(--diffBlob-deletion-bgColor-word)
+    color: var(--diffBlob-deletion-fgColor-text)
 
 ins
   &.diffmod, &.diffins
-    background: #cfc
+    background: var(--diffBlob-addition-bgColor-word)
+    color: var(--diffBlob-addition-fgColor-text)
 
 .text-diff
   padding: 1em
-  background-color: #f6f6f6
-  color: #505050
-  border: 1px solid #e4e4e4
+  background-color: var(--bgColor-muted)
+  border: 1px solid var(--borderColor-default)
   line-height: normal


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57151/activity

# What are you trying to accomplish?
Use Primer variables for diff matching colors

## Screenshots
**After**

<img width="250" alt="Bildschirmfoto 2024-08-19 um 11 13 37" src="https://github.com/user-attachments/assets/3775261c-485c-410a-9cf2-92bb012ddd09">

<img width="250" alt="Bildschirmfoto 2024-08-19 um 11 13 24" src="https://github.com/user-attachments/assets/3e2df0d8-a54b-4937-9831-159a05a0ac8d">

