### PR TITLE
[57527] Switching between work packages in the notification center resets the split screen width

### DIFF
--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -138,10 +138,6 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    // Reset the style when killing this directive, otherwise the style remains
-    if (this.resizingElement) {
-      this.setWidthVariable(this.elementMinWidth);
-    }
   }
 
   resizeStart() {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57527/activity

# What are you trying to accomplish?
Do not reset the width values on Destroy because we actually do want to keep the value. I honestly cannot remember why we added that in the first place 🤷‍♀️ 

