### PR TITLE
[56918] Counter in files tab of new split screen is not updated correctly

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
@@ -31,7 +31,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnInit,
   Output,
 } from '@angular/core';
 import { IAttachment } from 'core-app/core/state/attachments/attachment.model';
@@ -43,7 +42,7 @@ import { AttachmentsResourceService } from 'core-app/core/state/attachments/atta
   templateUrl: './attachment-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OpAttachmentListComponent extends UntilDestroyedMixin implements OnInit {
+export class OpAttachmentListComponent extends UntilDestroyedMixin {
   @Input() public attachments:IAttachment[] = [];
 
   @Input() public collectionKey:string;
@@ -58,11 +57,9 @@ export class OpAttachmentListComponent extends UntilDestroyedMixin implements On
     super();
   }
 
-  ngOnInit():void {
-  }
-
   public removeAttachment(attachment:IAttachment):void {
-    this.attachmentsResourceService.removeAttachment(this.collectionKey, attachment).subscribe();
-    this.attachmentRemoved.emit();
+    this.attachmentsResourceService.removeAttachment(this.collectionKey, attachment).subscribe(() => {
+      this.attachmentRemoved.emit();
+    });
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/56918#activity-15

# What are you trying to accomplish?
On production, the files counter was not correctly updated when an attachment was deleted. I assume that this happened because the event was fired too early and thus the counter was updated before the attachment actually got deleted.
This PR delays the event to when the attachment is really deleted.

