### PR TITLE
[#57298] Custom field filter in project list causes internal server error

### DIFF
--- a/app/models/queries/filters/shared/custom_fields/base.rb
+++ b/app/models/queries/filters/shared/custom_fields/base.rb
@@ -117,7 +117,7 @@ module Queries::Filters::Shared
 
       def condition
         [
-          custom_field_context.where_subselect_conditions(custom_field, context),
+          custom_field_context.where_subselect_conditions,
           operator_strategy.sql_for_field(values_replaced, CustomValue.table_name, "value")
         ].compact.join(" AND ")
       end

--- a/app/models/queries/projects/filters/custom_field_context.rb
+++ b/app/models/queries/projects/filters/custom_field_context.rb
@@ -52,9 +52,9 @@ module Queries::Projects::Filters::CustomFieldContext
       SQL
     end
 
-    def where_subselect_conditions(_custom_field, context)
+    def where_subselect_conditions
       # Allow searching projects only with :view_project_attributes permission
-      allowed_project_ids = Project.allowed_to(context.user, :view_project_attributes)
+      allowed_project_ids = Project.allowed_to(User.current, :view_project_attributes)
                                    .select(:id)
       <<~SQL.squish
         #{project_db_table}.id IN (#{allowed_project_ids.to_sql})

--- a/app/models/queries/work_packages/filter/custom_field_context.rb
+++ b/app/models/queries/work_packages/filter/custom_field_context.rb
@@ -74,7 +74,7 @@ module Queries::WorkPackages::Filter::CustomFieldContext
       joins
     end
 
-    def where_subselect_conditions(_custom_field, _context)
+    def where_subselect_conditions
       nil
     end
   end

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -404,7 +404,8 @@ RSpec.describe "Persisted lists on projects index page",
       projects_page.expect_sidebar_filter("Persisted query", selected: true, favored: false)
     end
 
-    it "loads the query with a custom field filter (Regression#57298)" do
+    it "loads the query with a custom field filter (Regression#57298)",
+       with_ee: %i[custom_fields_in_projects_list] do
       projects_page.set_sidebar_filter("Persisted query")
 
       projects_page.expect_filters_container_hidden

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -31,6 +31,7 @@ require "spec_helper"
 RSpec.describe "Persisted lists on projects index page",
                :js,
                :with_cuprite do
+  shared_let(:non_member) { create(:non_member, permissions: %i(view_project_attributes)) }
   shared_let(:admin) { create(:admin) }
   shared_let(:user) { create(:user) }
 
@@ -50,7 +51,10 @@ RSpec.describe "Persisted lists on projects index page",
                      name: "Public project",
                      identifier: "public-project",
                      public: true)
-    project.custom_field_values = { invisible_custom_field.id => "Secret CF" }
+    project.custom_field_values = {
+      invisible_custom_field.id => "Secret CF",
+      custom_field.id => "Visible CF"
+    }
     project.save
     project
   end
@@ -216,6 +220,7 @@ RSpec.describe "Persisted lists on projects index page",
     let!(:persisted_query) do
       build(:project_query, user:, name: "Persisted query")
         .where("active", "=", "t")
+        .where("cf_#{custom_field.id}", "~", ["Visible"])
         .select("name")
         .save!
     end
@@ -397,6 +402,13 @@ RSpec.describe "Persisted lists on projects index page",
 
       projects_page.unmark_query_favorite
       projects_page.expect_sidebar_filter("Persisted query", selected: true, favored: false)
+    end
+
+    it "loads the query with a custom field filter (Regression#57298)" do
+      projects_page.set_sidebar_filter("Persisted query")
+
+      projects_page.expect_filters_container_hidden
+      projects_page.expect_filter_set "cf_#{custom_field.id}"
     end
   end
 

--- a/spec/models/queries/projects/filters/custom_field_filter_spec.rb
+++ b/spec/models/queries/projects/filters/custom_field_filter_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
   describe "#apply_to" do
     describe "permissions" do
       let(:user) { build_stubbed(:user) }
+      current_user { user }
 
       it "includes the check for view_project_attributes permission" do
         projects_query = Project.allowed_to(user, :view_project_attributes)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57298

# What are you trying to accomplish?
Fix the error related to the saving project queries containing custom fields.

# What approach did you choose and why?
The context where the user was derived from in the filter is not available when loading saved queries.
Use the `User.current` instead, as that is more appropriate.

# Merge checklist

- [X] Added/updated tests
- [x] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
