### PR TITLE
Implementation/57028 removal of a project leaves some angular components as not clickable

### DIFF
--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
@@ -29,7 +29,7 @@
 module Settings
   module ProjectCustomFields
     module ProjectCustomFieldMapping
-      class RowComponent < Projects::RowComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
+      class RowComponent < Projects::RowComponent
         include OpTurbo::Streamable
 
         def wrapper_uniq_by

--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
@@ -28,54 +28,68 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  primer_form_with(
-    model: @project_storage,
-    url: admin_settings_storage_project_storage_path(id: @project_storage),
-    data: {
-      controller: 'disable-when-checked',
-      'disable-when-checked-reversed-value': true
-    },
-    method: :delete
-  ) do |form|
-    render(Primer::Alpha::Dialog.new(
-      id: id,
-      title: nil,
-      test_selector: id,
-      size: :large
-    )) do |dialog|
-      dialog.with_body do
-        flex_layout do |layout|
-          layout.with_row(mb: 3) do
-            render(Primer::Beta::Heading.new(tag: :h1, text_align: :center)) do
-              render(Primer::Beta::Octicon.new(icon: :alert, color: :danger, size: :medium))
+  component_wrapper do
+    primer_form_with(
+      model: @project_storage,
+      url: admin_settings_storage_project_storage_path(id: @project_storage),
+      data: {
+        turbo: true,
+        controller: 'disable-when-checked',
+        'disable-when-checked-reversed-value': true
+      },
+      method: :delete
+    ) do |form|
+      render(Primer::Alpha::Dialog.new(
+        id: id,
+        title: nil,
+        test_selector: id,
+        size: :large
+      )) do |dialog|
+        dialog.with_body do
+          flex_layout do |layout|
+            layout.with_row(mb: 3) do
+              render(Primer::Beta::Heading.new(tag: :h1, text_align: :center)) do
+                render(Primer::Beta::Octicon.new(icon: :alert, color: :danger, size: :medium))
+              end
             end
-          end
-          layout.with_row(mb: 1) do
-            render(Primer::Beta::Heading.new(tag: :h2, color: :default, text_align: :center)) do
-              heading
+
+            layout.with_row(mb: 1) do
+              render(Primer::Beta::Heading.new(tag: :h2, color: :default, text_align: :center)) do
+                heading
+              end
             end
-          end
-          layout.with_row(mb: 2) do
-            render(Primer::Beta::Text.new(tag: :p, color: :subtle, text_align: :center)) do
-              text
+
+            layout.with_row(mb: 2) do
+              render(Primer::Beta::Text.new(tag: :p, color: :subtle, text_align: :center)) do
+                text
+              end
             end
-          end
-          layout.with_row do
-            render(Primer::Alpha::CheckBox.new(
-              name: "confirm_delete",
-              label: confirmation_text,
-              data: { 'disable-when-checked-target': 'cause' }
-            ))
+
+            layout.with_row do
+              render(Primer::Alpha::CheckBox.new(
+                name: "confirm_delete",
+                label: confirmation_text,
+                data: { 'disable-when-checked-target': 'cause' }
+              ))
+            end
           end
         end
-      end
-      dialog.with_footer do
-        component_collection do |footer|
-          footer.with_component(Primer::ButtonComponent.new(data: { 'close-dialog-id': id })) do
-            I18n.t("button_close")
-          end
-          footer.with_component(Primer::ButtonComponent.new(scheme: :danger, type: :submit, test_selector: "remove-project-storage-button", disabled: true, data: { 'disable-when-checked-target': 'effect' })) do
-            I18n.t("button_remove")
+
+        dialog.with_footer do
+          component_collection do |footer|
+            footer.with_component(Primer::ButtonComponent.new(data: { "close-dialog-id": id })) do
+              I18n.t("button_close")
+            end
+
+            footer.with_component(
+              Primer::ButtonComponent.new(scheme: :danger, type: :submit,
+                                          test_selector: "remove-project-storage-button",
+                                          disabled: true,
+                                          data: {
+                                            "disable-when-checked-target": "effect",
+                                            "close-dialog-id": id
+                                          })
+            ) { I18n.t("button_remove") }
           end
         end
       end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -371,6 +371,7 @@ RSpec.describe "Admin lists project mappings for a storage",
           end
         end
 
+        expect(page).to have_no_selector("dialog")
         expect(page).to have_text("Successful deletion.")
         expect(page).to have_no_text(project.name)
       end


### PR DESCRIPTION
https://community.openproject.org/work_packages/57028

This reverts commit https://github.com/opf/openproject/commit/f3a0db2f149dfef639e88aa4500421f49e2549b2.

Update the controller to respond with partial turbo streams instead of a full page redirect with turbo enabled. This caused DOM load issues with angular components, as Turbo would not break out of it's navigation frame- to remount the angular web components. The solution here is also used in other similar pages such as project attributes.


https://github.com/user-attachments/assets/e9585878-c1f6-4a04-a29b-207946f0c005

