### PR TITLE
[57414] Non-working days are not correctly highlighted in the Gantt chart

### DIFF
--- a/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
@@ -4,9 +4,9 @@
     top: 0
     padding-top: 5px
     height: 100%
-    border-right: 1px solid var(--borderColor-neutral-muted)
+    border-right: 1px solid var(--borderColor-default)
     &_highlight
-      border-right: 1px solid var(--borderColor-default)
+      border-right: 1px solid var(--borderColor-emphasis)
 
   &--non-working-day
     background-color: var(--bgColor-disabled)

--- a/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
@@ -4,10 +4,9 @@
     top: 0
     padding-top: 5px
     height: 100%
-    border-right: 1px solid #dddddd5e
-
+    border-right: 1px solid var(--borderColor-neutral-muted)
     &_highlight
       border-right: 1px solid var(--borderColor-default)
 
   &--non-working-day
-    background-color: #f5f5f5
+    background-color: var(--bgColor-disabled)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57414/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Set a correct bg-color for non-working days in gantt chart

## Screenshots
Before:
![Screenshot 2024-09-02 at 13 31 54](https://github.com/user-attachments/assets/30f19365-941e-4754-aa1b-d07aad9d1944)

After:
![Screenshot 2024-09-02 at 13 31 32](https://github.com/user-attachments/assets/256e5e32-0ca6-49e8-bd3b-2f5155b9c2bd)


# What approach did you choose and why?
Use a correct primer variable for background color of non-working days in gantt chart

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
