### PR TITLE
[#57367] Disable edit for OneDrive/Sharepoint with AMPF enabled

### DIFF
--- a/modules/storages/app/components/storages/project_storages/projects/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/row_component.rb
@@ -40,24 +40,26 @@ module Storages::ProjectStorages::Projects
     def more_menu_items
       return [] unless can_view_more_menu_items?
 
-      @more_menu_items ||= [more_menu_edit_project_storage, more_menu_detach_project]
+      @more_menu_items ||= [more_menu_edit_project_storage, more_menu_detach_project].compact
     end
 
     private
 
     def more_menu_edit_project_storage
-      {
-        scheme: :default,
-        icon: :pencil,
-        label: I18n.t("project_storages.edit_project_folder.label"),
-        href: edit_admin_settings_storage_project_storage_path(
-          storage_id: project_storage.storage.id,
-          id: project_storage.id
-        ),
-        data: {
-          controller: "async-dialog"
+      if can_edit?
+        {
+          scheme: :default,
+          icon: :pencil,
+          label: I18n.t("project_storages.edit_project_folder.label"),
+          href: edit_admin_settings_storage_project_storage_path(
+            storage_id: project_storage.storage.id,
+            id: project_storage.id
+          ),
+          data: {
+            controller: "async-dialog"
+          }
         }
-      }
+      end
     end
 
     def more_menu_detach_project
@@ -76,6 +78,14 @@ module Storages::ProjectStorages::Projects
 
     def can_view_more_menu_items?
       User.current.admin && project.active?
+    end
+
+    def can_edit?
+      !one_drive_storage_ampf_enabled?
+    end
+
+    def one_drive_storage_ampf_enabled?
+      project_storage.storage.provider_type_one_drive? && project_storage.storage.automatic_management_enabled?
     end
 
     def project_storage

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -175,6 +175,13 @@ FactoryBot.define do
     end
   end
 
+  factory :one_drive_storage_configured, parent: :one_drive_storage do
+    after(:create) do |storage, _evaluator|
+      create(:oauth_client, integration: storage)
+      create(:oauth_application, integration: storage)
+    end
+  end
+
   factory :sharepoint_dev_drive_storage,
           parent: :one_drive_storage do
     automatically_managed { false }

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -319,6 +319,20 @@ RSpec.describe "Admin lists project mappings for a storage",
           end
         end
       end
+
+      context "with OneDrive/Sharepoint with AMPF enabled" do
+        let(:storage) { create(:one_drive_storage_configured, :as_automatically_managed) }
+        let(:project_storage) { create(:project_storage, storage:) }
+
+        it "does not show the edit option" do
+          project_storage
+
+          visit admin_settings_storage_project_storages_path(storage)
+          project_storages_index_page.activate_menu_of(project_storage.project) do
+            expect(page).to have_no_text("Edit project folder")
+          end
+        end
+      end
     end
 
     describe "Removal of a project from a storage" do


### PR DESCRIPTION
https://community.openproject.org/work_packages/57367

OneDrive/SharePoint storages that have AMPF activated do not have this option as the user can not change any settings. and the button should not be shown in that case.