### PR TITLE
Fix copy project background color in dark mode

### DIFF
--- a/frontend/src/app/shared/components/forms/highlighted-input.sass
+++ b/frontend/src/app/shared/components/forms/highlighted-input.sass
@@ -7,7 +7,7 @@
   border-radius: 4px
 
   &_active
-    border: 1px solid #90cdf4
-    background: #ebf8ff
+    border: 1px solid var(--borderColor-accent-muted)
+    background-color: var(--bgColor-accent-muted)
   & .ng-select-container
     background-color: var(--body-background) !important

--- a/frontend/src/app/shared/components/option-list/option-list.sass
+++ b/frontend/src/app/shared/components/option-list/option-list.sass
@@ -18,8 +18,8 @@
       margin-bottom: 0.5rem
 
     &_selected
-      border: 1px solid #90cdf4
-      background: #ebf8ff
+      border: 1px solid var(--borderColor-accent-muted)
+      background-color: var(--bgColor-accent-muted)
 
     &_disabled
       color: #959595


### PR DESCRIPTION
# What are you trying to accomplish?

Fix the dark mode display in copy project screen.

## Screenshots

### Before this PR

#### Light mode

<img width="878" alt="image" src="https://github.com/user-attachments/assets/f141ff1f-8239-4df4-b8c1-9747f914e4c3">

#### Dark mode

<img width="899" alt="image" src="https://github.com/user-attachments/assets/cec479d6-9df5-4aaa-8d77-d1768666fe57">

### After apply this PR

#### Light mode

<img width="898" alt="image" src="https://github.com/user-attachments/assets/666156d7-e5bb-42b0-8cc1-ed8a2f81481c">

#### Dark mode

<img width="910" alt="image" src="https://github.com/user-attachments/assets/f62b0593-1280-4122-a96b-761297fa2277">

# What approach did you choose and why?

Using [primer design system color](https://primer.style/foundations/color/overview#muted).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Safari 17.6 and Chrome 128)
