### PR TITLE
Bug/57612 work package report export fails if work package has unavailable attachments

### DIFF
--- a/app/models/work_package/pdf_export/markdown.rb
+++ b/app/models/work_package/pdf_export/markdown.rb
@@ -105,12 +105,24 @@ module WorkPackage::PDFExport::Markdown
 
   private
 
+  def attachment_image_local_file(attachment)
+    return nil if attachment.nil?
+
+    attachment.file.local_file
+  rescue StandardError => e
+    Rails.logger.error "Failed to access attachment #{attachment.id} file: #{e}"
+    nil # return nil as if the id was wrong and the attachment obj has not been found
+  end
+
   def attachment_image_filepath(work_package, src)
     # images are embedded into markup with the api-path as img.src
     attachment = attachment_by_api_content_src(work_package, src)
-    return nil if attachment.nil? || attachment.file.local_file.nil? || !pdf_embeddable?(attachment.content_type)
+    return nil if attachment.nil? || !pdf_embeddable?(attachment.content_type)
 
-    resize_image(attachment.file.local_file.path)
+    local_file = attachment_image_local_file(attachment)
+    return nil if local_file.nil?
+
+    resize_image(local_file.path)
   end
 
   def attachment_by_api_content_src(work_package, src)

--- a/app/models/work_package/pdf_export/markdown.rb
+++ b/app/models/work_package/pdf_export/markdown.rb
@@ -106,8 +106,6 @@ module WorkPackage::PDFExport::Markdown
   private
 
   def attachment_image_local_file(attachment)
-    return nil if attachment.nil?
-
     attachment.file.local_file
   rescue StandardError => e
     Rails.logger.error "Failed to access attachment #{attachment.id} file: #{e}"

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -244,6 +244,20 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       end
     end
 
+    describe "with a faulty image" do
+      before do
+        # simulate a null pointer exception
+        # https://appsignal.com/openproject-gmbh/sites/62a6d833d2a5e482c1ef825d/exceptions/incidents/2326/samples/62a6d833d2a5e482c1ef825d-848752493603098719217252846401
+        # where attachment data is in the database but the file is missing, corrupted or not accessible
+        allow(image_attachment).to receive(:file)
+                                     .and_return(nil)
+      end
+
+      it "still finishes the export" do
+        expect(pdf[:images].length).to eq(0)
+      end
+    end
+
     describe "with embedded work package attributes" do
       let(:supported_work_package_embeds) do
         [


### PR DESCRIPTION
# Ticket

If there are faulty attachments (attachment exists in db and work_package.attachments, but work_package.attachments[0].file.local_file throws an error. So the export is stopped.

https://community.openproject.org/work_packages/57612

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

=> Treat it like "attachment not found", catch and log the error but don't stop the export.

# Merge checklist

- [x] Added/updated tests
