### PR TITLE
Show only updated time, not actor if first notification is date alert

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -705,7 +705,7 @@ en:
           with_current_filter: "There are no notifications in this view at the moment"
         mark_all_read: "Mark all as read"
         mark_as_read: "Mark as read"
-        text_update_date: "%{date} by"
+        text_update_date_by: "%{date} by"
         total_count_warning: "Showing the %{newest_count} most recent notifications. %{more_count} more are not displayed."
         empty_state:
           no_notification: "Looks like you are all caught up."

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -1,21 +1,8 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 import { PrincipalLike } from 'core-app/shared/components/principal/principal-types';
-import {
-  Observable,
-  timer,
-} from 'rxjs';
-import {
-  distinctUntilChanged,
-  map,
-} from 'rxjs/operators';
+import { Observable, timer } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
@@ -47,13 +34,17 @@ export class InAppNotificationActorsLineComponent implements OnInit {
   text = {
     and: this.I18n.t('js.notifications.center.label_actor_and'),
     and_other_singular: this.I18n.t('js.notifications.center.and_more_users.one'),
-    and_other_plural: (count:number):string => this.I18n.t('js.notifications.center.and_more_users.other',
-      { count }),
+    and_other_plural: (count:number):string => this.I18n.t(
+      'js.notifications.center.and_more_users.other',
+      { count },
+    ),
     loading: this.I18n.t('js.ajax.loading'),
     placeholder: this.I18n.t('js.placeholders.default'),
     mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
-    updated_by_at: (age:string):string => this.I18n.t('js.notifications.center.text_update_date',
-      { date: age }),
+    updated_by_at: (age:string):string => this.I18n.t(
+      'js.notifications.center.text_update_date_by',
+      { date: age },
+    ),
   };
 
   constructor(
@@ -63,8 +54,12 @@ export class InAppNotificationActorsLineComponent implements OnInit {
   ) { }
 
   ngOnInit():void {
-    this.buildActors();
     this.buildTime();
+
+    // Don't show the actor if the first item is actor-less (date alert)
+    if (this.notification._links.actor) {
+      this.buildActors();
+    }
   }
 
   text_for_additional_authors(number:number):string {
@@ -79,9 +74,14 @@ export class InAppNotificationActorsLineComponent implements OnInit {
     this.fixedTime = this.timezoneService.formattedDatetime(this.notification.createdAt);
     this.relativeTime$ = timer(0, 10000)
       .pipe(
-        map(() => this.text.updated_by_at(
-          this.timezoneService.formattedRelativeDateTime(this.notification.createdAt),
-        )),
+        map(() => {
+          const time = this.timezoneService.formattedRelativeDateTime(this.notification.createdAt);
+          if (this.notification._links.actor) {
+            return this.text.updated_by_at(time);
+          }
+
+          return time;
+        }),
         distinctUntilChanged(),
       );
   }

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "features/page_objects/notification"
+
+RSpec.describe "Notification center date alert and mention",
+               :js,
+               :with_cuprite,
+               with_settings: { journal_aggregation_time_minutes: 0 } do
+  shared_let(:project) { create(:project) }
+  shared_let(:actor) { create(:user, firstname: "Actor", lastname: "User") }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: { project => %w[view_work_packages] })
+  end
+  shared_let(:work_package) { create(:work_package, project:, due_date: 1.day.ago) }
+
+  shared_let(:notification_mention) do
+    create(:notification,
+           reason: :mentioned,
+           recipient: user,
+           resource: work_package,
+           actor:,
+           project:)
+  end
+
+  shared_let(:notification_date_alert) do
+    create(:notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: work_package,
+           project:)
+  end
+
+  let(:center) { Pages::Notifications::Center.new }
+
+  before do
+    login_as user
+    visit notifications_center_path
+    wait_for_reload
+  end
+
+  context "with date alerts ee", with_ee: %i[date_alerts] do
+    it "shows only the date alert time, not the mentioned author" do
+      center.within_item(notification_date_alert) do
+        expect(page).to have_text("Date alert, Mentioned")
+        expect(page).to have_no_text("Actor user")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57279

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When the first/newest notification is a date alert, we should only show the timestamp, as that notification does not have an actor.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
