### PR TITLE
Use controller_name and action_name in authorization helpers

### DIFF
--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -109,7 +109,7 @@ class ColorsController < ApplicationController
   def default_breadcrumb; end
 
   def require_admin_unless_readonly_api_request
-    require_admin unless %w[index show].include? params[:action] and
+    require_admin unless %w[index show].include? action_name and
                          api_request?
   end
 end

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -46,9 +46,9 @@ module Accounts::Authorization
   private
 
   def authorization_check_required
-    unless authorization_is_ensured?(params[:action])
+    unless authorization_is_ensured?(action_name)
       raise <<-MESSAGE
-        Authorization check required for #{self.class.name}##{params[:action]}.
+        Authorization check required for #{self.class.name}##{action_name}.
 
         Use any method of
           #{METHODS_ENFORCING_AUTHORIZATION.join(', ')}
@@ -62,20 +62,20 @@ module Accounts::Authorization
   # Authorize the user for the requested controller action.
   # To be used in before_action hooks
   def authorize
-    do_authorize({ controller: params[:controller], action: params[:action] }, global: false)
+    do_authorize({ controller: controller_path, action: action_name }, global: false)
   end
 
   # Authorize the user for the requested controller action outside a project
   # To be used in before_action hooks
   def authorize_global
-    do_authorize({ controller: params[:controller], action: params[:action] }, global: true)
+    do_authorize({ controller: controller_path, action: action_name }, global: true)
   end
 
   # Find a project based on params[:project_id]
   def load_and_authorize_in_optional_project
     @project = Project.find(params[:project_id]) if params[:project_id].present?
 
-    do_authorize({ controller: params[:controller], action: params[:action] }, global: params[:project_id].blank?)
+    do_authorize({ controller: controller_path, action: action_name }, global: params[:project_id].blank?)
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -105,7 +105,7 @@ module Accounts::CurrentUser
   end
 
   def current_rss_key_user
-    if params[:format] == "atom" && params[:key] && accept_key_auth_actions.include?(params[:action])
+    if params[:format] == "atom" && params[:key] && accept_key_auth_actions.include?(action_name)
       # RSS key authentication does not start a session
       User.find_by_rss_key(params[:key])
     end
@@ -116,7 +116,7 @@ module Accounts::CurrentUser
 
     key = api_key_from_request
 
-    if key && accept_key_auth_actions.include?(params[:action])
+    if key && accept_key_auth_actions.include?(action_name)
       # Use API key
       User.find_by_api_key(key)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,7 +63,7 @@ module ApplicationHelper
     html_options = args.shift
     parameters_for_method_reference = args
 
-    return unless authorize_for(options[:controller] || params[:controller], options[:action])
+    return unless authorize_for(options[:controller] || controller_path, options[:action])
 
     if block_given?
       link_to(options, html_options, *parameters_for_method_reference, &)
@@ -241,11 +241,11 @@ module ApplicationHelper
   # Returns the theme, controller name, and action as css classes for the
   # HTML body.
   def body_css_classes
-    css = ["theme-" + OpenProject::CustomStyles::Design.identifier.to_s]
+    css = ["theme-#{OpenProject::CustomStyles::Design.identifier}"]
 
-    if params[:controller] && params[:action]
-      css << ("controller-" + params[:controller])
-      css << ("action-" + params[:action])
+    if controller_path && action_name
+      css << ("controller-#{controller_path}")
+      css << ("action-#{action_name}")
     end
 
     css << "ee-banners-#{EnterpriseToken.show_banners? ? 'visible' : 'hidden'}"

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -52,7 +52,7 @@ module PermissionSpecs
         controller_name, action_name = controller_action.split("#")
 
         it "allows calling #{controller_action} when having the permission #{permission}" do
-          controller.params = { controller: controller_name, action: action_name }
+          allow(controller).to receive_messages(controller_path: controller_name, action_name:)
 
           become_member_with_permissions(project, current_user, permission)
 
@@ -60,7 +60,7 @@ module PermissionSpecs
         end
 
         it "prevents calling #{controller_action} when not having the permission #{permission}" do
-          controller.params = { controller: controller_name, action: action_name }
+          allow(controller).to receive_messages(controller_path: controller_name, action_name:)
 
           become_member(project, current_user)
 


### PR DESCRIPTION
From https://guides.rubyonrails.org/action_controller_overview.html#routing-parameters:

> The params hash will always contain the :controller and :action keys, but you should use the methods [controller_name](https://api.rubyonrails.org/v7.2.1/classes/ActionController/Metal.html#method-i-controller_name) and [action_name](https://api.rubyonrails.org/v7.2.1/classes/AbstractController/Base.html#method-i-action_name) instead to access these values.

params[:action] will not be set if calling a controller manually from a rack env, e.g., `SesssionsController.action(:failure).call(rack_env)`. we will have to do that in OmniAuth for better errors, which is where I stumbled upon this.

Since we use the full controller path for authorization, such as `work_packages/reports`, we need to use `controller_path` instead (https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-controller_path)