### PR TITLE
Bug/56771 meeting timestamp in edit form not the same as in details

### DIFF
--- a/app/components/settings/time_zone_setting_component.rb
+++ b/app/components/settings/time_zone_setting_component.rb
@@ -30,7 +30,7 @@
 
 module Settings
   ##
-  # A text field to enter numeric values.
+  # A select field to select a time zone from.
   class TimeZoneSettingComponent < ::ApplicationComponent
     options :form, :title
     options container_class: "-wide"

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -49,7 +49,7 @@ class AnonymousUser < User
 
   def mail; nil end
 
-  def time_zone; nil end
+  def time_zone; ActiveSupport::TimeZone["Etc/UTC"] end
 
   def rss_key; nil end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -49,7 +49,7 @@ class AnonymousUser < User
 
   def mail; nil end
 
-  def time_zone; ActiveSupport::TimeZone["Etc/UTC"] end
+  def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
 
   def rss_key; nil end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -27,31 +27,25 @@
 #++
 
 class AnonymousUser < User
-  validate :validate_unique_anonymous_user, on: :create
-
-  # There should be only one AnonymousUser in the database
-  def validate_unique_anonymous_user
-    errors.add :base, "An anonymous user already exists." if AnonymousUser.any?
-  end
-
-  def available_custom_fields
-    []
-  end
-
-  # Overrides a few properties
-  def logged?; false end
-
-  def builtin?; true end
-
-  def admin; false end
+  include Users::FunctionUser
 
   def name(*_args); I18n.t(:label_user_anonymous) end
 
-  def mail; nil end
+  def self.first
+    anonymous_user = super
 
-  def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
+    if anonymous_user.nil?
+      (anonymous_user = new.tap do |u|
+        u.lastname = "Anonymous"
+        u.login = ""
+        u.firstname = ""
+        u.mail = ""
+        u.status = User.statuses[:active]
+      end).save
 
-  def rss_key; nil end
+      raise "Unable to create the anonymous user." if anonymous_user.new_record?
+    end
 
-  def destroy; false end
+    anonymous_user
+  end
 end

--- a/app/models/deleted_user.rb
+++ b/app/models/deleted_user.rb
@@ -17,7 +17,7 @@ class DeletedUser < User
   def admin = false
   def name(*_args) = I18n.t("user.deleted")
   def mail = nil
-  def time_zone = nil
+  def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
   def rss_key = nil
   def destroy = false
 end

--- a/app/models/deleted_user.rb
+++ b/app/models/deleted_user.rb
@@ -1,23 +1,9 @@
 class DeletedUser < User
-  validate :validate_unique_deleted_user, on: :create
-
-  # There should be only one DeletedUser in the database
-  def validate_unique_deleted_user
-    errors.add :base, "A DeletedUser already exists." if DeletedUser.any?
-  end
-
   def self.first
     super || create(type: to_s, status: statuses[:locked])
   end
 
-  # Overrides a few properties
-  def available_custom_fields = []
-  def logged? = false
-  def builtin? = true
-  def admin = false
+  include Users::FunctionUser
+
   def name(*_args) = I18n.t("user.deleted")
-  def mail = nil
-  def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
-  def rss_key = nil
-  def destroy = false
 end

--- a/app/models/exports/concerns/csv.rb
+++ b/app/models/exports/concerns/csv.rb
@@ -84,7 +84,7 @@ module Exports
       def csv_export_filename
         sane_filename(
           "#{Setting.app_title} #{title} \
-          #{format_time_as_date(Time.zone.now, '%Y-%m-%d')}.csv"
+          #{format_time_as_date(Time.zone.now, format: '%Y-%m-%d')}.csv"
         )
       end
     end

--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -47,7 +47,7 @@ class SystemUser < User
 
   def mail; nil end
 
-  def time_zone; nil end
+  def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
 
   def rss_key; nil end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -409,6 +409,12 @@ class User < Principal
     @time_zone ||= (pref.time_zone.blank? ? nil : ActiveSupport::TimeZone[pref.time_zone])
   end
 
+  def reload(*)
+    @time_zone = nil
+
+    super
+  end
+
   def wants_comments_in_reverse_order?
     pref.comments_in_reverse_order?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,7 +398,7 @@ class User < Principal
   end
 
   def log_successful_login
-    update_attribute(:last_login_on, Time.now)
+    update_attribute(:last_login_on, Time.current)
   end
 
   def pref

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -543,46 +543,12 @@ class User < Principal
 
   # Returns the anonymous user.  If the anonymous user does not exist, it is created.  There can be only
   # one anonymous user per database.
-  def self.anonymous # rubocop:disable Metrics/AbcSize
-    RequestStore[:anonymous_user] ||=
-      begin
-        anonymous_user = AnonymousUser.first
-
-        if anonymous_user.nil?
-          (anonymous_user = AnonymousUser.new.tap do |u|
-            u.lastname = "Anonymous"
-            u.login = ""
-            u.firstname = ""
-            u.mail = ""
-            u.status = User.statuses[:active]
-          end).save
-
-          raise "Unable to create the anonymous user." if anonymous_user.new_record?
-        end
-        anonymous_user
-      end
+  def self.anonymous
+    RequestStore[:anonymous_user] ||= AnonymousUser.first
   end
 
   def self.system
-    system_user = SystemUser.first
-
-    if system_user.nil?
-      system_user = SystemUser.new(
-        firstname: "",
-        lastname: "System",
-        login: "",
-        mail: "",
-        admin: true,
-        status: User.statuses[:active],
-        first_login: false
-      )
-
-      system_user.save(validate: false)
-
-      raise "Unable to create the automatic migration user." unless system_user.persisted?
-    end
-
-    system_user
+    SystemUser.first
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -406,7 +406,7 @@ class User < Principal
   end
 
   def time_zone
-    @time_zone ||= (pref.time_zone.blank? ? nil : ActiveSupport::TimeZone[pref.time_zone])
+    @time_zone ||= ActiveSupport::TimeZone[pref.time_zone] || ActiveSupport::TimeZone["Etc/UTC"]
   end
 
   def reload(*)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -688,6 +688,6 @@ class User < Principal
   end
 
   def self.default_admin_account_changed?
-    !User.active.find_by_login("admin").try(:current_password).try(:matches_plaintext?, "admin") # rubocop:disable Rails/DynamicFindBy
+    !User.active.find_by_login("admin").try(:current_password).try(:matches_plaintext?, "admin")
   end
 end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -132,7 +132,7 @@ class UserPreference < ApplicationRecord
   end
 
   def time_zone
-    super.presence || Setting.user_default_timezone.presence
+    super.presence || Setting.user_default_timezone.presence || "Etc/UTC"
   end
 
   def daily_reminders

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -135,6 +135,10 @@ class UserPreference < ApplicationRecord
     super.presence || Setting.user_default_timezone.presence || "Etc/UTC"
   end
 
+  def time_zone?
+    settings["time_zone"].present?
+  end
+
   def daily_reminders
     super.presence || { enabled: true, times: ["08:00:00+00:00"] }.with_indifferent_access
   end

--- a/app/models/users/function_user.rb
+++ b/app/models/users/function_user.rb
@@ -26,40 +26,31 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#
-# User for tasks like migrations
-#
+module Users::FunctionUser
+  extend ActiveSupport::Concern
 
-class SystemUser < User
-  include Users::FunctionUser
+  included do
+    validate :validate_unique_function_user, on: :create
 
-  def name(*_args); "System" end
-
-  def run_given
-    User.execute_as(self) do
-      yield self
-    end
-  end
-
-  def self.first
-    system_user = super
-
-    if system_user.nil?
-      system_user = new(
-        firstname: "",
-        lastname: "System",
-        login: "",
-        mail: "",
-        admin: true,
-        status: User.statuses[:active],
-        first_login: false
-      )
-
-      system_user.save
-
-      raise "Unable to create the system user." unless system_user.persisted?
+    # There should be only one such user in the database
+    def validate_unique_function_user
+      errors.add :base, "A #{self.class.name} already exists." if self.class.any?
     end
 
-    system_user
+    def available_custom_fields = []
+
+    def logged? = false
+
+    def builtin? = true
+
+    def name(*_args); raise NotImplementedError end
+
+    def mail = nil
+
+    def time_zone; ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"] end
+
+    def rss_key = nil
+
+    def destroy = false
   end
 end

--- a/app/models/work_package/pdf_export/page.rb
+++ b/app/models/work_package/pdf_export/page.rb
@@ -127,7 +127,7 @@ module WorkPackage::PDFExport::Page
   end
 
   def footer_date
-    format_time(Time.zone.now, true)
+    format_time(Time.zone.now)
   end
 
   def total_page_nr_text

--- a/app/views/admin/settings/users_settings/show.html.erb
+++ b/app/views/admin/settings/users_settings/show.html.erb
@@ -48,7 +48,6 @@ See COPYRIGHT and LICENSE files for more details.
 
     <%= render Settings::TimeZoneSettingComponent.new(
           "user_default_timezone",
-          container_class: "-slim",
           title: I18n.t("tooltip_user_default_timezone")
         )
     %>

--- a/app/views/users/_preferences.html.erb
+++ b/app/views/users/_preferences.html.erb
@@ -30,8 +30,10 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render Settings::TimeZoneSettingComponent.new(
     "time_zone",
     form: pref_fields,
+    include_blank: false,
     container_class: (defined? input_size) ? "-#{input_size}" : "-wide"
   )
+
   %>
   <div class="form--field">
     <%= pref_fields.select :theme, theme_options_for_select, container_class: '-middle' %>

--- a/app/views/users/_preferences.html.erb
+++ b/app/views/users/_preferences.html.erb
@@ -33,7 +33,6 @@ See COPYRIGHT and LICENSE files for more details.
     include_blank: false,
     container_class: (defined? input_size) ? "-#{input_size}" : "-wide"
   )
-
   %>
   <div class="form--field">
     <%= pref_fields.select :theme, theme_options_for_select, container_class: '-middle' %>

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -120,11 +120,7 @@ module Redmine
       return nil unless time
 
       zone = User.current.time_zone
-      local_date = (if zone
-                      time.in_time_zone(zone)
-                    else
-                      time.utc? ? time.localtime : time
-                    end).to_date
+      local_date = time.in_time_zone(zone).to_date
 
       if format
         local_date.strftime(format)

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -138,17 +138,14 @@ module Redmine
 
       time = time.to_time if time.is_a?(String)
       zone = User.current.time_zone
-      local = if zone
-                time.in_time_zone(zone)
-              else
-                (time.utc? ? time.to_time.localtime : time)
-              end
+      local = time.in_time_zone(zone)
+
       (include_date ? "#{format_date(local)} " : "") +
         (Setting.time_format.blank? ? ::I18n.l(local, format: :time) : local.strftime(Setting.time_format))
     end
 
     def format_time_zone
-      (User.current.time_zone || Time.zone).to_s[/\((.*?)\)/m, 1]
+      User.current.time_zone.to_s[/\((.*?)\)/m, 1]
     end
 
     def day_name(day)

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -129,6 +129,17 @@ module Redmine
       end
     end
 
+    # Formats the given time as a time string according to the user's time zone
+    # and optional specified format.
+    #
+    # @param time [Time, String] The time to format. Can be a Time object or a
+    #   String.
+    # @param include_date [Boolean] Whether to include the date in the formatted
+    #   output. Defaults to true.
+    # @param format [String] The strftime format to use for the time. Defaults
+    #   to the format in `Setting.time_format`.
+    # @return [String, nil] The formatted time string, or nil if the time is not
+    #   provided.
     def format_time(time, include_date: true, format: Setting.time_format)
       return nil unless time
 

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -147,6 +147,10 @@ module Redmine
         (Setting.time_format.blank? ? ::I18n.l(local, format: :time) : local.strftime(Setting.time_format))
     end
 
+    def format_time_zone
+      (User.current.time_zone || Time.zone).to_s[/\((.*?)\)/m, 1]
+    end
+
     def day_name(day)
       ::I18n.t("date.day_names")[day % 7]
     end

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -129,7 +129,7 @@ module Redmine
       end
     end
 
-    def format_time(time, include_date = true)
+    def format_time(time, include_date = true, format: Setting.time_format)
       return nil unless time
 
       time = time.to_time if time.is_a?(String)
@@ -137,7 +137,7 @@ module Redmine
       local = time.in_time_zone(zone)
 
       (include_date ? "#{format_date(local)} " : "") +
-        (Setting.time_format.blank? ? ::I18n.l(local, format: :time) : local.strftime(Setting.time_format))
+        (format.blank? ? ::I18n.l(local, format: :time) : local.strftime(format))
     end
 
     # Returns the offset to UTC (with utc prepended) currently active

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -113,9 +113,13 @@ module Redmine
       /(\[(.+?)\]\((.+?)\))/
     end
 
-    # Format the time to a date in the user time zone if one is set.
-    # If none is set and the time is in utc time zone (meaning it came from active record), format the date in the system timezone
-    # otherwise just use the date in the time zone attached to the time.
+    # Formats the given time as a date string according to the user's time zone and
+    # optional specified format.
+    #
+    # @param time [Time, String] The time to format. Can be a Time object or a String.
+    # @param format [String, nil] The strftime format to use for the date. If nil, the default
+    #   date format from `Setting.date_format` is used.
+    # @return [String, nil] The formatted date string, or nil if the time is not provided.
     def format_time_as_date(time, format: nil)
       return nil unless time
 

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -144,8 +144,14 @@ module Redmine
         (Setting.time_format.blank? ? ::I18n.l(local, format: :time) : local.strftime(Setting.time_format))
     end
 
-    def format_time_zone
-      User.current.time_zone.to_s[/\((.*?)\)/m, 1]
+    # Returns the offset to UTC (with utc prepended) currently active
+    # in the current users time zone. DST is factored in so the offset can
+    # shift over the course of the year
+    def formatted_time_zone_offset
+      # Doing User.current.time_zone and format that will not take heed of DST as it has no notion
+      # of a current time.
+      # https://github.com/rails/rails/issues/7297
+      "UTC#{User.current.time_zone.now.formatted_offset}"
     end
 
     def day_name(day)

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -116,7 +116,7 @@ module Redmine
     # Formats the given time as a date string according to the user's time zone and
     # optional specified format.
     #
-    # @param time [Time, String] The time to format. Can be a Time object or a String.
+    # @param time [Time] The time to format.
     # @param format [String, nil] The strftime format to use for the date. If nil, the default
     #   date format from `Setting.date_format` is used.
     # @return [String, nil] The formatted date string, or nil if the time is not provided.
@@ -136,8 +136,7 @@ module Redmine
     # Formats the given time as a time string according to the user's time zone
     # and optional specified format.
     #
-    # @param time [Time, String] The time to format. Can be a Time object or a
-    #   String.
+    # @param time [Time] The time to format.
     # @param include_date [Boolean] Whether to include the date in the formatted
     #   output. Defaults to true.
     # @param format [String] The strftime format to use for the time. Defaults
@@ -147,7 +146,6 @@ module Redmine
     def format_time(time, include_date: true, format: Setting.time_format)
       return nil unless time
 
-      time = time.to_time if time.is_a?(String)
       zone = User.current.time_zone
       local = time.in_time_zone(zone)
 

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -116,7 +116,7 @@ module Redmine
     # Format the time to a date in the user time zone if one is set.
     # If none is set and the time is in utc time zone (meaning it came from active record), format the date in the system timezone
     # otherwise just use the date in the time zone attached to the time.
-    def format_time_as_date(time, format = nil)
+    def format_time_as_date(time, format: nil)
       return nil unless time
 
       zone = User.current.time_zone
@@ -129,7 +129,7 @@ module Redmine
       end
     end
 
-    def format_time(time, include_date = true, format: Setting.time_format)
+    def format_time(time, include_date: true, format: Setting.time_format)
       return nil unless time
 
       time = time.to_time if time.is_a?(String)

--- a/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
@@ -43,7 +43,7 @@ module OpenProject::Bim::BcfXml
 
       sane_filename(
         "#{Setting.app_title} #{I18n.t(:label_work_package_plural)} \
-        #{format_time_as_date(Time.now, '%Y-%m-%d')}.bcf"
+        #{format_time_as_date(Time.current, format: '%Y-%m-%d')}.bcf"
       )
     end
 

--- a/modules/boards/app/components/boards/row_component.rb
+++ b/modules/boards/app/components/boards/row_component.rb
@@ -39,7 +39,7 @@ module Boards
     end
 
     def created_at
-      safe_join([helpers.format_date(model.created_at), helpers.format_time(model.created_at, false)], " ")
+      safe_join([helpers.format_date(model.created_at), helpers.format_time(model.created_at, include_date: false)], " ")
     end
 
     def type

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -47,7 +47,7 @@ module Meetings
     end
 
     def start_time
-      safe_join([helpers.format_date(model.start_time), helpers.format_time(model.start_time, false)], " ")
+      safe_join([helpers.format_date(model.start_time), helpers.format_time(model.start_time, include_date: false)], " ")
     end
 
     def duration

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -36,7 +36,7 @@
 
               time.with_column(ml: 2) do
                 render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
-                  format_time_zone
+                  formatted_time_zone_offset
                 end
               end
             end

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -36,7 +36,7 @@
 
               time.with_column(ml: 2) do
                 render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
-                  (User.current.time_zone || Time.zone).to_s[/\((.*?)\)/m, 1]
+                  format_time_zone
                 end
               end
             end

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -30,7 +30,7 @@
             flex_layout(align_items: :center) do |time|
               time.with_column do
                 render(Primer::Beta::Text.new) do
-                  "#{format_time(@meeting.start_time, false)} - #{format_time(@meeting.end_time, false)}"
+                  "#{format_time(@meeting.start_time, include_date: false)} - #{format_time(@meeting.end_time, include_date:false)}"
                 end
               end
 

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
@@ -45,11 +45,11 @@ module Meetings
     private
 
     def start_date_initial_value
-      format_time_as_date(@meeting.start_time, "%Y-%m-%d")
+      format_time_as_date(@meeting.start_time, format: "%Y-%m-%d")
     end
 
     def start_time_initial_value
-      format_time(@meeting.start_time, false, format: "%H:%M")
+      format_time(@meeting.start_time, include_date: false, format: "%H:%M")
     end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
@@ -45,11 +45,11 @@ module Meetings
     private
 
     def start_date_initial_value
-      @meeting.start_time&.strftime("%Y-%m-%d")
+      format_time_as_date(@meeting.start_time, "%Y-%m-%d")
     end
 
     def start_time_initial_value
-      @meeting.start_time&.strftime("%H:%M")
+      format_time(@meeting.start_time, false, format: "%H:%M")
     end
   end
 end

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -290,14 +290,7 @@ class MeetingsController < ApplicationController
   end
 
   def set_time_zone(&)
-    zone = User.current.time_zone
-    if zone.nil?
-      localzone = Time.current.utc_offset
-      localzone -= 3600 if Time.current.dst?
-      zone = ::ActiveSupport::TimeZone[localzone]
-    end
-
-    Time.use_zone(zone, &)
+    Time.use_zone(User.current.time_zone, &)
   end
 
   def build_meeting

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -27,7 +27,6 @@
 #++
 
 class MeetingsController < ApplicationController
-  around_action :set_time_zone
   before_action :load_and_authorize_in_optional_project, only: %i[index new show create history]
   before_action :verify_activities_module_activated, only: %i[history]
   before_action :determine_date_range, only: %i[history]
@@ -287,10 +286,6 @@ class MeetingsController < ApplicationController
     query
       .results
       .paginate(page: page_param, per_page: per_page_param)
-  end
-
-  def set_time_zone(&)
-    Time.use_zone(User.current.time_zone, &)
   end
 
   def build_meeting

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -96,8 +96,8 @@ class MeetingsController < ApplicationController
 
     if call.success?
       text = I18n.t(:notice_successful_create)
-      if User.current.time_zone.nil?
-        link = I18n.t(:notice_timezone_missing, zone: Time.zone)
+      unless User.current.pref.time_zone?
+        link = I18n.t(:notice_timezone_missing, zone: formatted_time_zone_offset)
         text += " #{view_context.link_to(link, { controller: '/my', action: :settings, anchor: 'pref_time_zone' },
                                          class: 'link_to_profile')}"
       end

--- a/modules/meeting/app/forms/meeting/start_time.rb
+++ b/modules/meeting/app/forms/meeting/start_time.rb
@@ -38,7 +38,7 @@ class Meeting::StartTime < ApplicationForm
       label: Meeting.human_attribute_name(:start_time),
       leading_visual: { icon: :clock },
       required: true,
-      caption: format_time_zone
+      caption: formatted_time_zone_offset
     )
   end
 

--- a/modules/meeting/app/forms/meeting/start_time.rb
+++ b/modules/meeting/app/forms/meeting/start_time.rb
@@ -27,6 +27,8 @@
 #++
 
 class Meeting::StartTime < ApplicationForm
+  include Redmine::I18n
+
   form do |meeting_form|
     meeting_form.text_field(
       name: :start_time_hour,
@@ -36,7 +38,7 @@ class Meeting::StartTime < ApplicationForm
       label: Meeting.human_attribute_name(:start_time),
       leading_visual: { icon: :clock },
       required: true,
-      caption: Time.zone.to_s[/\((.*?)\)/m, 1]
+      caption: format_time_zone
     )
   end
 

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -52,7 +52,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
             label: "#{meeting.project.name}: " \
                    "#{meeting.title} " \
                    "#{format_date(meeting.start_time)} " \
-                   "#{format_time(meeting.start_time, false)}",
+                   "#{format_time(meeting.start_time, include_date: false)}",
             value: meeting.id
           )
         end

--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -63,8 +63,6 @@ class MeetingMailer < UserMailer
     set_headers @meeting
 
     with_attached_ics(meeting, user) do
-      timezone = Time.zone || Time.zone_default
-      @formatted_timezone = format_timezone_offset timezone, @meeting.start_time
       subject = "[#{@meeting.project.name}] #{@meeting.title}"
       mail(to: user, subject:)
     end
@@ -94,10 +92,5 @@ class MeetingMailer < UserMailer
     open_project_headers "Project" => meeting.project.identifier, "Meeting-Id" => meeting.id
     headers["Content-Type"] = 'text/calendar; charset=utf-8; method="PUBLISH"; name="meeting.ics"'
     headers["Content-Transfer-Encoding"] = "8bit"
-  end
-
-  def format_timezone_offset(timezone, time)
-    offset = ::ActiveSupport::TimeZone.seconds_to_utc_offset time.utc_offest_for_timezone(timezone), true
-    "(GMT#{offset}) #{timezone.name}"
   end
 end

--- a/modules/meeting/app/models/activities/meeting_activity_provider.rb
+++ b/modules/meeting/app/models/activities/meeting_activity_provider.rb
@@ -109,8 +109,8 @@ class Activities::MeetingActivityProvider < Activities::BaseActivityProvider
       end_time = start_time + event["meeting_duration"].to_f.hours
 
       fstart_with = format_date start_time
-      fstart_without = format_time start_time, false
-      fend_without = format_time end_time, false
+      fstart_without = format_time start_time, include_date: false
+      fend_without = format_time end_time, include_date: false
 
       "#{I18n.t(:label_meeting)}: #{event['meeting_title']} (#{fstart_with} #{fstart_without}-#{fend_without})"
     else

--- a/modules/meeting/app/models/activities/meeting_event_mapper.rb
+++ b/modules/meeting/app/models/activities/meeting_event_mapper.rb
@@ -204,8 +204,8 @@ class Activities::MeetingEventMapper < Activities::EventMapper
     end_time = start_time + data[:meeting_duration].to_f.hours
 
     fstart_with = format_date start_time
-    fstart_without = format_time start_time, false
-    fend_without = format_time end_time, false
+    fstart_without = format_time start_time, include_date: false
+    fend_without = format_time end_time, include_date: false
 
     "#{I18n.t(:label_meeting)}: #{data[:meeting_title]} (#{fstart_with} #{fstart_without}-#{fend_without})"
   end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -260,8 +260,8 @@ class Meeting < ApplicationRecord
   end
 
   def update_derived_fields
-    @start_date = format_time_as_date(start_time, "%Y-%m-%d")
-    @start_time_hour = format_time(start_time, false, format: "%H:%M")
+    @start_date = format_time_as_date(start_time, format: "%Y-%m-%d")
+    @start_time_hour = format_time(start_time, include_date: false, format: "%H:%M")
   end
 
   private

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -253,14 +253,15 @@ class Meeting < ApplicationRecord
 
   def set_initial_values
     # set defaults
-    write_attribute(:start_time, Date.tomorrow + 10.hours) if start_time.nil?
+    # Start date is set to tomorrow at 10 AM (Current users local time)
+    write_attribute(:start_time, User.current.time_zone.now.at_midnight + 34.hours) if start_time.nil?
     self.duration ||= 1
     update_derived_fields
   end
 
   def update_derived_fields
-    @start_date = start_time.to_date.iso8601
-    @start_time_hour = start_time.strftime("%H:%M")
+    @start_date = format_time_as_date(start_time, "%Y-%m-%d")
+    @start_time_hour = format_time(start_time, false, format: "%H:%M")
   end
 
   private

--- a/modules/meeting/app/models/meeting/journalized.rb
+++ b/modules/meeting/app/models/meeting/journalized.rb
@@ -35,7 +35,7 @@ module Meeting::Journalized
     acts_as_event title: Proc.new { |o|
                            "#{I18n.t(:label_meeting)}: #{o.title} \
           #{format_date o.start_time} \
-          #{format_time o.start_time, false}-#{format_time o.end_time, false})"
+          #{format_time o.start_time, include_date: false}-#{format_time o.end_time, include_date: false})"
                          },
                   url: Proc.new { |o| { controller: "/meetings", action: "show", id: o } },
                   author: Proc.new(&:user),

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
@@ -4,7 +4,7 @@
 <p><%= t(:text_notificiation_invited) %></p>
 
 <ul>
-<li><%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= @formatted_timezone %></li>
+<li><%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)</li>
 <li><%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %></li>
 <li><%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %></li>
 <li><%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %></li>

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
@@ -4,7 +4,7 @@
 <p><%= t(:text_notificiation_invited) %></p>
 
 <ul>
-<li><%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>-<%= format_time @meeting.end_time, false %> <%= @formatted_timezone %></li>
+<li><%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= @formatted_timezone %></li>
 <li><%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %></li>
 <li><%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %></li>
 <li><%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %></li>

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
@@ -3,7 +3,7 @@
 
 <%= t(:text_notificiation_invited) %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>-<%= format_time @meeting.end_time, false %> <%= @formatted_timezone %>
+<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= @formatted_timezone %>
 <%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
@@ -3,7 +3,7 @@
 
 <%= t(:text_notificiation_invited) %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= @formatted_timezone %>
+<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
 <%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/invited.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.html.erb
@@ -45,9 +45,9 @@ See COPYRIGHT and LICENSE files for more details.
               <%= I18n.t(:label_meeting_date_time) %>
             </td>
             <td style="<%= placeholder_text_styles %>">
-              <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>
+              <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
               -
-              <%= format_time @meeting.end_time, false %> <%= Time.zone %>
+              <%= format_time @meeting.end_time, include_date: false %> <%= Time.zone %>
             </td>
           </tr>
           <% if @meeting.location.present? %>

--- a/modules/meeting/app/views/meeting_mailer/invited.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
             <td style="<%= placeholder_text_styles %>">
               <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
               -
-              <%= format_time @meeting.end_time, include_date: false %> <%= Time.zone %>
+              <%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
             </td>
           </tr>
           <% if @meeting.location.present? %>

--- a/modules/meeting/app/views/meeting_mailer/invited.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.text.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= @meeting.project.name %>: <%= @meeting.title %> (<%= meeting_url(@meeting) %>)
 <%= @meeting.author %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>-<%= format_time @meeting.end_time, false %> <%= Time.zone %>
+<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= Time.zone %>
 <%= Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%= Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%= Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/invited.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.text.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= @meeting.project.name %>: <%= @meeting.title %> (<%= meeting_url(@meeting) %>)
 <%= @meeting.author %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> <%= Time.zone %>
+<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
 <%= Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%= Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%= Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
@@ -48,7 +48,7 @@ See COPYRIGHT and LICENSE files for more details.
               <s>
                 <%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %>
                 -
-                <%= format_time (@changes[:old_start] + @changes[:old_duration].hours), include_date: false %> <%= formatted_time_zone_offset %>
+                <%= format_time (@changes[:old_start] + @changes[:old_duration].hours), include_date: false %> (<%= formatted_time_zone_offset %>)
               </s>
             </td>
           </tr>
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
             <td style="<%= placeholder_text_styles('font-weight': 'bold') %>">
               <%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %>
               -
-              <%= format_time (@changes[:new_start] + @changes[:new_duration].hours), include_date: false %> <%= formatted_time_zone_offset %>
+              <%= format_time (@changes[:new_start] + @changes[:new_duration].hours), include_date: false %> (<%= formatted_time_zone_offset %>)
             </td>
           </tr>
           <% if @meeting.location.present? %>

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
@@ -46,9 +46,9 @@ See COPYRIGHT and LICENSE files for more details.
             </td>
             <td style="<%= placeholder_text_styles %>">
               <s>
-                <%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], false %>
+                <%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %>
                 -
-                <%= format_time (@changes[:old_start] + @changes[:old_duration].hours), false %> <%= Time.zone %>
+                <%= format_time (@changes[:old_start] + @changes[:old_duration].hours), include_date: false %> <%= formatted_time_zone_offset %>
               </s>
             </td>
           </tr>
@@ -57,9 +57,9 @@ See COPYRIGHT and LICENSE files for more details.
               <%= t('meeting.email.rescheduled.new_date_time') %>
             </td>
             <td style="<%= placeholder_text_styles('font-weight': 'bold') %>">
-              <%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], false %>
+              <%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %>
               -
-              <%= format_time (@changes[:new_start] + @changes[:new_duration].hours), false %> <%= Time.zone %>
+              <%= format_time (@changes[:new_start] + @changes[:new_duration].hours), include_date: false %> <%= formatted_time_zone_offset %>
             </td>
           </tr>
           <% if @meeting.location.present? %>

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       title: @meeting.title) %>
 
 <%= t('meeting.email.rescheduled.old_date_time') %>:
-<%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), include_date: false %> <%= Time.zone %>
+<%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}
 
 <%= t('meeting.email.rescheduled.new_date_time') %>:
-<%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), include_date: false %> <%= Time.zone %>
+<%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       title: @meeting.title) %>
 
 <%= t('meeting.email.rescheduled.old_date_time') %>:
-<%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), false %> <%= Time.zone %>
+<%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), include_date: false %> <%= Time.zone %>
 
 <%= t('meeting.email.rescheduled.new_date_time') %>:
-<%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), false %> <%= Time.zone %>
+<%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), include_date: false %> <%= Time.zone %>

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -160,7 +160,7 @@ See COPYRIGHT and LICENSE files for more details.
         <%= Meeting.human_attribute_name(:start_time) %>
         <label lang="en">
           <%= t(:label_time_zone) %>
-          <%= Time.zone.to_s %>
+          <%= formatted_time_zone_offset %>
         </label>
       </label>
       <%= f.text_field :start_time_hour,
@@ -169,7 +169,7 @@ See COPYRIGHT and LICENSE files for more details.
                        type: 'time',
                        no_label: true,
                        step: 5.minutes,
-                       suffix: Time.zone.to_s,
+                       suffix: formatted_time_zone_offset,
                        container_class: '-xslim' %>
     </div>
   </div>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -100,8 +100,8 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
     <div class="grid-content small-6">
       <p>
-        <strong><%= Meeting.human_attribute_name(:start_time) %></strong>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>
-        - <%= format_time @meeting.end_time, false %> <%= formatted_time_zone_offset %></p>
+        <strong><%= Meeting.human_attribute_name(:start_time) %></strong>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
+        - <%= format_time @meeting.end_time, include_date: false %> <%= formatted_time_zone_offset %></p>
     </div>
     <div class="grid-content small-6">
       <p>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -101,7 +101,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="grid-content small-6">
       <p>
         <strong><%= Meeting.human_attribute_name(:start_time) %></strong>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, false %>
-        - <%= format_time @meeting.end_time, false %> <%= Time.zone %></p>
+        - <%= format_time @meeting.end_time, false %> <%= formatted_time_zone_offset %></p>
     </div>
     <div class="grid-content small-6">
       <p>

--- a/modules/meeting/spec/features/meetings_copy_spec.rb
+++ b/modules/meeting/spec/features/meetings_copy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Meetings copy", :js, :with_cuprite do
   shared_let(:user) do
     create(:user,
            member_with_permissions: { project => permissions }).tap do |u|
-      u.pref[:time_zone] = "UTC"
+      u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
     end
@@ -66,7 +66,7 @@ RSpec.describe "Meetings copy", :js, :with_cuprite do
     start_of_meeting = start_time.strftime(twelve_hour_format)
     end_of_meeting = (start_time + meeting.duration.hours).strftime(twelve_hour_format)
 
-    "Start time: #{date} #{start_of_meeting} - #{end_of_meeting} (GMT+00:00) UTC"
+    "Start time: #{date} #{start_of_meeting} - #{end_of_meeting} UTC+00:00"
   end
 
   before do

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -33,7 +33,7 @@ require_relative "../support/pages/meetings/index"
 RSpec.describe "Meetings new", :js, with_cuprite: false do
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   shared_let(:admin) { create(:admin) }
-  let(:time_zone) { "utc" }
+  let(:time_zone) { "Etc/UTC" }
   let(:user) do
     create(:user,
            lastname: "First",

--- a/modules/meeting/spec/features/structured_meetings/mobile_structure_meeting_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/mobile_structure_meeting_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Structured meetings CRUD",
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
                                                     close_meeting_agendas view_work_packages] }).tap do |u|
-      u.pref[:time_zone] = "utc"
+      u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
     end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Structured meetings CRUD",
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
                                                     view_work_packages] }).tap do |u|
-      u.pref[:time_zone] = "utc"
+      u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
     end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Structured meetings participants",
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
                                                     close_meeting_agendas view_work_packages] }).tap do |u|
-      u.pref[:time_zone] = "utc"
+      u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
     end

--- a/modules/meeting/spec/features/structured_meetings/turbo_links_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/turbo_links_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Structured meetings links caught by turbo",
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
                                                     view_work_packages] }).tap do |u|
-      u.pref[:time_zone] = "utc"
+      u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
     end

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe MeetingMailer do
   let(:meeting_agenda) do
     create(:meeting_agenda, meeting:)
   end
+  let(:tokyo_offset) { "UTC#{ActiveSupport::TimeZone['Asia/Tokyo'].now.formatted_offset}" }
+  let(:berlin_offset) { "UTC#{ActiveSupport::TimeZone['Europe/Berlin'].now.formatted_offset}" }
 
   before do
     User.current = author
@@ -88,11 +90,9 @@ RSpec.describe MeetingMailer do
     context "with a recipient with another time zone" do
       let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
 
-      it "renders the mail with the correcet locale" do
-        expect(mail.text_part.body).to include("Tokyo")
-        expect(mail.text_part.body).to include("GMT+09:00")
-        expect(mail.html_part.body).to include("Tokyo")
-        expect(mail.html_part.body).to include("GMT+09:00")
+      it "renders the mail with the correct locale" do
+        expect(mail.text_part.body).to include(tokyo_offset)
+        expect(mail.html_part.body).to include(tokyo_offset)
 
         expect(mail.to).to contain_exactly(watcher1.mail)
       end
@@ -111,8 +111,8 @@ RSpec.describe MeetingMailer do
 
         it "renders the mail with the correct locale" do
           expect(mail.html_part.body).to include("11/09/2021 11:00 PM")
-          expect(mail.html_part.body).to include("12:00 AM (GMT+01:00) Europe/Berlin")
-          expect(mail.text_part.body).to include("11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin")
+          expect(mail.html_part.body).to include("12:00 AM (#{berlin_offset})")
+          expect(mail.text_part.body).to include("11/09/2021 11:00 PM-12:00 AM (#{berlin_offset})")
 
           expect(mail.to).to contain_exactly(author.mail)
         end
@@ -124,9 +124,9 @@ RSpec.describe MeetingMailer do
 
         it "renders the mail with the correct locale" do
           expect(mail.html_part.body).to include("11/10/2021 07:00 AM")
-          expect(mail.html_part.body).to include("08:00 AM (GMT+09:00) Asia/Tokyo")
+          expect(mail.html_part.body).to include("08:00 AM (#{tokyo_offset})")
 
-          expect(mail.text_part.body).to include("11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo")
+          expect(mail.text_part.body).to include("11/10/2021 07:00 AM-08:00 AM (#{tokyo_offset})")
 
           expect(mail.to).to contain_exactly(watcher1.mail)
         end
@@ -160,7 +160,7 @@ RSpec.describe MeetingMailer do
         expect(body).to include(meeting.project.name)
         expect(body).to include(meeting.title)
         expect(body).to include(meeting.location)
-        expect(body).to include("01/19/2021 11:00 AM-12:00 PM (GMT+01:00) Europe/Berlin")
+        expect(body).to include("01/19/2021 11:00 AM-12:00 PM (#{berlin_offset})")
         expect(body).to include(meeting.participants[0].name)
         expect(body).to include(meeting.participants[1].name)
       end
@@ -174,7 +174,7 @@ RSpec.describe MeetingMailer do
         expect(body).to include(meeting.title)
         expect(body).to include(meeting.location)
         expect(body).to include("01/19/2021 11:00 AM")
-        expect(body).to include("12:00 PM (GMT+01:00) Europe/Berlin")
+        expect(body).to include("12:00 PM (#{berlin_offset})")
         expect(body).to include(meeting.participants[0].name)
         expect(body).to include(meeting.participants[1].name)
       end
@@ -207,9 +207,9 @@ RSpec.describe MeetingMailer do
       let(:mail) { described_class.icalendar_notification(meeting, watcher1, author) }
 
       it "renders the mail with the correct locale" do
-        expect(mail.text_part.body).to include("01/19/2021 07:00 PM-08:00 PM (GMT+09:00) Asia/Tokyo")
+        expect(mail.text_part.body).to include("01/19/2021 07:00 PM-08:00 PM (#{tokyo_offset})")
         expect(mail.html_part.body).to include("01/19/2021 07:00 PM")
-        expect(mail.html_part.body).to include("08:00 PM (GMT+09:00) Asia/Tokyo")
+        expect(mail.html_part.body).to include("08:00 PM (#{tokyo_offset})")
 
         expect(mail.to).to contain_exactly(watcher1.mail)
       end
@@ -227,9 +227,9 @@ RSpec.describe MeetingMailer do
         let(:mail) { described_class.icalendar_notification(meeting, author, author) }
 
         it "renders the mail with the correct locale" do
-          expect(mail.text_part.body).to include("11/09/2021 11:00 PM-12:00 AM (GMT+01:00) Europe/Berlin")
+          expect(mail.text_part.body).to include("11/09/2021 11:00 PM-12:00 AM (#{berlin_offset})")
           expect(mail.html_part.body).to include("11/09/2021 11:00 PM")
-          expect(mail.html_part.body).to include("12:00 AM (GMT+01:00) Europe/Berlin")
+          expect(mail.html_part.body).to include("12:00 AM (#{berlin_offset})")
 
           expect(mail.to).to contain_exactly(author.mail)
         end
@@ -240,8 +240,8 @@ RSpec.describe MeetingMailer do
         let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
 
         it "renders the mail with the correct locale" do
-          expect(mail.text_part.body).to include("11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo")
-          expect(mail.html_part.body).to include("11/10/2021 07:00 AM-08:00 AM (GMT+09:00) Asia/Tokyo")
+          expect(mail.text_part.body).to include("11/10/2021 07:00 AM-08:00 AM (#{tokyo_offset})")
+          expect(mail.html_part.body).to include("11/10/2021 07:00 AM-08:00 AM (#{tokyo_offset})")
 
           expect(mail.to).to contain_exactly(watcher1.mail)
         end
@@ -255,6 +255,7 @@ RSpec.describe MeetingMailer do
     expect(body).to include(i18n.format_date(meeting.start_date))
     expect(body).to include(i18n.format_time(meeting.start_time, include_date: false))
     expect(body).to include(i18n.format_time(meeting.end_time, include_date: false))
+    expect(body).to include(i18n.formatted_time_zone_offset)
     expect(body).to include(meeting.participants[0].name)
     expect(body).to include(meeting.participants[1].name)
   end

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -253,8 +253,8 @@ RSpec.describe MeetingMailer do
     expect(body).to include(meeting.project.name)
     expect(body).to include(meeting.title)
     expect(body).to include(i18n.format_date(meeting.start_date))
-    expect(body).to include(i18n.format_time(meeting.start_time, false))
-    expect(body).to include(i18n.format_time(meeting.end_time, false))
+    expect(body).to include(i18n.format_time(meeting.start_time, include_date: false))
+    expect(body).to include(i18n.format_time(meeting.end_time, include_date: false))
     expect(body).to include(meeting.participants[0].name)
     expect(body).to include(meeting.participants[1].name)
   end

--- a/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
+++ b/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
@@ -79,7 +79,7 @@ module XlsExport
       def xls_export_filename
         sane_filename(
           "#{Setting.app_title} #{spreadsheet_title} \
-          #{format_time_as_date(Time.zone.now, '%Y-%m-%d')}.xls"
+          #{format_time_as_date(Time.zone.now, format: '%Y-%m-%d')}.xls"
         )
       end
     end

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe API::V3::UserPreferences::UserPreferenceRepresenter,
     context "without a timezone set" do
       let(:preference) { build(:user_preference, time_zone: "") }
 
-      it "shows the timeZone as nil" do
-        expect(subject).to be_json_eql(nil.to_json).at_path("timeZone")
+      it "shows the timeZone as utc" do
+        expect(subject).to be_json_eql("Etc/UTC".to_json).at_path("timeZone")
       end
     end
 

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -374,6 +374,48 @@ module OpenProject
       end
     end
 
+    describe "#format_time_zone" do
+      current_user { build_stubbed(:user, preferences: { time_zone: user_time_zone }) }
+      let(:user_time_zone) { "" }
+
+      context "with the current user having set a time zone" do
+        let(:user_time_zone) { "Kathmandu" }
+
+        it "renders the time zone of the user" do
+          # No DST in this time zone so the expectation should be constant.
+          expect(format_time_zone).to eql "GMT+05:45"
+        end
+      end
+
+      context "without the current user having a time zone and no default one configured" do
+        let(:user_time_zone) { "" }
+
+        it "renders the UTC time zone" do
+          expect(format_time_zone).to eql "GMT+00:00"
+        end
+      end
+
+      context "without the current user having a time zone but with a default one configured",
+              with_settings: { user_default_timezone: "Kathmandu" } do
+        let(:user_time_zone) { "" }
+
+        it "renders the default time zone" do
+          # No DST in this time zone so the expectation should be constant.
+          expect(format_time_zone).to eql "GMT+05:45"
+        end
+      end
+
+      context "without the current user having a time zone and also a default one configured",
+              with_settings: { user_default_timezone: "Atlanta" } do
+        let(:user_time_zone) { "Kathmandu" }
+
+        it "renders the default time zone" do
+          # No DST in this time zone so the expectation should be constant.
+          expect(format_time_zone).to eql "GMT+05:45"
+        end
+      end
+    end
+
     describe "day names" do
       valid_languages.each do |lang|
         context "for locale #{lang}" do

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -43,12 +43,12 @@ module OpenProject
 
         it "returns a date string in the user timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format)).to eq "01/07/2013"
+          expect(format_time_as_date(time, format:)).to eq "01/07/2013"
         end
 
         it "returns a date string in the user timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format)).to eq "01/07/2013"
+          expect(format_time_as_date(time, format:)).to eq "01/07/2013"
         end
       end
 
@@ -57,12 +57,12 @@ module OpenProject
 
         it "returns a date string in the utc timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format)).to eq "30/06/2013"
+          expect(format_time_as_date(time, format:)).to eq "30/06/2013"
         end
 
         it "returns a date string in the utc timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format)).to eq "30/06/2013"
+          expect(format_time_as_date(time, format:)).to eq "30/06/2013"
         end
       end
     end
@@ -274,12 +274,12 @@ module OpenProject
       end
 
       it "with only hours" do
-        expect(format_time(now, false))
+        expect(format_time(now, include_date: false))
           .to eql now.strftime("%H %M")
       end
 
       it "renders correctly for only hours and when providing a custom format" do
-        expect(format_time(now, false, format: "%H:%M"))
+        expect(format_time(now, include_date: false, format: "%H:%M"))
           .to eql now.strftime("%H:%M")
       end
 
@@ -293,12 +293,12 @@ module OpenProject
         end
 
         it "renders correctly for only hours" do
-          expect(format_time(now, false))
+          expect(format_time(now, include_date: false))
             .to eql "21 30"
         end
 
         it "renders correctly for only hours and when providing a custom format" do
-          expect(format_time(now, false, format: "%H:%M"))
+          expect(format_time(now, include_date: false, format: "%H:%M"))
             .to eql "21:30"
         end
       end
@@ -313,7 +313,7 @@ module OpenProject
         end
 
         it "renders only hours" do
-          expect(format_time(now, false))
+          expect(format_time(now, include_date: false))
             .to eql "15:45"
         end
       end
@@ -328,7 +328,7 @@ module OpenProject
         end
 
         it "falls back to default for only hours" do
-          expect(format_time(now, false))
+          expect(format_time(now, include_date: false))
             .to eql "03:45 PM"
         end
 
@@ -343,7 +343,7 @@ module OpenProject
 
             it "raises no error for only hours" do
               described_class.with_locale lang do
-                expect { format_time(now, false) }
+                expect { format_time(now, include_date: false) }
                   .not_to raise_error
               end
             end
@@ -361,7 +361,7 @@ module OpenProject
         end
 
         it "falls back to default for only hours" do
-          expect(format_time(now, false))
+          expect(format_time(now, include_date: false))
             .to eql "03:45 PM"
         end
       end
@@ -376,7 +376,7 @@ module OpenProject
         end
 
         it "falls back to default for only hours" do
-          expect(format_time(now, false))
+          expect(format_time(now, include_date: false))
             .to eql "15:45"
         end
       end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -36,43 +36,33 @@ module OpenProject
     let(:user) { build_stubbed(:user) }
 
     describe "#format_time_as_date" do
+      current_user { build_stubbed(:user, preferences: { time_zone: user_time_zone }) }
+
       describe "with user time zone" do
-        before do
-          login_as user
-          allow(user).to receive(:time_zone).and_return(ActiveSupport::TimeZone["Athens"])
-        end
+        let(:user_time_zone) { "Europe/Athens" }
 
         it "returns a date in the user timezone for a utc timestamp" do
-          Time.use_zone("UTC") do
-            time = Time.zone.local(2013, 6, 30, 23, 59)
-            expect(format_time_as_date(time, format)).to eq "01/07/2013"
-          end
+          time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
+          expect(format_time_as_date(time, format)).to eq "01/07/2013"
         end
 
         it "returns a date in the user timezone for a non-utc timestamp" do
-          Time.use_zone("Berlin") do
-            time = Time.zone.local(2013, 6, 30, 23, 59)
-            expect(format_time_as_date(time, format)).to eq "01/07/2013"
-          end
+          time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
+          expect(format_time_as_date(time, format)).to eq "01/07/2013"
         end
       end
 
       describe "without user time zone" do
-        before { allow(User.current).to receive(:time_zone).and_return(nil) }
+        let(:user_time_zone) { "" }
 
-        it "returns a date in the local system timezone for a utc timestamp" do
-          Time.use_zone("UTC") do
-            time = Time.zone.local(2013, 6, 30, 23, 59)
-            allow(time).to receive(:localtime).and_return(ActiveSupport::TimeZone["Athens"].local(2013, 7, 1, 1, 59))
-            expect(format_time_as_date(time, format)).to eq "01/07/2013"
-          end
+        it "returns a date in the utc timezone for a utc timestamp" do
+          time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
+          expect(format_time_as_date(time, format)).to eq "30/06/2013"
         end
 
-        it "returns a date in the original timezone for a non-utc timestamp" do
-          Time.use_zone("Berlin") do
-            time = Time.zone.local(2013, 6, 30, 23, 59)
-            expect(format_time_as_date(time, format)).to eq "30/06/2013"
-          end
+        it "returns a date in the utc timezone for a non-utc timestamp" do
+          time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
+          expect(format_time_as_date(time, format)).to eq "30/06/2013"
         end
       end
     end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -382,16 +382,17 @@ module OpenProject
       end
     end
 
-    describe "#format_time_zone" do
+    describe "#formatted_time_zone_offset" do
       current_user { build_stubbed(:user, preferences: { time_zone: user_time_zone }) }
       let(:user_time_zone) { "" }
 
+      let(:berlin_gmt) { ActiveSupport::TimeZone["Europe/Berlin"].now.utc_offset == 7200 ? "UTC+02:00" : "UTC+01:00" }
+
       context "with the current user having set a time zone" do
-        let(:user_time_zone) { "Kathmandu" }
+        let(:user_time_zone) { "Europe/Berlin" }
 
         it "renders the time zone of the user" do
-          # No DST in this time zone so the expectation should be constant.
-          expect(format_time_zone).to eql "GMT+05:45"
+          expect(formatted_time_zone_offset).to eql berlin_gmt
         end
       end
 
@@ -399,27 +400,25 @@ module OpenProject
         let(:user_time_zone) { "" }
 
         it "renders the UTC time zone" do
-          expect(format_time_zone).to eql "GMT+00:00"
+          expect(formatted_time_zone_offset).to eql "UTC+00:00"
         end
       end
 
       context "without the current user having a time zone but with a default one configured",
-              with_settings: { user_default_timezone: "Kathmandu" } do
+              with_settings: { user_default_timezone: "Europe/Berlin" } do
         let(:user_time_zone) { "" }
 
         it "renders the default time zone" do
-          # No DST in this time zone so the expectation should be constant.
-          expect(format_time_zone).to eql "GMT+05:45"
+          expect(formatted_time_zone_offset).to eql berlin_gmt
         end
       end
 
       context "without the current user having a time zone and also a default one configured",
-              with_settings: { user_default_timezone: "Atlanta" } do
-        let(:user_time_zone) { "Kathmandu" }
+              with_settings: { user_default_timezone: "America/Atlanta" } do
+        let(:user_time_zone) { "Europe/Berlin" }
 
         it "renders the default time zone" do
-          # No DST in this time zone so the expectation should be constant.
-          expect(format_time_zone).to eql "GMT+05:45"
+          expect(formatted_time_zone_offset).to eql berlin_gmt
         end
       end
     end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -273,7 +273,10 @@ module OpenProject
       time_format: "%H %M",
       date_format: "%d %m %Y"
     } do
-      let!(:now) { Time.parse("2011-02-20 15:45:22") }
+      let(:user_time_zone) { "" }
+      let(:now) { Time.zone.parse("2011-02-20 15:45:22") }
+
+      current_user { build_stubbed(:user, preferences: { time_zone: user_time_zone }) }
 
       it "with date and hours" do
         expect(format_time(now))
@@ -285,14 +288,19 @@ module OpenProject
           .to eql now.strftime("%H %M")
       end
 
-      it "with a utc to date and hours" do
-        expect(format_time(now.utc))
-          .to eql now.localtime.strftime("%d %m %Y %H %M")
-      end
+      context "with another time zone configured for the user" do
+        # Kathmandu has a +05:45 offset
+        let(:user_time_zone) { "Kathmandu" }
 
-      it "with a utce to only hours" do
-        expect(format_time(now.utc, false))
-          .to eql now.localtime.strftime("%H %M")
+        it "renders correctly for data and hours" do
+          expect(format_time(now))
+            .to eql "20 02 2011 21 30"
+        end
+
+        it "renders correctly for only hours" do
+          expect(format_time(now, false))
+            .to eql "21 30"
+        end
       end
 
       context "with a different format defined", with_settings: {

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -41,12 +41,12 @@ module OpenProject
       describe "with user time zone" do
         let(:user_time_zone) { "Europe/Athens" }
 
-        it "returns a date in the user timezone for a utc timestamp" do
+        it "returns a date string in the user timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
           expect(format_time_as_date(time, format)).to eq "01/07/2013"
         end
 
-        it "returns a date in the user timezone for a non-utc timestamp" do
+        it "returns a date string in the user timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
           expect(format_time_as_date(time, format)).to eq "01/07/2013"
         end
@@ -55,12 +55,12 @@ module OpenProject
       describe "without user time zone" do
         let(:user_time_zone) { "" }
 
-        it "returns a date in the utc timezone for a utc timestamp" do
+        it "returns a date string in the utc timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
           expect(format_time_as_date(time, format)).to eq "30/06/2013"
         end
 
-        it "returns a date in the utc timezone for a non-utc timestamp" do
+        it "returns a date string in the utc timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
           expect(format_time_as_date(time, format)).to eq "30/06/2013"
         end
@@ -278,6 +278,11 @@ module OpenProject
           .to eql now.strftime("%H %M")
       end
 
+      it "renders correctly for only hours and when providing a custom format" do
+        expect(format_time(now, false, format: "%H:%M"))
+          .to eql now.strftime("%H:%M")
+      end
+
       context "with another time zone configured for the user" do
         # Kathmandu has a +05:45 offset
         let(:user_time_zone) { "Kathmandu" }
@@ -290,6 +295,11 @@ module OpenProject
         it "renders correctly for only hours" do
           expect(format_time(now, false))
             .to eql "21 30"
+        end
+
+        it "renders correctly for only hours and when providing a custom format" do
+          expect(format_time(now, false, format: "%H:%M"))
+            .to eql "21:30"
         end
       end
 

--- a/spec/models/deleted_user_spec.rb
+++ b/spec/models/deleted_user_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DeletedUser do
   end
 
   describe "#time_zone" do
-    it { expect(user.time_zone).to be_nil }
+    it { expect(user.time_zone).to eql ActiveSupport::TimeZone["Etc/UTC"] }
   end
 
   describe "#rss_key" do

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -222,4 +222,26 @@ RSpec.describe UserPreference do
       expect(subject[:auto_hide_popups]).to eql(value_auto_hide_popups)
     end
   end
+
+  describe "#time_zone" do
+    context "with a time zone set and a default configured", with_settings: { user_default_timezone: "America/Los_Angeles" } do
+      let(:settings) { { "time_zone" => "Africa/Algiers" } }
+
+      it "returns the time zone set" do
+        expect(preference.time_zone).to eql "Africa/Algiers"
+      end
+    end
+
+    context "with no time zone configured but a default", with_settings: { user_default_timezone: "America/Los_Angeles" } do
+      it "returns the default time zone" do
+        expect(preference.time_zone).to eql "America/Los_Angeles"
+      end
+    end
+
+    context "with neiter a time zone configured nor a default one", with_settings: { user_default_timezone: "" } do
+      it "returns UTC" do
+        expect(preference.time_zone).to eql "Etc/UTC"
+      end
+    end
+  end
 end

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -244,4 +244,26 @@ RSpec.describe UserPreference do
       end
     end
   end
+
+  describe "#time_zone?" do
+    context "with a time zone set and a default configured", with_settings: { user_default_timezone: "America/Los_Angeles" } do
+      let(:settings) { { "time_zone" => "Africa/Algiers" } }
+
+      it "is true" do
+        expect(preference).to be_time_zone
+      end
+    end
+
+    context "with no time zone configured but a default", with_settings: { user_default_timezone: "America/Los_Angeles" } do
+      it "is false" do
+        expect(preference).not_to be_time_zone
+      end
+    end
+
+    context "with neiter a time zone configured nor a default one", with_settings: { user_default_timezone: "" } do
+      it "is false" do
+        expect(preference).not_to be_time_zone
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -823,6 +823,39 @@ RSpec.describe User do
     end
   end
 
+  describe "#time_zone" do
+    let(:user) { build(:user, preferences:) }
+
+    context "with an existing time zone in the prefs" do
+      let(:preferences) { { "time_zone" => "Europe/Athens" } }
+
+      it "returns the matching ActiveSupport::TimeZone" do
+        expect(user.time_zone)
+          .to eql ActiveSupport::TimeZone["Europe/Athens"]
+      end
+    end
+
+    context "with an invalid time zone" do
+      # Would need to be Etc/UTC or UTC to be valid
+      let(:preferences) { { "time_zone" => "utc" } }
+
+      it "returns the utc ActiveSupport::TimeZone" do
+        expect(user.time_zone)
+          .to eql ActiveSupport::TimeZone["Etc/UTC"]
+      end
+    end
+
+    context "without a time zone" do
+      # Would need to be Etc/UTC or UTC to be valid
+      let(:preferences) { {} }
+
+      it "returns the utc ActiveSupport::TimeZone" do
+        expect(user.time_zone)
+          .to eql ActiveSupport::TimeZone["Etc/UTC"]
+      end
+    end
+  end
+
   describe "#find_by_mail" do
     let!(:user1) { create(:user, mail: "foo+test@example.org") }
     let!(:user2) { create(:user, mail: "foo@example.org") }

--- a/spec/models/users/default_timezone_spec.rb
+++ b/spec/models/users/default_timezone_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe User, "default time zone" do
   let(:user) { create(:user) }
 
   context "with no system default set" do
-    it "is not set" do
-      expect(user.pref.time_zone).to be_nil
+    it "is still set to Etc/UTC as that will be calculated with internally" do
+      expect(user.pref.time_zone).to eq "Etc/UTC"
     end
   end
 

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
     end
   end
   let(:export_time) { DateTime.new(2024, 4, 22, 12, 37) }
-  let(:export_time_formatted) { format_time(export_time, true) }
+  let(:export_time_formatted) { format_time(export_time, include_date: true) }
   let(:export) do
     login_as(user)
     work_packages

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
            member_with_permissions: { project => %w[view_work_packages export_work_packages] })
   end
   let(:export_time) { DateTime.new(2023, 6, 30, 23, 59) }
-  let(:export_time_formatted) { format_time(export_time, true) }
+  let(:export_time_formatted) { format_time(export_time, include_date: true) }
   let(:work_package_parent) do
     create(:work_package,
            project:,

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:category) { create(:category, project:, name: "Demo") }
   let(:version) { create(:version, project:) }
   let(:export_time) { DateTime.new(2023, 6, 30, 23, 59) }
-  let(:export_time_formatted) { format_time(export_time, true) }
+  let(:export_time_formatted) { format_time(export_time, include_date: true) }
   let(:image_path) { Rails.root.join("spec/fixtures/files/image.png") }
   let(:priority) { create(:priority_normal) }
   let(:image_attachment) { Attachment.new author: user, file: File.open(image_path) }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/56771

# What are you trying to accomplish?

The PR ensures that times and time zones displayed in the meetings module are always in the time zone of the current user. The bug originally reported in the work package could not be reproduced but before, different code paths have been used for rendering the time zone and the calculation on times was in part achieved by setting the request's time to be in the current user's time.  

# What approach did you choose and why?

* Querying for `User.current.time_zone` will now always return a value. It will never be `nil`. Either the time zone selected by the user or the time zone set as the default (`Setting.user_default_timezone`) is returned. This already used to be the case for logged in users. For those, in case no default is set, UTC is now returned. Internally, it was already handled as such as both server and database are running on UTC. The internal users (e.g. `AnonymousUser`) follow the same pattern. 
* The i18n helpers for `format_time` and `format_date_as_time` have been simplified. There used to be code in there that was working with the localtime. Since a few rails versions back, the server is always running in UTC so there is no need for this code. The only times now necessary are UTC and the user's local time. The server's local time should have no effect. Those methods get their signature updated to use named parameters.
* `formatted_time_zone_offset` is added to `I18n` which will give the currently active time offset to the user's time zone compared to UTC. This is now employed throughout the meeting module.
* Because time/date calculations are now handled at the places that matter, the before action that changed the request's time zone is no longer necessary and is thus removed.
* The user settings time zone select field has it's blank value removed. This is in line with the user always having UTC as their fallback timezone. Along the same line of thinking it would make sense to remove the blank value from the `Setting.user_default_timezone` select and set the value to UTC as a default but this is not done in the scope of this PR.

# Merge checklist

- [x] Added/updated tests
