### PR TITLE
Separate OmniAuth controller from Account controller

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -32,6 +32,7 @@ class AccountController < ApplicationController
   include Accounts::Registration
   include Accounts::UserConsent
   include Accounts::UserLimits
+  include Accounts::UserLogin
   include Accounts::UserPasswordChange
 
   # prevents login action to be filtered by check_if_login_required application scope filter

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -29,7 +29,7 @@
 class AccountController < ApplicationController
   include CustomFieldsHelper
   include OmniauthHelper
-  include Accounts::OmniauthLogin
+  include Accounts::Registration
   include Accounts::UserConsent
   include Accounts::UserLimits
   include Accounts::UserPasswordChange
@@ -346,49 +346,6 @@ class AccountController < ApplicationController
       .result
   end
 
-  def register_plain_user(user)
-    user.attributes = permitted_params.user.transform_values do |val|
-      if val.is_a? String
-        val.strip!
-      end
-
-      val
-    end
-    user.login = params[:user][:login].strip if params[:user][:login].present?
-    user.password = params[:user][:password]
-    user.password_confirmation = params[:user][:password_confirmation]
-
-    respond_for_registered_user(user)
-  end
-
-  def register_with_auth_source(user)
-    # on-the-fly registration via omniauth or via auth source
-    if pending_omniauth_registration?
-      user.assign_attributes permitted_params.user_register_via_omniauth
-      register_via_omniauth(session, user.attributes)
-    else
-      user.attributes = permitted_params.user
-      user.activate
-      user.login = session[:auth_source_registration][:login]
-      user.ldap_auth_source_id = session[:auth_source_registration][:ldap_auth_source_id]
-
-      respond_for_registered_user(user)
-    end
-  end
-
-  def respond_for_registered_user(user)
-    call = ::Users::RegisterUserService.new(user).call
-
-    if call.success?
-      flash[:notice] = call.message.presence
-      login_user_if_active(call.result, just_registered: true)
-    else
-      flash[:error] = error = call.message
-      Rails.logger.error "Registration of user #{user.login} failed: #{error}"
-      onthefly_creation_failed(user)
-    end
-  end
-
   def user_with_placeholder_name?(user)
     user.firstname == user.login and user.login == user.mail
   end
@@ -451,61 +408,6 @@ class AccountController < ApplicationController
     else
       # Valid user
       successful_authentication(user)
-    end
-  end
-
-  def login_user_if_active(user, just_registered:)
-    if user.active?
-      successful_authentication(user, just_registered:)
-      return
-    end
-
-    # Show an appropriate error unless
-    # the user was just registered
-    if !(just_registered && user.registered?)
-      account_inactive(user, flash_now: false)
-    end
-
-    redirect_to signin_path(back_url: params[:back_url])
-  end
-
-  def pending_auth_source_registration?
-    session[:auth_source_registration] && !pending_omniauth_registration?
-  end
-
-  def pending_omniauth_registration?
-    Hash(session[:auth_source_registration])[:omniauth]
-  end
-
-  # Onthefly creation failed, display the registration form to fill/fix attributes
-  def onthefly_creation_failed(user, auth_source_options = {})
-    @user = user
-    session[:auth_source_registration] = auth_source_options unless auth_source_options.empty?
-    render action: "register"
-  end
-
-  def self_registration_disabled
-    flash[:error] = I18n.t("account.error_self_registration_disabled")
-    redirect_to signin_url
-  end
-
-  # Call if an account is inactive - either registered or locked
-  def account_inactive(user, flash_now: true)
-    if user.registered?
-      account_not_activated(flash_now:)
-    else
-      flash_and_log_invalid_credentials(flash_now:)
-    end
-  end
-
-  # Log an attempt to log in to an account in "registered" state and show a flash message.
-  def account_not_activated(flash_now: true)
-    flash_error_message(log_reason: "NOT ACTIVATED", flash_now:) do
-      if Setting::SelfRegistration.by_email?
-        "account.error_inactive_activation_by_mail"
-      else
-        "account.error_inactive_manual_activation"
-      end
     end
   end
 

--- a/app/controllers/concerns/accounts/registration.rb
+++ b/app/controllers/concerns/accounts/registration.rb
@@ -1,0 +1,129 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "uri"
+
+##
+# Intended to be used by the AccountController and OmniAuthLoginController to handle registration flows
+module Accounts::Registration
+  ##
+  # Sends a user who was just registered to the activation stages
+  # or to the signin page if the user could not be activated
+  def login_user_if_active(user, just_registered:)
+    if user.active?
+      successful_authentication(user, just_registered:)
+      return
+    end
+
+    # Show an appropriate error unless
+    # the user was just registered
+    if !(just_registered && user.registered?)
+      account_inactive(user, flash_now: false)
+    end
+
+    redirect_to signin_path(back_url: params[:back_url])
+  end
+
+  def register_plain_user(user)
+    user.attributes = permitted_params.user.transform_values do |val|
+      if val.is_a? String
+        val.strip!
+      end
+
+      val
+    end
+    user.login = params[:user][:login].strip if params[:user][:login].present?
+    user.password = params[:user][:password]
+    user.password_confirmation = params[:user][:password_confirmation]
+
+    respond_for_registered_user(user)
+  end
+
+  def register_with_auth_source(user)
+    # on-the-fly registration via omniauth or via auth source
+    if pending_omniauth_registration?
+      user.assign_attributes permitted_params.user_register_via_omniauth
+      register_via_omniauth(session, user.attributes)
+    else
+      user.attributes = permitted_params.user
+      user.activate
+      user.login = session[:auth_source_registration][:login]
+      user.ldap_auth_source_id = session[:auth_source_registration][:ldap_auth_source_id]
+
+      respond_for_registered_user(user)
+    end
+  end
+
+  def respond_for_registered_user(user)
+    call = ::Users::RegisterUserService.new(user).call
+
+    if call.success?
+      flash[:notice] = call.message.presence
+      login_user_if_active(call.result, just_registered: true)
+    else
+      flash[:error] = error = call.message
+      Rails.logger.error "Registration of user #{user.login} failed: #{error}"
+      onthefly_creation_failed(user)
+    end
+  end
+
+  # Onthefly creation failed, display the registration form to fill/fix attributes
+  def onthefly_creation_failed(user, auth_source_options = {})
+    @user = user
+    session[:auth_source_registration] = auth_source_options unless auth_source_options.empty?
+    render action: "register"
+  end
+
+  def self_registration_disabled
+    flash[:error] = I18n.t("account.error_self_registration_disabled")
+    redirect_to signin_url
+  end
+
+  def account_inactive(user, flash_now: true)
+    if user.registered?
+      account_not_activated(flash_now:)
+    else
+      flash_and_log_invalid_credentials(flash_now:)
+    end
+  end
+
+  def pending_omniauth_registration?
+    Hash(session[:auth_source_registration])[:omniauth]
+  end
+
+  # Log an attempt to log in to an account in "registered" state and show a flash message.
+  def account_not_activated(flash_now: true)
+    flash_error_message(log_reason: "NOT ACTIVATED", flash_now:) do
+      if Setting::SelfRegistration.by_email?
+        "account.error_inactive_activation_by_mail"
+      else
+        "account.error_inactive_manual_activation"
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/accounts/user_login.rb
+++ b/app/controllers/concerns/accounts/user_login.rb
@@ -10,4 +10,33 @@ module Accounts::UserLogin
 
     redirect_after_login(user)
   end
+
+  ##
+  # Log an attempt to log in to a locked account or with invalid credentials
+  # and show a flash message.
+  def flash_and_log_invalid_credentials(flash_now: true, is_logged_in: false)
+    if is_logged_in
+      flash[:error] = I18n.t(:notice_account_wrong_password)
+      return
+    end
+
+    flash_error_message(log_reason: "invalid credentials", flash_now:) do
+      if Setting.brute_force_block_after_failed_logins.to_i > 0
+        :notice_account_invalid_credentials_or_blocked
+      else
+        :notice_account_invalid_credentials
+      end
+    end
+  end
+
+  def flash_error_message(log_reason: "", flash_now: true)
+    flash_hash = flash_now ? flash.now : flash
+
+    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip} " \
+                "at #{Time.now.utc}: #{log_reason}"
+
+    flash_message = yield
+
+    flash_hash[:error] = I18n.t(flash_message)
+  end
 end

--- a/app/controllers/concerns/accounts/user_password_change.rb
+++ b/app/controllers/concerns/accounts/user_password_change.rb
@@ -61,24 +61,6 @@ module Accounts::UserPasswordChange
     render_password_change user, call.message, show_user_name:
   end
 
-  ##
-  # Log an attempt to log in to a locked account or with invalid credentials
-  # and show a flash message.
-  def flash_and_log_invalid_credentials(flash_now: true, is_logged_in: false)
-    if is_logged_in
-      flash[:error] = I18n.t(:notice_account_wrong_password)
-      return
-    end
-
-    flash_error_message(log_reason: "invalid credentials", flash_now:) do
-      if Setting.brute_force_block_after_failed_logins.to_i > 0
-        :notice_account_invalid_credentials_or_blocked
-      else
-        :notice_account_invalid_credentials
-      end
-    end
-  end
-
   def render_password_change(user, message, show_user_name: false)
     flash[:error] = message unless message.nil?
     @user = user
@@ -97,16 +79,5 @@ module Accounts::UserPasswordChange
       return true
     end
     false
-  end
-
-  def flash_error_message(log_reason: "", flash_now: true)
-    flash_hash = flash_now ? flash.now : flash
-
-    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip} " \
-                "at #{Time.now.utc}: #{log_reason}"
-
-    flash_message = yield
-
-    flash_hash[:error] = I18n.t(flash_message)
   end
 end

--- a/app/controllers/omni_auth_login_controller.rb
+++ b/app/controllers/omni_auth_login_controller.rb
@@ -56,7 +56,7 @@ class OmniAuthLoginController < ApplicationController
 
   def failure
     log_omniauth_failure
-    show_error I18n.t(:error_external_authentication_failed, message: omniauth_error)
+    show_error I18n.t(:error_external_authentication_failed_message, message: omniauth_error)
   end
 
   private

--- a/app/controllers/omni_auth_login_controller.rb
+++ b/app/controllers/omni_auth_login_controller.rb
@@ -55,11 +55,21 @@ class OmniAuthLoginController < ApplicationController
   end
 
   def failure
-    logger.warn(params[:message]) if params[:message]
-    show_error I18n.t(:error_external_authentication_failed)
+    log_omniauth_failure
+    show_error I18n.t(:error_external_authentication_failed, message: omniauth_error)
   end
 
   private
+
+  def log_omniauth_failure
+    type = request.env["omniauth.error.type"] || "internal"
+    logger.warn "OmniAuth authentication failed (Error #{type}): #{omniauth_error}"
+  end
+
+  def omniauth_error
+    message = request.env["omniauth.error"] || request.env["omniauth.error.type"] || request.env["omniauth.error.message"]
+    message&.to_s || "Unknown error"
+  end
 
   def redirect_omniauth_register_modal(user, auth_hash)
     # Store a timestamp so we can later make sure that authentication information can

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -32,7 +32,7 @@ module OmniauthHelper
   end
 
   def direct_login_provider_url(params = {})
-    omniauth_start_url(direct_login_provider, params)
+    omni_auth_start_url(direct_login_provider, params)
   end
 
   ##

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -31,6 +31,10 @@ module OmniauthHelper
     direct_login_provider.is_a? String
   end
 
+  def direct_login_provider_url(params = {})
+    omniauth_start_url(direct_login_provider, params)
+  end
+
   ##
   # Per default the user may choose the usual password login as well as several omniauth providers
   # on the login page and in the login drop down menu.

--- a/app/views/hooks/login/_auth_provider.html.erb
+++ b/app/views/hooks/login/_auth_provider.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       opts[:origin] = params['back_url']
     end
   %>
-  <a href="<%= omniauth_start_path(:developer, opts) %>" class="auth-provider auth-provider-developer button">
+  <a href="<%= omni_auth_start_path(:developer, opts) %>" class="auth-provider auth-provider-developer button">
     <span class="auth-provider-name">Omniauth Developer</span>
   </a>
 <% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -28,6 +28,10 @@
 
 OmniAuth.config.logger = Rails.logger
 
+OmniAuth.config.on_failure = Proc.new do |env|
+  OmniAuthLoginController.action(:failure).call(env)
+end
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   unless Rails.env.production?
     provider :developer, fields: %i[first_name last_name email]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1748,7 +1748,7 @@ en:
     Can't rename "%{old_name}" to "%{new_name}" due to a conflict in the resulting menu item
     with the existing menu item "%{existing_caption}" (%{existing_identifier}).
 
-  error_external_authentication_failed: "An error occurred during external authentication. Please try again."
+  error_external_authentication_failed: "An error occurred during external authentication: %{message}"
   error_attribute_not_highlightable: "Attribute(s) not highlightable: %{attributes}"
 
   events:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1748,7 +1748,7 @@ en:
     Can't rename "%{old_name}" to "%{new_name}" due to a conflict in the resulting menu item
     with the existing menu item "%{existing_caption}" (%{existing_identifier}).
 
-  error_external_authentication_failed: "An error occurred during external authentication: %{message}"
+  error_external_authentication_failed_message: "An error occurred during external authentication: %{message}"
   error_attribute_not_highlightable: "Attribute(s) not highlightable: %{attributes}"
 
   events:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,8 +64,8 @@ Rails.application.routes.draw do
   # Add catch method for Rack OmniAuth to allow route helpers
   # Note: This renders a 404 in rails but is caught by omniauth in Rack before
   get "/auth/failure", to: "account#failure"
-  get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omniauth_start"
-  match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omniauth_callback", via: %i[get post]
+  get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
+  match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 
   # In case assets are actually delivered by a node server (e.g. in test env)
   # forward requests to the proxy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
 
   # Add catch method for Rack OmniAuth to allow route helpers
   # Note: This renders a 404 in rails but is caught by omniauth in Rack before
-  get "/auth/failure", to: "account#failure"
+  get "/auth/failure", to: "omni_auth_login#failure", as: "omni_auth_failure"
   get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
   match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,9 @@ Rails.application.routes.draw do
 
   # Add catch method for Rack OmniAuth to allow route helpers
   # Note: This renders a 404 in rails but is caught by omniauth in Rack before
-  get "/auth/failure", to: "account#omniauth_failure"
+  get "/auth/failure", to: "account#failure"
   get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omniauth_start"
-  match "/auth/:provider/callback", to: "account#omniauth_login", as: "omniauth_login", via: %i[get post]
+  match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omniauth_callback", via: %i[get post]
 
   # In case assets are actually delivered by a node server (e.g. in test env)
   # forward requests to the proxy

--- a/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
+++ b/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
     end
   %>
   <a
-    href="<%= omniauth_start_path(pro[:name], opts) %>"
+    href="<%= omni_auth_start_path(pro[:name], opts) %>"
     class="auth-provider auth-provider-<%= pro[:name] %> <%= pro[:icon] ? 'auth-provider--imaged' : '' %> button">
     <span class="auth-provider-name"><%= pro[:display_name] || pro[:name] %></span>
   </a>

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -73,7 +73,7 @@ module OpenProject
               # Set the uid and index for the logout in this session again
               session.merge! prev_session.slice(*h[:retain_from_session])
 
-              redirect_to omni_auth_start_path(h[:name]) + "/spslo"
+              redirect_to "#{omni_auth_start_path(h[:name])}/spslo"
             end
 
             h.symbolize_keys

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -73,7 +73,7 @@ module OpenProject
               # Set the uid and index for the logout in this session again
               session.merge! prev_session.slice(*h[:retain_from_session])
 
-              redirect_to omniauth_start_path(h[:name]) + "/spslo"
+              redirect_to omni_auth_start_path(h[:name]) + "/spslo"
             end
 
             h.symbolize_keys

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -45,7 +45,7 @@ module OpenProject::OpenIDConnect
           h[:single_sign_out_callback] = Proc.new do
             next unless h[:end_session_endpoint]
 
-            redirect_to "#{omniauth_start_path(h[:name])}/logout"
+            redirect_to "#{omni_auth_start_path(h[:name])}/logout"
           end
 
           # Remember oidc session values when logging in user

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -484,9 +484,10 @@ RSpec.describe OmniAuthLoginController, :skip_2fa_stage do # rubocop:disable RSp
 
       it "logs a warn message" do
         allow(Rails.logger).to receive(:warn)
-        post :failure, params: { message: "invalid_credentials" }
+        request.env["omniauth.error"] = "invalid_credentials"
+        post :failure
 
-        expect(Rails.logger).to have_received(:warn).with("invalid_credentials")
+        expect(Rails.logger).to have_received(:warn).with(/invalid_credentials/)
       end
     end
   end

--- a/spec/controllers/omni_auth_login_controller_spec.rb
+++ b/spec/controllers/omni_auth_login_controller_spec.rb
@@ -29,7 +29,7 @@
 require "spec_helper"
 
 # Concern is included into AccountController and depends on methods available there
-RSpec.describe OmniAuthLoginController, :skip_2fa_stage do # rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe OmniAuthLoginController, :skip_2fa_stage do
   let(:omniauth_strategy) { double("Google Strategy", name: "google") } # rubocop:disable RSpec/VerifiedDoubles
   let(:omniauth_hash) do
     OmniAuth::AuthHash.new(
@@ -477,9 +477,12 @@ RSpec.describe OmniAuthLoginController, :skip_2fa_stage do # rubocop:disable RSp
     end
 
     describe "Error occurs during authentication" do
-      it "redirects to login page" do
+      it "display the error" do
+        request.env["omniauth.error"] = "invalid_credentials"
         post :failure
+
         expect(response).to redirect_to signin_path
+        expect(flash[:error]).to include "invalid_credentials"
       end
 
       it "logs a warn message" do

--- a/spec/features/auth/auth_stages_spec.rb
+++ b/spec/features/auth/auth_stages_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Authentication Stages", :skip_2fa_stage do
 
     OpenProject::Authentication::Stage.register :dummy_step, "/login/stage_test"
 
-    allow_any_instance_of(AccountController)
+    allow_any_instance_of(ApplicationController) # rubocop:disable RSpec/AnyInstance
       .to receive(:stage_secret)
       .and_return("success") # usually 'success' would be a random hex string
   end

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe "Omniauth authentication" do
           OmniAuth::FailureEndpoint.new(env).redirect_to_failure
         end
         visit login_path
-        expect(page).to have_content(I18n.t(:error_external_authentication_failed))
+        expect(page).to have_content(I18n.t(:error_external_authentication_failed_message, message: "Unknown error"))
 
         if defined? instructions
           expect(page).to have_content instructions


### PR DESCRIPTION
# What are you trying to accomplish?
In preparation to add more functionality to the omniauth routes, specifically a setup route, I wanted to separate out the omniauth specific functionality from the concern mounted to AccountController into its own controller.

https://community.openproject.org/work_packages/57951