### PR TITLE
Copy project page not support turbo navigate yet.

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -342,7 +342,8 @@ module Projects
           scheme: :default,
           icon: :copy,
           label: I18n.t(:button_copy),
-          href: copy_project_path(project)
+          href: copy_project_path(project),
+          data: { turbo: false }
         }
       end
     end

--- a/app/views/projects/_toolbar.html.erb
+++ b/app/views/projects/_toolbar.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
   </li>
   <% if @project.copy_allowed? %>
     <li class="toolbar-item hidden-for-tablet">
-      <%= link_to copy_project_path(@project), class: 'button copy', accesskey: accesskey(:copy) do %>
+      <%= link_to copy_project_path(@project), class: 'button copy', accesskey: accesskey(:copy), data: { turbo: false } do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= t(:button_copy) %></span>
       <% end %>


### PR DESCRIPTION
## Screenshots

### Before (page content not fully loaded)

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/d5c22009-a9f0-492e-a1cd-f65b5558372b">

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/55b1dc11-9316-4b58-9cb1-1c150bb984c0">

### After (page content loaded)

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/82ebde3c-8e82-4965-a808-44ba71733710">


### After

# What approach did you choose and why?

Because fix the copy project page is hard for me, so just let copy project page refresh.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Safari)
