### PR TITLE
Docker builds: Only merge the digests from matrix.target

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Merge digests
         uses: actions/upload-artifact/merge@v4
         with:
-          pattern: digests-*
+          pattern: "digests-${{ matrix.target }}-*"
           overwrite: true
           name: "merged-digests-${{ matrix.target }}-${{ github.run_number }}-${{ github.run_attempt }}"
       - name: Download digests


### PR DESCRIPTION
14.4.0 and 14.4.1 pushed AIO and slim docker containers using the same images

https://community.openproject.org/work_packages/57561