### PR TITLE
Fix some test flakiness

### DIFF
--- a/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
+++ b/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
@@ -32,7 +32,7 @@ require Rails.root.join("db/migrate/20240805104004_rename_visible_to_admin_only_
 RSpec.describe RenameVisibleToAdminOnlyInCustomFields, type: :model do
   after do
     # Reset after each spec to ensure we have the column information up to date.
-    ProjectCustomField.reset_column_information
+    CustomField.reset_column_information
   end
 
   context "when migrating up" do


### PR DESCRIPTION
CustomField was not properly reset after the migration test renaming a column.

Minimal reproduction:

    rspec './spec/lib/custom_field_form_builder_spec.rb[1:1:1:1:1:1]' './spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb' --seed 47298

Found on this failed CI run: https://github.com/opf/openproject/actions/runs/10664728002/job/29557993440
After a bisect, full reproduction command was `rspec './modules/boards/spec/services/copy_service_integration_spec.rb[1:1:1,1:2:1:1]' './spec/lib/custom_field_form_builder_spec.rb[1:1:1:1:1:1,1:1:1:2:1:1,1:1:2:1:1:1,1:1:2:1:1:2:1,1:1:2:2:1:1,1:1:3:1:1,1:1:3:1:2:1,1:1:3:2,1:1:4:1:1,1:1:4:1:2:1,1:1:4:2,1:1:5:1:1,1:1:5:1:2:1,1:1:5:2,1:1:6:1:1,1:1:6:1:2:1,1:1:6:2,1:1:7:1:1,1:1:7:1:2:1,1:1:7:2,1:1:8:1:1,1:1:8:1:2:1,1:1:8:2,1:1:10:1:1,1:1:10:1:2:1,1:1:10:2,1:1:10:3:1,1:1:11:1:1,1:1:11:1:2:1,1:1:11:2,1:1:11:3:1]' './spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb[1:1:1]' './spec/models/custom_value/list_strategy_integration_spec.rb[1:1]' --seed 47298`