### PR TITLE
[#57615] Report type work package export doesn't display the correct query title

### DIFF
--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -38,12 +38,12 @@ module WorkPackages
 
       attr_reader :query, :project, :query_params
 
-      def initialize(query:, project:)
+      def initialize(query:, project:, title:)
         super
 
         @query = query
         @project = project
-        @query_params = ::API::V3::Queries::QueryParamsRepresenter.new(query).to_url_query(merge_params: { columns: [] })
+        @query_params = ::API::V3::Queries::QueryParamsRepresenter.new(query).to_url_query(merge_params: { columns: [], title: })
       end
 
       def export_format_url(format)

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -87,7 +87,7 @@ class WorkPackagesController < ApplicationController
   end
 
   def export_dialog
-    respond_with_dialog WorkPackages::Exports::ModalDialogComponent.new(query: @query, project: @project)
+    respond_with_dialog WorkPackages::Exports::ModalDialogComponent.new(query: @query, project: @project, title: params[:title])
   end
 
   protected


### PR DESCRIPTION
# Ticket

Bug: title of PDF report/PDF table is not correct

https://community.openproject.org/work_packages/57615

# What are you trying to accomplish?

* add query title parameter (which may be just a text from the frontend and not saved into the query) to the export dialog

# What approach did you choose and why?

* add the missing parameter

# Merge checklist

- [X] Added/updated tests
