### PR TITLE
[56064] Introduce `visible` to control a permission visibility in admin

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -43,7 +43,7 @@ module Roles
       else
         assignable_member_permissions
       end.reject do |permission|
-        !keep_public && permission.public?
+        (!keep_public && permission.public?) || permission.hidden?
       end
     end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -97,7 +97,7 @@ class RolesController < ApplicationController
 
   def report
     @roles = roles_scope
-    @permissions = OpenProject::AccessControl.permissions.reject(&:public?)
+    @permissions = visible_permissions
   end
 
   def bulk_update
@@ -110,7 +110,7 @@ class RolesController < ApplicationController
       redirect_to action: "index"
     else
       @calls = calls
-      @permissions = OpenProject::AccessControl.permissions.reject(&:public?)
+      @permissions = visible_permissions
       render action: "report"
     end
   end
@@ -137,6 +137,12 @@ class RolesController < ApplicationController
 
       update_role(role, new_permissions)
     end
+  end
+
+  def visible_permissions
+    OpenProject::AccessControl.permissions
+                              .reject(&:public?)
+                              .filter(&:visible?)
   end
 
   def roles_scope

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -49,7 +49,7 @@ Rails.application.reloader.to_prepare do
                      },
                      permissible_on: :global,
                      require: :loggedin,
-                     enabled: -> { OpenProject::Configuration.backup_enabled? }
+                     visible: -> { OpenProject::Configuration.backup_enabled? }
 
       map.permission :create_user,
                      {

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -39,12 +39,15 @@ module OpenProject
       # @param public [Boolean] when true, the permission is granted to anybody
       # having at least one role in a project, regardless of the role's
       # permissions.
+      # @param visible [true, false, Proc] When true, the permission is visible
+      # in the UI. When false, the permission is hidden. It can be dynamic by
+      # using a Proc.
       def initialize(name,
                      hash,
                      permissible_on:,
                      public: false,
                      require: nil,
-                     enabled: true,
+                     visible: true,
                      project_module: nil,
                      contract_actions: [],
                      grant_to_admin: true,
@@ -53,7 +56,8 @@ module OpenProject
         @public = public
         @require = require
         @permissible_on = Array(permissible_on)
-        @enabled = enabled
+        @enabled = true
+        @visible = visible
         @project_module = project_module
         @contract_actions = contract_actions
         @grant_to_admin = grant_to_admin
@@ -126,11 +130,19 @@ module OpenProject
       end
 
       def enabled?
-        if @enabled.respond_to?(:call)
-          @enabled.call
+        @enabled
+      end
+
+      def visible?
+        if @visible.respond_to?(:call)
+          @visible.call
         else
-          @enabled
+          @visible
         end
+      end
+
+      def hidden?
+        !visible?
       end
 
       def disable!

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -72,7 +72,7 @@ module OpenProject::GithubIntegration
                    },
                    permissible_on: :global,
                    require: :loggedin,
-                   enabled: -> { OpenProject::FeatureDecisions.deploy_targets_active? } # can only be enable at start-time
+                   visible: -> { OpenProject::FeatureDecisions.deploy_targets_active? }
       end
 
       menu :work_package_split_view,

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -71,12 +71,17 @@ RSpec.shared_examples_for "roles contract" do
   end
 
   describe "#assignable_permissions" do
-    let(:permission1) { instance_double(OpenProject::AccessControl::Permission, name: :perm1, public?: false) }
-    let(:permission2) { instance_double(OpenProject::AccessControl::Permission, name: :perm2, public?: true) }
-    let(:permission3) { instance_double(OpenProject::AccessControl::Permission, name: :perm3, public?: false) }
+    def permission(name:, public:, visible: true)
+      OpenProject::AccessControl::Permission.new(name, {}, permissible_on: :dummy, public:, visible:)
+    end
+    let(:permission1) { permission(name: :perm1, public: false, visible: true) }
+    let(:permission2) { permission(name: :perm2, public: true, visible: true) }
+    let(:permission3) { permission(name: :perm3, public: false, visible: true) }
+    let(:permission4) { permission(name: :perm4, public: false, visible: false) }
 
-    let(:all_permissions) { [permission1, permission2, permission3] }
+    let(:all_permissions) { [permission1, permission2, permission3, permission4] }
     let(:public_permissions) { [permission2] }
+    let(:hidden_permissions) { [permission4] }
 
     context "for a project role" do
       before do
@@ -84,7 +89,7 @@ RSpec.shared_examples_for "roles contract" do
       end
 
       it "is all project permissions" do
-        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions)
+        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions - hidden_permissions)
       end
     end
 
@@ -96,7 +101,7 @@ RSpec.shared_examples_for "roles contract" do
       end
 
       it "is all work package permissions" do
-        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions)
+        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions - hidden_permissions)
       end
     end
 
@@ -108,7 +113,7 @@ RSpec.shared_examples_for "roles contract" do
       end
 
       it "is all the global permissions" do
-        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions)
+        expect(contract.assignable_permissions).to match_array(all_permissions - public_permissions - hidden_permissions)
       end
     end
   end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe RolesController do
 
     it "assigns permissions" do
       expect(assigns(:permissions))
-        .to match OpenProject::AccessControl.permissions.reject(&:public?)
+        .to match OpenProject::AccessControl.permissions.reject(&:public?).reject(&:hidden?)
     end
 
     it "assigns roles" do

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -185,4 +185,39 @@ RSpec.describe OpenProject::AccessControl::Permission do
       end
     end
   end
+
+  describe "#visible?" do
+    def permission(visible:)
+      described_class.new(:perm, {}, permissible_on: :project, visible:)
+    end
+
+    context "with :visible initialization parameter being a boolean" do
+      it "returns its value" do
+        expect(permission(visible: true)).to be_visible
+        expect(permission(visible: false)).not_to be_visible
+      end
+    end
+
+    context "with :visible initialization parameter being a Proc" do
+      it "returns the value from the Proc evaluation" do
+        expect(permission(visible: -> { true })).to be_visible
+        expect(permission(visible: -> { true })).not_to be_hidden
+        expect(permission(visible: -> { false })).not_to be_visible
+        expect(permission(visible: -> { false })).to be_hidden
+      end
+
+      it "runs the Proc each time (value is not cached)" do
+        visible = false
+        proc = -> {
+          visible = !visible
+        }
+        permission = permission(visible: proc)
+
+        expect(permission).to be_visible
+        expect(permission).not_to be_visible
+        expect(permission).to be_visible
+        expect(permission).not_to be_visible
+      end
+    end
+  end
 end

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -455,22 +455,18 @@ RSpec.describe OpenProject::AccessControl do
     before do
       described_class.map do |map|
         map.project_module :some_module do |mod|
-          mod.permission :disabled_permission1,
+          # will be disabled a few lines later in the spec
+          mod.permission :disabled_permission,
                          { some: :action },
-                         permissible_on: :project,
-                         enabled: false
-
-          mod.permission :disabled_permission2,
-                         { some: :action,
-                           another: :action },
-                         permissible_on: :project,
-                         enabled: -> { false }
+                         permissible_on: :project
 
           mod.permission :enabled_permission,
                          { another: :action },
                          permissible_on: :project
         end
       end
+      permission_to_disable = described_class.permissions.find { _1.name == :disabled_permission }
+      permission_to_disable.disable!
     end
 
     it "is false for enabled permissions" do
@@ -480,7 +476,7 @@ RSpec.describe OpenProject::AccessControl do
 
     it "is true for disabled permission" do
       expect(subject)
-        .to be_disabled_permission(:disabled_permission1)
+        .to be_disabled_permission(:disabled_permission)
     end
 
     it "is true for action hash where permissions granting are disabled" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/56064

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Attribute `enabled` can not be used dynamically to control if a permission is available or not. Because enabled permissions is cached at in a class instance variable, this can fails in a multi-tenant architecture. For instance if the lambda reads a feature flag, the permission will be enabled depending on the feature flag of a tenant. Other tenants having a different value for this feature flag will get an unexpected behavior.

That the origin of the bug https://community.openproject.org/wp/56064

So from now on, `enabled` is no longer a `Permission` initialization parameter and is always initialized to `true`. It can be turned off at boot time (for instance when using `OPENPROJECT_ENABLED_MODULES`). It must not change during runtime.

Visibility in administration is now controlled with a new variable named `visible`.

The two permissions previsouly relying on `enabled` proc, `:create_backup` and `introspection`, are now using `visible` instead.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
