### PR TITLE
Replace inconsistent i18n-tasks spec with workflow

### DIFF
--- a/.github/workflows/i18n-tasks.yml
+++ b/.github/workflows/i18n-tasks.yml
@@ -1,0 +1,44 @@
+name: i18n-inconsistency-check
+
+on:
+  push:
+    branches:
+      - dev
+      - release/*
+    paths-ignore:
+      - 'docs/**'
+      - 'help/**'
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths-ignore:
+      - 'docs/**'
+      - 'help/**'
+      - 'packaging/**'
+      - '.pkgr.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  i18n-tasks:
+    permissions:
+      contents: read
+    if: github.repository == 'opf/openproject'
+    name: I18n inconsistency check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+
+      - name: Setup i18n-tasks
+        run: |
+          gem install i18n-tasks
+
+      - name: Run inconsistent translations check
+        run: |
+          i18n-tasks \
+            check-consistent-interpolations \
+            --config config/i18n-tasks-all-files.yml

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "I18n" do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
-  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
   it "does not have missing keys" do
     pending "Enable when i18n-tasks is enabled across the project, otherwise this spec will report false positives"
@@ -29,18 +28,5 @@ RSpec.describe "I18n" do
                     "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
                     "Please run `i18n-tasks normalize' to fix"
     expect(non_normalized).to be_empty, error_message
-  end
-
-  context "for all i18n files" do
-    let(:root_dir) { Pathname.new(__FILE__).dirname.join("..") }
-    let(:config_file) { root_dir.join("config/i18n-tasks-all-files.yml") }
-    let(:i18n) { I18n::Tasks::BaseTask.new(config_file:) }
-
-    it "does not have inconsistent interpolations" do
-      config_file_relative_path = config_file.relative_path_from(Dir.pwd)
-      error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
-                      "Run 'i18n-tasks check-consistent-interpolations --config #{config_file_relative_path}' to show them"
-      expect(inconsistent_interpolations).to be_empty, error_message
-    end
   end
 end


### PR DESCRIPTION
The task `i18n-tasks check-consistent-interpolations --config config/i18n-tasks-all-files.yml` is currently being run as part of the unit tests. 

Whenever there is an inconsistent translation on crowdin, we break the entire CI. This was for good reason, so that we become aware of this problem. At the same time, it slows down developers that aren't really able to help, creating a semaphore until someone resolves it.

If we create a task, we fail the PR, but do not fail the test suite.


<img width="1671" alt="Bildschirmfoto 2024-08-19 um 19 26 01" src="https://github.com/user-attachments/assets/81cc29d9-f480-40cb-8535-db8b725ba7db">

<img width="1186" alt="Bildschirmfoto 2024-08-19 um 19 26 04" src="https://github.com/user-attachments/assets/7dbf9bbb-6ebb-4ade-8859-c63526810ecd">
