### PR TITLE
[#57286] refactored nextcloud command for set_permission

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/set_permissions.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/set_permissions.rb
@@ -33,7 +33,8 @@ module Storages
     module StorageInteraction
       module Inputs
         # user_permissions - A list of user specific file permissions.
-        # IMPORTANT: the user ids are considered to be the ids of the remote identities.
+        # IMPORTANT: the user ids are considered to be the ids of the remote identities. If user permissions should be
+        # set via a group, a `group_id` must be provided instead of a `user_id`.
         #   Example:
         #     [
         #       {user_id: "d6e00f6d-1ae7-43e6-b0af-15d99a56d4ce", permissions: [ :read_files,
@@ -41,7 +42,8 @@ module Storages
         #                                                                        :create_files,
         #                                                                        :delete_files,
         #                                                                        :share_files ]},
-        #       {user_id: "f6e00f6d-1ae7-43e6-b0af-15d99a56d4ce", permissions: [:read_files, :write_files]}
+        #       {user_id: "f6e00f6d-1ae7-43e6-b0af-15d99a56d4ce", permissions: [:read_files, :write_files]},
+        #       {group_id: "fee9cd49-17e2-4430-9235-2060e7372568", permissions: [:read_files]},
         #     ]
         SetPermissions = Data.define(:file_id, :user_permissions) do
           private_class_method :new

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/set_permissions_contract.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/set_permissions_contract.rb
@@ -36,9 +36,18 @@ module Storages
           params do
             required(:file_id).filled(:string)
             required(:user_permissions).array(:hash) do
-              required(:user_id).filled(:string)
-              required(:permissions).array(:symbol, included_in?: OpenProject::Storages::Engine.permissions)
+              optional(:user_id).filled(:string)
+              optional(:group_id).filled(:string)
+              required(:permissions)
+                .array(:symbol, included_in?: OpenProject::Storages::Engine.external_file_permissions)
             end
+          end
+
+          rule(:user_permissions).each do
+            both = value.key?(:user_id) && value.key?(:group_id)
+            none = !value.key?(:user_id) && !value.key?(:group_id)
+
+            key.failure("must have either user_id or group_id") if both || none
           end
         end
       end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/internal/propfind_query.rb
@@ -44,8 +44,7 @@ module Storages
             #   d:getcontenttype
             #   d:resourcetype
             #   d:getcontentlength
-            #   d:permissions
-            #   d:size
+            #   oc:permissions
             #   oc:id
             #   oc:fileid
             #   oc:favorite
@@ -62,6 +61,10 @@ module Storages
             #   nc:contained-folder-count
             #   nc:contained-file-count
             #   nc:acl-list
+            #   nc:inherited-acl-list
+            #   nc:group-folder-id
+            #   nc:acl-enabled
+            #   nc:acl-can-manage
             # ].freeze
 
             def self.call(storage:, http:, username:, path:, props:)

--- a/modules/storages/app/services/storages/nextcloud_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/nextcloud_managed_folder_sync_service.rb
@@ -136,7 +136,9 @@ module Storages
         { user_id: identity.origin_user_id, permissions: }
       end
 
-      permissions = system_user + admin_permissions + users_permissions
+      group_permissions = [{ group_id: @storage.group, permissions: [] }]
+
+      permissions = system_user + admin_permissions + users_permissions + group_permissions
       project_folder_id = project_storage.project_folder_id
 
       build_set_permissions_input_data(project_folder_id, permissions)
@@ -156,7 +158,7 @@ module Storages
     def project_remote_identities(project_storage)
       remote_identities = remote_identities_scope.where.not(id: admin_remote_identities_scope).order(:id)
 
-      if project_storage.project.public? && ProjectRole.non_member.permissions.intersect?(PERMISSIONS_KEYS)
+      if project_storage.project.public? && ProjectRole.non_member.permissions.intersect?(FILE_PERMISSIONS)
         remote_identities
       else
         remote_identities.where(user: project_storage.project.users)

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -38,8 +38,8 @@ Dry::Validation.load_extensions(:monads)
 
 module OpenProject::Storages
   class Engine < ::Rails::Engine
-    def self.permissions
-      @permissions ||= Storages::NextcloudManagedFolderSyncService::PERMISSIONS_KEYS
+    def self.external_file_permissions
+      %i[read_files write_files create_files delete_files share_files].freeze
     end
 
     # engine name is used as a default prefix for module tables when generating
@@ -90,7 +90,7 @@ module OpenProject::Storages
         OpenProject::Notifications.subscribe(
           OpenProject::Events::ROLE_UPDATED
         ) do |payload|
-          if payload[:permissions_diff]&.intersect?(OpenProject::Storages::Engine.permissions)
+          if payload[:permissions_diff]&.intersect?(OpenProject::Storages::Engine.external_file_permissions)
             ::Storages::ManageStorageIntegrationsJob.debounce
           end
         end
@@ -98,7 +98,7 @@ module OpenProject::Storages
         OpenProject::Notifications.subscribe(
           OpenProject::Events::ROLE_DESTROYED
         ) do |payload|
-          if payload[:permissions]&.intersect?(OpenProject::Storages::Engine.permissions)
+          if payload[:permissions]&.intersect?(OpenProject::Storages::Engine.external_file_permissions)
             ::Storages::ManageStorageIntegrationsJob.debounce
           end
         end
@@ -166,7 +166,7 @@ module OpenProject::Storages
                      "storages/project_settings/project_storage_members": %i[index] },
                    permissible_on: :project,
                    dependencies: %i[]
-        OpenProject::Storages::Engine.permissions.each do |p|
+        OpenProject::Storages::Engine.external_file_permissions.each do |p|
           permission(p, {}, permissible_on: :project, dependencies: %i[])
         end
       end
@@ -219,10 +219,10 @@ module OpenProject::Storages
           prj.project_storages.each do |prj_storage|
             storage = prj_storage.storage
             hide_from_menu = !storage.configured? ||
-                             # the following check is required for ensure access modal final check being possible
-                             # the modal waiting for read_files permission on the project folder
-                             # otherwise polls backend until eternity
-                             (prj_storage.project_folder_automatic? && !u.allowed_in_project?(:read_files, prj))
+              # the following check is required for ensure access modal final check being possible
+              # the modal waiting for read_files permission on the project folder
+              # otherwise polls backend until eternity
+              (prj_storage.project_folder_automatic? && !u.allowed_in_project?(:read_files, prj))
             next if hide_from_menu
 
             icon = storage.provider_type_nextcloud? ? "op-mark-nextcloud" : "file-directory"

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/inputs/set_permissions_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/inputs/set_permissions_spec.rb
@@ -43,9 +43,14 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Inputs::SetPermissions
       expect(described_class.build(file_id: "1337", user_permissions: [])).to be_success
       expect(described_class.build(file_id: "1337",
                                    user_permissions: [{ user_id: "dart_vader", permissions: [] }])).to be_success
-      expect(described_class.build(file_id: "1337",
-                                   user_permissions: [{ user_id: "dart_vader",
-                                                        permissions: [:read_files] }])).to be_success
+      expect(described_class
+               .build(
+                 file_id: "1337",
+                 user_permissions: [
+                   { user_id: "dart_vader", permissions: %i[read_files write_files delete_files] },
+                   { group_id: "stormtroopers", permissions: [:read_files] }
+                 ]
+               )).to be_success
     end
 
     it "creates a failure result for invalid input data" do
@@ -60,6 +65,13 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Inputs::SetPermissions
                                    user_permissions: [{ user_id: "rey", permissions: [:read] }])).to be_failure
       expect(described_class.build(file_id: "1337",
                                    user_permissions: [{ user_id: "rey", permissions: {} }])).to be_failure
+
+      expect(described_class.build(file_id: "1337", user_permissions: [{ permissions: [:read_files] }])).to be_failure
+      expect(described_class
+               .build(
+                 file_id: "1337",
+                 user_permissions: [{ user_id: "rey", group_id: "jedi", permissions: [:read_files] }]
+               )).to be_failure
     end
   end
 end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command_spec.rb
@@ -33,7 +33,7 @@ require_module_spec_helper
 
 RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::SetPermissionsCommand, :webmock do
   let(:user) { create(:user) }
-  let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed) }
+  let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed, username: "vcr") }
   let(:auth_strategy) { Storages::Peripherals::Registry.resolve("nextcloud.authentication.userless").call }
 
   let(:test_folder) do

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/set_permissions_command_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::SetPermissionsCommand, :webmock do
+  let(:user) { create(:user) }
+  let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed) }
+  let(:auth_strategy) { Storages::Peripherals::Registry.resolve("nextcloud.authentication.userless").call }
+
+  let(:test_folder) do
+    Storages::Peripherals::Registry
+      .resolve("nextcloud.commands.create_folder")
+      .call(storage:,
+            auth_strategy:,
+            folder_name: "Permission Test Folder",
+            parent_location: Storages::Peripherals::ParentFolder.new("/VCR"))
+      .result
+  end
+
+  it_behaves_like "set_permissions_command: basic command setup"
+
+  context "if folder does not exists", vcr: "nextcloud/set_permissions_not_found_folder" do
+    let(:error_source) { Storages::Peripherals::StorageInteraction::Nextcloud::FileInfoQuery }
+    let(:input_data) { permission_input_data("1337", []) }
+
+    it_behaves_like "set_permissions_command: not found"
+  end
+
+  context "if no permissions exist", vcr: "nextcloud/set_permissions_new" do
+    let(:user_permissions) do
+      [
+        { user_id: "m.jade@death.star", permissions: %i[read_files write_files] },
+        { user_id: "admin", permissions: %i[read_files write_files create_files delete_files] }
+      ]
+    end
+
+    it_behaves_like "set_permissions_command: creates new permissions"
+  end
+
+  context "if a permission set already exist", vcr: "nextcloud/set_permissions_replacing_permissions" do
+    let(:previous_permissions) do
+      [{ user_id: "admin", permissions: %i[read_files write_files create_files delete_files] }]
+    end
+    let(:replacing_permissions) do
+      [{ user_id: "m.jade@death.star", permissions: %i[read_files write_files] }]
+    end
+
+    it_behaves_like "set_permissions_command: replaces already set permissions"
+  end
+
+  context "if a user does not exist",
+          skip: "When setting permissions for a user that does not exists, nextcloud's response doesn't contain the" \
+                "needed information. We need to work around this by maybe having a separate request fetching ACLs " \
+                "after setting them.",
+          vcr: "nextcloud/set_permissions_invalid_user_id" do
+    let(:user_permissions) do
+      [{ user_id: "luke_the_sky", permissions: %i[read_files write_files create_files delete_files share_files] }]
+    end
+
+    it_behaves_like "set_permissions_command: unknown remote identity"
+  end
+
+  private
+
+  def permission_input_data(file_id, user_permissions)
+    Storages::Peripherals::StorageInteraction::Inputs::SetPermissions.build(file_id:, user_permissions:).value!
+  end
+
+  def current_remote_permissions
+    Storages::Peripherals::StorageInteraction::Authentication[auth_strategy].call(storage:) do |http|
+      request_url = Storages::UrlBuilder.url(storage.uri,
+                                             "remote.php/dav/files",
+                                             storage.username,
+                                             test_folder.location)
+      response = http.request(:propfind, request_url, xml: permission_request_body)
+      parse_acl_xml response.body.to_s
+    end
+  end
+
+  def permission_request_body
+    Nokogiri::XML::Builder.new do |xml|
+      xml["d"].propfind(
+        "xmlns:d" => "DAV:",
+        "xmlns:nc" => "http://nextcloud.org/ns"
+      ) do
+        xml["d"].prop do
+          xml["nc"].send(:"acl-list")
+        end
+      end
+    end.to_xml
+  end
+
+  def parse_acl_xml(xml)
+    found_code = "d:status[text() = 'HTTP/1.1 200 OK']"
+    not_found_code = "d:status[text() = 'HTTP/1.1 404 Not Found']"
+    happy_path = "/d:multistatus/d:response/d:propstat[#{found_code}]/d:prop/nc:acl-list"
+    not_found_path = "/d:multistatus/d:response/d:propstat[#{not_found_code}]/d:prop"
+
+    if Nokogiri::XML(xml).xpath(not_found_path).children.map(&:name).include?("acl-list")
+      []
+    else
+      Nokogiri::XML(xml).xpath(happy_path).children.map do |acl|
+        acl.children.each_with_object({ user_id: "", permissions: [] }) do |entry, agg|
+          agg[:user_id] = entry.text if entry.name == "acl-mapping-id"
+          agg[:permissions] = translate_mask_to_permissions(entry.text.to_i) if entry.name == "acl-permissions"
+        end
+      end
+    end
+  end
+
+  def translate_mask_to_permissions(number)
+    described_class::PERMISSIONS_MAP.each_with_object([]) do |(permission, mask), list|
+      list << permission if number & mask == mask
+    end
+  end
+
+  # TODO: Delete folder for nextcloud still works on a location, not a file id.
+  def clean_up(_file_id)
+    Storages::Peripherals::Registry
+      .resolve("nextcloud.commands.delete_folder")
+      .call(storage:, auth_strategy:, location: test_folder.location)
+  end
+end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/one_drive/set_permissions_command_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::OneDrive::SetPermissio
 
   it_behaves_like "set_permissions_command: basic command setup"
 
-  context "if file does not exists", vcr: "one_drive/set_permissions_not_found_folder" do
+  context "if folder does not exists", vcr: "one_drive/set_permissions_not_found_folder" do
     let(:error_source) { described_class }
     let(:input_data) { permission_input_data("THIS_IS_NOT_THE_FOLDER_YOURE_LOOKING_FOR", []) }
 

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -94,7 +94,7 @@ FactoryBot.define do
 
     trait :as_automatically_managed do
       automatic_management_enabled { true }
-      username { ENV.fetch("NEXTCLOUD_LOCAL_GROUP_USER_NAME", "OpenProject") }
+      username { "OpenProject" }
       password { ENV.fetch("NEXTCLOUD_LOCAL_GROUP_USER_PASSWORD", "Password123") }
     end
   end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -94,8 +94,8 @@ FactoryBot.define do
 
     trait :as_automatically_managed do
       automatic_management_enabled { true }
-      username { "OpenProject" }
-      password { "Password123" }
+      username { ENV.fetch("NEXTCLOUD_LOCAL_GROUP_USER_NAME", "OpenProject") }
+      password { ENV.fetch("NEXTCLOUD_LOCAL_GROUP_USER_PASSWORD", "Password123") }
     end
   end
 

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_invalid_user_id.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_invalid_user_id.yml
@@ -1,0 +1,583 @@
+---
+http_interactions:
+- request:
+    method: mkcol
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:56 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Oc-Fileid:
+      - '00000799oc07ul6b4oaw'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=a927f62338c190206dc5985489ac588f; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=bRyCKQt%2BvaqozQGCq5O9nGsdRA3MYge1FOl%2FnoJTqhMCJc5Xtp%2FdIujs5xAgAMBNCJ79BmK0V8vPElc%2BTEuyeW9Dkox1pzuy%2B6XFnp7WA%2BWCW1YnjSvMgcgJ0QC4jAIk;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=a927f62338c190206dc5985489ac588f;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=a927f62338c190206dc5985489ac588f;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=a927f62338c190206dc5985489ac588f;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=afefc644483807ab0a20d724cedf17b8;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:56 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - qpmqxAN3kh1MgaA5M9kP
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - qpmqxAN3kh1MgaA5M9kP
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:28:56 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getlastmodified/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Depth:
+      - '1'
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '207'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:56 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=1d39bc244cb26834517f59232457fc22; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=VkeJavJBnWz4f4x0XDQPffKS8%2BmxaPnSGGnE1gaQSoSQ3zjp%2BnUAopgCI4CZPDFS%2BkPOSulMWsMwskL7gffn3lOWjMmkqmjjcIX8wP9cYH3734TAOB9VVXv%2FxIxKNOi8;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=1d39bc244cb26834517f59232457fc22;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=1d39bc244cb26834517f59232457fc22;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=1d39bc244cb26834517f59232457fc22;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=80adcb3565dc6113f9b26a8e4918e0c9;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:57 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - 8CKNsMHvkW8DFaT5EBfj
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 8CKNsMHvkW8DFaT5EBfj
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '317'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><oc:fileid>799</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Fri, 23 Aug 2024 15:28:56 GMT</d:getlastmodified><oc:owner-display-name>vcr</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:28:57 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:57 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=3966ed37ff3e0f3cfd19c0efb6d8e5e9; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=TqXez5efLfATpq9veN%2BMj8qIpQJSEjVN1vnSAl7Et4vPL8ZdiQ4e%2BKn3%2FA6qHQ7VQnqBxC%2BMgs6V9hKwGetPRg6BKPcwwAgG457QoJL2NLMxzu88wk%2B%2Fw3iGCkGZI8X9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=3966ed37ff3e0f3cfd19c0efb6d8e5e9;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=3966ed37ff3e0f3cfd19c0efb6d8e5e9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=3966ed37ff3e0f3cfd19c0efb6d8e5e9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5df37f195970f542580d33643b28241f;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:57 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - s3I6DIYrwZXkrXQfXTt3
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - s3I6DIYrwZXkrXQfXTt3
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '242'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:28:57 GMT
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/799
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:58 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=d43f88e2979cf5744aa37e33e9fe808e; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=l7F2I53dDSoDmEwI8u0o5Sc%2FwUSrQytyxOa9CZ3evnKXVI2ADz9KQdj9EcUpmLJCK37lYByr9h0pu9go6O%2FdAbqfzhapvqN6b5mokeTmSw%2BrY0tAj%2Fihc3V5KauWI7l0;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=d43f88e2979cf5744aa37e33e9fe808e;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=d43f88e2979cf5744aa37e33e9fe808e;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=d43f88e2979cf5744aa37e33e9fe808e;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=33cedf5c0faff47baa93a590ad0c7d98;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:58 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - xad6qPwHCbI24SjfJp4j
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '261'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":799,"name":"Permission
+        Test Folder","mtime":1724426936,"ctime":0,"mimetype":"application\/x-op-directory","size":0,"owner_name":"vcr","owner_id":"vcr","modifier_name":null,"modifier_id":null,"dav_permissions":"RMGDNVCK","path":"files\/VCR\/Permission
+        Test Folder\/"}}}'
+  recorded_at: Fri, 23 Aug 2024 15:28:58 GMT
+- request:
+    method: proppatch
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propertyupdate xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:set>
+            <d:prop>
+              <nc:acl-list>
+                <nc:acl>
+                  <nc:acl-mapping-type>user</nc:acl-mapping-type>
+                  <nc:acl-mapping-id>luke_the_sky</nc:acl-mapping-id>
+                  <nc:acl-mask>31</nc:acl-mask>
+                  <nc:acl-permissions>31</nc:acl-permissions>
+                </nc:acl>
+              </nc:acl-list>
+            </d:prop>
+          </d:set>
+        </d:propertyupdate>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '449'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:58 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=f64663a174cf63f891857f7cecdc762c; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=kxiSFoO%2Fr%2FrNvmP7Kqzm3SWiXigcteR7sx6qEntHCj4Zl48lekvxPqDcRyFbqgT1GteQrWX1%2FU9N2f2QRvEFQJKLkYAd2p69N5fnntsM7bhcHy7OfI8OMowg%2F7GZ33tm;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=f64663a174cf63f891857f7cecdc762c;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=f64663a174cf63f891857f7cecdc762c;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=f64663a174cf63f891857f7cecdc762c;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=096557518dff940079c61096954dfdbf;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:58 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - zia7mjrTwEB9gk82hKZB
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - zia7mjrTwEB9gk82hKZB
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:28:58 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:28:59 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=da2d0fc1963ec3d3360a5e70fa84eca9; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=IyxSuFDWZztk0FR3Z4uOt093IN56tzy7AkgiQvJMaeU%2FLC%2F0SfDzx3whifCPRYRlkND3lGzhHH38Bp2VYUkxYk81FEQcvuZcEnFymAGhtu8Gw75aL2mhvewJJycpCPvA;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=da2d0fc1963ec3d3360a5e70fa84eca9;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=da2d0fc1963ec3d3360a5e70fa84eca9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=da2d0fc1963ec3d3360a5e70fa84eca9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=b7bc2ca49f3404370d1993a9f245d55f;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:28:59 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - qd7FtewIuY0uBLkxF16D
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - qd7FtewIuY0uBLkxF16D
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '237'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:28:59 GMT
+- request:
+    method: delete
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Date:
+      - Fri, 23 Aug 2024 15:28:59 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=6c76f9e5a759e63644dcd13d1bc06b06; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=4oZSLGHq7iAinHIJWgDLoZNxlzts1Pucs35gdK8l%2FWnr9TvIRVrhg35w4UOCvP%2BVSVd6neLVQdU3fm%2FUSi%2FBhcDr2eKruTWxY%2BABX%2B1eGSKDrhFmuoY0EjDRGNRM96YI;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=6c76f9e5a759e63644dcd13d1bc06b06;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=6c76f9e5a759e63644dcd13d1bc06b06;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=6c76f9e5a759e63644dcd13d1bc06b06;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=ce46076e65d4e4ac29941b7014d77127;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:29:00 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - 4okZgkeMXq77RY0tGOdX
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 4okZgkeMXq77RY0tGOdX
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:29:00 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_new.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_new.yml
@@ -1,0 +1,589 @@
+---
+http_interactions:
+- request:
+    method: mkcol
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:06 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Oc-Fileid:
+      - '00000797oc07ul6b4oaw'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=74b176b39999321593cdb46fe93a1ab7; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=8OBhmDZnsGKvpQwTKnu3S98mkjwAAo4jTDbwXB8hP3R6tqTLZzBXI8vnTLh2f2U0KL9Wfcd9wYnc79QeTZqbenUXkazphMN1NZmHEnAe%2ForMjauG3UpJj6ZjsMY%2BysRI;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=74b176b39999321593cdb46fe93a1ab7;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=74b176b39999321593cdb46fe93a1ab7;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=74b176b39999321593cdb46fe93a1ab7;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=42eabe3621d5f85ca224a1b337b5aec9;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:06 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - gxLitMLErAVUKSLxgaR4
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - gxLitMLErAVUKSLxgaR4
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:24:06 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getlastmodified/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Depth:
+      - '1'
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '207'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:06 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=5c73dd535d041be35b60683308dc51b0; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=R6PHecef0iz1z6vQvhNYGs3kbomaUz10sryqnAmX6ZsbyGOmt35pIvr7q7skxzf6YZs4Em6SdmRilO6CoY72UCGQM5EuWPHfMRerJ1%2FBt0fS75QYqFhee7b6FRCWXfqg;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5c73dd535d041be35b60683308dc51b0;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=5c73dd535d041be35b60683308dc51b0;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5c73dd535d041be35b60683308dc51b0;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=bf2eedf5e9cb535e292d356d7edbbc31;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:07 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - PdF2WKadP5qYbIbgwpna
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - PdF2WKadP5qYbIbgwpna
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><oc:fileid>797</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Fri, 23 Aug 2024 15:24:06 GMT</d:getlastmodified><oc:owner-display-name>vcr</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:24:07 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:07 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=b4c42d807cf6c7f75a45e7b12a82cf86; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=SbwSJTxaDMzz4eg%2F3ox%2FWb1s8Bt5l2ZFaCmMcakuW4Sm0DE%2FpZr%2FBYJ8X9bWtM1%2B0ZVBswv2wB1SQLILciDAokNfRL2aLbOQjUbcKrTv9dv301Ujx8ApreNP8XQ73%2FNg;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=b4c42d807cf6c7f75a45e7b12a82cf86;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=b4c42d807cf6c7f75a45e7b12a82cf86;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=b4c42d807cf6c7f75a45e7b12a82cf86;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=7d0e57ac281d9fa686cc283083170a02;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:07 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - P0vKEAM4rlqxi5KErKT2
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - P0vKEAM4rlqxi5KErKT2
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '242'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:24:07 GMT
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/797
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:08 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=fc292c6fb77bc80750da2843fb90378d; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=g3S3TQIkXz8o7U5WMqvkpIUNs28DzalQJox4XKLUhPPbQZYlSbS4tHAjM7KeDJJNgw8K5GsNeEiTq7l87Js16%2BFnOy8%2BNOrk1biGvK50zR6gKiIZgZIwa1XN7G237r47;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=fc292c6fb77bc80750da2843fb90378d;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=fc292c6fb77bc80750da2843fb90378d;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=fc292c6fb77bc80750da2843fb90378d;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5037847659aef38cb75a7eaa7bc3840f;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:08 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 9tiQdU7th3tUXAYNB240
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '261'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":797,"name":"Permission
+        Test Folder","mtime":1724426646,"ctime":0,"mimetype":"application\/x-op-directory","size":0,"owner_name":"vcr","owner_id":"vcr","modifier_name":null,"modifier_id":null,"dav_permissions":"RMGDNVCK","path":"files\/VCR\/Permission
+        Test Folder\/"}}}'
+  recorded_at: Fri, 23 Aug 2024 15:24:08 GMT
+- request:
+    method: proppatch
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propertyupdate xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:set>
+            <d:prop>
+              <nc:acl-list>
+                <nc:acl>
+                  <nc:acl-mapping-type>user</nc:acl-mapping-type>
+                  <nc:acl-mapping-id>m.jade@death.star</nc:acl-mapping-id>
+                  <nc:acl-mask>31</nc:acl-mask>
+                  <nc:acl-permissions>3</nc:acl-permissions>
+                </nc:acl>
+                <nc:acl>
+                  <nc:acl-mapping-type>user</nc:acl-mapping-type>
+                  <nc:acl-mapping-id>admin</nc:acl-mapping-id>
+                  <nc:acl-mask>31</nc:acl-mask>
+                  <nc:acl-permissions>15</nc:acl-permissions>
+                </nc:acl>
+              </nc:acl-list>
+            </d:prop>
+          </d:set>
+        </d:propertyupdate>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '695'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:08 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=c99c90a58dec00489d188ab5ef3cee41; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=43WfCS9%2BycATIK%2BWfNV1V9LvsHDRd8ogMmfESfm0H9cZg8FiKMaaVPs%2BuRiLR0RhMwLq%2B9f5lbYWNga30l%2Fm5WljE%2FZ4S6mRlLvYRtIHJhzX7pXGHQgfrGRyG8bGDJAd;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=c99c90a58dec00489d188ab5ef3cee41;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=c99c90a58dec00489d188ab5ef3cee41;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=c99c90a58dec00489d188ab5ef3cee41;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=87863e4c9edc278c917fbfdc50cb859d;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:09 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - HRC46zIFqGq9lqyTaKLq
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - HRC46zIFqGq9lqyTaKLq
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:24:09 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:24:09 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=83b8c19174d62898c93cb76ac2aeb129; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=erl2KC3rO7N%2BJhYpvoIoNFaQPWs9%2FOkiqOSvL%2Bssc8mft38qNcXfCKtdvhfgKTJiKXwM9wvrYz%2BlC3WIOtWV5%2FihLtea6S6aQewYMgNgTGdjuB%2FLk9Mhu8IhGHZmIl9N;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=83b8c19174d62898c93cb76ac2aeb129;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=83b8c19174d62898c93cb76ac2aeb129;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=83b8c19174d62898c93cb76ac2aeb129;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4bdc08280204d6382d359d97b1d6774e;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:09 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - mLH7DEGThVPycAIFKroF
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - mLH7DEGThVPycAIFKroF
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '344'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list><nc:acl><nc:acl-mapping-type>user</nc:acl-mapping-type><nc:acl-mapping-id>m.jade@death.star</nc:acl-mapping-id><nc:acl-mapping-display-name>Mara Jade</nc:acl-mapping-display-name><nc:acl-mask>31</nc:acl-mask><nc:acl-permissions>3</nc:acl-permissions></nc:acl><nc:acl><nc:acl-mapping-type>user</nc:acl-mapping-type><nc:acl-mapping-id>admin</nc:acl-mapping-id><nc:acl-mapping-display-name>admin</nc:acl-mapping-display-name><nc:acl-mask>31</nc:acl-mask><nc:acl-permissions>15</nc:acl-permissions></nc:acl></nc:acl-list></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:24:09 GMT
+- request:
+    method: delete
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Date:
+      - Fri, 23 Aug 2024 15:24:09 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=df8ba7197fee1bd3c22d8cb5d4da5f0f; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=DKKB2DVEfvjfESplibbCXGSATJgbBuIljXzN0HO7g1sph7Bha%2B4eLbax8GSmeCncbA27kGjlae9gimPArVraSfk%2BmTHZZvB%2BadYhjSqGsa6bwfLbpFSNKkLveczOAuDX;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=df8ba7197fee1bd3c22d8cb5d4da5f0f;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=df8ba7197fee1bd3c22d8cb5d4da5f0f;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=df8ba7197fee1bd3c22d8cb5d4da5f0f;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5c8726bc48c7d7c1a14b813840d73df7;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:24:10 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - G8MAfZQcMdxpEya9IKDm
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - G8MAfZQcMdxpEya9IKDm
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:24:10 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_not_found_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_not_found_folder.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/1337
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Aug 2024 13:57:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=%2FHlV8RIDNjpe8JA3B1xRL9D4KJjPxF58URV3%2BSDrVF3NyRfBaqkNhybyvQsTnjK5IW5EMqdFAudwlsn12XwX45Jl1fc46dUblvpiAPhyHHpHr0hRstZcuh5nhbxjnFL5;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=35ca0a83fcacc147c7ca115af59be368;
+        path=/; secure; HttpOnly; SameSite=Lax
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - yvczEEmwKCNz0CSjXbKZ
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"","totalitems":"","itemsperpage":""},"data":{"status":"Not
+        Found","statuscode":404}}}'
+  recorded_at: Thu, 22 Aug 2024 13:57:21 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_replacing_permissions.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/set_permissions_replacing_permissions.yml
@@ -1,0 +1,753 @@
+---
+http_interactions:
+- request:
+    method: mkcol
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:33 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Oc-Fileid:
+      - '00000798oc07ul6b4oaw'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=4bdc955e4c45bfb489b7c6c6a8238af9; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=fULfFr9AnKFX8irP01I5BrbS1YksG23yjO3qhg9yszZA6XWAx1rlbETLIMNowhJULhPE%2BjyUleLAk4Y4q6XULT1mKf%2F3tHG8YkWvaHJbxZVN5StcfoBe0OYyxcf90Nrf;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4bdc955e4c45bfb489b7c6c6a8238af9;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=4bdc955e4c45bfb489b7c6c6a8238af9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4bdc955e4c45bfb489b7c6c6a8238af9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=7b6e76611b4ea143af914303426f98a0;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:33 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - d2Ro8iV9SHAOEB37vcy7
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - d2Ro8iV9SHAOEB37vcy7
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:26:33 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+          <d:prop>
+            <oc:fileid/>
+            <oc:size/>
+            <d:getlastmodified/>
+            <oc:owner-display-name/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Depth:
+      - '1'
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '207'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:33 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=828a5403f8b9b5d4234d61ffd4028a51; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=x2ZFPW1QB9Wly7wMZLypJbghpPWU%2B6bk3fXEadX0RNkc9qlBN1tdZAhIqJN2pCCOrajysHjPKcp7m%2FYBp4OwANLNEg%2Fluvq1puD5LCSN5mUBSWf3g9fv8MsUY2clAfAq;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=828a5403f8b9b5d4234d61ffd4028a51;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=828a5403f8b9b5d4234d61ffd4028a51;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=828a5403f8b9b5d4234d61ffd4028a51;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=ad7e5549db3469570c7cef3f307afdd7;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:34 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - QY2rFOq3Xd4NgNCeMQ5w
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - QY2rFOq3Xd4NgNCeMQ5w
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><oc:fileid>798</oc:fileid><oc:size>0</oc:size><d:getlastmodified>Fri, 23 Aug 2024 15:26:33 GMT</d:getlastmodified><oc:owner-display-name>vcr</oc:owner-display-name></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:26:34 GMT
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/798
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:34 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=ca139155711a124dbbab76f6ef3d8782; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=2kO7yTFilkF07qvq3qTJV%2BJM823VMmXy17yn7y3gYyO7fqXfQszyfMVgeNO27cPD9olAUjV0ID0W4OhdDMM5dLDz93VwSHISNHH%2BAiqKnIKdYn0pxwwSSilhjf%2BHypQc;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=ca139155711a124dbbab76f6ef3d8782;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=ca139155711a124dbbab76f6ef3d8782;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=ca139155711a124dbbab76f6ef3d8782;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=aa22a60f880597736d1ca317124abd1d;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:34 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - WClWp45DMBDLQ6XconNr
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '261'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":798,"name":"Permission
+        Test Folder","mtime":1724426793,"ctime":0,"mimetype":"application\/x-op-directory","size":0,"owner_name":"vcr","owner_id":"vcr","modifier_name":null,"modifier_id":null,"dav_permissions":"RMGDNVCK","path":"files\/VCR\/Permission
+        Test Folder\/"}}}'
+  recorded_at: Fri, 23 Aug 2024 15:26:34 GMT
+- request:
+    method: proppatch
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propertyupdate xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:set>
+            <d:prop>
+              <nc:acl-list>
+                <nc:acl>
+                  <nc:acl-mapping-type>user</nc:acl-mapping-type>
+                  <nc:acl-mapping-id>admin</nc:acl-mapping-id>
+                  <nc:acl-mask>31</nc:acl-mask>
+                  <nc:acl-permissions>15</nc:acl-permissions>
+                </nc:acl>
+              </nc:acl-list>
+            </d:prop>
+          </d:set>
+        </d:propertyupdate>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '442'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:34 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=e2e120d0dbe5cdec92afa2a123bdd9d9; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=lCZK%2BWqP%2F3gfto7vQL6maRU%2FUFEyKlUm67%2BQaJ5vwY1gkY9BKeU5bPeHHQjsxYpfIEHxyFcg6mZZStOUd71YYCstbAxqkSuZXDm7qSnX1nLN5NM37ijudNhMskJ1vwoZ;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e2e120d0dbe5cdec92afa2a123bdd9d9;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=e2e120d0dbe5cdec92afa2a123bdd9d9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e2e120d0dbe5cdec92afa2a123bdd9d9;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=ae983ee287222375c3b74e349612cd32;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:35 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - epFCyG538uE4TjdpMs0r
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - epFCyG538uE4TjdpMs0r
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:26:35 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:35 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=877eeca28064e7c6a6eaee885102e2ab; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=fNBRyW9Ml74UeyACErBwVJD1u%2BoZzGKm8syfmNqrcGb2IQ4YnXDyZMfJMx4uFTI3mt4mXkWCHmjjQ76EhSZxQTi3tj7trFwHvmWnfZnODNxTIiWoPMhByEdJzR5CSCKE;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=877eeca28064e7c6a6eaee885102e2ab;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=877eeca28064e7c6a6eaee885102e2ab;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=877eeca28064e7c6a6eaee885102e2ab;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5801f0074f37e8124555affc9f8164a9;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:35 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - 6R18cmvTStT5GzEHzgBv
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 6R18cmvTStT5GzEHzgBv
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list><nc:acl><nc:acl-mapping-type>user</nc:acl-mapping-type><nc:acl-mapping-id>admin</nc:acl-mapping-id><nc:acl-mapping-display-name>admin</nc:acl-mapping-display-name><nc:acl-mask>31</nc:acl-mask><nc:acl-permissions>15</nc:acl-permissions></nc:acl></nc:acl-list></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:26:35 GMT
+- request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/798
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:35 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=e1621dc4839a418a3da3b7482f4a4af4; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=e8EdRubABsLZSLVT15N0oi4RPL1pInsn3J1J1I3bG6niFmDglQgyLl%2FXHMTl4maA6CHOBmCA6HkLJdGFealwM%2Bafg9C97NYNx4CDefroo3gTT6iE8PfC%2FCk1D%2Bf03AX%2B;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1621dc4839a418a3da3b7482f4a4af4;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=e1621dc4839a418a3da3b7482f4a4af4;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1621dc4839a418a3da3b7482f4a4af4;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=27b832bfca74cd82d7aba2a5cc831a74;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:36 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 1MElYQLofrVumUuexucB
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '261'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":798,"name":"Permission
+        Test Folder","mtime":1724426793,"ctime":0,"mimetype":"application\/x-op-directory","size":0,"owner_name":"vcr","owner_id":"vcr","modifier_name":null,"modifier_id":null,"dav_permissions":"RMGDNVCK","path":"files\/VCR\/Permission
+        Test Folder\/"}}}'
+  recorded_at: Fri, 23 Aug 2024 15:26:36 GMT
+- request:
+    method: proppatch
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propertyupdate xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:set>
+            <d:prop>
+              <nc:acl-list>
+                <nc:acl>
+                  <nc:acl-mapping-type>user</nc:acl-mapping-type>
+                  <nc:acl-mapping-id>m.jade@death.star</nc:acl-mapping-id>
+                  <nc:acl-mask>31</nc:acl-mask>
+                  <nc:acl-permissions>3</nc:acl-permissions>
+                </nc:acl>
+              </nc:acl-list>
+            </d:prop>
+          </d:set>
+        </d:propertyupdate>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '453'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:36 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=998aa8e8349469e6025630b4ab7bd91b; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=o4FtzrnG5FA8fm1B2342KKh6zQ7whCp7y5%2FsPFGteKcL01ApoZsd49nCpzlq16gsI9J80RRspEy4SgxklUXopo6Vg6g6FQOE20jK3kVHw6vgMKH4nln%2BuegQcoLmFCti;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=998aa8e8349469e6025630b4ab7bd91b;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=998aa8e8349469e6025630b4ab7bd91b;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=998aa8e8349469e6025630b4ab7bd91b;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=44e4acfdb3693d7a001e982efed6634b;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:36 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - 7upsO7ftiIwKoTthQuUo
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 7upsO7ftiIwKoTthQuUo
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder</d:href><d:propstat><d:prop><nc:acl-list/></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:26:36 GMT
+- request:
+    method: propfind
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <nc:acl-list/>
+          </d:prop>
+        </d:propfind>
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/xml; charset=utf-8
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';
+      Content-Type:
+      - application/xml; charset=utf-8
+      Date:
+      - Fri, 23 Aug 2024 15:26:36 GMT
+      Dav:
+      - 1, 3, extended-mkcol, access-control, calendarserver-principal-property-search,
+        nextcloud-checksum-update, nc-calendar-search, nc-enable-birthday-calendar
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=52d69c1d7a7fe7eaf8d6ca52ab2f4a07; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=AqEZt%2BCZtSb0DfV9DWV%2BATHJMv4yxI5V5D0tjpb4xo5y6yTOVdPOSfxPy%2B4z7hhFNWkKaE2BsaJyg7pZaPwrIDuoI0I8t9zQx1StRAMIGi1fZ2ehFyxy6p5aXYU89adP;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=52d69c1d7a7fe7eaf8d6ca52ab2f4a07;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=52d69c1d7a7fe7eaf8d6ca52ab2f4a07;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=52d69c1d7a7fe7eaf8d6ca52ab2f4a07;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=a192ddb5cc0fd28366a3817e63918c03;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:37 GMT; Max-Age=3600
+      Vary:
+      - Brief,Prefer
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - Vm3bHPGdkJLTBdwxMjGA
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - Vm3bHPGdkJLTBdwxMjGA
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '323'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder/</d:href><d:propstat><d:prop><nc:acl-list><nc:acl><nc:acl-mapping-type>user</nc:acl-mapping-type><nc:acl-mapping-id>m.jade@death.star</nc:acl-mapping-id><nc:acl-mapping-display-name>Mara Jade</nc:acl-mapping-display-name><nc:acl-mask>31</nc:acl-mask><nc:acl-permissions>3</nc:acl-permissions></nc:acl></nc:acl-list></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+  recorded_at: Fri, 23 Aug 2024 15:26:37 GMT
+- request:
+    method: delete
+    uri: https://nextcloud.local/remote.php/dav/files/vcr/VCR/Permission%20Test%20Folder
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <BASIC_AUTH>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Security-Policy:
+      - default-src 'none';
+      Date:
+      - Fri, 23 Aug 2024 15:26:37 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=d34aa616c0c48ff9dbb536e8b80fd648; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=bmQJTIglM4KMdcaqKejNIGOz9M%2BTvm91oG%2FNR8MUhe6kzaAbO%2FoigUHR78Sjro%2BfCV43F8KKnYOR944ankZZ4VOQoR3uwzcCfyO7zYys%2B4OFcIqFE4foZW6yIyogP2LM;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=d34aa616c0c48ff9dbb536e8b80fd648;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=d34aa616c0c48ff9dbb536e8b80fd648;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=d34aa616c0c48ff9dbb536e8b80fd648;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=5c7e759e733203278a6d58494ecd1ded;
+        path=/; secure; HttpOnly; SameSite=Lax, cookie_test=test; expires=Fri, 23
+        Aug 2024 16:26:37 GMT; Max-Age=3600
+      X-Content-Type-Options:
+      - nosniff
+      X-Debug-Token:
+      - 42Fbkghfgc58fjOlgVs3
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - 42Fbkghfgc58fjOlgVs3
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 23 Aug 2024 15:26:37 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/shared_examples_for_adapters/set_permissions_command_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_adapters/set_permissions_command_examples.rb
@@ -86,6 +86,24 @@ RSpec.shared_examples_for "set_permissions_command: creates new permissions" do
   end
 end
 
+RSpec.shared_examples_for "set_permissions_command: unknown remote identity" do
+  it "returns a failure" do
+    file_id = test_folder.id
+    input_data = Storages::Peripherals::StorageInteraction::Inputs::SetPermissions
+                   .build(file_id:, user_permissions:)
+                   .value!
+    result = described_class.call(storage:, auth_strategy:, input_data:)
+
+    expect(result).to be_failure
+
+    error = result.errors
+    expect(error.code).to eq(:unknown_remote_identity)
+    expect(error.data.source).to eq(error_source)
+  ensure
+    clean_up file_id
+  end
+end
+
 RSpec.shared_examples_for "set_permissions_command: not found" do
   it "returns a failure" do
     result = described_class.call(storage:, auth_strategy:, input_data:)


### PR DESCRIPTION
# Ticket
[#57286](https://community.openproject.org/work_packages/57286)

# What are you trying to accomplish?
- nextcloud set_permission command should use the same interface as one drive equivalent

# What approach did you choose and why?
- added unit tests (with VCR support)
- amended command interface
- adapted usage in sync service
- open TODO: add additional behaviour to both commands, how to react on unknown remote identities

