### PR TITLE
[57512] Make it easier to clear all fields

### DIFF
--- a/app/services/duration_converter.rb
+++ b/app/services/duration_converter.rb
@@ -78,23 +78,7 @@ class DurationConverter
     def parse(duration_string)
       return nil if duration_string.blank?
 
-      # Assume the next logical unit to allow users to write
-      # durations such as "2h 1" assuming "1" is "1 minute"
-      last_unit_in_string = duration_string.scan(/[a-zA-Z]+/)
-                                           .last
-      default_unit = if last_unit_in_string
-                       last_unit_in_string
-                         .then { |last_unit| UNIT_ABBREVIATION_MAP[last_unit.downcase] }
-                         .then { |last_unit| NEXT_UNIT_MAP[last_unit] }
-                     else
-                       "hours"
-                     end
-
-      ChronicDuration.raise_exceptions = true
-      ChronicDuration.parse(duration_string,
-                            keep_zero: true,
-                            default_unit:,
-                            **duration_length_options) / 3600.to_f
+      do_parse(duration_string)
     end
 
     def valid?(duration)
@@ -130,7 +114,7 @@ class DurationConverter
         number >= 0
       else
         begin
-          internal_parse(duration_string)
+          do_parse(duration_string)
           true
         rescue ChronicDuration::DurationParseError
           false
@@ -138,7 +122,7 @@ class DurationConverter
       end
     end
 
-    def internal_parse(duration_string)
+    def do_parse(duration_string)
       # Assume the next logical unit to allow users to write
       # durations such as "2h 1" assuming "1" is "1 minute"
       last_unit_in_string = duration_string.scan(/[a-zA-Z]+/)

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/touched-field-marker.controller.ts
@@ -73,6 +73,9 @@ export default class TouchedFieldMarkerController extends Controller {
 
   private untouchFieldsWhenWorkIsEdited() {
     if (this.areBothTouched('remaining_hours', 'done_ratio')) {
+      if (this.isValueEmpty('done_ratio') && this.isValueEmpty('remaining_hours')) {
+        return;
+      }
       if (this.isValueEmpty('done_ratio')) {
         this.markUntouched('done_ratio');
       } else {

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -74,7 +74,7 @@ module ChronicDuration
   # return an integer (or float, if fractions of a
   # second are input)
   def parse(string, opts = {})
-    result = calculate_from_words(cleanup(string), opts)
+    result = calculate_from_words(cleanup(string, opts), opts)
     !opts[:keep_zero] && result == 0 ? nil : result
   end
 
@@ -247,11 +247,11 @@ module ChronicDuration
     val
   end
 
-  def cleanup(string)
+  def cleanup(string, opts = {})
     res = string.downcase
     res = filter_by_type(res)
     res = res.gsub(float_matcher) { |n| " #{n} " }.squeeze(" ").strip
-    filter_through_white_list(res)
+    filter_through_white_list(res, opts)
   end
 
   def convert_to_number(string)
@@ -308,7 +308,7 @@ module ChronicDuration
 
   # Get rid of unknown words and map found
   # words to defined time units
-  def filter_through_white_list(string)
+  def filter_through_white_list(string, opts)
     res = []
     string.split.each do |word|
       if word&.match?(float_matcher)
@@ -318,7 +318,7 @@ module ChronicDuration
       stripped_word = word.strip.gsub(/^,/, "").gsub(/,$/, "")
       if mappings.has_key?(stripped_word)
         res << mappings[stripped_word]
-      elsif !join_words.include?(stripped_word) and ChronicDuration.raise_exceptions # rubocop:disable Rails/NegateInclude
+      elsif !join_words.include?(stripped_word) and opts.fetch(:raise_exceptions, ChronicDuration.raise_exceptions) # rubocop:disable Rails/NegateInclude
         raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed."
       end
     end

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -532,9 +532,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       # scenario from https://community.openproject.org/wp/57370
       specify "Case 33-2: when remaining work and % complete are cleared, " \
               "changing or clearing work does not modify % complete at all" do
-        puts "#{Time.current.iso8601(3)} #{__FILE__}:#{__LINE__} "
         visit_progress_query_displaying_work_package
-        puts "#{Time.current.iso8601(3)} #{__FILE__}:#{__LINE__} "
 
         progress_popover.open
         progress_popover.set_values(remaining_work: "")

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
       end
 
       # scenario from https://community.openproject.org/wp/57370
-      specify "Case 33-14: when work and % complete are cleared, and then work " \
+      specify "Case 33-1: when work and % complete are cleared, and then work " \
               "is set again then % complete is derived again" do
         visit_progress_query_displaying_work_package
 
@@ -527,6 +527,33 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.set_values(work: "20h")
         # => % complete is derived
         progress_popover.expect_values(work: "20h", remaining_work: "4h", percent_complete: "80%")
+      end
+
+      # scenario from https://community.openproject.org/wp/57370
+      specify "Case 33-2: when remaining work and % complete are cleared, " \
+              "changing or clearing work does not modify % complete at all" do
+        puts "#{Time.current.iso8601(3)} #{__FILE__}:#{__LINE__} "
+        visit_progress_query_displaying_work_package
+        puts "#{Time.current.iso8601(3)} #{__FILE__}:#{__LINE__} "
+
+        progress_popover.open
+        progress_popover.set_values(remaining_work: "")
+        progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "60%")
+        progress_popover.expect_hints(work: :cleared_because_remaining_work_is_empty)
+
+        progress_popover.set_values(percent_complete: "")
+        progress_popover.expect_values(work: "10h", remaining_work: "", percent_complete: "")
+        progress_popover.expect_hints(work: nil, remaining_work: nil, percent_complete: nil)
+
+        # partially deleting work value like when pressing backspace
+        progress_popover.set_values(work: "1")
+        progress_popover.expect_values(work: "1", remaining_work: "", percent_complete: "")
+        progress_popover.expect_hints(work: nil, remaining_work: nil, percent_complete: nil)
+
+        # completly clearing work value
+        progress_popover.set_values(work: "")
+        progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "")
+        progress_popover.expect_hints(work: nil, remaining_work: nil, percent_complete: nil)
       end
     end
 

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe ChronicDuration do
         it "raises with ChronicDuration::DurationParseError" do
           expect { described_class.parse("23 gobblygoos") }.to raise_error(ChronicDuration::DurationParseError)
         end
+
+        context "when passing `raise_exceptions: false` as an option" do
+          it "overrides @@raise_exception and returns nil" do
+            expect(described_class.parse("gobblygoos", raise_exceptions: false)).to be_nil
+          end
+        end
+      end
+
+      context "when passing `raise_exceptions: true` as an option" do
+        it "overrides @@raise_exception and raises with ChronicDuration::DurationParseError" do
+          expect { described_class.parse("23 gobblygoos", raise_exceptions: true) }
+            .to raise_error(ChronicDuration::DurationParseError)
+        end
       end
     end
 

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -49,6 +49,15 @@ module Components
         work: :estimatedTime
       }.freeze
 
+      WORK_PACKAGE_FIELD_NAME_MAP = {
+        estimated_time: :estimated_hours,
+        percent_complete: :done_ratio,
+        percentage_done: :done_ratio,
+        remaining_work: :remaining_hours,
+        remaining_time: :remaining_hours,
+        work: :estimated_hours
+      }.freeze
+
       attr_reader :container, :create_form
 
       def initialize(container: page, create_form: false)
@@ -118,9 +127,22 @@ module Components
       end
 
       def expect_values(**field_value_pairs)
-        aggregate_failures("progress popover expectations") do
+        aggregate_failures("progress popover values expectations") do
           field_value_pairs.each do |field_name, value|
             expect_value(field_name, value)
+          end
+        end
+      end
+
+      def expect_hint(field_name, hint)
+        expected_caption = hint && I18n.t("work_package.progress.derivation_hints.#{wp_field_name(field_name)}.#{hint}")
+        field(field_name).expect_caption(expected_caption)
+      end
+
+      def expect_hints(**field_hint_pairs)
+        aggregate_failures("progress popover hints expectations") do
+          field_hint_pairs.each do |field_name, hint|
+            expect_hint(field_name, hint)
           end
         end
       end
@@ -136,6 +158,13 @@ module Components
         field_name = field_name.to_s.underscore.to_sym
         JS_FIELD_NAME_MAP.fetch(field_name) do
           raise ArgumentError, "cannot map '#{field_name.inspect}' to its javascript field name"
+        end
+      end
+
+      def wp_field_name(field_name)
+        field_name = field_name.to_s.underscore.to_sym
+        WORK_PACKAGE_FIELD_NAME_MAP.fetch(field_name) do
+          raise ArgumentError, "cannot map '#{field_name.inspect}' to its work package field name"
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57512

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Fix the issue spotted in this PR review: https://github.com/opf/openproject/pull/16419#pullrequestreview-2260868213

When work is modified and remaining work and % complete are both empty, the % complete field should remain empty. Otherwise it's tedious when one wants to clear all values.

## Screenshots

Before:

![before](https://github.com/user-attachments/assets/e9d1fc9d-31e9-40c2-b3f7-b0a99f3f5bdd)

After:

[after.webm](https://github.com/user-attachments/assets/927dd61d-436d-4b2d-9623-662681cc3979)


No more derivation of % complete to an empty value while it's already empty.

# What approach did you choose and why?

Added another if, and updated tests for this new scenario (33-2) and to also check for displayed hints.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
