### PR TITLE
[57620] New mobile split screen scrolls horizontally 

### DIFF
--- a/app/components/work_packages/split_view_component.sass
+++ b/app/components/work_packages/split_view_component.sass
@@ -6,4 +6,4 @@
 
   @media screen and (max-width: $breakpoint-lg)
     // Unfortunately, we have to enforce this style via !important as the resizer writes the width directly on the element as inline style
-    width: unset !important
+    min-width: unset !important

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -85,6 +85,9 @@
     display: none !important
 
 @media screen and (max-width: $breakpoint-lg)
+  #content:has(#content-bodyRight > *)
+    grid-template-columns: 1fr auto
+
   // As soon as the split screen has content (so basically when its opened), it takes the available whole space
   #content-bodyRight:has(*)
     grid-column: 1 / 3


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57620/activity

# What are you trying to accomplish?
Avoid that the mobile split screen overflows the screen due to the previously defined min-widths

## Screenshots

**Before**
<img width="435" alt="Bildschirmfoto 2024-09-03 um 08 36 06" src="https://github.com/user-attachments/assets/4482927c-8c28-4630-9774-392ace12efb4">

**After**
<img width="440" alt="Bildschirmfoto 2024-09-03 um 08 35 25" src="https://github.com/user-attachments/assets/abcbadaf-18a2-4a5e-bc45-3c268fee5fe2">

