### PR TITLE
Update macOS dev docs

### DIFF
--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -75,10 +75,11 @@ steps.
 
 ```shell
 # Install postgres database
-$ brew install postgres
+$ brew install postgresql
 
-# Create the database instance
-$ postgres -D /usr/local/var/postgres
+# Confirm that postgres has created a default database cluster if you see
+This formula has created a default database cluster with:
+  initdb --locale=C -E UTF-8 /opt/homebrew/var/postgresql@14 # /usr/local for Intel Macs
 ```
 
 Then, create the OpenProject database user and accompanied database.

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -197,9 +197,9 @@ automatically loaded to the application's environment.
 > [!TIP]
 > Instead of using the `gssencmode` flag in `config/database.yml`, you can add `export PGGSSENCMODE="disable"` to your
 > Shell profile (`~/.zprofile` by default). This will prevent Ruby crashes for *all* of your projects.
->
-> However, some users report Ruby crashes despite having set this flag to disable.
-> If this happens on your machine, try adding `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` to your Shell profile.
+
+Some users report Ruby crashes despite having set this flag to disable. If this is the case for you as well,
+try adding `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` to your Shell profile.
 
 ### Install other requirements
 

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -6,7 +6,7 @@ description: OpenProject development setup on Mac OS
 keywords: development setup macos
 ---
 
-# OpenProject development setup on Mac OS X
+# OpenProject development setup on macOS
 
 To develop OpenProject a setup similar to that for using OpenProject in production is needed.
 

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -10,7 +10,7 @@ keywords: development setup macos
 
 To develop OpenProject a setup similar to that for using OpenProject in production is needed.
 
-This guide assumes that you have a Mac OS X installation with administrative rights.
+This guide assumes that you have a macOS (used to be called Mac OS X) installation with administrative rights.
 OpenProject will be installed with a PostgreSQL database.
 
 **Please note**: This guide is NOT suitable for a production setup, but only for developing with it!

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -194,6 +194,13 @@ To configure the environment variables such as the number of web server threads 
 the `.env.example` to `.env` and add the environment variables you want to configure. The variables will be
 automatically loaded to the application's environment.
 
+> [!TIP]
+> Instead of using the `gssencmode` flag in `config/database.yml`, you can add `export PGGSSENCMODE="disable"` to your
+> Shell profile (`~/.zprofile` by default). This will prevent Ruby crashes for *all* of your projects.
+>
+> However, some users report Ruby crashes despite having setting this flag to disable.
+> If this happens on your machine, try adding `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` to your Shell profile.
+
 ### Install other requirements
 
 Some operations in OpenProject require additional software. These include PDF exports and interaction with an

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -194,6 +194,20 @@ To configure the environment variables such as the number of web server threads 
 the `.env.example` to `.env` and add the environment variables you want to configure. The variables will be
 automatically loaded to the application's environment.
 
+### Install other requirements
+
+Some operations in OpenProject require additional software. These include PDF exports and interaction with an
+LDAP server.
+
+In order to have OpenProject behave correctly, you need to install `imagemagick` and `java`.
+
+```shell
+brew install imagemagick java
+```
+
+As of writing, you need to manually create a symlink to OpenJDK for the Java installation to take effect. Homebrew will
+tell you how.
+
 ### Finish the Installation of OpenProject
 
 Install code dependencies, link plugin modules and export translation files.

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -173,6 +173,10 @@ It should look like this (just with your database name, username, and password):
 default: &default
   adapter: postgresql
   encoding: unicode
+  # Socket encryption must be disabled on macOS. There is an old bug in which forked processes cause problems on a Mac.
+  # TL;DR: set this flag, otherwise Ruby will crash whenever a route is accessed.
+  # Visit https://github.com/ged/ruby-pg/issues/311 to enter the rabbit hole.
+  gssencmode: disable
   host: localhost
   username: openproject
   password: openproject-dev-password

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -198,7 +198,7 @@ automatically loaded to the application's environment.
 > Instead of using the `gssencmode` flag in `config/database.yml`, you can add `export PGGSSENCMODE="disable"` to your
 > Shell profile (`~/.zprofile` by default). This will prevent Ruby crashes for *all* of your projects.
 >
-> However, some users report Ruby crashes despite having setting this flag to disable.
+> However, some users report Ruby crashes despite having set this flag to disable.
 > If this happens on your machine, try adding `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` to your Shell profile.
 
 ### Install other requirements

--- a/docs/development/development-environment/macos/README.md
+++ b/docs/development/development-environment/macos/README.md
@@ -10,7 +10,7 @@ keywords: development setup macos
 
 To develop OpenProject a setup similar to that for using OpenProject in production is needed.
 
-This guide assumes that you have a macOS (used to be called Mac OS X) installation with administrative rights.
+This guide assumes that you have a macOS installation with administrative rights.
 OpenProject will be installed with a PostgreSQL database.
 
 **Please note**: This guide is NOT suitable for a production setup, but only for developing with it!
@@ -199,7 +199,7 @@ automatically loaded to the application's environment.
 Some operations in OpenProject require additional software. These include PDF exports and interaction with an
 LDAP server.
 
-In order to have OpenProject behave correctly, you need to install `imagemagick` and `java`.
+In order to develop OpenProject in these areas, you need to install `imagemagick` and `java`.
 
 ```shell
 brew install imagemagick java


### PR DESCRIPTION
# What are you trying to accomplish?

We're updating the dev docs to better reflect the current state of the OP installation on macOS. 

The postgres install command has been changed a little and it now creates a DB instance by default. Also, a database connection flag needs to be added to prevent crashes, and steps to install java and imagemagick have been added.