### PR TITLE
remove unnecessary dot at the end of a listing

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1178,7 +1178,7 @@ en:
               confirmation: "Password confirmation does not match password."
               format: "%{message}"
             password:
-              weak: "Must contain characters of the following classes (at least %{min_count} of %{all_count}): %{rules}."
+              weak: "Must contain characters of the following classes (at least %{min_count} of %{all_count}): %{rules}"
               lowercase: "lowercase (e.g. 'a')"
               uppercase: "uppercase (e.g. 'A')"
               numeric: "numeric (e.g. '1')"

--- a/spec/support/pages/my/password_page.rb
+++ b/spec/support/pages/my/password_page.rb
@@ -51,7 +51,7 @@ module Pages
 
       def expect_password_weak_error_message
         expect_toast(type: :error,
-                     message: "Password Must contain characters of the following classes (at least 2 of 3): lowercase (e.g. 'a'), uppercase (e.g. 'A'), numeric (e.g. '1').")
+                     message: "Password Must contain characters of the following classes (at least 2 of 3): lowercase (e.g. 'a'), uppercase (e.g. 'A'), numeric (e.g. '1')")
       end
 
       def expect_password_updated_message


### PR DESCRIPTION

<img width="816" alt="image" src="https://github.com/user-attachments/assets/13ede946-327f-415c-9627-2e1c7e57552a">

The "." at the end of the listing is unnecessary and looks off.
