### PR TITLE
[#57368] Remove "No Specific folder" as on option in OneDrive/Sharepoint AMPF storage

### DIFF
--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -59,7 +59,7 @@ module Storages
 
     def available_project_folder_modes
       if automatic_management_enabled?
-        ["inactive", "automatic"]
+        ["automatic"]
       else
         ["inactive", "manual"]
       end

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Storages::ProjectStorage do
       context "when the storage is a one drive storage" do
         let(:storage) { build_stubbed(:one_drive_storage, :as_automatically_managed) }
 
-        it "returns true for project_folder_mode inactive" do
+        it "returns false for project_folder_mode inactive" do
           expect(project_storage.project_folder_mode_possible?("inactive")).to be false
         end
 

--- a/modules/storages/spec/models/storages/project_storage_spec.rb
+++ b/modules/storages/spec/models/storages/project_storage_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Storages::ProjectStorage do
         let(:storage) { build_stubbed(:one_drive_storage, :as_automatically_managed) }
 
         it "returns true for project_folder_mode inactive" do
-          expect(project_storage.project_folder_mode_possible?("inactive")).to be true
+          expect(project_storage.project_folder_mode_possible?("inactive")).to be false
         end
 
         it "returns true for project_folder_mode automatic" do


### PR DESCRIPTION
https://community.openproject.org/work_packages/57368

There is no use case with a _OneDrive/SharePoint_ storage that has the **permission inheritance chain** broken to allow a storage with no specific folder. Because no one would have access to anything.

---

<img width="1779" alt="Screenshot 2024-08-21 at 3 48 01 PM" src="https://github.com/user-attachments/assets/1a07820b-3f1e-492e-a149-5e9766e7f9fb">

---

<img width="1113" alt="Screenshot 2024-08-21 at 3 50 18 PM" src="https://github.com/user-attachments/assets/305626b6-e911-4745-b1c4-1445d48bb86b">

