### PR TITLE
[57282] OpenProject Dark Mode: reiterate hover/active button colour

### DIFF
--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -92,7 +92,7 @@ a.button
   &.-active
     @include button-style(var(--button-default-bgColor-active), var(--button-default-bgColor-active), var(--button-default-fgColor-rest))
     border-color: var(--button--active-border-color)
-    box-shadow: 0 0 3px var(--button--active-border-color) inset
+    box-shadow: 0 0 3px 1px var(--bgColor-neutral-muted) inset
 
 
   &.-transparent


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57282/activity

# What are you trying to accomplish?
Use stronger contrasting color for the "active" shadow effect of buttons. The color is not ideal, but the best I found of the avaible variables.

## Screenshots
**Before**
<img width="265" alt="Bildschirmfoto 2024-08-26 um 13 48 22" src="https://github.com/user-attachments/assets/ea9cc59e-13a0-4ef8-a21e-c140e76fa6b0">
<img width="269" alt="Bildschirmfoto 2024-08-26 um 13 48 41" src="https://github.com/user-attachments/assets/02831d2d-1b0e-4b72-9578-452688c361f6">

**After**
<img width="250" alt="Bildschirmfoto 2024-08-26 um 13 45 37" src="https://github.com/user-attachments/assets/28ee79cc-62fb-49b6-8532-af1bdbfa49c6">

<img width="250" alt="Bildschirmfoto 2024-08-26 um 13 27 45" src="https://github.com/user-attachments/assets/4e31adab-7868-4507-8062-0ccd434f44bd">


