### PR TITLE
[#57536] Remove menu entry in Administration submenu

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -45,11 +45,6 @@ module SettingsHelper
         label: :label_languages
       },
       {
-        name: "projects",
-        controller: "/admin/settings/projects_settings",
-        label: :label_project_plural
-      },
-      {
         name: "repositories",
         controller: "/admin/settings/repositories_settings",
         label: :label_repository_plural


### PR DESCRIPTION
The user can access the "Projects" Submenu" entry instead. This entry here has been redundant for a while and should be removed to avoid confusion for the user.

# Ticket
https://community.openproject.org/wp/57536



