### PR TITLE
[57646] Action menu item list is misaligned in 2FA page

### DIFF
--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
@@ -10,7 +10,7 @@
 
 <%= render(Primer::OpenProject::SubHeader.new) do |subheader|
   subheader.with_action_component do
-    render(Primer::Alpha::ActionMenu.new(anchor_align: :end)) do |menu|
+    render(Primer::Alpha::ActionMenu.new(anchor_align: :end, size: :small)) do |menu|
       menu.with_show_button(scheme: :primary,
                             test_selector: "two_factor_authentication_devices_button",
                             aria: { label: t('two_factor_authentication.label_device') }) do |button|


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57646/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Align the list of actions in action menu for creating a new device on 2FA page.

## Screenshots
Before:
![Screenshot 2024-09-04 at 12 28 09](https://github.com/user-attachments/assets/52dada37-576a-415d-aaf5-6425f6c8429f)

After:
![Screenshot 2024-09-04 at 12 38 50](https://github.com/user-attachments/assets/2b05937b-8a2f-443e-b7ab-157a1e6e8e5b)

# What approach did you choose and why?
Set size of action menu to small when its anchor_align is set to end.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
