### PR TITLE
[#57028] Fix Removal of a project leaves some js components  unusable

### DIFF
--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
@@ -32,7 +32,6 @@ See COPYRIGHT and LICENSE files for more details.
     model: @project_storage,
     url: admin_settings_storage_project_storage_path(id: @project_storage),
     data: {
-      turbo: true,
       controller: 'disable-when-checked',
       'disable-when-checked-reversed-value': true
     },


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57028

# What are you trying to accomplish?
Since this is a redirect and turbo would only replace the DOM contents, some JS events would not work after the contents were replaced. They rely on event handlers being registered and currently this only happens on full DOM load.
So we don't use turbo for this request any more to avoid this situation. There's already another work package to fix the behaviour of these elements, but that would be more work, so to be sure for now we're just using the "fast" solution here.

# Merge checklist

- [ ] Added/updated tests => not necessary
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) => not necessary
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...) => not necessary
