### PR TITLE
[57399] Label name is showing when meeting has no participants

### DIFF
--- a/app/components/op_primer/expandable_list_component.html.erb
+++ b/app/components/op_primer/expandable_list_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper(data: wrapper_data_attributes) do
     if elements.count == 0
-      render(Primer::Beta::Text.new(color: :subtle)) { t("label_meeting_no_items") }
+      render(Primer::Beta::Text.new(color: :subtle)) { t("label_meeting_no_participants") }
     elsif elements.count <= @cutoff_limit
       flex_layout do |list|
         elements.each do |item|


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57399/activity



# What are you trying to accomplish?
Use correct translation key
