### PR TITLE
Bug/34971 Fix query_id is missing for export CSV/PDF lead manual sorting lost.

### DIFF
--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -47,7 +47,13 @@ module WorkPackages
       end
 
       def export_format_url(format)
-        @project.nil? ? index_work_packages_path(format:) : project_work_packages_path(project, format:)
+        if @project.nil?
+          index_work_packages_path(format:)
+        elsif @query.id.present?
+          project_work_packages_path(project, query_id: @query.id, format:)
+        else
+          project_work_packages_path(project, format:)
+        end
       end
 
       def export_formats_settings

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
@@ -95,6 +95,7 @@ export interface QueryRequestParams {
   groupBy:string|null;
   filters:string;
   sortBy:string;
+  query_id:string|null;
   timestamps:string;
   valid_subset?:boolean;
 }

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -178,14 +178,17 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
   }
 
   private buildExportDialogHref(query:QueryResource):string {
-    const params:Partial<QueryRequestParams>&{ title:string } = this.urlParamsHelper
-      .buildV3GetQueryFromQueryResource(query) as Partial<QueryRequestParams>&{ title:string };
+    const params: Partial<QueryRequestParams> & { title: string } = this.urlParamsHelper
+      .buildV3GetQueryFromQueryResource(query) as Partial<QueryRequestParams> & { title: string };
     params['columns[]'] = this.wpTableColumns.getColumns().map((column) => column.id);
     params.title = this.queryTitle(query);
-    const queryString = this.urlParamsHelper.buildQueryString(params) || '';
     const url = new URL(window.location.href);
+    const queryId = url.searchParams.get('query_id');
+    if (queryId) {
+      params.query_id = queryId;
+    }
     url.pathname = `${url.pathname}/export_dialog`;
-    url.search = queryString;
+    url.search = this.urlParamsHelper.buildQueryString(params) || '';
     return url.toString();
   }
 


### PR DESCRIPTION
# Ticket

[Order of work packages in XLS, PDF, CSV export differs from order in OpenProject](https://community.openproject.org/projects/openproject/work_packages/34971/activity)

# What are you trying to accomplish?

To fix the bug.

# What approach did you choose and why?

I check code, found it's just due to URL not provide for query_id because manual sorting table ordered_work_packages.query_id, need it, typical SQL like below and if `ordered_work_packages.query_id = null` or missing query id, then we lost the manual sorting.

```sql
 SELECT ordered_work_packages.position, "work_packages"."id" AS t0_r0, "work_packages"."type_id" AS t0_r1, "work_packages"."project_id" AS t0_r2, "work_packages"."subject" AS t0_r3, "work_packages"."description" AS t0_r4, "work_packages"."due_date" AS t0_r5, "work_packages"."category_id" AS t0_r6, "work_packages"."status_id" AS t0_r7, "work_packages"."assigned_to_id" AS t0_r8, "work_packages"."priority_id" AS t0_r9, "work_packages"."version_id" AS t0_r10, "work_packages"."author_id" AS t0_r11, "work_packages"."lock_version" AS t0_r12, "work_packages"."done_ratio" AS t0_r13, "work_packages"."estimated_hours" AS t0_r14, "work_packages"."created_at" AS t0_r15, "work_packages"."updated_at" AS t0_r16, "work_packages"."start_date" AS t0_r17, "work_packages"."responsible_id" AS t0_r18, "work_packages"."budget_id" AS t0_r19, "work_packages"."position" AS t0_r20, "work_packages"."story_points" AS t0_r21, "work_packages"."remaining_hours" AS t0_r22, "work_packages"."derived_estimated_hours" AS t0_r23, "work_packages"."schedule_manually" AS t0_r24, "work_packages"."parent_id" AS t0_r25, "work_packages"."duration" AS t0_r26, "work_packages"."ignore_non_working_days" AS t0_r27, "work_packages"."derived_remaining_hours" AS t0_r28, "work_packages"."derived_done_ratio" AS t0_r29, "projects"."id" AS t1_r0, "projects"."name" AS t1_r1, "projects"."description" AS t1_r2, "projects"."public" AS t1_r3, "projects"."parent_id" AS t1_r4, "projects"."created_at" AS t1_r5, "projects"."updated_at" AS t1_r6, "projects"."identifier" AS t1_r7, "projects"."lft" AS t1_r8, "projects"."rgt" AS t1_r9, "projects"."active" AS t1_r10, "projects"."templated" AS t1_r11, "projects"."status_code" AS t1_r12, "projects"."status_explanation" AS t1_r13, "projects"."settings" AS t1_r14 
 FROM "work_packages" 
 INNER JOIN "statuses" ON "statuses"."id" = "work_packages"."status_id" 
 LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" 
 LEFT OUTER JOIN
            ordered_work_packages
          ON
            ordered_work_packages.work_package_id = work_packages.id
            AND ordered_work_packages.query_id = 10051 
WHERE ((work_packages.status_id IS NOT NULL) 
AND ((work_packages.type_id IS NULL OR work_packages.type_id NOT IN ('7','10'))) AND (projects.id IN (1403))) 
AND "work_packages"."id" IN (SELECT "work_packages"."id" 
FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" 
INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE 
WHERE "projects"."active" = TRUE) 
ORDER BY ordered_work_packages.position NULLS LAST, work_packages.id, work_packages.id DESC
```

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
