### PR TITLE
[57395] Color gradient gone in gantt charts for work packages with only start or due date

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -253,13 +253,13 @@ export class TimelineCellRenderer {
     if (_.isNaN(due.valueOf()) && !_.isNaN(start.valueOf())) {
       // Set due date to today
       due = moment();
-      bar.style.backgroundImage = 'linear-gradient(90deg, rgba(255,255,255,0) 0%, #F1F1F1 100%)';
+      bar.setAttribute('style', 'background-image: linear-gradient(90deg, rgba(255,255,255,0) 0%, #F1F1F1 100%) !important');
     }
 
     // only finish date, fade out bar to the left
     if (_.isNaN(start.valueOf()) && !_.isNaN(due.valueOf())) {
       start = due.clone();
-      bar.style.backgroundImage = 'linear-gradient(90deg, #F1F1F1 0%, rgba(255,255,255,0) 80%)';
+      bar.setAttribute('style', 'background-image: linear-gradient(90deg, #F1F1F1 0%, rgba(255,255,255,0) 80%) !important');
     }
 
     this.setElementPositionAndSize(element, renderInfo, start, due);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57395/activity

# What are you trying to accomplish?
For the dark mode, we did some calculations on the type specific colours. These colors are enforced via `!important` giving them a higher specificity then the inline styles. Since we want to enforce the gradient effect in the Gantt chart for some bars, we have to set `important` as well.

## Screenshots
**Before**

<img width="590" alt="Bildschirmfoto 2024-09-02 um 10 31 49" src="https://github.com/user-attachments/assets/d196718a-bcbd-47c5-b839-78ac94b1b39f">

**After**
<img width="560" alt="Bildschirmfoto 2024-09-02 um 09 59 55" src="https://github.com/user-attachments/assets/4437b0d1-9b04-4b40-aef4-67f5910ea303">
