### PR TITLE
Bug/57508 custom fields with format string, text, bool, link and date dont forbid multi select internally and have handling in ordering

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -277,17 +277,9 @@ class CustomField < ApplicationRecord
     field_format == "bool"
   end
 
-  def multi_value?
-    multi_value
-  end
-
   def multi_value_possible?
     %w[version user list].include?(field_format) &&
       [ProjectCustomField, WorkPackageCustomField, TimeEntryCustomField, VersionCustomField].include?(self.class)
-  end
-
-  def allow_non_open_versions?
-    allow_non_open_versions
   end
 
   def allow_non_open_versions_possible?

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -69,6 +69,9 @@ class CustomField < ApplicationRecord
   validates :min_length, numericality: { less_than_or_equal_to: :max_length, message: :smaller_than_or_equal_to_max_length },
                          unless: Proc.new { |cf| cf.max_length.blank? }
 
+  validates :multi_value, absence: true, unless: :multi_value_possible?
+  validates :allow_non_open_versions, absence: true, unless: :allow_non_open_versions_possible?
+
   before_validation :check_searchability
   after_destroy :destroy_help_text
 

--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -38,7 +38,7 @@ module CustomField::OrderStatements
       else
         [select_custom_option_position]
       end
-    when "string", "text", "date", "bool", "link"
+    when "string", "date", "bool", "link"
       if multi_value?
         [select_custom_values_as_group]
       else

--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -39,11 +39,7 @@ module CustomField::OrderStatements
         [select_custom_option_position]
       end
     when "string", "date", "bool", "link"
-      if multi_value?
-        [select_custom_values_as_group]
-      else
-        [coalesce_select_custom_value_as_string]
-      end
+      [coalesce_select_custom_value_as_string]
     when "int", "float"
       # Make the database cast values into numeric
       # Postgresql will raise an error if a value can not be casted!

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -118,7 +118,7 @@ See COPYRIGHT and LICENSE files for more details.
     </fieldset>
   <% end %>
 
-  <% if @custom_field.new_record? || @custom_field.version? || @custom_field.allow_non_open_versions_possible? %>
+  <% if @custom_field.new_record? || @custom_field.allow_non_open_versions_possible? %>
     <div class="form--field" <%= format_dependent.attributes(:allowNonOpenVersions) %>>
       <%= f.check_box :allow_non_open_versions %>
     </div>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -85,7 +85,7 @@ See COPYRIGHT and LICENSE files for more details.
     </span>
   </div>
 
-  <% if @custom_field.new_record? || @custom_field.list? || @custom_field.multi_value_possible? %>
+  <% if @custom_field.new_record? || @custom_field.multi_value_possible? %>
     <div class="form--field" <%= format_dependent.attributes(:multiSelect) %>>
       <%= f.check_box :multi_value,
                       data: { action: 'admin--custom-fields#checkOnlyOne' } %>


### PR DESCRIPTION
# Ticket
[OP#57508](https://community.openproject.org/work_packages/57508)

# What are you trying to accomplish?
Cleanup custom field ordering from unsupported cases, and check that `multi_value` (and `allow_non_open_versions`) are not assignable on model level and not only on UI level.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
