### PR TITLE
Fix: Stop Job Status Modal navigating back after redirect clicked 

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
@@ -10,6 +10,7 @@ export default class JobStatusPollingController extends Controller<HTMLElement> 
   declare readonly frameTarget:FrameElement;
 
   interval:ReturnType<typeof setInterval>;
+  userInteraction:boolean = false;
 
   connect() {
     this.interval = setInterval(() => this.frameTarget.reload(), 2000);
@@ -17,7 +18,7 @@ export default class JobStatusPollingController extends Controller<HTMLElement> 
 
   disconnect() {
     this.stopPolling();
-    if (this.backOnCloseValue) {
+    if (this.backOnCloseValue && !this.userInteraction) {
       window.history.back();
     }
   }
@@ -39,7 +40,14 @@ export default class JobStatusPollingController extends Controller<HTMLElement> 
     setTimeout(() => element.click(), 50);
   }
 
+  redirectClick(_:Event) {
+    this.userInteraction = true;
+  }
+
   redirectTargetConnected(element:HTMLLinkElement) {
-    setTimeout(() => { window.location.href = element.href; }, 2000);
+    setTimeout(() => {
+      this.userInteraction = true;
+      window.location.href = element.href;
+    }, 2000);
   }
 }

--- a/modules/job_status/app/components/job_status/dialog/body_component.html.erb
+++ b/modules/job_status/app/components/job_status/dialog/body_component.html.erb
@@ -19,6 +19,7 @@
           flex.with_row { render(Primer::Beta::Link.new(
             href: redirect_url,
             data: {
+              action: 'job-status-polling#redirectClick',
               "job-status-polling-target": job_errors.present? ? nil : "redirect"
             }
           )) { I18n.t('job_status_dialog.redirect_link') } }

--- a/modules/job_status/spec/features/job_status_spec.rb
+++ b/modules/job_status/spec/features/job_status_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Job status", :js do
     it "does not navigate back after user clicked the redirect" do
       visit "/projects"
       visit "/job_statuses/#{status.job_id}"
-      click_on I18n.t('job_status_dialog.redirect_link')
+      click_on I18n.t("job_status_dialog.redirect_link")
 
       expect(page).to have_current_path(home_path, wait: 10)
     end

--- a/modules/job_status/spec/features/job_status_spec.rb
+++ b/modules/job_status/spec/features/job_status_spec.rb
@@ -88,5 +88,13 @@ RSpec.describe "Job status", :js do
       expect(page).to have_content "Some error"
       expect(page).to have_css("a[href='#{home_url}']", text: "Please click here to continue")
     end
+
+    it "does not navigate back after user clicked the redirect" do
+      visit "/projects"
+      visit "/job_statuses/#{status.job_id}"
+      click_on I18n.t('job_status_dialog.redirect_link')
+
+      expect(page).to have_current_path(home_path, wait: 10)
+    end
   end
 end


### PR DESCRIPTION
# Ticket

FIX for https://community.openproject.org/projects/openproject/work_packages/48274/activity

# What are you trying to accomplish?

Job status modal (stand-alone variant at /jobstatuses/id) navigates back if the modal closes.

But **not** after the user a clicked a redirect link, as this would be undoing the redirect visit. 
Thanks @cbliard for finding the bug! 

# Merge checklist

- [X] Added/updated tests
