### PR TITLE
Fix/25592 Append BOM to ensure Excel can open CSV directly & correctly

### DIFF
--- a/app/models/exports/concerns/csv.rb
+++ b/app/models/exports/concerns/csv.rb
@@ -53,7 +53,7 @@ module Exports
         ::Exports::Result
           .new format: :csv,
                title: csv_export_filename,
-               content: serialized,
+               content: "\xEF\xBB\xBF#{serialized}", # Make Excel open CSV happy by append UTF8 BOM
                mime_type: "text/csv"
       end
 

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
       it "does not render project custom fields in the header" do
         expect(parsed.size).to eq 2
 
-        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public"]
+        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public"]
       end
 
       it "does not render the custom field values in the rows if enabled for a project" do
@@ -93,7 +93,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
         expect(cf_names).not_to include(not_used_string_cf.name)
         expect(cf_names).not_to include(hidden_cf.name)
 
-        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
       end
 
       it "renders the custom field values in the rows if enabled for a project" do
@@ -126,7 +126,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
         expect(cf_names).to include(not_used_string_cf.name)
         expect(cf_names).to include(hidden_cf.name)
 
-        expect(header).to eq ["id", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
       end
 
       it "renders the custom field values in the rows if enabled for a project" do

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
       data = CSV.parse instance.export!.content
 
       expect(data.size).to eq(5)
-      expect(data.pluck(0)).to eq ["Type", "Type A", "Type A", "Type A", "Type B"]
+      expect(data.pluck(0)).to eq ["\xEF\xBB\xBFType", "Type A", "Type A", "Type A", "Type B"]
     end
   end
 
@@ -171,7 +171,7 @@ RSpec.describe WorkPackage::Exports::CSV, "integration" do
       data = CSV.parse instance.export!.content
 
       expect(data.size).to eq(5)
-      expect(data.pluck(0)).to eq %w[Subject WP4 WP2 WP1 WP3]
+      expect(data.pluck(0)).to eq %w[WP4 WP2 WP1 WP3].unshift("\xEF\xBB\xBFSubject")
     end
   end
 end


### PR DESCRIPTION
# Ticket
[Umlaute not shown for CSV export](https://community.openproject.org/projects/openproject/work_packages/25592/activity)

# What are you trying to accomplish?

Avoid user using Excel Data->Iport->Text to using CSV file, allow user directly open CSV file which generated by OpenProject.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/388cbb2a-e356-49df-a2f5-e21f40a7f758)

### After

![image](https://github.com/user-attachments/assets/21b37ced-5cbc-44e3-8f54-4802ff21e866)


# What approach did you choose and why?

Because it works more smoothly for OpenProject end user and there is also no harm for other CSV consumer application like Apple Number, Preview or Pandas.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
