### PR TITLE
Navigate with query parameters kept in split view

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -4,7 +4,7 @@
       render(Primer::Alpha::UnderlineNav.new(align: :left, label: "Tabs", classes: "op-primer-adjustment--UnderlineNav_spaciousLeft")) do |component|
         menu_items.each do |node|
           component.with_tab(selected: @tab == node.name,
-                             href: url_for(node.url),
+                             href: helpers.url_for_with_params(**node.url),
                              test_selector: "wp-details-tab-component--tab-#{node.name}",
                              data: { turbo: true, turbo_stream: true, turbo_action: "replace" }
           ) do |c|
@@ -29,7 +29,7 @@
     flex.with_column(classes: "op-work-package-details-tab-component--action") do
       render(Primer::Beta::IconButton.new(icon: :x,
                                           tag: :a,
-                                          href: url_for(action: :close_split_view),
+                                          href: helpers.url_for_with_params(action: :close_split_view),
                                           data: { turbo: true, 'turbo-stream': true },
                                           scheme: :invisible,
                                           test_selector: "wp-details-tab-component--close",

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -65,7 +65,7 @@ class NotificationsController < ApplicationController
 
   private
 
-  def split_view_base_route = notifications_path
+  def split_view_base_route = notifications_path(request.query_parameters)
 
   def default_breadcrumb; end
 

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,6 @@
+module UrlHelper
+  def url_for_with_params(**args)
+    query = request.query_parameters
+    url_for(**query.merge(args))
+  end
+end

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -58,6 +58,30 @@ RSpec.describe "Notification center navigation", :js, :with_cuprite do
     end
   end
 
+  context "when filtering for notifications" do
+    it "keeps the state when opening and closing notifications (Regression #57067)" do
+      visit notifications_path
+
+      within_test_selector("op-submenu") do
+        click_link_or_button "Mentioned"
+      end
+      expect(page).to have_current_path "/notifications?filter=reason&name=mentioned"
+
+      # Details view of WP opens with activity tab
+      center.click_item notification
+      split_screen.expect_open
+      expect(page).to have_current_path "/notifications/details/#{work_package.id}/activity?filter=reason&name=mentioned"
+
+      # Switch to the relations tab
+      split_screen.switch_to_tab tab: "Relations"
+      expect(page).to have_current_path "/notifications/details/#{work_package.id}/relations?filter=reason&name=mentioned"
+
+      # Close the split screen
+      split_screen.close
+      expect(page).to have_current_path "/notifications?filter=reason&name=mentioned"
+    end
+  end
+
   it "opening a notification that does not exist returns to the center" do
     visit "/notifications/details/0"
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57067

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Keep the query parameters when navigating to other tabs in the split screen, or when closing them

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
