### PR TITLE
Allow codeBlock plugin in primer forms using custom modal target

### DIFF
--- a/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
+++ b/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
@@ -28,15 +28,26 @@
 
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { Injectable, Injector } from '@angular/core';
-import { WpButtonMacroModalComponent } from 'core-app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal';
-import { WikiIncludePageMacroModalComponent } from 'core-app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal';
-import { CodeBlockMacroModalComponent } from 'core-app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal';
-import { ChildPagesMacroModalComponent } from 'core-app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal';
+import {
+  WpButtonMacroModalComponent,
+} from 'core-app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal';
+import {
+  WikiIncludePageMacroModalComponent,
+} from 'core-app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal';
+import {
+  CodeBlockMacroModalComponent,
+} from 'core-app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal';
+import {
+  ChildPagesMacroModalComponent,
+} from 'core-app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal';
+import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
 
 @Injectable()
 export class EditorMacrosService {
-  constructor(readonly opModalService:OpModalService,
-    readonly injector:Injector) {
+  constructor(
+    readonly opModalService:OpModalService,
+    readonly injector:Injector,
+  ) {
   }
 
   /**
@@ -44,7 +55,7 @@ export class EditorMacrosService {
    * Used from within ckeditor-augmented-textarea.
    */
   public configureWorkPackageButton(typeName?:string, classes?:string):Promise<{ type:string, classes:string }> {
-    return new Promise<{ type:string, classes:string }>((resolve, reject) => {
+    return new Promise<{ type:string, classes:string }>((resolve, _) => {
       this.opModalService.show(
         WpButtonMacroModalComponent,
         this.injector,
@@ -82,10 +93,15 @@ export class EditorMacrosService {
    */
   public editCodeBlock(content:string, languageClass:string):Promise<{ content:string, languageClass:string }> {
     return new Promise<{ content:string, languageClass:string }>((resolve, _) => {
+      const target = document.querySelector('opce-custom-modal-overlay') ? PortalOutletTarget.Custom : PortalOutletTarget.Default;
+
       this.opModalService.show(
         CodeBlockMacroModalComponent,
         this.injector,
         { content, languageClass },
+        false,
+        false,
+        target,
       ).subscribe((modal) => modal.closingEvent.subscribe(() => {
         if (modal.changed) {
           resolve({ languageClass: modal.languageClass, content: modal.content });

--- a/lib/primer/open_project/forms/rich_text_area.html.erb
+++ b/lib/primer/open_project/forms/rich_text_area.html.erb
@@ -6,7 +6,6 @@
                             inputs: @rich_text_options.reverse_merge(
                               {
                                 textareaSelector: "##{builder.field_id(@input.name)}",
-                                removePlugins: ["CodeBlock"],
                                 macros: false,
                                 turboMode: true
                               }

--- a/modules/overviews/app/components/project_custom_fields/sections/edit_component.html.erb
+++ b/modules/overviews/app/components/project_custom_fields/sections/edit_component.html.erb
@@ -1,3 +1,4 @@
+<%= helpers.angular_component_tag 'opce-custom-modal-overlay' %>
 <%=
   component_wrapper do
     primer_form_with(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57525

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
In https://github.com/opf/openproject/pull/15277, we disabled `codeBlock` from primer forms so that they don't appear in dialog, as the angular modal would trigger below. As we now have a custom target renderable within the dialog, this can be reverted