### PR TITLE
[57208] Missing space between avatar and name on Project settings file page

### DIFF
--- a/app/components/admin/attachments_settings_header_component.html.erb
+++ b/app/components/admin/attachments_settings_header_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% helpers.html_title t(:label_administration), @title %>
 
-<%= render(Primer::OpenProject::PageHeader.new(border_bottom: 0)) do |header|
+<%= render(Primer::OpenProject::PageHeader.new) do |header|
   header.with_title { t(:"attributes.attachments") }
   header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
                            { href: admin_settings_storages_path, text: t("project_module_storages") },

--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -46,9 +46,7 @@ module Storages::ProjectStorages::Members
     end
 
     def name
-      icon = helpers.avatar principal, size: :mini
-
-      icon + principal_link
+      helpers.avatar principal, hide_name: false, size: :mini
     end
 
     def status
@@ -74,10 +72,6 @@ module Storages::ProjectStorages::Members
     private
 
     delegate :storage, to: :table
-
-    def principal_link
-      link_to principal.name, principal_show_path
-    end
 
     def principal_class_name
       principal.model_name.singular

--- a/modules/storages/app/components/storages/project_storages/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/row_component.rb
@@ -45,8 +45,7 @@ module Storages::ProjectStorages
     end
 
     def creator
-      icon = helpers.avatar project_storage.creator, size: :mini
-      icon + project_storage.creator.name
+      helpers.avatar project_storage.creator, hide_name: false, size: :mini
     end
 
     def button_links

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe "Project storage members connection status view" do
+RSpec.describe "Project storage members connection status view", :js do
   let(:user) { create(:user) }
   let(:group) { create(:group, members: [group_user]) }
   let(:placeholder_user) { create(:placeholder_user) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57208/activity

# What are you trying to accomplish?
* Use build-in functionality to display the name of a user next to the avatar instead of building it manually
* Remove obsolete border definition

## Screenshots
**Before**
<img width="217" alt="Bildschirmfoto 2024-08-19 um 12 14 07" src="https://github.com/user-attachments/assets/425f23ca-e3fe-4710-9ad5-847cffa85780">

**After**
<img width="260" alt="Bildschirmfoto 2024-08-19 um 12 13 15" src="https://github.com/user-attachments/assets/fbe5f47b-7d6a-4f0a-8d98-93352f586cf8">


