### PR TITLE
[57258] Fix issues found during review

### DIFF
--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -151,6 +151,7 @@ class WorkPackages::ProgressForm < ApplicationForm
       name:,
       value: field_value(name),
       label:,
+      caption: field_hint_message(name),
       readonly: true,
       classes: "input--readonly",
       placeholder: ("-" if placeholder)
@@ -199,9 +200,10 @@ class WorkPackages::ProgressForm < ApplicationForm
   end
 
   def default_field_options(name)
+    action = name == :status_id ? "change" : "input"
     data = { "work-packages--progress--preview-progress-target": "progressInput",
              "work-packages--progress--touched-field-marker-target": "progressInput",
-             action: "input->work-packages--progress--touched-field-marker#markFieldAsTouched" }
+             action: "#{action}->work-packages--progress--touched-field-marker#markFieldAsTouched" }
 
     if @focused_field == name
       data[:"work-packages--progress--focus-field-target"] = "fieldToFocus"

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -197,10 +197,9 @@ class WorkPackages::ProgressForm < ApplicationForm
   end
 
   def default_field_options(name)
-    action = name == :status_id ? "change" : "input"
     data = { "work-packages--progress--preview-progress-target": "progressInput",
              "work-packages--progress--touched-field-marker-target": "progressInput",
-             action: "#{action}->work-packages--progress--touched-field-marker#markFieldAsTouched" }
+             action: "work-packages--progress--touched-field-marker#markFieldAsTouched" }
 
     if @focused_field == name
       data[:"work-packages--progress--focus-field-target"] = "fieldToFocus"

--- a/app/forms/work_packages/progress_form.rb
+++ b/app/forms/work_packages/progress_form.rb
@@ -183,10 +183,7 @@ class WorkPackages::ProgressForm < ApplicationForm
   end
 
   def field_hint_message(field_name)
-    hint = work_package.derived_progress_hints[field_name]
-    return if hint.nil?
-
-    I18n.t("work_package.progress.derivation_hints.#{field_name}.#{hint}")
+    work_package.derived_progress_hint(field_name)&.message
   end
 
   def validation_message(name)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -332,12 +332,12 @@ class WorkPackage < ApplicationRecord
     write_attribute :done_ratio, convert_value_to_percentage(value)
   end
 
-  def derived_progress_hints=(hints)
-    @derived_progress_hints = hints
+  def set_derived_progress_hint(field_name, hint, **params)
+    derived_progress_hints[field_name] = ProgressHint.new("#{field_name}.#{hint}", params)
   end
 
-  def derived_progress_hints
-    @derived_progress_hints ||= {}
+  def derived_progress_hint(field_name)
+    derived_progress_hints[field_name]
   end
 
   def duration_in_hours
@@ -552,6 +552,10 @@ class WorkPackage < ApplicationRecord
   end
 
   private
+
+  def derived_progress_hints
+    @derived_progress_hints ||= {}
+  end
 
   def add_time_entry_for(user, attributes)
     return if time_entry_blank?(attributes)

--- a/app/models/work_package/progress_hint.rb
+++ b/app/models/work_package/progress_hint.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Hint to be displayed in the progress popover under a progress value.
+#
+# `key` is like `field_name`.`hint` and is used to build up the translation
+# key. `params` is the translation parameters as some translation are
+# parameterized.
+class WorkPackage
+  ProgressHint = Data.define(:key, :params) do
+    def initialize(key:, params: {})
+      super
+    end
+
+    def message
+      I18n.t("work_package.progress.derivation_hints.#{key}", **to_hours(params))
+    end
+
+    def reason
+      key.split(".", 2).last
+    end
+
+    def to_hours(params)
+      params.transform_values { |value| DurationConverter.output(value.abs) }
+    end
+  end
+end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
@@ -157,8 +157,8 @@ class WorkPackages::SetAttributesService
 
     private
 
-    def set_hint(field, hint)
-      work_package.derived_progress_hints[field] = hint
+    def set_hint(field, hint, **params)
+      work_package.set_derived_progress_hint(field, hint, **params)
     end
 
     def round_progress_values

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
@@ -79,6 +79,10 @@ class WorkPackages::SetAttributesService
       DurationConverter.valid?(work_package.estimated_hours_before_type_cast)
     end
 
+    def work_invalid?
+      !work_valid?
+    end
+
     def remaining_work
       work_package.remaining_hours
     end
@@ -113,6 +117,10 @@ class WorkPackages::SetAttributesService
 
     def remaining_work_valid?
       DurationConverter.valid?(work_package.remaining_hours_before_type_cast)
+    end
+
+    def remaining_work_invalid?
+      !remaining_work_valid?
     end
 
     def percent_complete

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_status_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_status_based.rb
@@ -33,24 +33,39 @@ class WorkPackages::SetAttributesService
     def derive_progress_attributes
       raise ArgumentError, "Cannot use #{self.class.name} in work-based mode" if WorkPackage.work_based_mode?
 
-      update_percent_complete
-      update_remaining_work_from_percent_complete
+      # do not change anything if some values are invalid: this will be detected
+      # by the contract and errors will be set.
+      return if invalid_progress_values?
+
+      update_percent_complete if derive_percent_complete?
+      update_remaining_work if derive_remaining_work?
+    end
+
+    def invalid_progress_values?
+      work_invalid?
+    end
+
+    def derive_percent_complete?
+      status_percent_complete_changed?
+    end
+
+    def derive_remaining_work?
+      status_percent_complete_changed? || work_changed?
+    end
+
+    def status_percent_complete_changed?
+      work_package.status_id_changed? && work_package.status.default_done_ratio != work_package.done_ratio_was
     end
 
     # Update +% complete+ from the status if the status changed.
     def update_percent_complete
-      return unless work_package.status_id_changed?
-
       self.percent_complete = work_package.status.default_done_ratio
     end
 
     # When in "Status-based" mode for progress calculation, remaining work is
     # always derived from % complete and work. If work is unset, then remaining
     # work must be unset too.
-    def update_remaining_work_from_percent_complete
-      return if remaining_work_came_from_user?
-      return if work&.negative?
-
+    def update_remaining_work
       if work_empty?
         return unless work_changed?
 

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -100,9 +100,9 @@ class WorkPackages::SetAttributesService
       elsif work_changed? && work_set? && remaining_work_set? && percent_complete_not_provided_by_user?
         delta = work - work_was
         if delta.positive?
-          set_hint(:remaining_hours, :increased_like_work, delta:)
+          set_hint(:remaining_hours, :increased_by_delta_like_work, delta:)
         elsif delta.negative?
-          set_hint(:remaining_hours, :decreased_like_work, delta:)
+          set_hint(:remaining_hours, :decreased_by_delta_like_work, delta:)
         end
         self.remaining_work = (remaining_work + delta).clamp(0.0, work)
       elsif work_empty?

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -161,14 +161,6 @@ class WorkPackages::SetAttributesService
       remaining_work / remaining_percent_complete
     end
 
-    def work_invalid?
-      !work_valid?
-    end
-
-    def remaining_work_invalid?
-      !remaining_work_valid?
-    end
-
     def percent_complete_unparsable?
       !PercentageConverter.valid?(work_package.done_ratio_before_type_cast)
     end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -100,9 +100,9 @@ class WorkPackages::SetAttributesService
       elsif work_changed? && work_set? && remaining_work_set? && percent_complete_not_provided_by_user?
         delta = work - work_was
         if delta.positive?
-          set_hint(:remaining_hours, :increased_like_work)
+          set_hint(:remaining_hours, :increased_like_work, delta:)
         elsif delta.negative?
-          set_hint(:remaining_hours, :decreased_like_work)
+          set_hint(:remaining_hours, :decreased_like_work, delta:)
         end
         self.remaining_work = (remaining_work + delta).clamp(0.0, work)
       elsif work_empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3773,9 +3773,9 @@ en:
         remaining_hours:
           cleared_because_work_is_empty: "Cleared because Work is empty."
           cleared_because_percent_complete_is_empty: "Cleared because % Complete is empty."
-          decreased_like_work: "Decreased by %{delta}, matching the reduction in Work."
+          decreased_by_delta_like_work: "Decreased by %{delta}, matching the reduction in Work."
           derived: "Derived from Work and % Complete."
-          increased_like_work: "Increased by %{delta}, matching the increase in Work."
+          increased_by_delta_like_work: "Increased by %{delta}, matching the increase in Work."
           same_as_work: "Set to same value as Work."
     permissions:
       comment: "Comment"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3773,9 +3773,9 @@ en:
         remaining_hours:
           cleared_because_work_is_empty: "Cleared because Work is empty."
           cleared_because_percent_complete_is_empty: "Cleared because % Complete is empty."
-          decreased_like_work: "Decreased by the same amount as Work."
+          decreased_like_work: "Decreased by %{delta}, matching the reduction in Work."
           derived: "Derived from Work and % Complete."
-          increased_like_work: "Increased by the same amount as Work."
+          increased_like_work: "Increased by %{delta}, matching the increase in Work."
           same_as_work: "Set to same value as Work."
     permissions:
       comment: "Comment"

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview-progress.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview-progress.controller.ts
@@ -61,7 +61,11 @@ export default class PreviewProgressController extends Controller {
     };
 
     this.progressInputTargets.forEach((target) => {
-      target.addEventListener('input', this.debouncedPreview);
+      if (target.tagName.toLowerCase() === 'select') {
+        target.addEventListener('change', this.debouncedPreview);
+      } else {
+        target.addEventListener('input', this.debouncedPreview);
+      }
       target.addEventListener('blur', this.debouncedPreview);
     });
 

--- a/spec/features/work_packages/progress_modal_pre_14_4_without_percent_complete_edition_spec.rb
+++ b/spec/features/work_packages/progress_modal_pre_14_4_without_percent_complete_edition_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "Progress modal", "pre 14.4 without percent complete edition", :j
         remaining_work_field = ProgressEditField.new(work_package_row, :remainingTime)
         work_field.activate!
 
-        remaining_work_field.expect_read_only_modal_field
+        remaining_work_field.expect_modal_field_read_only
       end
     end
 
@@ -356,7 +356,8 @@ RSpec.describe "Progress modal", "pre 14.4 without percent complete edition", :j
 
           work_edit_field.expect_modal_field_value("10h")
           remaining_work_edit_field.expect_modal_field_value("2.12h") # 2h 7m
-          percent_complete_edit_field.expect_modal_field_value("78", readonly: true)
+          percent_complete_edit_field.expect_modal_field_read_only
+          percent_complete_edit_field.expect_modal_field_value("78")
         end
       end
 
@@ -408,7 +409,8 @@ RSpec.describe "Progress modal", "pre 14.4 without percent complete edition", :j
 
           work_edit_field.expect_modal_field_value("")
           remaining_work_edit_field.expect_modal_field_value("", disabled: true)
-          percent_complete_edit_field.expect_modal_field_value("-", readonly: true)
+          percent_complete_edit_field.expect_modal_field_read_only
+          percent_complete_edit_field.expect_modal_field_value("-")
         end
       end
 
@@ -468,7 +470,7 @@ RSpec.describe "Progress modal", "pre 14.4 without percent complete edition", :j
 
       work_edit_field.activate!
 
-      percent_complete_edit_field.expect_read_only_modal_field
+      percent_complete_edit_field.expect_modal_field_read_only
     end
   end
 

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -436,6 +436,8 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(work: "")
         progress_popover.expect_values(remaining_work: "")
+        progress_popover.expect_hints(remaining_work: :cleared_because_work_is_empty,
+                                      percent_complete: nil)
       end
 
       specify "Case 2: when work is set to 12h, " \
@@ -447,9 +449,13 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(work: "12")
         progress_popover.expect_values(remaining_work: "6h")
+        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 2 } },
+                                      percent_complete: :derived)
 
         progress_popover.set_values(work: "14")
         progress_popover.expect_values(remaining_work: "8h")
+        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 4 } },
+                                      percent_complete: :derived)
       end
 
       specify "Case 3: when work is set to 2h, " \
@@ -461,9 +467,13 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(work: "2")
         progress_popover.expect_values(remaining_work: "0h")
+        progress_popover.expect_hints(remaining_work: { decreased_like_work: { delta: -8 } },
+                                      percent_complete: :derived)
 
         progress_popover.set_values(work: "12")
         progress_popover.expect_values(remaining_work: "6h")
+        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 2 } },
+                                      percent_complete: :derived)
       end
 
       specify "Case 23-7: when remaining work or % complete are set, work never " \
@@ -473,12 +483,21 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(remaining_work: "2h")
         progress_popover.expect_values(work: "10h", percent_complete: "80%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: nil,
+                                      percent_complete: :derived)
 
         progress_popover.set_values(percent_complete: "50%")
         progress_popover.expect_values(work: "10h", remaining_work: "5h")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: :derived,
+                                      percent_complete: nil)
 
         progress_popover.set_values(remaining_work: "9h")
         progress_popover.expect_values(work: "10h", percent_complete: "10%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: nil,
+                                      percent_complete: :derived)
       end
 
       # scenario from https://community.openproject.org/wp/57370
@@ -490,11 +509,17 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         # clear work
         progress_popover.set_values(work: "")
         progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "60%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: :cleared_because_work_is_empty,
+                                      percent_complete: nil)
 
         # set remaining work
         progress_popover.set_values(remaining_work: "8h")
         # work is derived
         progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
+        progress_popover.expect_hints(work: :derived,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
       end
 
       # scenario from https://community.openproject.org/wp/57370
@@ -506,11 +531,17 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         # clear work
         progress_popover.set_values(remaining_work: "")
         progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "60%")
+        progress_popover.expect_hints(work: :cleared_because_remaining_work_is_empty,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
 
-        # set remaining work
+        # set work
         progress_popover.set_values(work: "20h")
-        # => work is derived
+        # => remaining work is derived
         progress_popover.expect_values(work: "20h", remaining_work: "8h", percent_complete: "60%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: :derived,
+                                      percent_complete: nil)
       end
 
       # scenario from https://community.openproject.org/wp/57370
@@ -522,11 +553,17 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         # clear work and % complete
         progress_popover.set_values(work: "", percent_complete: "")
         progress_popover.expect_values(work: "", remaining_work: "4h", percent_complete: "")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
 
         # set work
         progress_popover.set_values(work: "20h")
         # => % complete is derived
         progress_popover.expect_values(work: "20h", remaining_work: "4h", percent_complete: "80%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: nil,
+                                      percent_complete: :derived)
       end
 
       # scenario from https://community.openproject.org/wp/57370
@@ -568,9 +605,15 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(remaining_work: "2h", percent_complete: "50%")
         progress_popover.expect_values(work: "4h")
+        progress_popover.expect_hints(work: :derived,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
 
         progress_popover.set_values(remaining_work: "10h")
         progress_popover.expect_values(work: "20h")
+        progress_popover.expect_hints(work: :derived,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
       end
 
       # scenario from https://community.openproject.org/wp/57370
@@ -581,12 +624,21 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(percent_complete: "40%")
         progress_popover.expect_values(work: "", remaining_work: "", percent_complete: "40%")
+        progress_popover.expect_hints(work: nil,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
 
         progress_popover.set_values(remaining_work: "60h")
         progress_popover.expect_values(work: "100h", remaining_work: "60h", percent_complete: "40%")
+        progress_popover.expect_hints(work: :derived,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
 
         progress_popover.set_values(percent_complete: "80%")
         progress_popover.expect_values(work: "300h", remaining_work: "60h", percent_complete: "80%")
+        progress_popover.expect_hints(work: :derived,
+                                      remaining_work: nil,
+                                      percent_complete: nil)
       end
     end
 

--- a/spec/features/work_packages/progress_modal_spec.rb
+++ b/spec/features/work_packages/progress_modal_spec.rb
@@ -449,12 +449,12 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(work: "12")
         progress_popover.expect_values(remaining_work: "6h")
-        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 2 } },
+        progress_popover.expect_hints(remaining_work: { increased_by_delta_like_work: { delta: 2 } },
                                       percent_complete: :derived)
 
         progress_popover.set_values(work: "14")
         progress_popover.expect_values(remaining_work: "8h")
-        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 4 } },
+        progress_popover.expect_hints(remaining_work: { increased_by_delta_like_work: { delta: 4 } },
                                       percent_complete: :derived)
       end
 
@@ -467,12 +467,12 @@ RSpec.describe "Progress modal", :js, :with_cuprite,
         progress_popover.open
         progress_popover.set_values(work: "2")
         progress_popover.expect_values(remaining_work: "0h")
-        progress_popover.expect_hints(remaining_work: { decreased_like_work: { delta: -8 } },
+        progress_popover.expect_hints(remaining_work: { decreased_by_delta_like_work: { delta: -8 } },
                                       percent_complete: :derived)
 
         progress_popover.set_values(work: "12")
         progress_popover.expect_values(remaining_work: "6h")
-        progress_popover.expect_hints(remaining_work: { increased_like_work: { delta: 2 } },
+        progress_popover.expect_hints(remaining_work: { increased_by_delta_like_work: { delta: 2 } },
                                       percent_complete: :derived)
       end
 

--- a/spec/models/work_package/progress_hint_spec.rb
+++ b/spec/models/work_package/progress_hint_spec.rb
@@ -41,32 +41,32 @@ RSpec.describe WorkPackage::ProgressHint, :aggreagate_failures do
     end
 
     it "converts parameter values to hours formatted according to setting" do
-      hint = described_class.new("remaining_hours.increased_like_work", { delta: 2 })
+      hint = described_class.new("remaining_hours.increased_by_delta_like_work", { delta: 2 })
       expect(hint.message).to eq("Increased by 2h, matching the increase in Work.")
 
-      hint = described_class.new("remaining_hours.increased_like_work", { delta: 15.5 })
+      hint = described_class.new("remaining_hours.increased_by_delta_like_work", { delta: 15.5 })
       expect(hint.message).to eq("Increased by 15.5h, matching the increase in Work.")
 
-      hint = described_class.new("remaining_hours.decreased_like_work", { delta: -24 })
+      hint = described_class.new("remaining_hours.decreased_by_delta_like_work", { delta: -24 })
       expect(hint.message).to eq("Decreased by 24h, matching the reduction in Work.")
 
       with_settings(duration_format: "days_and_hours") do
-        hint = described_class.new("remaining_hours.increased_like_work", { delta: 2 })
+        hint = described_class.new("remaining_hours.increased_by_delta_like_work", { delta: 2 })
         expect(hint.message).to eq("Increased by 2h, matching the increase in Work.")
 
-        hint = described_class.new("remaining_hours.increased_like_work", { delta: 15.5 })
+        hint = described_class.new("remaining_hours.increased_by_delta_like_work", { delta: 15.5 })
         expect(hint.message).to eq("Increased by 1d 7.5h, matching the increase in Work.")
 
-        hint = described_class.new("remaining_hours.decreased_like_work", { delta: -24 })
+        hint = described_class.new("remaining_hours.decreased_by_delta_like_work", { delta: -24 })
         expect(hint.message).to eq("Decreased by 3d, matching the reduction in Work.")
       end
     end
 
     it "rounds parameter values to 2 decimals" do
-      hint = described_class.new("remaining_hours.increased_like_work", { delta: 0.995 })
+      hint = described_class.new("remaining_hours.increased_by_delta_like_work", { delta: 0.995 })
       expect(hint.message).to eq("Increased by 1h, matching the increase in Work.")
 
-      hint = described_class.new("remaining_hours.decreased_like_work", { delta: -100.004 })
+      hint = described_class.new("remaining_hours.decreased_by_delta_like_work", { delta: -100.004 })
       expect(hint.message).to eq("Decreased by 100h, matching the reduction in Work.")
     end
   end

--- a/spec/models/work_package/progress_hint_spec.rb
+++ b/spec/models/work_package/progress_hint_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackage::ProgressHint, :aggreagate_failures do
+  describe "#message" do
+    it "returns the translated human message for a progress hint" do
+      hint = described_class.new("remaining_hours.derived")
+      expect(hint.message).to eq("Derived from Work and % Complete.")
+
+      hint = described_class.new("done_ratio.derived")
+      expect(hint.message).to eq("Derived from Work and Remaining work.")
+    end
+
+    it "converts parameter values to hours formatted according to setting" do
+      hint = described_class.new("remaining_hours.increased_like_work", { delta: 2 })
+      expect(hint.message).to eq("Increased by 2h, matching the increase in Work.")
+
+      hint = described_class.new("remaining_hours.increased_like_work", { delta: 15.5 })
+      expect(hint.message).to eq("Increased by 15.5h, matching the increase in Work.")
+
+      hint = described_class.new("remaining_hours.decreased_like_work", { delta: -24 })
+      expect(hint.message).to eq("Decreased by 24h, matching the reduction in Work.")
+
+      with_settings(duration_format: "days_and_hours") do
+        hint = described_class.new("remaining_hours.increased_like_work", { delta: 2 })
+        expect(hint.message).to eq("Increased by 2h, matching the increase in Work.")
+
+        hint = described_class.new("remaining_hours.increased_like_work", { delta: 15.5 })
+        expect(hint.message).to eq("Increased by 1d 7.5h, matching the increase in Work.")
+
+        hint = described_class.new("remaining_hours.decreased_like_work", { delta: -24 })
+        expect(hint.message).to eq("Decreased by 3d, matching the reduction in Work.")
+      end
+    end
+
+    it "rounds parameter values to 2 decimals" do
+      hint = described_class.new("remaining_hours.increased_like_work", { delta: 0.995 })
+      expect(hint.message).to eq("Increased by 1h, matching the increase in Work.")
+
+      hint = described_class.new("remaining_hours.decreased_like_work", { delta: -100.004 })
+      expect(hint.message).to eq("Decreased by 100h, matching the reduction in Work.")
+    end
+  end
+end

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is increased by the same amount, and % complete is derived",
                        expected_hints: {
-                         remaining_work: :increased_like_work,
+                         remaining_work: { increased_like_work: { delta: 10 } },
                          percent_complete: :derived
                        }
     end
@@ -137,7 +137,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is set to 0h and % Complete is cleared",
                        expected_hints: {
-                         remaining_work: :decreased_like_work,
+                         remaining_work: { decreased_like_work: { delta: -10 } },
                          percent_complete: :cleared_because_work_is_0h
                        }
     end
@@ -151,7 +151,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "work and remaining work are set to 0h (rounded) and % Complete is cleared",
                        expected_hints: {
-                         remaining_work: :decreased_like_work,
+                         remaining_work: { decreased_like_work: { delta: -9.9951 } },
                          percent_complete: :cleared_because_work_is_0h
                        }
     end
@@ -190,7 +190,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is decreased by the same amount, and % complete is derived",
                        expected_hints: {
-                         remaining_work: :decreased_like_work,
+                         remaining_work: { decreased_like_work: { delta: -2 } },
                          percent_complete: :derived
                        }
     end
@@ -205,7 +205,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work becomes 0h, and % complete becomes 100%",
                        expected_hints: {
-                         remaining_work: :decreased_like_work,
+                         remaining_work: { decreased_like_work: { delta: -8 } },
                          percent_complete: :derived
                        }
     end
@@ -710,7 +710,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is increased like work, and % complete is set to 0%",
                        expected_hints: {
-                         remaining_hours: :increased_like_work,
+                         remaining_hours: { increased_like_work: { delta: 5 } },
                          percent_complete: :derived
                        }
     end

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is increased by the same amount, and % complete is derived",
                        expected_hints: {
-                         remaining_work: { increased_like_work: { delta: 10 } },
+                         remaining_work: { increased_by_delta_like_work: { delta: 10 } },
                          percent_complete: :derived
                        }
     end
@@ -137,7 +137,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is set to 0h and % Complete is cleared",
                        expected_hints: {
-                         remaining_work: { decreased_like_work: { delta: -10 } },
+                         remaining_work: { decreased_by_delta_like_work: { delta: -10 } },
                          percent_complete: :cleared_because_work_is_0h
                        }
     end
@@ -151,7 +151,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "work and remaining work are set to 0h (rounded) and % Complete is cleared",
                        expected_hints: {
-                         remaining_work: { decreased_like_work: { delta: -9.9951 } },
+                         remaining_work: { decreased_by_delta_like_work: { delta: -9.9951 } },
                          percent_complete: :cleared_because_work_is_0h
                        }
     end
@@ -190,7 +190,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is decreased by the same amount, and % complete is derived",
                        expected_hints: {
-                         remaining_work: { decreased_like_work: { delta: -2 } },
+                         remaining_work: { decreased_by_delta_like_work: { delta: -2 } },
                          percent_complete: :derived
                        }
     end
@@ -205,7 +205,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work becomes 0h, and % complete becomes 100%",
                        expected_hints: {
-                         remaining_work: { decreased_like_work: { delta: -8 } },
+                         remaining_work: { decreased_by_delta_like_work: { delta: -8 } },
                          percent_complete: :derived
                        }
     end
@@ -710,7 +710,7 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
       include_examples "update progress values",
                        description: "remaining work is increased like work, and % complete is set to 0%",
                        expected_hints: {
-                         remaining_hours: { increased_like_work: { delta: 5 } },
+                         remaining_hours: { increased_by_delta_like_work: { delta: 5 } },
                          percent_complete: :derived
                        }
     end

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -111,7 +111,7 @@ module Components
       end
 
       def expect_read_only(field_name)
-        field(field_name).expect_read_only_modal_field
+        field(field_name).expect_modal_field_read_only
       end
 
       def expect_select_with_options(field_name, *options)

--- a/spec/support/components/work_packages/progress_popover.rb
+++ b/spec/support/components/work_packages/progress_popover.rb
@@ -135,8 +135,17 @@ module Components
       end
 
       def expect_hint(field_name, hint)
-        expected_caption = hint && I18n.t("work_package.progress.derivation_hints.#{wp_field_name(field_name)}.#{hint}")
-        field(field_name).expect_caption(expected_caption)
+        progress_hint =
+          case hint
+          when nil
+            nil
+          when Symbol
+            WorkPackage::ProgressHint.new("#{wp_field_name(field_name)}.#{hint}")
+          when Hash
+            hint, params = hint.first
+            WorkPackage::ProgressHint.new("#{wp_field_name(field_name)}.#{hint}", params)
+          end
+        field(field_name).expect_caption(progress_hint&.message)
       end
 
       def expect_hints(**field_hint_pairs)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57258

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Two issues have been found during review:

- [x] Derivation hints should be displayed in status-based mode
- [x] Hints when remaining work is increased/decreased like work should be reworked

This PR addresses them.

## Screenshots

**Derivation hints should be displayed in status-based mode**

Before:

![image](https://github.com/user-attachments/assets/68c23a73-3e6f-4a08-a5f5-8e08b4f6a57e)

After:

![image](https://github.com/user-attachments/assets/7b4f5a63-cc6e-4364-85a8-dfc0089709a1)

**Hints when remaining work is increased/decreased like work should be reworked**

The amount by which it is changed is indicated in the hint text.

Before:

![Aug-29-2024_11-33-42](https://github.com/user-attachments/assets/eb34da92-3df5-4435-9f1e-f8888f3146f1)

After: 

![new behavior with amount](https://github.com/user-attachments/assets/a6ffadbe-ed1a-497d-af94-ca82dfe64315)


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

**Derivation hints should be displayed in status-based mode**

Call the right method to set the caption from the calculated hint.
Then some hints were displayed inappropriately so they had to be fixed.

**Hints when remaining work is increased/decreased like work should be reworked**

The delta is added to the derived hint in the work package. A `WorkPackage::ProgressHint` class is introduced to manage the logic of converting the keys and the delta to a translated message with the duration converted into hours or hours and days depending on the configuration.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
