### PR TITLE
[57391] New split screen: fixed width breaks layout when resizing the screen

### DIFF
--- a/app/components/work_packages/split_view_component.html.erb
+++ b/app/components/work_packages/split_view_component.html.erb
@@ -19,7 +19,6 @@
                                         inputs: {
                                           work_package_id: params[:work_package_id] || @work_package.id,
                                           resizerClass: "op-work-package-split-view",
-                                          resizeStyle: "width",
                                           activeTab: @tab
                                         }
         end

--- a/app/components/work_packages/split_view_component.sass
+++ b/app/components/work_packages/split_view_component.sass
@@ -1,6 +1,6 @@
 .op-work-package-split-view
   height: 100%
-  width: 550px
+  min-width: 550px
   justify-content: space-around
   border-left: 1px solid var(--borderColor-muted)
 

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.html
@@ -90,6 +90,7 @@
        class="work-packages--tabletimeline--timeline--resizer hidden-for-mobile hide-when-print">
     <wp-resizer [elementClass]="'work-packages-tabletimeline--timeline-side'"
                 [resizeEvent]="'wp-resize.timeline'"
+                [variableName]="'--gantt-split-width'"
                 [localStorageKey]="'openProject-timelineFlexBasis'"></wp-resizer>
   </div>
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -81,6 +81,7 @@
 
       <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
         <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
+                    [variableName]="'--full-view-split-right-width'"
                     [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
       </div>
     </div>

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
@@ -43,7 +43,6 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
       [workPackageId]="workPackageId"
       [activeTab]="activeTab"
       [showTabs]="false"
-      [resizeStyle]="resizeStyle"
       [resizerClass]="resizerClass"
     ></op-wp-split-view>
   `,
@@ -53,7 +52,6 @@ export class WorkPackageSplitViewEntryComponent {
   @Input() workPackageId:string;
   @Input() activeTab:string;
   @Input() resizerClass:string;
-  @Input() resizeStyle:string;
 
   constructor(readonly elementRef:ElementRef) {
     populateInputsFromDataset(this);

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -76,7 +76,6 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
   @Input() activeTab?:string;
 
   @Input() resizerClass = 'work-packages-partitioned-page--content-right';
-  @Input() resizeStyle:'flexBasis'|'width' = 'flexBasis';
 
   constructor(
     public injector:Injector,

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
@@ -69,7 +69,6 @@
 
   <div class="work-packages--details--resizer hidden-for-mobile hide-when-print">
     <wp-resizer [elementClass]="resizerClass"
-                [resizeStyle]="resizeStyle"
                 [localStorageKey]="'openProject-splitViewFlexBasis'"></wp-resizer>
   </div>
 </div>

--- a/frontend/src/app/shared/components/resizer/resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer.component.ts
@@ -137,7 +137,6 @@ export class ResizerComponent implements OnDestroy {
   }
 
   private onMouseMove(event:MouseEvent|TouchEvent) {
-    event.preventDefault();
     event.stopPropagation();
 
     this.oldX = this.newX;

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -55,6 +55,8 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   @Input() localStorageKey:string;
 
+  @Input() variableName:string = "--split-screen-width";
+
   private resizingElement:HTMLElement;
 
   private elementWidth:number;
@@ -220,6 +222,6 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
   }
 
   private setWidthVariable(value:number):void {
-    document.documentElement.style.setProperty("--split-screen-width", `${value}px`);
+    document.documentElement.style.setProperty(this.variableName, `${value}px`);
   }
 }

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -29,7 +29,6 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { TransitionService } from '@uirouter/core';
-import { BrowserDetector } from 'core-app/core/browser/browser-detector.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ResizeDelta } from 'core-app/shared/components/resizer/resizer.component';
 import { fromEvent } from 'rxjs';
@@ -56,8 +55,6 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   @Input() localStorageKey:string;
 
-  @Input() resizeStyle:'flexBasis'|'width' = 'flexBasis';
-
   private resizingElement:HTMLElement;
 
   private elementWidth:number;
@@ -67,7 +64,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
   private resizer:HTMLElement;
 
   // Min-width this element is allowed to have
-  private elementMinWidth = 530;
+  private elementMinWidth = 550;
 
   public moving = false;
 
@@ -77,7 +74,6 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     readonly toggleService:MainMenuToggleService,
     private elementRef:ElementRef,
     readonly $transitions:TransitionService,
-    readonly browserDetector:BrowserDetector,
   ) {
     super();
   }
@@ -88,7 +84,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     // to still work in case an element is duplicated by Angular.
     const elements = document.getElementsByClassName(this.elementClass);
     this.resizingElement = <HTMLElement>elements[elements.length - 1];
-    
+
     if (!this.resizingElement) {
       return;
     }
@@ -106,7 +102,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
       this.elementWidth = this.resizingElement.parentElement.offsetWidth / 2;
     }
 
-    this.resizingElement.style[this.resizeStyle] = `${this.elementWidth}px`;
+    this.setWidthVariable(this.elementWidth);
 
     // Add event listener
     this.element = this.elementRef.nativeElement;
@@ -142,7 +138,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     super.ngOnDestroy();
     // Reset the style when killing this directive, otherwise the style remains
     if (this.resizingElement) {
-      this.resizingElement.style[this.resizeStyle] = '';
+      this.setWidthVariable(this.elementMinWidth);
     }
   }
 
@@ -193,7 +189,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     this.applyColumnLayout();
 
     // Set new width
-    this.resizingElement.style[this.resizeStyle] = `${newValue}px`;
+    this.setWidthVariable(newValue);
   }
 
   private parseLocalStorageValue():number|undefined {
@@ -221,5 +217,9 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     if (!shouldBePresent && this.resizer.classList.contains('-error-font')) {
       this.resizer.classList.remove('-error-font');
     }
+  }
+
+  private setWidthVariable(value:number):void {
+    document.documentElement.style.setProperty("--split-screen-width", `${value}px`);
   }
 }

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -55,7 +55,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   @Input() localStorageKey:string;
 
-  @Input() variableName:string = "--split-screen-width";
+  @Input() variableName:string = '--split-screen-width';
 
   private resizingElement:HTMLElement;
 

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -88,9 +88,11 @@ $right-space: 16px
 $bottom-space: 10px
 $left-space: 16px
 
+$left-side-min-width: 300px
+
 #content
   display: grid
-  grid-template-columns: 1fr auto
+  grid-template-columns: minmax($left-side-min-width, 1fr) auto
   grid-template-rows: auto 1fr
   grid-template-areas: "header bodyRight" "body bodyRight"
   padding: 0
@@ -101,6 +103,11 @@ $left-space: 16px
   @include styled-scroll-bar
   z-index: 10
   background-color: var(--body-background)
+
+  // Basically if the content-BodyRight is filled:
+  // Apply the user-defined split screen width but be able to shrink in case the screen is not wide enough
+  &:has(#content-bodyRight > *)
+    grid-template-columns: minmax($left-side-min-width, 1fr) minmax(550px, var(--split-screen-width))
 
   &.content--split
     overflow: hidden

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -39,7 +39,7 @@ body.router--work-packages-partitioned-split-view-new
     padding: 0
 
     // Will eventually be overridden by the resizer
-    flex-basis: 580px
+    flex-basis: var(--split-screen-width)
 
 .work-packages--details
   height: 100%

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -69,7 +69,8 @@
             line-height: calc(30px)
 
   &--split-right
-    min-width: 530px
+    flex-basis: var(--full-view-split-right-width)
+    min-width: 550px
     overflow-y: hidden
     overflow-x: auto
     position: relative

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -125,7 +125,7 @@ body[class*="router--"]
 // TIMELINE half of the tabletimeline flexbox
 .work-packages-tabletimeline--timeline-side
   border-left: 3px solid var(--borderColor-default)
-  flex-basis: 50%
+  flex-basis: var(--gantt-split-width)
   // Show the horizontal scrollbar _always_ (same as table)
   overflow-x: scroll
   // Show the vertical scrollbar when necessary

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -132,4 +132,6 @@
   --type-form-conf-attribute--background: var(--gray-light);
   --select-arrow-bg-color-url: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
   --split-screen-width: 550px;
+  --full-view-split-right-width: 550px;
+  --gantt-split-width: 50%;
 }

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -131,4 +131,5 @@
   --link-text-decoration: none;
   --type-form-conf-attribute--background: var(--gray-light);
   --select-arrow-bg-color-url: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
+  --split-screen-width: 550px;
 }

--- a/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
+++ b/modules/gantt/spec/features/timeline/timeline_dates_spec.rb
@@ -229,25 +229,25 @@ RSpec.describe "Work package timeline date formatting",
 
       it "displays the hover bar correctly" do
         # Expect no hover bar when hovering over a non working day
-        row.hover_bar(offset_days: -1)
+        row.hover_bar(offset_days: -2)
         row.expect_no_hovered_bar
 
         # Expect timeline bar when clicking on a non working day
-        row.click_bar(offset_days: -1)
+        row.click_bar(offset_days: -2)
         row.expect_no_bar
 
         # Expect hovered bar size to equal duration
-        row.hover_bar
+        row.hover_bar(offset_days: -1)
         row.expect_hovered_bar(duration: work_package_with_non_working_days.duration)
 
         # Expect hovered bar size to equal duration + non working days
         # when the hovered bar passes through non working days
-        row.hover_bar(offset_days: 1)
+        row.hover_bar(offset_days: 0)
         row.expect_hovered_bar(duration: work_package_with_non_working_days.duration + 2)
       end
 
       describe "set the start, due date while preserving duration" do
-        subject { row.click_bar }
+        subject { row.click_bar(offset_days: -1) }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }
@@ -260,7 +260,7 @@ RSpec.describe "Work package timeline date formatting",
       end
 
       describe "set the start, due date while preserving duration over the weekend" do
-        subject { row.click_bar(offset_days: 1) }
+        subject { row.click_bar }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }
@@ -273,7 +273,7 @@ RSpec.describe "Work package timeline date formatting",
       end
 
       describe "sets the start, due dates while preserving duration on a drag and drop create" do
-        subject { row.drag_and_drop(days: 5) }
+        subject { row.drag_and_drop(offset_days: -1, days: 5) }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }
@@ -286,7 +286,7 @@ RSpec.describe "Work package timeline date formatting",
       end
 
       describe "sets the start, due dates while preserving duration on a drag and drop create over the weekend" do
-        subject { row.drag_and_drop(offset_days: 1, days: 7) }
+        subject { row.drag_and_drop(days: 7) }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }
@@ -299,7 +299,7 @@ RSpec.describe "Work package timeline date formatting",
       end
 
       describe "sets the start, due dates and duration on a drag and drop create over the weekend" do
-        subject { row.drag_and_drop(offset_days: 1, days: 8) }
+        subject { row.drag_and_drop(days: 8) }
 
         it_behaves_like "sets dates, duration and displays bar" do
           let(:target_wp) { work_package_with_non_working_days }
@@ -313,13 +313,13 @@ RSpec.describe "Work package timeline date formatting",
 
       it "cancels when the drag starts or finishes on a weekend" do
         # Finish on the weekend
-        row.drag_and_drop(offset_days: 1, days: 5)
+        row.drag_and_drop(days: 5)
 
         row.expect_no_bar
         expect { work_package_with_non_working_days.reload }.not_to change { work_package_with_non_working_days }
 
         # Start on the weekend
-        row.drag_and_drop(offset_days: -1, days: 5)
+        row.drag_and_drop(offset_days: -2, days: 5)
 
         row.expect_no_bar
         expect { work_package_with_non_working_days.reload }.not_to change { work_package_with_non_working_days }
@@ -329,7 +329,7 @@ RSpec.describe "Work package timeline date formatting",
         let(:row) { wp_timeline.timeline_row work_package_without_non_working_days.id }
 
         describe "sets the start, due dates and duration on a drag and drop create over the weekend" do
-          subject { row.drag_and_drop(offset_days: 1, days: 8) }
+          subject { row.drag_and_drop(days: 8) }
 
           it_behaves_like "sets dates, duration and displays bar" do
             let(:target_wp) { work_package_without_non_working_days }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57391/activity

# What are you trying to accomplish?
The new split screen in the notification center should be resizable and respect the user defined width. There is however, an edge case in which the user defined width is larger than the availble space on the screen (e.g because the left-side menu was increased). In that cases, the split screen should shrink.

# What approach did you choose and why?
Instead of setting inline styles via JS, the resizer now simply changes a CSS variable. Thus we get rid of that ugly pattern of passing the expected style through to the component. We can now handle CSS in the actual CSS files (where it belongs). Further, we now gain more flexibility in the CSS and can for example define a flexible Grid for the new split screen.

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
