### PR TITLE
remove explicit project column from notifications

### DIFF
--- a/app/contracts/notifications/create_contract.rb
+++ b/app/contracts/notifications/create_contract.rb
@@ -31,7 +31,6 @@ module Notifications
     attribute :recipient
     attribute :subject
     attribute :reason
-    attribute :project
     attribute :actor
     attribute :resource
     attribute :journal

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -82,10 +82,9 @@ class DigestMailer < ApplicationMailer
   def load_notifications(notification_ids)
     Notification
       .where(id: notification_ids)
-      .includes(:project, :resource)
+      .includes(:resource)
       .reject do |notification|
         notification.resource.nil? ||
-        notification.project.nil? ||
         (notification.journal.nil? && !notification.date_alert?)
       end
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -48,7 +48,6 @@ class Notification < ApplicationRecord
 
   belongs_to :recipient, class_name: "User"
   belongs_to :actor, class_name: "User"
-  belongs_to :project
   belongs_to :journal
   belongs_to :resource, polymorphic: true
 

--- a/app/models/queries/notifications/filters/project_filter.rb
+++ b/app/models/queries/notifications/filters/project_filter.rb
@@ -28,4 +28,15 @@
 
 class Queries::Notifications::Filters::ProjectFilter < Queries::Notifications::Filters::NotificationFilter
   include Queries::Filters::Shared::ProjectFilter::Optional
+
+  # This is currently work package specific same as all the other parts of the NotificationQuery
+  self.model = WorkPackage
+
+  def joins
+    <<~SQL.squish
+      JOIN #{WorkPackage.table_name}
+      ON #{WorkPackage.table_name}.id = #{Notification.table_name}.resource_id
+      AND #{Notification.table_name}.resource_type = 'WorkPackage'
+    SQL
+  end
 end

--- a/app/models/queries/notifications/group_bys/group_by_project.rb
+++ b/app/models/queries/notifications/group_bys/group_by_project.rb
@@ -33,6 +33,16 @@ class Queries::Notifications::GroupBys::GroupByProject < Queries::GroupBys::Base
     :project
   end
 
+  def joins
+    # Only Notifications for work_packages are currently supported via the query.
+    # E.g. the visible statement used in the query is WorkPackage specific.
+    <<~SQL.squish
+      JOIN work_packages
+      ON notifications.resource_id = work_packages.id
+      AND notifications.resource_type = 'WorkPackage'
+    SQL
+  end
+
   def name
     :project_id
   end

--- a/app/models/queries/notifications/orders/project_order.rb
+++ b/app/models/queries/notifications/orders/project_order.rb
@@ -34,15 +34,23 @@ class Queries::Notifications::Orders::ProjectOrder < Queries::Orders::Base
   end
 
   def joins
-    :project
+    <<~SQL.squish
+      JOIN #{WorkPackage.table_name} work_packages_order
+      ON work_packages_order.id = #{Notification.table_name}.resource_id
+      AND #{Notification.table_name}.resource_type = 'WorkPackage'
+      JOIN #{Project.table_name}
+      ON #{Project.table_name}.id = work_packages_order.project_id
+    SQL
   end
 
   protected
 
   def order(scope)
-    order_string = "projects.name"
-    order_string += " DESC" if direction == :desc
+    with_raise_on_invalid do
+      order_string = "#{Project.table_name}.name"
+      order_string += " DESC" if direction == :desc
 
-    scope.order(order_string)
+      scope.order(order_string)
+    end
   end
 end

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -106,7 +106,6 @@ class Notifications::CreateFromModelService
   def create_notification(recipient_id, reason)
     notification_attributes = {
       recipient_id:,
-      project:,
       resource:,
       journal:,
       actor: user_with_fallback,

--- a/app/services/notifications/set_attributes_service.rb
+++ b/app/services/notifications/set_attributes_service.rb
@@ -27,20 +27,5 @@
 #++
 
 module Notifications
-  class SetAttributesService < ::BaseServices::SetAttributes
-    private
-
-    def set_default_attributes(params)
-      super
-
-      set_default_project unless model.project
-    end
-
-    ##
-    # Try to determine the project context from the journal (if any)
-    # or the resource if it has a project set
-    def set_default_project
-      model.project = model.journal&.project || model.resource.try(:project)
-    end
-  end
+  class SetAttributesService < ::BaseServices::SetAttributes; end
 end

--- a/app/workers/notifications/create_date_alerts_notifications_job/service.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job/service.rb
@@ -70,7 +70,6 @@ class Notifications::CreateDateAlertsNotificationsJob::Service
     create_service = Notifications::CreateService.new(user:)
     create_service.call(
       recipient_id: user.id,
-      project_id: work_package.project_id,
       resource: work_package,
       reason:
     )

--- a/db/migrate/20240820123011_remove_project_from_notification.rb
+++ b/db/migrate/20240820123011_remove_project_from_notification.rb
@@ -1,0 +1,83 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class RemoveProjectFromNotification < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |direction|
+      direction.down do
+        execute <<~SQL.squish
+          UPDATE notifications
+          SET project_id = work_package_journals.project_id
+          FROM journals
+          JOIN work_package_journals
+          ON journals.data_id = work_package_journals.id AND journals.data_type = 'Journal::WorkPackageJournal'
+          WHERE notifications.journal_id = journals.id AND notifications.resource_type = 'WorkPackage'
+        SQL
+
+        execute <<~SQL.squish
+          UPDATE notifications
+          SET project_id = forums.project_id
+          FROM journals
+          JOIN message_journals
+          ON journals.data_id = message_journals.id AND journals.data_type = 'Journal::MessageJournal'
+          JOIN forums ON message_journals.forum_id = forums.id
+          WHERE notifications.journal_id = journals.id AND notifications.resource_type = 'Message'
+        SQL
+
+        execute <<~SQL.squish
+          UPDATE notifications
+          SET project_id = wikis.project_id
+          FROM wiki_pages
+          JOIN wikis
+          ON wiki_pages.wiki_id = wikis.id
+          WHERE notifications.resource_id = wiki_pages.id AND notifications.resource_type = 'WikiPage'
+        SQL
+
+        execute <<~SQL.squish
+          UPDATE notifications
+          SET project_id = news_journals.project_id
+          FROM journals
+          JOIN news_journals
+          ON journals.data_id = news_journals.id AND journals.data_type = 'Journal::NewsJournal'
+          WHERE notifications.journal_id = journals.id AND notifications.resource_type = 'News'
+        SQL
+
+        execute <<~SQL.squish
+          UPDATE notifications
+          SET project_id = news.project_id
+          FROM comments
+          JOIN news
+          ON comments.commented_id = news.id AND comments.commented_type = 'News'
+          WHERE notifications.resource_id = comments.id AND notifications.resource_type = 'Comment'
+        SQL
+      end
+    end
+
+    remove_reference :notifications, :project
+  end
+end

--- a/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
+++ b/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
@@ -44,7 +44,10 @@ module API
           # because it is a polymorphic association. That being as it is, currently only
           # work packages are assigned.
           def set_resource(notifications)
-            work_packages_by_id = WorkPackage.where(id: notifications.pluck(:resource_id).uniq).index_by(&:id)
+            work_packages_by_id = WorkPackage
+                                    .includes(:project)
+                                    .where(id: notifications.pluck(:resource_id).uniq)
+                                    .index_by(&:id)
 
             notifications.each do |notification|
               notification.resource = work_packages_by_id[notification.resource_id]

--- a/lib/api/v3/notifications/notification_representer.rb
+++ b/lib/api/v3/notifications/notification_representer.rb
@@ -77,8 +77,6 @@ module API
                             skip_render: ->(*) { represented.actor.nil? },
                             v3_path: :user
 
-        associated_resource :project
-
         associated_resource :journal,
                             as: :activity,
                             representer: ::API::V3::Activities::ActivityRepresenter,
@@ -87,11 +85,26 @@ module API
 
         polymorphic_resource :resource
 
+        resource :project,
+                 getter: ->(*) {
+                           ::API::V3::Projects::ProjectRepresenter
+                             .create(represented.resource.project, current_user:, embed_links:)
+                         },
+                 link: ->(*) {
+                         {
+                           href: api_v3_paths.project(represented.resource.project.id),
+                           title: represented.resource.project.name
+                         }
+                       },
+                 setter: ->(*) {
+                           raise NotImplementedError
+                         }
+
         def _type
           "Notification"
         end
 
-        self.to_eager_load = %i[project actor journal]
+        self.to_eager_load = %i[actor journal]
       end
     end
   end

--- a/spec/contracts/notifications/create_contract_spec.rb
+++ b/spec/contracts/notifications/create_contract_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Notifications::CreateContract do
     end
   end
 
-  let(:notification_context) { build_stubbed(:project) }
   let(:notification_resource) { build_stubbed(:journal) }
   let(:notification_recipient) { build_stubbed(:user) }
   let(:notification_subject) { "Some text" }
@@ -46,8 +45,7 @@ RSpec.describe Notifications::CreateContract do
   let(:notification_mail_reminder_sent) { false }
 
   let(:notification) do
-    Notification.new(project: notification_context,
-                     recipient: notification_recipient,
+    Notification.new(recipient: notification_recipient,
                      subject: notification_subject,
                      reason: notification_reason,
                      resource: notification_resource,

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -6,11 +6,10 @@ FactoryBot.define do
     mail_alert_sent { false }
     reason { :mentioned }
     recipient factory: :user
-    project
-    resource { association :work_package, project: }
+    resource { association :work_package }
 
     trait :for_milestone do
-      resource { association :work_package, :is_milestone, project: }
+      resource { association :work_package, :is_milestone }
     end
     # journal and actor are not listed by intend.
     # They will be set in the after_build callback.

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Notification center navigation", :js, :with_cuprite do
   shared_let(:notification) do
     create(:notification,
            recipient:,
-           project:,
            resource: work_package,
            journal: work_package.journals.last)
   end
@@ -20,7 +19,6 @@ RSpec.describe "Notification center navigation", :js, :with_cuprite do
   shared_let(:second_notification) do
     create(:notification,
            recipient:,
-           project:,
            resource: second_work_package,
            journal: second_work_package.journals.last)
   end

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+require "features/page_objects/notification"
+
+RSpec.describe "Notification center date alert and mention",
+               :js,
+               :with_cuprite,
+               with_settings: { journal_aggregation_time_minutes: 0 } do
+  shared_let(:project) { create(:project) }
+  shared_let(:actor) { create(:user, firstname: "Actor", lastname: "User") }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: { project => %w[view_work_packages] })
+  end
+  shared_let(:work_package) { create(:work_package, project:, due_date: 1.day.ago) }
+
+  shared_let(:notification_mention) do
+    create(:notification,
+           reason: :mentioned,
+           recipient: user,
+           resource: work_package,
+           actor:)
+  end
+
+  shared_let(:notification_date_alert) do
+    create(:notification,
+           reason: :date_alert_due_date,
+           recipient: user,
+           resource: work_package)
+  end
+
+  let(:center) { Pages::Notifications::Center.new }
+
+  before do
+    login_as user
+    visit notifications_center_path
+    wait_for_reload
+  end
+
+  context "with date alerts ee", with_ee: %i[date_alerts] do
+    it "shows only the date alert time, not the mentioned author" do
+      center.within_item(notification_date_alert) do
+        expect(page).to have_text("Date alert, Mentioned")
+        expect(page).to have_no_text("Actor user")
+      end
+    end
+  end
+end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -90,16 +90,14 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
-           resource: milestone_wp_future,
-           project:)
+           resource: milestone_wp_future)
   end
 
   shared_let(:notification_wp_start_past) do
     create(:notification,
            reason: :date_alert_start_date,
            recipient: user,
-           resource: wp_start_past,
-           project:)
+           resource: wp_start_past)
   end
 
   # notification created by CreateDateAlertsNotificationsJob
@@ -121,30 +119,26 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
-           resource: wp_double_notification,
-           project:)
+           resource: wp_double_notification)
   end
 
   shared_let(:notification_wp_double_mention) do
     create(:notification,
            reason: :mentioned,
            recipient: user,
-           resource: wp_double_notification,
-           project:)
+           resource: wp_double_notification)
   end
 
   shared_let(:notification_wp_double_alerts) do
     due = create(:notification,
                  reason: :date_alert_due_date,
                  recipient: user,
-                 resource: wp_double_alert,
-                 project:)
+                 resource: wp_double_alert)
 
     start = create(:notification,
                    reason: :date_alert_start_date,
                    recipient: user,
-                   resource: wp_double_alert,
-                   project:)
+                   resource: wp_double_alert)
 
     [start, due]
   end
@@ -153,16 +147,14 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
-           resource: wp_unset_date,
-           project:)
+           resource: wp_unset_date)
   end
 
   shared_let(:notification_wp_due_today) do
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
-           resource: wp_due_today,
-           project:)
+           resource: wp_due_today)
   end
 
   let(:center) { Pages::Notifications::Center.new }

--- a/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_watched) do
     create(:notification,
            recipient:,
-           project:,
            resource: work_package,
            reason: :watched)
   end
@@ -36,7 +35,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_assigned) do
     create(:notification,
            recipient:,
-           project: project2,
            resource: work_package2,
            reason: :assigned)
   end
@@ -44,7 +42,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_responsible) do
     create(:notification,
            recipient:,
-           project: project3,
            resource: work_package3,
            reason: :responsible)
   end
@@ -52,7 +49,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_mentioned) do
     create(:notification,
            recipient:,
-           project: project3,
            resource: work_package4,
            reason: :mentioned)
   end
@@ -60,7 +56,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_date) do
     create(:notification,
            recipient:,
-           project: project3,
            resource: work_package5,
            reason: :date_alert_start_date)
   end
@@ -68,7 +63,6 @@ RSpec.describe "Notification center sidemenu",
   let(:notification_shared) do
     create(:notification,
            recipient:,
-           project: project3,
            resource: work_package6,
            reason: :shared)
   end

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -99,9 +99,10 @@ RSpec.describe "Notification center", :js, :with_cuprite,
       center.expect_bell_count 0
     end
 
-    context "with more the 100 notifications" do
+    context "with more than 100 notifications" do
       let(:notifications) do
-        attributes = { recipient:, project: project1, resource: work_package }
+        attributes = { recipient:, resource: work_package }
+
         create_list(:notification, 100, attributes.merge(reason: :mentioned)) +
         create_list(:notification, 105, attributes.merge(reason: :watched))
       end
@@ -192,7 +193,6 @@ RSpec.describe "Notification center", :js, :with_cuprite,
                reason: :commented,
                recipient:,
                resource: work_package3,
-               project: project1,
                actor: other_user,
                journal: work_package3.journals.reload.last,
                read_ian: true)
@@ -259,7 +259,6 @@ RSpec.describe "Notification center", :js, :with_cuprite,
                reason: :date_alert_start_date,
                recipient:,
                resource: starting_soon_work_package,
-               project: project1,
                read_ian: false)
       end
       let(:due_date_notification) do
@@ -267,7 +266,6 @@ RSpec.describe "Notification center", :js, :with_cuprite,
                reason: :date_alert_due_date,
                recipient:,
                resource: ending_soon_work_package,
-               project: project1,
                read_ian: false)
       end
       let(:overdue_date_notification) do
@@ -275,7 +273,6 @@ RSpec.describe "Notification center", :js, :with_cuprite,
                reason: :date_alert_due_date,
                recipient:,
                resource: overdue_milestone_work_package,
-               project: project1,
                read_ian: false)
       end
 
@@ -312,8 +309,7 @@ RSpec.describe "Notification center", :js, :with_cuprite,
         create(:notification,
                reason: :mentioned,
                recipient:,
-               resource: overdue_milestone_work_package,
-               project: project1)
+               resource: overdue_milestone_work_package)
 
         # We need to wait for the bell to poll for updates
         sleep 15

--- a/spec/features/notifications/notification_center/split_screen_spec.rb
+++ b/spec/features/notifications/notification_center/split_screen_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe "Split screen in the notification center", :js, :with_cuprite do
   shared_let(:notification) do
     create(:notification,
            recipient:,
-           project:,
            resource: work_package,
            journal: work_package.journals.last)
   end
@@ -24,7 +23,6 @@ RSpec.describe "Split screen in the notification center", :js, :with_cuprite do
   shared_let(:second_notification) do
     create(:notification,
            recipient:,
-           project:,
            resource: second_work_package,
            journal: second_work_package.journals.last)
   end

--- a/spec/features/work_packages/tabs/activity_notifications_spec.rb
+++ b/spec/features/work_packages/tabs/activity_notifications_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "Activity tab notifications", :js, :selenium do
     shared_let(:notification) do
       create(:notification,
              recipient: admin,
-             project:,
              resource: work_package,
              journal: work_package.journals.last)
     end

--- a/spec/lib/api/v3/notifications/notification_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_representer_rendering_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe API::V3::Notifications::NotificationRepresenter, "rendering" do
   let(:notification) do
     build_stubbed(:notification,
                   recipient:,
-                  project:,
                   resource:,
                   journal:,
                   actor:,

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe DigestMailer do
     [build_stubbed(:notification,
                    resource: work_package,
                    reason: :commented,
-                   journal:,
-                   project: project1)].tap do |notifications|
+                   journal:)].tap do |notifications|
       allow(Notification)
         .to receive(:where)
               .and_return(notifications)
@@ -144,8 +143,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_start_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -161,8 +159,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_start_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -178,8 +175,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -195,8 +191,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -213,8 +208,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -231,8 +225,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -246,8 +239,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -263,8 +255,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -280,8 +271,7 @@ RSpec.describe DigestMailer do
           create(:notification,
                  reason: :date_alert_due_date,
                  recipient:,
-                 resource: work_package,
-                 project: project1)
+                 resource: work_package)
         end
 
         it "matches generated text" do
@@ -296,7 +286,6 @@ RSpec.describe DigestMailer do
                  reason: :mentioned,
                  recipient:,
                  resource: work_package,
-                 project: project1,
                  journal: nil)
         end
 

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe Journal do
     let!(:notification) do
       create(:notification,
              journal:,
-             resource: work_package,
-             project: work_package.project)
+             resource: work_package)
     end
 
     it "has a notifications association" do

--- a/spec/models/notifications/scopes/visible_spec.rb
+++ b/spec/models/notifications/scopes/visible_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Notifications::Scopes::Visible do
 
     let(:notification) do
       create(:notification,
-             project:,
              resource: work_package,
              recipient: notification_recipient)
     end

--- a/spec/models/queries/notifications/notification_query_spec.rb
+++ b/spec/models/queries/notifications/notification_query_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Queries::Notifications::NotificationQuery do
   shared_let(:recipient) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
 
   shared_let(:work_package) { create(:work_package, project:) }
-  shared_let(:notification) { create(:notification, recipient:, project:, resource: work_package) }
+  shared_let(:notification) { create(:notification, recipient:, resource: work_package) }
 
   let(:instance) { described_class.new(user: recipient) }
   let(:base_scope) { Notification.visible(recipient).recipient(recipient) }
@@ -188,6 +188,9 @@ RSpec.describe Queries::Notifications::NotificationQuery do
     describe "#results" do
       it "is the same as handwriting the query" do
         expected = base_scope
+                     .joins("JOIN work_packages " \
+                            "ON notifications.resource_id = work_packages.id " \
+                            "AND notifications.resource_type = 'WorkPackage'")
                      .group(:project_id)
                      .order(project_id: :asc)
                      .select(:project_id, Arel.sql("COUNT(*)"))

--- a/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
 
   shared_let(:work_package) { create(:work_package, project:) }
 
-  shared_let(:notification1) { create(:notification, recipient:, project:, resource: work_package) }
-  shared_let(:notification2) { create(:notification, recipient:, project:, resource: work_package) }
-  shared_let(:notification3) { create(:notification, recipient:, project:, resource: work_package) }
+  shared_let(:notification1) { create(:notification, recipient:, resource: work_package) }
+  shared_let(:notification2) { create(:notification, recipient:, resource: work_package) }
+  shared_let(:notification3) { create(:notification, recipient:, resource: work_package) }
   shared_let(:other_user_notification) { create(:notification, recipient: other_recipient) }
 
   let(:filters) { nil }

--- a/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
@@ -38,19 +38,18 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
   shared_let(:recipient) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
   shared_let(:other_recipient) { create(:user) }
   shared_let(:notification1) do
-    create(:notification, recipient:, project:, resource: work_package, read_ian: true)
+    create(:notification, recipient:, resource: work_package, read_ian: true)
   end
   shared_let(:notification2) do
-    create(:notification, recipient:, project:, resource: work_package, read_ian: true)
+    create(:notification, recipient:, resource: work_package, read_ian: true)
   end
   shared_let(:notification3) do
-    create(:notification, recipient:, project:, resource: work_package, read_ian: true)
+    create(:notification, recipient:, resource: work_package, read_ian: true)
   end
   shared_let(:other_user_notification) do
     create(:notification,
            recipient: other_recipient,
            read_ian: true,
-           project:,
            resource: work_package)
   end
 

--- a/spec/requests/api/v3/notifications/details_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/details_resource_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
            member_with_permissions: { project => %i[view_work_packages] })
   end
 
-  let(:notification) { create(:notification, recipient:, resource:, project:, reason:) }
-  let(:milestone_notification) { create(:notification, recipient:, resource: milestone_resource, project:, reason:) }
+  let(:notification) { create(:notification, recipient:, resource:, reason:) }
+  let(:milestone_notification) { create(:notification, recipient:, resource: milestone_resource, reason:) }
   let(:reason) { :date_alert_start_date }
 
   # We have 1 detail item at maximum, and the id is coming

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -41,15 +41,13 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
     create(:notification,
            recipient:,
            resource: work_package,
-           project: work_package.project,
            journal: work_package.journals.first)
   end
   shared_let(:date_alert_notification) do
     create(:notification,
            recipient:,
            reason: :date_alert_start_date,
-           resource: work_package,
-           project: work_package.project)
+           resource: work_package)
   end
 
   let(:filters) { nil }
@@ -104,7 +102,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
       shared_let(:other_resource_notification) do
         create(:notification,
                recipient:,
-               project: work_package.project,
                resource: other_work_package)
       end
 
@@ -139,8 +136,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
       shared_let(:other_project_notification) do
         create(:notification,
                recipient:,
-               resource: other_work_package,
-               project: other_project)
+               resource: other_work_package)
       end
 
       let(:filters) do
@@ -165,7 +161,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
                reason: :assigned,
                recipient:,
                resource: work_package,
-               project: work_package.project,
                journal: work_package.journals.first)
       end
       shared_let(:responsible_notification) do
@@ -173,7 +168,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
                reason: :responsible,
                recipient:,
                resource: work_package,
-               project: work_package.project,
                journal: work_package.journals.first)
       end
 
@@ -245,7 +239,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
                read_ian: nil,
                recipient:,
                resource: wiki_page,
-               project: wiki_page.wiki.project,
                journal: wiki_page.journals.first)
       end
 
@@ -260,7 +253,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
                recipient:,
                reason: :responsible,
                resource: work_package,
-               project: work_package.project,
                journal: work_package.journals.first)
       end
 
@@ -268,8 +260,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
         create(:notification,
                recipient:,
                reason: :date_alert_due_date,
-               resource: work_package,
-               project: work_package.project)
+               resource: work_package)
       end
 
       let(:send_request) do
@@ -305,7 +296,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
       shared_let(:other_project_notification) do
         create(:notification,
                resource: work_package2,
-               project: other_project,
                recipient:,
                reason: :responsible,
                journal: work_package2.journals.first)

--- a/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
   shared_let(:notification) do
     create(:notification,
            recipient:,
-           resource: work_package,
-           project:)
+           resource: work_package)
   end
 
   let(:send_read) do

--- a/spec/requests/api/v3/notifications/show_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/show_resource_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe API::V3::Notifications::NotificationsAPI,
   shared_let(:notification) do
     create(:notification,
            recipient:,
-           project:,
            resource:,
            journal: resource.journals.last)
   end

--- a/spec/services/notifications/create_from_journal_job_shared.rb
+++ b/spec/services/notifications/create_from_journal_job_shared.rb
@@ -92,7 +92,6 @@ RSpec.shared_context "with CreateFromJournalJob context" do
       expect(notifications_service)
         .to have_received(:call)
               .with({ recipient_id: recipient.id,
-                      project:,
                       actor: sender,
                       journal:,
                       resource: }.merge(notification_channel_reasons))

--- a/spec/services/notifications/create_service_intergration_spec.rb
+++ b/spec/services/notifications/create_service_intergration_spec.rb
@@ -30,7 +30,6 @@ require "spec_helper"
 
 RSpec.describe Notifications::CreateService, "integration", type: :model do
   let(:work_package) { create(:work_package) }
-  let(:project) { work_package.project }
   let(:journal) { work_package.journals.first }
   let(:instance) { described_class.new(user: actor) }
   let(:attributes) { {} }
@@ -47,7 +46,6 @@ RSpec.describe Notifications::CreateService, "integration", type: :model do
     let(:attributes) do
       {
         recipient:,
-        project:,
         resource: work_package,
         journal:,
         actor:,

--- a/spec/services/notifications/set_attributes_service_spec.rb
+++ b/spec/services/notifications/set_attributes_service_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe Notifications::SetAttributesService, type: :model do
         reason:,
         resource: journable,
         journal:,
-        subject: event_subject,
-        project:
+        subject: event_subject
       }
     end
 
@@ -86,12 +85,11 @@ RSpec.describe Notifications::SetAttributesService, type: :model do
         .to be_success
       end
 
-      it "sets the attributes add adds default values" do
+      it "sets the attributes" do
         subject
 
         expect(event.attributes.compact.symbolize_keys)
           .to eql({
-                    project_id: project.id,
                     reason: "mentioned",
                     journal_id: journal.id,
                     recipient_id: 1,
@@ -126,7 +124,6 @@ RSpec.describe Notifications::SetAttributesService, type: :model do
 
           expect(event.attributes.compact.symbolize_keys)
             .to eql({
-                      project_id: project.id,
                       reason: "mentioned",
                       resource_id: journable.id,
                       resource_type: "WorkPackage",

--- a/spec/services/work_packages/delete_service_integration_spec.rb
+++ b/spec/services/work_packages/delete_service_integration_spec.rb
@@ -100,8 +100,7 @@ RSpec.describe WorkPackages::DeleteService, "integration", type: :model do
       create(:notification,
              recipient: user,
              actor: user,
-             resource: work_package,
-             project:)
+             resource: work_package)
     end
 
     let(:instance) do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57351

# What are you trying to accomplish?

The bug is caused by notifications having references to a deleted project. The project reference is not strictly necessary to have on notifications. It can be fetched from the resource (e.g. work package) that is notified on. 

# What approach did you choose and why?

The `project_id` column is removed from the `notifications` table. That way, the reference need not be maintained any more. It can still be fetched from the resource. That is done to keep the Notification representation intact, so no change to the API takes place.

This comes at the cost of more complicated queries particularly when sorting/grouping/filtering in the `NotificationQuery`. They for now have become way more WorkPackage specific. That query however was already work package specific given the way the visibility was checked.

The alternative would be to keep the `project` reference. In that case, whenever any resource is moved, the reference would have to be updated. That approach seems to be quite error prone, which is why it was discarded.

# Merge checklist

- [x] Added/updated tests
