### PR TITLE
[51545] Add to meeting button is chopped of in the work package meetings tab

### DIFF
--- a/modules/meeting/app/components/work_package_meetings_tab/heading_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/heading_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper do
     flex_layout(justify_content: :space_between, align_items: :center) do |flex|
-      flex.with_column do
+      flex.with_column(flex: 1) do
         render(Primer::Beta::Text.new(color: :subtle)) { t("text_add_work_package_to_meeting_description") }
       end
       if allowed_to_add_to_meeting?


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57545/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Make the 'Add to meeting' button always wholly visible.

## Screenshots
Before:
https://github.com/user-attachments/assets/200b3b91-a06a-4e08-9f00-0ce7fb10e7cf

After:
https://github.com/user-attachments/assets/946ae0e2-f86b-4d62-a44f-f65bd6f20690

# What approach did you choose and why?
I set the flex=1 for description element, therefore the size of the button will have the same width as its content, but the description element will have the remaining full space given to it.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, Safari)
