### PR TITLE
[57003] OpenProject Dark Mode: selection colour of table rows

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -4,8 +4,8 @@ $ian-bg-color: var(--body-background)
 $ian-bg-hover-color: var(--bgColor-neutral-muted)
 $ian-bg-read-color: var(--bgColor-muted)
 $ian-bg-read-hover-color: hsl(from var(--bgColor-neutral-muted) h s calc(l - 0.5))
-$ian-bg-selected-color: var(--selection-bgColor)
-$ian-bg-selected-hover-color: hsl(from var(--selection-bgColor) h calc(s - 30) l)
+$ian-bg-selected-color: var(--codeMirror-selection-bgColor)
+$ian-bg-selected-hover-color: hsl(from var(--codeMirror-selection-bgColor) h calc(s - 30) l)
 // This needs to be set in the itemSize of
 // the virtual scroller
 $ian-height: 100px

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -155,13 +155,13 @@ th.hidden
 
 tr.context-menu-selection,
 tr.-checked
-  background-color: var(--selection-bgColor) !important
+  background-color: var(--codeMirror-selection-bgColor) !important
   &[class*=__hl_background]
     outline: var(--table-row-highlighting-outline-color) solid 2px
 
   td
-    border-top: 1px solid var(--selection-bgColor) !important
-    border-bottom: 1px solid var(--selection-bgColor) !important
+    border-top: 1px solid var(--codeMirror-selection-bgColor) !important
+    border-bottom: 1px solid var(--codeMirror-selection-bgColor) !important
     color: var(--body-font-color) !important
     a
       color: var(--body-font-color) !important

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -74,7 +74,7 @@ body[class*="router--"]
     background: var(--bgColor-neutral-muted) !important
 
     &.-checked
-      background-color: hsl(from var(--selection-bgColor) h calc(s - 30) l) !important
+      background-color: hsl(from var(--codeMirror-selection-bgColor) h calc(s - 30) l) !important
 
 // Left part of the split view
 // == flex container for (table|timeline)

--- a/frontend/src/global_styles/layout/work_packages/_table_embedded.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_embedded.sass
@@ -77,7 +77,7 @@ $table-timeline--compact-row-height: 28px
     .wp-table--row
       border-bottom: none !important
       &:hover
-        background-color: var(--selection-bgColor)
+        background-color: var(--codeMirror-selection-bgColor)
 
     thead,
     .generic-table--sort-header-outer


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57003/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Change bg-color of selected item in notification center and WP table

## Screenshots
Before:
![Screenshot 2024-09-02 at 11 52 13](https://github.com/user-attachments/assets/a53df797-747d-4a60-9108-b15ad0c0f3f2)

![Screenshot 2024-09-02 at 11 51 55](https://github.com/user-attachments/assets/0181bf92-51a7-4387-91cb-c7b36ccf77ba)

After:
![Screenshot 2024-09-02 at 11 52 32](https://github.com/user-attachments/assets/f2bd8b5d-7697-432b-89a9-d568445c8445)

![Screenshot 2024-09-02 at 11 49 22](https://github.com/user-attachments/assets/bcb82974-6942-449e-88cd-39991df8cdb3)


# What approach did you choose and why?
Use another Primer variable for bg-color (--codeMirror-selection-bgColor) instead of current variable(--selection-bgColor)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
