### PR TITLE
Fix flaky move_work_package_spec.rb spec

### DIFF
--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe "Moving a work package through Rails view", :js do
           work_package.reload
           expect(work_package.project_id).to eq(project2.id)
 
+          # Page displays the background job status dialog, then the job
+          # finishes and the dialog updates to "Successful update." with a
+          # redirect link. After 2 seconds it automatically clicks the link
+          # which navigates to /work_packages/:id which finally redirects to
+          # /projects/:project_identifier/work_packages/:id/activity
+          #
+          # The following lines wait for this job status dialog to be discarded.
+          expect(page).to have_text "Successful update."
+          # Clicking the link directly would save 2 seconds, but there is a bug
+          # which redirects back. Sleep 2 seconds instead until it's fixed
+          sleep 2 # TODO replace with: click_on(I18n.t("job_status_dialog.redirect_link"))
+
           expect(page).to have_current_path "/projects/#{project2.identifier}/work_packages/#{work_package.id}/activity"
           page.find_by_id("projects-menu", text: "Target")
         end


### PR DESCRIPTION
The spec was triggering the move work package job, then was immediately making an assertion on the page current path. This assertion waits 4 seconds max, and it can be too few for the things being done:
- The job status dialog polls for status every 2 seconds.
- Then once it returns, it displays a successful message for another 2 seconds before redirecting automatically
- The redirection goes to /work_package/:id, which redirects to /projects/:project_identifier/work_packages/:id/activity

Only then will the assertion be true. On CI, it often takes more than 4 seconds to get to this state which leads to false negatives.

To prevent that:
- Wait for the job status dialog to display its success message.
- Then wait for 2 seconds for the auto-redirect to trigger.

It felt cleaner than adding a `wait: 10` to the `have_current_path` assertion.

Clicking the link would be better but there is a bug about it. Once the bug is fixed, the link can be clicked and that will reduce the test execution time.