### PR TITLE
Fix meeting participant counter

### DIFF
--- a/modules/meeting/app/components/meetings/side_panel/attachments_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/attachments_component.html.erb
@@ -3,7 +3,7 @@
     render(Primer::OpenProject::SidePanel::Section.new) do |section|
       section.with_title { t(:label_attachment_plural) }
       section.with_description { I18n.t('meeting.attachments.text') }
-      section.with_counter { @meeting.attachments.count }
+      section.with_counter(count: @meeting.attachments.count)
 
       section.with_footer_button(
         id: "meetings-add-attachments",

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
@@ -3,7 +3,7 @@
     render(Primer::OpenProject::SidePanel::Section.new) do |section|
       section.with_title { Meeting.human_attribute_name(:participants) }
       section.with_description { I18n.t('meeting.attachments.text') }
-      section.with_counter { @meeting.invited_or_attended_participants.count }
+      section.with_counter(count: @meeting.invited_or_attended_participants.count)
 
       if @meeting.editable?
         section.with_action_icon(

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
@@ -81,5 +81,7 @@ RSpec.describe "Structured meetings participants",
       check(id: "checkbox_invited_#{other_user.id}")
       click_on("Save")
     end
+
+    expect(page).to have_css("#meetings-side-panel-participants-component", text: 2)
   end
 end


### PR DESCRIPTION
When introducing the side panel in meetings, we missed the correct syntax for `with_counter`. Note that for attachments, uploading does not change the counter until a reload