### PR TITLE
[57093] Default user avatar is too big for work package table rendering (Safari)

### DIFF
--- a/frontend/src/global_styles/content/_avatar.sass
+++ b/frontend/src/global_styles/content/_avatar.sass
@@ -45,6 +45,8 @@ $user-avatar-mini-height: 20px
     // (medium height) 28 - 2(border pixels)
     line-height: 26px
     font-size: 13px
+    // Needed for Safari to avoid that the avatar is cut off
+    box-sizing: content-box
 
   // Different border styling for placeholders
   &_placeholder-user


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57093/activity

# What are you trying to accomplish?
Set box-sizing so that Safari does not cut off the bottom of the avatar

## Screenshots
**Before**
<img width="332" alt="Bildschirmfoto 2024-08-19 um 11 49 53" src="https://github.com/user-attachments/assets/1ecb5caa-d787-401a-8596-25dc717bc38f">

**After**
<img width="352" alt="Bildschirmfoto 2024-08-19 um 11 47 48" src="https://github.com/user-attachments/assets/86a894d2-84cc-4844-a7af-f9c21ef67636">

