### PR TITLE
Allow "Accountable" to be a settable field via inbound mails

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -377,17 +377,18 @@ class MailHandler < ActionMailer::Base
   # Returns a Hash of issue attributes extracted from keywords in the email body
   def wp_attributes_from_keywords(work_package)
     {
-      "type_id" => wp_type_from_keywords(work_package),
-      "status_id" => wp_status_from_keywords,
-      "parent_id" => wp_parent_from_keywords,
-      "priority_id" => wp_priority_from_keywords,
-      "category_id" => wp_category_from_keywords(work_package),
       "assigned_to_id" => wp_assignee_from_keywords(work_package),
-      "version_id" => wp_version_from_keywords(work_package),
-      "start_date" => wp_start_date_from_keywords,
+      "category_id" => wp_category_from_keywords(work_package),
       "due_date" => wp_due_date_from_keywords,
       "estimated_hours" => wp_estimated_hours_from_keywords,
-      "remaining_hours" => wp_remaining_hours_from_keywords
+      "parent_id" => wp_parent_from_keywords,
+      "priority_id" => wp_priority_from_keywords,
+      "remaining_hours" => wp_remaining_hours_from_keywords,
+      "responsible_id" => wp_accountable_from_keywords(work_package),
+      "start_date" => wp_start_date_from_keywords,
+      "status_id" => wp_status_from_keywords,
+      "type_id" => wp_type_from_keywords(work_package),
+      "version_id" => wp_version_from_keywords(work_package)
     }.compact_blank!
   end
 
@@ -541,8 +542,16 @@ class MailHandler < ActionMailer::Base
     lookup_case_insensitive_key(work_package.project.categories, :category)
   end
 
+  def wp_accountable_from_keywords(work_package)
+    get_assignable_principal_from_keywords(:responsible, work_package)
+  end
+
   def wp_assignee_from_keywords(work_package)
-    keyword = get_keyword(:assigned_to, override: true)
+    get_assignable_principal_from_keywords(:assigned_to, work_package)
+  end
+
+  def get_assignable_principal_from_keywords(keyword, work_package)
+    keyword = get_keyword(keyword, override: true)
 
     return nil if keyword.blank?
 

--- a/spec/fixtures/mail_handler/wp_mention_reply_with_attributes.eml
+++ b/spec/fixtures/mail_handler/wp_mention_reply_with_attributes.eml
@@ -52,6 +52,7 @@ The text of the reply.
 Status: Resolved
 due date: 2010-12-31
 Start Date:2010-01-01
+Accountable: jsmith@somenet.foo
 Assigned to: jsmith@somenet.foo
 float field: 52.6
 

--- a/spec/fixtures/mail_handler/wp_on_given_project.eml
+++ b/spec/fixtures/mail_handler/wp_on_given_project.eml
@@ -53,6 +53,7 @@ Project: onlinestore
 Status: Resolved
 due date: 2010-12-31
 Start Date:2010-01-01
+Accountable: John Smith
 Assigned to: John Smith
 Version: alpha
 estimated hours: 2.5

--- a/spec/fixtures/mail_handler/wp_on_given_project_group_assignment.eml
+++ b/spec/fixtures/mail_handler/wp_on_given_project_group_assignment.eml
@@ -53,6 +53,7 @@ Project: onlinestore
 Status: Resolved
 due date: 2010-12-31
 Start Date:2010-01-01
+Accountable: A-Team
 Assigned to: A-Team
 Version: alpha
 estimated hours: 2.5

--- a/spec/fixtures/mail_handler/wp_reply_with_quoted_reply_above.eml
+++ b/spec/fixtures/mail_handler/wp_reply_with_quoted_reply_above.eml
@@ -39,6 +39,7 @@ platea dictumst.
 >
 > Subject changed from Projects with JSON to Project JSON API
 > Status changed from New to Assigned
+> Accountable set to Jerry Smith
 > Assignee set to Eric Davis
 > Priority changed from Low to Normal
 > Estimated time deleted (1.00)

--- a/spec/fixtures/mail_handler/wp_with_invalid_attributes.eml
+++ b/spec/fixtures/mail_handler/wp_with_invalid_attributes.eml
@@ -40,6 +40,7 @@ pulvinar dui, a gravida orci mi eget odio. Nunc a lacus.
 Project: onlinestore
 Type: Feature request
 category: Stock management
+accountable: jerrysmith@foo.bar
 assigned to: miscuser9@foo.bar
 priority: foo
 start date: some day

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -557,6 +557,11 @@ RSpec.describe MailHandler do
             .to eql("2010-12-31")
         end
 
+        it "sets the accountable" do
+          expect(subject.responsible)
+            .to eql(user)
+        end
+
         it "sets the assignee" do
           expect(subject.assigned_to)
             .to eql(user)
@@ -651,6 +656,11 @@ RSpec.describe MailHandler do
         include_context "for wp on given project group assignment"
 
         it_behaves_like "work package created"
+
+        it "sets the accountable to the group" do
+          expect(subject.responsible)
+            .to eql(group)
+        end
 
         it "sets the assignee to the group" do
           expect(subject.assigned_to)
@@ -1078,6 +1088,9 @@ RSpec.describe MailHandler do
         it_behaves_like "work package created"
 
         it "ignores the invalid attributes and set default ones where possible" do
+          expect(subject.responsible)
+            .to be_nil
+
           expect(subject.assigned_to)
             .to be_nil
 
@@ -1212,14 +1225,18 @@ RSpec.describe MailHandler do
                             member_with_permissions: { project => %i(view_work_packages) },
                             notification_settings: [build(:notification_setting, assignee: true, responsible: true)])
 
+          responsible = create(:user,
+                               member_with_permissions: { project => %i(view_work_packages) },
+                               notification_settings: [build(:notification_setting, assignee: true, responsible: true)])
           work_package.update_column(:assigned_to_id, assignee.id)
+          work_package.update_column(:responsible_id, responsible.id)
 
           # Sends notifications for the assignee and the author who is listening for all changes.
           expect do
             perform_enqueued_jobs do
               subject
             end
-          end.to change(Notification, :count).by(1)
+          end.to change(Notification, :count).by(2)
         end
       end
 
@@ -1269,6 +1286,7 @@ RSpec.describe MailHandler do
             .to eql(
               "due_date" => [nil, Date.parse("Fri, 31 Dec 2010")],
               "status_id" => [original_status.id, resolved_status.id],
+              "responsible_id" => [nil, other_user.id],
               "assigned_to_id" => [nil, other_user.id],
               "start_date" => [nil, Date.parse("Fri, 01 Jan 2010")],
               "duration" => [nil, 365],


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/55206

# What are you trying to accomplish?
I'd like to be able to set the "Accountable" field on work packages via inbound mails just like we can with setting an Assignee.

# What approach did you choose and why?
It was a matter of extending the already existing mail handler to accept an extra field and updating the test coverage to ensure it's behaving as expected.

# Merge checklist

- [x] Added/updated tests
- [ ] ~Tested major browsers (Chrome, Firefox, Edge, ...)~